### PR TITLE
Fix name resolution in check_admits

### DIFF
--- a/src/ocaml-output/FStar_Common.ml
+++ b/src/ocaml-output/FStar_Common.ml
@@ -1,25 +1,24 @@
 open Prims
-let (has_cygpath : Prims.bool) =
+let has_cygpath: Prims.bool =
   try
-    let uu____7 = FStar_Util.run_proc "which" "cygpath" ""  in
+    let uu____7 = FStar_Util.run_proc "which" "cygpath" "" in
     match uu____7 with
     | (uu____14,t_out,uu____16) ->
         (FStar_Util.trim_string t_out) = "/usr/bin/cygpath"
-  with | uu____20 -> false 
-let (try_convert_file_name_to_mixed : Prims.string -> Prims.string) =
-  let cache = FStar_Util.smap_create (Prims.parse_int "20")  in
+  with | uu____20 -> false
+let try_convert_file_name_to_mixed: Prims.string -> Prims.string =
+  let cache = FStar_Util.smap_create (Prims.parse_int "20") in
   fun s  ->
     if has_cygpath && (FStar_Util.starts_with s "/")
     then
-      let uu____27 = FStar_Util.smap_try_find cache s  in
+      let uu____27 = FStar_Util.smap_try_find cache s in
       match uu____27 with
       | FStar_Pervasives_Native.Some s1 -> s1
       | FStar_Pervasives_Native.None  ->
           let uu____31 =
-            FStar_Util.run_proc "cygpath" (Prims.strcat "-m " s) ""  in
+            FStar_Util.run_proc "cygpath" (Prims.strcat "-m " s) "" in
           (match uu____31 with
            | (uu____38,out,uu____40) ->
-               let out1 = FStar_Util.trim_string out  in
+               let out1 = FStar_Util.trim_string out in
                (FStar_Util.smap_add cache s out1; out1))
     else s
-  

--- a/src/ocaml-output/FStar_Const.ml
+++ b/src/ocaml-output/FStar_Const.ml
@@ -1,150 +1,134 @@
 open Prims
 type signedness =
-  | Unsigned 
-  | Signed [@@deriving show]
-let (uu___is_Unsigned : signedness -> Prims.bool) =
+  | Unsigned
+  | Signed[@@deriving show]
+let uu___is_Unsigned: signedness -> Prims.bool =
   fun projectee  ->
     match projectee with | Unsigned  -> true | uu____4 -> false
-  
-let (uu___is_Signed : signedness -> Prims.bool) =
-  fun projectee  -> match projectee with | Signed  -> true | uu____8 -> false 
+let uu___is_Signed: signedness -> Prims.bool =
+  fun projectee  -> match projectee with | Signed  -> true | uu____8 -> false
 type width =
-  | Int8 
-  | Int16 
-  | Int32 
-  | Int64 [@@deriving show]
-let (uu___is_Int8 : width -> Prims.bool) =
-  fun projectee  -> match projectee with | Int8  -> true | uu____12 -> false 
-let (uu___is_Int16 : width -> Prims.bool) =
-  fun projectee  -> match projectee with | Int16  -> true | uu____16 -> false 
-let (uu___is_Int32 : width -> Prims.bool) =
-  fun projectee  -> match projectee with | Int32  -> true | uu____20 -> false 
-let (uu___is_Int64 : width -> Prims.bool) =
-  fun projectee  -> match projectee with | Int64  -> true | uu____24 -> false 
+  | Int8
+  | Int16
+  | Int32
+  | Int64[@@deriving show]
+let uu___is_Int8: width -> Prims.bool =
+  fun projectee  -> match projectee with | Int8  -> true | uu____12 -> false
+let uu___is_Int16: width -> Prims.bool =
+  fun projectee  -> match projectee with | Int16  -> true | uu____16 -> false
+let uu___is_Int32: width -> Prims.bool =
+  fun projectee  -> match projectee with | Int32  -> true | uu____20 -> false
+let uu___is_Int64: width -> Prims.bool =
+  fun projectee  -> match projectee with | Int64  -> true | uu____24 -> false
 type sconst =
-  | Const_effect 
-  | Const_unit 
-  | Const_bool of Prims.bool 
+  | Const_effect
+  | Const_unit
+  | Const_bool of Prims.bool
   | Const_int of
   (Prims.string,(signedness,width) FStar_Pervasives_Native.tuple2
                   FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
-  | Const_char of FStar_BaseTypes.char 
-  | Const_float of FStar_BaseTypes.double 
+  FStar_Pervasives_Native.tuple2
+  | Const_char of FStar_BaseTypes.char
+  | Const_float of FStar_BaseTypes.double
   | Const_bytearray of (FStar_BaseTypes.byte Prims.array,FStar_Range.range)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Const_string of (Prims.string,FStar_Range.range)
-  FStar_Pervasives_Native.tuple2 
-  | Const_range_of 
-  | Const_set_range_of 
-  | Const_range of FStar_Range.range 
-  | Const_reify 
-  | Const_reflect of FStar_Ident.lid [@@deriving show]
-let (uu___is_Const_effect : sconst -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | Const_range_of
+  | Const_set_range_of
+  | Const_range of FStar_Range.range
+  | Const_reify
+  | Const_reflect of FStar_Ident.lid[@@deriving show]
+let uu___is_Const_effect: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_effect  -> true | uu____80 -> false
-  
-let (uu___is_Const_unit : sconst -> Prims.bool) =
+let uu___is_Const_unit: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_unit  -> true | uu____84 -> false
-  
-let (uu___is_Const_bool : sconst -> Prims.bool) =
+let uu___is_Const_bool: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_bool _0 -> true | uu____89 -> false
-  
-let (__proj__Const_bool__item___0 : sconst -> Prims.bool) =
-  fun projectee  -> match projectee with | Const_bool _0 -> _0 
-let (uu___is_Const_int : sconst -> Prims.bool) =
+let __proj__Const_bool__item___0: sconst -> Prims.bool =
+  fun projectee  -> match projectee with | Const_bool _0 -> _0
+let uu___is_Const_int: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_int _0 -> true | uu____111 -> false
-  
-let (__proj__Const_int__item___0 :
+let __proj__Const_int__item___0:
   sconst ->
     (Prims.string,(signedness,width) FStar_Pervasives_Native.tuple2
                     FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Const_int _0 -> _0 
-let (uu___is_Const_char : sconst -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Const_int _0 -> _0
+let uu___is_Const_char: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_char _0 -> true | uu____153 -> false
-  
-let (__proj__Const_char__item___0 : sconst -> FStar_BaseTypes.char) =
-  fun projectee  -> match projectee with | Const_char _0 -> _0 
-let (uu___is_Const_float : sconst -> Prims.bool) =
+let __proj__Const_char__item___0: sconst -> FStar_BaseTypes.char =
+  fun projectee  -> match projectee with | Const_char _0 -> _0
+let uu___is_Const_float: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_float _0 -> true | uu____165 -> false
-  
-let (__proj__Const_float__item___0 : sconst -> FStar_BaseTypes.double) =
-  fun projectee  -> match projectee with | Const_float _0 -> _0 
-let (uu___is_Const_bytearray : sconst -> Prims.bool) =
+let __proj__Const_float__item___0: sconst -> FStar_BaseTypes.double =
+  fun projectee  -> match projectee with | Const_float _0 -> _0
+let uu___is_Const_bytearray: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_bytearray _0 -> true | uu____183 -> false
-  
-let (__proj__Const_bytearray__item___0 :
+let __proj__Const_bytearray__item___0:
   sconst ->
     (FStar_BaseTypes.byte Prims.array,FStar_Range.range)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Const_bytearray _0 -> _0 
-let (uu___is_Const_string : sconst -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Const_bytearray _0 -> _0
+let uu___is_Const_string: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_string _0 -> true | uu____217 -> false
-  
-let (__proj__Const_string__item___0 :
-  sconst -> (Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Const_string _0 -> _0 
-let (uu___is_Const_range_of : sconst -> Prims.bool) =
+let __proj__Const_string__item___0:
+  sconst -> (Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Const_string _0 -> _0
+let uu___is_Const_range_of: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_range_of  -> true | uu____240 -> false
-  
-let (uu___is_Const_set_range_of : sconst -> Prims.bool) =
+let uu___is_Const_set_range_of: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_set_range_of  -> true | uu____244 -> false
-  
-let (uu___is_Const_range : sconst -> Prims.bool) =
+let uu___is_Const_range: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_range _0 -> true | uu____249 -> false
-  
-let (__proj__Const_range__item___0 : sconst -> FStar_Range.range) =
-  fun projectee  -> match projectee with | Const_range _0 -> _0 
-let (uu___is_Const_reify : sconst -> Prims.bool) =
+let __proj__Const_range__item___0: sconst -> FStar_Range.range =
+  fun projectee  -> match projectee with | Const_range _0 -> _0
+let uu___is_Const_reify: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_reify  -> true | uu____260 -> false
-  
-let (uu___is_Const_reflect : sconst -> Prims.bool) =
+let uu___is_Const_reflect: sconst -> Prims.bool =
   fun projectee  ->
     match projectee with | Const_reflect _0 -> true | uu____265 -> false
-  
-let (__proj__Const_reflect__item___0 : sconst -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | Const_reflect _0 -> _0 
-let (eq_const : sconst -> sconst -> Prims.bool) =
+let __proj__Const_reflect__item___0: sconst -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | Const_reflect _0 -> _0
+let eq_const: sconst -> sconst -> Prims.bool =
   fun c1  ->
     fun c2  ->
       match (c1, c2) with
       | (Const_int (s1,o1),Const_int (s2,o2)) ->
-          (let uu____311 = FStar_Util.ensure_decimal s1  in
-           let uu____312 = FStar_Util.ensure_decimal s2  in
+          (let uu____311 = FStar_Util.ensure_decimal s1 in
+           let uu____312 = FStar_Util.ensure_decimal s2 in
            uu____311 = uu____312) && (o1 = o2)
       | (Const_bytearray (a,uu____320),Const_bytearray (b,uu____322)) ->
           a = b
       | (Const_string (a,uu____334),Const_string (b,uu____336)) -> a = b
       | (Const_reflect l1,Const_reflect l2) -> FStar_Ident.lid_equals l1 l2
       | uu____339 -> c1 = c2
-  
-let rec (pow2 : FStar_BigInt.bigint -> FStar_BigInt.bigint) =
+let rec pow2: FStar_BigInt.bigint -> FStar_BigInt.bigint =
   fun x  ->
-    let uu____347 = FStar_BigInt.eq_big_int x FStar_BigInt.zero  in
+    let uu____347 = FStar_BigInt.eq_big_int x FStar_BigInt.zero in
     if uu____347
     then FStar_BigInt.one
     else
       (let uu____349 =
-         let uu____350 = FStar_BigInt.pred_big_int x  in pow2 uu____350  in
+         let uu____350 = FStar_BigInt.pred_big_int x in pow2 uu____350 in
        FStar_BigInt.mult_big_int FStar_BigInt.two uu____349)
-  
-let (bounds :
+let bounds:
   signedness ->
     width ->
       (FStar_BigInt.bigint,FStar_BigInt.bigint)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun signedness  ->
     fun width  ->
@@ -153,34 +137,29 @@ let (bounds :
         | Int8  -> FStar_BigInt.big_int_of_string "8"
         | Int16  -> FStar_BigInt.big_int_of_string "16"
         | Int32  -> FStar_BigInt.big_int_of_string "32"
-        | Int64  -> FStar_BigInt.big_int_of_string "64"  in
+        | Int64  -> FStar_BigInt.big_int_of_string "64" in
       let uu____362 =
         match signedness with
         | Unsigned  ->
             let uu____371 =
-              let uu____372 = pow2 n1  in FStar_BigInt.pred_big_int uu____372
-               in
+              let uu____372 = pow2 n1 in FStar_BigInt.pred_big_int uu____372 in
             (FStar_BigInt.zero, uu____371)
         | Signed  ->
             let upper =
-              let uu____374 = FStar_BigInt.pred_big_int n1  in pow2 uu____374
-               in
-            let uu____375 = FStar_BigInt.minus_big_int upper  in
-            let uu____376 = FStar_BigInt.pred_big_int upper  in
-            (uu____375, uu____376)
-         in
+              let uu____374 = FStar_BigInt.pred_big_int n1 in pow2 uu____374 in
+            let uu____375 = FStar_BigInt.minus_big_int upper in
+            let uu____376 = FStar_BigInt.pred_big_int upper in
+            (uu____375, uu____376) in
       match uu____362 with | (lower,upper) -> (lower, upper)
-  
-let (within_bounds : Prims.string -> signedness -> width -> Prims.bool) =
+let within_bounds: Prims.string -> signedness -> width -> Prims.bool =
   fun repr  ->
     fun signedness  ->
       fun width  ->
-        let uu____392 = bounds signedness width  in
+        let uu____392 = bounds signedness width in
         match uu____392 with
         | (lower,upper) ->
             let value =
-              let uu____400 = FStar_Util.ensure_decimal repr  in
-              FStar_BigInt.big_int_of_string uu____400  in
+              let uu____400 = FStar_Util.ensure_decimal repr in
+              FStar_BigInt.big_int_of_string uu____400 in
             (FStar_BigInt.le_big_int lower value) &&
               (FStar_BigInt.le_big_int value upper)
-  

--- a/src/ocaml-output/FStar_Dependencies.ml
+++ b/src/ocaml-output/FStar_Dependencies.ml
@@ -1,11 +1,11 @@
 open Prims
-let (find_deps_if_needed :
+let find_deps_if_needed:
   Prims.string Prims.list ->
     (Prims.string Prims.list,FStar_Parser_Dep.deps)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun files  ->
-    let uu____14 = FStar_Parser_Dep.collect files  in
+    let uu____14 = FStar_Parser_Dep.collect files in
     match uu____14 with
     | (all_files,deps) ->
         (match all_files with
@@ -15,4 +15,3 @@ let (find_deps_if_needed :
                   "Dependency analysis failed; reverting to using only the files provided\n");
               (files, deps))
          | uu____42 -> ((FStar_List.rev all_files), deps))
-  

--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -1,2014 +1,1707 @@
 open Prims
 type raw_error =
-  | Error_DependencyAnalysisFailed 
-  | Error_IDETooManyPops 
-  | Error_IDEUnrecognized 
-  | Error_InductiveTypeNotSatisfyPositivityCondition 
-  | Error_InvalidUniverseVar 
-  | Error_MissingFileName 
-  | Error_ModuleFileNameMismatch 
-  | Error_OpPlusInUniverse 
-  | Error_OutOfRange 
-  | Error_ProofObligationFailed 
-  | Error_TooManyFiles 
-  | Error_TypeCheckerFailToProve 
-  | Error_TypeError 
-  | Error_UncontrainedUnificationVar 
-  | Error_UnexpectedGTotComputation 
-  | Error_UnexpectedInstance 
-  | Error_UnknownFatal_AssertionFailure 
-  | Error_Z3InvocationError 
-  | Error_IDEAssertionFailure 
-  | Error_Z3SolverError 
-  | Fatal_AbstractTypeDeclarationInInterface 
-  | Fatal_ActionMustHaveFunctionType 
-  | Fatal_AlreadyDefinedTopLevelDeclaration 
-  | Fatal_ArgumentLengthMismatch 
-  | Fatal_AssertionFailure 
-  | Fatal_AssignToImmutableValues 
-  | Fatal_AssumeValInInterface 
-  | Fatal_BadlyInstantiatedSynthByTactic 
-  | Fatal_BadSignatureShape 
-  | Fatal_BinderAndArgsLengthMismatch 
-  | Fatal_BothValAndLetInInterface 
-  | Fatal_CardinalityConstraintViolated 
-  | Fatal_ComputationNotTotal 
-  | Fatal_ComputationTypeNotAllowed 
-  | Fatal_ComputedTypeNotMatchAnnotation 
-  | Fatal_ConstructorArgLengthMismatch 
-  | Fatal_ConstructorFailedCheck 
-  | Fatal_ConstructorNotFound 
-  | Fatal_ConstsructorBuildWrongType 
-  | Fatal_CycleInRecTypeAbbreviation 
-  | Fatal_DataContructorNotFound 
-  | Fatal_DefaultQualifierNotAllowedOnEffects 
-  | Fatal_DefinitionNotFound 
-  | Fatal_DisjuctivePatternVarsMismatch 
-  | Fatal_DivergentComputationCannotBeIncludedInTotal 
-  | Fatal_DuplicateInImplementation 
-  | Fatal_DuplicateModuleOrInterface 
-  | Fatal_DuplicateTopLevelNames 
-  | Fatal_DuplicateTypeAnnotationAndValDecl 
-  | Fatal_EffectCannotBeReified 
-  | Fatal_EffectConstructorNotFullyApplied 
-  | Fatal_EffectfulAndPureComputationMismatch 
-  | Fatal_EffectNotFound 
-  | Fatal_EffectsCannotBeComposed 
-  | Fatal_ErrorInSolveDeferredConstraints 
-  | Fatal_ErrorsReported 
-  | Fatal_EscapedBoundVar 
-  | Fatal_ExpectedArrowAnnotatedType 
-  | Fatal_ExpectedGhostExpression 
-  | Fatal_ExpectedPureExpression 
-  | Fatal_ExpectNormalizedEffect 
-  | Fatal_ExpectTermGotFunction 
-  | Fatal_ExpectTrivialPreCondition 
-  | Fatal_FailToCompileNativeTactic 
-  | Fatal_FailToExtractNativeTactic 
-  | Fatal_FailToProcessPragma 
-  | Fatal_FailToResolveImplicitArgument 
-  | Fatal_FailToSolveUniverseInEquality 
-  | Fatal_FieldsNotBelongToSameRecordType 
-  | Fatal_ForbiddenReferenceToCurrentModule 
-  | Fatal_FreeVariables 
-  | Fatal_FunctionTypeExpected 
-  | Fatal_IdentifierNotFound 
-  | Fatal_IllAppliedConstant 
-  | Fatal_IllegalCharInByteArray 
-  | Fatal_IllegalCharInOperatorName 
-  | Fatal_IllTyped 
-  | Fatal_ImpossibleAbbrevLidBundle 
-  | Fatal_ImpossibleAbbrevRenameBundle 
-  | Fatal_ImpossibleInductiveWithAbbrev 
-  | Fatal_ImpossiblePrePostAbs 
-  | Fatal_ImpossiblePrePostArrow 
-  | Fatal_ImpossibleToGenerateDMEffect 
-  | Fatal_ImpossibleTypeAbbrevBundle 
-  | Fatal_ImpossibleTypeAbbrevSigeltBundle 
-  | Fatal_IncludeModuleNotPrepared 
-  | Fatal_IncoherentInlineUniverse 
-  | Fatal_IncompatibleKinds 
-  | Fatal_IncompatibleNumberOfTypes 
-  | Fatal_IncompatibleSetOfUniverse 
-  | Fatal_IncompatibleUniverse 
-  | Fatal_InconsistentImplicitArgumentAnnotation 
-  | Fatal_InconsistentImplicitQualifier 
-  | Fatal_InconsistentQualifierAnnotation 
-  | Fatal_InferredTypeCauseVarEscape 
-  | Fatal_InlineRenamedAsUnfold 
-  | Fatal_InsufficientPatternArguments 
-  | Fatal_InterfaceAlreadyProcessed 
-  | Fatal_InterfaceNotImplementedByModule 
-  | Fatal_InterfaceWithTypeImplementation 
-  | Fatal_InvalidFloatingPointNumber 
-  | Fatal_InvalidFSDocKeyword 
-  | Fatal_InvalidIdentifier 
-  | Fatal_InvalidLemmaArgument 
-  | Fatal_InvalidNumericLiteral 
-  | Fatal_InvalidRedefinitionOfLexT 
-  | Fatal_InvalidUnicodeInStringLiteral 
-  | Fatal_InvalidUTF8Encoding 
-  | Fatal_InvalidWarnErrorSetting 
-  | Fatal_LetBoundMonadicMismatch 
-  | Fatal_LetMutableForVariablesOnly 
-  | Fatal_LetOpenModuleOnly 
-  | Fatal_LetRecArgumentMismatch 
-  | Fatal_MalformedActionDeclaration 
-  | Fatal_MismatchedPatternType 
-  | Fatal_MismatchUniversePolymorphic 
-  | Fatal_MissingDataConstructor 
-  | Fatal_MissingExposeInterfacesOption 
-  | Fatal_MissingFieldInRecord 
-  | Fatal_MissingImplementation 
-  | Fatal_MissingImplicitArguments 
-  | Fatal_MissingInterface 
-  | Fatal_MissingNameInBinder 
-  | Fatal_MissingPrimsModule 
-  | Fatal_MissingQuantifierBinder 
-  | Fatal_ModuleExpected 
-  | Fatal_ModuleFileNotFound 
-  | Fatal_ModuleFirstStatement 
-  | Fatal_ModuleNotFound 
-  | Fatal_ModuleOrFileNotFound 
-  | Fatal_MonadAlreadyDefined 
-  | Fatal_MoreThanOneDeclaration 
-  | Fatal_MultipleLetBinding 
-  | Fatal_NameNotFound 
-  | Fatal_NameSpaceNotFound 
-  | Fatal_NegativeUniverseConstFatal_NotSupported 
-  | Fatal_NoFileProvided 
-  | Fatal_NonInductiveInMutuallyDefinedType 
-  | Fatal_NonLinearPatternNotPermitted 
-  | Fatal_NonLinearPatternVars 
-  | Fatal_NonSingletonTopLevel 
-  | Fatal_NonSingletonTopLevelModule 
-  | Fatal_NonTopRecFunctionNotFullyEncoded 
-  | Fatal_NonTrivialPreConditionInPrims 
-  | Fatal_NonVariableInductiveTypeParameter 
-  | Fatal_NotApplicationOrFv 
-  | Fatal_NotEnoughArgsToEffect 
-  | Fatal_NotEnoughArgumentsForEffect 
-  | Fatal_NotFunctionType 
-  | Fatal_NotSupported 
-  | Fatal_NotTopLevelModule 
-  | Fatal_NotValidFStarFile 
-  | Fatal_NotValidIncludeDirectory 
-  | Fatal_OneModulePerFile 
-  | Fatal_OpenGoalsInSynthesis 
-  | Fatal_OptionsNotCompatible 
-  | Fatal_OutOfOrder 
-  | Fatal_ParseErrors 
-  | Fatal_ParseItError 
-  | Fatal_PolyTypeExpected 
-  | Fatal_PossibleInfiniteTyp 
-  | Fatal_PreModuleMismatch 
-  | Fatal_QulifierListNotPermitted 
-  | Fatal_RecursiveFunctionLiteral 
-  | Fatal_ReflectOnlySupportedOnEffects 
-  | Fatal_ReservedPrefix 
-  | Fatal_SMTOutputParseError 
-  | Fatal_SMTSolverError 
-  | Fatal_SyntaxError 
-  | Fatal_SynthByTacticError 
-  | Fatal_TacticGotStuck 
-  | Fatal_TcOneFragmentFailed 
-  | Fatal_TermOutsideOfDefLanguage 
-  | Fatal_ToManyArgumentToFunction 
-  | Fatal_TooManyOrTooFewFileMatch 
-  | Fatal_TooManyPatternArguments 
-  | Fatal_TooManyUniverse 
-  | Fatal_TypeMismatch 
-  | Fatal_TypeWithinPatternsAllowedOnVariablesOnly 
-  | Fatal_UnableToReadFile 
-  | Fatal_UnepxectedOrUnboundOperator 
-  | Fatal_UnexpectedBinder 
-  | Fatal_UnexpectedBindShape 
-  | Fatal_UnexpectedChar 
-  | Fatal_UnexpectedComputationTypeForLetRec 
-  | Fatal_UnexpectedConstructorType 
-  | Fatal_UnexpectedDataConstructor 
-  | Fatal_UnexpectedEffect 
-  | Fatal_UnexpectedEmptyRecord 
-  | Fatal_UnexpectedExpressionType 
-  | Fatal_UnexpectedFunctionParameterType 
-  | Fatal_UnexpectedGeneralizedUniverse 
-  | Fatal_UnexpectedGTotForLetRec 
-  | Fatal_UnexpectedGuard 
-  | Fatal_UnexpectedIdentifier 
-  | Fatal_UnexpectedImplicitArgument 
-  | Fatal_UnexpectedImplictArgument 
-  | Fatal_UnexpectedInductivetype 
-  | Fatal_UnexpectedLetBinding 
-  | Fatal_UnexpectedModuleDeclaration 
-  | Fatal_UnexpectedNumberOfUniverse 
-  | Fatal_UnexpectedNumericLiteral 
-  | Fatal_UnexpectedOperatorSymbol 
-  | Fatal_UnexpectedPattern 
-  | Fatal_UnexpectedPosition 
-  | Fatal_UnExpectedPreCondition 
-  | Fatal_UnexpectedReturnShape 
-  | Fatal_UnexpectedSignatureForMonad 
-  | Fatal_UnexpectedTerm 
-  | Fatal_UnexpectedTermInUniverse 
-  | Fatal_UnexpectedTermType 
-  | Fatal_UnexpectedUniversePolymorphicReturn 
-  | Fatal_UnexpectedUniverseVariable 
-  | Fatal_UnfoldableDeprecated 
-  | Fatal_UnificationNotWellFormed 
-  | Fatal_Uninstantiated 
-  | Fatal_UninstantiatedUnificationVarInTactic 
-  | Fatal_UninstantiatedVarInTactic 
-  | Fatal_UniverseMightContainSumOfTwoUnivVars 
-  | Fatal_UniversePolymorphicInnerLetBound 
-  | Fatal_UnknownAttribute 
-  | Fatal_UnknownToolForDep 
-  | Fatal_UnrecognizedExtension 
-  | Fatal_UnresolvedPatternVar 
-  | Fatal_UnsupportedConstant 
-  | Fatal_UnsupportedDisjuctivePatterns 
-  | Fatal_UnsupportedQualifier 
-  | Fatal_UserTacticFailure 
-  | Fatal_ValueRestriction 
-  | Fatal_VariableNotFound 
-  | Fatal_WrongBodyTypeForReturnWP 
-  | Fatal_WrongDataAppHeadFormat 
-  | Fatal_WrongDefinitionOrder 
-  | Fatal_WrongResultTypeAfterConstrutor 
-  | Fatal_WrongTerm 
-  | Fatal_WhenClauseNotSupported 
-  | Fatal_CallNotImplemented 
-  | Warning_AddImplicitAssumeNewQualifier 
-  | Warning_AdmitWithoutDefinition 
-  | Warning_CachedFile 
-  | Warning_DefinitionNotTranslated 
-  | Warning_DependencyFound 
-  | Warning_DeprecatedEqualityOnBinder 
-  | Warning_DeprecatedOpaqueQualifier 
-  | Warning_DocOverwrite 
-  | Warning_FileNotWritten 
-  | Warning_Filtered 
-  | Warning_FunctionLiteralPrecisionLoss 
-  | Warning_FunctionNotExtacted 
-  | Warning_HintFailedToReplayProof 
-  | Warning_HitReplayFailed 
-  | Warning_IDEIgnoreCodeGen 
-  | Warning_IllFormedGoal 
-  | Warning_InaccessibleArgument 
-  | Warning_IncoherentImplicitQualifier 
-  | Warning_IrrelevantQualifierOnArgumentToReflect 
-  | Warning_IrrelevantQualifierOnArgumentToReify 
-  | Warning_MalformedWarnErrorList 
-  | Warning_MetaAlienNotATmUnknown 
-  | Warning_MultipleAscriptions 
-  | Warning_NondependentUserDefinedDataType 
-  | Warning_NonListLiteralSMTPattern 
-  | Warning_NormalizationFailure 
-  | Warning_NotDependentArrow 
-  | Warning_NotEmbedded 
-  | Warning_PatternMissingBoundVar 
-  | Warning_RecursiveDependency 
-  | Warning_RedundantExplicitCurrying 
-  | Warning_SMTPatTDeprecated 
-  | Warning_SMTPatternMissingBoundVar 
-  | Warning_TopLevelEffect 
-  | Warning_UnboundModuleReference 
-  | Warning_UnexpectedFile 
-  | Warning_UnexpectedFsTypApp 
-  | Warning_UnexpectedZ3Output 
-  | Warning_UnprotectedTerm 
-  | Warning_UnrecognizedAttribute 
-  | Warning_UpperBoundCandidateAlreadyVisited 
-  | Warning_UseDefaultEffect 
-  | Warning_WrongErrorLocation 
-  | Warning_Z3InvocationWarning 
-  | Warning_CallNotImplementedAsWarning 
-  | Warning_MissingInterfaceOrImplementation 
-  | Warning_ConstructorBuildsUnexpectedType 
-  | Warning_ModuleOrFileNotFoundWarning 
-  | Error_NoLetMutable 
-  | Error_BadImplicit 
-  | Warning_DeprecatedDefinition [@@deriving show]
-let (uu___is_Error_DependencyAnalysisFailed : raw_error -> Prims.bool) =
+  | Error_DependencyAnalysisFailed
+  | Error_IDETooManyPops
+  | Error_IDEUnrecognized
+  | Error_InductiveTypeNotSatisfyPositivityCondition
+  | Error_InvalidUniverseVar
+  | Error_MissingFileName
+  | Error_ModuleFileNameMismatch
+  | Error_OpPlusInUniverse
+  | Error_OutOfRange
+  | Error_ProofObligationFailed
+  | Error_TooManyFiles
+  | Error_TypeCheckerFailToProve
+  | Error_TypeError
+  | Error_UncontrainedUnificationVar
+  | Error_UnexpectedGTotComputation
+  | Error_UnexpectedInstance
+  | Error_UnknownFatal_AssertionFailure
+  | Error_Z3InvocationError
+  | Error_IDEAssertionFailure
+  | Error_Z3SolverError
+  | Fatal_AbstractTypeDeclarationInInterface
+  | Fatal_ActionMustHaveFunctionType
+  | Fatal_AlreadyDefinedTopLevelDeclaration
+  | Fatal_ArgumentLengthMismatch
+  | Fatal_AssertionFailure
+  | Fatal_AssignToImmutableValues
+  | Fatal_AssumeValInInterface
+  | Fatal_BadlyInstantiatedSynthByTactic
+  | Fatal_BadSignatureShape
+  | Fatal_BinderAndArgsLengthMismatch
+  | Fatal_BothValAndLetInInterface
+  | Fatal_CardinalityConstraintViolated
+  | Fatal_ComputationNotTotal
+  | Fatal_ComputationTypeNotAllowed
+  | Fatal_ComputedTypeNotMatchAnnotation
+  | Fatal_ConstructorArgLengthMismatch
+  | Fatal_ConstructorFailedCheck
+  | Fatal_ConstructorNotFound
+  | Fatal_ConstsructorBuildWrongType
+  | Fatal_CycleInRecTypeAbbreviation
+  | Fatal_DataContructorNotFound
+  | Fatal_DefaultQualifierNotAllowedOnEffects
+  | Fatal_DefinitionNotFound
+  | Fatal_DisjuctivePatternVarsMismatch
+  | Fatal_DivergentComputationCannotBeIncludedInTotal
+  | Fatal_DuplicateInImplementation
+  | Fatal_DuplicateModuleOrInterface
+  | Fatal_DuplicateTopLevelNames
+  | Fatal_DuplicateTypeAnnotationAndValDecl
+  | Fatal_EffectCannotBeReified
+  | Fatal_EffectConstructorNotFullyApplied
+  | Fatal_EffectfulAndPureComputationMismatch
+  | Fatal_EffectNotFound
+  | Fatal_EffectsCannotBeComposed
+  | Fatal_ErrorInSolveDeferredConstraints
+  | Fatal_ErrorsReported
+  | Fatal_EscapedBoundVar
+  | Fatal_ExpectedArrowAnnotatedType
+  | Fatal_ExpectedGhostExpression
+  | Fatal_ExpectedPureExpression
+  | Fatal_ExpectNormalizedEffect
+  | Fatal_ExpectTermGotFunction
+  | Fatal_ExpectTrivialPreCondition
+  | Fatal_FailToCompileNativeTactic
+  | Fatal_FailToExtractNativeTactic
+  | Fatal_FailToProcessPragma
+  | Fatal_FailToResolveImplicitArgument
+  | Fatal_FailToSolveUniverseInEquality
+  | Fatal_FieldsNotBelongToSameRecordType
+  | Fatal_ForbiddenReferenceToCurrentModule
+  | Fatal_FreeVariables
+  | Fatal_FunctionTypeExpected
+  | Fatal_IdentifierNotFound
+  | Fatal_IllAppliedConstant
+  | Fatal_IllegalCharInByteArray
+  | Fatal_IllegalCharInOperatorName
+  | Fatal_IllTyped
+  | Fatal_ImpossibleAbbrevLidBundle
+  | Fatal_ImpossibleAbbrevRenameBundle
+  | Fatal_ImpossibleInductiveWithAbbrev
+  | Fatal_ImpossiblePrePostAbs
+  | Fatal_ImpossiblePrePostArrow
+  | Fatal_ImpossibleToGenerateDMEffect
+  | Fatal_ImpossibleTypeAbbrevBundle
+  | Fatal_ImpossibleTypeAbbrevSigeltBundle
+  | Fatal_IncludeModuleNotPrepared
+  | Fatal_IncoherentInlineUniverse
+  | Fatal_IncompatibleKinds
+  | Fatal_IncompatibleNumberOfTypes
+  | Fatal_IncompatibleSetOfUniverse
+  | Fatal_IncompatibleUniverse
+  | Fatal_InconsistentImplicitArgumentAnnotation
+  | Fatal_InconsistentImplicitQualifier
+  | Fatal_InconsistentQualifierAnnotation
+  | Fatal_InferredTypeCauseVarEscape
+  | Fatal_InlineRenamedAsUnfold
+  | Fatal_InsufficientPatternArguments
+  | Fatal_InterfaceAlreadyProcessed
+  | Fatal_InterfaceNotImplementedByModule
+  | Fatal_InterfaceWithTypeImplementation
+  | Fatal_InvalidFloatingPointNumber
+  | Fatal_InvalidFSDocKeyword
+  | Fatal_InvalidIdentifier
+  | Fatal_InvalidLemmaArgument
+  | Fatal_InvalidNumericLiteral
+  | Fatal_InvalidRedefinitionOfLexT
+  | Fatal_InvalidUnicodeInStringLiteral
+  | Fatal_InvalidUTF8Encoding
+  | Fatal_InvalidWarnErrorSetting
+  | Fatal_LetBoundMonadicMismatch
+  | Fatal_LetMutableForVariablesOnly
+  | Fatal_LetOpenModuleOnly
+  | Fatal_LetRecArgumentMismatch
+  | Fatal_MalformedActionDeclaration
+  | Fatal_MismatchedPatternType
+  | Fatal_MismatchUniversePolymorphic
+  | Fatal_MissingDataConstructor
+  | Fatal_MissingExposeInterfacesOption
+  | Fatal_MissingFieldInRecord
+  | Fatal_MissingImplementation
+  | Fatal_MissingImplicitArguments
+  | Fatal_MissingInterface
+  | Fatal_MissingNameInBinder
+  | Fatal_MissingPrimsModule
+  | Fatal_MissingQuantifierBinder
+  | Fatal_ModuleExpected
+  | Fatal_ModuleFileNotFound
+  | Fatal_ModuleFirstStatement
+  | Fatal_ModuleNotFound
+  | Fatal_ModuleOrFileNotFound
+  | Fatal_MonadAlreadyDefined
+  | Fatal_MoreThanOneDeclaration
+  | Fatal_MultipleLetBinding
+  | Fatal_NameNotFound
+  | Fatal_NameSpaceNotFound
+  | Fatal_NegativeUniverseConstFatal_NotSupported
+  | Fatal_NoFileProvided
+  | Fatal_NonInductiveInMutuallyDefinedType
+  | Fatal_NonLinearPatternNotPermitted
+  | Fatal_NonLinearPatternVars
+  | Fatal_NonSingletonTopLevel
+  | Fatal_NonSingletonTopLevelModule
+  | Fatal_NonTopRecFunctionNotFullyEncoded
+  | Fatal_NonTrivialPreConditionInPrims
+  | Fatal_NonVariableInductiveTypeParameter
+  | Fatal_NotApplicationOrFv
+  | Fatal_NotEnoughArgsToEffect
+  | Fatal_NotEnoughArgumentsForEffect
+  | Fatal_NotFunctionType
+  | Fatal_NotSupported
+  | Fatal_NotTopLevelModule
+  | Fatal_NotValidFStarFile
+  | Fatal_NotValidIncludeDirectory
+  | Fatal_OneModulePerFile
+  | Fatal_OpenGoalsInSynthesis
+  | Fatal_OptionsNotCompatible
+  | Fatal_OutOfOrder
+  | Fatal_ParseErrors
+  | Fatal_ParseItError
+  | Fatal_PolyTypeExpected
+  | Fatal_PossibleInfiniteTyp
+  | Fatal_PreModuleMismatch
+  | Fatal_QulifierListNotPermitted
+  | Fatal_RecursiveFunctionLiteral
+  | Fatal_ReflectOnlySupportedOnEffects
+  | Fatal_ReservedPrefix
+  | Fatal_SMTOutputParseError
+  | Fatal_SMTSolverError
+  | Fatal_SyntaxError
+  | Fatal_SynthByTacticError
+  | Fatal_TacticGotStuck
+  | Fatal_TcOneFragmentFailed
+  | Fatal_TermOutsideOfDefLanguage
+  | Fatal_ToManyArgumentToFunction
+  | Fatal_TooManyOrTooFewFileMatch
+  | Fatal_TooManyPatternArguments
+  | Fatal_TooManyUniverse
+  | Fatal_TypeMismatch
+  | Fatal_TypeWithinPatternsAllowedOnVariablesOnly
+  | Fatal_UnableToReadFile
+  | Fatal_UnepxectedOrUnboundOperator
+  | Fatal_UnexpectedBinder
+  | Fatal_UnexpectedBindShape
+  | Fatal_UnexpectedChar
+  | Fatal_UnexpectedComputationTypeForLetRec
+  | Fatal_UnexpectedConstructorType
+  | Fatal_UnexpectedDataConstructor
+  | Fatal_UnexpectedEffect
+  | Fatal_UnexpectedEmptyRecord
+  | Fatal_UnexpectedExpressionType
+  | Fatal_UnexpectedFunctionParameterType
+  | Fatal_UnexpectedGeneralizedUniverse
+  | Fatal_UnexpectedGTotForLetRec
+  | Fatal_UnexpectedGuard
+  | Fatal_UnexpectedIdentifier
+  | Fatal_UnexpectedImplicitArgument
+  | Fatal_UnexpectedImplictArgument
+  | Fatal_UnexpectedInductivetype
+  | Fatal_UnexpectedLetBinding
+  | Fatal_UnexpectedModuleDeclaration
+  | Fatal_UnexpectedNumberOfUniverse
+  | Fatal_UnexpectedNumericLiteral
+  | Fatal_UnexpectedOperatorSymbol
+  | Fatal_UnexpectedPattern
+  | Fatal_UnexpectedPosition
+  | Fatal_UnExpectedPreCondition
+  | Fatal_UnexpectedReturnShape
+  | Fatal_UnexpectedSignatureForMonad
+  | Fatal_UnexpectedTerm
+  | Fatal_UnexpectedTermInUniverse
+  | Fatal_UnexpectedTermType
+  | Fatal_UnexpectedUniversePolymorphicReturn
+  | Fatal_UnexpectedUniverseVariable
+  | Fatal_UnfoldableDeprecated
+  | Fatal_UnificationNotWellFormed
+  | Fatal_Uninstantiated
+  | Fatal_UninstantiatedUnificationVarInTactic
+  | Fatal_UninstantiatedVarInTactic
+  | Fatal_UniverseMightContainSumOfTwoUnivVars
+  | Fatal_UniversePolymorphicInnerLetBound
+  | Fatal_UnknownAttribute
+  | Fatal_UnknownToolForDep
+  | Fatal_UnrecognizedExtension
+  | Fatal_UnresolvedPatternVar
+  | Fatal_UnsupportedConstant
+  | Fatal_UnsupportedDisjuctivePatterns
+  | Fatal_UnsupportedQualifier
+  | Fatal_UserTacticFailure
+  | Fatal_ValueRestriction
+  | Fatal_VariableNotFound
+  | Fatal_WrongBodyTypeForReturnWP
+  | Fatal_WrongDataAppHeadFormat
+  | Fatal_WrongDefinitionOrder
+  | Fatal_WrongResultTypeAfterConstrutor
+  | Fatal_WrongTerm
+  | Fatal_WhenClauseNotSupported
+  | Fatal_CallNotImplemented
+  | Warning_AddImplicitAssumeNewQualifier
+  | Warning_AdmitWithoutDefinition
+  | Warning_CachedFile
+  | Warning_DefinitionNotTranslated
+  | Warning_DependencyFound
+  | Warning_DeprecatedEqualityOnBinder
+  | Warning_DeprecatedOpaqueQualifier
+  | Warning_DocOverwrite
+  | Warning_FileNotWritten
+  | Warning_Filtered
+  | Warning_FunctionLiteralPrecisionLoss
+  | Warning_FunctionNotExtacted
+  | Warning_HintFailedToReplayProof
+  | Warning_HitReplayFailed
+  | Warning_IDEIgnoreCodeGen
+  | Warning_IllFormedGoal
+  | Warning_InaccessibleArgument
+  | Warning_IncoherentImplicitQualifier
+  | Warning_IrrelevantQualifierOnArgumentToReflect
+  | Warning_IrrelevantQualifierOnArgumentToReify
+  | Warning_MalformedWarnErrorList
+  | Warning_MetaAlienNotATmUnknown
+  | Warning_MultipleAscriptions
+  | Warning_NondependentUserDefinedDataType
+  | Warning_NonListLiteralSMTPattern
+  | Warning_NormalizationFailure
+  | Warning_NotDependentArrow
+  | Warning_NotEmbedded
+  | Warning_PatternMissingBoundVar
+  | Warning_RecursiveDependency
+  | Warning_RedundantExplicitCurrying
+  | Warning_SMTPatTDeprecated
+  | Warning_SMTPatternMissingBoundVar
+  | Warning_TopLevelEffect
+  | Warning_UnboundModuleReference
+  | Warning_UnexpectedFile
+  | Warning_UnexpectedFsTypApp
+  | Warning_UnexpectedZ3Output
+  | Warning_UnprotectedTerm
+  | Warning_UnrecognizedAttribute
+  | Warning_UpperBoundCandidateAlreadyVisited
+  | Warning_UseDefaultEffect
+  | Warning_WrongErrorLocation
+  | Warning_Z3InvocationWarning
+  | Warning_CallNotImplementedAsWarning
+  | Warning_MissingInterfaceOrImplementation
+  | Warning_ConstructorBuildsUnexpectedType
+  | Warning_ModuleOrFileNotFoundWarning
+  | Error_NoLetMutable
+  | Error_BadImplicit
+  | Warning_DeprecatedDefinition[@@deriving show]
+let uu___is_Error_DependencyAnalysisFailed: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_DependencyAnalysisFailed  -> true
     | uu____4 -> false
-  
-let (uu___is_Error_IDETooManyPops : raw_error -> Prims.bool) =
+let uu___is_Error_IDETooManyPops: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Error_IDETooManyPops  -> true | uu____8 -> false
-  
-let (uu___is_Error_IDEUnrecognized : raw_error -> Prims.bool) =
+let uu___is_Error_IDEUnrecognized: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Error_IDEUnrecognized  -> true | uu____12 -> false
-  
-let (uu___is_Error_InductiveTypeNotSatisfyPositivityCondition :
-  raw_error -> Prims.bool) =
+let uu___is_Error_InductiveTypeNotSatisfyPositivityCondition:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_InductiveTypeNotSatisfyPositivityCondition  -> true
     | uu____16 -> false
-  
-let (uu___is_Error_InvalidUniverseVar : raw_error -> Prims.bool) =
+let uu___is_Error_InvalidUniverseVar: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_InvalidUniverseVar  -> true
     | uu____20 -> false
-  
-let (uu___is_Error_MissingFileName : raw_error -> Prims.bool) =
+let uu___is_Error_MissingFileName: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Error_MissingFileName  -> true | uu____24 -> false
-  
-let (uu___is_Error_ModuleFileNameMismatch : raw_error -> Prims.bool) =
+let uu___is_Error_ModuleFileNameMismatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_ModuleFileNameMismatch  -> true
     | uu____28 -> false
-  
-let (uu___is_Error_OpPlusInUniverse : raw_error -> Prims.bool) =
+let uu___is_Error_OpPlusInUniverse: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_OpPlusInUniverse  -> true
     | uu____32 -> false
-  
-let (uu___is_Error_OutOfRange : raw_error -> Prims.bool) =
+let uu___is_Error_OutOfRange: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Error_OutOfRange  -> true | uu____36 -> false
-  
-let (uu___is_Error_ProofObligationFailed : raw_error -> Prims.bool) =
+let uu___is_Error_ProofObligationFailed: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_ProofObligationFailed  -> true
     | uu____40 -> false
-  
-let (uu___is_Error_TooManyFiles : raw_error -> Prims.bool) =
+let uu___is_Error_TooManyFiles: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Error_TooManyFiles  -> true | uu____44 -> false
-  
-let (uu___is_Error_TypeCheckerFailToProve : raw_error -> Prims.bool) =
+let uu___is_Error_TypeCheckerFailToProve: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_TypeCheckerFailToProve  -> true
     | uu____48 -> false
-  
-let (uu___is_Error_TypeError : raw_error -> Prims.bool) =
+let uu___is_Error_TypeError: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Error_TypeError  -> true | uu____52 -> false
-  
-let (uu___is_Error_UncontrainedUnificationVar : raw_error -> Prims.bool) =
+let uu___is_Error_UncontrainedUnificationVar: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_UncontrainedUnificationVar  -> true
     | uu____56 -> false
-  
-let (uu___is_Error_UnexpectedGTotComputation : raw_error -> Prims.bool) =
+let uu___is_Error_UnexpectedGTotComputation: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_UnexpectedGTotComputation  -> true
     | uu____60 -> false
-  
-let (uu___is_Error_UnexpectedInstance : raw_error -> Prims.bool) =
+let uu___is_Error_UnexpectedInstance: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_UnexpectedInstance  -> true
     | uu____64 -> false
-  
-let (uu___is_Error_UnknownFatal_AssertionFailure : raw_error -> Prims.bool) =
+let uu___is_Error_UnknownFatal_AssertionFailure: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_UnknownFatal_AssertionFailure  -> true
     | uu____68 -> false
-  
-let (uu___is_Error_Z3InvocationError : raw_error -> Prims.bool) =
+let uu___is_Error_Z3InvocationError: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_Z3InvocationError  -> true
     | uu____72 -> false
-  
-let (uu___is_Error_IDEAssertionFailure : raw_error -> Prims.bool) =
+let uu___is_Error_IDEAssertionFailure: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Error_IDEAssertionFailure  -> true
     | uu____76 -> false
-  
-let (uu___is_Error_Z3SolverError : raw_error -> Prims.bool) =
+let uu___is_Error_Z3SolverError: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Error_Z3SolverError  -> true | uu____80 -> false
-  
-let (uu___is_Fatal_AbstractTypeDeclarationInInterface :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_AbstractTypeDeclarationInInterface: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Fatal_AbstractTypeDeclarationInInterface  -> true
     | uu____84 -> false
-  
-let (uu___is_Fatal_ActionMustHaveFunctionType : raw_error -> Prims.bool) =
+let uu___is_Fatal_ActionMustHaveFunctionType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ActionMustHaveFunctionType  -> true
     | uu____88 -> false
-  
-let (uu___is_Fatal_AlreadyDefinedTopLevelDeclaration :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_AlreadyDefinedTopLevelDeclaration: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Fatal_AlreadyDefinedTopLevelDeclaration  -> true
     | uu____92 -> false
-  
-let (uu___is_Fatal_ArgumentLengthMismatch : raw_error -> Prims.bool) =
+let uu___is_Fatal_ArgumentLengthMismatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ArgumentLengthMismatch  -> true
     | uu____96 -> false
-  
-let (uu___is_Fatal_AssertionFailure : raw_error -> Prims.bool) =
+let uu___is_Fatal_AssertionFailure: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_AssertionFailure  -> true
     | uu____100 -> false
-  
-let (uu___is_Fatal_AssignToImmutableValues : raw_error -> Prims.bool) =
+let uu___is_Fatal_AssignToImmutableValues: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_AssignToImmutableValues  -> true
     | uu____104 -> false
-  
-let (uu___is_Fatal_AssumeValInInterface : raw_error -> Prims.bool) =
+let uu___is_Fatal_AssumeValInInterface: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_AssumeValInInterface  -> true
     | uu____108 -> false
-  
-let (uu___is_Fatal_BadlyInstantiatedSynthByTactic : raw_error -> Prims.bool)
-  =
+let uu___is_Fatal_BadlyInstantiatedSynthByTactic: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_BadlyInstantiatedSynthByTactic  -> true
     | uu____112 -> false
-  
-let (uu___is_Fatal_BadSignatureShape : raw_error -> Prims.bool) =
+let uu___is_Fatal_BadSignatureShape: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_BadSignatureShape  -> true
     | uu____116 -> false
-  
-let (uu___is_Fatal_BinderAndArgsLengthMismatch : raw_error -> Prims.bool) =
+let uu___is_Fatal_BinderAndArgsLengthMismatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_BinderAndArgsLengthMismatch  -> true
     | uu____120 -> false
-  
-let (uu___is_Fatal_BothValAndLetInInterface : raw_error -> Prims.bool) =
+let uu___is_Fatal_BothValAndLetInInterface: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_BothValAndLetInInterface  -> true
     | uu____124 -> false
-  
-let (uu___is_Fatal_CardinalityConstraintViolated : raw_error -> Prims.bool) =
+let uu___is_Fatal_CardinalityConstraintViolated: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_CardinalityConstraintViolated  -> true
     | uu____128 -> false
-  
-let (uu___is_Fatal_ComputationNotTotal : raw_error -> Prims.bool) =
+let uu___is_Fatal_ComputationNotTotal: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ComputationNotTotal  -> true
     | uu____132 -> false
-  
-let (uu___is_Fatal_ComputationTypeNotAllowed : raw_error -> Prims.bool) =
+let uu___is_Fatal_ComputationTypeNotAllowed: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ComputationTypeNotAllowed  -> true
     | uu____136 -> false
-  
-let (uu___is_Fatal_ComputedTypeNotMatchAnnotation : raw_error -> Prims.bool)
-  =
+let uu___is_Fatal_ComputedTypeNotMatchAnnotation: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ComputedTypeNotMatchAnnotation  -> true
     | uu____140 -> false
-  
-let (uu___is_Fatal_ConstructorArgLengthMismatch : raw_error -> Prims.bool) =
+let uu___is_Fatal_ConstructorArgLengthMismatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ConstructorArgLengthMismatch  -> true
     | uu____144 -> false
-  
-let (uu___is_Fatal_ConstructorFailedCheck : raw_error -> Prims.bool) =
+let uu___is_Fatal_ConstructorFailedCheck: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ConstructorFailedCheck  -> true
     | uu____148 -> false
-  
-let (uu___is_Fatal_ConstructorNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_ConstructorNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ConstructorNotFound  -> true
     | uu____152 -> false
-  
-let (uu___is_Fatal_ConstsructorBuildWrongType : raw_error -> Prims.bool) =
+let uu___is_Fatal_ConstsructorBuildWrongType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ConstsructorBuildWrongType  -> true
     | uu____156 -> false
-  
-let (uu___is_Fatal_CycleInRecTypeAbbreviation : raw_error -> Prims.bool) =
+let uu___is_Fatal_CycleInRecTypeAbbreviation: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_CycleInRecTypeAbbreviation  -> true
     | uu____160 -> false
-  
-let (uu___is_Fatal_DataContructorNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_DataContructorNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_DataContructorNotFound  -> true
     | uu____164 -> false
-  
-let (uu___is_Fatal_DefaultQualifierNotAllowedOnEffects :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_DefaultQualifierNotAllowedOnEffects:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_DefaultQualifierNotAllowedOnEffects  -> true
     | uu____168 -> false
-  
-let (uu___is_Fatal_DefinitionNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_DefinitionNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_DefinitionNotFound  -> true
     | uu____172 -> false
-  
-let (uu___is_Fatal_DisjuctivePatternVarsMismatch : raw_error -> Prims.bool) =
+let uu___is_Fatal_DisjuctivePatternVarsMismatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_DisjuctivePatternVarsMismatch  -> true
     | uu____176 -> false
-  
-let (uu___is_Fatal_DivergentComputationCannotBeIncludedInTotal :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_DivergentComputationCannotBeIncludedInTotal:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_DivergentComputationCannotBeIncludedInTotal  -> true
     | uu____180 -> false
-  
-let (uu___is_Fatal_DuplicateInImplementation : raw_error -> Prims.bool) =
+let uu___is_Fatal_DuplicateInImplementation: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_DuplicateInImplementation  -> true
     | uu____184 -> false
-  
-let (uu___is_Fatal_DuplicateModuleOrInterface : raw_error -> Prims.bool) =
+let uu___is_Fatal_DuplicateModuleOrInterface: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_DuplicateModuleOrInterface  -> true
     | uu____188 -> false
-  
-let (uu___is_Fatal_DuplicateTopLevelNames : raw_error -> Prims.bool) =
+let uu___is_Fatal_DuplicateTopLevelNames: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_DuplicateTopLevelNames  -> true
     | uu____192 -> false
-  
-let (uu___is_Fatal_DuplicateTypeAnnotationAndValDecl :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_DuplicateTypeAnnotationAndValDecl: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Fatal_DuplicateTypeAnnotationAndValDecl  -> true
     | uu____196 -> false
-  
-let (uu___is_Fatal_EffectCannotBeReified : raw_error -> Prims.bool) =
+let uu___is_Fatal_EffectCannotBeReified: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_EffectCannotBeReified  -> true
     | uu____200 -> false
-  
-let (uu___is_Fatal_EffectConstructorNotFullyApplied :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_EffectConstructorNotFullyApplied: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_EffectConstructorNotFullyApplied  -> true
     | uu____204 -> false
-  
-let (uu___is_Fatal_EffectfulAndPureComputationMismatch :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_EffectfulAndPureComputationMismatch:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_EffectfulAndPureComputationMismatch  -> true
     | uu____208 -> false
-  
-let (uu___is_Fatal_EffectNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_EffectNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_EffectNotFound  -> true | uu____212 -> false
-  
-let (uu___is_Fatal_EffectsCannotBeComposed : raw_error -> Prims.bool) =
+let uu___is_Fatal_EffectsCannotBeComposed: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_EffectsCannotBeComposed  -> true
     | uu____216 -> false
-  
-let (uu___is_Fatal_ErrorInSolveDeferredConstraints : raw_error -> Prims.bool)
-  =
+let uu___is_Fatal_ErrorInSolveDeferredConstraints: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ErrorInSolveDeferredConstraints  -> true
     | uu____220 -> false
-  
-let (uu___is_Fatal_ErrorsReported : raw_error -> Prims.bool) =
+let uu___is_Fatal_ErrorsReported: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_ErrorsReported  -> true | uu____224 -> false
-  
-let (uu___is_Fatal_EscapedBoundVar : raw_error -> Prims.bool) =
+let uu___is_Fatal_EscapedBoundVar: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_EscapedBoundVar  -> true
     | uu____228 -> false
-  
-let (uu___is_Fatal_ExpectedArrowAnnotatedType : raw_error -> Prims.bool) =
+let uu___is_Fatal_ExpectedArrowAnnotatedType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ExpectedArrowAnnotatedType  -> true
     | uu____232 -> false
-  
-let (uu___is_Fatal_ExpectedGhostExpression : raw_error -> Prims.bool) =
+let uu___is_Fatal_ExpectedGhostExpression: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ExpectedGhostExpression  -> true
     | uu____236 -> false
-  
-let (uu___is_Fatal_ExpectedPureExpression : raw_error -> Prims.bool) =
+let uu___is_Fatal_ExpectedPureExpression: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ExpectedPureExpression  -> true
     | uu____240 -> false
-  
-let (uu___is_Fatal_ExpectNormalizedEffect : raw_error -> Prims.bool) =
+let uu___is_Fatal_ExpectNormalizedEffect: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ExpectNormalizedEffect  -> true
     | uu____244 -> false
-  
-let (uu___is_Fatal_ExpectTermGotFunction : raw_error -> Prims.bool) =
+let uu___is_Fatal_ExpectTermGotFunction: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ExpectTermGotFunction  -> true
     | uu____248 -> false
-  
-let (uu___is_Fatal_ExpectTrivialPreCondition : raw_error -> Prims.bool) =
+let uu___is_Fatal_ExpectTrivialPreCondition: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ExpectTrivialPreCondition  -> true
     | uu____252 -> false
-  
-let (uu___is_Fatal_FailToCompileNativeTactic : raw_error -> Prims.bool) =
+let uu___is_Fatal_FailToCompileNativeTactic: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_FailToCompileNativeTactic  -> true
     | uu____256 -> false
-  
-let (uu___is_Fatal_FailToExtractNativeTactic : raw_error -> Prims.bool) =
+let uu___is_Fatal_FailToExtractNativeTactic: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_FailToExtractNativeTactic  -> true
     | uu____260 -> false
-  
-let (uu___is_Fatal_FailToProcessPragma : raw_error -> Prims.bool) =
+let uu___is_Fatal_FailToProcessPragma: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_FailToProcessPragma  -> true
     | uu____264 -> false
-  
-let (uu___is_Fatal_FailToResolveImplicitArgument : raw_error -> Prims.bool) =
+let uu___is_Fatal_FailToResolveImplicitArgument: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_FailToResolveImplicitArgument  -> true
     | uu____268 -> false
-  
-let (uu___is_Fatal_FailToSolveUniverseInEquality : raw_error -> Prims.bool) =
+let uu___is_Fatal_FailToSolveUniverseInEquality: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_FailToSolveUniverseInEquality  -> true
     | uu____272 -> false
-  
-let (uu___is_Fatal_FieldsNotBelongToSameRecordType : raw_error -> Prims.bool)
-  =
+let uu___is_Fatal_FieldsNotBelongToSameRecordType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_FieldsNotBelongToSameRecordType  -> true
     | uu____276 -> false
-  
-let (uu___is_Fatal_ForbiddenReferenceToCurrentModule :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_ForbiddenReferenceToCurrentModule: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Fatal_ForbiddenReferenceToCurrentModule  -> true
     | uu____280 -> false
-  
-let (uu___is_Fatal_FreeVariables : raw_error -> Prims.bool) =
+let uu___is_Fatal_FreeVariables: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_FreeVariables  -> true | uu____284 -> false
-  
-let (uu___is_Fatal_FunctionTypeExpected : raw_error -> Prims.bool) =
+let uu___is_Fatal_FunctionTypeExpected: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_FunctionTypeExpected  -> true
     | uu____288 -> false
-  
-let (uu___is_Fatal_IdentifierNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_IdentifierNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IdentifierNotFound  -> true
     | uu____292 -> false
-  
-let (uu___is_Fatal_IllAppliedConstant : raw_error -> Prims.bool) =
+let uu___is_Fatal_IllAppliedConstant: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IllAppliedConstant  -> true
     | uu____296 -> false
-  
-let (uu___is_Fatal_IllegalCharInByteArray : raw_error -> Prims.bool) =
+let uu___is_Fatal_IllegalCharInByteArray: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IllegalCharInByteArray  -> true
     | uu____300 -> false
-  
-let (uu___is_Fatal_IllegalCharInOperatorName : raw_error -> Prims.bool) =
+let uu___is_Fatal_IllegalCharInOperatorName: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IllegalCharInOperatorName  -> true
     | uu____304 -> false
-  
-let (uu___is_Fatal_IllTyped : raw_error -> Prims.bool) =
+let uu___is_Fatal_IllTyped: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_IllTyped  -> true | uu____308 -> false
-  
-let (uu___is_Fatal_ImpossibleAbbrevLidBundle : raw_error -> Prims.bool) =
+let uu___is_Fatal_ImpossibleAbbrevLidBundle: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ImpossibleAbbrevLidBundle  -> true
     | uu____312 -> false
-  
-let (uu___is_Fatal_ImpossibleAbbrevRenameBundle : raw_error -> Prims.bool) =
+let uu___is_Fatal_ImpossibleAbbrevRenameBundle: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ImpossibleAbbrevRenameBundle  -> true
     | uu____316 -> false
-  
-let (uu___is_Fatal_ImpossibleInductiveWithAbbrev : raw_error -> Prims.bool) =
+let uu___is_Fatal_ImpossibleInductiveWithAbbrev: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ImpossibleInductiveWithAbbrev  -> true
     | uu____320 -> false
-  
-let (uu___is_Fatal_ImpossiblePrePostAbs : raw_error -> Prims.bool) =
+let uu___is_Fatal_ImpossiblePrePostAbs: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ImpossiblePrePostAbs  -> true
     | uu____324 -> false
-  
-let (uu___is_Fatal_ImpossiblePrePostArrow : raw_error -> Prims.bool) =
+let uu___is_Fatal_ImpossiblePrePostArrow: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ImpossiblePrePostArrow  -> true
     | uu____328 -> false
-  
-let (uu___is_Fatal_ImpossibleToGenerateDMEffect : raw_error -> Prims.bool) =
+let uu___is_Fatal_ImpossibleToGenerateDMEffect: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ImpossibleToGenerateDMEffect  -> true
     | uu____332 -> false
-  
-let (uu___is_Fatal_ImpossibleTypeAbbrevBundle : raw_error -> Prims.bool) =
+let uu___is_Fatal_ImpossibleTypeAbbrevBundle: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ImpossibleTypeAbbrevBundle  -> true
     | uu____336 -> false
-  
-let (uu___is_Fatal_ImpossibleTypeAbbrevSigeltBundle :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_ImpossibleTypeAbbrevSigeltBundle: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ImpossibleTypeAbbrevSigeltBundle  -> true
     | uu____340 -> false
-  
-let (uu___is_Fatal_IncludeModuleNotPrepared : raw_error -> Prims.bool) =
+let uu___is_Fatal_IncludeModuleNotPrepared: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IncludeModuleNotPrepared  -> true
     | uu____344 -> false
-  
-let (uu___is_Fatal_IncoherentInlineUniverse : raw_error -> Prims.bool) =
+let uu___is_Fatal_IncoherentInlineUniverse: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IncoherentInlineUniverse  -> true
     | uu____348 -> false
-  
-let (uu___is_Fatal_IncompatibleKinds : raw_error -> Prims.bool) =
+let uu___is_Fatal_IncompatibleKinds: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IncompatibleKinds  -> true
     | uu____352 -> false
-  
-let (uu___is_Fatal_IncompatibleNumberOfTypes : raw_error -> Prims.bool) =
+let uu___is_Fatal_IncompatibleNumberOfTypes: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IncompatibleNumberOfTypes  -> true
     | uu____356 -> false
-  
-let (uu___is_Fatal_IncompatibleSetOfUniverse : raw_error -> Prims.bool) =
+let uu___is_Fatal_IncompatibleSetOfUniverse: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IncompatibleSetOfUniverse  -> true
     | uu____360 -> false
-  
-let (uu___is_Fatal_IncompatibleUniverse : raw_error -> Prims.bool) =
+let uu___is_Fatal_IncompatibleUniverse: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_IncompatibleUniverse  -> true
     | uu____364 -> false
-  
-let (uu___is_Fatal_InconsistentImplicitArgumentAnnotation :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_InconsistentImplicitArgumentAnnotation:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InconsistentImplicitArgumentAnnotation  -> true
     | uu____368 -> false
-  
-let (uu___is_Fatal_InconsistentImplicitQualifier : raw_error -> Prims.bool) =
+let uu___is_Fatal_InconsistentImplicitQualifier: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InconsistentImplicitQualifier  -> true
     | uu____372 -> false
-  
-let (uu___is_Fatal_InconsistentQualifierAnnotation : raw_error -> Prims.bool)
-  =
+let uu___is_Fatal_InconsistentQualifierAnnotation: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InconsistentQualifierAnnotation  -> true
     | uu____376 -> false
-  
-let (uu___is_Fatal_InferredTypeCauseVarEscape : raw_error -> Prims.bool) =
+let uu___is_Fatal_InferredTypeCauseVarEscape: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InferredTypeCauseVarEscape  -> true
     | uu____380 -> false
-  
-let (uu___is_Fatal_InlineRenamedAsUnfold : raw_error -> Prims.bool) =
+let uu___is_Fatal_InlineRenamedAsUnfold: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InlineRenamedAsUnfold  -> true
     | uu____384 -> false
-  
-let (uu___is_Fatal_InsufficientPatternArguments : raw_error -> Prims.bool) =
+let uu___is_Fatal_InsufficientPatternArguments: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InsufficientPatternArguments  -> true
     | uu____388 -> false
-  
-let (uu___is_Fatal_InterfaceAlreadyProcessed : raw_error -> Prims.bool) =
+let uu___is_Fatal_InterfaceAlreadyProcessed: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InterfaceAlreadyProcessed  -> true
     | uu____392 -> false
-  
-let (uu___is_Fatal_InterfaceNotImplementedByModule : raw_error -> Prims.bool)
-  =
+let uu___is_Fatal_InterfaceNotImplementedByModule: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InterfaceNotImplementedByModule  -> true
     | uu____396 -> false
-  
-let (uu___is_Fatal_InterfaceWithTypeImplementation : raw_error -> Prims.bool)
-  =
+let uu___is_Fatal_InterfaceWithTypeImplementation: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InterfaceWithTypeImplementation  -> true
     | uu____400 -> false
-  
-let (uu___is_Fatal_InvalidFloatingPointNumber : raw_error -> Prims.bool) =
+let uu___is_Fatal_InvalidFloatingPointNumber: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InvalidFloatingPointNumber  -> true
     | uu____404 -> false
-  
-let (uu___is_Fatal_InvalidFSDocKeyword : raw_error -> Prims.bool) =
+let uu___is_Fatal_InvalidFSDocKeyword: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InvalidFSDocKeyword  -> true
     | uu____408 -> false
-  
-let (uu___is_Fatal_InvalidIdentifier : raw_error -> Prims.bool) =
+let uu___is_Fatal_InvalidIdentifier: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InvalidIdentifier  -> true
     | uu____412 -> false
-  
-let (uu___is_Fatal_InvalidLemmaArgument : raw_error -> Prims.bool) =
+let uu___is_Fatal_InvalidLemmaArgument: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InvalidLemmaArgument  -> true
     | uu____416 -> false
-  
-let (uu___is_Fatal_InvalidNumericLiteral : raw_error -> Prims.bool) =
+let uu___is_Fatal_InvalidNumericLiteral: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InvalidNumericLiteral  -> true
     | uu____420 -> false
-  
-let (uu___is_Fatal_InvalidRedefinitionOfLexT : raw_error -> Prims.bool) =
+let uu___is_Fatal_InvalidRedefinitionOfLexT: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InvalidRedefinitionOfLexT  -> true
     | uu____424 -> false
-  
-let (uu___is_Fatal_InvalidUnicodeInStringLiteral : raw_error -> Prims.bool) =
+let uu___is_Fatal_InvalidUnicodeInStringLiteral: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InvalidUnicodeInStringLiteral  -> true
     | uu____428 -> false
-  
-let (uu___is_Fatal_InvalidUTF8Encoding : raw_error -> Prims.bool) =
+let uu___is_Fatal_InvalidUTF8Encoding: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InvalidUTF8Encoding  -> true
     | uu____432 -> false
-  
-let (uu___is_Fatal_InvalidWarnErrorSetting : raw_error -> Prims.bool) =
+let uu___is_Fatal_InvalidWarnErrorSetting: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_InvalidWarnErrorSetting  -> true
     | uu____436 -> false
-  
-let (uu___is_Fatal_LetBoundMonadicMismatch : raw_error -> Prims.bool) =
+let uu___is_Fatal_LetBoundMonadicMismatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_LetBoundMonadicMismatch  -> true
     | uu____440 -> false
-  
-let (uu___is_Fatal_LetMutableForVariablesOnly : raw_error -> Prims.bool) =
+let uu___is_Fatal_LetMutableForVariablesOnly: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_LetMutableForVariablesOnly  -> true
     | uu____444 -> false
-  
-let (uu___is_Fatal_LetOpenModuleOnly : raw_error -> Prims.bool) =
+let uu___is_Fatal_LetOpenModuleOnly: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_LetOpenModuleOnly  -> true
     | uu____448 -> false
-  
-let (uu___is_Fatal_LetRecArgumentMismatch : raw_error -> Prims.bool) =
+let uu___is_Fatal_LetRecArgumentMismatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_LetRecArgumentMismatch  -> true
     | uu____452 -> false
-  
-let (uu___is_Fatal_MalformedActionDeclaration : raw_error -> Prims.bool) =
+let uu___is_Fatal_MalformedActionDeclaration: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MalformedActionDeclaration  -> true
     | uu____456 -> false
-  
-let (uu___is_Fatal_MismatchedPatternType : raw_error -> Prims.bool) =
+let uu___is_Fatal_MismatchedPatternType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MismatchedPatternType  -> true
     | uu____460 -> false
-  
-let (uu___is_Fatal_MismatchUniversePolymorphic : raw_error -> Prims.bool) =
+let uu___is_Fatal_MismatchUniversePolymorphic: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MismatchUniversePolymorphic  -> true
     | uu____464 -> false
-  
-let (uu___is_Fatal_MissingDataConstructor : raw_error -> Prims.bool) =
+let uu___is_Fatal_MissingDataConstructor: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MissingDataConstructor  -> true
     | uu____468 -> false
-  
-let (uu___is_Fatal_MissingExposeInterfacesOption : raw_error -> Prims.bool) =
+let uu___is_Fatal_MissingExposeInterfacesOption: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MissingExposeInterfacesOption  -> true
     | uu____472 -> false
-  
-let (uu___is_Fatal_MissingFieldInRecord : raw_error -> Prims.bool) =
+let uu___is_Fatal_MissingFieldInRecord: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MissingFieldInRecord  -> true
     | uu____476 -> false
-  
-let (uu___is_Fatal_MissingImplementation : raw_error -> Prims.bool) =
+let uu___is_Fatal_MissingImplementation: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MissingImplementation  -> true
     | uu____480 -> false
-  
-let (uu___is_Fatal_MissingImplicitArguments : raw_error -> Prims.bool) =
+let uu___is_Fatal_MissingImplicitArguments: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MissingImplicitArguments  -> true
     | uu____484 -> false
-  
-let (uu___is_Fatal_MissingInterface : raw_error -> Prims.bool) =
+let uu___is_Fatal_MissingInterface: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MissingInterface  -> true
     | uu____488 -> false
-  
-let (uu___is_Fatal_MissingNameInBinder : raw_error -> Prims.bool) =
+let uu___is_Fatal_MissingNameInBinder: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MissingNameInBinder  -> true
     | uu____492 -> false
-  
-let (uu___is_Fatal_MissingPrimsModule : raw_error -> Prims.bool) =
+let uu___is_Fatal_MissingPrimsModule: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MissingPrimsModule  -> true
     | uu____496 -> false
-  
-let (uu___is_Fatal_MissingQuantifierBinder : raw_error -> Prims.bool) =
+let uu___is_Fatal_MissingQuantifierBinder: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MissingQuantifierBinder  -> true
     | uu____500 -> false
-  
-let (uu___is_Fatal_ModuleExpected : raw_error -> Prims.bool) =
+let uu___is_Fatal_ModuleExpected: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_ModuleExpected  -> true | uu____504 -> false
-  
-let (uu___is_Fatal_ModuleFileNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_ModuleFileNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ModuleFileNotFound  -> true
     | uu____508 -> false
-  
-let (uu___is_Fatal_ModuleFirstStatement : raw_error -> Prims.bool) =
+let uu___is_Fatal_ModuleFirstStatement: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ModuleFirstStatement  -> true
     | uu____512 -> false
-  
-let (uu___is_Fatal_ModuleNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_ModuleNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_ModuleNotFound  -> true | uu____516 -> false
-  
-let (uu___is_Fatal_ModuleOrFileNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_ModuleOrFileNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ModuleOrFileNotFound  -> true
     | uu____520 -> false
-  
-let (uu___is_Fatal_MonadAlreadyDefined : raw_error -> Prims.bool) =
+let uu___is_Fatal_MonadAlreadyDefined: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MonadAlreadyDefined  -> true
     | uu____524 -> false
-  
-let (uu___is_Fatal_MoreThanOneDeclaration : raw_error -> Prims.bool) =
+let uu___is_Fatal_MoreThanOneDeclaration: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MoreThanOneDeclaration  -> true
     | uu____528 -> false
-  
-let (uu___is_Fatal_MultipleLetBinding : raw_error -> Prims.bool) =
+let uu___is_Fatal_MultipleLetBinding: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_MultipleLetBinding  -> true
     | uu____532 -> false
-  
-let (uu___is_Fatal_NameNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_NameNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_NameNotFound  -> true | uu____536 -> false
-  
-let (uu___is_Fatal_NameSpaceNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_NameSpaceNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NameSpaceNotFound  -> true
     | uu____540 -> false
-  
-let (uu___is_Fatal_NegativeUniverseConstFatal_NotSupported :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_NegativeUniverseConstFatal_NotSupported:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NegativeUniverseConstFatal_NotSupported  -> true
     | uu____544 -> false
-  
-let (uu___is_Fatal_NoFileProvided : raw_error -> Prims.bool) =
+let uu___is_Fatal_NoFileProvided: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_NoFileProvided  -> true | uu____548 -> false
-  
-let (uu___is_Fatal_NonInductiveInMutuallyDefinedType :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_NonInductiveInMutuallyDefinedType: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Fatal_NonInductiveInMutuallyDefinedType  -> true
     | uu____552 -> false
-  
-let (uu___is_Fatal_NonLinearPatternNotPermitted : raw_error -> Prims.bool) =
+let uu___is_Fatal_NonLinearPatternNotPermitted: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NonLinearPatternNotPermitted  -> true
     | uu____556 -> false
-  
-let (uu___is_Fatal_NonLinearPatternVars : raw_error -> Prims.bool) =
+let uu___is_Fatal_NonLinearPatternVars: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NonLinearPatternVars  -> true
     | uu____560 -> false
-  
-let (uu___is_Fatal_NonSingletonTopLevel : raw_error -> Prims.bool) =
+let uu___is_Fatal_NonSingletonTopLevel: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NonSingletonTopLevel  -> true
     | uu____564 -> false
-  
-let (uu___is_Fatal_NonSingletonTopLevelModule : raw_error -> Prims.bool) =
+let uu___is_Fatal_NonSingletonTopLevelModule: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NonSingletonTopLevelModule  -> true
     | uu____568 -> false
-  
-let (uu___is_Fatal_NonTopRecFunctionNotFullyEncoded :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_NonTopRecFunctionNotFullyEncoded: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NonTopRecFunctionNotFullyEncoded  -> true
     | uu____572 -> false
-  
-let (uu___is_Fatal_NonTrivialPreConditionInPrims : raw_error -> Prims.bool) =
+let uu___is_Fatal_NonTrivialPreConditionInPrims: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NonTrivialPreConditionInPrims  -> true
     | uu____576 -> false
-  
-let (uu___is_Fatal_NonVariableInductiveTypeParameter :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_NonVariableInductiveTypeParameter: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Fatal_NonVariableInductiveTypeParameter  -> true
     | uu____580 -> false
-  
-let (uu___is_Fatal_NotApplicationOrFv : raw_error -> Prims.bool) =
+let uu___is_Fatal_NotApplicationOrFv: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NotApplicationOrFv  -> true
     | uu____584 -> false
-  
-let (uu___is_Fatal_NotEnoughArgsToEffect : raw_error -> Prims.bool) =
+let uu___is_Fatal_NotEnoughArgsToEffect: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NotEnoughArgsToEffect  -> true
     | uu____588 -> false
-  
-let (uu___is_Fatal_NotEnoughArgumentsForEffect : raw_error -> Prims.bool) =
+let uu___is_Fatal_NotEnoughArgumentsForEffect: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NotEnoughArgumentsForEffect  -> true
     | uu____592 -> false
-  
-let (uu___is_Fatal_NotFunctionType : raw_error -> Prims.bool) =
+let uu___is_Fatal_NotFunctionType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NotFunctionType  -> true
     | uu____596 -> false
-  
-let (uu___is_Fatal_NotSupported : raw_error -> Prims.bool) =
+let uu___is_Fatal_NotSupported: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_NotSupported  -> true | uu____600 -> false
-  
-let (uu___is_Fatal_NotTopLevelModule : raw_error -> Prims.bool) =
+let uu___is_Fatal_NotTopLevelModule: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NotTopLevelModule  -> true
     | uu____604 -> false
-  
-let (uu___is_Fatal_NotValidFStarFile : raw_error -> Prims.bool) =
+let uu___is_Fatal_NotValidFStarFile: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NotValidFStarFile  -> true
     | uu____608 -> false
-  
-let (uu___is_Fatal_NotValidIncludeDirectory : raw_error -> Prims.bool) =
+let uu___is_Fatal_NotValidIncludeDirectory: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_NotValidIncludeDirectory  -> true
     | uu____612 -> false
-  
-let (uu___is_Fatal_OneModulePerFile : raw_error -> Prims.bool) =
+let uu___is_Fatal_OneModulePerFile: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_OneModulePerFile  -> true
     | uu____616 -> false
-  
-let (uu___is_Fatal_OpenGoalsInSynthesis : raw_error -> Prims.bool) =
+let uu___is_Fatal_OpenGoalsInSynthesis: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_OpenGoalsInSynthesis  -> true
     | uu____620 -> false
-  
-let (uu___is_Fatal_OptionsNotCompatible : raw_error -> Prims.bool) =
+let uu___is_Fatal_OptionsNotCompatible: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_OptionsNotCompatible  -> true
     | uu____624 -> false
-  
-let (uu___is_Fatal_OutOfOrder : raw_error -> Prims.bool) =
+let uu___is_Fatal_OutOfOrder: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_OutOfOrder  -> true | uu____628 -> false
-  
-let (uu___is_Fatal_ParseErrors : raw_error -> Prims.bool) =
+let uu___is_Fatal_ParseErrors: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_ParseErrors  -> true | uu____632 -> false
-  
-let (uu___is_Fatal_ParseItError : raw_error -> Prims.bool) =
+let uu___is_Fatal_ParseItError: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_ParseItError  -> true | uu____636 -> false
-  
-let (uu___is_Fatal_PolyTypeExpected : raw_error -> Prims.bool) =
+let uu___is_Fatal_PolyTypeExpected: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_PolyTypeExpected  -> true
     | uu____640 -> false
-  
-let (uu___is_Fatal_PossibleInfiniteTyp : raw_error -> Prims.bool) =
+let uu___is_Fatal_PossibleInfiniteTyp: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_PossibleInfiniteTyp  -> true
     | uu____644 -> false
-  
-let (uu___is_Fatal_PreModuleMismatch : raw_error -> Prims.bool) =
+let uu___is_Fatal_PreModuleMismatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_PreModuleMismatch  -> true
     | uu____648 -> false
-  
-let (uu___is_Fatal_QulifierListNotPermitted : raw_error -> Prims.bool) =
+let uu___is_Fatal_QulifierListNotPermitted: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_QulifierListNotPermitted  -> true
     | uu____652 -> false
-  
-let (uu___is_Fatal_RecursiveFunctionLiteral : raw_error -> Prims.bool) =
+let uu___is_Fatal_RecursiveFunctionLiteral: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_RecursiveFunctionLiteral  -> true
     | uu____656 -> false
-  
-let (uu___is_Fatal_ReflectOnlySupportedOnEffects : raw_error -> Prims.bool) =
+let uu___is_Fatal_ReflectOnlySupportedOnEffects: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ReflectOnlySupportedOnEffects  -> true
     | uu____660 -> false
-  
-let (uu___is_Fatal_ReservedPrefix : raw_error -> Prims.bool) =
+let uu___is_Fatal_ReservedPrefix: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_ReservedPrefix  -> true | uu____664 -> false
-  
-let (uu___is_Fatal_SMTOutputParseError : raw_error -> Prims.bool) =
+let uu___is_Fatal_SMTOutputParseError: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_SMTOutputParseError  -> true
     | uu____668 -> false
-  
-let (uu___is_Fatal_SMTSolverError : raw_error -> Prims.bool) =
+let uu___is_Fatal_SMTSolverError: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_SMTSolverError  -> true | uu____672 -> false
-  
-let (uu___is_Fatal_SyntaxError : raw_error -> Prims.bool) =
+let uu___is_Fatal_SyntaxError: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_SyntaxError  -> true | uu____676 -> false
-  
-let (uu___is_Fatal_SynthByTacticError : raw_error -> Prims.bool) =
+let uu___is_Fatal_SynthByTacticError: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_SynthByTacticError  -> true
     | uu____680 -> false
-  
-let (uu___is_Fatal_TacticGotStuck : raw_error -> Prims.bool) =
+let uu___is_Fatal_TacticGotStuck: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_TacticGotStuck  -> true | uu____684 -> false
-  
-let (uu___is_Fatal_TcOneFragmentFailed : raw_error -> Prims.bool) =
+let uu___is_Fatal_TcOneFragmentFailed: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_TcOneFragmentFailed  -> true
     | uu____688 -> false
-  
-let (uu___is_Fatal_TermOutsideOfDefLanguage : raw_error -> Prims.bool) =
+let uu___is_Fatal_TermOutsideOfDefLanguage: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_TermOutsideOfDefLanguage  -> true
     | uu____692 -> false
-  
-let (uu___is_Fatal_ToManyArgumentToFunction : raw_error -> Prims.bool) =
+let uu___is_Fatal_ToManyArgumentToFunction: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ToManyArgumentToFunction  -> true
     | uu____696 -> false
-  
-let (uu___is_Fatal_TooManyOrTooFewFileMatch : raw_error -> Prims.bool) =
+let uu___is_Fatal_TooManyOrTooFewFileMatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_TooManyOrTooFewFileMatch  -> true
     | uu____700 -> false
-  
-let (uu___is_Fatal_TooManyPatternArguments : raw_error -> Prims.bool) =
+let uu___is_Fatal_TooManyPatternArguments: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_TooManyPatternArguments  -> true
     | uu____704 -> false
-  
-let (uu___is_Fatal_TooManyUniverse : raw_error -> Prims.bool) =
+let uu___is_Fatal_TooManyUniverse: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_TooManyUniverse  -> true
     | uu____708 -> false
-  
-let (uu___is_Fatal_TypeMismatch : raw_error -> Prims.bool) =
+let uu___is_Fatal_TypeMismatch: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_TypeMismatch  -> true | uu____712 -> false
-  
-let (uu___is_Fatal_TypeWithinPatternsAllowedOnVariablesOnly :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_TypeWithinPatternsAllowedOnVariablesOnly:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_TypeWithinPatternsAllowedOnVariablesOnly  -> true
     | uu____716 -> false
-  
-let (uu___is_Fatal_UnableToReadFile : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnableToReadFile: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnableToReadFile  -> true
     | uu____720 -> false
-  
-let (uu___is_Fatal_UnepxectedOrUnboundOperator : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnepxectedOrUnboundOperator: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnepxectedOrUnboundOperator  -> true
     | uu____724 -> false
-  
-let (uu___is_Fatal_UnexpectedBinder : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedBinder: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedBinder  -> true
     | uu____728 -> false
-  
-let (uu___is_Fatal_UnexpectedBindShape : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedBindShape: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedBindShape  -> true
     | uu____732 -> false
-  
-let (uu___is_Fatal_UnexpectedChar : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedChar: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_UnexpectedChar  -> true | uu____736 -> false
-  
-let (uu___is_Fatal_UnexpectedComputationTypeForLetRec :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedComputationTypeForLetRec: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedComputationTypeForLetRec  -> true
     | uu____740 -> false
-  
-let (uu___is_Fatal_UnexpectedConstructorType : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedConstructorType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedConstructorType  -> true
     | uu____744 -> false
-  
-let (uu___is_Fatal_UnexpectedDataConstructor : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedDataConstructor: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedDataConstructor  -> true
     | uu____748 -> false
-  
-let (uu___is_Fatal_UnexpectedEffect : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedEffect: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedEffect  -> true
     | uu____752 -> false
-  
-let (uu___is_Fatal_UnexpectedEmptyRecord : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedEmptyRecord: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedEmptyRecord  -> true
     | uu____756 -> false
-  
-let (uu___is_Fatal_UnexpectedExpressionType : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedExpressionType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedExpressionType  -> true
     | uu____760 -> false
-  
-let (uu___is_Fatal_UnexpectedFunctionParameterType : raw_error -> Prims.bool)
-  =
+let uu___is_Fatal_UnexpectedFunctionParameterType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedFunctionParameterType  -> true
     | uu____764 -> false
-  
-let (uu___is_Fatal_UnexpectedGeneralizedUniverse : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedGeneralizedUniverse: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedGeneralizedUniverse  -> true
     | uu____768 -> false
-  
-let (uu___is_Fatal_UnexpectedGTotForLetRec : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedGTotForLetRec: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedGTotForLetRec  -> true
     | uu____772 -> false
-  
-let (uu___is_Fatal_UnexpectedGuard : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedGuard: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedGuard  -> true
     | uu____776 -> false
-  
-let (uu___is_Fatal_UnexpectedIdentifier : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedIdentifier: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedIdentifier  -> true
     | uu____780 -> false
-  
-let (uu___is_Fatal_UnexpectedImplicitArgument : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedImplicitArgument: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedImplicitArgument  -> true
     | uu____784 -> false
-  
-let (uu___is_Fatal_UnexpectedImplictArgument : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedImplictArgument: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedImplictArgument  -> true
     | uu____788 -> false
-  
-let (uu___is_Fatal_UnexpectedInductivetype : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedInductivetype: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedInductivetype  -> true
     | uu____792 -> false
-  
-let (uu___is_Fatal_UnexpectedLetBinding : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedLetBinding: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedLetBinding  -> true
     | uu____796 -> false
-  
-let (uu___is_Fatal_UnexpectedModuleDeclaration : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedModuleDeclaration: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedModuleDeclaration  -> true
     | uu____800 -> false
-  
-let (uu___is_Fatal_UnexpectedNumberOfUniverse : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedNumberOfUniverse: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedNumberOfUniverse  -> true
     | uu____804 -> false
-  
-let (uu___is_Fatal_UnexpectedNumericLiteral : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedNumericLiteral: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedNumericLiteral  -> true
     | uu____808 -> false
-  
-let (uu___is_Fatal_UnexpectedOperatorSymbol : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedOperatorSymbol: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedOperatorSymbol  -> true
     | uu____812 -> false
-  
-let (uu___is_Fatal_UnexpectedPattern : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedPattern: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedPattern  -> true
     | uu____816 -> false
-  
-let (uu___is_Fatal_UnexpectedPosition : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedPosition: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedPosition  -> true
     | uu____820 -> false
-  
-let (uu___is_Fatal_UnExpectedPreCondition : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnExpectedPreCondition: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnExpectedPreCondition  -> true
     | uu____824 -> false
-  
-let (uu___is_Fatal_UnexpectedReturnShape : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedReturnShape: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedReturnShape  -> true
     | uu____828 -> false
-  
-let (uu___is_Fatal_UnexpectedSignatureForMonad : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedSignatureForMonad: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedSignatureForMonad  -> true
     | uu____832 -> false
-  
-let (uu___is_Fatal_UnexpectedTerm : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedTerm: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_UnexpectedTerm  -> true | uu____836 -> false
-  
-let (uu___is_Fatal_UnexpectedTermInUniverse : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedTermInUniverse: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedTermInUniverse  -> true
     | uu____840 -> false
-  
-let (uu___is_Fatal_UnexpectedTermType : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedTermType: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedTermType  -> true
     | uu____844 -> false
-  
-let (uu___is_Fatal_UnexpectedUniversePolymorphicReturn :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedUniversePolymorphicReturn:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedUniversePolymorphicReturn  -> true
     | uu____848 -> false
-  
-let (uu___is_Fatal_UnexpectedUniverseVariable : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnexpectedUniverseVariable: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnexpectedUniverseVariable  -> true
     | uu____852 -> false
-  
-let (uu___is_Fatal_UnfoldableDeprecated : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnfoldableDeprecated: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnfoldableDeprecated  -> true
     | uu____856 -> false
-  
-let (uu___is_Fatal_UnificationNotWellFormed : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnificationNotWellFormed: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnificationNotWellFormed  -> true
     | uu____860 -> false
-  
-let (uu___is_Fatal_Uninstantiated : raw_error -> Prims.bool) =
+let uu___is_Fatal_Uninstantiated: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_Uninstantiated  -> true | uu____864 -> false
-  
-let (uu___is_Fatal_UninstantiatedUnificationVarInTactic :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_UninstantiatedUnificationVarInTactic:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UninstantiatedUnificationVarInTactic  -> true
     | uu____868 -> false
-  
-let (uu___is_Fatal_UninstantiatedVarInTactic : raw_error -> Prims.bool) =
+let uu___is_Fatal_UninstantiatedVarInTactic: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UninstantiatedVarInTactic  -> true
     | uu____872 -> false
-  
-let (uu___is_Fatal_UniverseMightContainSumOfTwoUnivVars :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_UniverseMightContainSumOfTwoUnivVars:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UniverseMightContainSumOfTwoUnivVars  -> true
     | uu____876 -> false
-  
-let (uu___is_Fatal_UniversePolymorphicInnerLetBound :
-  raw_error -> Prims.bool) =
+let uu___is_Fatal_UniversePolymorphicInnerLetBound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UniversePolymorphicInnerLetBound  -> true
     | uu____880 -> false
-  
-let (uu___is_Fatal_UnknownAttribute : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnknownAttribute: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnknownAttribute  -> true
     | uu____884 -> false
-  
-let (uu___is_Fatal_UnknownToolForDep : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnknownToolForDep: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnknownToolForDep  -> true
     | uu____888 -> false
-  
-let (uu___is_Fatal_UnrecognizedExtension : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnrecognizedExtension: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnrecognizedExtension  -> true
     | uu____892 -> false
-  
-let (uu___is_Fatal_UnresolvedPatternVar : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnresolvedPatternVar: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnresolvedPatternVar  -> true
     | uu____896 -> false
-  
-let (uu___is_Fatal_UnsupportedConstant : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnsupportedConstant: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnsupportedConstant  -> true
     | uu____900 -> false
-  
-let (uu___is_Fatal_UnsupportedDisjuctivePatterns : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnsupportedDisjuctivePatterns: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnsupportedDisjuctivePatterns  -> true
     | uu____904 -> false
-  
-let (uu___is_Fatal_UnsupportedQualifier : raw_error -> Prims.bool) =
+let uu___is_Fatal_UnsupportedQualifier: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UnsupportedQualifier  -> true
     | uu____908 -> false
-  
-let (uu___is_Fatal_UserTacticFailure : raw_error -> Prims.bool) =
+let uu___is_Fatal_UserTacticFailure: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_UserTacticFailure  -> true
     | uu____912 -> false
-  
-let (uu___is_Fatal_ValueRestriction : raw_error -> Prims.bool) =
+let uu___is_Fatal_ValueRestriction: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_ValueRestriction  -> true
     | uu____916 -> false
-  
-let (uu___is_Fatal_VariableNotFound : raw_error -> Prims.bool) =
+let uu___is_Fatal_VariableNotFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_VariableNotFound  -> true
     | uu____920 -> false
-  
-let (uu___is_Fatal_WrongBodyTypeForReturnWP : raw_error -> Prims.bool) =
+let uu___is_Fatal_WrongBodyTypeForReturnWP: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_WrongBodyTypeForReturnWP  -> true
     | uu____924 -> false
-  
-let (uu___is_Fatal_WrongDataAppHeadFormat : raw_error -> Prims.bool) =
+let uu___is_Fatal_WrongDataAppHeadFormat: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_WrongDataAppHeadFormat  -> true
     | uu____928 -> false
-  
-let (uu___is_Fatal_WrongDefinitionOrder : raw_error -> Prims.bool) =
+let uu___is_Fatal_WrongDefinitionOrder: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_WrongDefinitionOrder  -> true
     | uu____932 -> false
-  
-let (uu___is_Fatal_WrongResultTypeAfterConstrutor : raw_error -> Prims.bool)
-  =
+let uu___is_Fatal_WrongResultTypeAfterConstrutor: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_WrongResultTypeAfterConstrutor  -> true
     | uu____936 -> false
-  
-let (uu___is_Fatal_WrongTerm : raw_error -> Prims.bool) =
+let uu___is_Fatal_WrongTerm: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Fatal_WrongTerm  -> true | uu____940 -> false
-  
-let (uu___is_Fatal_WhenClauseNotSupported : raw_error -> Prims.bool) =
+let uu___is_Fatal_WhenClauseNotSupported: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_WhenClauseNotSupported  -> true
     | uu____944 -> false
-  
-let (uu___is_Fatal_CallNotImplemented : raw_error -> Prims.bool) =
+let uu___is_Fatal_CallNotImplemented: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Fatal_CallNotImplemented  -> true
     | uu____948 -> false
-  
-let (uu___is_Warning_AddImplicitAssumeNewQualifier : raw_error -> Prims.bool)
-  =
+let uu___is_Warning_AddImplicitAssumeNewQualifier: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_AddImplicitAssumeNewQualifier  -> true
     | uu____952 -> false
-  
-let (uu___is_Warning_AdmitWithoutDefinition : raw_error -> Prims.bool) =
+let uu___is_Warning_AdmitWithoutDefinition: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_AdmitWithoutDefinition  -> true
     | uu____956 -> false
-  
-let (uu___is_Warning_CachedFile : raw_error -> Prims.bool) =
+let uu___is_Warning_CachedFile: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Warning_CachedFile  -> true | uu____960 -> false
-  
-let (uu___is_Warning_DefinitionNotTranslated : raw_error -> Prims.bool) =
+let uu___is_Warning_DefinitionNotTranslated: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_DefinitionNotTranslated  -> true
     | uu____964 -> false
-  
-let (uu___is_Warning_DependencyFound : raw_error -> Prims.bool) =
+let uu___is_Warning_DependencyFound: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_DependencyFound  -> true
     | uu____968 -> false
-  
-let (uu___is_Warning_DeprecatedEqualityOnBinder : raw_error -> Prims.bool) =
+let uu___is_Warning_DeprecatedEqualityOnBinder: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_DeprecatedEqualityOnBinder  -> true
     | uu____972 -> false
-  
-let (uu___is_Warning_DeprecatedOpaqueQualifier : raw_error -> Prims.bool) =
+let uu___is_Warning_DeprecatedOpaqueQualifier: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_DeprecatedOpaqueQualifier  -> true
     | uu____976 -> false
-  
-let (uu___is_Warning_DocOverwrite : raw_error -> Prims.bool) =
+let uu___is_Warning_DocOverwrite: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Warning_DocOverwrite  -> true | uu____980 -> false
-  
-let (uu___is_Warning_FileNotWritten : raw_error -> Prims.bool) =
+let uu___is_Warning_FileNotWritten: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_FileNotWritten  -> true
     | uu____984 -> false
-  
-let (uu___is_Warning_Filtered : raw_error -> Prims.bool) =
+let uu___is_Warning_Filtered: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Warning_Filtered  -> true | uu____988 -> false
-  
-let (uu___is_Warning_FunctionLiteralPrecisionLoss : raw_error -> Prims.bool)
-  =
+let uu___is_Warning_FunctionLiteralPrecisionLoss: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_FunctionLiteralPrecisionLoss  -> true
     | uu____992 -> false
-  
-let (uu___is_Warning_FunctionNotExtacted : raw_error -> Prims.bool) =
+let uu___is_Warning_FunctionNotExtacted: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_FunctionNotExtacted  -> true
     | uu____996 -> false
-  
-let (uu___is_Warning_HintFailedToReplayProof : raw_error -> Prims.bool) =
+let uu___is_Warning_HintFailedToReplayProof: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_HintFailedToReplayProof  -> true
     | uu____1000 -> false
-  
-let (uu___is_Warning_HitReplayFailed : raw_error -> Prims.bool) =
+let uu___is_Warning_HitReplayFailed: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_HitReplayFailed  -> true
     | uu____1004 -> false
-  
-let (uu___is_Warning_IDEIgnoreCodeGen : raw_error -> Prims.bool) =
+let uu___is_Warning_IDEIgnoreCodeGen: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_IDEIgnoreCodeGen  -> true
     | uu____1008 -> false
-  
-let (uu___is_Warning_IllFormedGoal : raw_error -> Prims.bool) =
+let uu___is_Warning_IllFormedGoal: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_IllFormedGoal  -> true
     | uu____1012 -> false
-  
-let (uu___is_Warning_InaccessibleArgument : raw_error -> Prims.bool) =
+let uu___is_Warning_InaccessibleArgument: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_InaccessibleArgument  -> true
     | uu____1016 -> false
-  
-let (uu___is_Warning_IncoherentImplicitQualifier : raw_error -> Prims.bool) =
+let uu___is_Warning_IncoherentImplicitQualifier: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_IncoherentImplicitQualifier  -> true
     | uu____1020 -> false
-  
-let (uu___is_Warning_IrrelevantQualifierOnArgumentToReflect :
-  raw_error -> Prims.bool) =
+let uu___is_Warning_IrrelevantQualifierOnArgumentToReflect:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_IrrelevantQualifierOnArgumentToReflect  -> true
     | uu____1024 -> false
-  
-let (uu___is_Warning_IrrelevantQualifierOnArgumentToReify :
-  raw_error -> Prims.bool) =
+let uu___is_Warning_IrrelevantQualifierOnArgumentToReify:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_IrrelevantQualifierOnArgumentToReify  -> true
     | uu____1028 -> false
-  
-let (uu___is_Warning_MalformedWarnErrorList : raw_error -> Prims.bool) =
+let uu___is_Warning_MalformedWarnErrorList: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_MalformedWarnErrorList  -> true
     | uu____1032 -> false
-  
-let (uu___is_Warning_MetaAlienNotATmUnknown : raw_error -> Prims.bool) =
+let uu___is_Warning_MetaAlienNotATmUnknown: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_MetaAlienNotATmUnknown  -> true
     | uu____1036 -> false
-  
-let (uu___is_Warning_MultipleAscriptions : raw_error -> Prims.bool) =
+let uu___is_Warning_MultipleAscriptions: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_MultipleAscriptions  -> true
     | uu____1040 -> false
-  
-let (uu___is_Warning_NondependentUserDefinedDataType :
-  raw_error -> Prims.bool) =
+let uu___is_Warning_NondependentUserDefinedDataType: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Warning_NondependentUserDefinedDataType  -> true
     | uu____1044 -> false
-  
-let (uu___is_Warning_NonListLiteralSMTPattern : raw_error -> Prims.bool) =
+let uu___is_Warning_NonListLiteralSMTPattern: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_NonListLiteralSMTPattern  -> true
     | uu____1048 -> false
-  
-let (uu___is_Warning_NormalizationFailure : raw_error -> Prims.bool) =
+let uu___is_Warning_NormalizationFailure: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_NormalizationFailure  -> true
     | uu____1052 -> false
-  
-let (uu___is_Warning_NotDependentArrow : raw_error -> Prims.bool) =
+let uu___is_Warning_NotDependentArrow: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_NotDependentArrow  -> true
     | uu____1056 -> false
-  
-let (uu___is_Warning_NotEmbedded : raw_error -> Prims.bool) =
+let uu___is_Warning_NotEmbedded: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Warning_NotEmbedded  -> true | uu____1060 -> false
-  
-let (uu___is_Warning_PatternMissingBoundVar : raw_error -> Prims.bool) =
+let uu___is_Warning_PatternMissingBoundVar: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_PatternMissingBoundVar  -> true
     | uu____1064 -> false
-  
-let (uu___is_Warning_RecursiveDependency : raw_error -> Prims.bool) =
+let uu___is_Warning_RecursiveDependency: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_RecursiveDependency  -> true
     | uu____1068 -> false
-  
-let (uu___is_Warning_RedundantExplicitCurrying : raw_error -> Prims.bool) =
+let uu___is_Warning_RedundantExplicitCurrying: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_RedundantExplicitCurrying  -> true
     | uu____1072 -> false
-  
-let (uu___is_Warning_SMTPatTDeprecated : raw_error -> Prims.bool) =
+let uu___is_Warning_SMTPatTDeprecated: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_SMTPatTDeprecated  -> true
     | uu____1076 -> false
-  
-let (uu___is_Warning_SMTPatternMissingBoundVar : raw_error -> Prims.bool) =
+let uu___is_Warning_SMTPatternMissingBoundVar: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_SMTPatternMissingBoundVar  -> true
     | uu____1080 -> false
-  
-let (uu___is_Warning_TopLevelEffect : raw_error -> Prims.bool) =
+let uu___is_Warning_TopLevelEffect: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_TopLevelEffect  -> true
     | uu____1084 -> false
-  
-let (uu___is_Warning_UnboundModuleReference : raw_error -> Prims.bool) =
+let uu___is_Warning_UnboundModuleReference: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_UnboundModuleReference  -> true
     | uu____1088 -> false
-  
-let (uu___is_Warning_UnexpectedFile : raw_error -> Prims.bool) =
+let uu___is_Warning_UnexpectedFile: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_UnexpectedFile  -> true
     | uu____1092 -> false
-  
-let (uu___is_Warning_UnexpectedFsTypApp : raw_error -> Prims.bool) =
+let uu___is_Warning_UnexpectedFsTypApp: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_UnexpectedFsTypApp  -> true
     | uu____1096 -> false
-  
-let (uu___is_Warning_UnexpectedZ3Output : raw_error -> Prims.bool) =
+let uu___is_Warning_UnexpectedZ3Output: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_UnexpectedZ3Output  -> true
     | uu____1100 -> false
-  
-let (uu___is_Warning_UnprotectedTerm : raw_error -> Prims.bool) =
+let uu___is_Warning_UnprotectedTerm: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_UnprotectedTerm  -> true
     | uu____1104 -> false
-  
-let (uu___is_Warning_UnrecognizedAttribute : raw_error -> Prims.bool) =
+let uu___is_Warning_UnrecognizedAttribute: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_UnrecognizedAttribute  -> true
     | uu____1108 -> false
-  
-let (uu___is_Warning_UpperBoundCandidateAlreadyVisited :
-  raw_error -> Prims.bool) =
+let uu___is_Warning_UpperBoundCandidateAlreadyVisited:
+  raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_UpperBoundCandidateAlreadyVisited  -> true
     | uu____1112 -> false
-  
-let (uu___is_Warning_UseDefaultEffect : raw_error -> Prims.bool) =
+let uu___is_Warning_UseDefaultEffect: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_UseDefaultEffect  -> true
     | uu____1116 -> false
-  
-let (uu___is_Warning_WrongErrorLocation : raw_error -> Prims.bool) =
+let uu___is_Warning_WrongErrorLocation: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_WrongErrorLocation  -> true
     | uu____1120 -> false
-  
-let (uu___is_Warning_Z3InvocationWarning : raw_error -> Prims.bool) =
+let uu___is_Warning_Z3InvocationWarning: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_Z3InvocationWarning  -> true
     | uu____1124 -> false
-  
-let (uu___is_Warning_CallNotImplementedAsWarning : raw_error -> Prims.bool) =
+let uu___is_Warning_CallNotImplementedAsWarning: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_CallNotImplementedAsWarning  -> true
     | uu____1128 -> false
-  
-let (uu___is_Warning_MissingInterfaceOrImplementation :
-  raw_error -> Prims.bool) =
+let uu___is_Warning_MissingInterfaceOrImplementation: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Warning_MissingInterfaceOrImplementation  -> true
     | uu____1132 -> false
-  
-let (uu___is_Warning_ConstructorBuildsUnexpectedType :
-  raw_error -> Prims.bool) =
+let uu___is_Warning_ConstructorBuildsUnexpectedType: raw_error -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | Warning_ConstructorBuildsUnexpectedType  -> true
     | uu____1136 -> false
-  
-let (uu___is_Warning_ModuleOrFileNotFoundWarning : raw_error -> Prims.bool) =
+let uu___is_Warning_ModuleOrFileNotFoundWarning: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_ModuleOrFileNotFoundWarning  -> true
     | uu____1140 -> false
-  
-let (uu___is_Error_NoLetMutable : raw_error -> Prims.bool) =
+let uu___is_Error_NoLetMutable: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Error_NoLetMutable  -> true | uu____1144 -> false
-  
-let (uu___is_Error_BadImplicit : raw_error -> Prims.bool) =
+let uu___is_Error_BadImplicit: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with | Error_BadImplicit  -> true | uu____1148 -> false
-  
-let (uu___is_Warning_DeprecatedDefinition : raw_error -> Prims.bool) =
+let uu___is_Warning_DeprecatedDefinition: raw_error -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Warning_DeprecatedDefinition  -> true
     | uu____1152 -> false
-  
 type flag =
-  | CError 
-  | CFatal 
-  | CWarning 
-  | CSilent [@@deriving show]
-let (uu___is_CError : flag -> Prims.bool) =
+  | CError
+  | CFatal
+  | CWarning
+  | CSilent[@@deriving show]
+let uu___is_CError: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | CError  -> true | uu____1156 -> false
-  
-let (uu___is_CFatal : flag -> Prims.bool) =
+let uu___is_CFatal: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | CFatal  -> true | uu____1160 -> false
-  
-let (uu___is_CWarning : flag -> Prims.bool) =
+let uu___is_CWarning: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | CWarning  -> true | uu____1164 -> false
-  
-let (uu___is_CSilent : flag -> Prims.bool) =
+let uu___is_CSilent: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | CSilent  -> true | uu____1168 -> false
-  
-let (default_flags :
-  (raw_error,flag) FStar_Pervasives_Native.tuple2 Prims.list) =
+let default_flags: (raw_error,flag) FStar_Pervasives_Native.tuple2 Prims.list
+  =
   [(Error_DependencyAnalysisFailed, CError);
   (Error_IDETooManyPops, CError);
   (Error_IDEUnrecognized, CError);
@@ -2295,241 +1988,217 @@ let (default_flags :
   (Warning_ConstructorBuildsUnexpectedType, CWarning);
   (Warning_ModuleOrFileNotFoundWarning, CWarning);
   (Error_BadImplicit, CError);
-  (Warning_DeprecatedDefinition, CWarning)] 
-exception Err of (raw_error,Prims.string) FStar_Pervasives_Native.tuple2 
-let (uu___is_Err : Prims.exn -> Prims.bool) =
+  (Warning_DeprecatedDefinition, CWarning)]
+exception Err of (raw_error,Prims.string) FStar_Pervasives_Native.tuple2
+let uu___is_Err: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | Err uu____2337 -> true | uu____2342 -> false
-  
-let (__proj__Err__item__uu___ :
-  Prims.exn -> (raw_error,Prims.string) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Err uu____2357 -> uu____2357 
+let __proj__Err__item__uu___:
+  Prims.exn -> (raw_error,Prims.string) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Err uu____2357 -> uu____2357
 exception Error of (raw_error,Prims.string,FStar_Range.range)
-  FStar_Pervasives_Native.tuple3 
-let (uu___is_Error : Prims.exn -> Prims.bool) =
+  FStar_Pervasives_Native.tuple3
+let uu___is_Error: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | Error uu____2374 -> true | uu____2381 -> false
-  
-let (__proj__Error__item__uu___ :
+let __proj__Error__item__uu___:
   Prims.exn ->
-    (raw_error,Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Error uu____2400 -> uu____2400 
+    (raw_error,Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Error uu____2400 -> uu____2400
 exception Warning of (raw_error,Prims.string,FStar_Range.range)
-  FStar_Pervasives_Native.tuple3 
-let (uu___is_Warning : Prims.exn -> Prims.bool) =
+  FStar_Pervasives_Native.tuple3
+let uu___is_Warning: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | Warning uu____2419 -> true | uu____2426 -> false
-  
-let (__proj__Warning__item__uu___ :
+let __proj__Warning__item__uu___:
   Prims.exn ->
-    (raw_error,Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Warning uu____2445 -> uu____2445 
-exception Stop 
-let (uu___is_Stop : Prims.exn -> Prims.bool) =
+    (raw_error,Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Warning uu____2445 -> uu____2445
+exception Stop
+let uu___is_Stop: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | Stop  -> true | uu____2455 -> false
-  
-exception Empty_frag 
-let (uu___is_Empty_frag : Prims.exn -> Prims.bool) =
+exception Empty_frag
+let uu___is_Empty_frag: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | Empty_frag  -> true | uu____2459 -> false
-  
 type issue_level =
-  | ENotImplemented 
-  | EInfo 
-  | EWarning 
-  | EError [@@deriving show]
-let (uu___is_ENotImplemented : issue_level -> Prims.bool) =
+  | ENotImplemented
+  | EInfo
+  | EWarning
+  | EError[@@deriving show]
+let uu___is_ENotImplemented: issue_level -> Prims.bool =
   fun projectee  ->
     match projectee with | ENotImplemented  -> true | uu____2463 -> false
-  
-let (uu___is_EInfo : issue_level -> Prims.bool) =
+let uu___is_EInfo: issue_level -> Prims.bool =
   fun projectee  ->
     match projectee with | EInfo  -> true | uu____2467 -> false
-  
-let (uu___is_EWarning : issue_level -> Prims.bool) =
+let uu___is_EWarning: issue_level -> Prims.bool =
   fun projectee  ->
     match projectee with | EWarning  -> true | uu____2471 -> false
-  
-let (uu___is_EError : issue_level -> Prims.bool) =
+let uu___is_EError: issue_level -> Prims.bool =
   fun projectee  ->
     match projectee with | EError  -> true | uu____2475 -> false
-  
 type issue =
   {
-  issue_message: Prims.string ;
-  issue_level: issue_level ;
-  issue_range: FStar_Range.range FStar_Pervasives_Native.option ;
-  issue_number: Prims.int FStar_Pervasives_Native.option }[@@deriving show]
-let (__proj__Mkissue__item__issue_message : issue -> Prims.string) =
+  issue_message: Prims.string;
+  issue_level: issue_level;
+  issue_range: FStar_Range.range FStar_Pervasives_Native.option;
+  issue_number: Prims.int FStar_Pervasives_Native.option;}[@@deriving show]
+let __proj__Mkissue__item__issue_message: issue -> Prims.string =
   fun projectee  ->
     match projectee with
     | { issue_message = __fname__issue_message;
         issue_level = __fname__issue_level;
         issue_range = __fname__issue_range;
         issue_number = __fname__issue_number;_} -> __fname__issue_message
-  
-let (__proj__Mkissue__item__issue_level : issue -> issue_level) =
+let __proj__Mkissue__item__issue_level: issue -> issue_level =
   fun projectee  ->
     match projectee with
     | { issue_message = __fname__issue_message;
         issue_level = __fname__issue_level;
         issue_range = __fname__issue_range;
         issue_number = __fname__issue_number;_} -> __fname__issue_level
-  
-let (__proj__Mkissue__item__issue_range :
-  issue -> FStar_Range.range FStar_Pervasives_Native.option) =
+let __proj__Mkissue__item__issue_range:
+  issue -> FStar_Range.range FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { issue_message = __fname__issue_message;
         issue_level = __fname__issue_level;
         issue_range = __fname__issue_range;
         issue_number = __fname__issue_number;_} -> __fname__issue_range
-  
-let (__proj__Mkissue__item__issue_number :
-  issue -> Prims.int FStar_Pervasives_Native.option) =
+let __proj__Mkissue__item__issue_number:
+  issue -> Prims.int FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { issue_message = __fname__issue_message;
         issue_level = __fname__issue_level;
         issue_range = __fname__issue_range;
         issue_number = __fname__issue_number;_} -> __fname__issue_number
-  
 type error_handler =
   {
-  eh_add_one: issue -> Prims.unit ;
-  eh_count_errors: Prims.unit -> Prims.int ;
-  eh_report: Prims.unit -> issue Prims.list ;
-  eh_clear: Prims.unit -> Prims.unit }[@@deriving show]
-let (__proj__Mkerror_handler__item__eh_add_one :
-  error_handler -> issue -> Prims.unit) =
+  eh_add_one: issue -> Prims.unit;
+  eh_count_errors: Prims.unit -> Prims.int;
+  eh_report: Prims.unit -> issue Prims.list;
+  eh_clear: Prims.unit -> Prims.unit;}[@@deriving show]
+let __proj__Mkerror_handler__item__eh_add_one:
+  error_handler -> issue -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { eh_add_one = __fname__eh_add_one;
         eh_count_errors = __fname__eh_count_errors;
         eh_report = __fname__eh_report; eh_clear = __fname__eh_clear;_} ->
         __fname__eh_add_one
-  
-let (__proj__Mkerror_handler__item__eh_count_errors :
-  error_handler -> Prims.unit -> Prims.int) =
+let __proj__Mkerror_handler__item__eh_count_errors:
+  error_handler -> Prims.unit -> Prims.int =
   fun projectee  ->
     match projectee with
     | { eh_add_one = __fname__eh_add_one;
         eh_count_errors = __fname__eh_count_errors;
         eh_report = __fname__eh_report; eh_clear = __fname__eh_clear;_} ->
         __fname__eh_count_errors
-  
-let (__proj__Mkerror_handler__item__eh_report :
-  error_handler -> Prims.unit -> issue Prims.list) =
+let __proj__Mkerror_handler__item__eh_report:
+  error_handler -> Prims.unit -> issue Prims.list =
   fun projectee  ->
     match projectee with
     | { eh_add_one = __fname__eh_add_one;
         eh_count_errors = __fname__eh_count_errors;
         eh_report = __fname__eh_report; eh_clear = __fname__eh_clear;_} ->
         __fname__eh_report
-  
-let (__proj__Mkerror_handler__item__eh_clear :
-  error_handler -> Prims.unit -> Prims.unit) =
+let __proj__Mkerror_handler__item__eh_clear:
+  error_handler -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { eh_add_one = __fname__eh_add_one;
         eh_count_errors = __fname__eh_count_errors;
         eh_report = __fname__eh_report; eh_clear = __fname__eh_clear;_} ->
         __fname__eh_clear
-  
-let (format_issue : issue -> Prims.string) =
+let format_issue: issue -> Prims.string =
   fun issue  ->
     let level_header =
       match issue.issue_level with
       | EInfo  -> "Info"
       | EWarning  -> "Warning"
       | EError  -> "Error"
-      | ENotImplemented  -> "Feature not yet implemented: "  in
+      | ENotImplemented  -> "Feature not yet implemented: " in
     let uu____2674 =
       match issue.issue_range with
       | FStar_Pervasives_Native.None  -> ("", "")
       | FStar_Pervasives_Native.Some r ->
           let uu____2684 =
-            let uu____2685 = FStar_Range.string_of_use_range r  in
-            FStar_Util.format1 "%s: " uu____2685  in
+            let uu____2685 = FStar_Range.string_of_use_range r in
+            FStar_Util.format1 "%s: " uu____2685 in
           let uu____2686 =
             let uu____2687 =
-              let uu____2688 = FStar_Range.use_range r  in
-              let uu____2689 = FStar_Range.def_range r  in
-              uu____2688 = uu____2689  in
+              let uu____2688 = FStar_Range.use_range r in
+              let uu____2689 = FStar_Range.def_range r in
+              uu____2688 = uu____2689 in
             if uu____2687
             then ""
             else
-              (let uu____2691 = FStar_Range.string_of_range r  in
-               FStar_Util.format1 " (see also %s)" uu____2691)
-             in
-          (uu____2684, uu____2686)
-       in
+              (let uu____2691 = FStar_Range.string_of_range r in
+               FStar_Util.format1 " (see also %s)" uu____2691) in
+          (uu____2684, uu____2686) in
     match uu____2674 with
     | (range_str,see_also_str) ->
         let issue_number =
           match issue.issue_number with
           | FStar_Pervasives_Native.None  -> ""
           | FStar_Pervasives_Native.Some n1 ->
-              let uu____2696 = FStar_Util.string_of_int n1  in
-              FStar_Util.format1 " %s" uu____2696
-           in
+              let uu____2696 = FStar_Util.string_of_int n1 in
+              FStar_Util.format1 " %s" uu____2696 in
         FStar_Util.format5 "%s(%s%s) %s%s\n" range_str level_header
           issue_number issue.issue_message see_also_str
-  
-let (print_issue : issue -> Prims.unit) =
+let print_issue: issue -> Prims.unit =
   fun issue  ->
     let printer =
       match issue.issue_level with
       | EInfo  -> FStar_Util.print_string
       | EWarning  -> FStar_Util.print_warning
       | EError  -> FStar_Util.print_error
-      | ENotImplemented  -> FStar_Util.print_error  in
-    let uu____2705 = format_issue issue  in printer uu____2705
-  
-let (compare_issues : issue -> issue -> Prims.int) =
+      | ENotImplemented  -> FStar_Util.print_error in
+    let uu____2705 = format_issue issue in printer uu____2705
+let compare_issues: issue -> issue -> Prims.int =
   fun i1  ->
     fun i2  ->
       match ((i1.issue_range), (i2.issue_range)) with
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.None ) ->
-          (Prims.parse_int "0")
+          Prims.parse_int "0"
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some
-         uu____2720) -> ~- (Prims.parse_int "1")
+         uu____2720) -> - (Prims.parse_int "1")
       | (FStar_Pervasives_Native.Some uu____2725,FStar_Pervasives_Native.None
-         ) -> (Prims.parse_int "1")
+         ) -> Prims.parse_int "1"
       | (FStar_Pervasives_Native.Some r1,FStar_Pervasives_Native.Some r2) ->
           FStar_Range.compare_use_range r1 r2
-  
-let (default_handler : error_handler) =
-  let errs = FStar_Util.mk_ref []  in
+let default_handler: error_handler =
+  let errs = FStar_Util.mk_ref [] in
   let add_one e =
     match e.issue_level with
     | EError  ->
         let uu____2747 =
-          let uu____2750 = FStar_ST.op_Bang errs  in e :: uu____2750  in
+          let uu____2750 = FStar_ST.op_Bang errs in e :: uu____2750 in
         FStar_ST.op_Colon_Equals errs uu____2747
-    | uu____2843 -> print_issue e  in
+    | uu____2843 -> print_issue e in
   let count_errors uu____2847 =
-    let uu____2848 = FStar_ST.op_Bang errs  in FStar_List.length uu____2848
-     in
+    let uu____2848 = FStar_ST.op_Bang errs in FStar_List.length uu____2848 in
   let report uu____2901 =
     let sorted1 =
-      let uu____2905 = FStar_ST.op_Bang errs  in
-      FStar_List.sortWith compare_issues uu____2905  in
-    FStar_List.iter print_issue sorted1; sorted1  in
-  let clear1 uu____2957 = FStar_ST.op_Colon_Equals errs []  in
+      let uu____2905 = FStar_ST.op_Bang errs in
+      FStar_List.sortWith compare_issues uu____2905 in
+    FStar_List.iter print_issue sorted1; sorted1 in
+  let clear1 uu____2957 = FStar_ST.op_Colon_Equals errs [] in
   {
     eh_add_one = add_one;
     eh_count_errors = count_errors;
     eh_report = report;
     eh_clear = clear1
-  } 
-let (current_handler : error_handler FStar_ST.ref) =
-  FStar_Util.mk_ref default_handler 
-let (mk_issue :
+  }
+let current_handler: error_handler FStar_ST.ref =
+  FStar_Util.mk_ref default_handler
+let mk_issue:
   issue_level ->
     FStar_Range.range FStar_Pervasives_Native.option ->
-      Prims.string -> Prims.int FStar_Pervasives_Native.option -> issue)
+      Prims.string -> Prims.int FStar_Pervasives_Native.option -> issue
   =
   fun level  ->
     fun range  ->
@@ -2541,96 +2210,85 @@ let (mk_issue :
             issue_range = range;
             issue_number = n1
           }
-  
-let (get_err_count : Prims.unit -> Prims.int) =
+let get_err_count: Prims.unit -> Prims.int =
   fun uu____3042  ->
     let uu____3043 =
-      let uu____3046 = FStar_ST.op_Bang current_handler  in
-      uu____3046.eh_count_errors  in
+      let uu____3046 = FStar_ST.op_Bang current_handler in
+      uu____3046.eh_count_errors in
     uu____3043 ()
-  
-let (add_one : issue -> Prims.unit) =
+let add_one: issue -> Prims.unit =
   fun issue  ->
     FStar_Util.atomically
       (fun uu____3071  ->
          let uu____3072 =
-           let uu____3075 = FStar_ST.op_Bang current_handler  in
-           uu____3075.eh_add_one  in
+           let uu____3075 = FStar_ST.op_Bang current_handler in
+           uu____3075.eh_add_one in
          uu____3072 issue)
-  
-let (add_many : issue Prims.list -> Prims.unit) =
+let add_many: issue Prims.list -> Prims.unit =
   fun issues  ->
     FStar_Util.atomically
       (fun uu____3104  ->
          let uu____3105 =
-           let uu____3108 = FStar_ST.op_Bang current_handler  in
-           uu____3108.eh_add_one  in
+           let uu____3108 = FStar_ST.op_Bang current_handler in
+           uu____3108.eh_add_one in
          FStar_List.iter uu____3105 issues)
-  
-let (report_all : Prims.unit -> issue Prims.list) =
+let report_all: Prims.unit -> issue Prims.list =
   fun uu____3132  ->
     let uu____3133 =
-      let uu____3138 = FStar_ST.op_Bang current_handler  in
-      uu____3138.eh_report  in
+      let uu____3138 = FStar_ST.op_Bang current_handler in
+      uu____3138.eh_report in
     uu____3133 ()
-  
-let (clear : Prims.unit -> Prims.unit) =
+let clear: Prims.unit -> Prims.unit =
   fun uu____3160  ->
     let uu____3161 =
-      let uu____3164 = FStar_ST.op_Bang current_handler  in
-      uu____3164.eh_clear  in
+      let uu____3164 = FStar_ST.op_Bang current_handler in
+      uu____3164.eh_clear in
     uu____3161 ()
-  
-let (set_handler : error_handler -> Prims.unit) =
+let set_handler: error_handler -> Prims.unit =
   fun handler  ->
-    let issues = report_all ()  in
+    let issues = report_all () in
     clear ();
     FStar_ST.op_Colon_Equals current_handler handler;
     add_many issues
-  
 type error_message_prefix =
   {
-  set_prefix: Prims.string -> Prims.unit ;
-  append_prefix: Prims.string -> Prims.string ;
-  clear_prefix: Prims.unit -> Prims.unit }[@@deriving show]
-let (__proj__Mkerror_message_prefix__item__set_prefix :
-  error_message_prefix -> Prims.string -> Prims.unit) =
+  set_prefix: Prims.string -> Prims.unit;
+  append_prefix: Prims.string -> Prims.string;
+  clear_prefix: Prims.unit -> Prims.unit;}[@@deriving show]
+let __proj__Mkerror_message_prefix__item__set_prefix:
+  error_message_prefix -> Prims.string -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { set_prefix = __fname__set_prefix;
         append_prefix = __fname__append_prefix;
         clear_prefix = __fname__clear_prefix;_} -> __fname__set_prefix
-  
-let (__proj__Mkerror_message_prefix__item__append_prefix :
-  error_message_prefix -> Prims.string -> Prims.string) =
+let __proj__Mkerror_message_prefix__item__append_prefix:
+  error_message_prefix -> Prims.string -> Prims.string =
   fun projectee  ->
     match projectee with
     | { set_prefix = __fname__set_prefix;
         append_prefix = __fname__append_prefix;
         clear_prefix = __fname__clear_prefix;_} -> __fname__append_prefix
-  
-let (__proj__Mkerror_message_prefix__item__clear_prefix :
-  error_message_prefix -> Prims.unit -> Prims.unit) =
+let __proj__Mkerror_message_prefix__item__clear_prefix:
+  error_message_prefix -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { set_prefix = __fname__set_prefix;
         append_prefix = __fname__append_prefix;
         clear_prefix = __fname__clear_prefix;_} -> __fname__clear_prefix
-  
-let (message_prefix : error_message_prefix) =
-  let pfx = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+let message_prefix: error_message_prefix =
+  let pfx = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   let set_prefix s =
-    FStar_ST.op_Colon_Equals pfx (FStar_Pervasives_Native.Some s)  in
+    FStar_ST.op_Colon_Equals pfx (FStar_Pervasives_Native.Some s) in
   let clear_prefix uu____3342 =
-    FStar_ST.op_Colon_Equals pfx FStar_Pervasives_Native.None  in
+    FStar_ST.op_Colon_Equals pfx FStar_Pervasives_Native.None in
   let append_prefix s =
-    let uu____3392 = FStar_ST.op_Bang pfx  in
+    let uu____3392 = FStar_ST.op_Bang pfx in
     match uu____3392 with
     | FStar_Pervasives_Native.None  -> s
-    | FStar_Pervasives_Native.Some p -> Prims.strcat p (Prims.strcat ": " s)
-     in
-  { set_prefix; append_prefix; clear_prefix } 
-let findIndex :
+    | FStar_Pervasives_Native.Some p -> Prims.strcat p (Prims.strcat ": " s) in
+  { set_prefix; append_prefix; clear_prefix }
+let findIndex:
   'Auu____3445 'Auu____3446 .
     ('Auu____3446,'Auu____3445) FStar_Pervasives_Native.tuple2 Prims.list ->
       'Auu____3446 -> Prims.int
@@ -2643,39 +2301,36 @@ let findIndex :
               match uu___26_3480 with
               | (e,uu____3486) when e = v1 -> true
               | uu____3487 -> false))
-  
-let (errno_of_error : raw_error -> Prims.int) =
-  fun e  -> findIndex default_flags e 
-let (flags : flag Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
-let (init_warn_error_flags : Prims.unit) =
+let errno_of_error: raw_error -> Prims.int =
+  fun e  -> findIndex default_flags e
+let flags: flag Prims.list FStar_ST.ref = FStar_Util.mk_ref []
+let init_warn_error_flags: Prims.unit =
   let rec aux r l =
-    match l with | [] -> r | (e,f)::tl1 -> aux (FStar_List.append r [f]) tl1
-     in
-  let uu____3556 = aux [] default_flags  in
-  FStar_ST.op_Colon_Equals flags uu____3556 
-let (diag : FStar_Range.range -> Prims.string -> Prims.unit) =
+    match l with | [] -> r | (e,f)::tl1 -> aux (FStar_List.append r [f]) tl1 in
+  let uu____3556 = aux [] default_flags in
+  FStar_ST.op_Colon_Equals flags uu____3556
+let diag: FStar_Range.range -> Prims.string -> Prims.unit =
   fun r  ->
     fun msg  ->
-      let uu____3588 = FStar_Options.debug_any ()  in
+      let uu____3588 = FStar_Options.debug_any () in
       if uu____3588
       then
         add_one
           (mk_issue EInfo (FStar_Pervasives_Native.Some r) msg
              FStar_Pervasives_Native.None)
       else ()
-  
-let (log_issue :
+let log_issue:
   FStar_Range.range ->
-    (raw_error,Prims.string) FStar_Pervasives_Native.tuple2 -> Prims.unit)
+    (raw_error,Prims.string) FStar_Pervasives_Native.tuple2 -> Prims.unit
   =
   fun r  ->
     fun uu____3599  ->
       match uu____3599 with
       | (e,msg) ->
-          let errno = errno_of_error e  in
+          let errno = errno_of_error e in
           let uu____3607 =
-            let uu____3608 = FStar_ST.op_Bang flags  in
-            FStar_List.nth uu____3608 errno  in
+            let uu____3608 = FStar_ST.op_Bang flags in
+            FStar_List.nth uu____3608 errno in
           (match uu____3607 with
            | CError  ->
                add_one
@@ -2689,23 +2344,20 @@ let (log_issue :
            | CFatal  ->
                let i =
                  mk_issue EError (FStar_Pervasives_Native.Some r) msg
-                   (FStar_Pervasives_Native.Some errno)
-                  in
-               let uu____3635 = FStar_Options.ide ()  in
+                   (FStar_Pervasives_Native.Some errno) in
+               let uu____3635 = FStar_Options.ide () in
                if uu____3635
                then add_one i
                else
                  (let uu____3637 =
-                    let uu____3638 = format_issue i  in
+                    let uu____3638 = format_issue i in
                     Prims.strcat
                       "don't use log_issue to report fatal error, should use raise_error: "
-                      uu____3638
-                     in
+                      uu____3638 in
                   failwith uu____3637))
-  
-let (add_errors :
+let add_errors:
   (raw_error,Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple3
-    Prims.list -> Prims.unit)
+    Prims.list -> Prims.unit
   =
   fun errs  ->
     FStar_Util.atomically
@@ -2715,49 +2367,43 @@ let (add_errors :
               match uu____3671 with
               | (e,msg,r) ->
                   let uu____3681 =
-                    let uu____3686 = message_prefix.append_prefix msg  in
-                    (e, uu____3686)  in
+                    let uu____3686 = message_prefix.append_prefix msg in
+                    (e, uu____3686) in
                   log_issue r uu____3681) errs)
-  
-let (issue_of_exn : Prims.exn -> issue FStar_Pervasives_Native.option) =
+let issue_of_exn: Prims.exn -> issue FStar_Pervasives_Native.option =
   fun uu___27_3691  ->
     match uu___27_3691 with
     | Error (e,msg,r) ->
-        let errno = errno_of_error e  in
+        let errno = errno_of_error e in
         let uu____3698 =
-          let uu____3699 = message_prefix.append_prefix msg  in
+          let uu____3699 = message_prefix.append_prefix msg in
           mk_issue EError (FStar_Pervasives_Native.Some r) uu____3699
-            (FStar_Pervasives_Native.Some errno)
-           in
+            (FStar_Pervasives_Native.Some errno) in
         FStar_Pervasives_Native.Some uu____3698
     | FStar_Util.NYI msg ->
         let uu____3701 =
-          let uu____3702 = message_prefix.append_prefix msg  in
+          let uu____3702 = message_prefix.append_prefix msg in
           mk_issue ENotImplemented FStar_Pervasives_Native.None uu____3702
-            FStar_Pervasives_Native.None
-           in
+            FStar_Pervasives_Native.None in
         FStar_Pervasives_Native.Some uu____3701
     | Err (e,msg) ->
-        let errno = errno_of_error e  in
+        let errno = errno_of_error e in
         let uu____3706 =
-          let uu____3707 = message_prefix.append_prefix msg  in
+          let uu____3707 = message_prefix.append_prefix msg in
           mk_issue EError FStar_Pervasives_Native.None uu____3707
-            (FStar_Pervasives_Native.Some errno)
-           in
+            (FStar_Pervasives_Native.Some errno) in
         FStar_Pervasives_Native.Some uu____3706
     | uu____3708 -> FStar_Pervasives_Native.None
-  
-let (err_exn : Prims.exn -> Prims.unit) =
+let err_exn: Prims.exn -> Prims.unit =
   fun exn  ->
     if exn = Stop
     then ()
     else
-      (let uu____3713 = issue_of_exn exn  in
+      (let uu____3713 = issue_of_exn exn in
        match uu____3713 with
        | FStar_Pervasives_Native.Some issue -> add_one issue
        | FStar_Pervasives_Native.None  -> FStar_Exn.raise exn)
-  
-let (handleable : Prims.exn -> Prims.bool) =
+let handleable: Prims.exn -> Prims.bool =
   fun uu___28_3719  ->
     match uu___28_3719 with
     | Error uu____3720 -> true
@@ -2765,15 +2411,12 @@ let (handleable : Prims.exn -> Prims.bool) =
     | Stop  -> true
     | Err uu____3728 -> true
     | uu____3733 -> false
-  
-let (stop_if_err : Prims.unit -> Prims.unit) =
+let stop_if_err: Prims.unit -> Prims.unit =
   fun uu____3736  ->
     let uu____3737 =
-      let uu____3738 = get_err_count ()  in
-      uu____3738 > (Prims.parse_int "0")  in
+      let uu____3738 = get_err_count () in uu____3738 > (Prims.parse_int "0") in
     if uu____3737 then FStar_Exn.raise Stop else ()
-  
-let raise_error :
+let raise_error:
   'Auu____3743 .
     (raw_error,Prims.string) FStar_Pervasives_Native.tuple2 ->
       FStar_Range.range -> 'Auu____3743
@@ -2781,26 +2424,22 @@ let raise_error :
   fun uu____3754  ->
     fun r  ->
       match uu____3754 with | (e,msg) -> FStar_Exn.raise (Error (e, msg, r))
-  
-let raise_err :
+let raise_err:
   'Auu____3764 .
     (raw_error,Prims.string) FStar_Pervasives_Native.tuple2 -> 'Auu____3764
   =
   fun uu____3772  ->
     match uu____3772 with | (e,msg) -> FStar_Exn.raise (Err (e, msg))
-  
-let (update_flags :
-  (flag,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list -> Prims.unit)
+let update_flags:
+  (flag,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list -> Prims.unit
   =
   fun l  ->
     let compare1 uu____3815 uu____3816 =
       match (uu____3815, uu____3816) with
       | ((uu____3849,(a,uu____3851)),(uu____3852,(b,uu____3854))) ->
           if a > b
-          then (Prims.parse_int "1")
-          else
-            if a < b then ~- (Prims.parse_int "1") else (Prims.parse_int "0")
-       in
+          then Prims.parse_int "1"
+          else if a < b then - (Prims.parse_int "1") else Prims.parse_int "0" in
     let set_one_flag f d =
       match (f, d) with
       | (CWarning ,CError ) ->
@@ -2814,46 +2453,43 @@ let (update_flags :
           raise_err
             (Fatal_InvalidWarnErrorSetting,
               "cannot reset the error level of a fatal error")
-      | uu____3889 -> f  in
+      | uu____3889 -> f in
     let rec set_flag i l1 =
       let d =
-        let uu____3922 = FStar_ST.op_Bang flags  in
-        FStar_List.nth uu____3922 i  in
+        let uu____3922 = FStar_ST.op_Bang flags in
+        FStar_List.nth uu____3922 i in
       match l1 with
       | [] -> d
       | (f,(l2,h))::tl1 ->
           if (i >= l2) && (i <= h)
           then set_one_flag f d
-          else if i < l2 then d else set_flag i tl1
-       in
+          else if i < l2 then d else set_flag i tl1 in
     let rec aux f i l1 sorted1 =
       match l1 with
       | [] -> f
       | hd1::tl1 ->
           let uu____4033 =
             let uu____4036 =
-              let uu____4039 = set_flag i sorted1  in [uu____4039]  in
-            FStar_List.append f uu____4036  in
-          aux uu____4033 (i + (Prims.parse_int "1")) tl1 sorted1
-       in
+              let uu____4039 = set_flag i sorted1 in [uu____4039] in
+            FStar_List.append f uu____4036 in
+          aux uu____4033 (i + (Prims.parse_int "1")) tl1 sorted1 in
     let rec compute_range result l1 =
       match l1 with
       | [] -> result
       | (f,s)::tl1 ->
-          let r = FStar_Util.split s ".."  in
+          let r = FStar_Util.split s ".." in
           let uu____4119 =
             match r with
             | r1::r2::[] ->
-                let uu____4130 = FStar_Util.int_of_string r1  in
-                let uu____4131 = FStar_Util.int_of_string r2  in
+                let uu____4130 = FStar_Util.int_of_string r1 in
+                let uu____4131 = FStar_Util.int_of_string r2 in
                 (uu____4130, uu____4131)
             | uu____4132 ->
                 let uu____4135 =
                   let uu____4140 =
-                    FStar_Util.format1 "Malformed warn-error range %s" s  in
-                  (Fatal_InvalidWarnErrorSetting, uu____4140)  in
-                raise_err uu____4135
-             in
+                    FStar_Util.format1 "Malformed warn-error range %s" s in
+                  (Fatal_InvalidWarnErrorSetting, uu____4140) in
+                raise_err uu____4135 in
           (match uu____4119 with
            | (l2,h) ->
                (if
@@ -2862,20 +2498,17 @@ let (update_flags :
                 then
                   (let uu____4162 =
                      let uu____4167 =
-                       let uu____4168 = FStar_Util.string_of_int l2  in
-                       let uu____4169 = FStar_Util.string_of_int h  in
+                       let uu____4168 = FStar_Util.string_of_int l2 in
+                       let uu____4169 = FStar_Util.string_of_int h in
                        FStar_Util.format2 "No error for warn_error %s..%s"
-                         uu____4168 uu____4169
-                        in
-                     (Fatal_InvalidWarnErrorSetting, uu____4167)  in
+                         uu____4168 uu____4169 in
+                     (Fatal_InvalidWarnErrorSetting, uu____4167) in
                    raise_err uu____4162)
                 else ();
-                compute_range (FStar_List.append result [(f, (l2, h))]) tl1))
-       in
-    let range = compute_range [] l  in
-    let sorted1 = FStar_List.sortWith compare1 range  in
+                compute_range (FStar_List.append result [(f, (l2, h))]) tl1)) in
+    let range = compute_range [] l in
+    let sorted1 = FStar_List.sortWith compare1 range in
     let uu____4237 =
-      let uu____4240 = FStar_ST.op_Bang flags  in
-      aux [] (Prims.parse_int "0") uu____4240 sorted1  in
+      let uu____4240 = FStar_ST.op_Bang flags in
+      aux [] (Prims.parse_int "0") uu____4240 sorted1 in
     FStar_ST.op_Colon_Equals flags uu____4237
-  

--- a/src/ocaml-output/FStar_Extraction_Kremlin.ml
+++ b/src/ocaml-output/FStar_Extraction_Kremlin.ml
@@ -3,27 +3,27 @@ type decl =
   | DGlobal of
   (flag Prims.list,(Prims.string Prims.list,Prims.string)
                      FStar_Pervasives_Native.tuple2,Prims.int,typ,expr)
-  FStar_Pervasives_Native.tuple5 
+  FStar_Pervasives_Native.tuple5
   | DFunction of
   (cc FStar_Pervasives_Native.option,flag Prims.list,Prims.int,typ,(Prims.string
                                                                     Prims.list,
                                                                     Prims.string)
                                                                     FStar_Pervasives_Native.tuple2,
-  binder Prims.list,expr) FStar_Pervasives_Native.tuple7 
+  binder Prims.list,expr) FStar_Pervasives_Native.tuple7
   | DTypeAlias of
   ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
-  flag Prims.list,Prims.int,typ) FStar_Pervasives_Native.tuple4 
+  flag Prims.list,Prims.int,typ) FStar_Pervasives_Native.tuple4
   | DTypeFlat of
   ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
   flag Prims.list,Prims.int,(Prims.string,(typ,Prims.bool)
                                             FStar_Pervasives_Native.tuple2)
                               FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple4 
+  FStar_Pervasives_Native.tuple4
   | DExternal of
   (cc FStar_Pervasives_Native.option,flag Prims.list,(Prims.string Prims.list,
                                                        Prims.string)
                                                        FStar_Pervasives_Native.tuple2,
-  typ) FStar_Pervasives_Native.tuple4 
+  typ) FStar_Pervasives_Native.tuple4
   | DTypeVariant of
   ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
   flag Prims.list,Prims.int,(Prims.string,(Prims.string,(typ,Prims.bool)
@@ -31,189 +31,182 @@ type decl =
                                             FStar_Pervasives_Native.tuple2
                                             Prims.list)
                               FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple4 [@@deriving show]
+  FStar_Pervasives_Native.tuple4[@@deriving show]
 and cc =
-  | StdCall 
-  | CDecl 
-  | FastCall [@@deriving show]
+  | StdCall
+  | CDecl
+  | FastCall[@@deriving show]
 and flag =
-  | Private 
-  | WipeBody 
-  | CInline 
-  | Substitute 
-  | GCType 
-  | Comment of Prims.string 
-  | MustDisappear [@@deriving show]
+  | Private
+  | WipeBody
+  | CInline
+  | Substitute
+  | GCType
+  | Comment of Prims.string
+  | MustDisappear[@@deriving show]
 and lifetime =
-  | Eternal 
-  | Stack 
-  | ManuallyManaged [@@deriving show]
+  | Eternal
+  | Stack
+  | ManuallyManaged[@@deriving show]
 and expr =
-  | EBound of Prims.int 
+  | EBound of Prims.int
   | EQualified of (Prims.string Prims.list,Prims.string)
-  FStar_Pervasives_Native.tuple2 
-  | EConstant of (width,Prims.string) FStar_Pervasives_Native.tuple2 
-  | EUnit 
-  | EApp of (expr,expr Prims.list) FStar_Pervasives_Native.tuple2 
-  | ETypApp of (expr,typ Prims.list) FStar_Pervasives_Native.tuple2 
-  | ELet of (binder,expr,expr) FStar_Pervasives_Native.tuple3 
-  | EIfThenElse of (expr,expr,expr) FStar_Pervasives_Native.tuple3 
-  | ESequence of expr Prims.list 
-  | EAssign of (expr,expr) FStar_Pervasives_Native.tuple2 
-  | EBufCreate of (lifetime,expr,expr) FStar_Pervasives_Native.tuple3 
-  | EBufRead of (expr,expr) FStar_Pervasives_Native.tuple2 
-  | EBufWrite of (expr,expr,expr) FStar_Pervasives_Native.tuple3 
-  | EBufSub of (expr,expr) FStar_Pervasives_Native.tuple2 
-  | EBufBlit of (expr,expr,expr,expr,expr) FStar_Pervasives_Native.tuple5 
+  FStar_Pervasives_Native.tuple2
+  | EConstant of (width,Prims.string) FStar_Pervasives_Native.tuple2
+  | EUnit
+  | EApp of (expr,expr Prims.list) FStar_Pervasives_Native.tuple2
+  | ETypApp of (expr,typ Prims.list) FStar_Pervasives_Native.tuple2
+  | ELet of (binder,expr,expr) FStar_Pervasives_Native.tuple3
+  | EIfThenElse of (expr,expr,expr) FStar_Pervasives_Native.tuple3
+  | ESequence of expr Prims.list
+  | EAssign of (expr,expr) FStar_Pervasives_Native.tuple2
+  | EBufCreate of (lifetime,expr,expr) FStar_Pervasives_Native.tuple3
+  | EBufRead of (expr,expr) FStar_Pervasives_Native.tuple2
+  | EBufWrite of (expr,expr,expr) FStar_Pervasives_Native.tuple3
+  | EBufSub of (expr,expr) FStar_Pervasives_Native.tuple2
+  | EBufBlit of (expr,expr,expr,expr,expr) FStar_Pervasives_Native.tuple5
   | EMatch of (expr,(pattern,expr) FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | EOp of (op,width) FStar_Pervasives_Native.tuple2 
-  | ECast of (expr,typ) FStar_Pervasives_Native.tuple2 
-  | EPushFrame 
-  | EPopFrame 
-  | EBool of Prims.bool 
-  | EAny 
-  | EAbort 
-  | EReturn of expr 
+  FStar_Pervasives_Native.tuple2
+  | EOp of (op,width) FStar_Pervasives_Native.tuple2
+  | ECast of (expr,typ) FStar_Pervasives_Native.tuple2
+  | EPushFrame
+  | EPopFrame
+  | EBool of Prims.bool
+  | EAny
+  | EAbort
+  | EReturn of expr
   | EFlat of
   (typ,(Prims.string,expr) FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | EField of (typ,expr,Prims.string) FStar_Pervasives_Native.tuple3 
-  | EWhile of (expr,expr) FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
+  | EField of (typ,expr,Prims.string) FStar_Pervasives_Native.tuple3
+  | EWhile of (expr,expr) FStar_Pervasives_Native.tuple2
   | EBufCreateL of (lifetime,expr Prims.list) FStar_Pervasives_Native.tuple2
-  
-  | ETuple of expr Prims.list 
+  | ETuple of expr Prims.list
   | ECons of (typ,Prims.string,expr Prims.list)
-  FStar_Pervasives_Native.tuple3 
-  | EBufFill of (expr,expr,expr) FStar_Pervasives_Native.tuple3 
-  | EString of Prims.string 
-  | EFun of (binder Prims.list,expr,typ) FStar_Pervasives_Native.tuple3 
-  | EAbortS of Prims.string 
-  | EBufFree of expr [@@deriving show]
+  FStar_Pervasives_Native.tuple3
+  | EBufFill of (expr,expr,expr) FStar_Pervasives_Native.tuple3
+  | EString of Prims.string
+  | EFun of (binder Prims.list,expr,typ) FStar_Pervasives_Native.tuple3
+  | EAbortS of Prims.string
+  | EBufFree of expr[@@deriving show]
 and op =
-  | Add 
-  | AddW 
-  | Sub 
-  | SubW 
-  | Div 
-  | DivW 
-  | Mult 
-  | MultW 
-  | Mod 
-  | BOr 
-  | BAnd 
-  | BXor 
-  | BShiftL 
-  | BShiftR 
-  | BNot 
-  | Eq 
-  | Neq 
-  | Lt 
-  | Lte 
-  | Gt 
-  | Gte 
-  | And 
-  | Or 
-  | Xor 
-  | Not [@@deriving show]
+  | Add
+  | AddW
+  | Sub
+  | SubW
+  | Div
+  | DivW
+  | Mult
+  | MultW
+  | Mod
+  | BOr
+  | BAnd
+  | BXor
+  | BShiftL
+  | BShiftR
+  | BNot
+  | Eq
+  | Neq
+  | Lt
+  | Lte
+  | Gt
+  | Gte
+  | And
+  | Or
+  | Xor
+  | Not[@@deriving show]
 and pattern =
-  | PUnit 
-  | PBool of Prims.bool 
-  | PVar of binder 
-  | PCons of (Prims.string,pattern Prims.list) FStar_Pervasives_Native.tuple2
-  
-  | PTuple of pattern Prims.list 
+  | PUnit
+  | PBool of Prims.bool
+  | PVar of binder
+  | PCons of (Prims.string,pattern Prims.list)
+  FStar_Pervasives_Native.tuple2
+  | PTuple of pattern Prims.list
   | PRecord of (Prims.string,pattern) FStar_Pervasives_Native.tuple2
-  Prims.list 
-  | PConstant of (width,Prims.string) FStar_Pervasives_Native.tuple2 
-[@@deriving show]
+  Prims.list
+  | PConstant of (width,Prims.string) FStar_Pervasives_Native.tuple2[@@deriving
+                                                                    show]
 and width =
-  | UInt8 
-  | UInt16 
-  | UInt32 
-  | UInt64 
-  | Int8 
-  | Int16 
-  | Int32 
-  | Int64 
-  | Bool 
-  | CInt [@@deriving show]
+  | UInt8
+  | UInt16
+  | UInt32
+  | UInt64
+  | Int8
+  | Int16
+  | Int32
+  | Int64
+  | Bool
+  | CInt[@@deriving show]
 and binder = {
-  name: Prims.string ;
-  typ: typ ;
-  mut: Prims.bool }[@@deriving show]
+  name: Prims.string;
+  typ: typ;
+  mut: Prims.bool;}[@@deriving show]
 and typ =
-  | TInt of width 
-  | TBuf of typ 
-  | TUnit 
+  | TInt of width
+  | TBuf of typ
+  | TUnit
   | TQualified of (Prims.string Prims.list,Prims.string)
-  FStar_Pervasives_Native.tuple2 
-  | TBool 
-  | TAny 
-  | TArrow of (typ,typ) FStar_Pervasives_Native.tuple2 
-  | TBound of Prims.int 
+  FStar_Pervasives_Native.tuple2
+  | TBool
+  | TAny
+  | TArrow of (typ,typ) FStar_Pervasives_Native.tuple2
+  | TBound of Prims.int
   | TApp of
   ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
-  typ Prims.list) FStar_Pervasives_Native.tuple2 
-  | TTuple of typ Prims.list [@@deriving show]
-let (uu___is_DGlobal : decl -> Prims.bool) =
+  typ Prims.list) FStar_Pervasives_Native.tuple2
+  | TTuple of typ Prims.list[@@deriving show]
+let uu___is_DGlobal: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DGlobal _0 -> true | uu____551 -> false
-  
-let (__proj__DGlobal__item___0 :
+let __proj__DGlobal__item___0:
   decl ->
     (flag Prims.list,(Prims.string Prims.list,Prims.string)
                        FStar_Pervasives_Native.tuple2,Prims.int,typ,expr)
-      FStar_Pervasives_Native.tuple5)
-  = fun projectee  -> match projectee with | DGlobal _0 -> _0 
-let (uu___is_DFunction : decl -> Prims.bool) =
+      FStar_Pervasives_Native.tuple5
+  = fun projectee  -> match projectee with | DGlobal _0 -> _0
+let uu___is_DFunction: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DFunction _0 -> true | uu____643 -> false
-  
-let (__proj__DFunction__item___0 :
+let __proj__DFunction__item___0:
   decl ->
     (cc FStar_Pervasives_Native.option,flag Prims.list,Prims.int,typ,
       (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
-      binder Prims.list,expr) FStar_Pervasives_Native.tuple7)
-  = fun projectee  -> match projectee with | DFunction _0 -> _0 
-let (uu___is_DTypeAlias : decl -> Prims.bool) =
+      binder Prims.list,expr) FStar_Pervasives_Native.tuple7
+  = fun projectee  -> match projectee with | DFunction _0 -> _0
+let uu___is_DTypeAlias: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DTypeAlias _0 -> true | uu____749 -> false
-  
-let (__proj__DTypeAlias__item___0 :
+let __proj__DTypeAlias__item___0:
   decl ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
-      flag Prims.list,Prims.int,typ) FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | DTypeAlias _0 -> _0 
-let (uu___is_DTypeFlat : decl -> Prims.bool) =
+      flag Prims.list,Prims.int,typ) FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | DTypeAlias _0 -> _0
+let uu___is_DTypeFlat: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DTypeFlat _0 -> true | uu____835 -> false
-  
-let (__proj__DTypeFlat__item___0 :
+let __proj__DTypeFlat__item___0:
   decl ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
       flag Prims.list,Prims.int,(Prims.string,(typ,Prims.bool)
                                                 FStar_Pervasives_Native.tuple2)
                                   FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | DTypeFlat _0 -> _0 
-let (uu___is_DExternal : decl -> Prims.bool) =
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | DTypeFlat _0 -> _0
+let uu___is_DExternal: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DExternal _0 -> true | uu____943 -> false
-  
-let (__proj__DExternal__item___0 :
+let __proj__DExternal__item___0:
   decl ->
     (cc FStar_Pervasives_Native.option,flag Prims.list,(Prims.string
                                                           Prims.list,
                                                          Prims.string)
                                                          FStar_Pervasives_Native.tuple2,
-      typ) FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | DExternal _0 -> _0 
-let (uu___is_DTypeVariant : decl -> Prims.bool) =
+      typ) FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | DExternal _0 -> _0
+let uu___is_DTypeVariant: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DTypeVariant _0 -> true | uu____1041 -> false
-  
-let (__proj__DTypeVariant__item___0 :
+let __proj__DTypeVariant__item___0:
   decl ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
       flag Prims.list,Prims.int,(Prims.string,(Prims.string,(typ,Prims.bool)
@@ -221,520 +214,430 @@ let (__proj__DTypeVariant__item___0 :
                                                 FStar_Pervasives_Native.tuple2
                                                 Prims.list)
                                   FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | DTypeVariant _0 -> _0 
-let (uu___is_StdCall : cc -> Prims.bool) =
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | DTypeVariant _0 -> _0
+let uu___is_StdCall: cc -> Prims.bool =
   fun projectee  ->
     match projectee with | StdCall  -> true | uu____1148 -> false
-  
-let (uu___is_CDecl : cc -> Prims.bool) =
+let uu___is_CDecl: cc -> Prims.bool =
   fun projectee  ->
     match projectee with | CDecl  -> true | uu____1152 -> false
-  
-let (uu___is_FastCall : cc -> Prims.bool) =
+let uu___is_FastCall: cc -> Prims.bool =
   fun projectee  ->
     match projectee with | FastCall  -> true | uu____1156 -> false
-  
-let (uu___is_Private : flag -> Prims.bool) =
+let uu___is_Private: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | Private  -> true | uu____1160 -> false
-  
-let (uu___is_WipeBody : flag -> Prims.bool) =
+let uu___is_WipeBody: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | WipeBody  -> true | uu____1164 -> false
-  
-let (uu___is_CInline : flag -> Prims.bool) =
+let uu___is_CInline: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | CInline  -> true | uu____1168 -> false
-  
-let (uu___is_Substitute : flag -> Prims.bool) =
+let uu___is_Substitute: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | Substitute  -> true | uu____1172 -> false
-  
-let (uu___is_GCType : flag -> Prims.bool) =
+let uu___is_GCType: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | GCType  -> true | uu____1176 -> false
-  
-let (uu___is_Comment : flag -> Prims.bool) =
+let uu___is_Comment: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | Comment _0 -> true | uu____1181 -> false
-  
-let (__proj__Comment__item___0 : flag -> Prims.string) =
-  fun projectee  -> match projectee with | Comment _0 -> _0 
-let (uu___is_MustDisappear : flag -> Prims.bool) =
+let __proj__Comment__item___0: flag -> Prims.string =
+  fun projectee  -> match projectee with | Comment _0 -> _0
+let uu___is_MustDisappear: flag -> Prims.bool =
   fun projectee  ->
     match projectee with | MustDisappear  -> true | uu____1192 -> false
-  
-let (uu___is_Eternal : lifetime -> Prims.bool) =
+let uu___is_Eternal: lifetime -> Prims.bool =
   fun projectee  ->
     match projectee with | Eternal  -> true | uu____1196 -> false
-  
-let (uu___is_Stack : lifetime -> Prims.bool) =
+let uu___is_Stack: lifetime -> Prims.bool =
   fun projectee  ->
     match projectee with | Stack  -> true | uu____1200 -> false
-  
-let (uu___is_ManuallyManaged : lifetime -> Prims.bool) =
+let uu___is_ManuallyManaged: lifetime -> Prims.bool =
   fun projectee  ->
     match projectee with | ManuallyManaged  -> true | uu____1204 -> false
-  
-let (uu___is_EBound : expr -> Prims.bool) =
+let uu___is_EBound: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBound _0 -> true | uu____1209 -> false
-  
-let (__proj__EBound__item___0 : expr -> Prims.int) =
-  fun projectee  -> match projectee with | EBound _0 -> _0 
-let (uu___is_EQualified : expr -> Prims.bool) =
+let __proj__EBound__item___0: expr -> Prims.int =
+  fun projectee  -> match projectee with | EBound _0 -> _0
+let uu___is_EQualified: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EQualified _0 -> true | uu____1227 -> false
-  
-let (__proj__EQualified__item___0 :
+let __proj__EQualified__item___0:
   expr ->
-    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | EQualified _0 -> _0 
-let (uu___is_EConstant : expr -> Prims.bool) =
+    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | EQualified _0 -> _0
+let uu___is_EConstant: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EConstant _0 -> true | uu____1261 -> false
-  
-let (__proj__EConstant__item___0 :
-  expr -> (width,Prims.string) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | EConstant _0 -> _0 
-let (uu___is_EUnit : expr -> Prims.bool) =
+let __proj__EConstant__item___0:
+  expr -> (width,Prims.string) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | EConstant _0 -> _0
+let uu___is_EUnit: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EUnit  -> true | uu____1284 -> false
-  
-let (uu___is_EApp : expr -> Prims.bool) =
+let uu___is_EApp: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EApp _0 -> true | uu____1295 -> false
-  
-let (__proj__EApp__item___0 :
-  expr -> (expr,expr Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | EApp _0 -> _0 
-let (uu___is_ETypApp : expr -> Prims.bool) =
+let __proj__EApp__item___0:
+  expr -> (expr,expr Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | EApp _0 -> _0
+let uu___is_ETypApp: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | ETypApp _0 -> true | uu____1331 -> false
-  
-let (__proj__ETypApp__item___0 :
-  expr -> (expr,typ Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | ETypApp _0 -> _0 
-let (uu___is_ELet : expr -> Prims.bool) =
+let __proj__ETypApp__item___0:
+  expr -> (expr,typ Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | ETypApp _0 -> _0
+let uu___is_ELet: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | ELet _0 -> true | uu____1367 -> false
-  
-let (__proj__ELet__item___0 :
-  expr -> (binder,expr,expr) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | ELet _0 -> _0 
-let (uu___is_EIfThenElse : expr -> Prims.bool) =
+let __proj__ELet__item___0:
+  expr -> (binder,expr,expr) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | ELet _0 -> _0
+let uu___is_EIfThenElse: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EIfThenElse _0 -> true | uu____1403 -> false
-  
-let (__proj__EIfThenElse__item___0 :
-  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | EIfThenElse _0 -> _0 
-let (uu___is_ESequence : expr -> Prims.bool) =
+let __proj__EIfThenElse__item___0:
+  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | EIfThenElse _0 -> _0
+let uu___is_ESequence: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | ESequence _0 -> true | uu____1435 -> false
-  
-let (__proj__ESequence__item___0 : expr -> expr Prims.list) =
-  fun projectee  -> match projectee with | ESequence _0 -> _0 
-let (uu___is_EAssign : expr -> Prims.bool) =
+let __proj__ESequence__item___0: expr -> expr Prims.list =
+  fun projectee  -> match projectee with | ESequence _0 -> _0
+let uu___is_EAssign: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EAssign _0 -> true | uu____1457 -> false
-  
-let (__proj__EAssign__item___0 :
-  expr -> (expr,expr) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | EAssign _0 -> _0 
-let (uu___is_EBufCreate : expr -> Prims.bool) =
+let __proj__EAssign__item___0:
+  expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | EAssign _0 -> _0
+let uu___is_EBufCreate: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBufCreate _0 -> true | uu____1487 -> false
-  
-let (__proj__EBufCreate__item___0 :
-  expr -> (lifetime,expr,expr) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | EBufCreate _0 -> _0 
-let (uu___is_EBufRead : expr -> Prims.bool) =
+let __proj__EBufCreate__item___0:
+  expr -> (lifetime,expr,expr) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | EBufCreate _0 -> _0
+let uu___is_EBufRead: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBufRead _0 -> true | uu____1521 -> false
-  
-let (__proj__EBufRead__item___0 :
-  expr -> (expr,expr) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | EBufRead _0 -> _0 
-let (uu___is_EBufWrite : expr -> Prims.bool) =
+let __proj__EBufRead__item___0:
+  expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | EBufRead _0 -> _0
+let uu___is_EBufWrite: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBufWrite _0 -> true | uu____1551 -> false
-  
-let (__proj__EBufWrite__item___0 :
-  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | EBufWrite _0 -> _0 
-let (uu___is_EBufSub : expr -> Prims.bool) =
+let __proj__EBufWrite__item___0:
+  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | EBufWrite _0 -> _0
+let uu___is_EBufSub: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBufSub _0 -> true | uu____1585 -> false
-  
-let (__proj__EBufSub__item___0 :
-  expr -> (expr,expr) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | EBufSub _0 -> _0 
-let (uu___is_EBufBlit : expr -> Prims.bool) =
+let __proj__EBufSub__item___0:
+  expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | EBufSub _0 -> _0
+let uu___is_EBufBlit: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBufBlit _0 -> true | uu____1619 -> false
-  
-let (__proj__EBufBlit__item___0 :
-  expr -> (expr,expr,expr,expr,expr) FStar_Pervasives_Native.tuple5) =
-  fun projectee  -> match projectee with | EBufBlit _0 -> _0 
-let (uu___is_EMatch : expr -> Prims.bool) =
+let __proj__EBufBlit__item___0:
+  expr -> (expr,expr,expr,expr,expr) FStar_Pervasives_Native.tuple5 =
+  fun projectee  -> match projectee with | EBufBlit _0 -> _0
+let uu___is_EMatch: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EMatch _0 -> true | uu____1671 -> false
-  
-let (__proj__EMatch__item___0 :
+let __proj__EMatch__item___0:
   expr ->
     (expr,(pattern,expr) FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | EMatch _0 -> _0 
-let (uu___is_EOp : expr -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | EMatch _0 -> _0
+let uu___is_EOp: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EOp _0 -> true | uu____1717 -> false
-  
-let (__proj__EOp__item___0 :
-  expr -> (op,width) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | EOp _0 -> _0 
-let (uu___is_ECast : expr -> Prims.bool) =
+let __proj__EOp__item___0: expr -> (op,width) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | EOp _0 -> _0
+let uu___is_ECast: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | ECast _0 -> true | uu____1745 -> false
-  
-let (__proj__ECast__item___0 :
-  expr -> (expr,typ) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | ECast _0 -> _0 
-let (uu___is_EPushFrame : expr -> Prims.bool) =
+let __proj__ECast__item___0:
+  expr -> (expr,typ) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | ECast _0 -> _0
+let uu___is_EPushFrame: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EPushFrame  -> true | uu____1768 -> false
-  
-let (uu___is_EPopFrame : expr -> Prims.bool) =
+let uu___is_EPopFrame: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EPopFrame  -> true | uu____1772 -> false
-  
-let (uu___is_EBool : expr -> Prims.bool) =
+let uu___is_EBool: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBool _0 -> true | uu____1777 -> false
-  
-let (__proj__EBool__item___0 : expr -> Prims.bool) =
-  fun projectee  -> match projectee with | EBool _0 -> _0 
-let (uu___is_EAny : expr -> Prims.bool) =
+let __proj__EBool__item___0: expr -> Prims.bool =
+  fun projectee  -> match projectee with | EBool _0 -> _0
+let uu___is_EAny: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EAny  -> true | uu____1788 -> false
-  
-let (uu___is_EAbort : expr -> Prims.bool) =
+let uu___is_EAbort: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EAbort  -> true | uu____1792 -> false
-  
-let (uu___is_EReturn : expr -> Prims.bool) =
+let uu___is_EReturn: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EReturn _0 -> true | uu____1797 -> false
-  
-let (__proj__EReturn__item___0 : expr -> expr) =
-  fun projectee  -> match projectee with | EReturn _0 -> _0 
-let (uu___is_EFlat : expr -> Prims.bool) =
+let __proj__EReturn__item___0: expr -> expr =
+  fun projectee  -> match projectee with | EReturn _0 -> _0
+let uu___is_EFlat: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EFlat _0 -> true | uu____1819 -> false
-  
-let (__proj__EFlat__item___0 :
+let __proj__EFlat__item___0:
   expr ->
     (typ,(Prims.string,expr) FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | EFlat _0 -> _0 
-let (uu___is_EField : expr -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | EFlat _0 -> _0
+let uu___is_EField: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EField _0 -> true | uu____1867 -> false
-  
-let (__proj__EField__item___0 :
-  expr -> (typ,expr,Prims.string) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | EField _0 -> _0 
-let (uu___is_EWhile : expr -> Prims.bool) =
+let __proj__EField__item___0:
+  expr -> (typ,expr,Prims.string) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | EField _0 -> _0
+let uu___is_EWhile: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EWhile _0 -> true | uu____1901 -> false
-  
-let (__proj__EWhile__item___0 :
-  expr -> (expr,expr) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | EWhile _0 -> _0 
-let (uu___is_EBufCreateL : expr -> Prims.bool) =
+let __proj__EWhile__item___0:
+  expr -> (expr,expr) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | EWhile _0 -> _0
+let uu___is_EBufCreateL: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBufCreateL _0 -> true | uu____1931 -> false
-  
-let (__proj__EBufCreateL__item___0 :
-  expr -> (lifetime,expr Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | EBufCreateL _0 -> _0 
-let (uu___is_ETuple : expr -> Prims.bool) =
+let __proj__EBufCreateL__item___0:
+  expr -> (lifetime,expr Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | EBufCreateL _0 -> _0
+let uu___is_ETuple: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | ETuple _0 -> true | uu____1963 -> false
-  
-let (__proj__ETuple__item___0 : expr -> expr Prims.list) =
-  fun projectee  -> match projectee with | ETuple _0 -> _0 
-let (uu___is_ECons : expr -> Prims.bool) =
+let __proj__ETuple__item___0: expr -> expr Prims.list =
+  fun projectee  -> match projectee with | ETuple _0 -> _0
+let uu___is_ECons: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | ECons _0 -> true | uu____1989 -> false
-  
-let (__proj__ECons__item___0 :
-  expr -> (typ,Prims.string,expr Prims.list) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | ECons _0 -> _0 
-let (uu___is_EBufFill : expr -> Prims.bool) =
+let __proj__ECons__item___0:
+  expr -> (typ,Prims.string,expr Prims.list) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | ECons _0 -> _0
+let uu___is_EBufFill: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBufFill _0 -> true | uu____2031 -> false
-  
-let (__proj__EBufFill__item___0 :
-  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | EBufFill _0 -> _0 
-let (uu___is_EString : expr -> Prims.bool) =
+let __proj__EBufFill__item___0:
+  expr -> (expr,expr,expr) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | EBufFill _0 -> _0
+let uu___is_EString: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EString _0 -> true | uu____2061 -> false
-  
-let (__proj__EString__item___0 : expr -> Prims.string) =
-  fun projectee  -> match projectee with | EString _0 -> _0 
-let (uu___is_EFun : expr -> Prims.bool) =
+let __proj__EString__item___0: expr -> Prims.string =
+  fun projectee  -> match projectee with | EString _0 -> _0
+let uu___is_EFun: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EFun _0 -> true | uu____2081 -> false
-  
-let (__proj__EFun__item___0 :
-  expr -> (binder Prims.list,expr,typ) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | EFun _0 -> _0 
-let (uu___is_EAbortS : expr -> Prims.bool) =
+let __proj__EFun__item___0:
+  expr -> (binder Prims.list,expr,typ) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | EFun _0 -> _0
+let uu___is_EAbortS: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EAbortS _0 -> true | uu____2117 -> false
-  
-let (__proj__EAbortS__item___0 : expr -> Prims.string) =
-  fun projectee  -> match projectee with | EAbortS _0 -> _0 
-let (uu___is_EBufFree : expr -> Prims.bool) =
+let __proj__EAbortS__item___0: expr -> Prims.string =
+  fun projectee  -> match projectee with | EAbortS _0 -> _0
+let uu___is_EBufFree: expr -> Prims.bool =
   fun projectee  ->
     match projectee with | EBufFree _0 -> true | uu____2129 -> false
-  
-let (__proj__EBufFree__item___0 : expr -> expr) =
-  fun projectee  -> match projectee with | EBufFree _0 -> _0 
-let (uu___is_Add : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Add  -> true | uu____2140 -> false 
-let (uu___is_AddW : op -> Prims.bool) =
+let __proj__EBufFree__item___0: expr -> expr =
+  fun projectee  -> match projectee with | EBufFree _0 -> _0
+let uu___is_Add: op -> Prims.bool =
+  fun projectee  -> match projectee with | Add  -> true | uu____2140 -> false
+let uu___is_AddW: op -> Prims.bool =
   fun projectee  ->
     match projectee with | AddW  -> true | uu____2144 -> false
-  
-let (uu___is_Sub : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Sub  -> true | uu____2148 -> false 
-let (uu___is_SubW : op -> Prims.bool) =
+let uu___is_Sub: op -> Prims.bool =
+  fun projectee  -> match projectee with | Sub  -> true | uu____2148 -> false
+let uu___is_SubW: op -> Prims.bool =
   fun projectee  ->
     match projectee with | SubW  -> true | uu____2152 -> false
-  
-let (uu___is_Div : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Div  -> true | uu____2156 -> false 
-let (uu___is_DivW : op -> Prims.bool) =
+let uu___is_Div: op -> Prims.bool =
+  fun projectee  -> match projectee with | Div  -> true | uu____2156 -> false
+let uu___is_DivW: op -> Prims.bool =
   fun projectee  ->
     match projectee with | DivW  -> true | uu____2160 -> false
-  
-let (uu___is_Mult : op -> Prims.bool) =
+let uu___is_Mult: op -> Prims.bool =
   fun projectee  ->
     match projectee with | Mult  -> true | uu____2164 -> false
-  
-let (uu___is_MultW : op -> Prims.bool) =
+let uu___is_MultW: op -> Prims.bool =
   fun projectee  ->
     match projectee with | MultW  -> true | uu____2168 -> false
-  
-let (uu___is_Mod : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Mod  -> true | uu____2172 -> false 
-let (uu___is_BOr : op -> Prims.bool) =
-  fun projectee  -> match projectee with | BOr  -> true | uu____2176 -> false 
-let (uu___is_BAnd : op -> Prims.bool) =
+let uu___is_Mod: op -> Prims.bool =
+  fun projectee  -> match projectee with | Mod  -> true | uu____2172 -> false
+let uu___is_BOr: op -> Prims.bool =
+  fun projectee  -> match projectee with | BOr  -> true | uu____2176 -> false
+let uu___is_BAnd: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BAnd  -> true | uu____2180 -> false
-  
-let (uu___is_BXor : op -> Prims.bool) =
+let uu___is_BXor: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BXor  -> true | uu____2184 -> false
-  
-let (uu___is_BShiftL : op -> Prims.bool) =
+let uu___is_BShiftL: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BShiftL  -> true | uu____2188 -> false
-  
-let (uu___is_BShiftR : op -> Prims.bool) =
+let uu___is_BShiftR: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BShiftR  -> true | uu____2192 -> false
-  
-let (uu___is_BNot : op -> Prims.bool) =
+let uu___is_BNot: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BNot  -> true | uu____2196 -> false
-  
-let (uu___is_Eq : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Eq  -> true | uu____2200 -> false 
-let (uu___is_Neq : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Neq  -> true | uu____2204 -> false 
-let (uu___is_Lt : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Lt  -> true | uu____2208 -> false 
-let (uu___is_Lte : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Lte  -> true | uu____2212 -> false 
-let (uu___is_Gt : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Gt  -> true | uu____2216 -> false 
-let (uu___is_Gte : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Gte  -> true | uu____2220 -> false 
-let (uu___is_And : op -> Prims.bool) =
-  fun projectee  -> match projectee with | And  -> true | uu____2224 -> false 
-let (uu___is_Or : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Or  -> true | uu____2228 -> false 
-let (uu___is_Xor : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Xor  -> true | uu____2232 -> false 
-let (uu___is_Not : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Not  -> true | uu____2236 -> false 
-let (uu___is_PUnit : pattern -> Prims.bool) =
+let uu___is_Eq: op -> Prims.bool =
+  fun projectee  -> match projectee with | Eq  -> true | uu____2200 -> false
+let uu___is_Neq: op -> Prims.bool =
+  fun projectee  -> match projectee with | Neq  -> true | uu____2204 -> false
+let uu___is_Lt: op -> Prims.bool =
+  fun projectee  -> match projectee with | Lt  -> true | uu____2208 -> false
+let uu___is_Lte: op -> Prims.bool =
+  fun projectee  -> match projectee with | Lte  -> true | uu____2212 -> false
+let uu___is_Gt: op -> Prims.bool =
+  fun projectee  -> match projectee with | Gt  -> true | uu____2216 -> false
+let uu___is_Gte: op -> Prims.bool =
+  fun projectee  -> match projectee with | Gte  -> true | uu____2220 -> false
+let uu___is_And: op -> Prims.bool =
+  fun projectee  -> match projectee with | And  -> true | uu____2224 -> false
+let uu___is_Or: op -> Prims.bool =
+  fun projectee  -> match projectee with | Or  -> true | uu____2228 -> false
+let uu___is_Xor: op -> Prims.bool =
+  fun projectee  -> match projectee with | Xor  -> true | uu____2232 -> false
+let uu___is_Not: op -> Prims.bool =
+  fun projectee  -> match projectee with | Not  -> true | uu____2236 -> false
+let uu___is_PUnit: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | PUnit  -> true | uu____2240 -> false
-  
-let (uu___is_PBool : pattern -> Prims.bool) =
+let uu___is_PBool: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | PBool _0 -> true | uu____2245 -> false
-  
-let (__proj__PBool__item___0 : pattern -> Prims.bool) =
-  fun projectee  -> match projectee with | PBool _0 -> _0 
-let (uu___is_PVar : pattern -> Prims.bool) =
+let __proj__PBool__item___0: pattern -> Prims.bool =
+  fun projectee  -> match projectee with | PBool _0 -> _0
+let uu___is_PVar: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | PVar _0 -> true | uu____2257 -> false
-  
-let (__proj__PVar__item___0 : pattern -> binder) =
-  fun projectee  -> match projectee with | PVar _0 -> _0 
-let (uu___is_PCons : pattern -> Prims.bool) =
+let __proj__PVar__item___0: pattern -> binder =
+  fun projectee  -> match projectee with | PVar _0 -> _0
+let uu___is_PCons: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | PCons _0 -> true | uu____2275 -> false
-  
-let (__proj__PCons__item___0 :
-  pattern -> (Prims.string,pattern Prims.list) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | PCons _0 -> _0 
-let (uu___is_PTuple : pattern -> Prims.bool) =
+let __proj__PCons__item___0:
+  pattern -> (Prims.string,pattern Prims.list) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | PCons _0 -> _0
+let uu___is_PTuple: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | PTuple _0 -> true | uu____2307 -> false
-  
-let (__proj__PTuple__item___0 : pattern -> pattern Prims.list) =
-  fun projectee  -> match projectee with | PTuple _0 -> _0 
-let (uu___is_PRecord : pattern -> Prims.bool) =
+let __proj__PTuple__item___0: pattern -> pattern Prims.list =
+  fun projectee  -> match projectee with | PTuple _0 -> _0
+let uu___is_PRecord: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | PRecord _0 -> true | uu____2331 -> false
-  
-let (__proj__PRecord__item___0 :
-  pattern -> (Prims.string,pattern) FStar_Pervasives_Native.tuple2 Prims.list)
-  = fun projectee  -> match projectee with | PRecord _0 -> _0 
-let (uu___is_PConstant : pattern -> Prims.bool) =
+let __proj__PRecord__item___0:
+  pattern -> (Prims.string,pattern) FStar_Pervasives_Native.tuple2 Prims.list
+  = fun projectee  -> match projectee with | PRecord _0 -> _0
+let uu___is_PConstant: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | PConstant _0 -> true | uu____2365 -> false
-  
-let (__proj__PConstant__item___0 :
-  pattern -> (width,Prims.string) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | PConstant _0 -> _0 
-let (uu___is_UInt8 : width -> Prims.bool) =
+let __proj__PConstant__item___0:
+  pattern -> (width,Prims.string) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | PConstant _0 -> _0
+let uu___is_UInt8: width -> Prims.bool =
   fun projectee  ->
     match projectee with | UInt8  -> true | uu____2388 -> false
-  
-let (uu___is_UInt16 : width -> Prims.bool) =
+let uu___is_UInt16: width -> Prims.bool =
   fun projectee  ->
     match projectee with | UInt16  -> true | uu____2392 -> false
-  
-let (uu___is_UInt32 : width -> Prims.bool) =
+let uu___is_UInt32: width -> Prims.bool =
   fun projectee  ->
     match projectee with | UInt32  -> true | uu____2396 -> false
-  
-let (uu___is_UInt64 : width -> Prims.bool) =
+let uu___is_UInt64: width -> Prims.bool =
   fun projectee  ->
     match projectee with | UInt64  -> true | uu____2400 -> false
-  
-let (uu___is_Int8 : width -> Prims.bool) =
+let uu___is_Int8: width -> Prims.bool =
   fun projectee  ->
     match projectee with | Int8  -> true | uu____2404 -> false
-  
-let (uu___is_Int16 : width -> Prims.bool) =
+let uu___is_Int16: width -> Prims.bool =
   fun projectee  ->
     match projectee with | Int16  -> true | uu____2408 -> false
-  
-let (uu___is_Int32 : width -> Prims.bool) =
+let uu___is_Int32: width -> Prims.bool =
   fun projectee  ->
     match projectee with | Int32  -> true | uu____2412 -> false
-  
-let (uu___is_Int64 : width -> Prims.bool) =
+let uu___is_Int64: width -> Prims.bool =
   fun projectee  ->
     match projectee with | Int64  -> true | uu____2416 -> false
-  
-let (uu___is_Bool : width -> Prims.bool) =
+let uu___is_Bool: width -> Prims.bool =
   fun projectee  ->
     match projectee with | Bool  -> true | uu____2420 -> false
-  
-let (uu___is_CInt : width -> Prims.bool) =
+let uu___is_CInt: width -> Prims.bool =
   fun projectee  ->
     match projectee with | CInt  -> true | uu____2424 -> false
-  
-let (__proj__Mkbinder__item__name : binder -> Prims.string) =
+let __proj__Mkbinder__item__name: binder -> Prims.string =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; typ = __fname__typ; mut = __fname__mut;_} ->
         __fname__name
-  
-let (__proj__Mkbinder__item__typ : binder -> typ) =
+let __proj__Mkbinder__item__typ: binder -> typ =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; typ = __fname__typ; mut = __fname__mut;_} ->
         __fname__typ
-  
-let (__proj__Mkbinder__item__mut : binder -> Prims.bool) =
+let __proj__Mkbinder__item__mut: binder -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; typ = __fname__typ; mut = __fname__mut;_} ->
         __fname__mut
-  
-let (uu___is_TInt : typ -> Prims.bool) =
+let uu___is_TInt: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TInt _0 -> true | uu____2447 -> false
-  
-let (__proj__TInt__item___0 : typ -> width) =
-  fun projectee  -> match projectee with | TInt _0 -> _0 
-let (uu___is_TBuf : typ -> Prims.bool) =
+let __proj__TInt__item___0: typ -> width =
+  fun projectee  -> match projectee with | TInt _0 -> _0
+let uu___is_TBuf: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TBuf _0 -> true | uu____2459 -> false
-  
-let (__proj__TBuf__item___0 : typ -> typ) =
-  fun projectee  -> match projectee with | TBuf _0 -> _0 
-let (uu___is_TUnit : typ -> Prims.bool) =
+let __proj__TBuf__item___0: typ -> typ =
+  fun projectee  -> match projectee with | TBuf _0 -> _0
+let uu___is_TUnit: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TUnit  -> true | uu____2470 -> false
-  
-let (uu___is_TQualified : typ -> Prims.bool) =
+let uu___is_TQualified: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TQualified _0 -> true | uu____2481 -> false
-  
-let (__proj__TQualified__item___0 :
+let __proj__TQualified__item___0:
   typ ->
-    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | TQualified _0 -> _0 
-let (uu___is_TBool : typ -> Prims.bool) =
+    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | TQualified _0 -> _0
+let uu___is_TBool: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TBool  -> true | uu____2510 -> false
-  
-let (uu___is_TAny : typ -> Prims.bool) =
+let uu___is_TAny: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TAny  -> true | uu____2514 -> false
-  
-let (uu___is_TArrow : typ -> Prims.bool) =
+let uu___is_TArrow: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TArrow _0 -> true | uu____2523 -> false
-  
-let (__proj__TArrow__item___0 :
-  typ -> (typ,typ) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | TArrow _0 -> _0 
-let (uu___is_TBound : typ -> Prims.bool) =
+let __proj__TArrow__item___0: typ -> (typ,typ) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | TArrow _0 -> _0
+let uu___is_TBound: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TBound _0 -> true | uu____2547 -> false
-  
-let (__proj__TBound__item___0 : typ -> Prims.int) =
-  fun projectee  -> match projectee with | TBound _0 -> _0 
-let (uu___is_TApp : typ -> Prims.bool) =
+let __proj__TBound__item___0: typ -> Prims.int =
+  fun projectee  -> match projectee with | TBound _0 -> _0
+let uu___is_TApp: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TApp _0 -> true | uu____2571 -> false
-  
-let (__proj__TApp__item___0 :
+let __proj__TApp__item___0:
   typ ->
     ((Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2,
-      typ Prims.list) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | TApp _0 -> _0 
-let (uu___is_TTuple : typ -> Prims.bool) =
+      typ Prims.list) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | TApp _0 -> _0
+let uu___is_TTuple: typ -> Prims.bool =
   fun projectee  ->
     match projectee with | TTuple _0 -> true | uu____2621 -> false
-  
-let (__proj__TTuple__item___0 : typ -> typ Prims.list) =
-  fun projectee  -> match projectee with | TTuple _0 -> _0 
+let __proj__TTuple__item___0: typ -> typ Prims.list =
+  fun projectee  -> match projectee with | TTuple _0 -> _0
 type program = decl Prims.list[@@deriving show]
 type ident = Prims.string[@@deriving show]
 type fields_t =
@@ -755,27 +658,27 @@ type lident =
   (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
 [@@deriving show]
 type version = Prims.int[@@deriving show]
-let (current_version : version) = (Prims.parse_int "27") 
+let current_version: version = Prims.parse_int "27"
 type file = (Prims.string,program) FStar_Pervasives_Native.tuple2[@@deriving
                                                                    show]
 type binary_format = (version,file Prims.list) FStar_Pervasives_Native.tuple2
 [@@deriving show]
-let fst3 :
+let fst3:
   'Auu____2697 'Auu____2698 'Auu____2699 .
     ('Auu____2699,'Auu____2698,'Auu____2697) FStar_Pervasives_Native.tuple3
       -> 'Auu____2699
-  = fun uu____2709  -> match uu____2709 with | (x,uu____2717,uu____2718) -> x 
-let snd3 :
+  = fun uu____2709  -> match uu____2709 with | (x,uu____2717,uu____2718) -> x
+let snd3:
   'Auu____2723 'Auu____2724 'Auu____2725 .
     ('Auu____2725,'Auu____2724,'Auu____2723) FStar_Pervasives_Native.tuple3
       -> 'Auu____2724
-  = fun uu____2735  -> match uu____2735 with | (uu____2742,x,uu____2744) -> x 
-let thd3 :
+  = fun uu____2735  -> match uu____2735 with | (uu____2742,x,uu____2744) -> x
+let thd3:
   'Auu____2749 'Auu____2750 'Auu____2751 .
     ('Auu____2751,'Auu____2750,'Auu____2749) FStar_Pervasives_Native.tuple3
       -> 'Auu____2749
-  = fun uu____2761  -> match uu____2761 with | (uu____2768,uu____2769,x) -> x 
-let (mk_width : Prims.string -> width FStar_Pervasives_Native.option) =
+  = fun uu____2761  -> match uu____2761 with | (uu____2768,uu____2769,x) -> x
+let mk_width: Prims.string -> width FStar_Pervasives_Native.option =
   fun uu___34_2775  ->
     match uu___34_2775 with
     | "UInt8" -> FStar_Pervasives_Native.Some UInt8
@@ -787,8 +690,7 @@ let (mk_width : Prims.string -> width FStar_Pervasives_Native.option) =
     | "Int32" -> FStar_Pervasives_Native.Some Int32
     | "Int64" -> FStar_Pervasives_Native.Some Int64
     | uu____2778 -> FStar_Pervasives_Native.None
-  
-let (mk_bool_op : Prims.string -> op FStar_Pervasives_Native.option) =
+let mk_bool_op: Prims.string -> op FStar_Pervasives_Native.option =
   fun uu___35_2783  ->
     match uu___35_2783 with
     | "op_Negation" -> FStar_Pervasives_Native.Some Not
@@ -797,10 +699,9 @@ let (mk_bool_op : Prims.string -> op FStar_Pervasives_Native.option) =
     | "op_Equality" -> FStar_Pervasives_Native.Some Eq
     | "op_disEquality" -> FStar_Pervasives_Native.Some Neq
     | uu____2786 -> FStar_Pervasives_Native.None
-  
-let (is_bool_op : Prims.string -> Prims.bool) =
-  fun op  -> (mk_bool_op op) <> FStar_Pervasives_Native.None 
-let (mk_op : Prims.string -> op FStar_Pervasives_Native.option) =
+let is_bool_op: Prims.string -> Prims.bool =
+  fun op  -> (mk_bool_op op) <> FStar_Pervasives_Native.None
+let mk_op: Prims.string -> op FStar_Pervasives_Native.option =
   fun uu___36_2796  ->
     match uu___36_2796 with
     | "add" -> FStar_Pervasives_Native.Some Add
@@ -843,103 +744,92 @@ let (mk_op : Prims.string -> op FStar_Pervasives_Native.option) =
     | "op_Less_Equals_Hat" -> FStar_Pervasives_Native.Some Lte
     | "lte" -> FStar_Pervasives_Native.Some Lte
     | uu____2799 -> FStar_Pervasives_Native.None
-  
-let (is_op : Prims.string -> Prims.bool) =
-  fun op  -> (mk_op op) <> FStar_Pervasives_Native.None 
-let (is_machine_int : Prims.string -> Prims.bool) =
-  fun m  -> (mk_width m) <> FStar_Pervasives_Native.None 
+let is_op: Prims.string -> Prims.bool =
+  fun op  -> (mk_op op) <> FStar_Pervasives_Native.None
+let is_machine_int: Prims.string -> Prims.bool =
+  fun m  -> (mk_width m) <> FStar_Pervasives_Native.None
 type env =
   {
-  names: name Prims.list ;
-  names_t: Prims.string Prims.list ;
-  module_name: Prims.string Prims.list }[@@deriving show]
+  names: name Prims.list;
+  names_t: Prims.string Prims.list;
+  module_name: Prims.string Prims.list;}[@@deriving show]
 and name = {
-  pretty: Prims.string ;
-  mut: Prims.bool }[@@deriving show]
-let (__proj__Mkenv__item__names : env -> name Prims.list) =
+  pretty: Prims.string;
+  mut: Prims.bool;}[@@deriving show]
+let __proj__Mkenv__item__names: env -> name Prims.list =
   fun projectee  ->
     match projectee with
     | { names = __fname__names; names_t = __fname__names_t;
         module_name = __fname__module_name;_} -> __fname__names
-  
-let (__proj__Mkenv__item__names_t : env -> Prims.string Prims.list) =
+let __proj__Mkenv__item__names_t: env -> Prims.string Prims.list =
   fun projectee  ->
     match projectee with
     | { names = __fname__names; names_t = __fname__names_t;
         module_name = __fname__module_name;_} -> __fname__names_t
-  
-let (__proj__Mkenv__item__module_name : env -> Prims.string Prims.list) =
+let __proj__Mkenv__item__module_name: env -> Prims.string Prims.list =
   fun projectee  ->
     match projectee with
     | { names = __fname__names; names_t = __fname__names_t;
         module_name = __fname__module_name;_} -> __fname__module_name
-  
-let (__proj__Mkname__item__pretty : name -> Prims.string) =
+let __proj__Mkname__item__pretty: name -> Prims.string =
   fun projectee  ->
     match projectee with
     | { pretty = __fname__pretty; mut = __fname__mut;_} -> __fname__pretty
-  
-let (__proj__Mkname__item__mut : name -> Prims.bool) =
+let __proj__Mkname__item__mut: name -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { pretty = __fname__pretty; mut = __fname__mut;_} -> __fname__mut
-  
-let (empty : Prims.string Prims.list -> env) =
-  fun module_name  -> { names = []; names_t = []; module_name } 
-let (extend : env -> Prims.string -> Prims.bool -> env) =
+let empty: Prims.string Prims.list -> env =
+  fun module_name  -> { names = []; names_t = []; module_name }
+let extend: env -> Prims.string -> Prims.bool -> env =
   fun env  ->
     fun x  ->
       fun is_mut  ->
-        let uu___42_2910 = env  in
+        let uu___42_2910 = env in
         {
           names = ({ pretty = x; mut = is_mut } :: (env.names));
           names_t = (uu___42_2910.names_t);
           module_name = (uu___42_2910.module_name)
         }
-  
-let (extend_t : env -> Prims.string -> env) =
+let extend_t: env -> Prims.string -> env =
   fun env  ->
     fun x  ->
-      let uu___43_2917 = env  in
+      let uu___43_2917 = env in
       {
         names = (uu___43_2917.names);
         names_t = (x :: (env.names_t));
         module_name = (uu___43_2917.module_name)
       }
-  
-let (find_name : env -> Prims.string -> name) =
+let find_name: env -> Prims.string -> name =
   fun env  ->
     fun x  ->
       let uu____2924 =
-        FStar_List.tryFind (fun name  -> name.pretty = x) env.names  in
+        FStar_List.tryFind (fun name  -> name.pretty = x) env.names in
       match uu____2924 with
       | FStar_Pervasives_Native.Some name -> name
       | FStar_Pervasives_Native.None  ->
           failwith "internal error: name not found"
-  
-let (is_mutable : env -> Prims.string -> Prims.bool) =
-  fun env  -> fun x  -> let uu____2936 = find_name env x  in uu____2936.mut 
-let (find : env -> Prims.string -> Prims.int) =
+let is_mutable: env -> Prims.string -> Prims.bool =
+  fun env  -> fun x  -> let uu____2936 = find_name env x in uu____2936.mut
+let find: env -> Prims.string -> Prims.int =
   fun env  ->
     fun x  ->
       try FStar_List.index (fun name  -> name.pretty = x) env.names
       with
       | uu____2951 ->
           let uu____2952 =
-            FStar_Util.format1 "Internal error: name not found %s\n" x  in
+            FStar_Util.format1 "Internal error: name not found %s\n" x in
           failwith uu____2952
-  
-let (find_t : env -> Prims.string -> Prims.int) =
+let find_t: env -> Prims.string -> Prims.int =
   fun env  ->
     fun x  ->
       try FStar_List.index (fun name  -> name = x) env.names_t
       with
       | uu____2967 ->
           let uu____2968 =
-            FStar_Util.format1 "Internal error: name not found %s\n" x  in
+            FStar_Util.format1 "Internal error: name not found %s\n" x in
           failwith uu____2968
-  
-let add_binders :
+let add_binders:
   'Auu____2972 .
     env ->
       (Prims.string,'Auu____2972) FStar_Pervasives_Native.tuple2 Prims.list
@@ -952,57 +842,51 @@ let add_binders :
            fun uu____3002  ->
              match uu____3002 with
              | (name,uu____3008) -> extend env1 name false) env binders
-  
-let rec (translate : FStar_Extraction_ML_Syntax.mllib -> file Prims.list) =
+let rec translate: FStar_Extraction_ML_Syntax.mllib -> file Prims.list =
   fun uu____3149  ->
     match uu____3149 with
     | FStar_Extraction_ML_Syntax.MLLib modules ->
         FStar_List.filter_map
           (fun m  ->
              let m_name =
-               let uu____3197 = m  in
+               let uu____3197 = m in
                match uu____3197 with
                | (path,uu____3211,uu____3212) ->
-                   FStar_Extraction_ML_Syntax.string_of_mlpath path
-                in
+                   FStar_Extraction_ML_Syntax.string_of_mlpath path in
              try
                FStar_Util.print1 "Attempting to translate module %s\n" m_name;
-               (let uu____3234 = translate_module m  in
+               (let uu____3234 = translate_module m in
                 FStar_Pervasives_Native.Some uu____3234)
              with
              | e ->
-                 ((let uu____3243 = FStar_Util.print_exn e  in
+                 ((let uu____3243 = FStar_Util.print_exn e in
                    FStar_Util.print2
                      "Unable to translate module: %s because:\n  %s\n" m_name
                      uu____3243);
                   FStar_Pervasives_Native.None)) modules
-
-and (translate_module :
+and translate_module:
   (FStar_Extraction_ML_Syntax.mlpath,(FStar_Extraction_ML_Syntax.mlsig,
                                        FStar_Extraction_ML_Syntax.mlmodule)
                                        FStar_Pervasives_Native.tuple2
                                        FStar_Pervasives_Native.option,
     FStar_Extraction_ML_Syntax.mllib) FStar_Pervasives_Native.tuple3 -> 
-    file)
+    file
   =
   fun uu____3244  ->
     match uu____3244 with
     | (module_name,modul,uu____3259) ->
         let module_name1 =
           FStar_List.append (FStar_Pervasives_Native.fst module_name)
-            [FStar_Pervasives_Native.snd module_name]
-           in
+            [FStar_Pervasives_Native.snd module_name] in
         let program =
           match modul with
           | FStar_Pervasives_Native.Some (_signature,decls) ->
               FStar_List.collect (translate_decl (empty module_name1)) decls
           | uu____3290 ->
-              failwith "Unexpected standalone interface or nested modules"
-           in
+              failwith "Unexpected standalone interface or nested modules" in
         ((FStar_String.concat "_" module_name1), program)
-
-and (translate_flags :
-  FStar_Extraction_ML_Syntax.meta Prims.list -> flag Prims.list) =
+and translate_flags:
+  FStar_Extraction_ML_Syntax.meta Prims.list -> flag Prims.list =
   fun flags1  ->
     FStar_List.choose
       (fun uu___37_3305  ->
@@ -1022,9 +906,8 @@ and (translate_flags :
          | FStar_Extraction_ML_Syntax.StackInline  ->
              FStar_Pervasives_Native.Some MustDisappear
          | uu____3309 -> FStar_Pervasives_Native.None) flags1
-
-and (translate_decl :
-  env -> FStar_Extraction_ML_Syntax.mlmodule1 -> decl Prims.list) =
+and translate_decl:
+  env -> FStar_Extraction_ML_Syntax.mlmodule1 -> decl Prims.list =
   fun env  ->
     fun d  ->
       match d with
@@ -1039,11 +922,10 @@ and (translate_decl :
           (FStar_Util.print1_warning
              "Skipping the translation of exception: %s\n" m;
            [])
-
-and (translate_let :
+and translate_let:
   env ->
     FStar_Extraction_ML_Syntax.mlletflavor ->
-      FStar_Extraction_ML_Syntax.mllb -> decl FStar_Pervasives_Native.option)
+      FStar_Extraction_ML_Syntax.mllb -> decl FStar_Pervasives_Native.option
   =
   fun env  ->
     fun flavor  ->
@@ -1066,64 +948,59 @@ and (translate_let :
                 (fun uu___38_3373  ->
                    match uu___38_3373 with
                    | FStar_Extraction_ML_Syntax.Assumed  -> true
-                   | uu____3374 -> false) meta
-               in
+                   | uu____3374 -> false) meta in
             let env1 =
               if flavor = FStar_Extraction_ML_Syntax.Rec
               then extend env name false
-              else env  in
+              else env in
             let env2 =
               FStar_List.fold_left
-                (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars
-               in
+                (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars in
             let rec find_return_type eff i uu___39_3395 =
               match uu___39_3395 with
               | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3400,eff1,t) when
                   i > (Prims.parse_int "0") ->
                   find_return_type eff1 (i - (Prims.parse_int "1")) t
-              | t -> (eff, t)  in
+              | t -> (eff, t) in
             let uu____3404 =
               find_return_type FStar_Extraction_ML_Syntax.E_PURE
-                (FStar_List.length args) t0
-               in
+                (FStar_List.length args) t0 in
             (match uu____3404 with
              | (eff,t) ->
-                 let t1 = translate_type env2 t  in
-                 let binders = translate_binders env2 args  in
-                 let env3 = add_binders env2 args  in
-                 let name1 = ((env3.module_name), name)  in
+                 let t1 = translate_type env2 t in
+                 let binders = translate_binders env2 args in
+                 let env3 = add_binders env2 args in
+                 let name1 = ((env3.module_name), name) in
                  let meta1 =
                    match (eff, t1) with
                    | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____3436) ->
-                       let uu____3437 = translate_flags meta  in
-                       MustDisappear :: uu____3437
+                       let uu____3437 = translate_flags meta in MustDisappear
+                         :: uu____3437
                    | (FStar_Extraction_ML_Syntax.E_PURE ,TUnit ) ->
-                       let uu____3440 = translate_flags meta  in
-                       MustDisappear :: uu____3440
-                   | uu____3443 -> translate_flags meta  in
+                       let uu____3440 = translate_flags meta in MustDisappear
+                         :: uu____3440
+                   | uu____3443 -> translate_flags meta in
                  if assumed
                  then
                    (if (FStar_List.length tvars) = (Prims.parse_int "0")
                     then
                       let uu____3452 =
                         let uu____3453 =
-                          let uu____3472 = translate_type env3 t0  in
+                          let uu____3472 = translate_type env3 t0 in
                           (FStar_Pervasives_Native.None, meta1, name1,
-                            uu____3472)
-                           in
-                        DExternal uu____3453  in
+                            uu____3472) in
+                        DExternal uu____3453 in
                       FStar_Pervasives_Native.Some uu____3452
                     else
                       ((let uu____3485 =
-                          FStar_Extraction_ML_Syntax.string_of_mlpath name1
-                           in
+                          FStar_Extraction_ML_Syntax.string_of_mlpath name1 in
                         FStar_Util.print1_warning
                           "No writing anything for %s (polymorphic assume)\n"
                           uu____3485);
                        FStar_Pervasives_Native.None))
                  else
                    (try
-                      let body1 = translate_expr env3 body  in
+                      let body1 = translate_expr env3 body in
                       FStar_Pervasives_Native.Some
                         (DFunction
                            (FStar_Pervasives_Native.None, meta1,
@@ -1131,25 +1008,21 @@ and (translate_let :
                              body1))
                     with
                     | e ->
-                        let msg = FStar_Util.print_exn e  in
+                        let msg = FStar_Util.print_exn e in
                         ((let uu____3518 =
                             let uu____3523 =
                               let uu____3524 =
                                 FStar_Extraction_ML_Syntax.string_of_mlpath
-                                  name1
-                                 in
+                                  name1 in
                               FStar_Util.format2
-                                "Writing a stub for %s (%s)\n" uu____3524 msg
-                               in
+                                "Writing a stub for %s (%s)\n" uu____3524 msg in
                             (FStar_Errors.Warning_FunctionNotExtacted,
-                              uu____3523)
-                             in
+                              uu____3523) in
                           FStar_Errors.log_issue FStar_Range.dummyRange
                             uu____3518);
                          (let msg1 =
                             Prims.strcat "This function was not extracted:\n"
-                              msg
-                             in
+                              msg in
                           FStar_Pervasives_Native.Some
                             (DFunction
                                (FStar_Pervasives_Native.None, meta1,
@@ -1177,64 +1050,59 @@ and (translate_let :
                 (fun uu___38_3570  ->
                    match uu___38_3570 with
                    | FStar_Extraction_ML_Syntax.Assumed  -> true
-                   | uu____3571 -> false) meta
-               in
+                   | uu____3571 -> false) meta in
             let env1 =
               if flavor = FStar_Extraction_ML_Syntax.Rec
               then extend env name false
-              else env  in
+              else env in
             let env2 =
               FStar_List.fold_left
-                (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars
-               in
+                (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars in
             let rec find_return_type eff i uu___39_3592 =
               match uu___39_3592 with
               | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3597,eff1,t) when
                   i > (Prims.parse_int "0") ->
                   find_return_type eff1 (i - (Prims.parse_int "1")) t
-              | t -> (eff, t)  in
+              | t -> (eff, t) in
             let uu____3601 =
               find_return_type FStar_Extraction_ML_Syntax.E_PURE
-                (FStar_List.length args) t0
-               in
+                (FStar_List.length args) t0 in
             (match uu____3601 with
              | (eff,t) ->
-                 let t1 = translate_type env2 t  in
-                 let binders = translate_binders env2 args  in
-                 let env3 = add_binders env2 args  in
-                 let name1 = ((env3.module_name), name)  in
+                 let t1 = translate_type env2 t in
+                 let binders = translate_binders env2 args in
+                 let env3 = add_binders env2 args in
+                 let name1 = ((env3.module_name), name) in
                  let meta1 =
                    match (eff, t1) with
                    | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____3633) ->
-                       let uu____3634 = translate_flags meta  in
-                       MustDisappear :: uu____3634
+                       let uu____3634 = translate_flags meta in MustDisappear
+                         :: uu____3634
                    | (FStar_Extraction_ML_Syntax.E_PURE ,TUnit ) ->
-                       let uu____3637 = translate_flags meta  in
-                       MustDisappear :: uu____3637
-                   | uu____3640 -> translate_flags meta  in
+                       let uu____3637 = translate_flags meta in MustDisappear
+                         :: uu____3637
+                   | uu____3640 -> translate_flags meta in
                  if assumed
                  then
                    (if (FStar_List.length tvars) = (Prims.parse_int "0")
                     then
                       let uu____3649 =
                         let uu____3650 =
-                          let uu____3669 = translate_type env3 t0  in
+                          let uu____3669 = translate_type env3 t0 in
                           (FStar_Pervasives_Native.None, meta1, name1,
-                            uu____3669)
-                           in
-                        DExternal uu____3650  in
+                            uu____3669) in
+                        DExternal uu____3650 in
                       FStar_Pervasives_Native.Some uu____3649
                     else
                       ((let uu____3682 =
-                          FStar_Extraction_ML_Syntax.string_of_mlpath name1
-                           in
+                          FStar_Extraction_ML_Syntax.string_of_mlpath name1 in
                         FStar_Util.print1_warning
                           "No writing anything for %s (polymorphic assume)\n"
                           uu____3682);
                        FStar_Pervasives_Native.None))
                  else
                    (try
-                      let body1 = translate_expr env3 body  in
+                      let body1 = translate_expr env3 body in
                       FStar_Pervasives_Native.Some
                         (DFunction
                            (FStar_Pervasives_Native.None, meta1,
@@ -1242,25 +1110,21 @@ and (translate_let :
                              body1))
                     with
                     | e ->
-                        let msg = FStar_Util.print_exn e  in
+                        let msg = FStar_Util.print_exn e in
                         ((let uu____3715 =
                             let uu____3720 =
                               let uu____3721 =
                                 FStar_Extraction_ML_Syntax.string_of_mlpath
-                                  name1
-                                 in
+                                  name1 in
                               FStar_Util.format2
-                                "Writing a stub for %s (%s)\n" uu____3721 msg
-                               in
+                                "Writing a stub for %s (%s)\n" uu____3721 msg in
                             (FStar_Errors.Warning_FunctionNotExtacted,
-                              uu____3720)
-                             in
+                              uu____3720) in
                           FStar_Errors.log_issue FStar_Range.dummyRange
                             uu____3715);
                          (let msg1 =
                             Prims.strcat "This function was not extracted:\n"
-                              msg
-                             in
+                              msg in
                           FStar_Pervasives_Native.Some
                             (DFunction
                                (FStar_Pervasives_Native.None, meta1,
@@ -1273,15 +1137,14 @@ and (translate_let :
             FStar_Extraction_ML_Syntax.mllb_def = expr;
             FStar_Extraction_ML_Syntax.mllb_meta = meta;
             FStar_Extraction_ML_Syntax.print_typ = uu____3741;_} ->
-            let meta1 = translate_flags meta  in
+            let meta1 = translate_flags meta in
             let env1 =
               FStar_List.fold_left
-                (fun env1  -> fun name1  -> extend_t env1 name1) env tvars
-               in
-            let t1 = translate_type env1 t  in
-            let name1 = ((env1.module_name), name)  in
+                (fun env1  -> fun name1  -> extend_t env1 name1) env tvars in
+            let t1 = translate_type env1 t in
+            let name1 = ((env1.module_name), name) in
             (try
-               let expr1 = translate_expr env1 expr  in
+               let expr1 = translate_expr env1 expr in
                FStar_Pervasives_Native.Some
                  (DGlobal
                     (meta1, name1, (FStar_List.length tvars), t1, expr1))
@@ -1290,16 +1153,13 @@ and (translate_let :
                  ((let uu____3788 =
                      let uu____3793 =
                        let uu____3794 =
-                         FStar_Extraction_ML_Syntax.string_of_mlpath name1
-                          in
-                       let uu____3795 = FStar_Util.print_exn e  in
+                         FStar_Extraction_ML_Syntax.string_of_mlpath name1 in
+                       let uu____3795 = FStar_Util.print_exn e in
                        FStar_Util.format2
                          "Not translating definition for %s (%s)\n"
-                         uu____3794 uu____3795
-                        in
+                         uu____3794 uu____3795 in
                      (FStar_Errors.Warning_DefinitionNotTranslated,
-                       uu____3793)
-                      in
+                       uu____3793) in
                    FStar_Errors.log_issue FStar_Range.dummyRange uu____3788);
                   FStar_Pervasives_Native.Some
                     (DGlobal
@@ -1313,78 +1173,71 @@ and (translate_let :
             ((let uu____3813 =
                 let uu____3818 =
                   FStar_Util.format1 "Not translating definition for %s\n"
-                    name
-                   in
-                (FStar_Errors.Warning_DefinitionNotTranslated, uu____3818)
-                 in
+                    name in
+                (FStar_Errors.Warning_DefinitionNotTranslated, uu____3818) in
               FStar_Errors.log_issue FStar_Range.dummyRange uu____3813);
              (match ts with
               | FStar_Pervasives_Native.Some (idents,t) ->
                   let uu____3826 =
-                    FStar_Extraction_ML_Code.string_of_mlty ([], "") t  in
+                    FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
                   FStar_Util.print2 "Type scheme is: forall %s. %s\n"
                     (FStar_String.concat ", " idents) uu____3826
               | FStar_Pervasives_Native.None  -> ());
              FStar_Pervasives_Native.None)
-
-and (translate_type_decl :
+and translate_type_decl:
   env ->
     FStar_Extraction_ML_Syntax.one_mltydecl ->
-      decl FStar_Pervasives_Native.option)
+      decl FStar_Pervasives_Native.option
   =
   fun env  ->
     fun ty  ->
       match ty with
       | (assumed,name,_mangled_name,args,flags1,FStar_Pervasives_Native.Some
          (FStar_Extraction_ML_Syntax.MLTD_Abbrev t)) ->
-          let name1 = ((env.module_name), name)  in
+          let name1 = ((env.module_name), name) in
           let env1 =
             FStar_List.fold_left
-              (fun env1  -> fun name2  -> extend_t env1 name2) env args
-             in
+              (fun env1  -> fun name2  -> extend_t env1 name2) env args in
           if assumed
           then
-            let name2 = FStar_Extraction_ML_Syntax.string_of_mlpath name1  in
+            let name2 = FStar_Extraction_ML_Syntax.string_of_mlpath name1 in
             (FStar_Util.print1_warning
                "Not translating type definition (assumed) for %s\n" name2;
              FStar_Pervasives_Native.None)
           else
             (let uu____3864 =
                let uu____3865 =
-                 let uu____3882 = translate_flags flags1  in
-                 let uu____3885 = translate_type env1 t  in
-                 (name1, uu____3882, (FStar_List.length args), uu____3885)
-                  in
-               DTypeAlias uu____3865  in
+                 let uu____3882 = translate_flags flags1 in
+                 let uu____3885 = translate_type env1 t in
+                 (name1, uu____3882, (FStar_List.length args), uu____3885) in
+               DTypeAlias uu____3865 in
              FStar_Pervasives_Native.Some uu____3864)
       | (uu____3894,name,_mangled_name,args,flags1,FStar_Pervasives_Native.Some
          (FStar_Extraction_ML_Syntax.MLTD_Record fields)) ->
-          let name1 = ((env.module_name), name)  in
+          let name1 = ((env.module_name), name) in
           let env1 =
             FStar_List.fold_left
-              (fun env1  -> fun name2  -> extend_t env1 name2) env args
-             in
+              (fun env1  -> fun name2  -> extend_t env1 name2) env args in
           let uu____3926 =
             let uu____3927 =
-              let uu____3954 = translate_flags flags1  in
+              let uu____3954 = translate_flags flags1 in
               let uu____3957 =
                 FStar_List.map
                   (fun uu____3984  ->
                      match uu____3984 with
                      | (f,t) ->
                          let uu____3999 =
-                           let uu____4004 = translate_type env1 t  in
-                           (uu____4004, false)  in
-                         (f, uu____3999)) fields
-                 in
-              (name1, uu____3954, (FStar_List.length args), uu____3957)  in
-            DTypeFlat uu____3927  in
+                           let uu____4004 = translate_type env1 t in
+                           (uu____4004, false) in
+                         (f, uu____3999)) fields in
+              (name1, uu____3954, (FStar_List.length args), uu____3957) in
+            DTypeFlat uu____3927 in
           FStar_Pervasives_Native.Some uu____3926
       | (uu____4027,name,_mangled_name,args,flags1,FStar_Pervasives_Native.Some
          (FStar_Extraction_ML_Syntax.MLTD_DType branches)) ->
-          let name1 = ((env.module_name), name)  in
-          let flags2 = translate_flags flags1  in
-          let env1 = FStar_List.fold_left extend_t env args  in
+          let name1 = ((env.module_name), name) in
+          let flags2 = translate_flags flags1 in
+          let env1 = FStar_List.fold_left extend_t env args in
           let uu____4064 =
             let uu____4065 =
               let uu____4098 =
@@ -1398,169 +1251,153 @@ and (translate_type_decl :
                                 match uu____4209 with
                                 | (name2,t) ->
                                     let uu____4224 =
-                                      let uu____4229 = translate_type env1 t
-                                         in
-                                      (uu____4229, false)  in
-                                    (name2, uu____4224)) ts
-                            in
-                         (cons1, uu____4182)) branches
-                 in
-              (name1, flags2, (FStar_List.length args), uu____4098)  in
-            DTypeVariant uu____4065  in
+                                      let uu____4229 = translate_type env1 t in
+                                      (uu____4229, false) in
+                                    (name2, uu____4224)) ts in
+                         (cons1, uu____4182)) branches in
+              (name1, flags2, (FStar_List.length args), uu____4098) in
+            DTypeVariant uu____4065 in
           FStar_Pervasives_Native.Some uu____4064
       | (uu____4268,name,_mangled_name,uu____4271,uu____4272,uu____4273) ->
           ((let uu____4283 =
               let uu____4288 =
                 FStar_Util.format1 "Not translating type definition for %s\n"
-                  name
-                 in
-              (FStar_Errors.Warning_DefinitionNotTranslated, uu____4288)  in
+                  name in
+              (FStar_Errors.Warning_DefinitionNotTranslated, uu____4288) in
             FStar_Errors.log_issue FStar_Range.dummyRange uu____4283);
            FStar_Pervasives_Native.None)
-
-and (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
+and translate_type: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
   fun env  ->
     fun t  ->
       match t with
       | FStar_Extraction_ML_Syntax.MLTY_Tuple [] -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Top  -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Var name ->
-          let uu____4292 = find_t env name  in TBound uu____4292
+          let uu____4292 = find_t env name in TBound uu____4292
       | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____4294,t2) ->
           let uu____4296 =
-            let uu____4301 = translate_type env t1  in
-            let uu____4302 = translate_type env t2  in
-            (uu____4301, uu____4302)  in
+            let uu____4301 = translate_type env t1 in
+            let uu____4302 = translate_type env t2 in
+            (uu____4301, uu____4302) in
           TArrow uu____4296
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____4306 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4306 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4306 = "Prims.unit" -> TUnit
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____4310 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4310 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4310 = "Prims.bool" -> TBool
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t")) when
           is_machine_int m ->
-          let uu____4322 = FStar_Util.must (mk_width m)  in TInt uu____4322
+          let uu____4322 = FStar_Util.must (mk_width m) in TInt uu____4322
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t'")) when
           is_machine_int m ->
-          let uu____4334 = FStar_Util.must (mk_width m)  in TInt uu____4334
+          let uu____4334 = FStar_Util.must (mk_width m) in TInt uu____4334
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
-          let uu____4339 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4339 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4339 = "FStar.Monotonic.HyperStack.mem" -> TUnit
       | FStar_Extraction_ML_Syntax.MLTY_Named
           (uu____4340::arg::uu____4342::[],p) when
-          (((let uu____4348 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
+          (((let uu____4348 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
              uu____4348 = "FStar.Monotonic.HyperStack.s_mref") ||
-              (let uu____4350 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                  in
+              (let uu____4350 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
                uu____4350 = "FStar.Monotonic.HyperHeap.mrref"))
              ||
-             (let uu____4352 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                 in
+             (let uu____4352 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
               uu____4352 = "FStar.HyperStack.ST.m_rref"))
             ||
-            (let uu____4354 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
+            (let uu____4354 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
              uu____4354 = "FStar.HyperStack.ST.s_mref")
-          -> let uu____4355 = translate_type env arg  in TBuf uu____4355
+          -> let uu____4355 = translate_type env arg in TBuf uu____4355
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::uu____4357::[],p) when
           ((((((((((let uu____4363 =
-                      FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                      FStar_Extraction_ML_Syntax.string_of_mlpath p in
                     uu____4363 = "FStar.Monotonic.HyperStack.mreference") ||
                      (let uu____4365 =
-                        FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                        FStar_Extraction_ML_Syntax.string_of_mlpath p in
                       uu____4365 = "FStar.Monotonic.HyperStack.mstackref"))
                     ||
                     (let uu____4367 =
-                       FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                       FStar_Extraction_ML_Syntax.string_of_mlpath p in
                      uu____4367 = "FStar.Monotonic.HyperStack.mref"))
                    ||
                    (let uu____4369 =
-                      FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                      FStar_Extraction_ML_Syntax.string_of_mlpath p in
                     uu____4369 = "FStar.Monotonic.HyperStack.mmmstackref"))
                   ||
                   (let uu____4371 =
-                     FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                     FStar_Extraction_ML_Syntax.string_of_mlpath p in
                    uu____4371 = "FStar.Monotonic.HyperStack.mmmref"))
                  ||
                  (let uu____4373 =
-                    FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                    FStar_Extraction_ML_Syntax.string_of_mlpath p in
                   uu____4373 = "FStar.Monotonic.Heap.mref"))
                 ||
                 (let uu____4375 =
-                   FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                   FStar_Extraction_ML_Syntax.string_of_mlpath p in
                  uu____4375 = "FStar.HyperStack.ST.mreference"))
                ||
                (let uu____4377 =
-                  FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                  FStar_Extraction_ML_Syntax.string_of_mlpath p in
                 uu____4377 = "FStar.HyperStack.ST.mstackref"))
               ||
-              (let uu____4379 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                  in
+              (let uu____4379 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
                uu____4379 = "FStar.HyperStack.ST.mref"))
              ||
-             (let uu____4381 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                 in
+             (let uu____4381 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
               uu____4381 = "FStar.HyperStack.ST.mmmstackref"))
             ||
-            (let uu____4383 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
+            (let uu____4383 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
              uu____4383 = "FStar.HyperStack.ST.mmmref")
-          -> let uu____4384 = translate_type env arg  in TBuf uu____4384
+          -> let uu____4384 = translate_type env arg in TBuf uu____4384
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
           ((((((((((let uu____4391 =
-                      FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                      FStar_Extraction_ML_Syntax.string_of_mlpath p in
                     uu____4391 = "FStar.Buffer.buffer") ||
                      (let uu____4393 =
-                        FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                        FStar_Extraction_ML_Syntax.string_of_mlpath p in
                       uu____4393 = "FStar.HyperStack.reference"))
                     ||
                     (let uu____4395 =
-                       FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                       FStar_Extraction_ML_Syntax.string_of_mlpath p in
                      uu____4395 = "FStar.HyperStack.stackref"))
                    ||
                    (let uu____4397 =
-                      FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                      FStar_Extraction_ML_Syntax.string_of_mlpath p in
                     uu____4397 = "FStar.HyperStack.ref"))
                   ||
                   (let uu____4399 =
-                     FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                     FStar_Extraction_ML_Syntax.string_of_mlpath p in
                    uu____4399 = "FStar.HyperStack.mmstackref"))
                  ||
                  (let uu____4401 =
-                    FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                    FStar_Extraction_ML_Syntax.string_of_mlpath p in
                   uu____4401 = "FStar.HyperStack.mmref"))
                 ||
                 (let uu____4403 =
-                   FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                   FStar_Extraction_ML_Syntax.string_of_mlpath p in
                  uu____4403 = "FStar.HyperStack.ST.reference"))
                ||
                (let uu____4405 =
-                  FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                  FStar_Extraction_ML_Syntax.string_of_mlpath p in
                 uu____4405 = "FStar.HyperStack.ST.stackref"))
               ||
-              (let uu____4407 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                  in
+              (let uu____4407 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
                uu____4407 = "FStar.HyperStack.ST.ref"))
              ||
-             (let uu____4409 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                 in
+             (let uu____4409 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
               uu____4409 = "FStar.HyperStack.ST.mmstackref"))
             ||
-            (let uu____4411 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
+            (let uu____4411 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
              uu____4411 = "FStar.HyperStack.ST.mmref")
-          -> let uu____4412 = translate_type env arg  in TBuf uu____4412
+          -> let uu____4412 = translate_type env arg in TBuf uu____4412
       | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4413::arg::[],p) when
-          (let uu____4420 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          (let uu____4420 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
            uu____4420 = "FStar.HyperStack.s_ref") ||
-            (let uu____4422 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
+            (let uu____4422 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
              uu____4422 = "FStar.HyperStack.ST.s_ref")
-          -> let uu____4423 = translate_type env arg  in TBuf uu____4423
+          -> let uu____4423 = translate_type env arg in TBuf uu____4423
       | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4424::[],p) when
-          let uu____4428 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4428 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4428 = "FStar.Ghost.erased" -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],(path,type_name)) ->
           TQualified (path, type_name)
@@ -1568,58 +1405,55 @@ and (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
           ((ns = ["Prims"]) || (ns = ["FStar"; "Pervasives"; "Native"])) &&
             (FStar_Util.starts_with t1 "tuple")
           ->
-          let uu____4466 = FStar_List.map (translate_type env) args  in
+          let uu____4466 = FStar_List.map (translate_type env) args in
           TTuple uu____4466
       | FStar_Extraction_ML_Syntax.MLTY_Named (args,lid) ->
           if (FStar_List.length args) > (Prims.parse_int "0")
           then
             let uu____4475 =
-              let uu____4488 = FStar_List.map (translate_type env) args  in
-              (lid, uu____4488)  in
+              let uu____4488 = FStar_List.map (translate_type env) args in
+              (lid, uu____4488) in
             TApp uu____4475
           else TQualified lid
       | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-          let uu____4497 = FStar_List.map (translate_type env) ts  in
+          let uu____4497 = FStar_List.map (translate_type env) ts in
           TTuple uu____4497
-
-and (translate_binders :
+and translate_binders:
   env ->
     (FStar_Extraction_ML_Syntax.mlident,FStar_Extraction_ML_Syntax.mlty)
-      FStar_Pervasives_Native.tuple2 Prims.list -> binder Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list -> binder Prims.list
   = fun env  -> fun args  -> FStar_List.map (translate_binder env) args
-
-and (translate_binder :
+and translate_binder:
   env ->
     (FStar_Extraction_ML_Syntax.mlident,FStar_Extraction_ML_Syntax.mlty)
-      FStar_Pervasives_Native.tuple2 -> binder)
+      FStar_Pervasives_Native.tuple2 -> binder
   =
   fun env  ->
     fun uu____4513  ->
       match uu____4513 with
       | (name,typ) ->
-          let uu____4520 = translate_type env typ  in
+          let uu____4520 = translate_type env typ in
           { name; typ = uu____4520; mut = false }
-
-and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
+and translate_expr: env -> FStar_Extraction_ML_Syntax.mlexpr -> expr =
   fun env  ->
     fun e  ->
       match e.FStar_Extraction_ML_Syntax.expr with
       | FStar_Extraction_ML_Syntax.MLE_Tuple [] -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_Const c -> translate_constant c
       | FStar_Extraction_ML_Syntax.MLE_Var name ->
-          let uu____4525 = find env name  in EBound uu____4525
+          let uu____4525 = find env name in EBound uu____4525
       | FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op) when
           (is_machine_int m) && (is_op op) ->
           let uu____4530 =
-            let uu____4535 = FStar_Util.must (mk_op op)  in
-            let uu____4536 = FStar_Util.must (mk_width m)  in
-            (uu____4535, uu____4536)  in
+            let uu____4535 = FStar_Util.must (mk_op op) in
+            let uu____4536 = FStar_Util.must (mk_width m) in
+            (uu____4535, uu____4536) in
           EOp uu____4530
       | FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op) when
           is_bool_op op ->
           let uu____4540 =
-            let uu____4545 = FStar_Util.must (mk_bool_op op)  in
-            (uu____4545, Bool)  in
+            let uu____4545 = FStar_Util.must (mk_bool_op op) in
+            (uu____4545, Bool) in
           EOp uu____4540
       | FStar_Extraction_ML_Syntax.MLE_Name n1 -> EQualified n1
       | FStar_Extraction_ML_Syntax.MLE_Let
@@ -1636,8 +1470,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
               (fun uu___40_4573  ->
                  match uu___40_4573 with
                  | FStar_Extraction_ML_Syntax.Mutable  -> true
-                 | uu____4574 -> false) flags1
-             in
+                 | uu____4574 -> false) flags1 in
           let uu____4575 =
             if is_mut
             then
@@ -1645,19 +1478,16 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                 match typ with
                 | FStar_Extraction_ML_Syntax.MLTY_Named (t::[],p) when
                     let uu____4589 =
-                      FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                      FStar_Extraction_ML_Syntax.string_of_mlpath p in
                     uu____4589 = "FStar.ST.stackref" -> t
                 | uu____4590 ->
                     let uu____4591 =
                       let uu____4592 =
-                        FStar_Extraction_ML_Code.string_of_mlty ([], "") typ
-                         in
+                        FStar_Extraction_ML_Code.string_of_mlty ([], "") typ in
                       FStar_Util.format1
                         "unexpected: bad desugaring of Mutable (typ is %s)"
-                        uu____4592
-                       in
-                    failwith uu____4591
-                 in
+                        uu____4592 in
+                    failwith uu____4591 in
               let uu____4595 =
                 match body with
                 | {
@@ -1667,24 +1497,23 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                     FStar_Extraction_ML_Syntax.mlty = uu____4598;
                     FStar_Extraction_ML_Syntax.loc = uu____4599;_} -> body1
                 | uu____4602 ->
-                    failwith "unexpected: bad desugaring of Mutable"
-                 in
+                    failwith "unexpected: bad desugaring of Mutable" in
               (uu____4584, uu____4595)
-            else (typ, body)  in
+            else (typ, body) in
           (match uu____4575 with
            | (typ1,body1) ->
                let binder =
-                 let uu____4607 = translate_type env typ1  in
-                 { name; typ = uu____4607; mut = is_mut }  in
-               let body2 = translate_expr env body1  in
-               let env1 = extend env name is_mut  in
-               let continuation1 = translate_expr env1 continuation  in
+                 let uu____4607 = translate_type env typ1 in
+                 { name; typ = uu____4607; mut = is_mut } in
+               let body2 = translate_expr env body1 in
+               let env1 = extend env name is_mut in
+               let continuation1 = translate_expr env1 continuation in
                ELet (binder, body2, continuation1))
       | FStar_Extraction_ML_Syntax.MLE_Match (expr,branches) ->
           let uu____4633 =
-            let uu____4644 = translate_expr env expr  in
-            let uu____4645 = translate_branches env branches  in
-            (uu____4644, uu____4645)  in
+            let uu____4644 = translate_expr env expr in
+            let uu____4645 = translate_branches env branches in
+            (uu____4644, uu____4645) in
           EMatch uu____4633
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1698,12 +1527,11 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4662;
              FStar_Extraction_ML_Syntax.loc = uu____4663;_},arg::[])
           when
-          let uu____4669 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4669 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4669 = "FStar.Dyn.undyn" ->
           let uu____4670 =
-            let uu____4675 = translate_expr env arg  in
-            let uu____4676 = translate_type env t  in
-            (uu____4675, uu____4676)  in
+            let uu____4675 = translate_expr env arg in
+            let uu____4676 = translate_type env t in (uu____4675, uu____4676) in
           ECast uu____4670
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1717,7 +1545,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4681;
              FStar_Extraction_ML_Syntax.loc = uu____4682;_},uu____4683)
           when
-          let uu____4692 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4692 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4692 = "Prims.admit" -> EAbort
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1731,15 +1559,12 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4697;
              FStar_Extraction_ML_Syntax.loc = uu____4698;_},arg::[])
           when
-          ((let uu____4708 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-               in
+          ((let uu____4708 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
             uu____4708 = "FStar.HyperStack.All.failwith") ||
-             (let uu____4710 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                 in
+             (let uu____4710 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
               uu____4710 = "FStar.Error.unexpected"))
             ||
-            (let uu____4712 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
+            (let uu____4712 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
              uu____4712 = "FStar.Error.unreachable")
           ->
           (match arg with
@@ -1755,20 +1580,16 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                    let uu____4719 =
                      let uu____4720 =
                        FStar_Ident.lid_of_str
-                         "FStar.HyperStack.IO.print_string"
-                        in
-                     FStar_Extraction_ML_Syntax.mlpath_of_lident uu____4720
-                      in
-                   FStar_Extraction_ML_Syntax.MLE_Name uu____4719  in
+                         "FStar.HyperStack.IO.print_string" in
+                     FStar_Extraction_ML_Syntax.mlpath_of_lident uu____4720 in
+                   FStar_Extraction_ML_Syntax.MLE_Name uu____4719 in
                  FStar_Extraction_ML_Syntax.with_ty
-                   FStar_Extraction_ML_Syntax.MLTY_Top uu____4718
-                  in
+                   FStar_Extraction_ML_Syntax.MLTY_Top uu____4718 in
                let print8 =
                  FStar_Extraction_ML_Syntax.with_ty
                    FStar_Extraction_ML_Syntax.MLTY_Top
-                   (FStar_Extraction_ML_Syntax.MLE_App (print7, [arg]))
-                  in
-               let t = translate_expr env print8  in ESequence [t; EAbort])
+                   (FStar_Extraction_ML_Syntax.MLE_App (print7, [arg])) in
+               let t = translate_expr env print8 in ESequence [t; EAbort])
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1784,9 +1605,9 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                                                               FStar_Extraction_ML_Syntax.loc
                                                                 = uu____4730;_}::[])
           when
-          (let uu____4735 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          (let uu____4735 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
            uu____4735 = "FStar.HyperStack.ST.op_Bang") && (is_mutable env v1)
-          -> let uu____4736 = find env v1  in EBound uu____4736
+          -> let uu____4736 = find env v1 in EBound uu____4736
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1802,15 +1623,15 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                                                               FStar_Extraction_ML_Syntax.loc
                                                                 = uu____4742;_}::e1::[])
           when
-          (let uu____4748 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          (let uu____4748 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
            uu____4748 = "FStar.HyperStack.ST.op_Colon_Equals") &&
             (is_mutable env v1)
           ->
           let uu____4749 =
             let uu____4754 =
-              let uu____4755 = find env v1  in EBound uu____4755  in
-            let uu____4756 = translate_expr env e1  in
-            (uu____4754, uu____4756)  in
+              let uu____4755 = find env v1 in EBound uu____4755 in
+            let uu____4756 = translate_expr env e1 in
+            (uu____4754, uu____4756) in
           EAssign uu____4749
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1824,16 +1645,15 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4761;
              FStar_Extraction_ML_Syntax.loc = uu____4762;_},e1::e2::[])
           when
-          (let uu____4773 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          (let uu____4773 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
            uu____4773 = "FStar.Buffer.index") ||
-            (let uu____4775 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
+            (let uu____4775 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
              uu____4775 = "FStar.Buffer.op_Array_Access")
           ->
           let uu____4776 =
-            let uu____4781 = translate_expr env e1  in
-            let uu____4782 = translate_expr env e2  in
-            (uu____4781, uu____4782)  in
+            let uu____4781 = translate_expr env e1 in
+            let uu____4782 = translate_expr env e2 in
+            (uu____4781, uu____4782) in
           EBufRead uu____4776
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1847,11 +1667,11 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4787;
              FStar_Extraction_ML_Syntax.loc = uu____4788;_},e1::[])
           when
-          let uu____4796 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4796 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4796 = "FStar.HyperStack.ST.op_Bang" ->
           let uu____4797 =
-            let uu____4802 = translate_expr env e1  in
-            (uu____4802, (EConstant (UInt32, "0")))  in
+            let uu____4802 = translate_expr env e1 in
+            (uu____4802, (EConstant (UInt32, "0"))) in
           EBufRead uu____4797
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1865,12 +1685,12 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4807;
              FStar_Extraction_ML_Syntax.loc = uu____4808;_},e1::e2::[])
           when
-          let uu____4817 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4817 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4817 = "FStar.Buffer.create" ->
           let uu____4818 =
-            let uu____4825 = translate_expr env e1  in
-            let uu____4826 = translate_expr env e2  in
-            (Stack, uu____4825, uu____4826)  in
+            let uu____4825 = translate_expr env e1 in
+            let uu____4826 = translate_expr env e2 in
+            (Stack, uu____4825, uu____4826) in
           EBufCreate uu____4818
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1884,11 +1704,11 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4831;
              FStar_Extraction_ML_Syntax.loc = uu____4832;_},init1::[])
           when
-          let uu____4840 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4840 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4840 = "FStar.HyperStack.ST.salloc" ->
           let uu____4841 =
-            let uu____4848 = translate_expr env init1  in
-            (Eternal, uu____4848, (EConstant (UInt32, "1")))  in
+            let uu____4848 = translate_expr env init1 in
+            (Eternal, uu____4848, (EConstant (UInt32, "1"))) in
           EBufCreate uu____4841
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1902,11 +1722,11 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4853;
              FStar_Extraction_ML_Syntax.loc = uu____4854;_},_rid::init1::[])
           when
-          let uu____4863 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4863 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4863 = "FStar.HyperStack.ST.ralloc" ->
           let uu____4864 =
-            let uu____4871 = translate_expr env init1  in
-            (Eternal, uu____4871, (EConstant (UInt32, "1")))  in
+            let uu____4871 = translate_expr env init1 in
+            (Eternal, uu____4871, (EConstant (UInt32, "1"))) in
           EBufCreate uu____4864
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1920,12 +1740,12 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4876;
              FStar_Extraction_ML_Syntax.loc = uu____4877;_},_e0::e1::e2::[])
           when
-          let uu____4887 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4887 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4887 = "FStar.Buffer.rcreate" ->
           let uu____4888 =
-            let uu____4895 = translate_expr env e1  in
-            let uu____4896 = translate_expr env e2  in
-            (Eternal, uu____4895, uu____4896)  in
+            let uu____4895 = translate_expr env e1 in
+            let uu____4896 = translate_expr env e2 in
+            (Eternal, uu____4895, uu____4896) in
           EBufCreate uu____4888
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1939,12 +1759,12 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4901;
              FStar_Extraction_ML_Syntax.loc = uu____4902;_},_e0::e1::e2::[])
           when
-          let uu____4912 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4912 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4912 = "FStar.Buffer.rcreate_mm" ->
           let uu____4913 =
-            let uu____4920 = translate_expr env e1  in
-            let uu____4921 = translate_expr env e2  in
-            (ManuallyManaged, uu____4920, uu____4921)  in
+            let uu____4920 = translate_expr env e1 in
+            let uu____4921 = translate_expr env e2 in
+            (ManuallyManaged, uu____4920, uu____4921) in
           EBufCreate uu____4913
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1958,7 +1778,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____4926;
              FStar_Extraction_ML_Syntax.loc = uu____4927;_},e2::[])
           when
-          let uu____4935 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____4935 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____4935 = "FStar.Buffer.createL" ->
           let rec list_elements acc e21 =
             match e21.FStar_Extraction_ML_Syntax.expr with
@@ -1969,14 +1789,13 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                 FStar_List.rev acc
             | uu____4973 ->
                 failwith
-                  "Argument of FStar.Buffer.createL is not a string literal!"
-             in
-          let list_elements1 = list_elements []  in
+                  "Argument of FStar.Buffer.createL is not a string literal!" in
+          let list_elements1 = list_elements [] in
           let uu____4981 =
             let uu____4988 =
-              let uu____4991 = list_elements1 e2  in
-              FStar_List.map (translate_expr env) uu____4991  in
-            (Stack, uu____4988)  in
+              let uu____4991 = list_elements1 e2 in
+              FStar_List.map (translate_expr env) uu____4991 in
+            (Stack, uu____4988) in
           EBufCreateL uu____4981
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -1990,9 +1809,9 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5000;
              FStar_Extraction_ML_Syntax.loc = uu____5001;_},e2::[])
           when
-          let uu____5009 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5009 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5009 = "FStar.Buffer.rfree" ->
-          let uu____5010 = translate_expr env e2  in EBufFree uu____5010
+          let uu____5010 = translate_expr env e2 in EBufFree uu____5010
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2005,12 +1824,12 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5015;
              FStar_Extraction_ML_Syntax.loc = uu____5016;_},e1::e2::_e3::[])
           when
-          let uu____5026 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5026 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5026 = "FStar.Buffer.sub" ->
           let uu____5027 =
-            let uu____5032 = translate_expr env e1  in
-            let uu____5033 = translate_expr env e2  in
-            (uu____5032, uu____5033)  in
+            let uu____5032 = translate_expr env e1 in
+            let uu____5033 = translate_expr env e2 in
+            (uu____5032, uu____5033) in
           EBufSub uu____5027
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2024,7 +1843,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5038;
              FStar_Extraction_ML_Syntax.loc = uu____5039;_},e1::e2::[])
           when
-          let uu____5048 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5048 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5048 = "FStar.Buffer.join" -> translate_expr env e1
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2038,12 +1857,12 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5053;
              FStar_Extraction_ML_Syntax.loc = uu____5054;_},e1::e2::[])
           when
-          let uu____5063 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5063 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5063 = "FStar.Buffer.offset" ->
           let uu____5064 =
-            let uu____5069 = translate_expr env e1  in
-            let uu____5070 = translate_expr env e2  in
-            (uu____5069, uu____5070)  in
+            let uu____5069 = translate_expr env e1 in
+            let uu____5070 = translate_expr env e2 in
+            (uu____5069, uu____5070) in
           EBufSub uu____5064
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2057,17 +1876,16 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5075;
              FStar_Extraction_ML_Syntax.loc = uu____5076;_},e1::e2::e3::[])
           when
-          (let uu____5088 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          (let uu____5088 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
            uu____5088 = "FStar.Buffer.upd") ||
-            (let uu____5090 = FStar_Extraction_ML_Syntax.string_of_mlpath p
-                in
+            (let uu____5090 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
              uu____5090 = "FStar.Buffer.op_Array_Assignment")
           ->
           let uu____5091 =
-            let uu____5098 = translate_expr env e1  in
-            let uu____5099 = translate_expr env e2  in
-            let uu____5100 = translate_expr env e3  in
-            (uu____5098, uu____5099, uu____5100)  in
+            let uu____5098 = translate_expr env e1 in
+            let uu____5099 = translate_expr env e2 in
+            let uu____5100 = translate_expr env e3 in
+            (uu____5098, uu____5099, uu____5100) in
           EBufWrite uu____5091
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2081,12 +1899,12 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5105;
              FStar_Extraction_ML_Syntax.loc = uu____5106;_},e1::e2::[])
           when
-          let uu____5115 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5115 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5115 = "FStar.HyperStack.ST.op_Colon_Equals" ->
           let uu____5116 =
-            let uu____5123 = translate_expr env e1  in
-            let uu____5124 = translate_expr env e2  in
-            (uu____5123, (EConstant (UInt32, "0")), uu____5124)  in
+            let uu____5123 = translate_expr env e1 in
+            let uu____5124 = translate_expr env e2 in
+            (uu____5123, (EConstant (UInt32, "0")), uu____5124) in
           EBufWrite uu____5116
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2095,7 +1913,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5126;
              FStar_Extraction_ML_Syntax.loc = uu____5127;_},uu____5128::[])
           when
-          let uu____5131 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5131 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5131 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2104,7 +1922,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5133;
              FStar_Extraction_ML_Syntax.loc = uu____5134;_},uu____5135::[])
           when
-          let uu____5138 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5138 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5138 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2118,15 +1936,15 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5143;
              FStar_Extraction_ML_Syntax.loc = uu____5144;_},e1::e2::e3::e4::e5::[])
           when
-          let uu____5156 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5156 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5156 = "FStar.Buffer.blit" ->
           let uu____5157 =
-            let uu____5168 = translate_expr env e1  in
-            let uu____5169 = translate_expr env e2  in
-            let uu____5170 = translate_expr env e3  in
-            let uu____5171 = translate_expr env e4  in
-            let uu____5172 = translate_expr env e5  in
-            (uu____5168, uu____5169, uu____5170, uu____5171, uu____5172)  in
+            let uu____5168 = translate_expr env e1 in
+            let uu____5169 = translate_expr env e2 in
+            let uu____5170 = translate_expr env e3 in
+            let uu____5171 = translate_expr env e4 in
+            let uu____5172 = translate_expr env e5 in
+            (uu____5168, uu____5169, uu____5170, uu____5171, uu____5172) in
           EBufBlit uu____5157
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2140,13 +1958,13 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5177;
              FStar_Extraction_ML_Syntax.loc = uu____5178;_},e1::e2::e3::[])
           when
-          let uu____5188 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5188 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5188 = "FStar.Buffer.fill" ->
           let uu____5189 =
-            let uu____5196 = translate_expr env e1  in
-            let uu____5197 = translate_expr env e2  in
-            let uu____5198 = translate_expr env e3  in
-            (uu____5196, uu____5197, uu____5198)  in
+            let uu____5196 = translate_expr env e1 in
+            let uu____5197 = translate_expr env e2 in
+            let uu____5198 = translate_expr env e3 in
+            (uu____5196, uu____5197, uu____5198) in
           EBufFill uu____5189
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2155,7 +1973,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5200;
              FStar_Extraction_ML_Syntax.loc = uu____5201;_},uu____5202::[])
           when
-          let uu____5205 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5205 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5205 = "FStar.HyperStack.ST.get" -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2164,10 +1982,10 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5207;
              FStar_Extraction_ML_Syntax.loc = uu____5208;_},e1::[])
           when
-          let uu____5212 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          let uu____5212 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
           uu____5212 = "Obj.repr" ->
           let uu____5213 =
-            let uu____5218 = translate_expr env e1  in (uu____5218, TAny)  in
+            let uu____5218 = translate_expr env e1 in (uu____5218, TAny) in
           ECast uu____5213
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2176,8 +1994,8 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5221;
              FStar_Extraction_ML_Syntax.loc = uu____5222;_},args)
           when (is_machine_int m) && (is_op op) ->
-          let uu____5230 = FStar_Util.must (mk_width m)  in
-          let uu____5231 = FStar_Util.must (mk_op op)  in
+          let uu____5230 = FStar_Util.must (mk_width m) in
+          let uu____5231 = FStar_Util.must (mk_op op) in
           mk_op_app env uu____5230 uu____5231 args
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2186,7 +2004,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.mlty = uu____5233;
              FStar_Extraction_ML_Syntax.loc = uu____5234;_},args)
           when is_bool_op op ->
-          let uu____5242 = FStar_Util.must (mk_bool_op op)  in
+          let uu____5242 = FStar_Util.must (mk_bool_op op) in
           mk_op_app env Bool uu____5242 args
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2207,8 +2025,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                                                                 = uu____5248;_}::[])
           when is_machine_int m ->
           let uu____5263 =
-            let uu____5268 = FStar_Util.must (mk_width m)  in (uu____5268, c)
-             in
+            let uu____5268 = FStar_Util.must (mk_width m) in (uu____5268, c) in
           EConstant uu____5263
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2229,8 +2046,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                                                                 = uu____5274;_}::[])
           when is_machine_int m ->
           let uu____5289 =
-            let uu____5294 = FStar_Util.must (mk_width m)  in (uu____5294, c)
-             in
+            let uu____5294 = FStar_Util.must (mk_width m) in (uu____5294, c) in
           EConstant uu____5289
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -2288,153 +2104,146 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                  || (FStar_Util.starts_with c "int8"))
                 || (FStar_Util.starts_with c "int16"))
                || (FStar_Util.starts_with c "int32"))
-              || (FStar_Util.starts_with c "int64")
-             in
+              || (FStar_Util.starts_with c "int64") in
           if (FStar_Util.ends_with c "uint64") && is_known_type
           then
             let uu____5326 =
-              let uu____5331 = translate_expr env arg  in
-              (uu____5331, (TInt UInt64))  in
+              let uu____5331 = translate_expr env arg in
+              (uu____5331, (TInt UInt64)) in
             ECast uu____5326
           else
             if (FStar_Util.ends_with c "uint32") && is_known_type
             then
               (let uu____5333 =
-                 let uu____5338 = translate_expr env arg  in
-                 (uu____5338, (TInt UInt32))  in
+                 let uu____5338 = translate_expr env arg in
+                 (uu____5338, (TInt UInt32)) in
                ECast uu____5333)
             else
               if (FStar_Util.ends_with c "uint16") && is_known_type
               then
                 (let uu____5340 =
-                   let uu____5345 = translate_expr env arg  in
-                   (uu____5345, (TInt UInt16))  in
+                   let uu____5345 = translate_expr env arg in
+                   (uu____5345, (TInt UInt16)) in
                  ECast uu____5340)
               else
                 if (FStar_Util.ends_with c "uint8") && is_known_type
                 then
                   (let uu____5347 =
-                     let uu____5352 = translate_expr env arg  in
-                     (uu____5352, (TInt UInt8))  in
+                     let uu____5352 = translate_expr env arg in
+                     (uu____5352, (TInt UInt8)) in
                    ECast uu____5347)
                 else
                   if (FStar_Util.ends_with c "int64") && is_known_type
                   then
                     (let uu____5354 =
-                       let uu____5359 = translate_expr env arg  in
-                       (uu____5359, (TInt Int64))  in
+                       let uu____5359 = translate_expr env arg in
+                       (uu____5359, (TInt Int64)) in
                      ECast uu____5354)
                   else
                     if (FStar_Util.ends_with c "int32") && is_known_type
                     then
                       (let uu____5361 =
-                         let uu____5366 = translate_expr env arg  in
-                         (uu____5366, (TInt Int32))  in
+                         let uu____5366 = translate_expr env arg in
+                         (uu____5366, (TInt Int32)) in
                        ECast uu____5361)
                     else
                       if (FStar_Util.ends_with c "int16") && is_known_type
                       then
                         (let uu____5368 =
-                           let uu____5373 = translate_expr env arg  in
-                           (uu____5373, (TInt Int16))  in
+                           let uu____5373 = translate_expr env arg in
+                           (uu____5373, (TInt Int16)) in
                          ECast uu____5368)
                       else
                         if (FStar_Util.ends_with c "int8") && is_known_type
                         then
                           (let uu____5375 =
-                             let uu____5380 = translate_expr env arg  in
-                             (uu____5380, (TInt Int8))  in
+                             let uu____5380 = translate_expr env arg in
+                             (uu____5380, (TInt Int8)) in
                            ECast uu____5375)
                         else
                           (let uu____5382 =
                              let uu____5389 =
-                               let uu____5392 = translate_expr env arg  in
-                               [uu____5392]  in
+                               let uu____5392 = translate_expr env arg in
+                               [uu____5392] in
                              ((EQualified (["FStar"; "Int"; "Cast"], c)),
-                               uu____5389)
-                              in
+                               uu____5389) in
                            EApp uu____5382)
       | FStar_Extraction_ML_Syntax.MLE_App (head1,args) ->
           let uu____5403 =
-            let uu____5410 = translate_expr env head1  in
-            let uu____5411 = FStar_List.map (translate_expr env) args  in
-            (uu____5410, uu____5411)  in
+            let uu____5410 = translate_expr env head1 in
+            let uu____5411 = FStar_List.map (translate_expr env) args in
+            (uu____5410, uu____5411) in
           EApp uu____5403
       | FStar_Extraction_ML_Syntax.MLE_TApp (head1,ty_args) ->
           let uu____5422 =
-            let uu____5429 = translate_expr env head1  in
-            let uu____5430 = FStar_List.map (translate_type env) ty_args  in
-            (uu____5429, uu____5430)  in
+            let uu____5429 = translate_expr env head1 in
+            let uu____5430 = FStar_List.map (translate_type env) ty_args in
+            (uu____5429, uu____5430) in
           ETypApp uu____5422
       | FStar_Extraction_ML_Syntax.MLE_Coerce (e1,t_from,t_to) ->
           let uu____5438 =
-            let uu____5443 = translate_expr env e1  in
-            let uu____5444 = translate_type env t_to  in
-            (uu____5443, uu____5444)  in
+            let uu____5443 = translate_expr env e1 in
+            let uu____5444 = translate_type env t_to in
+            (uu____5443, uu____5444) in
           ECast uu____5438
       | FStar_Extraction_ML_Syntax.MLE_Record (uu____5445,fields) ->
           let uu____5463 =
-            let uu____5474 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
-               in
+            let uu____5474 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty in
             let uu____5475 =
               FStar_List.map
                 (fun uu____5494  ->
                    match uu____5494 with
                    | (field,expr) ->
-                       let uu____5505 = translate_expr env expr  in
-                       (field, uu____5505)) fields
-               in
-            (uu____5474, uu____5475)  in
+                       let uu____5505 = translate_expr env expr in
+                       (field, uu____5505)) fields in
+            (uu____5474, uu____5475) in
           EFlat uu____5463
       | FStar_Extraction_ML_Syntax.MLE_Proj (e1,path) ->
           let uu____5514 =
             let uu____5521 =
-              assert_lid env e1.FStar_Extraction_ML_Syntax.mlty  in
-            let uu____5522 = translate_expr env e1  in
-            (uu____5521, uu____5522, (FStar_Pervasives_Native.snd path))  in
+              assert_lid env e1.FStar_Extraction_ML_Syntax.mlty in
+            let uu____5522 = translate_expr env e1 in
+            (uu____5521, uu____5522, (FStar_Pervasives_Native.snd path)) in
           EField uu____5514
       | FStar_Extraction_ML_Syntax.MLE_Let uu____5525 ->
           failwith "todo: translate_expr [MLE_Let]"
       | FStar_Extraction_ML_Syntax.MLE_App (head1,uu____5537) ->
           let uu____5542 =
             let uu____5543 =
-              FStar_Extraction_ML_Code.string_of_mlexpr ([], "") head1  in
+              FStar_Extraction_ML_Code.string_of_mlexpr ([], "") head1 in
             FStar_Util.format1 "todo: translate_expr [MLE_App] (head is: %s)"
-              uu____5543
-             in
+              uu____5543 in
           failwith uu____5542
       | FStar_Extraction_ML_Syntax.MLE_Seq seqs ->
-          let uu____5549 = FStar_List.map (translate_expr env) seqs  in
+          let uu____5549 = FStar_List.map (translate_expr env) seqs in
           ESequence uu____5549
       | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
-          let uu____5555 = FStar_List.map (translate_expr env) es  in
+          let uu____5555 = FStar_List.map (translate_expr env) es in
           ETuple uu____5555
       | FStar_Extraction_ML_Syntax.MLE_CTor ((uu____5558,cons1),es) ->
           let uu____5575 =
-            let uu____5584 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
-               in
-            let uu____5585 = FStar_List.map (translate_expr env) es  in
-            (uu____5584, cons1, uu____5585)  in
+            let uu____5584 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty in
+            let uu____5585 = FStar_List.map (translate_expr env) es in
+            (uu____5584, cons1, uu____5585) in
           ECons uu____5575
       | FStar_Extraction_ML_Syntax.MLE_Fun (args,body) ->
-          let binders = translate_binders env args  in
-          let env1 = add_binders env args  in
+          let binders = translate_binders env args in
+          let env1 = add_binders env args in
           let uu____5608 =
-            let uu____5617 = translate_expr env1 body  in
+            let uu____5617 = translate_expr env1 body in
             let uu____5618 =
-              translate_type env1 body.FStar_Extraction_ML_Syntax.mlty  in
-            (binders, uu____5617, uu____5618)  in
+              translate_type env1 body.FStar_Extraction_ML_Syntax.mlty in
+            (binders, uu____5617, uu____5618) in
           EFun uu____5608
       | FStar_Extraction_ML_Syntax.MLE_If (e1,e2,e3) ->
           let uu____5628 =
-            let uu____5635 = translate_expr env e1  in
-            let uu____5636 = translate_expr env e2  in
+            let uu____5635 = translate_expr env e1 in
+            let uu____5636 = translate_expr env e2 in
             let uu____5637 =
               match e3 with
               | FStar_Pervasives_Native.None  -> EUnit
-              | FStar_Pervasives_Native.Some e31 -> translate_expr env e31
-               in
-            (uu____5635, uu____5636, uu____5637)  in
+              | FStar_Pervasives_Native.Some e31 -> translate_expr env e31 in
+            (uu____5635, uu____5636, uu____5637) in
           EIfThenElse uu____5628
       | FStar_Extraction_ML_Syntax.MLE_Raise uu____5639 ->
           failwith "todo: translate_expr [MLE_Raise]"
@@ -2442,8 +2251,7 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
           failwith "todo: translate_expr [MLE_Try]"
       | FStar_Extraction_ML_Syntax.MLE_Coerce uu____5661 ->
           failwith "todo: translate_expr [MLE_Coerce]"
-
-and (assert_lid : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
+and assert_lid: env -> FStar_Extraction_ML_Syntax.mlty -> typ =
   fun env  ->
     fun t  ->
       match t with
@@ -2451,27 +2259,25 @@ and (assert_lid : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
           if (FStar_List.length ts) > (Prims.parse_int "0")
           then
             let uu____5676 =
-              let uu____5689 = FStar_List.map (translate_type env) ts  in
-              (lid, uu____5689)  in
+              let uu____5689 = FStar_List.map (translate_type env) ts in
+              (lid, uu____5689) in
             TApp uu____5676
           else TQualified lid
       | uu____5695 -> failwith "invalid argument: assert_lid"
-
-and (translate_branches :
+and translate_branches:
   env ->
     (FStar_Extraction_ML_Syntax.mlpattern,FStar_Extraction_ML_Syntax.mlexpr
                                             FStar_Pervasives_Native.option,
       FStar_Extraction_ML_Syntax.mlexpr) FStar_Pervasives_Native.tuple3
-      Prims.list -> (pattern,expr) FStar_Pervasives_Native.tuple2 Prims.list)
+      Prims.list -> (pattern,expr) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun env  -> fun branches  -> FStar_List.map (translate_branch env) branches
-
-and (translate_branch :
+and translate_branch:
   env ->
     (FStar_Extraction_ML_Syntax.mlpattern,FStar_Extraction_ML_Syntax.mlexpr
                                             FStar_Pervasives_Native.option,
       FStar_Extraction_ML_Syntax.mlexpr) FStar_Pervasives_Native.tuple3 ->
-      (pattern,expr) FStar_Pervasives_Native.tuple2)
+      (pattern,expr) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun uu____5721  ->
@@ -2479,16 +2285,15 @@ and (translate_branch :
       | (pat,guard,expr) ->
           if guard = FStar_Pervasives_Native.None
           then
-            let uu____5747 = translate_pat env pat  in
+            let uu____5747 = translate_pat env pat in
             (match uu____5747 with
              | (env1,pat1) ->
-                 let uu____5758 = translate_expr env1 expr  in
+                 let uu____5758 = translate_expr env1 expr in
                  (pat1, uu____5758))
           else failwith "todo: translate_branch"
-
-and (translate_width :
+and translate_width:
   (FStar_Const.signedness,FStar_Const.width) FStar_Pervasives_Native.tuple2
-    FStar_Pervasives_Native.option -> width)
+    FStar_Pervasives_Native.option -> width
   =
   fun uu___41_5764  ->
     match uu___41_5764 with
@@ -2509,11 +2314,10 @@ and (translate_width :
         -> UInt32
     | FStar_Pervasives_Native.Some (FStar_Const.Unsigned ,FStar_Const.Int64 )
         -> UInt64
-
-and (translate_pat :
+and translate_pat:
   env ->
     FStar_Extraction_ML_Syntax.mlpattern ->
-      (env,pattern) FStar_Pervasives_Native.tuple2)
+      (env,pattern) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun p  ->
@@ -2526,14 +2330,14 @@ and (translate_pat :
           (FStar_Extraction_ML_Syntax.MLC_Int (s,sw)) ->
           let uu____5828 =
             let uu____5829 =
-              let uu____5834 = translate_width sw  in (uu____5834, s)  in
-            PConstant uu____5829  in
+              let uu____5834 = translate_width sw in (uu____5834, s) in
+            PConstant uu____5829 in
           (env, uu____5828)
       | FStar_Extraction_ML_Syntax.MLP_Var name ->
-          let env1 = extend env name false  in
+          let env1 = extend env name false in
           (env1, (PVar { name; typ = TAny; mut = false }))
       | FStar_Extraction_ML_Syntax.MLP_Wild  ->
-          let env1 = extend env "_" false  in
+          let env1 = extend env "_" false in
           (env1, (PVar { name = "_"; typ = TAny; mut = false }))
       | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____5838,cons1),ps) ->
           let uu____5855 =
@@ -2542,10 +2346,9 @@ and (translate_pat :
                  fun p1  ->
                    match uu____5875 with
                    | (env1,acc) ->
-                       let uu____5895 = translate_pat env1 p1  in
+                       let uu____5895 = translate_pat env1 p1 in
                        (match uu____5895 with
-                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
-             in
+                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps in
           (match uu____5855 with
            | (env1,ps1) -> (env1, (PCons (cons1, (FStar_List.rev ps1)))))
       | FStar_Extraction_ML_Syntax.MLP_Record (uu____5924,ps) ->
@@ -2555,11 +2358,10 @@ and (translate_pat :
                  fun uu____5977  ->
                    match (uu____5976, uu____5977) with
                    | ((env1,acc),(field,p1)) ->
-                       let uu____6046 = translate_pat env1 p1  in
+                       let uu____6046 = translate_pat env1 p1 in
                        (match uu____6046 with
                         | (env2,p2) -> (env2, ((field, p2) :: acc))))
-              (env, []) ps
-             in
+              (env, []) ps in
           (match uu____5942 with
            | (env1,ps1) -> (env1, (PRecord (FStar_List.rev ps1))))
       | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
@@ -2569,45 +2371,41 @@ and (translate_pat :
                  fun p1  ->
                    match uu____6128 with
                    | (env1,acc) ->
-                       let uu____6148 = translate_pat env1 p1  in
+                       let uu____6148 = translate_pat env1 p1 in
                        (match uu____6148 with
-                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
-             in
+                        | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps in
           (match uu____6108 with
            | (env1,ps1) -> (env1, (PTuple (FStar_List.rev ps1))))
       | FStar_Extraction_ML_Syntax.MLP_Const uu____6175 ->
           failwith "todo: translate_pat [MLP_Const]"
       | FStar_Extraction_ML_Syntax.MLP_Branch uu____6180 ->
           failwith "todo: translate_pat [MLP_Branch]"
-
-and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
+and translate_constant: FStar_Extraction_ML_Syntax.mlconstant -> expr =
   fun c  ->
     match c with
     | FStar_Extraction_ML_Syntax.MLC_Unit  -> EUnit
     | FStar_Extraction_ML_Syntax.MLC_Bool b -> EBool b
     | FStar_Extraction_ML_Syntax.MLC_String s ->
         ((let uu____6191 =
-            let uu____6192 = FStar_String.list_of_string s  in
+            let uu____6192 = FStar_String.list_of_string s in
             FStar_All.pipe_right uu____6192
               (FStar_Util.for_some
                  (fun c1  ->
-                    c1 = (FStar_Char.char_of_int (Prims.parse_int "0"))))
-             in
+                    c1 = (FStar_Char.char_of_int (Prims.parse_int "0")))) in
           if uu____6191
           then
             let uu____6204 =
               FStar_Util.format1
                 "Refusing to translate a string literal that contains a null character: %s"
-                s
-               in
+                s in
             failwith uu____6204
           else ());
          EString s)
     | FStar_Extraction_ML_Syntax.MLC_Char c1 ->
-        let i = FStar_Util.int_of_char c1  in
-        let s = FStar_Util.string_of_int i  in
-        let c2 = EConstant (UInt32, s)  in
-        let char_of_int1 = EQualified (["FStar"; "Char"], "char_of_int")  in
+        let i = FStar_Util.int_of_char c1 in
+        let s = FStar_Util.string_of_int i in
+        let c2 = EConstant (UInt32, s) in
+        let char_of_int1 = EQualified (["FStar"; "Char"], "char_of_int") in
         EApp (char_of_int1, [c2])
     | FStar_Extraction_ML_Syntax.MLC_Int
         (s,FStar_Pervasives_Native.Some uu____6216) ->
@@ -2619,15 +2417,14 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
         failwith "todo: translate_expr [MLC_Bytes]"
     | FStar_Extraction_ML_Syntax.MLC_Int (s,FStar_Pervasives_Native.None ) ->
         EConstant (CInt, s)
-
-and (mk_op_app :
-  env -> width -> op -> FStar_Extraction_ML_Syntax.mlexpr Prims.list -> expr)
+and mk_op_app:
+  env -> width -> op -> FStar_Extraction_ML_Syntax.mlexpr Prims.list -> expr
   =
   fun env  ->
     fun w  ->
       fun op  ->
         fun args  ->
           let uu____6252 =
-            let uu____6259 = FStar_List.map (translate_expr env) args  in
-            ((EOp (op, w)), uu____6259)  in
+            let uu____6259 = FStar_List.map (translate_expr env) args in
+            ((EOp (op, w)), uu____6259) in
           EApp uu____6252

--- a/src/ocaml-output/FStar_Extraction_ML_Code.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Code.ml
@@ -1,82 +1,78 @@
 open Prims
 type assoc =
-  | ILeft 
-  | IRight 
-  | Left 
-  | Right 
-  | NonAssoc [@@deriving show]
-let (uu___is_ILeft : assoc -> Prims.bool) =
-  fun projectee  -> match projectee with | ILeft  -> true | uu____4 -> false 
-let (uu___is_IRight : assoc -> Prims.bool) =
-  fun projectee  -> match projectee with | IRight  -> true | uu____8 -> false 
-let (uu___is_Left : assoc -> Prims.bool) =
-  fun projectee  -> match projectee with | Left  -> true | uu____12 -> false 
-let (uu___is_Right : assoc -> Prims.bool) =
-  fun projectee  -> match projectee with | Right  -> true | uu____16 -> false 
-let (uu___is_NonAssoc : assoc -> Prims.bool) =
+  | ILeft
+  | IRight
+  | Left
+  | Right
+  | NonAssoc[@@deriving show]
+let uu___is_ILeft: assoc -> Prims.bool =
+  fun projectee  -> match projectee with | ILeft  -> true | uu____4 -> false
+let uu___is_IRight: assoc -> Prims.bool =
+  fun projectee  -> match projectee with | IRight  -> true | uu____8 -> false
+let uu___is_Left: assoc -> Prims.bool =
+  fun projectee  -> match projectee with | Left  -> true | uu____12 -> false
+let uu___is_Right: assoc -> Prims.bool =
+  fun projectee  -> match projectee with | Right  -> true | uu____16 -> false
+let uu___is_NonAssoc: assoc -> Prims.bool =
   fun projectee  ->
     match projectee with | NonAssoc  -> true | uu____20 -> false
-  
 type fixity =
-  | Prefix 
-  | Postfix 
-  | Infix of assoc [@@deriving show]
-let (uu___is_Prefix : fixity -> Prims.bool) =
+  | Prefix
+  | Postfix
+  | Infix of assoc[@@deriving show]
+let uu___is_Prefix: fixity -> Prims.bool =
   fun projectee  ->
     match projectee with | Prefix  -> true | uu____28 -> false
-  
-let (uu___is_Postfix : fixity -> Prims.bool) =
+let uu___is_Postfix: fixity -> Prims.bool =
   fun projectee  ->
     match projectee with | Postfix  -> true | uu____32 -> false
-  
-let (uu___is_Infix : fixity -> Prims.bool) =
+let uu___is_Infix: fixity -> Prims.bool =
   fun projectee  ->
     match projectee with | Infix _0 -> true | uu____37 -> false
-  
-let (__proj__Infix__item___0 : fixity -> assoc) =
-  fun projectee  -> match projectee with | Infix _0 -> _0 
+let __proj__Infix__item___0: fixity -> assoc =
+  fun projectee  -> match projectee with | Infix _0 -> _0
 type opprec = (Prims.int,fixity) FStar_Pervasives_Native.tuple2[@@deriving
                                                                  show]
 type level = (opprec,assoc) FStar_Pervasives_Native.tuple2[@@deriving show]
-let (t_prio_fun : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "10"), (Infix Right)) 
-let (t_prio_tpl : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "20"), (Infix NonAssoc)) 
-let (t_prio_name : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "30"), Postfix) 
-let (e_bin_prio_lambda : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "5"), Prefix) 
-let (e_bin_prio_if : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "15"), Prefix) 
-let (e_bin_prio_letin : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "19"), Prefix) 
-let (e_bin_prio_or : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "20"), (Infix Left)) 
-let (e_bin_prio_and : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "25"), (Infix Left)) 
-let (e_bin_prio_eq : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "27"), (Infix NonAssoc)) 
-let (e_bin_prio_order : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "29"), (Infix NonAssoc)) 
-let (e_bin_prio_op1 : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "30"), (Infix Left)) 
-let (e_bin_prio_op2 : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "40"), (Infix Left)) 
-let (e_bin_prio_op3 : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "50"), (Infix Left)) 
-let (e_bin_prio_op4 : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "60"), (Infix Left)) 
-let (e_bin_prio_comb : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "70"), (Infix Left)) 
-let (e_bin_prio_seq : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "100"), (Infix Left)) 
-let (e_app_prio : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "10000"), (Infix Left)) 
-let (min_op_prec : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  ((~- (Prims.parse_int "1")), (Infix NonAssoc)) 
-let (max_op_prec : (Prims.int,fixity) FStar_Pervasives_Native.tuple2) =
-  (FStar_Util.max_int, (Infix NonAssoc)) 
-let rec in_ns :
+let t_prio_fun: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "10"), (Infix Right))
+let t_prio_tpl: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "20"), (Infix NonAssoc))
+let t_prio_name: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "30"), Postfix)
+let e_bin_prio_lambda: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "5"), Prefix)
+let e_bin_prio_if: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "15"), Prefix)
+let e_bin_prio_letin: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "19"), Prefix)
+let e_bin_prio_or: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "20"), (Infix Left))
+let e_bin_prio_and: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "25"), (Infix Left))
+let e_bin_prio_eq: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "27"), (Infix NonAssoc))
+let e_bin_prio_order: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "29"), (Infix NonAssoc))
+let e_bin_prio_op1: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "30"), (Infix Left))
+let e_bin_prio_op2: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "40"), (Infix Left))
+let e_bin_prio_op3: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "50"), (Infix Left))
+let e_bin_prio_op4: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "60"), (Infix Left))
+let e_bin_prio_comb: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "70"), (Infix Left))
+let e_bin_prio_seq: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "100"), (Infix Left))
+let e_app_prio: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "10000"), (Infix Left))
+let min_op_prec: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  ((- (Prims.parse_int "1")), (Infix NonAssoc))
+let max_op_prec: (Prims.int,fixity) FStar_Pervasives_Native.tuple2 =
+  (FStar_Util.max_int, (Infix NonAssoc))
+let rec in_ns:
   'a .
     ('a Prims.list,'a Prims.list) FStar_Pervasives_Native.tuple2 ->
       Prims.bool
@@ -86,26 +82,25 @@ let rec in_ns :
     | ([],uu____153) -> true
     | (x1::t1,x2::t2) when x1 = x2 -> in_ns (t1, t2)
     | (uu____176,uu____177) -> false
-  
-let (path_of_ns :
+let path_of_ns:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    Prims.string Prims.list -> Prims.string Prims.list)
+    Prims.string Prims.list -> Prims.string Prims.list
   =
   fun currentModule  ->
     fun ns  ->
-      let ns' = FStar_Extraction_ML_Util.flatten_ns ns  in
+      let ns' = FStar_Extraction_ML_Util.flatten_ns ns in
       if ns' = currentModule
       then []
       else
-        (let cg_libs = FStar_Options.codegen_libs ()  in
-         let ns_len = FStar_List.length ns  in
+        (let cg_libs = FStar_Options.codegen_libs () in
+         let ns_len = FStar_List.length ns in
          let found =
            FStar_Util.find_map cg_libs
              (fun cg_path  ->
-                let cg_len = FStar_List.length cg_path  in
+                let cg_len = FStar_List.length cg_path in
                 if (FStar_List.length cg_path) < ns_len
                 then
-                  let uu____235 = FStar_Util.first_N cg_len ns  in
+                  let uu____235 = FStar_Util.first_N cg_len ns in
                   match uu____235 with
                   | (pfx,sfx) ->
                       (if pfx = cg_path
@@ -113,86 +108,79 @@ let (path_of_ns :
                          let uu____268 =
                            let uu____271 =
                              let uu____274 =
-                               FStar_Extraction_ML_Util.flatten_ns sfx  in
-                             [uu____274]  in
-                           FStar_List.append pfx uu____271  in
+                               FStar_Extraction_ML_Util.flatten_ns sfx in
+                             [uu____274] in
+                           FStar_List.append pfx uu____271 in
                          FStar_Pervasives_Native.Some uu____268
                        else FStar_Pervasives_Native.None)
-                else FStar_Pervasives_Native.None)
-            in
+                else FStar_Pervasives_Native.None) in
          match found with
          | FStar_Pervasives_Native.None  -> [ns']
          | FStar_Pervasives_Native.Some x -> x)
-  
-let (mlpath_of_mlpath :
+let mlpath_of_mlpath:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlpath)
+    FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlpath
   =
   fun currentModule  ->
     fun x  ->
-      let uu____298 = FStar_Extraction_ML_Syntax.string_of_mlpath x  in
+      let uu____298 = FStar_Extraction_ML_Syntax.string_of_mlpath x in
       match uu____298 with
       | "Prims.Some" -> ([], "Some")
       | "Prims.None" -> ([], "None")
       | uu____303 ->
-          let uu____304 = x  in
+          let uu____304 = x in
           (match uu____304 with
            | (ns,x1) ->
-               let uu____311 = path_of_ns currentModule ns  in
-               (uu____311, x1))
-  
-let (ptsym_of_symbol :
-  FStar_Extraction_ML_Syntax.mlsymbol -> FStar_Extraction_ML_Syntax.mlsymbol)
+               let uu____311 = path_of_ns currentModule ns in (uu____311, x1))
+let ptsym_of_symbol:
+  FStar_Extraction_ML_Syntax.mlsymbol -> FStar_Extraction_ML_Syntax.mlsymbol
   =
   fun s  ->
     let uu____319 =
       let uu____320 =
-        let uu____322 = FStar_String.get s (Prims.parse_int "0")  in
-        FStar_Char.lowercase uu____322  in
-      let uu____324 = FStar_String.get s (Prims.parse_int "0")  in
-      uu____320 <> uu____324  in
+        let uu____322 = FStar_String.get s (Prims.parse_int "0") in
+        FStar_Char.lowercase uu____322 in
+      let uu____324 = FStar_String.get s (Prims.parse_int "0") in
+      uu____320 <> uu____324 in
     if uu____319 then Prims.strcat "l__" s else s
-  
-let (ptsym :
+let ptsym:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlsymbol)
+    FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlsymbol
   =
   fun currentModule  ->
     fun mlp  ->
       if FStar_List.isEmpty (FStar_Pervasives_Native.fst mlp)
       then ptsym_of_symbol (FStar_Pervasives_Native.snd mlp)
       else
-        (let uu____339 = mlpath_of_mlpath currentModule mlp  in
+        (let uu____339 = mlpath_of_mlpath currentModule mlp in
          match uu____339 with
          | (p,s) ->
              let uu____346 =
                let uu____349 =
-                 let uu____352 = ptsym_of_symbol s  in [uu____352]  in
-               FStar_List.append p uu____349  in
+                 let uu____352 = ptsym_of_symbol s in [uu____352] in
+               FStar_List.append p uu____349 in
              FStar_String.concat "." uu____346)
-  
-let (ptctor :
+let ptctor:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlsymbol)
+    FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlsymbol
   =
   fun currentModule  ->
     fun mlp  ->
-      let uu____359 = mlpath_of_mlpath currentModule mlp  in
+      let uu____359 = mlpath_of_mlpath currentModule mlp in
       match uu____359 with
       | (p,s) ->
           let s1 =
             let uu____367 =
               let uu____368 =
-                let uu____370 = FStar_String.get s (Prims.parse_int "0")  in
-                FStar_Char.uppercase uu____370  in
-              let uu____372 = FStar_String.get s (Prims.parse_int "0")  in
-              uu____368 <> uu____372  in
-            if uu____367 then Prims.strcat "U__" s else s  in
+                let uu____370 = FStar_String.get s (Prims.parse_int "0") in
+                FStar_Char.uppercase uu____370 in
+              let uu____372 = FStar_String.get s (Prims.parse_int "0") in
+              uu____368 <> uu____372 in
+            if uu____367 then Prims.strcat "U__" s else s in
           FStar_String.concat "." (FStar_List.append p [s1])
-  
-let (infix_prim_ops :
+let infix_prim_ops:
   (Prims.string,(Prims.int,fixity) FStar_Pervasives_Native.tuple2,Prims.string)
-    FStar_Pervasives_Native.tuple3 Prims.list)
+    FStar_Pervasives_Native.tuple3 Prims.list
   =
   [("op_Addition", e_bin_prio_op1, "+");
   ("op_Subtraction", e_bin_prio_op1, "-");
@@ -207,33 +195,31 @@ let (infix_prim_ops :
   ("op_GreaterThanOrEqual", e_bin_prio_order, ">=");
   ("op_LessThan", e_bin_prio_order, "<");
   ("op_GreaterThan", e_bin_prio_order, ">");
-  ("op_Modulus", e_bin_prio_order, "mod")] 
-let (prim_uni_ops :
+  ("op_Modulus", e_bin_prio_order, "mod")]
+let prim_uni_ops:
   Prims.unit ->
-    (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list)
+    (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun uu____602  ->
     let op_minus =
-      let uu____604 = FStar_Options.codegen_fsharp ()  in
-      if uu____604 then "-" else "~-"  in
+      let uu____604 = FStar_Options.codegen_fsharp () in
+      if uu____604 then "-" else "~-" in
     [("op_Negation", "not");
     ("op_Minus", op_minus);
     ("op_Bang", "Support.ST.read")]
-  
-let prim_types : 'Auu____623 . Prims.unit -> 'Auu____623 Prims.list =
-  fun uu____626  -> [] 
-let (prim_constructors :
-  (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list) =
-  [("Some", "Some"); ("None", "None"); ("Nil", "[]"); ("Cons", "::")] 
-let (is_prims_ns :
-  FStar_Extraction_ML_Syntax.mlsymbol Prims.list -> Prims.bool) =
-  fun ns  -> ns = ["Prims"] 
-let (as_bin_op :
+let prim_types: 'Auu____623 . Prims.unit -> 'Auu____623 Prims.list =
+  fun uu____626  -> []
+let prim_constructors:
+  (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list =
+  [("Some", "Some"); ("None", "None"); ("Nil", "[]"); ("Cons", "::")]
+let is_prims_ns: FStar_Extraction_ML_Syntax.mlsymbol Prims.list -> Prims.bool
+  = fun ns  -> ns = ["Prims"]
+let as_bin_op:
   FStar_Extraction_ML_Syntax.mlpath ->
     (FStar_Extraction_ML_Syntax.mlsymbol,(Prims.int,fixity)
                                            FStar_Pervasives_Native.tuple2,
       Prims.string) FStar_Pervasives_Native.tuple3
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun uu____676  ->
     match uu____676 with
@@ -245,37 +231,33 @@ let (as_bin_op :
                match uu____721 with | (y,uu____733,uu____734) -> x = y)
             infix_prim_ops
         else FStar_Pervasives_Native.None
-  
-let (is_bin_op : FStar_Extraction_ML_Syntax.mlpath -> Prims.bool) =
+let is_bin_op: FStar_Extraction_ML_Syntax.mlpath -> Prims.bool =
   fun p  ->
-    let uu____757 = as_bin_op p  in uu____757 <> FStar_Pervasives_Native.None
-  
-let (as_uni_op :
+    let uu____757 = as_bin_op p in uu____757 <> FStar_Pervasives_Native.None
+let as_uni_op:
   FStar_Extraction_ML_Syntax.mlpath ->
     (FStar_Extraction_ML_Syntax.mlsymbol,Prims.string)
-      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun uu____800  ->
     match uu____800 with
     | (ns,x) ->
         if is_prims_ns ns
         then
-          let uu____819 = prim_uni_ops ()  in
+          let uu____819 = prim_uni_ops () in
           FStar_List.tryFind
             (fun uu____833  -> match uu____833 with | (y,uu____839) -> x = y)
             uu____819
         else FStar_Pervasives_Native.None
-  
-let (is_uni_op : FStar_Extraction_ML_Syntax.mlpath -> Prims.bool) =
+let is_uni_op: FStar_Extraction_ML_Syntax.mlpath -> Prims.bool =
   fun p  ->
-    let uu____848 = as_uni_op p  in uu____848 <> FStar_Pervasives_Native.None
-  
-let (is_standard_type : FStar_Extraction_ML_Syntax.mlpath -> Prims.bool) =
-  fun p  -> false 
-let (as_standard_constructor :
+    let uu____848 = as_uni_op p in uu____848 <> FStar_Pervasives_Native.None
+let is_standard_type: FStar_Extraction_ML_Syntax.mlpath -> Prims.bool =
+  fun p  -> false
+let as_standard_constructor:
   FStar_Extraction_ML_Syntax.mlpath ->
     (FStar_Extraction_ML_Syntax.mlsymbol,Prims.string)
-      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun uu____876  ->
     match uu____876 with
@@ -286,18 +268,16 @@ let (as_standard_constructor :
             (fun uu____902  -> match uu____902 with | (y,uu____908) -> x = y)
             prim_constructors
         else FStar_Pervasives_Native.None
-  
-let (is_standard_constructor :
-  FStar_Extraction_ML_Syntax.mlpath -> Prims.bool) =
+let is_standard_constructor: FStar_Extraction_ML_Syntax.mlpath -> Prims.bool
+  =
   fun p  ->
-    let uu____917 = as_standard_constructor p  in
+    let uu____917 = as_standard_constructor p in
     uu____917 <> FStar_Pervasives_Native.None
-  
-let (maybe_paren :
+let maybe_paren:
   ((Prims.int,fixity) FStar_Pervasives_Native.tuple2,assoc)
     FStar_Pervasives_Native.tuple2 ->
     (Prims.int,fixity) FStar_Pervasives_Native.tuple2 ->
-      FStar_Format.doc -> FStar_Format.doc)
+      FStar_Format.doc -> FStar_Format.doc
   =
   fun uu____952  ->
     fun inner  ->
@@ -305,10 +285,10 @@ let (maybe_paren :
         match uu____952 with
         | (outer,side) ->
             let noparens _inner _outer side1 =
-              let uu____1003 = _inner  in
+              let uu____1003 = _inner in
               match uu____1003 with
               | (pi,fi) ->
-                  let uu____1010 = _outer  in
+                  let uu____1010 = _outer in
                   (match uu____1010 with
                    | (po,fo) ->
                        (pi > po) ||
@@ -324,18 +304,16 @@ let (maybe_paren :
                            | (Infix (Right ),IRight ) ->
                                (pi = po) && (fo = (Infix Right))
                            | (uu____1017,NonAssoc ) -> (pi = po) && (fi = fo)
-                           | (uu____1018,uu____1019) -> false)))
-               in
+                           | (uu____1018,uu____1019) -> false))) in
             if noparens inner outer side
             then doc1
             else FStar_Format.parens doc1
-  
-let (escape_byte_hex : FStar_BaseTypes.byte -> Prims.string) =
-  fun x  -> Prims.strcat "\\x" (FStar_Util.hex_string_of_byte x) 
-let (escape_char_hex : FStar_BaseTypes.char -> Prims.string) =
-  fun x  -> escape_byte_hex (FStar_Util.byte_of_char x) 
-let (escape_or :
-  (FStar_Char.char -> Prims.string) -> FStar_Char.char -> Prims.string) =
+let escape_byte_hex: FStar_BaseTypes.byte -> Prims.string =
+  fun x  -> Prims.strcat "\\x" (FStar_Util.hex_string_of_byte x)
+let escape_char_hex: FStar_BaseTypes.char -> Prims.string =
+  fun x  -> escape_byte_hex (FStar_Util.byte_of_char x)
+let escape_or:
+  (FStar_Char.char -> Prims.string) -> FStar_Char.char -> Prims.string =
   fun fallback  ->
     fun uu___65_1037  ->
       match uu___65_1037 with
@@ -351,17 +329,16 @@ let (escape_or :
       | c when FStar_Util.is_punctuation c -> FStar_Util.string_of_char c
       | c when FStar_Util.is_symbol c -> FStar_Util.string_of_char c
       | c -> fallback c
-  
-let (string_of_mlconstant :
-  FStar_Extraction_ML_Syntax.mlconstant -> Prims.string) =
+let string_of_mlconstant:
+  FStar_Extraction_ML_Syntax.mlconstant -> Prims.string =
   fun sctt  ->
     match sctt with
     | FStar_Extraction_ML_Syntax.MLC_Unit  -> "()"
     | FStar_Extraction_ML_Syntax.MLC_Bool (true ) -> "true"
     | FStar_Extraction_ML_Syntax.MLC_Bool (false ) -> "false"
     | FStar_Extraction_ML_Syntax.MLC_Char c ->
-        let nc = FStar_Char.int_of_char c  in
-        let uu____1087 = FStar_Util.string_of_int nc  in
+        let nc = FStar_Char.int_of_char c in
+        let uu____1087 = FStar_Util.string_of_int nc in
         Prims.strcat uu____1087
           (if
              ((nc >= (Prims.parse_int "32")) &&
@@ -389,22 +366,20 @@ let (string_of_mlconstant :
     | FStar_Extraction_ML_Syntax.MLC_Bytes bytes ->
         let uu____1172 =
           let uu____1173 =
-            FStar_Compiler_Bytes.f_encode escape_byte_hex bytes  in
-          Prims.strcat uu____1173 "\""  in
+            FStar_Compiler_Bytes.f_encode escape_byte_hex bytes in
+          Prims.strcat uu____1173 "\"" in
         Prims.strcat "\"" uu____1172
     | FStar_Extraction_ML_Syntax.MLC_String chars ->
         let uu____1175 =
           let uu____1176 =
-            FStar_String.collect (escape_or FStar_Util.string_of_char) chars
-             in
-          Prims.strcat uu____1176 "\""  in
+            FStar_String.collect (escape_or FStar_Util.string_of_char) chars in
+          Prims.strcat uu____1176 "\"" in
         Prims.strcat "\"" uu____1175
     | uu____1177 ->
         failwith "TODO: extract integer constants properly into OCaml"
-  
-let rec (doc_of_mltype' :
+let rec doc_of_mltype':
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    level -> FStar_Extraction_ML_Syntax.mlty -> FStar_Format.doc)
+    level -> FStar_Extraction_ML_Syntax.mlty -> FStar_Format.doc
   =
   fun currentModule  ->
     fun outer  ->
@@ -414,19 +389,18 @@ let rec (doc_of_mltype' :
             let escape_tyvar s =
               if FStar_Util.starts_with s "'_"
               then FStar_Util.replace_char s 95 117
-              else s  in
+              else s in
             FStar_Format.text (escape_tyvar x)
         | FStar_Extraction_ML_Syntax.MLTY_Tuple tys ->
             let doc1 =
               FStar_List.map (doc_of_mltype currentModule (t_prio_tpl, Left))
-                tys
-               in
+                tys in
             let doc2 =
               let uu____1212 =
                 let uu____1213 =
-                  FStar_Format.combine (FStar_Format.text " * ") doc1  in
-                FStar_Format.hbox uu____1213  in
-              FStar_Format.parens uu____1212  in
+                  FStar_Format.combine (FStar_Format.text " * ") doc1 in
+                FStar_Format.hbox uu____1213 in
+              FStar_Format.parens uu____1212 in
             doc2
         | FStar_Extraction_ML_Syntax.MLTY_Named (args,name) ->
             let args1 =
@@ -438,129 +412,118 @@ let rec (doc_of_mltype' :
                   let args1 =
                     FStar_List.map
                       (doc_of_mltype currentModule (min_op_prec, NonAssoc))
-                      args
-                     in
+                      args in
                   let uu____1236 =
                     let uu____1237 =
-                      FStar_Format.combine (FStar_Format.text ", ") args1  in
-                    FStar_Format.hbox uu____1237  in
-                  FStar_Format.parens uu____1236
-               in
-            let name1 = ptsym currentModule name  in
+                      FStar_Format.combine (FStar_Format.text ", ") args1 in
+                    FStar_Format.hbox uu____1237 in
+                  FStar_Format.parens uu____1236 in
+            let name1 = ptsym currentModule name in
             let uu____1239 =
-              FStar_Format.reduce1 [args1; FStar_Format.text name1]  in
+              FStar_Format.reduce1 [args1; FStar_Format.text name1] in
             FStar_Format.hbox uu____1239
         | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____1241,t2) ->
-            let d1 = doc_of_mltype currentModule (t_prio_fun, Left) t1  in
-            let d2 = doc_of_mltype currentModule (t_prio_fun, Right) t2  in
+            let d1 = doc_of_mltype currentModule (t_prio_fun, Left) t1 in
+            let d2 = doc_of_mltype currentModule (t_prio_fun, Right) t2 in
             let uu____1253 =
               let uu____1254 =
-                FStar_Format.reduce1 [d1; FStar_Format.text " -> "; d2]  in
-              FStar_Format.hbox uu____1254  in
+                FStar_Format.reduce1 [d1; FStar_Format.text " -> "; d2] in
+              FStar_Format.hbox uu____1254 in
             maybe_paren outer t_prio_fun uu____1253
         | FStar_Extraction_ML_Syntax.MLTY_Top  ->
-            let uu____1255 = FStar_Options.codegen_fsharp ()  in
+            let uu____1255 = FStar_Options.codegen_fsharp () in
             if uu____1255
             then FStar_Format.text "obj"
             else FStar_Format.text "Obj.t"
-
-and (doc_of_mltype :
+and doc_of_mltype:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    level -> FStar_Extraction_ML_Syntax.mlty -> FStar_Format.doc)
+    level -> FStar_Extraction_ML_Syntax.mlty -> FStar_Format.doc
   =
   fun currentModule  ->
     fun outer  ->
       fun ty  ->
-        let uu____1260 = FStar_Extraction_ML_Util.resugar_mlty ty  in
+        let uu____1260 = FStar_Extraction_ML_Util.resugar_mlty ty in
         doc_of_mltype' currentModule outer uu____1260
-
-let rec (doc_of_expr :
+let rec doc_of_expr:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    level -> FStar_Extraction_ML_Syntax.mlexpr -> FStar_Format.doc)
+    level -> FStar_Extraction_ML_Syntax.mlexpr -> FStar_Format.doc
   =
   fun currentModule  ->
     fun outer  ->
       fun e  ->
         match e.FStar_Extraction_ML_Syntax.expr with
         | FStar_Extraction_ML_Syntax.MLE_Coerce (e1,t,t') ->
-            let doc1 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1
-               in
-            let uu____1314 = FStar_Options.codegen_fsharp ()  in
+            let doc1 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
+            let uu____1314 = FStar_Options.codegen_fsharp () in
             if uu____1314
             then
               let uu____1315 =
                 FStar_Format.reduce
-                  [FStar_Format.text "Prims.unsafe_coerce "; doc1]
-                 in
+                  [FStar_Format.text "Prims.unsafe_coerce "; doc1] in
               FStar_Format.parens uu____1315
             else
               (let uu____1317 =
                  FStar_Format.reduce
-                   [FStar_Format.text "Obj.magic "; FStar_Format.parens doc1]
-                  in
+                   [FStar_Format.text "Obj.magic "; FStar_Format.parens doc1] in
                FStar_Format.parens uu____1317)
         | FStar_Extraction_ML_Syntax.MLE_Seq es ->
             let docs =
               FStar_List.map
-                (doc_of_expr currentModule (min_op_prec, NonAssoc)) es
-               in
+                (doc_of_expr currentModule (min_op_prec, NonAssoc)) es in
             let docs1 =
               FStar_List.map
                 (fun d  ->
                    FStar_Format.reduce
-                     [d; FStar_Format.text ";"; FStar_Format.hardline]) docs
-               in
-            let uu____1333 = FStar_Format.reduce docs1  in
+                     [d; FStar_Format.text ";"; FStar_Format.hardline]) docs in
+            let uu____1333 = FStar_Format.reduce docs1 in
             FStar_Format.parens uu____1333
         | FStar_Extraction_ML_Syntax.MLE_Const c ->
-            let uu____1335 = string_of_mlconstant c  in
+            let uu____1335 = string_of_mlconstant c in
             FStar_Format.text uu____1335
         | FStar_Extraction_ML_Syntax.MLE_Var x -> FStar_Format.text x
         | FStar_Extraction_ML_Syntax.MLE_Name path ->
-            let uu____1338 = ptsym currentModule path  in
+            let uu____1338 = ptsym currentModule path in
             FStar_Format.text uu____1338
         | FStar_Extraction_ML_Syntax.MLE_Record (path,fields) ->
             let for1 uu____1364 =
               match uu____1364 with
               | (name,e1) ->
                   let doc1 =
-                    doc_of_expr currentModule (min_op_prec, NonAssoc) e1  in
+                    doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
                   let uu____1376 =
                     let uu____1379 =
-                      let uu____1380 = ptsym currentModule (path, name)  in
-                      FStar_Format.text uu____1380  in
-                    [uu____1379; FStar_Format.text "="; doc1]  in
-                  FStar_Format.reduce1 uu____1376
-               in
+                      let uu____1380 = ptsym currentModule (path, name) in
+                      FStar_Format.text uu____1380 in
+                    [uu____1379; FStar_Format.text "="; doc1] in
+                  FStar_Format.reduce1 uu____1376 in
             let uu____1383 =
-              let uu____1384 = FStar_List.map for1 fields  in
-              FStar_Format.combine (FStar_Format.text "; ") uu____1384  in
+              let uu____1384 = FStar_List.map for1 fields in
+              FStar_Format.combine (FStar_Format.text "; ") uu____1384 in
             FStar_Format.cbrackets uu____1383
         | FStar_Extraction_ML_Syntax.MLE_CTor (ctor,[]) ->
             let name =
-              let uu____1395 = is_standard_constructor ctor  in
+              let uu____1395 = is_standard_constructor ctor in
               if uu____1395
               then
                 let uu____1396 =
-                  let uu____1401 = as_standard_constructor ctor  in
-                  FStar_Option.get uu____1401  in
+                  let uu____1401 = as_standard_constructor ctor in
+                  FStar_Option.get uu____1401 in
                 FStar_Pervasives_Native.snd uu____1396
-              else ptctor currentModule ctor  in
+              else ptctor currentModule ctor in
             FStar_Format.text name
         | FStar_Extraction_ML_Syntax.MLE_CTor (ctor,args) ->
             let name =
-              let uu____1420 = is_standard_constructor ctor  in
+              let uu____1420 = is_standard_constructor ctor in
               if uu____1420
               then
                 let uu____1421 =
-                  let uu____1426 = as_standard_constructor ctor  in
-                  FStar_Option.get uu____1426  in
+                  let uu____1426 = as_standard_constructor ctor in
+                  FStar_Option.get uu____1426 in
                 FStar_Pervasives_Native.snd uu____1421
-              else ptctor currentModule ctor  in
+              else ptctor currentModule ctor in
             let args1 =
               FStar_List.map
-                (doc_of_expr currentModule (min_op_prec, NonAssoc)) args
-               in
+                (doc_of_expr currentModule (min_op_prec, NonAssoc)) args in
             let doc1 =
               match (name, args1) with
               | ("::",x::xs::[]) ->
@@ -571,26 +534,23 @@ let rec (doc_of_expr :
                     let uu____1461 =
                       let uu____1464 =
                         let uu____1465 =
-                          FStar_Format.combine (FStar_Format.text ", ") args1
-                           in
-                        FStar_Format.parens uu____1465  in
-                      [uu____1464]  in
-                    (FStar_Format.text name) :: uu____1461  in
-                  FStar_Format.reduce1 uu____1458
-               in
+                          FStar_Format.combine (FStar_Format.text ", ") args1 in
+                        FStar_Format.parens uu____1465 in
+                      [uu____1464] in
+                    (FStar_Format.text name) :: uu____1461 in
+                  FStar_Format.reduce1 uu____1458 in
             maybe_paren outer e_app_prio doc1
         | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
             let docs =
               FStar_List.map
                 (fun x  ->
                    let uu____1475 =
-                     doc_of_expr currentModule (min_op_prec, NonAssoc) x  in
-                   FStar_Format.parens uu____1475) es
-               in
+                     doc_of_expr currentModule (min_op_prec, NonAssoc) x in
+                   FStar_Format.parens uu____1475) es in
             let docs1 =
               let uu____1481 =
-                FStar_Format.combine (FStar_Format.text ", ") docs  in
-              FStar_Format.parens uu____1481  in
+                FStar_Format.combine (FStar_Format.text ", ") docs in
+              FStar_Format.parens uu____1481 in
             docs1
         | FStar_Extraction_ML_Syntax.MLE_Let ((rec_,lets),body) ->
             let pre =
@@ -601,25 +561,24 @@ let rec (doc_of_expr :
                 let uu____1496 =
                   let uu____1499 =
                     let uu____1502 =
-                      doc_of_loc e.FStar_Extraction_ML_Syntax.loc  in
-                    [uu____1502]  in
-                  FStar_Format.hardline :: uu____1499  in
+                      doc_of_loc e.FStar_Extraction_ML_Syntax.loc in
+                    [uu____1502] in
+                  FStar_Format.hardline :: uu____1499 in
                 FStar_Format.reduce uu____1496
-              else FStar_Format.empty  in
-            let doc1 = doc_of_lets currentModule (rec_, false, lets)  in
+              else FStar_Format.empty in
+            let doc1 = doc_of_lets currentModule (rec_, false, lets) in
             let body1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) body  in
+              doc_of_expr currentModule (min_op_prec, NonAssoc) body in
             let uu____1512 =
               let uu____1513 =
                 let uu____1516 =
                   let uu____1519 =
                     let uu____1522 =
-                      FStar_Format.reduce1 [FStar_Format.text "in"; body1]
-                       in
-                    [uu____1522]  in
-                  doc1 :: uu____1519  in
-                pre :: uu____1516  in
-              FStar_Format.combine FStar_Format.hardline uu____1513  in
+                      FStar_Format.reduce1 [FStar_Format.text "in"; body1] in
+                    [uu____1522] in
+                  doc1 :: uu____1519 in
+                pre :: uu____1516 in
+              FStar_Format.combine FStar_Format.hardline uu____1513 in
             FStar_Format.parens uu____1512
         | FStar_Extraction_ML_Syntax.MLE_App (e1,args) ->
             (match ((e1.FStar_Extraction_ML_Syntax.expr), args) with
@@ -642,7 +601,7 @@ let rec (doc_of_expr :
                                                                     uu____1540;_}::[])
                  when
                  let uu____1575 =
-                   FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+                   FStar_Extraction_ML_Syntax.string_of_mlpath p in
                  uu____1575 = "FStar.All.try_with" ->
                  let branches =
                    match possible_match with
@@ -659,8 +618,7 @@ let rec (doc_of_expr :
                        arg = arg' -> branches
                    | e2 ->
                        [(FStar_Extraction_ML_Syntax.MLP_Wild,
-                          FStar_Pervasives_Native.None, e2)]
-                    in
+                          FStar_Pervasives_Native.None, e2)] in
                  doc_of_expr currentModule outer
                    {
                      FStar_Extraction_ML_Syntax.expr =
@@ -696,18 +654,16 @@ let rec (doc_of_expr :
                    (unitVal = FStar_Extraction_ML_Syntax.ml_unit)
                  -> doc_of_uniop currentModule p e11
              | uu____1680 ->
-                 let e2 = doc_of_expr currentModule (e_app_prio, ILeft) e1
-                    in
+                 let e2 = doc_of_expr currentModule (e_app_prio, ILeft) e1 in
                  let args1 =
                    FStar_List.map
-                     (doc_of_expr currentModule (e_app_prio, IRight)) args
-                    in
-                 let uu____1699 = FStar_Format.reduce1 (e2 :: args1)  in
+                     (doc_of_expr currentModule (e_app_prio, IRight)) args in
+                 let uu____1699 = FStar_Format.reduce1 (e2 :: args1) in
                  FStar_Format.parens uu____1699)
         | FStar_Extraction_ML_Syntax.MLE_Proj (e1,f) ->
-            let e2 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1  in
+            let e2 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
             let doc1 =
-              let uu____1708 = FStar_Options.codegen_fsharp ()  in
+              let uu____1708 = FStar_Options.codegen_fsharp () in
               if uu____1708
               then
                 FStar_Format.reduce
@@ -719,17 +675,16 @@ let rec (doc_of_expr :
                    let uu____1715 =
                      let uu____1718 =
                        let uu____1721 =
-                         let uu____1722 = ptsym currentModule f  in
-                         FStar_Format.text uu____1722  in
-                       [uu____1721]  in
-                     (FStar_Format.text ".") :: uu____1718  in
-                   e2 :: uu____1715  in
-                 FStar_Format.reduce uu____1712)
-               in
+                         let uu____1722 = ptsym currentModule f in
+                         FStar_Format.text uu____1722 in
+                       [uu____1721] in
+                     (FStar_Format.text ".") :: uu____1718 in
+                   e2 :: uu____1715 in
+                 FStar_Format.reduce uu____1712) in
             doc1
         | FStar_Extraction_ML_Syntax.MLE_Fun (ids,body) ->
             let bvar_annot x xt =
-              let uu____1748 = FStar_Options.codegen_fsharp ()  in
+              let uu____1748 = FStar_Options.codegen_fsharp () in
               if uu____1748
               then
                 let uu____1749 =
@@ -741,37 +696,36 @@ let rec (doc_of_expr :
                             let uu____1760 =
                               let uu____1763 =
                                 let uu____1766 =
-                                  doc_of_mltype currentModule outer xxt  in
-                                [uu____1766]  in
-                              (FStar_Format.text " : ") :: uu____1763  in
+                                  doc_of_mltype currentModule outer xxt in
+                                [uu____1766] in
+                              (FStar_Format.text " : ") :: uu____1763 in
                             FStar_Format.reduce1 uu____1760
-                        | uu____1767 -> FStar_Format.text ""  in
-                      [uu____1758; FStar_Format.text ")"]  in
-                    (FStar_Format.text x) :: uu____1755  in
-                  (FStar_Format.text "(") :: uu____1752  in
+                        | uu____1767 -> FStar_Format.text "" in
+                      [uu____1758; FStar_Format.text ")"] in
+                    (FStar_Format.text x) :: uu____1755 in
+                  (FStar_Format.text "(") :: uu____1752 in
                 FStar_Format.reduce1 uu____1749
-              else FStar_Format.text x  in
+              else FStar_Format.text x in
             let ids1 =
               FStar_List.map
                 (fun uu____1781  ->
                    match uu____1781 with
                    | (x,xt) -> bvar_annot x (FStar_Pervasives_Native.Some xt))
-                ids
-               in
+                ids in
             let body1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) body  in
+              doc_of_expr currentModule (min_op_prec, NonAssoc) body in
             let doc1 =
               let uu____1794 =
                 let uu____1797 =
-                  let uu____1800 = FStar_Format.reduce1 ids1  in
-                  [uu____1800; FStar_Format.text "->"; body1]  in
-                (FStar_Format.text "fun") :: uu____1797  in
-              FStar_Format.reduce1 uu____1794  in
+                  let uu____1800 = FStar_Format.reduce1 ids1 in
+                  [uu____1800; FStar_Format.text "->"; body1] in
+                (FStar_Format.text "fun") :: uu____1797 in
+              FStar_Format.reduce1 uu____1794 in
             FStar_Format.parens doc1
         | FStar_Extraction_ML_Syntax.MLE_If
             (cond,e1,FStar_Pervasives_Native.None ) ->
             let cond1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) cond  in
+              doc_of_expr currentModule (min_op_prec, NonAssoc) cond in
             let doc1 =
               let uu____1811 =
                 let uu____1814 =
@@ -779,19 +733,18 @@ let rec (doc_of_expr :
                     [FStar_Format.text "if";
                     cond1;
                     FStar_Format.text "then";
-                    FStar_Format.text "begin"]
-                   in
+                    FStar_Format.text "begin"] in
                 let uu____1815 =
                   let uu____1818 =
-                    doc_of_expr currentModule (min_op_prec, NonAssoc) e1  in
-                  [uu____1818; FStar_Format.text "end"]  in
-                uu____1814 :: uu____1815  in
-              FStar_Format.combine FStar_Format.hardline uu____1811  in
+                    doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
+                  [uu____1818; FStar_Format.text "end"] in
+                uu____1814 :: uu____1815 in
+              FStar_Format.combine FStar_Format.hardline uu____1811 in
             maybe_paren outer e_bin_prio_if doc1
         | FStar_Extraction_ML_Syntax.MLE_If
             (cond,e1,FStar_Pervasives_Native.Some e2) ->
             let cond1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) cond  in
+              doc_of_expr currentModule (min_op_prec, NonAssoc) cond in
             let doc1 =
               let uu____1834 =
                 let uu____1837 =
@@ -799,140 +752,129 @@ let rec (doc_of_expr :
                     [FStar_Format.text "if";
                     cond1;
                     FStar_Format.text "then";
-                    FStar_Format.text "begin"]
-                   in
+                    FStar_Format.text "begin"] in
                 let uu____1838 =
                   let uu____1841 =
-                    doc_of_expr currentModule (min_op_prec, NonAssoc) e1  in
+                    doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
                   let uu____1846 =
                     let uu____1849 =
                       FStar_Format.reduce1
                         [FStar_Format.text "end";
                         FStar_Format.text "else";
-                        FStar_Format.text "begin"]
-                       in
+                        FStar_Format.text "begin"] in
                     let uu____1850 =
                       let uu____1853 =
-                        doc_of_expr currentModule (min_op_prec, NonAssoc) e2
-                         in
-                      [uu____1853; FStar_Format.text "end"]  in
-                    uu____1849 :: uu____1850  in
-                  uu____1841 :: uu____1846  in
-                uu____1837 :: uu____1838  in
-              FStar_Format.combine FStar_Format.hardline uu____1834  in
+                        doc_of_expr currentModule (min_op_prec, NonAssoc) e2 in
+                      [uu____1853; FStar_Format.text "end"] in
+                    uu____1849 :: uu____1850 in
+                  uu____1841 :: uu____1846 in
+                uu____1837 :: uu____1838 in
+              FStar_Format.combine FStar_Format.hardline uu____1834 in
             maybe_paren outer e_bin_prio_if doc1
         | FStar_Extraction_ML_Syntax.MLE_Match (cond,pats) ->
             let cond1 =
-              doc_of_expr currentModule (min_op_prec, NonAssoc) cond  in
-            let pats1 = FStar_List.map (doc_of_branch currentModule) pats  in
+              doc_of_expr currentModule (min_op_prec, NonAssoc) cond in
+            let pats1 = FStar_List.map (doc_of_branch currentModule) pats in
             let doc1 =
               let uu____1891 =
                 FStar_Format.reduce1
                   [FStar_Format.text "match";
                   FStar_Format.parens cond1;
-                  FStar_Format.text "with"]
-                 in
-              uu____1891 :: pats1  in
-            let doc2 = FStar_Format.combine FStar_Format.hardline doc1  in
+                  FStar_Format.text "with"] in
+              uu____1891 :: pats1 in
+            let doc2 = FStar_Format.combine FStar_Format.hardline doc1 in
             FStar_Format.parens doc2
         | FStar_Extraction_ML_Syntax.MLE_Raise (exn,[]) ->
             let uu____1896 =
               let uu____1899 =
                 let uu____1902 =
-                  let uu____1903 = ptctor currentModule exn  in
-                  FStar_Format.text uu____1903  in
-                [uu____1902]  in
-              (FStar_Format.text "raise") :: uu____1899  in
+                  let uu____1903 = ptctor currentModule exn in
+                  FStar_Format.text uu____1903 in
+                [uu____1902] in
+              (FStar_Format.text "raise") :: uu____1899 in
             FStar_Format.reduce1 uu____1896
         | FStar_Extraction_ML_Syntax.MLE_Raise (exn,args) ->
             let args1 =
               FStar_List.map
-                (doc_of_expr currentModule (min_op_prec, NonAssoc)) args
-               in
+                (doc_of_expr currentModule (min_op_prec, NonAssoc)) args in
             let uu____1917 =
               let uu____1920 =
                 let uu____1923 =
-                  let uu____1924 = ptctor currentModule exn  in
-                  FStar_Format.text uu____1924  in
+                  let uu____1924 = ptctor currentModule exn in
+                  FStar_Format.text uu____1924 in
                 let uu____1925 =
                   let uu____1928 =
                     let uu____1929 =
-                      FStar_Format.combine (FStar_Format.text ", ") args1  in
-                    FStar_Format.parens uu____1929  in
-                  [uu____1928]  in
-                uu____1923 :: uu____1925  in
-              (FStar_Format.text "raise") :: uu____1920  in
+                      FStar_Format.combine (FStar_Format.text ", ") args1 in
+                    FStar_Format.parens uu____1929 in
+                  [uu____1928] in
+                uu____1923 :: uu____1925 in
+              (FStar_Format.text "raise") :: uu____1920 in
             FStar_Format.reduce1 uu____1917
         | FStar_Extraction_ML_Syntax.MLE_Try (e1,pats) ->
             let uu____1952 =
               let uu____1955 =
                 let uu____1958 =
-                  doc_of_expr currentModule (min_op_prec, NonAssoc) e1  in
+                  doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
                 let uu____1963 =
                   let uu____1966 =
                     let uu____1969 =
                       let uu____1970 =
-                        FStar_List.map (doc_of_branch currentModule) pats  in
-                      FStar_Format.combine FStar_Format.hardline uu____1970
-                       in
-                    [uu____1969]  in
-                  (FStar_Format.text "with") :: uu____1966  in
-                uu____1958 :: uu____1963  in
-              (FStar_Format.text "try") :: uu____1955  in
+                        FStar_List.map (doc_of_branch currentModule) pats in
+                      FStar_Format.combine FStar_Format.hardline uu____1970 in
+                    [uu____1969] in
+                  (FStar_Format.text "with") :: uu____1966 in
+                uu____1958 :: uu____1963 in
+              (FStar_Format.text "try") :: uu____1955 in
             FStar_Format.combine FStar_Format.hardline uu____1952
         | FStar_Extraction_ML_Syntax.MLE_TApp (head1,ty_args) ->
             doc_of_expr currentModule outer head1
-
-and (doc_of_binop :
+and doc_of_binop:
   FStar_Extraction_ML_Syntax.mlsymbol ->
     FStar_Extraction_ML_Syntax.mlpath ->
       FStar_Extraction_ML_Syntax.mlexpr ->
-        FStar_Extraction_ML_Syntax.mlexpr -> FStar_Format.doc)
+        FStar_Extraction_ML_Syntax.mlexpr -> FStar_Format.doc
   =
   fun currentModule  ->
     fun p  ->
       fun e1  ->
         fun e2  ->
           let uu____1983 =
-            let uu____1994 = as_bin_op p  in FStar_Option.get uu____1994  in
+            let uu____1994 = as_bin_op p in FStar_Option.get uu____1994 in
           match uu____1983 with
           | (uu____2017,prio,txt) ->
-              let e11 = doc_of_expr currentModule (prio, Left) e1  in
-              let e21 = doc_of_expr currentModule (prio, Right) e2  in
+              let e11 = doc_of_expr currentModule (prio, Left) e1 in
+              let e21 = doc_of_expr currentModule (prio, Right) e2 in
               let doc1 =
-                FStar_Format.reduce1 [e11; FStar_Format.text txt; e21]  in
+                FStar_Format.reduce1 [e11; FStar_Format.text txt; e21] in
               FStar_Format.parens doc1
-
-and (doc_of_uniop :
+and doc_of_uniop:
   FStar_Extraction_ML_Syntax.mlsymbol ->
     FStar_Extraction_ML_Syntax.mlpath ->
-      FStar_Extraction_ML_Syntax.mlexpr -> FStar_Format.doc)
+      FStar_Extraction_ML_Syntax.mlexpr -> FStar_Format.doc
   =
   fun currentModule  ->
     fun p  ->
       fun e1  ->
         let uu____2042 =
-          let uu____2047 = as_uni_op p  in FStar_Option.get uu____2047  in
+          let uu____2047 = as_uni_op p in FStar_Option.get uu____2047 in
         match uu____2042 with
         | (uu____2058,txt) ->
-            let e11 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1
-               in
+            let e11 = doc_of_expr currentModule (min_op_prec, NonAssoc) e1 in
             let doc1 =
               FStar_Format.reduce1
-                [FStar_Format.text txt; FStar_Format.parens e11]
-               in
+                [FStar_Format.text txt; FStar_Format.parens e11] in
             FStar_Format.parens doc1
-
-and (doc_of_pattern :
+and doc_of_pattern:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlpattern -> FStar_Format.doc)
+    FStar_Extraction_ML_Syntax.mlpattern -> FStar_Format.doc
   =
   fun currentModule  ->
     fun pattern  ->
       match pattern with
       | FStar_Extraction_ML_Syntax.MLP_Wild  -> FStar_Format.text "_"
       | FStar_Extraction_ML_Syntax.MLP_Const c ->
-          let uu____2069 = string_of_mlconstant c  in
+          let uu____2069 = string_of_mlconstant c in
           FStar_Format.text uu____2069
       | FStar_Extraction_ML_Syntax.MLP_Var x -> FStar_Format.text x
       | FStar_Extraction_ML_Syntax.MLP_Record (path,fields) ->
@@ -941,64 +883,63 @@ and (doc_of_pattern :
             | (name,p) ->
                 let uu____2103 =
                   let uu____2106 =
-                    let uu____2107 = ptsym currentModule (path, name)  in
-                    FStar_Format.text uu____2107  in
+                    let uu____2107 = ptsym currentModule (path, name) in
+                    FStar_Format.text uu____2107 in
                   let uu____2110 =
                     let uu____2113 =
-                      let uu____2116 = doc_of_pattern currentModule p  in
-                      [uu____2116]  in
-                    (FStar_Format.text "=") :: uu____2113  in
-                  uu____2106 :: uu____2110  in
-                FStar_Format.reduce1 uu____2103
-             in
+                      let uu____2116 = doc_of_pattern currentModule p in
+                      [uu____2116] in
+                    (FStar_Format.text "=") :: uu____2113 in
+                  uu____2106 :: uu____2110 in
+                FStar_Format.reduce1 uu____2103 in
           let uu____2117 =
-            let uu____2118 = FStar_List.map for1 fields  in
-            FStar_Format.combine (FStar_Format.text "; ") uu____2118  in
+            let uu____2118 = FStar_List.map for1 fields in
+            FStar_Format.combine (FStar_Format.text "; ") uu____2118 in
           FStar_Format.cbrackets uu____2117
       | FStar_Extraction_ML_Syntax.MLP_CTor (ctor,[]) ->
           let name =
-            let uu____2129 = is_standard_constructor ctor  in
+            let uu____2129 = is_standard_constructor ctor in
             if uu____2129
             then
               let uu____2130 =
-                let uu____2135 = as_standard_constructor ctor  in
-                FStar_Option.get uu____2135  in
+                let uu____2135 = as_standard_constructor ctor in
+                FStar_Option.get uu____2135 in
               FStar_Pervasives_Native.snd uu____2130
-            else ptctor currentModule ctor  in
+            else ptctor currentModule ctor in
           FStar_Format.text name
       | FStar_Extraction_ML_Syntax.MLP_CTor (ctor,pats) ->
           let name =
-            let uu____2154 = is_standard_constructor ctor  in
+            let uu____2154 = is_standard_constructor ctor in
             if uu____2154
             then
               let uu____2155 =
-                let uu____2160 = as_standard_constructor ctor  in
-                FStar_Option.get uu____2160  in
+                let uu____2160 = as_standard_constructor ctor in
+                FStar_Option.get uu____2160 in
               FStar_Pervasives_Native.snd uu____2155
-            else ptctor currentModule ctor  in
+            else ptctor currentModule ctor in
           let doc1 =
             match (name, pats) with
             | ("::",x::xs::[]) ->
                 let uu____2179 =
                   let uu____2182 =
-                    let uu____2183 = doc_of_pattern currentModule x  in
-                    FStar_Format.parens uu____2183  in
+                    let uu____2183 = doc_of_pattern currentModule x in
+                    FStar_Format.parens uu____2183 in
                   let uu____2184 =
                     let uu____2187 =
-                      let uu____2190 = doc_of_pattern currentModule xs  in
-                      [uu____2190]  in
-                    (FStar_Format.text "::") :: uu____2187  in
-                  uu____2182 :: uu____2184  in
+                      let uu____2190 = doc_of_pattern currentModule xs in
+                      [uu____2190] in
+                    (FStar_Format.text "::") :: uu____2187 in
+                  uu____2182 :: uu____2184 in
                 FStar_Format.reduce uu____2179
             | (uu____2191,(FStar_Extraction_ML_Syntax.MLP_Tuple
                uu____2192)::[]) ->
                 let uu____2197 =
                   let uu____2200 =
                     let uu____2203 =
-                      let uu____2204 = FStar_List.hd pats  in
-                      doc_of_pattern currentModule uu____2204  in
-                    [uu____2203]  in
-                  (FStar_Format.text name) :: uu____2200  in
+                      let uu____2204 = FStar_List.hd pats in
+                      doc_of_pattern currentModule uu____2204 in
+                    [uu____2203] in
+                  (FStar_Format.text name) :: uu____2200 in
                 FStar_Format.reduce1 uu____2197
             | uu____2205 ->
                 let uu____2212 =
@@ -1006,30 +947,25 @@ and (doc_of_pattern :
                     let uu____2218 =
                       let uu____2219 =
                         let uu____2220 =
-                          FStar_List.map (doc_of_pattern currentModule) pats
-                           in
+                          FStar_List.map (doc_of_pattern currentModule) pats in
                         FStar_Format.combine (FStar_Format.text ", ")
-                          uu____2220
-                         in
-                      FStar_Format.parens uu____2219  in
-                    [uu____2218]  in
-                  (FStar_Format.text name) :: uu____2215  in
-                FStar_Format.reduce1 uu____2212
-             in
+                          uu____2220 in
+                      FStar_Format.parens uu____2219 in
+                    [uu____2218] in
+                  (FStar_Format.text name) :: uu____2215 in
+                FStar_Format.reduce1 uu____2212 in
           maybe_paren (min_op_prec, NonAssoc) e_app_prio doc1
       | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
-          let ps1 = FStar_List.map (doc_of_pattern currentModule) ps  in
-          let uu____2233 = FStar_Format.combine (FStar_Format.text ", ") ps1
-             in
+          let ps1 = FStar_List.map (doc_of_pattern currentModule) ps in
+          let uu____2233 = FStar_Format.combine (FStar_Format.text ", ") ps1 in
           FStar_Format.parens uu____2233
       | FStar_Extraction_ML_Syntax.MLP_Branch ps ->
-          let ps1 = FStar_List.map (doc_of_pattern currentModule) ps  in
-          let ps2 = FStar_List.map FStar_Format.parens ps1  in
+          let ps1 = FStar_List.map (doc_of_pattern currentModule) ps in
+          let ps2 = FStar_List.map FStar_Format.parens ps1 in
           FStar_Format.combine (FStar_Format.text " | ") ps2
-
-and (doc_of_branch :
+and doc_of_branch:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlbranch -> FStar_Format.doc)
+    FStar_Extraction_ML_Syntax.mlbranch -> FStar_Format.doc
   =
   fun currentModule  ->
     fun uu____2244  ->
@@ -1040,37 +976,33 @@ and (doc_of_branch :
             | FStar_Pervasives_Native.None  ->
                 let uu____2253 =
                   let uu____2256 =
-                    let uu____2259 = doc_of_pattern currentModule p  in
-                    [uu____2259]  in
-                  (FStar_Format.text "|") :: uu____2256  in
+                    let uu____2259 = doc_of_pattern currentModule p in
+                    [uu____2259] in
+                  (FStar_Format.text "|") :: uu____2256 in
                 FStar_Format.reduce1 uu____2253
             | FStar_Pervasives_Native.Some c ->
-                let c1 = doc_of_expr currentModule (min_op_prec, NonAssoc) c
-                   in
+                let c1 = doc_of_expr currentModule (min_op_prec, NonAssoc) c in
                 let uu____2266 =
                   let uu____2269 =
-                    let uu____2272 = doc_of_pattern currentModule p  in
-                    [uu____2272; FStar_Format.text "when"; c1]  in
-                  (FStar_Format.text "|") :: uu____2269  in
-                FStar_Format.reduce1 uu____2266
-             in
+                    let uu____2272 = doc_of_pattern currentModule p in
+                    [uu____2272; FStar_Format.text "when"; c1] in
+                  (FStar_Format.text "|") :: uu____2269 in
+                FStar_Format.reduce1 uu____2266 in
           let uu____2273 =
             let uu____2276 =
               FStar_Format.reduce1
-                [case; FStar_Format.text "->"; FStar_Format.text "begin"]
-               in
+                [case; FStar_Format.text "->"; FStar_Format.text "begin"] in
             let uu____2277 =
               let uu____2280 =
-                doc_of_expr currentModule (min_op_prec, NonAssoc) e  in
-              [uu____2280; FStar_Format.text "end"]  in
-            uu____2276 :: uu____2277  in
+                doc_of_expr currentModule (min_op_prec, NonAssoc) e in
+              [uu____2280; FStar_Format.text "end"] in
+            uu____2276 :: uu____2277 in
           FStar_Format.combine FStar_Format.hardline uu____2273
-
-and (doc_of_lets :
+and doc_of_lets:
   FStar_Extraction_ML_Syntax.mlsymbol ->
     (FStar_Extraction_ML_Syntax.mlletflavor,Prims.bool,FStar_Extraction_ML_Syntax.mllb
                                                          Prims.list)
-      FStar_Pervasives_Native.tuple3 -> FStar_Format.doc)
+      FStar_Pervasives_Native.tuple3 -> FStar_Format.doc
   =
   fun currentModule  ->
     fun uu____2286  ->
@@ -1084,9 +1016,8 @@ and (doc_of_lets :
                 FStar_Extraction_ML_Syntax.mllb_def = e;
                 FStar_Extraction_ML_Syntax.mllb_meta = uu____2310;
                 FStar_Extraction_ML_Syntax.print_typ = pt;_} ->
-                let e1 = doc_of_expr currentModule (min_op_prec, NonAssoc) e
-                   in
-                let ids = []  in
+                let e1 = doc_of_expr currentModule (min_op_prec, NonAssoc) e in
+                let ids = [] in
                 let ty_annot =
                   if Prims.op_Negation pt
                   then FStar_Format.text ""
@@ -1094,8 +1025,7 @@ and (doc_of_lets :
                     (let uu____2324 =
                        (FStar_Options.codegen_fsharp ()) &&
                          ((rec_ = FStar_Extraction_ML_Syntax.Rec) ||
-                            top_level)
-                        in
+                            top_level) in
                      if uu____2324
                      then
                        match tys with
@@ -1107,8 +1037,7 @@ and (doc_of_lets :
                        | FStar_Pervasives_Native.Some ([],ty) ->
                            let ty1 =
                              doc_of_mltype currentModule
-                               (min_op_prec, NonAssoc) ty
-                              in
+                               (min_op_prec, NonAssoc) ty in
                            FStar_Format.reduce1 [FStar_Format.text ":"; ty1]
                      else
                        if top_level
@@ -1119,15 +1048,13 @@ and (doc_of_lets :
                           | FStar_Pervasives_Native.Some ([],ty) ->
                               let ty1 =
                                 doc_of_mltype currentModule
-                                  (min_op_prec, NonAssoc) ty
-                                 in
+                                  (min_op_prec, NonAssoc) ty in
                               FStar_Format.reduce1
                                 [FStar_Format.text ":"; ty1]
                           | FStar_Pervasives_Native.Some (vs,ty) ->
                               let ty1 =
                                 doc_of_mltype currentModule
-                                  (min_op_prec, NonAssoc) ty
-                                 in
+                                  (min_op_prec, NonAssoc) ty in
                               let vars =
                                 let uu____2379 =
                                   FStar_All.pipe_right vs
@@ -1136,32 +1063,28 @@ and (doc_of_lets :
                                           doc_of_mltype currentModule
                                             (min_op_prec, NonAssoc)
                                             (FStar_Extraction_ML_Syntax.MLTY_Var
-                                               x)))
-                                   in
+                                               x))) in
                                 FStar_All.pipe_right uu____2379
-                                  FStar_Format.reduce1
-                                 in
+                                  FStar_Format.reduce1 in
                               FStar_Format.reduce1
                                 [FStar_Format.text ":";
                                 vars;
                                 FStar_Format.text ".";
                                 ty1])
-                       else FStar_Format.text "")
-                   in
+                       else FStar_Format.text "") in
                 let uu____2393 =
                   let uu____2396 =
-                    let uu____2399 = FStar_Format.reduce1 ids  in
-                    [uu____2399; ty_annot; FStar_Format.text "="; e1]  in
-                  (FStar_Format.text name) :: uu____2396  in
-                FStar_Format.reduce1 uu____2393
-             in
+                    let uu____2399 = FStar_Format.reduce1 ids in
+                    [uu____2399; ty_annot; FStar_Format.text "="; e1] in
+                  (FStar_Format.text name) :: uu____2396 in
+                FStar_Format.reduce1 uu____2393 in
           let letdoc =
             if rec_ = FStar_Extraction_ML_Syntax.Rec
             then
               FStar_Format.reduce1
                 [FStar_Format.text "let"; FStar_Format.text "rec"]
-            else FStar_Format.text "let"  in
-          let lets1 = FStar_List.map for1 lets  in
+            else FStar_Format.text "let" in
+          let lets1 = FStar_List.map for1 lets in
           let lets2 =
             FStar_List.mapi
               (fun i  ->
@@ -1170,30 +1093,26 @@ and (doc_of_lets :
                      [if i = (Prims.parse_int "0")
                       then letdoc
                       else FStar_Format.text "and";
-                     doc1]) lets1
-             in
+                     doc1]) lets1 in
           FStar_Format.combine FStar_Format.hardline lets2
-
-and (doc_of_loc : FStar_Extraction_ML_Syntax.mlloc -> FStar_Format.doc) =
+and doc_of_loc: FStar_Extraction_ML_Syntax.mlloc -> FStar_Format.doc =
   fun uu____2413  ->
     match uu____2413 with
     | (lineno,file) ->
         let uu____2416 =
           (FStar_Options.no_location_info ()) ||
-            (FStar_Options.codegen_fsharp ())
-           in
+            (FStar_Options.codegen_fsharp ()) in
         if uu____2416
         then FStar_Format.empty
         else
-          (let file1 = FStar_Util.basename file  in
+          (let file1 = FStar_Util.basename file in
            FStar_Format.reduce1
              [FStar_Format.text "#";
              FStar_Format.num lineno;
              FStar_Format.text (Prims.strcat "\"" (Prims.strcat file1 "\""))])
-
-let (doc_of_mltydecl :
+let doc_of_mltydecl:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mltydecl -> FStar_Format.doc)
+    FStar_Extraction_ML_Syntax.mltydecl -> FStar_Format.doc
   =
   fun currentModule  ->
     fun decls  ->
@@ -1203,19 +1122,17 @@ let (doc_of_mltydecl :
             let x1 =
               match mangle_opt with
               | FStar_Pervasives_Native.None  -> x
-              | FStar_Pervasives_Native.Some y -> y  in
+              | FStar_Pervasives_Native.Some y -> y in
             let tparams1 =
               match tparams with
               | [] -> FStar_Format.empty
               | x2::[] -> FStar_Format.text x2
               | uu____2487 ->
                   let doc1 =
-                    FStar_List.map (fun x2  -> FStar_Format.text x2) tparams
-                     in
+                    FStar_List.map (fun x2  -> FStar_Format.text x2) tparams in
                   let uu____2495 =
-                    FStar_Format.combine (FStar_Format.text ", ") doc1  in
-                  FStar_Format.parens uu____2495
-               in
+                    FStar_Format.combine (FStar_Format.text ", ") doc1 in
+                  FStar_Format.parens uu____2495 in
             let forbody body1 =
               match body1 with
               | FStar_Extraction_ML_Syntax.MLTD_Abbrev ty ->
@@ -1224,24 +1141,21 @@ let (doc_of_mltydecl :
                   let forfield uu____2519 =
                     match uu____2519 with
                     | (name,ty) ->
-                        let name1 = FStar_Format.text name  in
+                        let name1 = FStar_Format.text name in
                         let ty1 =
                           doc_of_mltype currentModule (min_op_prec, NonAssoc)
-                            ty
-                           in
+                            ty in
                         FStar_Format.reduce1
-                          [name1; FStar_Format.text ":"; ty1]
-                     in
+                          [name1; FStar_Format.text ":"; ty1] in
                   let uu____2532 =
-                    let uu____2533 = FStar_List.map forfield fields  in
-                    FStar_Format.combine (FStar_Format.text "; ") uu____2533
-                     in
+                    let uu____2533 = FStar_List.map forfield fields in
+                    FStar_Format.combine (FStar_Format.text "; ") uu____2533 in
                   FStar_Format.cbrackets uu____2532
               | FStar_Extraction_ML_Syntax.MLTD_DType ctors ->
                   let forctor uu____2566 =
                     match uu____2566 with
                     | (name,tys) ->
-                        let uu____2591 = FStar_List.split tys  in
+                        let uu____2591 = FStar_List.split tys in
                         (match uu____2591 with
                          | (_names,tys1) ->
                              (match tys1 with
@@ -1250,62 +1164,55 @@ let (doc_of_mltydecl :
                                   let tys2 =
                                     FStar_List.map
                                       (doc_of_mltype currentModule
-                                         (t_prio_tpl, Left)) tys1
-                                     in
+                                         (t_prio_tpl, Left)) tys1 in
                                   let tys3 =
                                     FStar_Format.combine
-                                      (FStar_Format.text " * ") tys2
-                                     in
+                                      (FStar_Format.text " * ") tys2 in
                                   FStar_Format.reduce1
                                     [FStar_Format.text name;
                                     FStar_Format.text "of";
-                                    tys3]))
-                     in
-                  let ctors1 = FStar_List.map forctor ctors  in
+                                    tys3])) in
+                  let ctors1 = FStar_List.map forctor ctors in
                   let ctors2 =
                     FStar_List.map
                       (fun d  ->
                          FStar_Format.reduce1 [FStar_Format.text "|"; d])
-                      ctors1
-                     in
-                  FStar_Format.combine FStar_Format.hardline ctors2
-               in
+                      ctors1 in
+                  FStar_Format.combine FStar_Format.hardline ctors2 in
             let doc1 =
               let uu____2640 =
                 let uu____2643 =
                   let uu____2646 =
-                    let uu____2647 = ptsym currentModule ([], x1)  in
-                    FStar_Format.text uu____2647  in
-                  [uu____2646]  in
-                tparams1 :: uu____2643  in
-              FStar_Format.reduce1 uu____2640  in
+                    let uu____2647 = ptsym currentModule ([], x1) in
+                    FStar_Format.text uu____2647 in
+                  [uu____2646] in
+                tparams1 :: uu____2643 in
+              FStar_Format.reduce1 uu____2640 in
             (match body with
              | FStar_Pervasives_Native.None  -> doc1
              | FStar_Pervasives_Native.Some body1 ->
-                 let body2 = forbody body1  in
+                 let body2 = forbody body1 in
                  let uu____2652 =
                    let uu____2655 =
-                     FStar_Format.reduce1 [doc1; FStar_Format.text "="]  in
-                   [uu____2655; body2]  in
-                 FStar_Format.combine FStar_Format.hardline uu____2652)
-         in
-      let doc1 = FStar_List.map for1 decls  in
+                     FStar_Format.reduce1 [doc1; FStar_Format.text "="] in
+                   [uu____2655; body2] in
+                 FStar_Format.combine FStar_Format.hardline uu____2652) in
+      let doc1 = FStar_List.map for1 decls in
       let doc2 =
         if (FStar_List.length doc1) > (Prims.parse_int "0")
         then
           let uu____2678 =
             let uu____2681 =
               let uu____2684 =
-                FStar_Format.combine (FStar_Format.text " \n and ") doc1  in
-              [uu____2684]  in
-            (FStar_Format.text "type") :: uu____2681  in
+                FStar_Format.combine (FStar_Format.text " \n and ") doc1 in
+              [uu____2684] in
+            (FStar_Format.text "type") :: uu____2681 in
           FStar_Format.reduce1 uu____2678
-        else FStar_Format.text ""  in
+        else FStar_Format.text "" in
       doc2
-  
-let rec (doc_of_sig1 :
+let rec doc_of_sig1:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlsig1 -> FStar_Format.doc)
+    FStar_Extraction_ML_Syntax.mlsig1 -> FStar_Format.doc
   =
   fun currentModule  ->
     fun s  ->
@@ -1316,16 +1223,15 @@ let rec (doc_of_sig1 :
               FStar_Format.reduce1
                 [FStar_Format.text "module";
                 FStar_Format.text x;
-                FStar_Format.text "="]
-               in
+                FStar_Format.text "="] in
             let uu____2706 =
-              let uu____2709 = doc_of_sig currentModule subsig  in
+              let uu____2709 = doc_of_sig currentModule subsig in
               let uu____2710 =
                 let uu____2713 =
-                  FStar_Format.reduce1 [FStar_Format.text "end"]  in
-                [uu____2713]  in
-              uu____2709 :: uu____2710  in
-            uu____2705 :: uu____2706  in
+                  FStar_Format.reduce1 [FStar_Format.text "end"] in
+                [uu____2713] in
+              uu____2709 :: uu____2710 in
+            uu____2705 :: uu____2706 in
           FStar_Format.combine FStar_Format.hardline uu____2702
       | FStar_Extraction_ML_Syntax.MLS_Exn (x,[]) ->
           FStar_Format.reduce1
@@ -1333,20 +1239,18 @@ let rec (doc_of_sig1 :
       | FStar_Extraction_ML_Syntax.MLS_Exn (x,args) ->
           let args1 =
             FStar_List.map
-              (doc_of_mltype currentModule (min_op_prec, NonAssoc)) args
-             in
+              (doc_of_mltype currentModule (min_op_prec, NonAssoc)) args in
           let args2 =
             let uu____2731 =
-              FStar_Format.combine (FStar_Format.text " * ") args1  in
-            FStar_Format.parens uu____2731  in
+              FStar_Format.combine (FStar_Format.text " * ") args1 in
+            FStar_Format.parens uu____2731 in
           FStar_Format.reduce1
             [FStar_Format.text "exception";
             FStar_Format.text x;
             FStar_Format.text "of";
             args2]
       | FStar_Extraction_ML_Syntax.MLS_Val (x,(uu____2733,ty)) ->
-          let ty1 = doc_of_mltype currentModule (min_op_prec, NonAssoc) ty
-             in
+          let ty1 = doc_of_mltype currentModule (min_op_prec, NonAssoc) ty in
           FStar_Format.reduce1
             [FStar_Format.text "val";
             FStar_Format.text x;
@@ -1354,25 +1258,22 @@ let rec (doc_of_sig1 :
             ty1]
       | FStar_Extraction_ML_Syntax.MLS_Ty decls ->
           doc_of_mltydecl currentModule decls
-
-and (doc_of_sig :
+and doc_of_sig:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlsig -> FStar_Format.doc)
+    FStar_Extraction_ML_Syntax.mlsig -> FStar_Format.doc
   =
   fun currentModule  ->
     fun s  ->
-      let docs = FStar_List.map (doc_of_sig1 currentModule) s  in
+      let docs = FStar_List.map (doc_of_sig1 currentModule) s in
       let docs1 =
         FStar_List.map
           (fun x  ->
              FStar_Format.reduce
-               [x; FStar_Format.hardline; FStar_Format.hardline]) docs
-         in
+               [x; FStar_Format.hardline; FStar_Format.hardline]) docs in
       FStar_Format.reduce docs1
-
-let (doc_of_mod1 :
+let doc_of_mod1:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlmodule1 -> FStar_Format.doc)
+    FStar_Extraction_ML_Syntax.mlmodule1 -> FStar_Format.doc
   =
   fun currentModule  ->
     fun m  ->
@@ -1381,15 +1282,14 @@ let (doc_of_mod1 :
           FStar_Format.reduce1
             [FStar_Format.text "exception"; FStar_Format.text x]
       | FStar_Extraction_ML_Syntax.MLM_Exn (x,args) ->
-          let args1 = FStar_List.map FStar_Pervasives_Native.snd args  in
+          let args1 = FStar_List.map FStar_Pervasives_Native.snd args in
           let args2 =
             FStar_List.map
-              (doc_of_mltype currentModule (min_op_prec, NonAssoc)) args1
-             in
+              (doc_of_mltype currentModule (min_op_prec, NonAssoc)) args1 in
           let args3 =
             let uu____2801 =
-              FStar_Format.combine (FStar_Format.text " * ") args2  in
-            FStar_Format.parens uu____2801  in
+              FStar_Format.combine (FStar_Format.text " * ") args2 in
+            FStar_Format.parens uu____2801 in
           FStar_Format.reduce1
             [FStar_Format.text "exception";
             FStar_Format.text x;
@@ -1405,36 +1305,33 @@ let (doc_of_mod1 :
               let uu____2818 =
                 let uu____2821 =
                   let uu____2824 =
-                    doc_of_expr currentModule (min_op_prec, NonAssoc) e  in
-                  [uu____2824]  in
-                (FStar_Format.text "=") :: uu____2821  in
-              (FStar_Format.text "_") :: uu____2818  in
-            (FStar_Format.text "let") :: uu____2815  in
+                    doc_of_expr currentModule (min_op_prec, NonAssoc) e in
+                  [uu____2824] in
+                (FStar_Format.text "=") :: uu____2821 in
+              (FStar_Format.text "_") :: uu____2818 in
+            (FStar_Format.text "let") :: uu____2815 in
           FStar_Format.reduce1 uu____2812
       | FStar_Extraction_ML_Syntax.MLM_Loc loc -> doc_of_loc loc
-  
-let (doc_of_mod :
+let doc_of_mod:
   FStar_Extraction_ML_Syntax.mlsymbol ->
-    FStar_Extraction_ML_Syntax.mlmodule -> FStar_Format.doc)
+    FStar_Extraction_ML_Syntax.mlmodule -> FStar_Format.doc
   =
   fun currentModule  ->
     fun m  ->
       let docs =
         FStar_List.map
           (fun x  ->
-             let doc1 = doc_of_mod1 currentModule x  in
+             let doc1 = doc_of_mod1 currentModule x in
              [doc1;
              (match x with
               | FStar_Extraction_ML_Syntax.MLM_Loc uu____2848 ->
                   FStar_Format.empty
               | uu____2849 -> FStar_Format.hardline);
-             FStar_Format.hardline]) m
-         in
+             FStar_Format.hardline]) m in
       FStar_Format.reduce (FStar_List.flatten docs)
-  
-let rec (doc_of_mllib_r :
+let rec doc_of_mllib_r:
   FStar_Extraction_ML_Syntax.mllib ->
-    (Prims.string,FStar_Format.doc) FStar_Pervasives_Native.tuple2 Prims.list)
+    (Prims.string,FStar_Format.doc) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun uu____2858  ->
     match uu____2858 with
@@ -1442,64 +1339,56 @@ let rec (doc_of_mllib_r :
         let rec for1_sig uu____2924 =
           match uu____2924 with
           | (x,sigmod,FStar_Extraction_ML_Syntax.MLLib sub1) ->
-              let x1 = FStar_Extraction_ML_Util.flatten_mlpath x  in
+              let x1 = FStar_Extraction_ML_Util.flatten_mlpath x in
               let head1 =
                 FStar_Format.reduce1
                   [FStar_Format.text "module";
                   FStar_Format.text x1;
                   FStar_Format.text ":";
-                  FStar_Format.text "sig"]
-                 in
-              let tail1 = FStar_Format.reduce1 [FStar_Format.text "end"]  in
+                  FStar_Format.text "sig"] in
+              let tail1 = FStar_Format.reduce1 [FStar_Format.text "end"] in
               let doc1 =
                 FStar_Option.map
                   (fun uu____2997  ->
                      match uu____2997 with
-                     | (s,uu____3003) -> doc_of_sig x1 s) sigmod
-                 in
-              let sub2 = FStar_List.map for1_sig sub1  in
+                     | (s,uu____3003) -> doc_of_sig x1 s) sigmod in
+              let sub2 = FStar_List.map for1_sig sub1 in
               let sub3 =
                 FStar_List.map
                   (fun x2  ->
                      FStar_Format.reduce
                        [x2; FStar_Format.hardline; FStar_Format.hardline])
-                  sub2
-                 in
+                  sub2 in
               let uu____3030 =
                 let uu____3033 =
                   let uu____3036 =
-                    let uu____3039 = FStar_Format.reduce sub3  in
+                    let uu____3039 = FStar_Format.reduce sub3 in
                     [uu____3039;
-                    FStar_Format.cat tail1 FStar_Format.hardline]  in
+                    FStar_Format.cat tail1 FStar_Format.hardline] in
                   (match doc1 with
                    | FStar_Pervasives_Native.None  -> FStar_Format.empty
                    | FStar_Pervasives_Native.Some s ->
                        FStar_Format.cat s FStar_Format.hardline)
-                    :: uu____3036
-                   in
-                (FStar_Format.cat head1 FStar_Format.hardline) :: uu____3033
-                 in
+                    :: uu____3036 in
+                (FStar_Format.cat head1 FStar_Format.hardline) :: uu____3033 in
               FStar_Format.reduce uu____3030
-        
         and for1_mod istop uu____3042 =
           match uu____3042 with
           | (mod_name1,sigmod,FStar_Extraction_ML_Syntax.MLLib sub1) ->
               let target_mod_name =
-                FStar_Extraction_ML_Util.flatten_mlpath mod_name1  in
+                FStar_Extraction_ML_Util.flatten_mlpath mod_name1 in
               let maybe_open_pervasives =
                 match mod_name1 with
                 | ("FStar"::[],"Pervasives") -> []
                 | uu____3110 ->
                     let pervasives1 =
                       FStar_Extraction_ML_Util.flatten_mlpath
-                        (["FStar"], "Pervasives")
-                       in
+                        (["FStar"], "Pervasives") in
                     [FStar_Format.hardline;
-                    FStar_Format.text (Prims.strcat "open " pervasives1)]
-                 in
+                    FStar_Format.text (Prims.strcat "open " pervasives1)] in
               let head1 =
                 let uu____3121 =
-                  let uu____3124 = FStar_Options.codegen_fsharp ()  in
+                  let uu____3124 = FStar_Options.codegen_fsharp () in
                   if uu____3124
                   then
                     [FStar_Format.text "module";
@@ -1511,95 +1400,84 @@ let rec (doc_of_mllib_r :
                       FStar_Format.text target_mod_name;
                       FStar_Format.text "=";
                       FStar_Format.text "struct"]
-                    else []
-                   in
-                FStar_Format.reduce1 uu____3121  in
+                    else [] in
+                FStar_Format.reduce1 uu____3121 in
               let tail1 =
                 if Prims.op_Negation istop
                 then FStar_Format.reduce1 [FStar_Format.text "end"]
-                else FStar_Format.reduce1 []  in
+                else FStar_Format.reduce1 [] in
               let doc1 =
                 FStar_Option.map
                   (fun uu____3143  ->
                      match uu____3143 with
-                     | (uu____3148,m) -> doc_of_mod target_mod_name m) sigmod
-                 in
-              let sub2 = FStar_List.map (for1_mod false) sub1  in
+                     | (uu____3148,m) -> doc_of_mod target_mod_name m) sigmod in
+              let sub2 = FStar_List.map (for1_mod false) sub1 in
               let sub3 =
                 FStar_List.map
                   (fun x  ->
                      FStar_Format.reduce
                        [x; FStar_Format.hardline; FStar_Format.hardline])
-                  sub2
-                 in
+                  sub2 in
               let prefix1 =
-                let uu____3179 = FStar_Options.codegen_fsharp ()  in
+                let uu____3179 = FStar_Options.codegen_fsharp () in
                 if uu____3179
                 then
                   [FStar_Format.cat (FStar_Format.text "#light \"off\"")
                      FStar_Format.hardline]
-                else []  in
+                else [] in
               let uu____3183 =
                 let uu____3186 =
                   let uu____3189 =
                     let uu____3192 =
                       let uu____3195 =
                         let uu____3198 =
-                          let uu____3201 = FStar_Format.reduce sub3  in
+                          let uu____3201 = FStar_Format.reduce sub3 in
                           [uu____3201;
-                          FStar_Format.cat tail1 FStar_Format.hardline]  in
+                          FStar_Format.cat tail1 FStar_Format.hardline] in
                         (match doc1 with
                          | FStar_Pervasives_Native.None  ->
                              FStar_Format.empty
                          | FStar_Pervasives_Native.Some s ->
                              FStar_Format.cat s FStar_Format.hardline)
-                          :: uu____3198
-                         in
-                      FStar_Format.hardline :: uu____3195  in
-                    FStar_List.append maybe_open_pervasives uu____3192  in
+                          :: uu____3198 in
+                      FStar_Format.hardline :: uu____3195 in
+                    FStar_List.append maybe_open_pervasives uu____3192 in
                   FStar_List.append
                     [head1;
                     FStar_Format.hardline;
-                    FStar_Format.text "open Prims"] uu____3189
-                   in
-                FStar_List.append prefix1 uu____3186  in
-              FStar_All.pipe_left FStar_Format.reduce uu____3183
-         in
+                    FStar_Format.text "open Prims"] uu____3189 in
+                FStar_List.append prefix1 uu____3186 in
+              FStar_All.pipe_left FStar_Format.reduce uu____3183 in
         let docs =
           FStar_List.map
             (fun uu____3240  ->
                match uu____3240 with
                | (x,s,m) ->
-                   let uu____3290 = FStar_Extraction_ML_Util.flatten_mlpath x
-                      in
-                   let uu____3291 = for1_mod true (x, s, m)  in
-                   (uu____3290, uu____3291)) mllib
-           in
+                   let uu____3290 = FStar_Extraction_ML_Util.flatten_mlpath x in
+                   let uu____3291 = for1_mod true (x, s, m) in
+                   (uu____3290, uu____3291)) mllib in
         docs
-  
-let (doc_of_mllib :
+let doc_of_mllib:
   FStar_Extraction_ML_Syntax.mllib ->
-    (Prims.string,FStar_Format.doc) FStar_Pervasives_Native.tuple2 Prims.list)
-  = fun mllib  -> doc_of_mllib_r mllib 
-let (string_of_mlexpr :
+    (Prims.string,FStar_Format.doc) FStar_Pervasives_Native.tuple2 Prims.list
+  = fun mllib  -> doc_of_mllib_r mllib
+let string_of_mlexpr:
   FStar_Extraction_ML_Syntax.mlpath ->
-    FStar_Extraction_ML_Syntax.mlexpr -> Prims.string)
+    FStar_Extraction_ML_Syntax.mlexpr -> Prims.string
   =
   fun cmod  ->
     fun e  ->
       let doc1 =
-        let uu____3320 = FStar_Extraction_ML_Util.flatten_mlpath cmod  in
-        doc_of_expr uu____3320 (min_op_prec, NonAssoc) e  in
+        let uu____3320 = FStar_Extraction_ML_Util.flatten_mlpath cmod in
+        doc_of_expr uu____3320 (min_op_prec, NonAssoc) e in
       FStar_Format.pretty (Prims.parse_int "0") doc1
-  
-let (string_of_mlty :
+let string_of_mlty:
   FStar_Extraction_ML_Syntax.mlpath ->
-    FStar_Extraction_ML_Syntax.mlty -> Prims.string)
+    FStar_Extraction_ML_Syntax.mlty -> Prims.string
   =
   fun cmod  ->
     fun e  ->
       let doc1 =
-        let uu____3332 = FStar_Extraction_ML_Util.flatten_mlpath cmod  in
-        doc_of_mltype uu____3332 (min_op_prec, NonAssoc) e  in
+        let uu____3332 = FStar_Extraction_ML_Util.flatten_mlpath cmod in
+        doc_of_mltype uu____3332 (min_op_prec, NonAssoc) e in
       FStar_Format.pretty (Prims.parse_int "0") doc1
-  

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -1,8 +1,8 @@
 open Prims
-let (fail_exp :
+let fail_exp:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun lid  ->
     fun t  ->
@@ -12,10 +12,9 @@ let (fail_exp :
             let uu____28 =
               FStar_Syntax_Syntax.fvar FStar_Parser_Const.failwith_lid
                 FStar_Syntax_Syntax.Delta_constant
-                FStar_Pervasives_Native.None
-               in
+                FStar_Pervasives_Native.None in
             let uu____29 =
-              let uu____32 = FStar_Syntax_Syntax.iarg t  in
+              let uu____32 = FStar_Syntax_Syntax.iarg t in
               let uu____33 =
                 let uu____36 =
                   let uu____37 =
@@ -25,33 +24,29 @@ let (fail_exp :
                           let uu____43 =
                             let uu____48 =
                               let uu____49 =
-                                FStar_Syntax_Print.lid_to_string lid  in
-                              Prims.strcat "Not yet implemented:" uu____49
-                               in
-                            (uu____48, FStar_Range.dummyRange)  in
-                          FStar_Const.Const_string uu____43  in
-                        FStar_Syntax_Syntax.Tm_constant uu____42  in
-                      FStar_Syntax_Syntax.mk uu____41  in
+                                FStar_Syntax_Print.lid_to_string lid in
+                              Prims.strcat "Not yet implemented:" uu____49 in
+                            (uu____48, FStar_Range.dummyRange) in
+                          FStar_Const.Const_string uu____43 in
+                        FStar_Syntax_Syntax.Tm_constant uu____42 in
+                      FStar_Syntax_Syntax.mk uu____41 in
                     uu____38 FStar_Pervasives_Native.None
-                      FStar_Range.dummyRange
-                     in
-                  FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____37  in
-                [uu____36]  in
-              uu____32 :: uu____33  in
-            (uu____28, uu____29)  in
-          FStar_Syntax_Syntax.Tm_app uu____13  in
-        FStar_Syntax_Syntax.mk uu____12  in
+                      FStar_Range.dummyRange in
+                  FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____37 in
+                [uu____36] in
+              uu____32 :: uu____33 in
+            (uu____28, uu____29) in
+          FStar_Syntax_Syntax.Tm_app uu____13 in
+        FStar_Syntax_Syntax.mk uu____12 in
       uu____9 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (mangle_projector_lid : FStar_Ident.lident -> FStar_Ident.lident) =
-  fun x  -> x 
-let (lident_as_mlsymbol :
-  FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlsymbol) =
+let mangle_projector_lid: FStar_Ident.lident -> FStar_Ident.lident =
+  fun x  -> x
+let lident_as_mlsymbol:
+  FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlsymbol =
   fun id1  ->
     FStar_Extraction_ML_Syntax.avoid_keyword
       (id1.FStar_Ident.ident).FStar_Ident.idText
-  
-let as_pair :
+let as_pair:
   'Auu____66 .
     'Auu____66 Prims.list ->
       ('Auu____66,'Auu____66) FStar_Pervasives_Native.tuple2
@@ -60,11 +55,10 @@ let as_pair :
     match uu___69_76 with
     | a::b::[] -> (a, b)
     | uu____81 -> failwith "Expected a list with 2 elements"
-  
-let (is_tactic_decl :
+let is_tactic_decl:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.term ->
-      FStar_Extraction_ML_Syntax.mlpath -> Prims.bool)
+      FStar_Extraction_ML_Syntax.mlpath -> Prims.bool
   =
   fun tac_lid  ->
     fun h  ->
@@ -72,8 +66,8 @@ let (is_tactic_decl :
         match h.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_uinst (h',uu____98) ->
             let uu____103 =
-              let uu____104 = FStar_Syntax_Subst.compress h'  in
-              uu____104.FStar_Syntax_Syntax.n  in
+              let uu____104 = FStar_Syntax_Subst.compress h' in
+              uu____104.FStar_Syntax_Syntax.n in
             (match uu____103 with
              | FStar_Syntax_Syntax.Tm_fvar fv when
                  FStar_Syntax_Syntax.fv_eq_lid fv
@@ -82,26 +76,24 @@ let (is_tactic_decl :
                  let uu____108 =
                    let uu____109 =
                      FStar_Extraction_ML_Syntax.string_of_mlpath
-                       current_module1
-                      in
-                   FStar_Util.starts_with uu____109 "FStar.Tactics"  in
+                       current_module1 in
+                   FStar_Util.starts_with uu____109 "FStar.Tactics" in
                  Prims.op_Negation uu____108
              | uu____110 -> false)
         | uu____111 -> false
-  
-let rec (extract_meta :
+let rec extract_meta:
   FStar_Syntax_Syntax.term ->
-    FStar_Extraction_ML_Syntax.meta FStar_Pervasives_Native.option)
+    FStar_Extraction_ML_Syntax.meta FStar_Pervasives_Native.option
   =
   fun x  ->
-    let uu____117 = FStar_Syntax_Subst.compress x  in
+    let uu____117 = FStar_Syntax_Subst.compress x in
     match uu____117 with
     | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
         FStar_Syntax_Syntax.pos = uu____121;
         FStar_Syntax_Syntax.vars = uu____122;_} when
         let uu____125 =
-          let uu____126 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          FStar_Ident.string_of_lid uu____126  in
+          let uu____126 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu____126 in
         uu____125 = "FStar.Pervasives.PpxDerivingShow" ->
         FStar_Pervasives_Native.Some
           FStar_Extraction_ML_Syntax.PpxDerivingShow
@@ -109,24 +101,24 @@ let rec (extract_meta :
         FStar_Syntax_Syntax.pos = uu____128;
         FStar_Syntax_Syntax.vars = uu____129;_} when
         let uu____132 =
-          let uu____133 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          FStar_Ident.string_of_lid uu____133  in
+          let uu____133 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu____133 in
         uu____132 = "FStar.Pervasives.CInline" ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.CInline
     | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
         FStar_Syntax_Syntax.pos = uu____135;
         FStar_Syntax_Syntax.vars = uu____136;_} when
         let uu____139 =
-          let uu____140 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          FStar_Ident.string_of_lid uu____140  in
+          let uu____140 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu____140 in
         uu____139 = "FStar.Pervasives.Substitute" ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Substitute
     | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
         FStar_Syntax_Syntax.pos = uu____142;
         FStar_Syntax_Syntax.vars = uu____143;_} when
         let uu____146 =
-          let uu____147 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          FStar_Ident.string_of_lid uu____147  in
+          let uu____147 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu____147 in
         uu____146 = "FStar.Pervasives.Gc" ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.GCType
     | {
@@ -146,8 +138,8 @@ let rec (extract_meta :
         FStar_Syntax_Syntax.pos = uu____156;
         FStar_Syntax_Syntax.vars = uu____157;_} when
         let uu____188 =
-          let uu____189 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          FStar_Ident.string_of_lid uu____189  in
+          let uu____189 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu____189 in
         uu____188 = "FStar.Pervasives.PpxDerivingShowConstant" ->
         FStar_Pervasives_Native.Some
           (FStar_Extraction_ML_Syntax.PpxDerivingShowConstant s)
@@ -168,8 +160,8 @@ let rec (extract_meta :
         FStar_Syntax_Syntax.pos = uu____198;
         FStar_Syntax_Syntax.vars = uu____199;_} when
         let uu____230 =
-          let uu____231 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          FStar_Ident.string_of_lid uu____231  in
+          let uu____231 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu____231 in
         uu____230 = "FStar.Pervasives.Comment" ->
         FStar_Pervasives_Native.Some (FStar_Extraction_ML_Syntax.Comment s)
     | {
@@ -194,12 +186,11 @@ let rec (extract_meta :
         FStar_Syntax_Syntax.pos = uu____252;
         FStar_Syntax_Syntax.vars = uu____253;_} -> extract_meta x1
     | a -> FStar_Pervasives_Native.None
-  
-let (extract_metadata :
+let extract_metadata:
   FStar_Syntax_Syntax.term Prims.list ->
-    FStar_Extraction_ML_Syntax.meta Prims.list)
-  = fun metas  -> FStar_List.choose extract_meta metas 
-let binders_as_mlty_binders :
+    FStar_Extraction_ML_Syntax.meta Prims.list
+  = fun metas  -> FStar_List.choose extract_meta metas
+let binders_as_mlty_binders:
   'Auu____273 .
     FStar_Extraction_ML_UEnv.env ->
       (FStar_Syntax_Syntax.bv,'Auu____273) FStar_Pervasives_Native.tuple2
@@ -218,15 +209,13 @@ let binders_as_mlty_binders :
                    let uu____323 =
                      let uu____326 =
                        let uu____327 =
-                         FStar_Extraction_ML_UEnv.bv_as_ml_tyvar bv  in
-                       FStar_Extraction_ML_Syntax.MLTY_Var uu____327  in
-                     FStar_Pervasives_Native.Some uu____326  in
-                   FStar_Extraction_ML_UEnv.extend_ty env1 bv uu____323  in
-                 let uu____328 = FStar_Extraction_ML_UEnv.bv_as_ml_tyvar bv
-                    in
+                         FStar_Extraction_ML_UEnv.bv_as_ml_tyvar bv in
+                       FStar_Extraction_ML_Syntax.MLTY_Var uu____327 in
+                     FStar_Pervasives_Native.Some uu____326 in
+                   FStar_Extraction_ML_UEnv.extend_ty env1 bv uu____323 in
+                 let uu____328 = FStar_Extraction_ML_UEnv.bv_as_ml_tyvar bv in
                  (uu____322, uu____328)) env bs
-  
-let (extract_typ_abbrev :
+let extract_typ_abbrev:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.fv ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -234,30 +223,29 @@ let (extract_typ_abbrev :
           FStar_Syntax_Syntax.term ->
             (FStar_Extraction_ML_UEnv.env,FStar_Extraction_ML_Syntax.mlmodule1
                                             Prims.list)
-              FStar_Pervasives_Native.tuple2)
+              FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun fv  ->
       fun quals  ->
         fun attrs  ->
           fun def  ->
-            let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-               in
+            let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
             let def1 =
               let uu____360 =
-                let uu____361 = FStar_Syntax_Subst.compress def  in
-                FStar_All.pipe_right uu____361 FStar_Syntax_Util.unmeta  in
-              FStar_All.pipe_right uu____360 FStar_Syntax_Util.un_uinst  in
+                let uu____361 = FStar_Syntax_Subst.compress def in
+                FStar_All.pipe_right uu____361 FStar_Syntax_Util.unmeta in
+              FStar_All.pipe_right uu____360 FStar_Syntax_Util.un_uinst in
             let def2 =
               match def1.FStar_Syntax_Syntax.n with
               | FStar_Syntax_Syntax.Tm_abs uu____363 ->
                   FStar_Extraction_ML_Term.normalize_abs def1
-              | uu____380 -> def1  in
+              | uu____380 -> def1 in
             let uu____381 =
               match def2.FStar_Syntax_Syntax.n with
               | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____392) ->
                   FStar_Syntax_Subst.open_term bs body
-              | uu____413 -> ([], def2)  in
+              | uu____413 -> ([], def2) in
             match uu____381 with
             | (bs,body) ->
                 let assumed =
@@ -265,18 +253,16 @@ let (extract_typ_abbrev :
                     (fun uu___70_434  ->
                        match uu___70_434 with
                        | FStar_Syntax_Syntax.Assumption  -> true
-                       | uu____435 -> false) quals
-                   in
-                let uu____436 = binders_as_mlty_binders env bs  in
+                       | uu____435 -> false) quals in
+                let uu____436 = binders_as_mlty_binders env bs in
                 (match uu____436 with
                  | (env1,ml_bs) ->
                      let body1 =
                        let uu____456 =
-                         FStar_Extraction_ML_Term.term_as_mlty env1 body  in
+                         FStar_Extraction_ML_Term.term_as_mlty env1 body in
                        FStar_All.pipe_right uu____456
                          (FStar_Extraction_ML_Util.eraseTypeDeep
-                            (FStar_Extraction_ML_Util.udelta_unfold env1))
-                        in
+                            (FStar_Extraction_ML_Util.udelta_unfold env1)) in
                      let mangled_projector =
                        let uu____460 =
                          FStar_All.pipe_right quals
@@ -285,32 +271,29 @@ let (extract_typ_abbrev :
                                  match uu___71_465 with
                                  | FStar_Syntax_Syntax.Projector uu____466 ->
                                      true
-                                 | uu____471 -> false))
-                          in
+                                 | uu____471 -> false)) in
                        if uu____460
                        then
-                         let mname = mangle_projector_lid lid  in
+                         let mname = mangle_projector_lid lid in
                          FStar_Pervasives_Native.Some
                            ((mname.FStar_Ident.ident).FStar_Ident.idText)
-                       else FStar_Pervasives_Native.None  in
-                     let metadata = extract_metadata attrs  in
+                       else FStar_Pervasives_Native.None in
+                     let metadata = extract_metadata attrs in
                      let td =
                        let uu____502 =
-                         let uu____523 = lident_as_mlsymbol lid  in
+                         let uu____523 = lident_as_mlsymbol lid in
                          (assumed, uu____523, mangled_projector, ml_bs,
                            metadata,
                            (FStar_Pervasives_Native.Some
-                              (FStar_Extraction_ML_Syntax.MLTD_Abbrev body1)))
-                          in
-                       [uu____502]  in
+                              (FStar_Extraction_ML_Syntax.MLTD_Abbrev body1))) in
+                       [uu____502] in
                      let def3 =
                        let uu____575 =
                          let uu____576 =
                            FStar_Extraction_ML_Util.mlloc_of_range
-                             (FStar_Ident.range_of_lid lid)
-                            in
-                         FStar_Extraction_ML_Syntax.MLM_Loc uu____576  in
-                       [uu____575; FStar_Extraction_ML_Syntax.MLM_Ty td]  in
+                             (FStar_Ident.range_of_lid lid) in
+                         FStar_Extraction_ML_Syntax.MLM_Loc uu____576 in
+                       [uu____575; FStar_Extraction_ML_Syntax.MLM_Ty td] in
                      let env2 =
                        let uu____578 =
                          FStar_All.pipe_right quals
@@ -319,114 +302,100 @@ let (extract_typ_abbrev :
                                  match uu___72_582 with
                                  | FStar_Syntax_Syntax.Assumption  -> true
                                  | FStar_Syntax_Syntax.New  -> true
-                                 | uu____583 -> false))
-                          in
+                                 | uu____583 -> false)) in
                        if uu____578
                        then FStar_Extraction_ML_UEnv.extend_type_name env1 fv
-                       else FStar_Extraction_ML_UEnv.extend_tydef env1 fv td
-                        in
+                       else FStar_Extraction_ML_UEnv.extend_tydef env1 fv td in
                      (env2, def3))
-  
 type data_constructor =
   {
-  dname: FStar_Ident.lident ;
-  dtyp: FStar_Syntax_Syntax.typ }[@@deriving show]
-let (__proj__Mkdata_constructor__item__dname :
-  data_constructor -> FStar_Ident.lident) =
+  dname: FStar_Ident.lident;
+  dtyp: FStar_Syntax_Syntax.typ;}[@@deriving show]
+let __proj__Mkdata_constructor__item__dname:
+  data_constructor -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { dname = __fname__dname; dtyp = __fname__dtyp;_} -> __fname__dname
-  
-let (__proj__Mkdata_constructor__item__dtyp :
-  data_constructor -> FStar_Syntax_Syntax.typ) =
+let __proj__Mkdata_constructor__item__dtyp:
+  data_constructor -> FStar_Syntax_Syntax.typ =
   fun projectee  ->
     match projectee with
     | { dname = __fname__dname; dtyp = __fname__dtyp;_} -> __fname__dtyp
-  
 type inductive_family =
   {
-  iname: FStar_Ident.lident ;
-  iparams: FStar_Syntax_Syntax.binders ;
-  ityp: FStar_Syntax_Syntax.term ;
-  idatas: data_constructor Prims.list ;
-  iquals: FStar_Syntax_Syntax.qualifier Prims.list ;
-  imetadata: FStar_Extraction_ML_Syntax.metadata }[@@deriving show]
-let (__proj__Mkinductive_family__item__iname :
-  inductive_family -> FStar_Ident.lident) =
+  iname: FStar_Ident.lident;
+  iparams: FStar_Syntax_Syntax.binders;
+  ityp: FStar_Syntax_Syntax.term;
+  idatas: data_constructor Prims.list;
+  iquals: FStar_Syntax_Syntax.qualifier Prims.list;
+  imetadata: FStar_Extraction_ML_Syntax.metadata;}[@@deriving show]
+let __proj__Mkinductive_family__item__iname:
+  inductive_family -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { iname = __fname__iname; iparams = __fname__iparams;
         ityp = __fname__ityp; idatas = __fname__idatas;
         iquals = __fname__iquals; imetadata = __fname__imetadata;_} ->
         __fname__iname
-  
-let (__proj__Mkinductive_family__item__iparams :
-  inductive_family -> FStar_Syntax_Syntax.binders) =
+let __proj__Mkinductive_family__item__iparams:
+  inductive_family -> FStar_Syntax_Syntax.binders =
   fun projectee  ->
     match projectee with
     | { iname = __fname__iname; iparams = __fname__iparams;
         ityp = __fname__ityp; idatas = __fname__idatas;
         iquals = __fname__iquals; imetadata = __fname__imetadata;_} ->
         __fname__iparams
-  
-let (__proj__Mkinductive_family__item__ityp :
-  inductive_family -> FStar_Syntax_Syntax.term) =
+let __proj__Mkinductive_family__item__ityp:
+  inductive_family -> FStar_Syntax_Syntax.term =
   fun projectee  ->
     match projectee with
     | { iname = __fname__iname; iparams = __fname__iparams;
         ityp = __fname__ityp; idatas = __fname__idatas;
         iquals = __fname__iquals; imetadata = __fname__imetadata;_} ->
         __fname__ityp
-  
-let (__proj__Mkinductive_family__item__idatas :
-  inductive_family -> data_constructor Prims.list) =
+let __proj__Mkinductive_family__item__idatas:
+  inductive_family -> data_constructor Prims.list =
   fun projectee  ->
     match projectee with
     | { iname = __fname__iname; iparams = __fname__iparams;
         ityp = __fname__ityp; idatas = __fname__idatas;
         iquals = __fname__iquals; imetadata = __fname__imetadata;_} ->
         __fname__idatas
-  
-let (__proj__Mkinductive_family__item__iquals :
-  inductive_family -> FStar_Syntax_Syntax.qualifier Prims.list) =
+let __proj__Mkinductive_family__item__iquals:
+  inductive_family -> FStar_Syntax_Syntax.qualifier Prims.list =
   fun projectee  ->
     match projectee with
     | { iname = __fname__iname; iparams = __fname__iparams;
         ityp = __fname__ityp; idatas = __fname__idatas;
         iquals = __fname__iquals; imetadata = __fname__imetadata;_} ->
         __fname__iquals
-  
-let (__proj__Mkinductive_family__item__imetadata :
-  inductive_family -> FStar_Extraction_ML_Syntax.metadata) =
+let __proj__Mkinductive_family__item__imetadata:
+  inductive_family -> FStar_Extraction_ML_Syntax.metadata =
   fun projectee  ->
     match projectee with
     | { iname = __fname__iname; iparams = __fname__iparams;
         ityp = __fname__ityp; idatas = __fname__idatas;
         iquals = __fname__iquals; imetadata = __fname__imetadata;_} ->
         __fname__imetadata
-  
-let (print_ifamily : inductive_family -> Prims.unit) =
+let print_ifamily: inductive_family -> Prims.unit =
   fun i  ->
-    let uu____722 = FStar_Syntax_Print.lid_to_string i.iname  in
-    let uu____723 = FStar_Syntax_Print.binders_to_string " " i.iparams  in
-    let uu____724 = FStar_Syntax_Print.term_to_string i.ityp  in
+    let uu____722 = FStar_Syntax_Print.lid_to_string i.iname in
+    let uu____723 = FStar_Syntax_Print.binders_to_string " " i.iparams in
+    let uu____724 = FStar_Syntax_Print.term_to_string i.ityp in
     let uu____725 =
       let uu____726 =
         FStar_All.pipe_right i.idatas
           (FStar_List.map
              (fun d  ->
-                let uu____737 = FStar_Syntax_Print.lid_to_string d.dname  in
+                let uu____737 = FStar_Syntax_Print.lid_to_string d.dname in
                 let uu____738 =
-                  let uu____739 = FStar_Syntax_Print.term_to_string d.dtyp
-                     in
-                  Prims.strcat " : " uu____739  in
-                Prims.strcat uu____737 uu____738))
-         in
-      FStar_All.pipe_right uu____726 (FStar_String.concat "\n\t\t")  in
+                  let uu____739 = FStar_Syntax_Print.term_to_string d.dtyp in
+                  Prims.strcat " : " uu____739 in
+                Prims.strcat uu____737 uu____738)) in
+      FStar_All.pipe_right uu____726 (FStar_String.concat "\n\t\t") in
     FStar_Util.print4 "\n\t%s %s : %s { %s }\n" uu____722 uu____723 uu____724
       uu____725
-  
-let bundle_as_inductive_families :
+let bundle_as_inductive_families:
   'Auu____747 .
     FStar_Extraction_ML_UEnv.env ->
       FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -446,7 +415,7 @@ let bundle_as_inductive_families :
                    match se.FStar_Syntax_Syntax.sigel with
                    | FStar_Syntax_Syntax.Sig_inductive_typ
                        (l,_us,bs,t,_mut_i,datas) ->
-                       let uu____825 = FStar_Syntax_Subst.open_term bs t  in
+                       let uu____825 = FStar_Syntax_Subst.open_term bs t in
                        (match uu____825 with
                         | (bs1,t1) ->
                             let datas1 =
@@ -460,15 +429,13 @@ let bundle_as_inductive_families :
                                           when FStar_Ident.lid_equals l l' ->
                                           let uu____873 =
                                             FStar_Syntax_Util.arrow_formals
-                                              t2
-                                             in
+                                              t2 in
                                           (match uu____873 with
                                            | (bs',body) ->
                                                let uu____906 =
                                                  FStar_Util.first_N
                                                    (FStar_List.length bs1)
-                                                   bs'
-                                                  in
+                                                   bs' in
                                                (match uu____906 with
                                                 | (bs_params,rest) ->
                                                     let subst1 =
@@ -486,45 +453,36 @@ let bundle_as_inductive_families :
                                                                    let uu____1014
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
-                                                                    b  in
+                                                                    b in
                                                                    (b',
-                                                                    uu____1014)
-                                                                    in
+                                                                    uu____1014) in
                                                                  FStar_Syntax_Syntax.NT
                                                                    uu____1007)
-                                                        bs_params bs1
-                                                       in
+                                                        bs_params bs1 in
                                                     let t3 =
                                                       let uu____1016 =
                                                         let uu____1019 =
                                                           FStar_Syntax_Syntax.mk_Total
-                                                            body
-                                                           in
+                                                            body in
                                                         FStar_Syntax_Util.arrow
-                                                          rest uu____1019
-                                                         in
+                                                          rest uu____1019 in
                                                       FStar_All.pipe_right
                                                         uu____1016
                                                         (FStar_Syntax_Subst.subst
-                                                           subst1)
-                                                       in
+                                                           subst1) in
                                                     [{ dname = d; dtyp = t3 }]))
-                                      | uu____1024 -> []))
-                               in
+                                      | uu____1024 -> [])) in
                             let metadata =
                               extract_metadata
                                 (FStar_List.append
-                                   se.FStar_Syntax_Syntax.sigattrs attrs)
-                               in
+                                   se.FStar_Syntax_Syntax.sigattrs attrs) in
                             let env2 =
                               let uu____1029 =
                                 FStar_Syntax_Syntax.lid_as_fv l
                                   FStar_Syntax_Syntax.Delta_constant
-                                  FStar_Pervasives_Native.None
-                                 in
+                                  FStar_Pervasives_Native.None in
                               FStar_Extraction_ML_UEnv.extend_type_name env1
-                                uu____1029
-                               in
+                                uu____1029 in
                             (env2,
                               [{
                                  iname = l;
@@ -534,42 +492,38 @@ let bundle_as_inductive_families :
                                  iquals = (se.FStar_Syntax_Syntax.sigquals);
                                  imetadata = metadata
                                }]))
-                   | uu____1032 -> (env1, [])) env ses
-             in
+                   | uu____1032 -> (env1, [])) env ses in
           match uu____778 with
           | (env1,ifams) -> (env1, (FStar_List.flatten ifams))
-  
 type env_t = FStar_Extraction_ML_UEnv.env[@@deriving show]
-let (extract_bundle :
+let extract_bundle:
   env_t ->
     FStar_Syntax_Syntax.sigelt ->
       (env_t,FStar_Extraction_ML_Syntax.mlmodule1 Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun se  ->
       let extract_ctor ml_tyvars env1 ctor =
         let mlt =
           let uu____1108 =
-            FStar_Extraction_ML_Term.term_as_mlty env1 ctor.dtyp  in
+            FStar_Extraction_ML_Term.term_as_mlty env1 ctor.dtyp in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env1) uu____1108
-           in
+            (FStar_Extraction_ML_Util.udelta_unfold env1) uu____1108 in
         let steps =
           [FStar_TypeChecker_Normalize.Inlining;
           FStar_TypeChecker_Normalize.UnfoldUntil
             FStar_Syntax_Syntax.Delta_constant;
           FStar_TypeChecker_Normalize.EraseUniverses;
-          FStar_TypeChecker_Normalize.AllowUnboundUniverses]  in
+          FStar_TypeChecker_Normalize.AllowUnboundUniverses] in
         let names1 =
           let uu____1115 =
             let uu____1116 =
               let uu____1119 =
                 FStar_TypeChecker_Normalize.normalize steps
-                  env1.FStar_Extraction_ML_UEnv.tcenv ctor.dtyp
-                 in
-              FStar_Syntax_Subst.compress uu____1119  in
-            uu____1116.FStar_Syntax_Syntax.n  in
+                  env1.FStar_Extraction_ML_UEnv.tcenv ctor.dtyp in
+              FStar_Syntax_Subst.compress uu____1119 in
+            uu____1116.FStar_Syntax_Syntax.n in
           match uu____1115 with
           | FStar_Syntax_Syntax.Tm_arrow (bs,uu____1123) ->
               FStar_List.map
@@ -579,32 +533,30 @@ let (extract_bundle :
                         FStar_Syntax_Syntax.index = uu____1155;
                         FStar_Syntax_Syntax.sort = uu____1156;_},uu____1157)
                        -> ppname.FStar_Ident.idText) bs
-          | uu____1160 -> []  in
-        let tys = (ml_tyvars, mlt)  in
-        let fvv = FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp  in
+          | uu____1160 -> [] in
+        let tys = (ml_tyvars, mlt) in
+        let fvv = FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp in
         let uu____1171 =
           let uu____1172 =
-            FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false  in
-          FStar_Pervasives_Native.fst uu____1172  in
+            FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false in
+          FStar_Pervasives_Native.fst uu____1172 in
         let uu____1177 =
-          let uu____1188 = lident_as_mlsymbol ctor.dname  in
+          let uu____1188 = lident_as_mlsymbol ctor.dname in
           let uu____1189 =
-            let uu____1196 = FStar_Extraction_ML_Util.argTypes mlt  in
-            FStar_List.zip names1 uu____1196  in
-          (uu____1188, uu____1189)  in
-        (uu____1171, uu____1177)  in
+            let uu____1196 = FStar_Extraction_ML_Util.argTypes mlt in
+            FStar_List.zip names1 uu____1196 in
+          (uu____1188, uu____1189) in
+        (uu____1171, uu____1177) in
       let extract_one_family env1 ind =
-        let uu____1244 = binders_as_mlty_binders env1 ind.iparams  in
+        let uu____1244 = binders_as_mlty_binders env1 ind.iparams in
         match uu____1244 with
         | (env2,vars) ->
             let uu____1279 =
               FStar_All.pipe_right ind.idatas
-                (FStar_Util.fold_map (extract_ctor vars) env2)
-               in
+                (FStar_Util.fold_map (extract_ctor vars) env2) in
             (match uu____1279 with
              | (env3,ctors) ->
-                 let uu____1372 = FStar_Syntax_Util.arrow_formals ind.ityp
-                    in
+                 let uu____1372 = FStar_Syntax_Util.arrow_formals ind.ityp in
                  (match uu____1372 with
                   | (indices,uu____1408) ->
                       let ml_params =
@@ -614,10 +566,9 @@ let (extract_bundle :
                                (fun i  ->
                                   fun uu____1447  ->
                                     let uu____1452 =
-                                      FStar_Util.string_of_int i  in
-                                    Prims.strcat "'dummyV" uu____1452))
-                           in
-                        FStar_List.append vars uu____1428  in
+                                      FStar_Util.string_of_int i in
+                                    Prims.strcat "'dummyV" uu____1452)) in
+                        FStar_List.append vars uu____1428 in
                       let tbody =
                         let uu____1454 =
                           FStar_Util.find_opt
@@ -625,12 +576,11 @@ let (extract_bundle :
                                match uu___73_1459 with
                                | FStar_Syntax_Syntax.RecordType uu____1460 ->
                                    true
-                               | uu____1469 -> false) ind.iquals
-                           in
+                               | uu____1469 -> false) ind.iquals in
                         match uu____1454 with
                         | FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.RecordType (ns,ids)) ->
-                            let uu____1480 = FStar_List.hd ctors  in
+                            let uu____1480 = FStar_List.hd ctors in
                             (match uu____1480 with
                              | (uu____1501,c_ty) ->
                                  let fields =
@@ -641,25 +591,20 @@ let (extract_bundle :
                                           | (uu____1549,ty) ->
                                               let lid =
                                                 FStar_Ident.lid_of_ids
-                                                  (FStar_List.append ns [id1])
-                                                 in
+                                                  (FStar_List.append ns [id1]) in
                                               let uu____1552 =
-                                                lident_as_mlsymbol lid  in
-                                              (uu____1552, ty)) ids c_ty
-                                    in
+                                                lident_as_mlsymbol lid in
+                                              (uu____1552, ty)) ids c_ty in
                                  FStar_Extraction_ML_Syntax.MLTD_Record
                                    fields)
                         | uu____1553 ->
-                            FStar_Extraction_ML_Syntax.MLTD_DType ctors
-                         in
+                            FStar_Extraction_ML_Syntax.MLTD_DType ctors in
                       let uu____1556 =
-                        let uu____1575 = lident_as_mlsymbol ind.iname  in
+                        let uu____1575 = lident_as_mlsymbol ind.iname in
                         (false, uu____1575, FStar_Pervasives_Native.None,
                           ml_params, (ind.imetadata),
-                          (FStar_Pervasives_Native.Some tbody))
-                         in
-                      (env3, uu____1556)))
-         in
+                          (FStar_Pervasives_Native.Some tbody)) in
+                      (env3, uu____1556))) in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
       with
@@ -672,33 +617,31 @@ let (extract_bundle :
             FStar_Syntax_Syntax.sigmeta = uu____1616;
             FStar_Syntax_Syntax.sigattrs = uu____1617;_}::[],uu____1618),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____1635 = extract_ctor [] env { dname = l; dtyp = t }  in
+          let uu____1635 = extract_ctor [] env { dname = l; dtyp = t } in
           (match uu____1635 with
            | (env1,ctor) -> (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
       | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____1681),quals) ->
           let uu____1695 =
             bundle_as_inductive_families env ses quals
-              se.FStar_Syntax_Syntax.sigattrs
-             in
+              se.FStar_Syntax_Syntax.sigattrs in
           (match uu____1695 with
            | (env1,ifams) ->
                let uu____1716 =
-                 FStar_Util.fold_map extract_one_family env1 ifams  in
+                 FStar_Util.fold_map extract_one_family env1 ifams in
                (match uu____1716 with
                 | (env2,td) -> (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
       | uu____1809 -> failwith "Unexpected signature element"
-  
-let rec (extract_sig :
+let rec extract_sig:
   env_t ->
     FStar_Syntax_Syntax.sigelt ->
       (env_t,FStar_Extraction_ML_Syntax.mlmodule1 Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun se  ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____1844 = FStar_Syntax_Print.sigelt_to_string se  in
+           let uu____1844 = FStar_Syntax_Print.sigelt_to_string se in
            FStar_Util.print1 ">>>> extract_sig %s \n" uu____1844);
       (match se.FStar_Syntax_Syntax.sigel with
        | FStar_Syntax_Syntax.Sig_bundle uu____1851 -> extract_bundle g se
@@ -714,19 +657,16 @@ let rec (extract_sig :
                let uu____1920 =
                  FStar_Syntax_Syntax.lid_as_fv lid
                    FStar_Syntax_Syntax.Delta_equational
-                   FStar_Pervasives_Native.None
-                  in
+                   FStar_Pervasives_Native.None in
                FStar_Extraction_ML_UEnv.extend_fv' g1 uu____1920 ml_name tysc
-                 false false
-                in
+                 false false in
              match uu____1915 with
              | (g2,mangled_name) ->
                  ((let uu____1928 =
                      FStar_All.pipe_left
                        (FStar_TypeChecker_Env.debug
                           g2.FStar_Extraction_ML_UEnv.tcenv)
-                       (FStar_Options.Other "ExtractionReify")
-                      in
+                       (FStar_Options.Other "ExtractionReify") in
                    if uu____1928
                    then FStar_Util.print1 "Mangled name: %s\n" mangled_name
                    else ());
@@ -739,70 +679,61 @@ let rec (extract_sig :
                        FStar_Extraction_ML_Syntax.mllb_def = tm;
                        FStar_Extraction_ML_Syntax.mllb_meta = [];
                        FStar_Extraction_ML_Syntax.print_typ = false
-                     }  in
+                     } in
                    (g2,
                      (FStar_Extraction_ML_Syntax.MLM_Let
-                        (FStar_Extraction_ML_Syntax.NonRec, [lb])))))
-              in
+                        (FStar_Extraction_ML_Syntax.NonRec, [lb]))))) in
            let rec extract_fv tm =
              (let uu____1942 =
                 FStar_All.pipe_left
                   (FStar_TypeChecker_Env.debug
                      g.FStar_Extraction_ML_UEnv.tcenv)
-                  (FStar_Options.Other "ExtractionReify")
-                 in
+                  (FStar_Options.Other "ExtractionReify") in
               if uu____1942
               then
-                let uu____1943 = FStar_Syntax_Print.term_to_string tm  in
+                let uu____1943 = FStar_Syntax_Print.term_to_string tm in
                 FStar_Util.print1 "extract_fv term: %s\n" uu____1943
               else ());
              (let uu____1945 =
-                let uu____1946 = FStar_Syntax_Subst.compress tm  in
-                uu____1946.FStar_Syntax_Syntax.n  in
+                let uu____1946 = FStar_Syntax_Subst.compress tm in
+                uu____1946.FStar_Syntax_Syntax.n in
               match uu____1945 with
               | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____1954) ->
                   extract_fv tm1
               | FStar_Syntax_Syntax.Tm_fvar fv ->
                   let mlp =
                     FStar_Extraction_ML_Syntax.mlpath_of_lident
-                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                     in
+                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                   let uu____1961 =
-                    let uu____1970 = FStar_Extraction_ML_UEnv.lookup_fv g fv
-                       in
-                    FStar_All.pipe_left FStar_Util.right uu____1970  in
+                    let uu____1970 = FStar_Extraction_ML_UEnv.lookup_fv g fv in
+                    FStar_All.pipe_left FStar_Util.right uu____1970 in
                   (match uu____1961 with
                    | (uu____2027,uu____2028,tysc,uu____2030) ->
                        let uu____2031 =
                          FStar_All.pipe_left
                            (FStar_Extraction_ML_Syntax.with_ty
                               FStar_Extraction_ML_Syntax.MLTY_Top)
-                           (FStar_Extraction_ML_Syntax.MLE_Name mlp)
-                          in
+                           (FStar_Extraction_ML_Syntax.MLE_Name mlp) in
                        (uu____2031, tysc))
-              | uu____2032 -> failwith "Not an fv")
-              in
+              | uu____2032 -> failwith "Not an fv") in
            let extract_action g1 a =
              (let uu____2058 =
                 FStar_All.pipe_left
                   (FStar_TypeChecker_Env.debug
                      g1.FStar_Extraction_ML_UEnv.tcenv)
-                  (FStar_Options.Other "ExtractionReify")
-                 in
+                  (FStar_Options.Other "ExtractionReify") in
               if uu____2058
               then
                 let uu____2059 =
                   FStar_Syntax_Print.term_to_string
-                    a.FStar_Syntax_Syntax.action_typ
-                   in
+                    a.FStar_Syntax_Syntax.action_typ in
                 let uu____2060 =
                   FStar_Syntax_Print.term_to_string
-                    a.FStar_Syntax_Syntax.action_defn
-                   in
+                    a.FStar_Syntax_Syntax.action_defn in
                 FStar_Util.print2 "Action type %s and term %s\n" uu____2059
                   uu____2060
               else ());
-             (let uu____2062 = FStar_Extraction_ML_UEnv.action_name ed a  in
+             (let uu____2062 = FStar_Extraction_ML_UEnv.action_name ed a in
               match uu____2062 with
               | (a_nm,a_lid) ->
                   let lbname =
@@ -810,40 +741,35 @@ let rec (extract_sig :
                       FStar_Syntax_Syntax.new_bv
                         (FStar_Pervasives_Native.Some
                            ((a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos))
-                        FStar_Syntax_Syntax.tun
-                       in
-                    FStar_Util.Inl uu____2078  in
+                        FStar_Syntax_Syntax.tun in
+                    FStar_Util.Inl uu____2078 in
                   let lb =
                     FStar_Syntax_Syntax.mk_lb
                       (lbname, (a.FStar_Syntax_Syntax.action_univs),
                         FStar_Parser_Const.effect_Tot_lid,
                         (a.FStar_Syntax_Syntax.action_typ),
-                        (a.FStar_Syntax_Syntax.action_defn))
-                     in
-                  let lbs = (false, [lb])  in
+                        (a.FStar_Syntax_Syntax.action_defn)) in
+                  let lbs = (false, [lb]) in
                   let action_lb =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_let
                          (lbs, FStar_Syntax_Util.exp_false_bool))
                       FStar_Pervasives_Native.None
-                      (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
-                     in
+                      (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                   let uu____2104 =
-                    FStar_Extraction_ML_Term.term_as_mlexpr g1 action_lb  in
+                    FStar_Extraction_ML_Term.term_as_mlexpr g1 action_lb in
                   (match uu____2104 with
                    | (a_let,uu____2116,ty) ->
                        ((let uu____2119 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug
                                 g1.FStar_Extraction_ML_UEnv.tcenv)
-                             (FStar_Options.Other "ExtractionReify")
-                            in
+                             (FStar_Options.Other "ExtractionReify") in
                          if uu____2119
                          then
                            let uu____2120 =
                              FStar_Extraction_ML_Code.string_of_mlexpr a_nm
-                               a_let
-                              in
+                               a_let in
                            FStar_Util.print1 "Extracted action term: %s\n"
                              uu____2120
                          else ());
@@ -858,22 +784,20 @@ let rec (extract_sig :
                                       tysc)
                                 | FStar_Pervasives_Native.None  ->
                                     failwith "No type scheme")
-                           | uu____2151 -> failwith "Impossible"  in
+                           | uu____2151 -> failwith "Impossible" in
                          match uu____2122 with
                          | (exp,tysc) ->
                              ((let uu____2163 =
                                  FStar_All.pipe_left
                                    (FStar_TypeChecker_Env.debug
                                       g1.FStar_Extraction_ML_UEnv.tcenv)
-                                   (FStar_Options.Other "ExtractionReify")
-                                  in
+                                   (FStar_Options.Other "ExtractionReify") in
                                if uu____2163
                                then
                                  ((let uu____2165 =
                                      FStar_Extraction_ML_Code.string_of_mlty
                                        a_nm
-                                       (FStar_Pervasives_Native.snd tysc)
-                                      in
+                                       (FStar_Pervasives_Native.snd tysc) in
                                    FStar_Util.print1
                                      "Extracted action type: %s\n" uu____2165);
                                   FStar_List.iter
@@ -882,44 +806,38 @@ let rec (extract_sig :
                                          x)
                                     (FStar_Pervasives_Native.fst tysc))
                                else ());
-                              extend_env g1 a_lid a_nm exp tysc)))))
-              in
+                              extend_env g1 a_lid a_nm exp tysc))))) in
            let uu____2169 =
              let uu____2174 =
                extract_fv
                  (FStar_Pervasives_Native.snd
-                    ed.FStar_Syntax_Syntax.return_repr)
-                in
+                    ed.FStar_Syntax_Syntax.return_repr) in
              match uu____2174 with
              | (return_tm,ty_sc) ->
                  let uu____2187 =
-                   FStar_Extraction_ML_UEnv.monad_op_name ed "return"  in
+                   FStar_Extraction_ML_UEnv.monad_op_name ed "return" in
                  (match uu____2187 with
                   | (return_nm,return_lid) ->
-                      extend_env g return_lid return_nm return_tm ty_sc)
-              in
+                      extend_env g return_lid return_nm return_tm ty_sc) in
            (match uu____2169 with
             | (g1,return_decl) ->
                 let uu____2206 =
                   let uu____2211 =
                     extract_fv
                       (FStar_Pervasives_Native.snd
-                         ed.FStar_Syntax_Syntax.bind_repr)
-                     in
+                         ed.FStar_Syntax_Syntax.bind_repr) in
                   match uu____2211 with
                   | (bind_tm,ty_sc) ->
                       let uu____2224 =
-                        FStar_Extraction_ML_UEnv.monad_op_name ed "bind"  in
+                        FStar_Extraction_ML_UEnv.monad_op_name ed "bind" in
                       (match uu____2224 with
                        | (bind_nm,bind_lid) ->
-                           extend_env g1 bind_lid bind_nm bind_tm ty_sc)
-                   in
+                           extend_env g1 bind_lid bind_nm bind_tm ty_sc) in
                 (match uu____2206 with
                  | (g2,bind_decl) ->
                      let uu____2243 =
                        FStar_Util.fold_map extract_action g2
-                         ed.FStar_Syntax_Syntax.actions
-                        in
+                         ed.FStar_Syntax_Syntax.actions in
                      (match uu____2243 with
                       | (g3,actions) ->
                           (g3,
@@ -928,8 +846,8 @@ let rec (extract_sig :
        | FStar_Syntax_Syntax.Sig_new_effect uu____2264 -> (g, [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____2268,t) when
            FStar_Extraction_ML_Term.is_arity g t ->
-           let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let attrs = se.FStar_Syntax_Syntax.sigattrs  in
+           let quals = se.FStar_Syntax_Syntax.sigquals in
+           let attrs = se.FStar_Syntax_Syntax.sigattrs in
            let uu____2276 =
              let uu____2277 =
                FStar_All.pipe_right quals
@@ -937,65 +855,57 @@ let rec (extract_sig :
                     (fun uu___74_2281  ->
                        match uu___74_2281 with
                        | FStar_Syntax_Syntax.Assumption  -> true
-                       | uu____2282 -> false))
-                in
-             Prims.op_Negation uu____2277  in
+                       | uu____2282 -> false)) in
+             Prims.op_Negation uu____2277 in
            if uu____2276
            then (g, [])
            else
-             (let uu____2292 = FStar_Syntax_Util.arrow_formals t  in
+             (let uu____2292 = FStar_Syntax_Util.arrow_formals t in
               match uu____2292 with
               | (bs,uu____2312) ->
                   let fv =
                     FStar_Syntax_Syntax.lid_as_fv lid
                       FStar_Syntax_Syntax.Delta_constant
-                      FStar_Pervasives_Native.None
-                     in
+                      FStar_Pervasives_Native.None in
                   let uu____2330 =
                     FStar_Syntax_Util.abs bs FStar_Syntax_Syntax.t_unit
-                      FStar_Pervasives_Native.None
-                     in
+                      FStar_Pervasives_Native.None in
                   extract_typ_abbrev g fv quals attrs uu____2330)
        | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____2332) when
            FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
            ->
-           let quals = se.FStar_Syntax_Syntax.sigquals  in
+           let quals = se.FStar_Syntax_Syntax.sigquals in
            let uu____2348 =
              let uu____2357 =
                FStar_TypeChecker_Env.open_universes_in
                  g.FStar_Extraction_ML_UEnv.tcenv
                  lb.FStar_Syntax_Syntax.lbunivs
-                 [lb.FStar_Syntax_Syntax.lbdef; lb.FStar_Syntax_Syntax.lbtyp]
-                in
+                 [lb.FStar_Syntax_Syntax.lbdef; lb.FStar_Syntax_Syntax.lbtyp] in
              match uu____2357 with
              | (tcenv,uu____2381,def_typ) ->
-                 let uu____2387 = as_pair def_typ  in (tcenv, uu____2387)
-              in
+                 let uu____2387 = as_pair def_typ in (tcenv, uu____2387) in
            (match uu____2348 with
             | (tcenv,(lbdef,lbtyp)) ->
                 let lbtyp1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Normalize.Beta;
                     FStar_TypeChecker_Normalize.UnfoldUntil
-                      FStar_Syntax_Syntax.Delta_constant] tcenv lbtyp
-                   in
+                      FStar_Syntax_Syntax.Delta_constant] tcenv lbtyp in
                 let lbdef1 =
                   FStar_TypeChecker_Normalize.eta_expand_with_type tcenv
-                    lbdef lbtyp1
-                   in
+                    lbdef lbtyp1 in
                 let uu____2411 =
-                  FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
+                  FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
                 extract_typ_abbrev g uu____2411 quals
                   se.FStar_Syntax_Syntax.sigattrs lbdef1)
        | FStar_Syntax_Syntax.Sig_let (lbs,uu____2413) ->
-           let attrs = se.FStar_Syntax_Syntax.sigattrs  in
-           let quals = se.FStar_Syntax_Syntax.sigquals  in
+           let attrs = se.FStar_Syntax_Syntax.sigattrs in
+           let quals = se.FStar_Syntax_Syntax.sigquals in
            let elet =
              FStar_Syntax_Syntax.mk
                (FStar_Syntax_Syntax.Tm_let
                   (lbs, FStar_Syntax_Util.exp_false_bool))
-               FStar_Pervasives_Native.None se.FStar_Syntax_Syntax.sigrng
-              in
+               FStar_Pervasives_Native.None se.FStar_Syntax_Syntax.sigrng in
            let tactic_registration_decl =
              let mk_registration tac_lid assm_lid t bs =
                let h =
@@ -1003,35 +913,30 @@ let rec (extract_sig :
                    let uu____2461 =
                      let uu____2462 =
                        FStar_Ident.lid_of_str
-                         "FStar_Tactics_Native.register_tactic"
-                        in
-                     FStar_Extraction_ML_Syntax.mlpath_of_lident uu____2462
-                      in
-                   FStar_Extraction_ML_Syntax.MLE_Name uu____2461  in
+                         "FStar_Tactics_Native.register_tactic" in
+                     FStar_Extraction_ML_Syntax.mlpath_of_lident uu____2462 in
+                   FStar_Extraction_ML_Syntax.MLE_Name uu____2461 in
                  FStar_All.pipe_left
                    (FStar_Extraction_ML_Syntax.with_ty
-                      FStar_Extraction_ML_Syntax.MLTY_Top) uu____2460
-                  in
+                      FStar_Extraction_ML_Syntax.MLTY_Top) uu____2460 in
                let lid_arg =
                  let uu____2464 =
-                   let uu____2465 = FStar_Ident.string_of_lid assm_lid  in
-                   FStar_Extraction_ML_Syntax.MLC_String uu____2465  in
-                 FStar_Extraction_ML_Syntax.MLE_Const uu____2464  in
-               let tac_arity = FStar_List.length bs  in
+                   let uu____2465 = FStar_Ident.string_of_lid assm_lid in
+                   FStar_Extraction_ML_Syntax.MLC_String uu____2465 in
+                 FStar_Extraction_ML_Syntax.MLE_Const uu____2464 in
+               let tac_arity = FStar_List.length bs in
                let arity =
                  let uu____2472 =
                    let uu____2473 =
                      let uu____2474 =
                        FStar_Util.string_of_int
-                         (tac_arity + (Prims.parse_int "1"))
-                        in
-                     FStar_Ident.lid_of_str uu____2474  in
-                   FStar_Extraction_ML_Syntax.mlpath_of_lident uu____2473  in
-                 FStar_Extraction_ML_Syntax.MLE_Name uu____2472  in
+                         (tac_arity + (Prims.parse_int "1")) in
+                     FStar_Ident.lid_of_str uu____2474 in
+                   FStar_Extraction_ML_Syntax.mlpath_of_lident uu____2473 in
+                 FStar_Extraction_ML_Syntax.MLE_Name uu____2472 in
                let uu____2481 =
                  FStar_Extraction_ML_Util.mk_interpretation_fun
-                   g.FStar_Extraction_ML_UEnv.tcenv tac_lid lid_arg t bs
-                  in
+                   g.FStar_Extraction_ML_UEnv.tcenv tac_lid lid_arg t bs in
                match uu____2481 with
                | FStar_Pervasives_Native.Some tac_interpretation ->
                    let app =
@@ -1041,70 +946,61 @@ let rec (extract_sig :
                            FStar_List.map
                              (FStar_Extraction_ML_Syntax.with_ty
                                 FStar_Extraction_ML_Syntax.MLTY_Top)
-                             [lid_arg; arity; tac_interpretation]
-                            in
-                         (h, uu____2496)  in
-                       FStar_Extraction_ML_Syntax.MLE_App uu____2489  in
+                             [lid_arg; arity; tac_interpretation] in
+                         (h, uu____2496) in
+                       FStar_Extraction_ML_Syntax.MLE_App uu____2489 in
                      FStar_All.pipe_left
                        (FStar_Extraction_ML_Syntax.with_ty
-                          FStar_Extraction_ML_Syntax.MLTY_Top) uu____2488
-                      in
+                          FStar_Extraction_ML_Syntax.MLTY_Top) uu____2488 in
                    [FStar_Extraction_ML_Syntax.MLM_Top app]
-               | FStar_Pervasives_Native.None  -> []  in
+               | FStar_Pervasives_Native.None  -> [] in
              let uu____2501 =
-               let uu____2502 = FStar_Options.codegen ()  in
-               uu____2502 = (FStar_Pervasives_Native.Some "tactics")  in
+               let uu____2502 = FStar_Options.codegen () in
+               uu____2502 = (FStar_Pervasives_Native.Some "tactics") in
              if uu____2501
              then
                match FStar_Pervasives_Native.snd lbs with
                | hd1::[] ->
                    let uu____2514 =
                      FStar_Syntax_Util.arrow_formals_comp
-                       hd1.FStar_Syntax_Syntax.lbtyp
-                      in
+                       hd1.FStar_Syntax_Syntax.lbtyp in
                    (match uu____2514 with
                     | (bs,comp) ->
-                        let t = FStar_Syntax_Util.comp_result comp  in
+                        let t = FStar_Syntax_Util.comp_result comp in
                         let uu____2544 =
-                          let uu____2545 = FStar_Syntax_Subst.compress t  in
-                          uu____2545.FStar_Syntax_Syntax.n  in
+                          let uu____2545 = FStar_Syntax_Subst.compress t in
+                          uu____2545.FStar_Syntax_Syntax.n in
                         (match uu____2544 with
                          | FStar_Syntax_Syntax.Tm_app (h,args) ->
                              let tac_lid =
                                let uu____2573 =
                                  let uu____2576 =
                                    FStar_Util.right
-                                     hd1.FStar_Syntax_Syntax.lbname
-                                    in
-                                 uu____2576.FStar_Syntax_Syntax.fv_name  in
-                               uu____2573.FStar_Syntax_Syntax.v  in
+                                     hd1.FStar_Syntax_Syntax.lbname in
+                                 uu____2576.FStar_Syntax_Syntax.fv_name in
+                               uu____2573.FStar_Syntax_Syntax.v in
                              let assm_lid =
                                let uu____2578 =
                                  FStar_All.pipe_left FStar_Ident.id_of_text
                                    (Prims.strcat "__"
-                                      (tac_lid.FStar_Ident.ident).FStar_Ident.idText)
-                                  in
+                                      (tac_lid.FStar_Ident.ident).FStar_Ident.idText) in
                                FStar_Ident.lid_of_ns_and_id
-                                 tac_lid.FStar_Ident.ns uu____2578
-                                in
+                                 tac_lid.FStar_Ident.ns uu____2578 in
                              let uu____2579 =
-                               let uu____2580 = FStar_Syntax_Subst.compress h
-                                  in
+                               let uu____2580 = FStar_Syntax_Subst.compress h in
                                is_tactic_decl assm_lid uu____2580
-                                 g.FStar_Extraction_ML_UEnv.currentModule
-                                in
+                                 g.FStar_Extraction_ML_UEnv.currentModule in
                              if uu____2579
                              then
                                let uu____2583 =
-                                 let uu____2584 = FStar_List.hd args  in
-                                 FStar_Pervasives_Native.fst uu____2584  in
+                                 let uu____2584 = FStar_List.hd args in
+                                 FStar_Pervasives_Native.fst uu____2584 in
                                mk_registration tac_lid assm_lid uu____2583 bs
                              else []
                          | uu____2600 -> []))
                | uu____2601 -> []
-             else []  in
-           let uu____2605 = FStar_Extraction_ML_Term.term_as_mlexpr g elet
-              in
+             else [] in
+           let uu____2605 = FStar_Extraction_ML_Term.term_as_mlexpr g elet in
            (match uu____2605 with
             | (ml_let,uu____2619,uu____2620) ->
                 (match ml_let.FStar_Extraction_ML_Syntax.expr with
@@ -1124,9 +1020,8 @@ let rec (extract_sig :
                                 FStar_Pervasives_Native.Some
                                   FStar_Extraction_ML_Syntax.NoExtract
                             | uu____2647 -> FStar_Pervasives_Native.None)
-                         quals
-                        in
-                     let flags' = extract_metadata attrs  in
+                         quals in
+                     let flags' = extract_metadata attrs in
                      let uu____2651 =
                        FStar_List.fold_left2
                          (fun uu____2682  ->
@@ -1150,15 +1045,14 @@ let rec (extract_sig :
                                     let lb_lid =
                                       let uu____2736 =
                                         let uu____2739 =
-                                          FStar_Util.right lbname  in
-                                        uu____2739.FStar_Syntax_Syntax.fv_name
-                                         in
-                                      uu____2736.FStar_Syntax_Syntax.v  in
+                                          FStar_Util.right lbname in
+                                        uu____2739.FStar_Syntax_Syntax.fv_name in
+                                      uu____2736.FStar_Syntax_Syntax.v in
                                     let flags'' =
                                       let uu____2743 =
                                         let uu____2744 =
-                                          FStar_Syntax_Subst.compress t  in
-                                        uu____2744.FStar_Syntax_Syntax.n  in
+                                          FStar_Syntax_Subst.compress t in
+                                        uu____2744.FStar_Syntax_Syntax.n in
                                       match uu____2743 with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (uu____2749,{
@@ -1182,18 +1076,17 @@ let rec (extract_sig :
                                                           = uu____2756;_})
                                           when
                                           let uu____2785 =
-                                            FStar_Ident.string_of_lid e  in
+                                            FStar_Ident.string_of_lid e in
                                           uu____2785 =
                                             "FStar.HyperStack.ST.StackInline"
                                           ->
                                           [FStar_Extraction_ML_Syntax.StackInline]
-                                      | uu____2786 -> []  in
+                                      | uu____2786 -> [] in
                                     let meta =
                                       FStar_List.append flags1
-                                        (FStar_List.append flags' flags'')
-                                       in
+                                        (FStar_List.append flags' flags'') in
                                     let ml_lb1 =
-                                      let uu___79_2791 = ml_lb  in
+                                      let uu___79_2791 = ml_lb in
                                       {
                                         FStar_Extraction_ML_Syntax.mllb_name
                                           =
@@ -1211,7 +1104,7 @@ let rec (extract_sig :
                                         FStar_Extraction_ML_Syntax.print_typ
                                           =
                                           (uu___79_2791.FStar_Extraction_ML_Syntax.print_typ)
-                                      }  in
+                                      } in
                                     let uu____2792 =
                                       let uu____2797 =
                                         FStar_All.pipe_right quals
@@ -1220,32 +1113,28 @@ let rec (extract_sig :
                                                 match uu___76_2802 with
                                                 | FStar_Syntax_Syntax.Projector
                                                     uu____2803 -> true
-                                                | uu____2808 -> false))
-                                         in
+                                                | uu____2808 -> false)) in
                                       if uu____2797
                                       then
                                         let mname =
                                           let uu____2814 =
-                                            mangle_projector_lid lb_lid  in
+                                            mangle_projector_lid lb_lid in
                                           FStar_All.pipe_right uu____2814
-                                            FStar_Extraction_ML_Syntax.mlpath_of_lident
-                                           in
+                                            FStar_Extraction_ML_Syntax.mlpath_of_lident in
                                         let uu____2815 =
                                           let uu____2820 =
-                                            FStar_Util.right lbname  in
+                                            FStar_Util.right lbname in
                                           let uu____2821 =
                                             FStar_Util.must
-                                              ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
-                                             in
+                                              ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
                                           FStar_Extraction_ML_UEnv.extend_fv'
                                             env uu____2820 mname uu____2821
                                             ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
-                                            false
-                                           in
+                                            false in
                                         match uu____2815 with
                                         | (env1,uu____2827) ->
                                             (env1,
-                                              (let uu___80_2829 = ml_lb1  in
+                                              (let uu___80_2829 = ml_lb1 in
                                                {
                                                  FStar_Extraction_ML_Syntax.mllb_name
                                                    =
@@ -1272,24 +1161,19 @@ let rec (extract_sig :
                                            let uu____2834 =
                                              let uu____2839 =
                                                FStar_Util.must
-                                                 ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
-                                                in
+                                                 ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
                                              FStar_Extraction_ML_UEnv.extend_lb
                                                env lbname t uu____2839
                                                ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
-                                               false
-                                              in
+                                               false in
                                            FStar_All.pipe_left
                                              FStar_Pervasives_Native.fst
-                                             uu____2834
-                                            in
-                                         (uu____2833, ml_lb1))
-                                       in
+                                             uu____2834 in
+                                         (uu____2833, ml_lb1)) in
                                     (match uu____2792 with
                                      | (g1,ml_lb2) ->
                                          (g1, (ml_lb2 :: ml_lbs)))) (g, [])
-                         bindings (FStar_Pervasives_Native.snd lbs)
-                        in
+                         bindings (FStar_Pervasives_Native.snd lbs) in
                      (match uu____2651 with
                       | (g1,ml_lbs') ->
                           let uu____2870 =
@@ -1297,59 +1181,49 @@ let rec (extract_sig :
                               let uu____2876 =
                                 let uu____2877 =
                                   FStar_Extraction_ML_Util.mlloc_of_range
-                                    se.FStar_Syntax_Syntax.sigrng
-                                   in
-                                FStar_Extraction_ML_Syntax.MLM_Loc uu____2877
-                                 in
+                                    se.FStar_Syntax_Syntax.sigrng in
+                                FStar_Extraction_ML_Syntax.MLM_Loc uu____2877 in
                               [uu____2876;
                               FStar_Extraction_ML_Syntax.MLM_Let
-                                (flavor, (FStar_List.rev ml_lbs'))]
-                               in
+                                (flavor, (FStar_List.rev ml_lbs'))] in
                             FStar_List.append uu____2873
-                              tactic_registration_decl
-                             in
+                              tactic_registration_decl in
                           (g1, uu____2870))
                  | uu____2882 ->
                      let uu____2883 =
                        let uu____2884 =
                          FStar_Extraction_ML_Code.string_of_mlexpr
-                           g.FStar_Extraction_ML_UEnv.currentModule ml_let
-                          in
+                           g.FStar_Extraction_ML_UEnv.currentModule ml_let in
                        FStar_Util.format1
                          "Impossible: Translated a let to a non-let: %s"
-                         uu____2884
-                        in
+                         uu____2884 in
                      failwith uu____2883))
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____2892,t) ->
-           let quals = se.FStar_Syntax_Syntax.sigquals  in
+           let quals = se.FStar_Syntax_Syntax.sigquals in
            let uu____2897 =
              FStar_All.pipe_right quals
-               (FStar_List.contains FStar_Syntax_Syntax.Assumption)
-              in
+               (FStar_List.contains FStar_Syntax_Syntax.Assumption) in
            if uu____2897
            then
              let always_fail =
                let imp =
-                 let uu____2908 = FStar_Syntax_Util.arrow_formals t  in
+                 let uu____2908 = FStar_Syntax_Util.arrow_formals t in
                  match uu____2908 with
                  | ([],t1) ->
                      let b =
                        let uu____2937 =
                          FStar_Syntax_Syntax.gen_bv "_"
-                           FStar_Pervasives_Native.None t1
-                          in
+                           FStar_Pervasives_Native.None t1 in
                        FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder
-                         uu____2937
-                        in
-                     let uu____2938 = fail_exp lid t1  in
+                         uu____2937 in
+                     let uu____2938 = fail_exp lid t1 in
                      FStar_Syntax_Util.abs [b] uu____2938
                        FStar_Pervasives_Native.None
                  | (bs,t1) ->
-                     let uu____2957 = fail_exp lid t1  in
+                     let uu____2957 = fail_exp lid t1 in
                      FStar_Syntax_Util.abs bs uu____2957
-                       FStar_Pervasives_Native.None
-                  in
-               let uu___81_2958 = se  in
+                       FStar_Pervasives_Native.None in
+               let uu___81_2958 = se in
                let uu____2959 =
                  let uu____2960 =
                    let uu____2967 =
@@ -1359,9 +1233,8 @@ let rec (extract_sig :
                            let uu____2983 =
                              FStar_Syntax_Syntax.lid_as_fv lid
                                FStar_Syntax_Syntax.Delta_constant
-                               FStar_Pervasives_Native.None
-                              in
-                           FStar_Util.Inr uu____2983  in
+                               FStar_Pervasives_Native.None in
+                           FStar_Util.Inr uu____2983 in
                          {
                            FStar_Syntax_Syntax.lbname = uu____2978;
                            FStar_Syntax_Syntax.lbunivs = [];
@@ -1370,11 +1243,11 @@ let rec (extract_sig :
                              FStar_Parser_Const.effect_ML_lid;
                            FStar_Syntax_Syntax.lbdef = imp;
                            FStar_Syntax_Syntax.lbattrs = []
-                         }  in
-                       [uu____2977]  in
-                     (false, uu____2974)  in
-                   (uu____2967, [])  in
-                 FStar_Syntax_Syntax.Sig_let uu____2960  in
+                         } in
+                       [uu____2977] in
+                     (false, uu____2974) in
+                   (uu____2967, []) in
+                 FStar_Syntax_Syntax.Sig_let uu____2960 in
                {
                  FStar_Syntax_Syntax.sigel = uu____2959;
                  FStar_Syntax_Syntax.sigrng =
@@ -1385,8 +1258,8 @@ let rec (extract_sig :
                    (uu___81_2958.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
                    (uu___81_2958.FStar_Syntax_Syntax.sigattrs)
-               }  in
-             let uu____2996 = extract_sig g always_fail  in
+               } in
+             let uu____2996 = extract_sig g always_fail in
              (match uu____2996 with
               | (g1,mlm) ->
                   let uu____3015 =
@@ -1395,24 +1268,21 @@ let rec (extract_sig :
                          match uu___77_3020 with
                          | FStar_Syntax_Syntax.Discriminator l ->
                              FStar_Pervasives_Native.Some l
-                         | uu____3024 -> FStar_Pervasives_Native.None)
-                     in
+                         | uu____3024 -> FStar_Pervasives_Native.None) in
                   (match uu____3015 with
                    | FStar_Pervasives_Native.Some l ->
                        let uu____3032 =
                          let uu____3035 =
                            let uu____3036 =
                              FStar_Extraction_ML_Util.mlloc_of_range
-                               se.FStar_Syntax_Syntax.sigrng
-                              in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____3036  in
+                               se.FStar_Syntax_Syntax.sigrng in
+                           FStar_Extraction_ML_Syntax.MLM_Loc uu____3036 in
                          let uu____3037 =
                            let uu____3040 =
                              FStar_Extraction_ML_Term.ind_discriminator_body
-                               g1 lid l
-                              in
-                           [uu____3040]  in
-                         uu____3035 :: uu____3037  in
+                               g1 lid l in
+                           [uu____3040] in
+                         uu____3035 :: uu____3037 in
                        (g1, uu____3032)
                    | uu____3043 ->
                        let uu____3046 =
@@ -1421,25 +1291,22 @@ let rec (extract_sig :
                               match uu___78_3052 with
                               | FStar_Syntax_Syntax.Projector (l,uu____3056)
                                   -> FStar_Pervasives_Native.Some l
-                              | uu____3057 -> FStar_Pervasives_Native.None)
-                          in
+                              | uu____3057 -> FStar_Pervasives_Native.None) in
                        (match uu____3046 with
                         | FStar_Pervasives_Native.Some uu____3064 -> (g1, [])
                         | uu____3067 -> (g1, mlm))))
            else (g, [])
        | FStar_Syntax_Syntax.Sig_main e ->
-           let uu____3076 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
+           let uu____3076 = FStar_Extraction_ML_Term.term_as_mlexpr g e in
            (match uu____3076 with
             | (ml_main,uu____3090,uu____3091) ->
                 let uu____3092 =
                   let uu____3095 =
                     let uu____3096 =
                       FStar_Extraction_ML_Util.mlloc_of_range
-                        se.FStar_Syntax_Syntax.sigrng
-                       in
-                    FStar_Extraction_ML_Syntax.MLM_Loc uu____3096  in
-                  [uu____3095; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
-                   in
+                        se.FStar_Syntax_Syntax.sigrng in
+                    FStar_Extraction_ML_Syntax.MLM_Loc uu____3096 in
+                  [uu____3095; FStar_Extraction_ML_Syntax.MLM_Top ml_main] in
                 (g, uu____3092))
        | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____3099 ->
            failwith "impossible -- removed by tc.fs"
@@ -1447,7 +1314,7 @@ let rec (extract_sig :
        | FStar_Syntax_Syntax.Sig_sub_effect uu____3115 -> (g, [])
        | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3118 -> (g, [])
        | FStar_Syntax_Syntax.Sig_pragma p ->
-           let codegen_opt = FStar_Options.codegen ()  in
+           let codegen_opt = FStar_Options.codegen () in
            (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
             (match codegen_opt with
              | FStar_Pervasives_Native.Some "tactics" ->
@@ -1455,28 +1322,25 @@ let rec (extract_sig :
                    (FStar_Options.String "tactics")
              | uu____3139 -> ());
             (g, [])))
-  
-let (extract_iface :
-  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.modul -> env_t) =
+let extract_iface:
+  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.modul -> env_t =
   fun g  ->
     fun m  ->
       let uu____3150 =
-        FStar_Util.fold_map extract_sig g m.FStar_Syntax_Syntax.declarations
-         in
+        FStar_Util.fold_map extract_sig g m.FStar_Syntax_Syntax.declarations in
       FStar_All.pipe_right uu____3150 FStar_Pervasives_Native.fst
-  
-let (extract' :
+let extract':
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.modul ->
       (FStar_Extraction_ML_UEnv.env,FStar_Extraction_ML_Syntax.mllib
                                       Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun m  ->
       FStar_Syntax_Syntax.reset_gensym ();
-      (let codegen_opt = FStar_Options.codegen ()  in
-       let uu____3195 = FStar_Options.restore_cmd_line_options true  in
+      (let codegen_opt = FStar_Options.codegen () in
+       let uu____3195 = FStar_Options.restore_cmd_line_options true in
        (match codegen_opt with
         | FStar_Pervasives_Native.Some "tactics" ->
             FStar_Options.set_option "codegen"
@@ -1484,14 +1348,12 @@ let (extract' :
         | uu____3197 -> ());
        (let name =
           FStar_Extraction_ML_Syntax.mlpath_of_lident
-            m.FStar_Syntax_Syntax.name
-           in
+            m.FStar_Syntax_Syntax.name in
         let g1 =
-          let uu___82_3202 = g  in
+          let uu___82_3202 = g in
           let uu____3203 =
             FStar_TypeChecker_Env.set_current_module
-              g.FStar_Extraction_ML_UEnv.tcenv m.FStar_Syntax_Syntax.name
-             in
+              g.FStar_Extraction_ML_UEnv.tcenv m.FStar_Syntax_Syntax.name in
           {
             FStar_Extraction_ML_UEnv.tcenv = uu____3203;
             FStar_Extraction_ML_UEnv.gamma =
@@ -1501,56 +1363,51 @@ let (extract' :
             FStar_Extraction_ML_UEnv.type_names =
               (uu___82_3202.FStar_Extraction_ML_UEnv.type_names);
             FStar_Extraction_ML_UEnv.currentModule = name
-          }  in
+          } in
         let uu____3204 =
           FStar_Util.fold_map extract_sig g1
-            m.FStar_Syntax_Syntax.declarations
-           in
+            m.FStar_Syntax_Syntax.declarations in
         match uu____3204 with
         | (g2,sigs) ->
-            let mlm = FStar_List.flatten sigs  in
+            let mlm = FStar_List.flatten sigs in
             let is_kremlin =
-              let uu____3233 = FStar_Options.codegen ()  in
+              let uu____3233 = FStar_Options.codegen () in
               match uu____3233 with
               | FStar_Pervasives_Native.Some "Kremlin" -> true
-              | uu____3236 -> false  in
+              | uu____3236 -> false in
             let uu____3239 =
               (((m.FStar_Syntax_Syntax.name).FStar_Ident.str <> "Prims") &&
                  (is_kremlin ||
                     (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)))
                 &&
                 (FStar_Options.should_extract
-                   (m.FStar_Syntax_Syntax.name).FStar_Ident.str)
-               in
+                   (m.FStar_Syntax_Syntax.name).FStar_Ident.str) in
             if uu____3239
             then
               ((let uu____3247 =
-                  FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name
-                   in
+                  FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name in
                 FStar_Util.print1 "Extracted module %s\n" uu____3247);
                (g2,
                  [FStar_Extraction_ML_Syntax.MLLib
                     [(name, (FStar_Pervasives_Native.Some ([], mlm)),
                        (FStar_Extraction_ML_Syntax.MLLib []))]]))
             else (g2, [])))
-  
-let (extract :
+let extract:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.modul ->
       (FStar_Extraction_ML_UEnv.env,FStar_Extraction_ML_Syntax.mllib
                                       Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun m  ->
-      let uu____3321 = FStar_Options.debug_any ()  in
+      let uu____3321 = FStar_Options.debug_any () in
       if uu____3321
       then
         let msg =
           let uu____3329 =
-            FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name  in
-          FStar_Util.format1 "Extracting module %s\n" uu____3329  in
+            FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name in
+          FStar_Util.format1 "Extracting module %s\n" uu____3329 in
         FStar_Util.measure_execution_time msg
           (fun uu____3337  -> extract' g m)
       else extract' g m
-  

--- a/src/ocaml-output/FStar_Extraction_ML_Syntax.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Syntax.ml
@@ -3,7 +3,7 @@ type mlsymbol = Prims.string[@@deriving show]
 type mlident = mlsymbol[@@deriving show]
 type mlpath = (mlsymbol Prims.list,mlsymbol) FStar_Pervasives_Native.tuple2
 [@@deriving show]
-let (ocamlkeywords : Prims.string Prims.list) =
+let ocamlkeywords: Prims.string Prims.list =
   ["and";
   "as";
   "assert";
@@ -59,8 +59,8 @@ let (ocamlkeywords : Prims.string Prims.list) =
   "when";
   "while";
   "with";
-  "nonrec"] 
-let (fsharpkeywords : Prims.string Prims.list) =
+  "nonrec"]
+let fsharpkeywords: Prims.string Prims.list =
   ["abstract";
   "and";
   "as";
@@ -163,567 +163,498 @@ let (fsharpkeywords : Prims.string Prims.list) =
   "tailcall";
   "trait";
   "virtual";
-  "volatile"] 
-let (is_reserved : Prims.string -> Prims.bool) =
+  "volatile"]
+let is_reserved: Prims.string -> Prims.bool =
   fun k  ->
     let reserved_keywords uu____19 =
-      let uu____20 = FStar_Options.codegen_fsharp ()  in
-      if uu____20 then fsharpkeywords else ocamlkeywords  in
-    let uu____24 = reserved_keywords ()  in
+      let uu____20 = FStar_Options.codegen_fsharp () in
+      if uu____20 then fsharpkeywords else ocamlkeywords in
+    let uu____24 = reserved_keywords () in
     FStar_List.existsb (fun k'  -> k' = k) uu____24
-  
-let (string_of_mlpath : mlpath -> mlsymbol) =
+let string_of_mlpath: mlpath -> mlsymbol =
   fun uu____31  ->
     match uu____31 with
     | (p,s) -> FStar_String.concat "." (FStar_List.append p [s])
-  
 type gensym_t =
   {
-  gensym: Prims.unit -> mlident ;
-  reset: Prims.unit -> Prims.unit }[@@deriving show]
-let (__proj__Mkgensym_t__item__gensym : gensym_t -> Prims.unit -> mlident) =
+  gensym: Prims.unit -> mlident;
+  reset: Prims.unit -> Prims.unit;}[@@deriving show]
+let __proj__Mkgensym_t__item__gensym: gensym_t -> Prims.unit -> mlident =
   fun projectee  ->
     match projectee with
     | { gensym = __fname__gensym; reset = __fname__reset;_} ->
         __fname__gensym
-  
-let (__proj__Mkgensym_t__item__reset : gensym_t -> Prims.unit -> Prims.unit)
-  =
+let __proj__Mkgensym_t__item__reset: gensym_t -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { gensym = __fname__gensym; reset = __fname__reset;_} -> __fname__reset
-  
-let (gs : gensym_t) =
-  let ctr = FStar_Util.mk_ref (Prims.parse_int "0")  in
-  let n_resets = FStar_Util.mk_ref (Prims.parse_int "0")  in
+let gs: gensym_t =
+  let ctr = FStar_Util.mk_ref (Prims.parse_int "0") in
+  let n_resets = FStar_Util.mk_ref (Prims.parse_int "0") in
   {
     gensym =
       (fun uu____92  ->
          FStar_Util.incr ctr;
          (let uu____127 =
             let uu____128 =
-              let uu____129 = FStar_ST.op_Bang n_resets  in
-              FStar_Util.string_of_int uu____129  in
+              let uu____129 = FStar_ST.op_Bang n_resets in
+              FStar_Util.string_of_int uu____129 in
             let uu____171 =
               let uu____172 =
-                let uu____173 = FStar_ST.op_Bang ctr  in
-                FStar_Util.string_of_int uu____173  in
-              Prims.strcat "_" uu____172  in
-            Prims.strcat uu____128 uu____171  in
+                let uu____173 = FStar_ST.op_Bang ctr in
+                FStar_Util.string_of_int uu____173 in
+              Prims.strcat "_" uu____172 in
+            Prims.strcat uu____128 uu____171 in
           Prims.strcat "_" uu____127));
     reset =
       (fun uu____217  ->
          FStar_ST.op_Colon_Equals ctr (Prims.parse_int "0");
          FStar_Util.incr n_resets)
-  } 
-let (gensym : Prims.unit -> mlident) = fun uu____295  -> gs.gensym () 
-let (reset_gensym : Prims.unit -> Prims.unit) = fun uu____298  -> gs.reset () 
-let rec (gensyms : Prims.int -> mlident Prims.list) =
+  }
+let gensym: Prims.unit -> mlident = fun uu____295  -> gs.gensym ()
+let reset_gensym: Prims.unit -> Prims.unit = fun uu____298  -> gs.reset ()
+let rec gensyms: Prims.int -> mlident Prims.list =
   fun x  ->
     match x with
     | _0_27 when _0_27 = (Prims.parse_int "0") -> []
     | n1 ->
-        let uu____307 = gensym ()  in
-        let uu____308 = gensyms (n1 - (Prims.parse_int "1"))  in uu____307 ::
+        let uu____307 = gensym () in
+        let uu____308 = gensyms (n1 - (Prims.parse_int "1")) in uu____307 ::
           uu____308
-  
-let (mlpath_of_lident : FStar_Ident.lident -> mlpath) =
+let mlpath_of_lident: FStar_Ident.lident -> mlpath =
   fun x  ->
     if FStar_Ident.lid_equals x FStar_Parser_Const.failwith_lid
     then ([], ((x.FStar_Ident.ident).FStar_Ident.idText))
     else
       (let uu____317 =
-         FStar_List.map (fun x1  -> x1.FStar_Ident.idText) x.FStar_Ident.ns
-          in
+         FStar_List.map (fun x1  -> x1.FStar_Ident.idText) x.FStar_Ident.ns in
        (uu____317, ((x.FStar_Ident.ident).FStar_Ident.idText)))
-  
 type mlidents = mlident Prims.list[@@deriving show]
 type mlsymbols = mlsymbol Prims.list[@@deriving show]
 type e_tag =
-  | E_PURE 
-  | E_GHOST 
-  | E_IMPURE [@@deriving show]
-let (uu___is_E_PURE : e_tag -> Prims.bool) =
+  | E_PURE
+  | E_GHOST
+  | E_IMPURE[@@deriving show]
+let uu___is_E_PURE: e_tag -> Prims.bool =
   fun projectee  ->
     match projectee with | E_PURE  -> true | uu____331 -> false
-  
-let (uu___is_E_GHOST : e_tag -> Prims.bool) =
+let uu___is_E_GHOST: e_tag -> Prims.bool =
   fun projectee  ->
     match projectee with | E_GHOST  -> true | uu____335 -> false
-  
-let (uu___is_E_IMPURE : e_tag -> Prims.bool) =
+let uu___is_E_IMPURE: e_tag -> Prims.bool =
   fun projectee  ->
     match projectee with | E_IMPURE  -> true | uu____339 -> false
-  
 type mlloc = (Prims.int,Prims.string) FStar_Pervasives_Native.tuple2[@@deriving
                                                                     show]
-let (dummy_loc : (Prims.int,Prims.string) FStar_Pervasives_Native.tuple2) =
-  ((Prims.parse_int "0"), "") 
+let dummy_loc: (Prims.int,Prims.string) FStar_Pervasives_Native.tuple2 =
+  ((Prims.parse_int "0"), "")
 type mlty =
-  | MLTY_Var of mlident 
-  | MLTY_Fun of (mlty,e_tag,mlty) FStar_Pervasives_Native.tuple3 
-  | MLTY_Named of (mlty Prims.list,mlpath) FStar_Pervasives_Native.tuple2 
-  | MLTY_Tuple of mlty Prims.list 
-  | MLTY_Top [@@deriving show]
-let (uu___is_MLTY_Var : mlty -> Prims.bool) =
+  | MLTY_Var of mlident
+  | MLTY_Fun of (mlty,e_tag,mlty) FStar_Pervasives_Native.tuple3
+  | MLTY_Named of (mlty Prims.list,mlpath) FStar_Pervasives_Native.tuple2
+  | MLTY_Tuple of mlty Prims.list
+  | MLTY_Top[@@deriving show]
+let uu___is_MLTY_Var: mlty -> Prims.bool =
   fun projectee  ->
     match projectee with | MLTY_Var _0 -> true | uu____382 -> false
-  
-let (__proj__MLTY_Var__item___0 : mlty -> mlident) =
-  fun projectee  -> match projectee with | MLTY_Var _0 -> _0 
-let (uu___is_MLTY_Fun : mlty -> Prims.bool) =
+let __proj__MLTY_Var__item___0: mlty -> mlident =
+  fun projectee  -> match projectee with | MLTY_Var _0 -> _0
+let uu___is_MLTY_Fun: mlty -> Prims.bool =
   fun projectee  ->
     match projectee with | MLTY_Fun _0 -> true | uu____400 -> false
-  
-let (__proj__MLTY_Fun__item___0 :
-  mlty -> (mlty,e_tag,mlty) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | MLTY_Fun _0 -> _0 
-let (uu___is_MLTY_Named : mlty -> Prims.bool) =
+let __proj__MLTY_Fun__item___0:
+  mlty -> (mlty,e_tag,mlty) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | MLTY_Fun _0 -> _0
+let uu___is_MLTY_Named: mlty -> Prims.bool =
   fun projectee  ->
     match projectee with | MLTY_Named _0 -> true | uu____436 -> false
-  
-let (__proj__MLTY_Named__item___0 :
-  mlty -> (mlty Prims.list,mlpath) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | MLTY_Named _0 -> _0 
-let (uu___is_MLTY_Tuple : mlty -> Prims.bool) =
+let __proj__MLTY_Named__item___0:
+  mlty -> (mlty Prims.list,mlpath) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLTY_Named _0 -> _0
+let uu___is_MLTY_Tuple: mlty -> Prims.bool =
   fun projectee  ->
     match projectee with | MLTY_Tuple _0 -> true | uu____468 -> false
-  
-let (__proj__MLTY_Tuple__item___0 : mlty -> mlty Prims.list) =
-  fun projectee  -> match projectee with | MLTY_Tuple _0 -> _0 
-let (uu___is_MLTY_Top : mlty -> Prims.bool) =
+let __proj__MLTY_Tuple__item___0: mlty -> mlty Prims.list =
+  fun projectee  -> match projectee with | MLTY_Tuple _0 -> _0
+let uu___is_MLTY_Top: mlty -> Prims.bool =
   fun projectee  ->
     match projectee with | MLTY_Top  -> true | uu____485 -> false
-  
 type mltyscheme = (mlidents,mlty) FStar_Pervasives_Native.tuple2[@@deriving
                                                                   show]
 type mlconstant =
-  | MLC_Unit 
-  | MLC_Bool of Prims.bool 
+  | MLC_Unit
+  | MLC_Bool of Prims.bool
   | MLC_Int of
   (Prims.string,(FStar_Const.signedness,FStar_Const.width)
                   FStar_Pervasives_Native.tuple2
                   FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
-  | MLC_Float of FStar_BaseTypes.float 
-  | MLC_Char of FStar_BaseTypes.char 
-  | MLC_String of Prims.string 
-  | MLC_Bytes of FStar_BaseTypes.byte Prims.array [@@deriving show]
-let (uu___is_MLC_Unit : mlconstant -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | MLC_Float of FStar_BaseTypes.float
+  | MLC_Char of FStar_BaseTypes.char
+  | MLC_String of Prims.string
+  | MLC_Bytes of FStar_BaseTypes.byte Prims.array[@@deriving show]
+let uu___is_MLC_Unit: mlconstant -> Prims.bool =
   fun projectee  ->
     match projectee with | MLC_Unit  -> true | uu____529 -> false
-  
-let (uu___is_MLC_Bool : mlconstant -> Prims.bool) =
+let uu___is_MLC_Bool: mlconstant -> Prims.bool =
   fun projectee  ->
     match projectee with | MLC_Bool _0 -> true | uu____534 -> false
-  
-let (__proj__MLC_Bool__item___0 : mlconstant -> Prims.bool) =
-  fun projectee  -> match projectee with | MLC_Bool _0 -> _0 
-let (uu___is_MLC_Int : mlconstant -> Prims.bool) =
+let __proj__MLC_Bool__item___0: mlconstant -> Prims.bool =
+  fun projectee  -> match projectee with | MLC_Bool _0 -> _0
+let uu___is_MLC_Int: mlconstant -> Prims.bool =
   fun projectee  ->
     match projectee with | MLC_Int _0 -> true | uu____556 -> false
-  
-let (__proj__MLC_Int__item___0 :
+let __proj__MLC_Int__item___0:
   mlconstant ->
     (Prims.string,(FStar_Const.signedness,FStar_Const.width)
                     FStar_Pervasives_Native.tuple2
                     FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MLC_Int _0 -> _0 
-let (uu___is_MLC_Float : mlconstant -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | MLC_Int _0 -> _0
+let uu___is_MLC_Float: mlconstant -> Prims.bool =
   fun projectee  ->
     match projectee with | MLC_Float _0 -> true | uu____598 -> false
-  
-let (__proj__MLC_Float__item___0 : mlconstant -> FStar_BaseTypes.float) =
-  fun projectee  -> match projectee with | MLC_Float _0 -> _0 
-let (uu___is_MLC_Char : mlconstant -> Prims.bool) =
+let __proj__MLC_Float__item___0: mlconstant -> FStar_BaseTypes.float =
+  fun projectee  -> match projectee with | MLC_Float _0 -> _0
+let uu___is_MLC_Char: mlconstant -> Prims.bool =
   fun projectee  ->
     match projectee with | MLC_Char _0 -> true | uu____610 -> false
-  
-let (__proj__MLC_Char__item___0 : mlconstant -> FStar_BaseTypes.char) =
-  fun projectee  -> match projectee with | MLC_Char _0 -> _0 
-let (uu___is_MLC_String : mlconstant -> Prims.bool) =
+let __proj__MLC_Char__item___0: mlconstant -> FStar_BaseTypes.char =
+  fun projectee  -> match projectee with | MLC_Char _0 -> _0
+let uu___is_MLC_String: mlconstant -> Prims.bool =
   fun projectee  ->
     match projectee with | MLC_String _0 -> true | uu____622 -> false
-  
-let (__proj__MLC_String__item___0 : mlconstant -> Prims.string) =
-  fun projectee  -> match projectee with | MLC_String _0 -> _0 
-let (uu___is_MLC_Bytes : mlconstant -> Prims.bool) =
+let __proj__MLC_String__item___0: mlconstant -> Prims.string =
+  fun projectee  -> match projectee with | MLC_String _0 -> _0
+let uu___is_MLC_Bytes: mlconstant -> Prims.bool =
   fun projectee  ->
     match projectee with | MLC_Bytes _0 -> true | uu____636 -> false
-  
-let (__proj__MLC_Bytes__item___0 :
-  mlconstant -> FStar_BaseTypes.byte Prims.array) =
-  fun projectee  -> match projectee with | MLC_Bytes _0 -> _0 
+let __proj__MLC_Bytes__item___0:
+  mlconstant -> FStar_BaseTypes.byte Prims.array =
+  fun projectee  -> match projectee with | MLC_Bytes _0 -> _0
 type mlpattern =
-  | MLP_Wild 
-  | MLP_Const of mlconstant 
-  | MLP_Var of mlident 
+  | MLP_Wild
+  | MLP_Const of mlconstant
+  | MLP_Var of mlident
   | MLP_CTor of (mlpath,mlpattern Prims.list) FStar_Pervasives_Native.tuple2
-  
-  | MLP_Branch of mlpattern Prims.list 
+  | MLP_Branch of mlpattern Prims.list
   | MLP_Record of
   (mlsymbol Prims.list,(mlsymbol,mlpattern) FStar_Pervasives_Native.tuple2
                          Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | MLP_Tuple of mlpattern Prims.list [@@deriving show]
-let (uu___is_MLP_Wild : mlpattern -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | MLP_Tuple of mlpattern Prims.list[@@deriving show]
+let uu___is_MLP_Wild: mlpattern -> Prims.bool =
   fun projectee  ->
     match projectee with | MLP_Wild  -> true | uu____699 -> false
-  
-let (uu___is_MLP_Const : mlpattern -> Prims.bool) =
+let uu___is_MLP_Const: mlpattern -> Prims.bool =
   fun projectee  ->
     match projectee with | MLP_Const _0 -> true | uu____704 -> false
-  
-let (__proj__MLP_Const__item___0 : mlpattern -> mlconstant) =
-  fun projectee  -> match projectee with | MLP_Const _0 -> _0 
-let (uu___is_MLP_Var : mlpattern -> Prims.bool) =
+let __proj__MLP_Const__item___0: mlpattern -> mlconstant =
+  fun projectee  -> match projectee with | MLP_Const _0 -> _0
+let uu___is_MLP_Var: mlpattern -> Prims.bool =
   fun projectee  ->
     match projectee with | MLP_Var _0 -> true | uu____716 -> false
-  
-let (__proj__MLP_Var__item___0 : mlpattern -> mlident) =
-  fun projectee  -> match projectee with | MLP_Var _0 -> _0 
-let (uu___is_MLP_CTor : mlpattern -> Prims.bool) =
+let __proj__MLP_Var__item___0: mlpattern -> mlident =
+  fun projectee  -> match projectee with | MLP_Var _0 -> _0
+let uu___is_MLP_CTor: mlpattern -> Prims.bool =
   fun projectee  ->
     match projectee with | MLP_CTor _0 -> true | uu____734 -> false
-  
-let (__proj__MLP_CTor__item___0 :
-  mlpattern -> (mlpath,mlpattern Prims.list) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MLP_CTor _0 -> _0 
-let (uu___is_MLP_Branch : mlpattern -> Prims.bool) =
+let __proj__MLP_CTor__item___0:
+  mlpattern -> (mlpath,mlpattern Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLP_CTor _0 -> _0
+let uu___is_MLP_Branch: mlpattern -> Prims.bool =
   fun projectee  ->
     match projectee with | MLP_Branch _0 -> true | uu____766 -> false
-  
-let (__proj__MLP_Branch__item___0 : mlpattern -> mlpattern Prims.list) =
-  fun projectee  -> match projectee with | MLP_Branch _0 -> _0 
-let (uu___is_MLP_Record : mlpattern -> Prims.bool) =
+let __proj__MLP_Branch__item___0: mlpattern -> mlpattern Prims.list =
+  fun projectee  -> match projectee with | MLP_Branch _0 -> _0
+let uu___is_MLP_Record: mlpattern -> Prims.bool =
   fun projectee  ->
     match projectee with | MLP_Record _0 -> true | uu____796 -> false
-  
-let (__proj__MLP_Record__item___0 :
+let __proj__MLP_Record__item___0:
   mlpattern ->
     (mlsymbol Prims.list,(mlsymbol,mlpattern) FStar_Pervasives_Native.tuple2
                            Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MLP_Record _0 -> _0 
-let (uu___is_MLP_Tuple : mlpattern -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | MLP_Record _0 -> _0
+let uu___is_MLP_Tuple: mlpattern -> Prims.bool =
   fun projectee  ->
     match projectee with | MLP_Tuple _0 -> true | uu____846 -> false
-  
-let (__proj__MLP_Tuple__item___0 : mlpattern -> mlpattern Prims.list) =
-  fun projectee  -> match projectee with | MLP_Tuple _0 -> _0 
+let __proj__MLP_Tuple__item___0: mlpattern -> mlpattern Prims.list =
+  fun projectee  -> match projectee with | MLP_Tuple _0 -> _0
 type meta =
-  | Mutable 
-  | Assumed 
-  | Private 
-  | NoExtract 
-  | CInline 
-  | Substitute 
-  | GCType 
-  | PpxDerivingShow 
-  | PpxDerivingShowConstant of Prims.string 
-  | Comment of Prims.string 
-  | StackInline [@@deriving show]
-let (uu___is_Mutable : meta -> Prims.bool) =
+  | Mutable
+  | Assumed
+  | Private
+  | NoExtract
+  | CInline
+  | Substitute
+  | GCType
+  | PpxDerivingShow
+  | PpxDerivingShowConstant of Prims.string
+  | Comment of Prims.string
+  | StackInline[@@deriving show]
+let uu___is_Mutable: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | Mutable  -> true | uu____871 -> false
-  
-let (uu___is_Assumed : meta -> Prims.bool) =
+let uu___is_Assumed: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | Assumed  -> true | uu____875 -> false
-  
-let (uu___is_Private : meta -> Prims.bool) =
+let uu___is_Private: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | Private  -> true | uu____879 -> false
-  
-let (uu___is_NoExtract : meta -> Prims.bool) =
+let uu___is_NoExtract: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | NoExtract  -> true | uu____883 -> false
-  
-let (uu___is_CInline : meta -> Prims.bool) =
+let uu___is_CInline: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | CInline  -> true | uu____887 -> false
-  
-let (uu___is_Substitute : meta -> Prims.bool) =
+let uu___is_Substitute: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | Substitute  -> true | uu____891 -> false
-  
-let (uu___is_GCType : meta -> Prims.bool) =
+let uu___is_GCType: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | GCType  -> true | uu____895 -> false
-  
-let (uu___is_PpxDerivingShow : meta -> Prims.bool) =
+let uu___is_PpxDerivingShow: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | PpxDerivingShow  -> true | uu____899 -> false
-  
-let (uu___is_PpxDerivingShowConstant : meta -> Prims.bool) =
+let uu___is_PpxDerivingShowConstant: meta -> Prims.bool =
   fun projectee  ->
     match projectee with
     | PpxDerivingShowConstant _0 -> true
     | uu____904 -> false
-  
-let (__proj__PpxDerivingShowConstant__item___0 : meta -> Prims.string) =
-  fun projectee  -> match projectee with | PpxDerivingShowConstant _0 -> _0 
-let (uu___is_Comment : meta -> Prims.bool) =
+let __proj__PpxDerivingShowConstant__item___0: meta -> Prims.string =
+  fun projectee  -> match projectee with | PpxDerivingShowConstant _0 -> _0
+let uu___is_Comment: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | Comment _0 -> true | uu____916 -> false
-  
-let (__proj__Comment__item___0 : meta -> Prims.string) =
-  fun projectee  -> match projectee with | Comment _0 -> _0 
-let (uu___is_StackInline : meta -> Prims.bool) =
+let __proj__Comment__item___0: meta -> Prims.string =
+  fun projectee  -> match projectee with | Comment _0 -> _0
+let uu___is_StackInline: meta -> Prims.bool =
   fun projectee  ->
     match projectee with | StackInline  -> true | uu____927 -> false
-  
 type metadata = meta Prims.list[@@deriving show]
 type mlletflavor =
-  | Rec 
-  | NonRec [@@deriving show]
-let (uu___is_Rec : mlletflavor -> Prims.bool) =
-  fun projectee  -> match projectee with | Rec  -> true | uu____933 -> false 
-let (uu___is_NonRec : mlletflavor -> Prims.bool) =
+  | Rec
+  | NonRec[@@deriving show]
+let uu___is_Rec: mlletflavor -> Prims.bool =
+  fun projectee  -> match projectee with | Rec  -> true | uu____933 -> false
+let uu___is_NonRec: mlletflavor -> Prims.bool =
   fun projectee  ->
     match projectee with | NonRec  -> true | uu____937 -> false
-  
 type mlexpr' =
-  | MLE_Const of mlconstant 
-  | MLE_Var of mlident 
-  | MLE_Name of mlpath 
+  | MLE_Const of mlconstant
+  | MLE_Var of mlident
+  | MLE_Name of mlpath
   | MLE_Let of
   ((mlletflavor,mllb Prims.list) FStar_Pervasives_Native.tuple2,mlexpr)
-  FStar_Pervasives_Native.tuple2 
-  | MLE_App of (mlexpr,mlexpr Prims.list) FStar_Pervasives_Native.tuple2 
-  | MLE_TApp of (mlexpr,mlty Prims.list) FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
+  | MLE_App of (mlexpr,mlexpr Prims.list) FStar_Pervasives_Native.tuple2
+  | MLE_TApp of (mlexpr,mlty Prims.list) FStar_Pervasives_Native.tuple2
   | MLE_Fun of
   ((mlident,mlty) FStar_Pervasives_Native.tuple2 Prims.list,mlexpr)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | MLE_Match of
   (mlexpr,(mlpattern,mlexpr FStar_Pervasives_Native.option,mlexpr)
             FStar_Pervasives_Native.tuple3 Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | MLE_Coerce of (mlexpr,mlty,mlty) FStar_Pervasives_Native.tuple3 
-  | MLE_CTor of (mlpath,mlexpr Prims.list) FStar_Pervasives_Native.tuple2 
-  | MLE_Seq of mlexpr Prims.list 
-  | MLE_Tuple of mlexpr Prims.list 
+  FStar_Pervasives_Native.tuple2
+  | MLE_Coerce of (mlexpr,mlty,mlty) FStar_Pervasives_Native.tuple3
+  | MLE_CTor of (mlpath,mlexpr Prims.list) FStar_Pervasives_Native.tuple2
+  | MLE_Seq of mlexpr Prims.list
+  | MLE_Tuple of mlexpr Prims.list
   | MLE_Record of
   (mlsymbol Prims.list,(mlsymbol,mlexpr) FStar_Pervasives_Native.tuple2
                          Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | MLE_Proj of (mlexpr,mlpath) FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
+  | MLE_Proj of (mlexpr,mlpath) FStar_Pervasives_Native.tuple2
   | MLE_If of (mlexpr,mlexpr,mlexpr FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple3 
-  | MLE_Raise of (mlpath,mlexpr Prims.list) FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple3
+  | MLE_Raise of (mlpath,mlexpr Prims.list) FStar_Pervasives_Native.tuple2
   | MLE_Try of
   (mlexpr,(mlpattern,mlexpr FStar_Pervasives_Native.option,mlexpr)
             FStar_Pervasives_Native.tuple3 Prims.list)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
+  FStar_Pervasives_Native.tuple2[@@deriving show]
 and mlexpr = {
-  expr: mlexpr' ;
-  mlty: mlty ;
-  loc: mlloc }[@@deriving show]
+  expr: mlexpr';
+  mlty: mlty;
+  loc: mlloc;}[@@deriving show]
 and mllb =
   {
-  mllb_name: mlident ;
-  mllb_tysc: mltyscheme FStar_Pervasives_Native.option ;
-  mllb_add_unit: Prims.bool ;
-  mllb_def: mlexpr ;
-  mllb_meta: metadata ;
-  print_typ: Prims.bool }[@@deriving show]
-let (uu___is_MLE_Const : mlexpr' -> Prims.bool) =
+  mllb_name: mlident;
+  mllb_tysc: mltyscheme FStar_Pervasives_Native.option;
+  mllb_add_unit: Prims.bool;
+  mllb_def: mlexpr;
+  mllb_meta: metadata;
+  print_typ: Prims.bool;}[@@deriving show]
+let uu___is_MLE_Const: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Const _0 -> true | uu____1154 -> false
-  
-let (__proj__MLE_Const__item___0 : mlexpr' -> mlconstant) =
-  fun projectee  -> match projectee with | MLE_Const _0 -> _0 
-let (uu___is_MLE_Var : mlexpr' -> Prims.bool) =
+let __proj__MLE_Const__item___0: mlexpr' -> mlconstant =
+  fun projectee  -> match projectee with | MLE_Const _0 -> _0
+let uu___is_MLE_Var: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Var _0 -> true | uu____1166 -> false
-  
-let (__proj__MLE_Var__item___0 : mlexpr' -> mlident) =
-  fun projectee  -> match projectee with | MLE_Var _0 -> _0 
-let (uu___is_MLE_Name : mlexpr' -> Prims.bool) =
+let __proj__MLE_Var__item___0: mlexpr' -> mlident =
+  fun projectee  -> match projectee with | MLE_Var _0 -> _0
+let uu___is_MLE_Name: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Name _0 -> true | uu____1178 -> false
-  
-let (__proj__MLE_Name__item___0 : mlexpr' -> mlpath) =
-  fun projectee  -> match projectee with | MLE_Name _0 -> _0 
-let (uu___is_MLE_Let : mlexpr' -> Prims.bool) =
+let __proj__MLE_Name__item___0: mlexpr' -> mlpath =
+  fun projectee  -> match projectee with | MLE_Name _0 -> _0
+let uu___is_MLE_Let: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Let _0 -> true | uu____1200 -> false
-  
-let (__proj__MLE_Let__item___0 :
+let __proj__MLE_Let__item___0:
   mlexpr' ->
     ((mlletflavor,mllb Prims.list) FStar_Pervasives_Native.tuple2,mlexpr)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MLE_Let _0 -> _0 
-let (uu___is_MLE_App : mlexpr' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | MLE_Let _0 -> _0
+let uu___is_MLE_App: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_App _0 -> true | uu____1248 -> false
-  
-let (__proj__MLE_App__item___0 :
-  mlexpr' -> (mlexpr,mlexpr Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | MLE_App _0 -> _0 
-let (uu___is_MLE_TApp : mlexpr' -> Prims.bool) =
+let __proj__MLE_App__item___0:
+  mlexpr' -> (mlexpr,mlexpr Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLE_App _0 -> _0
+let uu___is_MLE_TApp: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_TApp _0 -> true | uu____1284 -> false
-  
-let (__proj__MLE_TApp__item___0 :
-  mlexpr' -> (mlexpr,mlty Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | MLE_TApp _0 -> _0 
-let (uu___is_MLE_Fun : mlexpr' -> Prims.bool) =
+let __proj__MLE_TApp__item___0:
+  mlexpr' -> (mlexpr,mlty Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLE_TApp _0 -> _0
+let uu___is_MLE_Fun: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Fun _0 -> true | uu____1324 -> false
-  
-let (__proj__MLE_Fun__item___0 :
+let __proj__MLE_Fun__item___0:
   mlexpr' ->
     ((mlident,mlty) FStar_Pervasives_Native.tuple2 Prims.list,mlexpr)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MLE_Fun _0 -> _0 
-let (uu___is_MLE_Match : mlexpr' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | MLE_Fun _0 -> _0
+let uu___is_MLE_Match: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Match _0 -> true | uu____1380 -> false
-  
-let (__proj__MLE_Match__item___0 :
+let __proj__MLE_Match__item___0:
   mlexpr' ->
     (mlexpr,(mlpattern,mlexpr FStar_Pervasives_Native.option,mlexpr)
               FStar_Pervasives_Native.tuple3 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MLE_Match _0 -> _0 
-let (uu___is_MLE_Coerce : mlexpr' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | MLE_Match _0 -> _0
+let uu___is_MLE_Coerce: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Coerce _0 -> true | uu____1440 -> false
-  
-let (__proj__MLE_Coerce__item___0 :
-  mlexpr' -> (mlexpr,mlty,mlty) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | MLE_Coerce _0 -> _0 
-let (uu___is_MLE_CTor : mlexpr' -> Prims.bool) =
+let __proj__MLE_Coerce__item___0:
+  mlexpr' -> (mlexpr,mlty,mlty) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | MLE_Coerce _0 -> _0
+let uu___is_MLE_CTor: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_CTor _0 -> true | uu____1476 -> false
-  
-let (__proj__MLE_CTor__item___0 :
-  mlexpr' -> (mlpath,mlexpr Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | MLE_CTor _0 -> _0 
-let (uu___is_MLE_Seq : mlexpr' -> Prims.bool) =
+let __proj__MLE_CTor__item___0:
+  mlexpr' -> (mlpath,mlexpr Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLE_CTor _0 -> _0
+let uu___is_MLE_Seq: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Seq _0 -> true | uu____1508 -> false
-  
-let (__proj__MLE_Seq__item___0 : mlexpr' -> mlexpr Prims.list) =
-  fun projectee  -> match projectee with | MLE_Seq _0 -> _0 
-let (uu___is_MLE_Tuple : mlexpr' -> Prims.bool) =
+let __proj__MLE_Seq__item___0: mlexpr' -> mlexpr Prims.list =
+  fun projectee  -> match projectee with | MLE_Seq _0 -> _0
+let uu___is_MLE_Tuple: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Tuple _0 -> true | uu____1528 -> false
-  
-let (__proj__MLE_Tuple__item___0 : mlexpr' -> mlexpr Prims.list) =
-  fun projectee  -> match projectee with | MLE_Tuple _0 -> _0 
-let (uu___is_MLE_Record : mlexpr' -> Prims.bool) =
+let __proj__MLE_Tuple__item___0: mlexpr' -> mlexpr Prims.list =
+  fun projectee  -> match projectee with | MLE_Tuple _0 -> _0
+let uu___is_MLE_Record: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Record _0 -> true | uu____1558 -> false
-  
-let (__proj__MLE_Record__item___0 :
+let __proj__MLE_Record__item___0:
   mlexpr' ->
     (mlsymbol Prims.list,(mlsymbol,mlexpr) FStar_Pervasives_Native.tuple2
                            Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MLE_Record _0 -> _0 
-let (uu___is_MLE_Proj : mlexpr' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | MLE_Record _0 -> _0
+let uu___is_MLE_Proj: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Proj _0 -> true | uu____1610 -> false
-  
-let (__proj__MLE_Proj__item___0 :
-  mlexpr' -> (mlexpr,mlpath) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | MLE_Proj _0 -> _0 
-let (uu___is_MLE_If : mlexpr' -> Prims.bool) =
+let __proj__MLE_Proj__item___0:
+  mlexpr' -> (mlexpr,mlpath) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLE_Proj _0 -> _0
+let uu___is_MLE_If: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_If _0 -> true | uu____1642 -> false
-  
-let (__proj__MLE_If__item___0 :
+let __proj__MLE_If__item___0:
   mlexpr' ->
     (mlexpr,mlexpr,mlexpr FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | MLE_If _0 -> _0 
-let (uu___is_MLE_Raise : mlexpr' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | MLE_If _0 -> _0
+let uu___is_MLE_Raise: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Raise _0 -> true | uu____1684 -> false
-  
-let (__proj__MLE_Raise__item___0 :
-  mlexpr' -> (mlpath,mlexpr Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | MLE_Raise _0 -> _0 
-let (uu___is_MLE_Try : mlexpr' -> Prims.bool) =
+let __proj__MLE_Raise__item___0:
+  mlexpr' -> (mlpath,mlexpr Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLE_Raise _0 -> _0
+let uu___is_MLE_Try: mlexpr' -> Prims.bool =
   fun projectee  ->
     match projectee with | MLE_Try _0 -> true | uu____1728 -> false
-  
-let (__proj__MLE_Try__item___0 :
+let __proj__MLE_Try__item___0:
   mlexpr' ->
     (mlexpr,(mlpattern,mlexpr FStar_Pervasives_Native.option,mlexpr)
               FStar_Pervasives_Native.tuple3 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MLE_Try _0 -> _0 
-let (__proj__Mkmlexpr__item__expr : mlexpr -> mlexpr') =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | MLE_Try _0 -> _0
+let __proj__Mkmlexpr__item__expr: mlexpr -> mlexpr' =
   fun projectee  ->
     match projectee with
     | { expr = __fname__expr; mlty = __fname__mlty; loc = __fname__loc;_} ->
         __fname__expr
-  
-let (__proj__Mkmlexpr__item__mlty : mlexpr -> mlty) =
+let __proj__Mkmlexpr__item__mlty: mlexpr -> mlty =
   fun projectee  ->
     match projectee with
     | { expr = __fname__expr; mlty = __fname__mlty; loc = __fname__loc;_} ->
         __fname__mlty
-  
-let (__proj__Mkmlexpr__item__loc : mlexpr -> mlloc) =
+let __proj__Mkmlexpr__item__loc: mlexpr -> mlloc =
   fun projectee  ->
     match projectee with
     | { expr = __fname__expr; mlty = __fname__mlty; loc = __fname__loc;_} ->
         __fname__loc
-  
-let (__proj__Mkmllb__item__mllb_name : mllb -> mlident) =
+let __proj__Mkmllb__item__mllb_name: mllb -> mlident =
   fun projectee  ->
     match projectee with
     | { mllb_name = __fname__mllb_name; mllb_tysc = __fname__mllb_tysc;
         mllb_add_unit = __fname__mllb_add_unit; mllb_def = __fname__mllb_def;
         mllb_meta = __fname__mllb_meta; print_typ = __fname__print_typ;_} ->
         __fname__mllb_name
-  
-let (__proj__Mkmllb__item__mllb_tysc :
-  mllb -> mltyscheme FStar_Pervasives_Native.option) =
+let __proj__Mkmllb__item__mllb_tysc:
+  mllb -> mltyscheme FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { mllb_name = __fname__mllb_name; mllb_tysc = __fname__mllb_tysc;
         mllb_add_unit = __fname__mllb_add_unit; mllb_def = __fname__mllb_def;
         mllb_meta = __fname__mllb_meta; print_typ = __fname__print_typ;_} ->
         __fname__mllb_tysc
-  
-let (__proj__Mkmllb__item__mllb_add_unit : mllb -> Prims.bool) =
+let __proj__Mkmllb__item__mllb_add_unit: mllb -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { mllb_name = __fname__mllb_name; mllb_tysc = __fname__mllb_tysc;
         mllb_add_unit = __fname__mllb_add_unit; mllb_def = __fname__mllb_def;
         mllb_meta = __fname__mllb_meta; print_typ = __fname__print_typ;_} ->
         __fname__mllb_add_unit
-  
-let (__proj__Mkmllb__item__mllb_def : mllb -> mlexpr) =
+let __proj__Mkmllb__item__mllb_def: mllb -> mlexpr =
   fun projectee  ->
     match projectee with
     | { mllb_name = __fname__mllb_name; mllb_tysc = __fname__mllb_tysc;
         mllb_add_unit = __fname__mllb_add_unit; mllb_def = __fname__mllb_def;
         mllb_meta = __fname__mllb_meta; print_typ = __fname__print_typ;_} ->
         __fname__mllb_def
-  
-let (__proj__Mkmllb__item__mllb_meta : mllb -> metadata) =
+let __proj__Mkmllb__item__mllb_meta: mllb -> metadata =
   fun projectee  ->
     match projectee with
     | { mllb_name = __fname__mllb_name; mllb_tysc = __fname__mllb_tysc;
         mllb_add_unit = __fname__mllb_add_unit; mllb_def = __fname__mllb_def;
         mllb_meta = __fname__mllb_meta; print_typ = __fname__print_typ;_} ->
         __fname__mllb_meta
-  
-let (__proj__Mkmllb__item__print_typ : mllb -> Prims.bool) =
+let __proj__Mkmllb__item__print_typ: mllb -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { mllb_name = __fname__mllb_name; mllb_tysc = __fname__mllb_tysc;
         mllb_add_unit = __fname__mllb_add_unit; mllb_def = __fname__mllb_def;
         mllb_meta = __fname__mllb_meta; print_typ = __fname__print_typ;_} ->
         __fname__print_typ
-  
 type mlbranch =
   (mlpattern,mlexpr FStar_Pervasives_Native.option,mlexpr)
     FStar_Pervasives_Native.tuple3[@@deriving show]
@@ -731,189 +662,169 @@ type mlletbinding =
   (mlletflavor,mllb Prims.list) FStar_Pervasives_Native.tuple2[@@deriving
                                                                 show]
 type mltybody =
-  | MLTD_Abbrev of mlty 
+  | MLTD_Abbrev of mlty
   | MLTD_Record of (mlsymbol,mlty) FStar_Pervasives_Native.tuple2 Prims.list
-  
   | MLTD_DType of
   (mlsymbol,(mlsymbol,mlty) FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple2 Prims.list [@@deriving show]
-let (uu___is_MLTD_Abbrev : mltybody -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2 Prims.list[@@deriving show]
+let uu___is_MLTD_Abbrev: mltybody -> Prims.bool =
   fun projectee  ->
     match projectee with | MLTD_Abbrev _0 -> true | uu____1914 -> false
-  
-let (__proj__MLTD_Abbrev__item___0 : mltybody -> mlty) =
-  fun projectee  -> match projectee with | MLTD_Abbrev _0 -> _0 
-let (uu___is_MLTD_Record : mltybody -> Prims.bool) =
+let __proj__MLTD_Abbrev__item___0: mltybody -> mlty =
+  fun projectee  -> match projectee with | MLTD_Abbrev _0 -> _0
+let uu___is_MLTD_Record: mltybody -> Prims.bool =
   fun projectee  ->
     match projectee with | MLTD_Record _0 -> true | uu____1932 -> false
-  
-let (__proj__MLTD_Record__item___0 :
-  mltybody -> (mlsymbol,mlty) FStar_Pervasives_Native.tuple2 Prims.list) =
-  fun projectee  -> match projectee with | MLTD_Record _0 -> _0 
-let (uu___is_MLTD_DType : mltybody -> Prims.bool) =
+let __proj__MLTD_Record__item___0:
+  mltybody -> (mlsymbol,mlty) FStar_Pervasives_Native.tuple2 Prims.list =
+  fun projectee  -> match projectee with | MLTD_Record _0 -> _0
+let uu___is_MLTD_DType: mltybody -> Prims.bool =
   fun projectee  ->
     match projectee with | MLTD_DType _0 -> true | uu____1974 -> false
-  
-let (__proj__MLTD_DType__item___0 :
+let __proj__MLTD_DType__item___0:
   mltybody ->
     (mlsymbol,(mlsymbol,mlty) FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2 Prims.list)
-  = fun projectee  -> match projectee with | MLTD_DType _0 -> _0 
+      FStar_Pervasives_Native.tuple2 Prims.list
+  = fun projectee  -> match projectee with | MLTD_DType _0 -> _0
 type one_mltydecl =
   (Prims.bool,mlsymbol,mlsymbol FStar_Pervasives_Native.option,mlidents,
     metadata,mltybody FStar_Pervasives_Native.option)
     FStar_Pervasives_Native.tuple6[@@deriving show]
 type mltydecl = one_mltydecl Prims.list[@@deriving show]
 type mlmodule1 =
-  | MLM_Ty of mltydecl 
-  | MLM_Let of mlletbinding 
+  | MLM_Ty of mltydecl
+  | MLM_Let of mlletbinding
   | MLM_Exn of
   (mlsymbol,(mlsymbol,mlty) FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | MLM_Top of mlexpr 
-  | MLM_Loc of mlloc [@@deriving show]
-let (uu___is_MLM_Ty : mlmodule1 -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | MLM_Top of mlexpr
+  | MLM_Loc of mlloc[@@deriving show]
+let uu___is_MLM_Ty: mlmodule1 -> Prims.bool =
   fun projectee  ->
     match projectee with | MLM_Ty _0 -> true | uu____2070 -> false
-  
-let (__proj__MLM_Ty__item___0 : mlmodule1 -> mltydecl) =
-  fun projectee  -> match projectee with | MLM_Ty _0 -> _0 
-let (uu___is_MLM_Let : mlmodule1 -> Prims.bool) =
+let __proj__MLM_Ty__item___0: mlmodule1 -> mltydecl =
+  fun projectee  -> match projectee with | MLM_Ty _0 -> _0
+let uu___is_MLM_Let: mlmodule1 -> Prims.bool =
   fun projectee  ->
     match projectee with | MLM_Let _0 -> true | uu____2082 -> false
-  
-let (__proj__MLM_Let__item___0 : mlmodule1 -> mlletbinding) =
-  fun projectee  -> match projectee with | MLM_Let _0 -> _0 
-let (uu___is_MLM_Exn : mlmodule1 -> Prims.bool) =
+let __proj__MLM_Let__item___0: mlmodule1 -> mlletbinding =
+  fun projectee  -> match projectee with | MLM_Let _0 -> _0
+let uu___is_MLM_Exn: mlmodule1 -> Prims.bool =
   fun projectee  ->
     match projectee with | MLM_Exn _0 -> true | uu____2104 -> false
-  
-let (__proj__MLM_Exn__item___0 :
+let __proj__MLM_Exn__item___0:
   mlmodule1 ->
     (mlsymbol,(mlsymbol,mlty) FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MLM_Exn _0 -> _0 
-let (uu___is_MLM_Top : mlmodule1 -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | MLM_Exn _0 -> _0
+let uu___is_MLM_Top: mlmodule1 -> Prims.bool =
   fun projectee  ->
     match projectee with | MLM_Top _0 -> true | uu____2146 -> false
-  
-let (__proj__MLM_Top__item___0 : mlmodule1 -> mlexpr) =
-  fun projectee  -> match projectee with | MLM_Top _0 -> _0 
-let (uu___is_MLM_Loc : mlmodule1 -> Prims.bool) =
+let __proj__MLM_Top__item___0: mlmodule1 -> mlexpr =
+  fun projectee  -> match projectee with | MLM_Top _0 -> _0
+let uu___is_MLM_Loc: mlmodule1 -> Prims.bool =
   fun projectee  ->
     match projectee with | MLM_Loc _0 -> true | uu____2158 -> false
-  
-let (__proj__MLM_Loc__item___0 : mlmodule1 -> mlloc) =
-  fun projectee  -> match projectee with | MLM_Loc _0 -> _0 
+let __proj__MLM_Loc__item___0: mlmodule1 -> mlloc =
+  fun projectee  -> match projectee with | MLM_Loc _0 -> _0
 type mlmodule = mlmodule1 Prims.list[@@deriving show]
 type mlsig1 =
-  | MLS_Mod of (mlsymbol,mlsig1 Prims.list) FStar_Pervasives_Native.tuple2 
-  | MLS_Ty of mltydecl 
-  | MLS_Val of (mlsymbol,mltyscheme) FStar_Pervasives_Native.tuple2 
-  | MLS_Exn of (mlsymbol,mlty Prims.list) FStar_Pervasives_Native.tuple2 
+  | MLS_Mod of (mlsymbol,mlsig1 Prims.list) FStar_Pervasives_Native.tuple2
+  | MLS_Ty of mltydecl
+  | MLS_Val of (mlsymbol,mltyscheme) FStar_Pervasives_Native.tuple2
+  | MLS_Exn of (mlsymbol,mlty Prims.list) FStar_Pervasives_Native.tuple2
 [@@deriving show]
-let (uu___is_MLS_Mod : mlsig1 -> Prims.bool) =
+let uu___is_MLS_Mod: mlsig1 -> Prims.bool =
   fun projectee  ->
     match projectee with | MLS_Mod _0 -> true | uu____2210 -> false
-  
-let (__proj__MLS_Mod__item___0 :
-  mlsig1 -> (mlsymbol,mlsig1 Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | MLS_Mod _0 -> _0 
-let (uu___is_MLS_Ty : mlsig1 -> Prims.bool) =
+let __proj__MLS_Mod__item___0:
+  mlsig1 -> (mlsymbol,mlsig1 Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLS_Mod _0 -> _0
+let uu___is_MLS_Ty: mlsig1 -> Prims.bool =
   fun projectee  ->
     match projectee with | MLS_Ty _0 -> true | uu____2240 -> false
-  
-let (__proj__MLS_Ty__item___0 : mlsig1 -> mltydecl) =
-  fun projectee  -> match projectee with | MLS_Ty _0 -> _0 
-let (uu___is_MLS_Val : mlsig1 -> Prims.bool) =
+let __proj__MLS_Ty__item___0: mlsig1 -> mltydecl =
+  fun projectee  -> match projectee with | MLS_Ty _0 -> _0
+let uu___is_MLS_Val: mlsig1 -> Prims.bool =
   fun projectee  ->
     match projectee with | MLS_Val _0 -> true | uu____2256 -> false
-  
-let (__proj__MLS_Val__item___0 :
-  mlsig1 -> (mlsymbol,mltyscheme) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | MLS_Val _0 -> _0 
-let (uu___is_MLS_Exn : mlsig1 -> Prims.bool) =
+let __proj__MLS_Val__item___0:
+  mlsig1 -> (mlsymbol,mltyscheme) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLS_Val _0 -> _0
+let uu___is_MLS_Exn: mlsig1 -> Prims.bool =
   fun projectee  ->
     match projectee with | MLS_Exn _0 -> true | uu____2286 -> false
-  
-let (__proj__MLS_Exn__item___0 :
-  mlsig1 -> (mlsymbol,mlty Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | MLS_Exn _0 -> _0 
+let __proj__MLS_Exn__item___0:
+  mlsig1 -> (mlsymbol,mlty Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | MLS_Exn _0 -> _0
 type mlsig = mlsig1 Prims.list[@@deriving show]
-let (with_ty_loc : mlty -> mlexpr' -> mlloc -> mlexpr) =
-  fun t  -> fun e  -> fun l  -> { expr = e; mlty = t; loc = l } 
-let (with_ty : mlty -> mlexpr' -> mlexpr) =
-  fun t  -> fun e  -> with_ty_loc t e dummy_loc 
+let with_ty_loc: mlty -> mlexpr' -> mlloc -> mlexpr =
+  fun t  -> fun e  -> fun l  -> { expr = e; mlty = t; loc = l }
+let with_ty: mlty -> mlexpr' -> mlexpr =
+  fun t  -> fun e  -> with_ty_loc t e dummy_loc
 type mllib =
   | MLLib of
   (mlpath,(mlsig,mlmodule) FStar_Pervasives_Native.tuple2
             FStar_Pervasives_Native.option,mllib)
-  FStar_Pervasives_Native.tuple3 Prims.list [@@deriving show]
-let (uu___is_MLLib : mllib -> Prims.bool) = fun projectee  -> true 
-let (__proj__MLLib__item___0 :
+  FStar_Pervasives_Native.tuple3 Prims.list[@@deriving show]
+let uu___is_MLLib: mllib -> Prims.bool = fun projectee  -> true
+let __proj__MLLib__item___0:
   mllib ->
     (mlpath,(mlsig,mlmodule) FStar_Pervasives_Native.tuple2
               FStar_Pervasives_Native.option,mllib)
-      FStar_Pervasives_Native.tuple3 Prims.list)
-  = fun projectee  -> match projectee with | MLLib _0 -> _0 
-let (ml_unit_ty : mlty) = MLTY_Named ([], (["Prims"], "unit")) 
-let (ml_bool_ty : mlty) = MLTY_Named ([], (["Prims"], "bool")) 
-let (ml_int_ty : mlty) = MLTY_Named ([], (["Prims"], "int")) 
-let (ml_string_ty : mlty) = MLTY_Named ([], (["Prims"], "string")) 
-let (ml_unit : mlexpr) = with_ty ml_unit_ty (MLE_Const MLC_Unit) 
-let (mlp_lalloc :
-  (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2) =
-  (["SST"], "lalloc") 
-let (apply_obj_repr : mlexpr -> mlty -> mlexpr) =
+      FStar_Pervasives_Native.tuple3 Prims.list
+  = fun projectee  -> match projectee with | MLLib _0 -> _0
+let ml_unit_ty: mlty = MLTY_Named ([], (["Prims"], "unit"))
+let ml_bool_ty: mlty = MLTY_Named ([], (["Prims"], "bool"))
+let ml_int_ty: mlty = MLTY_Named ([], (["Prims"], "int"))
+let ml_string_ty: mlty = MLTY_Named ([], (["Prims"], "string"))
+let ml_unit: mlexpr = with_ty ml_unit_ty (MLE_Const MLC_Unit)
+let mlp_lalloc:
+  (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2 =
+  (["SST"], "lalloc")
+let apply_obj_repr: mlexpr -> mlty -> mlexpr =
   fun x  ->
     fun t  ->
       let obj_ns =
-        let uu____2451 = FStar_Options.codegen_fsharp ()  in
-        if uu____2451 then "FSharp.Compatibility.OCaml.Obj" else "Obj"  in
+        let uu____2451 = FStar_Options.codegen_fsharp () in
+        if uu____2451 then "FSharp.Compatibility.OCaml.Obj" else "Obj" in
       let obj_repr =
         with_ty (MLTY_Fun (t, E_PURE, MLTY_Top))
-          (MLE_Name ([obj_ns], "repr"))
-         in
+          (MLE_Name ([obj_ns], "repr")) in
       with_ty_loc MLTY_Top (MLE_App (obj_repr, [x])) x.loc
-  
-let (avoid_keyword : Prims.string -> Prims.string) =
+let avoid_keyword: Prims.string -> Prims.string =
   fun s  ->
-    let uu____2461 = is_reserved s  in
+    let uu____2461 = is_reserved s in
     if uu____2461 then Prims.strcat s "_" else s
-  
-let (bv_as_mlident : FStar_Syntax_Syntax.bv -> mlident) =
+let bv_as_mlident: FStar_Syntax_Syntax.bv -> mlident =
   fun x  ->
     let uu____2466 =
       ((FStar_Util.starts_with
           (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
           FStar_Ident.reserved_prefix)
          || (FStar_Syntax_Syntax.is_null_bv x))
-        || (is_reserved (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText)
-       in
+        || (is_reserved (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText) in
     if uu____2466
     then
       let uu____2467 =
         let uu____2468 =
           let uu____2469 =
-            FStar_Util.string_of_int x.FStar_Syntax_Syntax.index  in
-          Prims.strcat "_" uu____2469  in
+            FStar_Util.string_of_int x.FStar_Syntax_Syntax.index in
+          Prims.strcat "_" uu____2469 in
         Prims.strcat (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-          uu____2468
-         in
+          uu____2468 in
       FStar_All.pipe_left avoid_keyword uu____2467
     else
       FStar_All.pipe_left avoid_keyword
         (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-  
-let (push_unit : mltyscheme -> mltyscheme) =
+let push_unit: mltyscheme -> mltyscheme =
   fun ts  ->
-    let uu____2474 = ts  in
+    let uu____2474 = ts in
     match uu____2474 with
     | (vs,ty) -> (vs, (MLTY_Fun (ml_unit_ty, E_PURE, ty)))
-  
-let (pop_unit : mltyscheme -> mltyscheme) =
+let pop_unit: mltyscheme -> mltyscheme =
   fun ts  ->
-    let uu____2480 = ts  in
+    let uu____2480 = ts in
     match uu____2480 with
     | (vs,ty) ->
         (match ty with
@@ -922,4 +833,3 @@ let (pop_unit : mltyscheme -> mltyscheme) =
              then (vs, t)
              else failwith "unexpected: pop_unit: domain was not unit"
          | uu____2486 -> failwith "unexpected: pop_unit: not a function type")
-  

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -1,54 +1,49 @@
 open Prims
-exception Un_extractable 
-let (uu___is_Un_extractable : Prims.exn -> Prims.bool) =
+exception Un_extractable
+let uu___is_Un_extractable: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | Un_extractable  -> true | uu____4 -> false
-  
-let (type_leq :
+let type_leq:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Extraction_ML_Syntax.mlty ->
-      FStar_Extraction_ML_Syntax.mlty -> Prims.bool)
+      FStar_Extraction_ML_Syntax.mlty -> Prims.bool
   =
   fun g  ->
     fun t1  ->
       fun t2  ->
         FStar_Extraction_ML_Util.type_leq
           (FStar_Extraction_ML_Util.udelta_unfold g) t1 t2
-  
-let (type_leq_c :
+let type_leq_c:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Extraction_ML_Syntax.mlexpr FStar_Pervasives_Native.option ->
       FStar_Extraction_ML_Syntax.mlty ->
         FStar_Extraction_ML_Syntax.mlty ->
           (Prims.bool,FStar_Extraction_ML_Syntax.mlexpr
                         FStar_Pervasives_Native.option)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun t1  ->
       fun t2  ->
         FStar_Extraction_ML_Util.type_leq_c
           (FStar_Extraction_ML_Util.udelta_unfold g) t1 t2
-  
-let (erasableType :
+let erasableType:
   FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.mlty -> Prims.bool)
+    FStar_Extraction_ML_Syntax.mlty -> Prims.bool
   =
   fun g  ->
     fun t  ->
       FStar_Extraction_ML_Util.erasableType
         (FStar_Extraction_ML_Util.udelta_unfold g) t
-  
-let (eraseTypeDeep :
+let eraseTypeDeep:
   FStar_Extraction_ML_UEnv.env ->
-    FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty)
+    FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty
   =
   fun g  ->
     fun t  ->
       FStar_Extraction_ML_Util.eraseTypeDeep
         (FStar_Extraction_ML_Util.udelta_unfold g) t
-  
-let record_fields :
+let record_fields:
   'Auu____50 .
     FStar_Ident.ident Prims.list ->
       'Auu____50 Prims.list ->
@@ -57,14 +52,13 @@ let record_fields :
   fun fs  ->
     fun vs  ->
       FStar_List.map2 (fun f  -> fun e  -> ((f.FStar_Ident.idText), e)) fs vs
-  
-let fail :
+let fail:
   'Auu____84 .
     FStar_Range.range ->
       (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2 ->
         'Auu____84
-  = fun r  -> fun err  -> FStar_Errors.raise_error err r 
-let err_uninst :
+  = fun r  -> fun err  -> FStar_Errors.raise_error err r
+let err_uninst:
   'Auu____106 .
     FStar_Extraction_ML_UEnv.env ->
       FStar_Syntax_Syntax.term ->
@@ -80,22 +74,19 @@ let err_uninst :
           | (vars,ty) ->
               let uu____141 =
                 let uu____146 =
-                  let uu____147 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____147 = FStar_Syntax_Print.term_to_string t in
                   let uu____148 =
-                    FStar_All.pipe_right vars (FStar_String.concat ", ")  in
+                    FStar_All.pipe_right vars (FStar_String.concat ", ") in
                   let uu____151 =
                     FStar_Extraction_ML_Code.string_of_mlty
-                      env.FStar_Extraction_ML_UEnv.currentModule ty
-                     in
-                  let uu____152 = FStar_Syntax_Print.term_to_string app  in
+                      env.FStar_Extraction_ML_UEnv.currentModule ty in
+                  let uu____152 = FStar_Syntax_Print.term_to_string app in
                   FStar_Util.format4
                     "Variable %s has a polymorphic type (forall %s. %s); expected it to be fully instantiated, but got %s"
-                    uu____147 uu____148 uu____151 uu____152
-                   in
-                (FStar_Errors.Fatal_Uninstantiated, uu____146)  in
+                    uu____147 uu____148 uu____151 uu____152 in
+                (FStar_Errors.Fatal_Uninstantiated, uu____146) in
               fail t.FStar_Syntax_Syntax.pos uu____141
-  
-let err_ill_typed_application :
+let err_ill_typed_application:
   'Auu____159 'Auu____160 .
     FStar_Extraction_ML_UEnv.env ->
       FStar_Syntax_Syntax.term ->
@@ -108,7 +99,7 @@ let err_ill_typed_application :
         fun ty  ->
           let uu____189 =
             let uu____194 =
-              let uu____195 = FStar_Syntax_Print.term_to_string t  in
+              let uu____195 = FStar_Syntax_Print.term_to_string t in
               let uu____196 =
                 let uu____197 =
                   FStar_All.pipe_right args
@@ -116,37 +107,31 @@ let err_ill_typed_application :
                        (fun uu____215  ->
                           match uu____215 with
                           | (x,uu____221) ->
-                              FStar_Syntax_Print.term_to_string x))
-                   in
-                FStar_All.pipe_right uu____197 (FStar_String.concat " ")  in
+                              FStar_Syntax_Print.term_to_string x)) in
+                FStar_All.pipe_right uu____197 (FStar_String.concat " ") in
               let uu____224 =
                 FStar_Extraction_ML_Code.string_of_mlty
-                  env.FStar_Extraction_ML_UEnv.currentModule ty
-                 in
+                  env.FStar_Extraction_ML_UEnv.currentModule ty in
               FStar_Util.format3
                 "Ill-typed application: application is %s \n remaining args are %s\nml type of head is %s\n"
-                uu____195 uu____196 uu____224
-               in
-            (FStar_Errors.Fatal_IllTyped, uu____194)  in
+                uu____195 uu____196 uu____224 in
+            (FStar_Errors.Fatal_IllTyped, uu____194) in
           fail t.FStar_Syntax_Syntax.pos uu____189
-  
-let err_value_restriction :
+let err_value_restriction:
   'Auu____227 .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> 'Auu____227
   =
   fun t  ->
     let uu____236 =
       let uu____241 =
-        let uu____242 = FStar_Syntax_Print.tag_of_term t  in
-        let uu____243 = FStar_Syntax_Print.term_to_string t  in
+        let uu____242 = FStar_Syntax_Print.tag_of_term t in
+        let uu____243 = FStar_Syntax_Print.term_to_string t in
         FStar_Util.format2
           "Refusing to generalize because of the value restriction: (%s) %s"
-          uu____242 uu____243
-         in
-      (FStar_Errors.Fatal_ValueRestriction, uu____241)  in
+          uu____242 uu____243 in
+      (FStar_Errors.Fatal_ValueRestriction, uu____241) in
     fail t.FStar_Syntax_Syntax.pos uu____236
-  
-let err_unexpected_eff :
+let err_unexpected_eff:
   'Auu____248 .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       FStar_Extraction_ML_Syntax.e_tag ->
@@ -157,40 +142,35 @@ let err_unexpected_eff :
       fun f1  ->
         let uu____265 =
           let uu____270 =
-            let uu____271 = FStar_Syntax_Print.term_to_string t  in
+            let uu____271 = FStar_Syntax_Print.term_to_string t in
             FStar_Util.format3
               "for expression %s, Expected effect %s; got effect %s"
               uu____271 (FStar_Extraction_ML_Util.eff_to_string f0)
-              (FStar_Extraction_ML_Util.eff_to_string f1)
-             in
-          (FStar_Errors.Fatal_UnexpectedEffect, uu____270)  in
+              (FStar_Extraction_ML_Util.eff_to_string f1) in
+          (FStar_Errors.Fatal_UnexpectedEffect, uu____270) in
         fail t.FStar_Syntax_Syntax.pos uu____265
-  
-let (effect_as_etag :
+let effect_as_etag:
   FStar_Extraction_ML_UEnv.env ->
-    FStar_Ident.lident -> FStar_Extraction_ML_Syntax.e_tag)
+    FStar_Ident.lident -> FStar_Extraction_ML_Syntax.e_tag
   =
-  let cache = FStar_Util.smap_create (Prims.parse_int "20")  in
+  let cache = FStar_Util.smap_create (Prims.parse_int "20") in
   let rec delta_norm_eff g l =
-    let uu____286 = FStar_Util.smap_try_find cache l.FStar_Ident.str  in
+    let uu____286 = FStar_Util.smap_try_find cache l.FStar_Ident.str in
     match uu____286 with
     | FStar_Pervasives_Native.Some l1 -> l1
     | FStar_Pervasives_Native.None  ->
         let res =
           let uu____291 =
             FStar_TypeChecker_Env.lookup_effect_abbrev
-              g.FStar_Extraction_ML_UEnv.tcenv [FStar_Syntax_Syntax.U_zero] l
-             in
+              g.FStar_Extraction_ML_UEnv.tcenv [FStar_Syntax_Syntax.U_zero] l in
           match uu____291 with
           | FStar_Pervasives_Native.None  -> l
           | FStar_Pervasives_Native.Some (uu____302,c) ->
-              delta_norm_eff g (FStar_Syntax_Util.comp_effect_name c)
-           in
-        (FStar_Util.smap_add cache l.FStar_Ident.str res; res)
-     in
+              delta_norm_eff g (FStar_Syntax_Util.comp_effect_name c) in
+        (FStar_Util.smap_add cache l.FStar_Ident.str res; res) in
   fun g  ->
     fun l  ->
-      let l1 = delta_norm_eff g l  in
+      let l1 = delta_norm_eff g l in
       if FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_PURE_lid
       then FStar_Extraction_ML_Syntax.E_PURE
       else
@@ -199,28 +179,25 @@ let (effect_as_etag :
         else
           (let ed_opt =
              FStar_TypeChecker_Env.effect_decl_opt
-               g.FStar_Extraction_ML_UEnv.tcenv l1
-              in
+               g.FStar_Extraction_ML_UEnv.tcenv l1 in
            match ed_opt with
            | FStar_Pervasives_Native.Some (ed,qualifiers) ->
                let uu____335 =
                  FStar_All.pipe_right qualifiers
-                   (FStar_List.contains FStar_Syntax_Syntax.Reifiable)
-                  in
+                   (FStar_List.contains FStar_Syntax_Syntax.Reifiable) in
                if uu____335
                then FStar_Extraction_ML_Syntax.E_PURE
                else FStar_Extraction_ML_Syntax.E_IMPURE
            | FStar_Pervasives_Native.None  ->
                FStar_Extraction_ML_Syntax.E_IMPURE)
-  
-let rec (is_arity :
-  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let rec is_arity:
+  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun env  ->
     fun t  ->
-      let t1 = FStar_Syntax_Util.unmeta t  in
+      let t1 = FStar_Syntax_Util.unmeta t in
       let uu____352 =
-        let uu____353 = FStar_Syntax_Subst.compress t1  in
-        uu____353.FStar_Syntax_Syntax.n  in
+        let uu____353 = FStar_Syntax_Subst.compress t1 in
+        uu____353.FStar_Syntax_Syntax.n in
       match uu____352 with
       | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_delayed uu____356 -> failwith "Impossible"
@@ -240,16 +217,15 @@ let rec (is_arity :
               FStar_TypeChecker_Normalize.EraseUniverses;
               FStar_TypeChecker_Normalize.UnfoldUntil
                 FStar_Syntax_Syntax.Delta_constant]
-              env.FStar_Extraction_ML_UEnv.tcenv t1
-             in
+              env.FStar_Extraction_ML_UEnv.tcenv t1 in
           let uu____456 =
-            let uu____457 = FStar_Syntax_Subst.compress t2  in
-            uu____457.FStar_Syntax_Syntax.n  in
+            let uu____457 = FStar_Syntax_Subst.compress t2 in
+            uu____457.FStar_Syntax_Syntax.n in
           (match uu____456 with
            | FStar_Syntax_Syntax.Tm_fvar uu____460 -> false
            | uu____461 -> is_arity env t2)
       | FStar_Syntax_Syntax.Tm_app uu____462 ->
-          let uu____477 = FStar_Syntax_Util.head_and_args t1  in
+          let uu____477 = FStar_Syntax_Util.head_and_args t1 in
           (match uu____477 with | (head1,uu____493) -> is_arity env head1)
       | FStar_Syntax_Syntax.Tm_uinst (head1,uu____515) -> is_arity env head1
       | FStar_Syntax_Syntax.Tm_refine (x,uu____521) ->
@@ -261,22 +237,21 @@ let rec (is_arity :
           (match branches with
            | (uu____605,uu____606,e)::uu____608 -> is_arity env e
            | uu____655 -> false)
-  
-let rec (is_type_aux :
-  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let rec is_type_aux:
+  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun env  ->
     fun t  ->
-      let t1 = FStar_Syntax_Subst.compress t  in
+      let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_delayed uu____679 ->
           let uu____704 =
-            let uu____705 = FStar_Syntax_Print.tag_of_term t1  in
-            FStar_Util.format1 "Impossible: %s" uu____705  in
+            let uu____705 = FStar_Syntax_Print.tag_of_term t1 in
+            FStar_Util.format1 "Impossible: %s" uu____705 in
           failwith uu____704
       | FStar_Syntax_Syntax.Tm_unknown  ->
           let uu____706 =
-            let uu____707 = FStar_Syntax_Print.tag_of_term t1  in
-            FStar_Util.format1 "Impossible: %s" uu____707  in
+            let uu____707 = FStar_Syntax_Print.tag_of_term t1 in
+            FStar_Util.format1 "Impossible: %s" uu____707 in
           failwith uu____706
       | FStar_Syntax_Syntax.Tm_constant uu____708 -> false
       | FStar_Syntax_Syntax.Tm_type uu____709 -> true
@@ -302,55 +277,52 @@ let rec (is_type_aux :
           is_type_aux env t2
       | FStar_Syntax_Syntax.Tm_uinst (t2,uu____812) -> is_type_aux env t2
       | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____819) ->
-          let uu____840 = FStar_Syntax_Subst.open_term bs body  in
+          let uu____840 = FStar_Syntax_Subst.open_term bs body in
           (match uu____840 with | (uu____845,body1) -> is_type_aux env body1)
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-          let x = FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
+          let x = FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
           let uu____862 =
             let uu____867 =
-              let uu____868 = FStar_Syntax_Syntax.mk_binder x  in [uu____868]
-               in
-            FStar_Syntax_Subst.open_term uu____867 body  in
+              let uu____868 = FStar_Syntax_Syntax.mk_binder x in [uu____868] in
+            FStar_Syntax_Subst.open_term uu____867 body in
           (match uu____862 with | (uu____869,body1) -> is_type_aux env body1)
       | FStar_Syntax_Syntax.Tm_let ((uu____871,lbs),body) ->
-          let uu____888 = FStar_Syntax_Subst.open_let_rec lbs body  in
+          let uu____888 = FStar_Syntax_Subst.open_let_rec lbs body in
           (match uu____888 with | (uu____895,body1) -> is_type_aux env body1)
       | FStar_Syntax_Syntax.Tm_match (uu____901,branches) ->
           (match branches with
            | b::uu____940 ->
-               let uu____985 = FStar_Syntax_Subst.open_branch b  in
+               let uu____985 = FStar_Syntax_Subst.open_branch b in
                (match uu____985 with
                 | (uu____986,uu____987,e) -> is_type_aux env e)
            | uu____1005 -> false)
       | FStar_Syntax_Syntax.Tm_meta (t2,uu____1023) -> is_type_aux env t2
       | FStar_Syntax_Syntax.Tm_app (head1,uu____1029) ->
           is_type_aux env head1
-  
-let (is_type :
-  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_type:
+  FStar_Extraction_ML_UEnv.env -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun env  ->
     fun t  ->
       FStar_Extraction_ML_UEnv.debug env
         (fun uu____1060  ->
-           let uu____1061 = FStar_Syntax_Print.tag_of_term t  in
-           let uu____1062 = FStar_Syntax_Print.term_to_string t  in
+           let uu____1061 = FStar_Syntax_Print.tag_of_term t in
+           let uu____1062 = FStar_Syntax_Print.term_to_string t in
            FStar_Util.print2 "checking is_type (%s) %s\n" uu____1061
              uu____1062);
-      (let b = is_type_aux env t  in
+      (let b = is_type_aux env t in
        FStar_Extraction_ML_UEnv.debug env
          (fun uu____1068  ->
             if b
             then
-              let uu____1069 = FStar_Syntax_Print.term_to_string t  in
-              let uu____1070 = FStar_Syntax_Print.tag_of_term t  in
+              let uu____1069 = FStar_Syntax_Print.term_to_string t in
+              let uu____1070 = FStar_Syntax_Print.tag_of_term t in
               FStar_Util.print2 "is_type %s (%s)\n" uu____1069 uu____1070
             else
-              (let uu____1072 = FStar_Syntax_Print.term_to_string t  in
-               let uu____1073 = FStar_Syntax_Print.tag_of_term t  in
+              (let uu____1072 = FStar_Syntax_Print.term_to_string t in
+               let uu____1073 = FStar_Syntax_Print.tag_of_term t in
                FStar_Util.print2 "not a type %s (%s)\n" uu____1072 uu____1073));
        b)
-  
-let is_type_binder :
+let is_type_binder:
   'Auu____1077 .
     FStar_Extraction_ML_UEnv.env ->
       (FStar_Syntax_Syntax.bv,'Auu____1077) FStar_Pervasives_Native.tuple2 ->
@@ -359,12 +331,11 @@ let is_type_binder :
   fun env  ->
     fun x  ->
       is_arity env (FStar_Pervasives_Native.fst x).FStar_Syntax_Syntax.sort
-  
-let (is_constructor : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_constructor: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____1097 =
-      let uu____1098 = FStar_Syntax_Subst.compress t  in
-      uu____1098.FStar_Syntax_Syntax.n  in
+      let uu____1098 = FStar_Syntax_Subst.compress t in
+      uu____1098.FStar_Syntax_Syntax.n in
     match uu____1097 with
     | FStar_Syntax_Syntax.Tm_fvar
         { FStar_Syntax_Syntax.fv_name = uu____1101;
@@ -379,19 +350,18 @@ let (is_constructor : FStar_Syntax_Syntax.term -> Prims.bool) =
             (FStar_Syntax_Syntax.Record_ctor uu____1105);_}
         -> true
     | uu____1112 -> false
-  
-let rec (is_fstar_value : FStar_Syntax_Syntax.term -> Prims.bool) =
+let rec is_fstar_value: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____1116 =
-      let uu____1117 = FStar_Syntax_Subst.compress t  in
-      uu____1117.FStar_Syntax_Syntax.n  in
+      let uu____1117 = FStar_Syntax_Subst.compress t in
+      uu____1117.FStar_Syntax_Syntax.n in
     match uu____1116 with
     | FStar_Syntax_Syntax.Tm_constant uu____1120 -> true
     | FStar_Syntax_Syntax.Tm_bvar uu____1121 -> true
     | FStar_Syntax_Syntax.Tm_fvar uu____1122 -> true
     | FStar_Syntax_Syntax.Tm_abs uu____1123 -> true
     | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-        let uu____1162 = is_constructor head1  in
+        let uu____1162 = is_constructor head1 in
         if uu____1162
         then
           FStar_All.pipe_right args
@@ -404,8 +374,7 @@ let rec (is_fstar_value : FStar_Syntax_Syntax.term -> Prims.bool) =
     | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____1193,uu____1194) ->
         is_fstar_value t1
     | uu____1235 -> false
-  
-let rec (is_ml_value : FStar_Extraction_ML_Syntax.mlexpr -> Prims.bool) =
+let rec is_ml_value: FStar_Extraction_ML_Syntax.mlexpr -> Prims.bool =
   fun e  ->
     match e.FStar_Extraction_ML_Syntax.expr with
     | FStar_Extraction_ML_Syntax.MLE_Const uu____1239 -> true
@@ -423,58 +392,52 @@ let rec (is_ml_value : FStar_Extraction_ML_Syntax.mlexpr -> Prims.bool) =
           fields
     | FStar_Extraction_ML_Syntax.MLE_TApp (h,uu____1295) -> is_ml_value h
     | uu____1300 -> false
-  
-let (fresh : Prims.string -> Prims.string) =
-  let c = FStar_Util.mk_ref (Prims.parse_int "0")  in
+let fresh: Prims.string -> Prims.string =
+  let c = FStar_Util.mk_ref (Prims.parse_int "0") in
   fun x  ->
     FStar_Util.incr c;
     (let uu____1341 =
-       let uu____1342 = FStar_ST.op_Bang c  in
-       FStar_Util.string_of_int uu____1342  in
+       let uu____1342 = FStar_ST.op_Bang c in
+       FStar_Util.string_of_int uu____1342 in
      Prims.strcat x uu____1341)
-  
-let (normalize_abs : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let normalize_abs: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun t0  ->
     let rec aux bs t copt =
-      let t1 = FStar_Syntax_Subst.compress t  in
+      let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_abs (bs',body,copt1) ->
           aux (FStar_List.append bs bs') body copt1
       | uu____1441 ->
-          let e' = FStar_Syntax_Util.unascribe t1  in
-          let uu____1443 = FStar_Syntax_Util.is_fun e'  in
+          let e' = FStar_Syntax_Util.unascribe t1 in
+          let uu____1443 = FStar_Syntax_Util.is_fun e' in
           if uu____1443
           then aux bs e' copt
-          else FStar_Syntax_Util.abs bs e' copt
-       in
+          else FStar_Syntax_Util.abs bs e' copt in
     aux [] t0 FStar_Pervasives_Native.None
-  
-let (unit_binder : FStar_Syntax_Syntax.binder) =
+let unit_binder: FStar_Syntax_Syntax.binder =
   let uu____1449 =
     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-      FStar_Syntax_Syntax.t_unit
-     in
-  FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____1449 
-let (check_pats_for_ite :
+      FStar_Syntax_Syntax.t_unit in
+  FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____1449
+let check_pats_for_ite:
   (FStar_Syntax_Syntax.pat,FStar_Syntax_Syntax.term
                              FStar_Pervasives_Native.option,FStar_Syntax_Syntax.term)
     FStar_Pervasives_Native.tuple3 Prims.list ->
     (Prims.bool,FStar_Syntax_Syntax.term FStar_Pervasives_Native.option,
       FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3)
+      FStar_Pervasives_Native.tuple3
   =
   fun l  ->
     let def =
-      (false, FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)  in
+      (false, FStar_Pervasives_Native.None, FStar_Pervasives_Native.None) in
     if (FStar_List.length l) <> (Prims.parse_int "2")
     then def
     else
-      (let uu____1527 = FStar_List.hd l  in
+      (let uu____1527 = FStar_List.hd l in
        match uu____1527 with
        | (p1,w1,e1) ->
            let uu____1561 =
-             let uu____1570 = FStar_List.tl l  in FStar_List.hd uu____1570
-              in
+             let uu____1570 = FStar_List.tl l in FStar_List.hd uu____1570 in
            (match uu____1561 with
             | (p2,w2,e2) ->
                 (match (w1, w2, (p1.FStar_Syntax_Syntax.v),
@@ -495,41 +458,39 @@ let (check_pats_for_ite :
                      (true, (FStar_Pervasives_Native.Some e2),
                        (FStar_Pervasives_Native.Some e1))
                  | uu____1644 -> def)))
-  
-let (instantiate :
+let instantiate:
   FStar_Extraction_ML_Syntax.mltyscheme ->
     FStar_Extraction_ML_Syntax.mlty Prims.list ->
-      FStar_Extraction_ML_Syntax.mlty)
-  = fun s  -> fun args  -> FStar_Extraction_ML_Util.subst s args 
-let (erasable :
+      FStar_Extraction_ML_Syntax.mlty
+  = fun s  -> fun args  -> FStar_Extraction_ML_Util.subst s args
+let erasable:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Extraction_ML_Syntax.e_tag ->
-      FStar_Extraction_ML_Syntax.mlty -> Prims.bool)
+      FStar_Extraction_ML_Syntax.mlty -> Prims.bool
   =
   fun g  ->
     fun f  ->
       fun t  ->
         (f = FStar_Extraction_ML_Syntax.E_GHOST) ||
           ((f = FStar_Extraction_ML_Syntax.E_PURE) && (erasableType g t))
-  
-let (erase :
+let erase:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Extraction_ML_Syntax.mlexpr ->
       FStar_Extraction_ML_Syntax.mlty ->
         FStar_Extraction_ML_Syntax.e_tag ->
           (FStar_Extraction_ML_Syntax.mlexpr,FStar_Extraction_ML_Syntax.e_tag,
-            FStar_Extraction_ML_Syntax.mlty) FStar_Pervasives_Native.tuple3)
+            FStar_Extraction_ML_Syntax.mlty) FStar_Pervasives_Native.tuple3
   =
   fun g  ->
     fun e  ->
       fun ty  ->
         fun f  ->
           let e1 =
-            let uu____1701 = erasable g f ty  in
+            let uu____1701 = erasable g f ty in
             if uu____1701
             then
               let uu____1702 =
-                type_leq g ty FStar_Extraction_ML_Syntax.ml_unit_ty  in
+                type_leq g ty FStar_Extraction_ML_Syntax.ml_unit_ty in
               (if uu____1702
                then FStar_Extraction_ML_Syntax.ml_unit
                else
@@ -537,65 +498,59 @@ let (erase :
                    (FStar_Extraction_ML_Syntax.MLE_Coerce
                       (FStar_Extraction_ML_Syntax.ml_unit,
                         FStar_Extraction_ML_Syntax.ml_unit_ty, ty)))
-            else e  in
+            else e in
           (e1, f, ty)
-  
-let (eta_expand :
+let eta_expand:
   FStar_Extraction_ML_Syntax.mlty ->
-    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr)
+    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr
   =
   fun t  ->
     fun e  ->
-      let uu____1711 = FStar_Extraction_ML_Util.doms_and_cod t  in
+      let uu____1711 = FStar_Extraction_ML_Util.doms_and_cod t in
       match uu____1711 with
       | (ts,r) ->
           if ts = []
           then e
           else
-            (let vs = FStar_List.map (fun uu____1731  -> fresh "a") ts  in
-             let vs_ts = FStar_List.zip vs ts  in
+            (let vs = FStar_List.map (fun uu____1731  -> fresh "a") ts in
+             let vs_ts = FStar_List.zip vs ts in
              let vs_es =
-               let uu____1742 = FStar_List.zip vs ts  in
+               let uu____1742 = FStar_List.zip vs ts in
                FStar_List.map
                  (fun uu____1756  ->
                     match uu____1756 with
                     | (v1,t1) ->
                         FStar_Extraction_ML_Syntax.with_ty t1
-                          (FStar_Extraction_ML_Syntax.MLE_Var v1)) uu____1742
-                in
+                          (FStar_Extraction_ML_Syntax.MLE_Var v1)) uu____1742 in
              let body =
                FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty r)
-                 (FStar_Extraction_ML_Syntax.MLE_App (e, vs_es))
-                in
+                 (FStar_Extraction_ML_Syntax.MLE_App (e, vs_es)) in
              FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t)
                (FStar_Extraction_ML_Syntax.MLE_Fun (vs_ts, body)))
-  
-let (maybe_eta_expand :
+let maybe_eta_expand:
   FStar_Extraction_ML_Syntax.mlty ->
-    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr)
+    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr
   =
   fun expect  ->
     fun e  ->
       let uu____1778 =
         (FStar_Options.ml_no_eta_expand_coertions ()) ||
-          (let uu____1780 = FStar_Options.codegen ()  in
-           uu____1780 = (FStar_Pervasives_Native.Some "Kremlin"))
-         in
+          (let uu____1780 = FStar_Options.codegen () in
+           uu____1780 = (FStar_Pervasives_Native.Some "Kremlin")) in
       if uu____1778 then e else eta_expand expect e
-  
-let (maybe_coerce :
+let maybe_coerce:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Extraction_ML_Syntax.mlexpr ->
       FStar_Extraction_ML_Syntax.mlty ->
-        FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlexpr)
+        FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlexpr
   =
   fun g  ->
     fun e  ->
       fun ty  ->
         fun expect  ->
-          let ty1 = eraseTypeDeep g ty  in
+          let ty1 = eraseTypeDeep g ty in
           let uu____1799 =
-            type_leq_c g (FStar_Pervasives_Native.Some e) ty1 expect  in
+            type_leq_c g (FStar_Pervasives_Native.Some e) ty1 expect in
           match uu____1799 with
           | (true ,FStar_Pervasives_Native.Some e') -> e'
           | uu____1809 ->
@@ -603,40 +558,34 @@ let (maybe_coerce :
                  (fun uu____1821  ->
                     let uu____1822 =
                       FStar_Extraction_ML_Code.string_of_mlexpr
-                        g.FStar_Extraction_ML_UEnv.currentModule e
-                       in
+                        g.FStar_Extraction_ML_UEnv.currentModule e in
                     let uu____1823 =
                       FStar_Extraction_ML_Code.string_of_mlty
-                        g.FStar_Extraction_ML_UEnv.currentModule ty1
-                       in
+                        g.FStar_Extraction_ML_UEnv.currentModule ty1 in
                     let uu____1824 =
                       FStar_Extraction_ML_Code.string_of_mlty
-                        g.FStar_Extraction_ML_UEnv.currentModule expect
-                       in
+                        g.FStar_Extraction_ML_UEnv.currentModule expect in
                     FStar_Util.print3
                       "\n (*needed to coerce expression \n %s \n of type \n %s \n to type \n %s *) \n"
                       uu____1822 uu____1823 uu____1824);
                (let uu____1825 =
                   FStar_All.pipe_left
                     (FStar_Extraction_ML_Syntax.with_ty expect)
-                    (FStar_Extraction_ML_Syntax.MLE_Coerce (e, ty1, expect))
-                   in
+                    (FStar_Extraction_ML_Syntax.MLE_Coerce (e, ty1, expect)) in
                 maybe_eta_expand expect uu____1825))
-  
-let (bv_as_mlty :
+let bv_as_mlty:
   FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty)
+    FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty
   =
   fun g  ->
     fun bv  ->
-      let uu____1832 = FStar_Extraction_ML_UEnv.lookup_bv g bv  in
+      let uu____1832 = FStar_Extraction_ML_UEnv.lookup_bv g bv in
       match uu____1832 with
       | FStar_Util.Inl (uu____1833,t) -> t
       | uu____1847 -> FStar_Extraction_ML_Syntax.MLTY_Top
-  
-let rec (term_as_mlty :
+let rec term_as_mlty:
   FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlty)
+    FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlty
   =
   fun g  ->
     fun t0  ->
@@ -644,11 +593,11 @@ let rec (term_as_mlty :
         match t with
         | FStar_Extraction_ML_Syntax.MLTY_Top  -> true
         | FStar_Extraction_ML_Syntax.MLTY_Named uu____1890 ->
-            let uu____1897 = FStar_Extraction_ML_Util.udelta_unfold g t  in
+            let uu____1897 = FStar_Extraction_ML_Util.udelta_unfold g t in
             (match uu____1897 with
              | FStar_Pervasives_Native.None  -> false
              | FStar_Pervasives_Native.Some t1 -> is_top_ty t1)
-        | uu____1901 -> false  in
+        | uu____1901 -> false in
       let t =
         FStar_TypeChecker_Normalize.normalize
           [FStar_TypeChecker_Normalize.Beta;
@@ -658,10 +607,9 @@ let rec (term_as_mlty :
           FStar_TypeChecker_Normalize.Inlining;
           FStar_TypeChecker_Normalize.EraseUniverses;
           FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-          g.FStar_Extraction_ML_UEnv.tcenv t0
-         in
-      let mlt = term_as_mlty' g t  in
-      let uu____1904 = is_top_ty mlt  in
+          g.FStar_Extraction_ML_UEnv.tcenv t0 in
+      let mlt = term_as_mlty' g t in
+      let uu____1904 = is_top_ty mlt in
       if uu____1904
       then
         let t1 =
@@ -675,36 +623,31 @@ let rec (term_as_mlty :
             FStar_TypeChecker_Normalize.Inlining;
             FStar_TypeChecker_Normalize.EraseUniverses;
             FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-            g.FStar_Extraction_ML_UEnv.tcenv t0
-           in
+            g.FStar_Extraction_ML_UEnv.tcenv t0 in
         term_as_mlty' g t1
       else mlt
-
-and (term_as_mlty' :
+and term_as_mlty':
   FStar_Extraction_ML_UEnv.env ->
-    FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlty)
+    FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlty
   =
   fun env  ->
     fun t  ->
-      let t1 = FStar_Syntax_Subst.compress t  in
+      let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_bvar uu____1910 ->
           let uu____1911 =
-            let uu____1912 = FStar_Syntax_Print.term_to_string t1  in
-            FStar_Util.format1 "Impossible: Unexpected term %s" uu____1912
-             in
+            let uu____1912 = FStar_Syntax_Print.term_to_string t1 in
+            FStar_Util.format1 "Impossible: Unexpected term %s" uu____1912 in
           failwith uu____1911
       | FStar_Syntax_Syntax.Tm_delayed uu____1913 ->
           let uu____1938 =
-            let uu____1939 = FStar_Syntax_Print.term_to_string t1  in
-            FStar_Util.format1 "Impossible: Unexpected term %s" uu____1939
-             in
+            let uu____1939 = FStar_Syntax_Print.term_to_string t1 in
+            FStar_Util.format1 "Impossible: Unexpected term %s" uu____1939 in
           failwith uu____1938
       | FStar_Syntax_Syntax.Tm_unknown  ->
           let uu____1940 =
-            let uu____1941 = FStar_Syntax_Print.term_to_string t1  in
-            FStar_Util.format1 "Impossible: Unexpected term %s" uu____1941
-             in
+            let uu____1941 = FStar_Syntax_Print.term_to_string t1 in
+            FStar_Util.format1 "Impossible: Unexpected term %s" uu____1941 in
           failwith uu____1940
       | FStar_Syntax_Syntax.Tm_constant uu____1942 ->
           FStar_Extraction_ML_UEnv.unknownType
@@ -722,47 +665,41 @@ and (term_as_mlty' :
       | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
       | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv []
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____2051 = FStar_Syntax_Subst.open_comp bs c  in
+          let uu____2051 = FStar_Syntax_Subst.open_comp bs c in
           (match uu____2051 with
            | (bs1,c1) ->
-               let uu____2058 = binders_as_ml_binders env bs1  in
+               let uu____2058 = binders_as_ml_binders env bs1 in
                (match uu____2058 with
                 | (mlbs,env1) ->
                     let t_ret =
                       let eff =
                         FStar_TypeChecker_Env.norm_eff_name
                           env1.FStar_Extraction_ML_UEnv.tcenv
-                          (FStar_Syntax_Util.comp_effect_name c1)
-                         in
+                          (FStar_Syntax_Util.comp_effect_name c1) in
                       let uu____2085 =
                         let uu____2092 =
                           FStar_TypeChecker_Env.effect_decl_opt
-                            env1.FStar_Extraction_ML_UEnv.tcenv eff
-                           in
-                        FStar_Util.must uu____2092  in
+                            env1.FStar_Extraction_ML_UEnv.tcenv eff in
+                        FStar_Util.must uu____2092 in
                       match uu____2085 with
                       | (ed,qualifiers) ->
                           let uu____2113 =
                             FStar_All.pipe_right qualifiers
                               (FStar_List.contains
-                                 FStar_Syntax_Syntax.Reifiable)
-                             in
+                                 FStar_Syntax_Syntax.Reifiable) in
                           if uu____2113
                           then
                             let t2 =
                               FStar_TypeChecker_Env.reify_comp
                                 env1.FStar_Extraction_ML_UEnv.tcenv c1
-                                FStar_Syntax_Syntax.U_unknown
-                               in
-                            let res = term_as_mlty' env1 t2  in res
+                                FStar_Syntax_Syntax.U_unknown in
+                            let res = term_as_mlty' env1 t2 in res
                           else
                             term_as_mlty' env1
-                              (FStar_Syntax_Util.comp_result c1)
-                       in
+                              (FStar_Syntax_Util.comp_result c1) in
                     let erase1 =
                       effect_as_etag env1
-                        (FStar_Syntax_Util.comp_effect_name c1)
-                       in
+                        (FStar_Syntax_Util.comp_effect_name c1) in
                     let uu____2120 =
                       FStar_List.fold_right
                         (fun uu____2139  ->
@@ -771,14 +708,13 @@ and (term_as_mlty' :
                              | ((uu____2161,t2),(tag,t')) ->
                                  (FStar_Extraction_ML_Syntax.E_PURE,
                                    (FStar_Extraction_ML_Syntax.MLTY_Fun
-                                      (t2, tag, t')))) mlbs (erase1, t_ret)
-                       in
+                                      (t2, tag, t')))) mlbs (erase1, t_ret) in
                     (match uu____2120 with | (uu____2173,t2) -> t2)))
       | FStar_Syntax_Syntax.Tm_app (head1,args) ->
           let res =
             let uu____2198 =
-              let uu____2199 = FStar_Syntax_Util.un_uinst head1  in
-              uu____2199.FStar_Syntax_Syntax.n  in
+              let uu____2199 = FStar_Syntax_Util.un_uinst head1 in
+              uu____2199.FStar_Syntax_Syntax.n in
             match uu____2198 with
             | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
             | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv args
@@ -787,16 +723,15 @@ and (term_as_mlty' :
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app
                        (head2, (FStar_List.append args' args)))
-                    FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
-                   in
+                    FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos in
                 term_as_mlty' env uu____2226
-            | uu____2243 -> FStar_Extraction_ML_UEnv.unknownType  in
+            | uu____2243 -> FStar_Extraction_ML_UEnv.unknownType in
           res
       | FStar_Syntax_Syntax.Tm_abs (bs,ty,uu____2246) ->
-          let uu____2267 = FStar_Syntax_Subst.open_term bs ty  in
+          let uu____2267 = FStar_Syntax_Subst.open_term bs ty in
           (match uu____2267 with
            | (bs1,ty1) ->
-               let uu____2274 = binders_as_ml_binders env bs1  in
+               let uu____2274 = binders_as_ml_binders env bs1 in
                (match uu____2274 with | (bts,env1) -> term_as_mlty' env1 ty1))
       | FStar_Syntax_Syntax.Tm_type uu____2299 ->
           FStar_Extraction_ML_UEnv.unknownType
@@ -804,25 +739,23 @@ and (term_as_mlty' :
           FStar_Extraction_ML_UEnv.unknownType
       | FStar_Syntax_Syntax.Tm_match uu____2313 ->
           FStar_Extraction_ML_UEnv.unknownType
-
-and (arg_as_mlty :
+and arg_as_mlty:
   FStar_Extraction_ML_UEnv.env ->
     (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2 -> FStar_Extraction_ML_Syntax.mlty)
+      FStar_Pervasives_Native.tuple2 -> FStar_Extraction_ML_Syntax.mlty
   =
   fun g  ->
     fun uu____2337  ->
       match uu____2337 with
       | (a,uu____2343) ->
-          let uu____2344 = is_type g a  in
+          let uu____2344 = is_type g a in
           if uu____2344
           then term_as_mlty' g a
           else FStar_Extraction_ML_UEnv.erasedContent
-
-and (fv_app_as_mlty :
+and fv_app_as_mlty:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.fv ->
-      FStar_Syntax_Syntax.args -> FStar_Extraction_ML_Syntax.mlty)
+      FStar_Syntax_Syntax.args -> FStar_Extraction_ML_Syntax.mlty
   =
   fun g  ->
     fun fv  ->
@@ -830,52 +763,46 @@ and (fv_app_as_mlty :
         let uu____2349 =
           let uu____2362 =
             FStar_TypeChecker_Env.lookup_lid g.FStar_Extraction_ML_UEnv.tcenv
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           match uu____2362 with
           | ((uu____2383,fvty),uu____2385) ->
               let fvty1 =
                 FStar_TypeChecker_Normalize.normalize
                   [FStar_TypeChecker_Normalize.UnfoldUntil
                      FStar_Syntax_Syntax.Delta_constant]
-                  g.FStar_Extraction_ML_UEnv.tcenv fvty
-                 in
-              FStar_Syntax_Util.arrow_formals fvty1
-           in
+                  g.FStar_Extraction_ML_UEnv.tcenv fvty in
+              FStar_Syntax_Util.arrow_formals fvty1 in
         match uu____2349 with
         | (formals,uu____2392) ->
-            let mlargs = FStar_List.map (arg_as_mlty g) args  in
+            let mlargs = FStar_List.map (arg_as_mlty g) args in
             let mlargs1 =
-              let n_args = FStar_List.length args  in
+              let n_args = FStar_List.length args in
               if (FStar_List.length formals) > n_args
               then
-                let uu____2436 = FStar_Util.first_N n_args formals  in
+                let uu____2436 = FStar_Util.first_N n_args formals in
                 match uu____2436 with
                 | (uu____2463,rest) ->
                     let uu____2489 =
                       FStar_List.map
                         (fun uu____2497  ->
-                           FStar_Extraction_ML_UEnv.erasedContent) rest
-                       in
+                           FStar_Extraction_ML_UEnv.erasedContent) rest in
                     FStar_List.append mlargs uu____2489
-              else mlargs  in
+              else mlargs in
             let nm =
               let uu____2504 =
-                FStar_Extraction_ML_UEnv.maybe_mangle_type_projector g fv  in
+                FStar_Extraction_ML_UEnv.maybe_mangle_type_projector g fv in
               match uu____2504 with
               | FStar_Pervasives_Native.Some p -> p
               | FStar_Pervasives_Native.None  ->
                   FStar_Extraction_ML_Syntax.mlpath_of_lident
-                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-               in
+                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
             FStar_Extraction_ML_Syntax.MLTY_Named (mlargs1, nm)
-
-and (binders_as_ml_binders :
+and binders_as_ml_binders:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.binders ->
       ((FStar_Extraction_ML_Syntax.mlident,FStar_Extraction_ML_Syntax.mlty)
          FStar_Pervasives_Native.tuple2 Prims.list,FStar_Extraction_ML_UEnv.env)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun bs  ->
@@ -886,42 +813,36 @@ and (binders_as_ml_binders :
                 fun b  ->
                   match uu____2565 with
                   | (ml_bs,env) ->
-                      let uu____2605 = is_type_binder g b  in
+                      let uu____2605 = is_type_binder g b in
                       if uu____2605
                       then
-                        let b1 = FStar_Pervasives_Native.fst b  in
+                        let b1 = FStar_Pervasives_Native.fst b in
                         let env1 =
                           FStar_Extraction_ML_UEnv.extend_ty env b1
                             (FStar_Pervasives_Native.Some
-                               FStar_Extraction_ML_Syntax.MLTY_Top)
-                           in
+                               FStar_Extraction_ML_Syntax.MLTY_Top) in
                         let ml_b =
                           let uu____2623 =
-                            FStar_Extraction_ML_UEnv.bv_as_ml_termvar b1  in
-                          (uu____2623, FStar_Extraction_ML_Syntax.ml_unit_ty)
-                           in
+                            FStar_Extraction_ML_UEnv.bv_as_ml_termvar b1 in
+                          (uu____2623, FStar_Extraction_ML_Syntax.ml_unit_ty) in
                         ((ml_b :: ml_bs), env1)
                       else
-                        (let b1 = FStar_Pervasives_Native.fst b  in
-                         let t = term_as_mlty env b1.FStar_Syntax_Syntax.sort
-                            in
+                        (let b1 = FStar_Pervasives_Native.fst b in
+                         let t = term_as_mlty env b1.FStar_Syntax_Syntax.sort in
                          let uu____2637 =
                            FStar_Extraction_ML_UEnv.extend_bv env b1 
-                             ([], t) false false false
-                            in
+                             ([], t) false false false in
                          match uu____2637 with
                          | (env1,b2) ->
                              let ml_b =
                                let uu____2661 =
-                                 FStar_Extraction_ML_UEnv.removeTick b2  in
-                               (uu____2661, t)  in
-                             ((ml_b :: ml_bs), env1))) ([], g))
-         in
+                                 FStar_Extraction_ML_UEnv.removeTick b2 in
+                               (uu____2661, t) in
+                             ((ml_b :: ml_bs), env1))) ([], g)) in
       match uu____2522 with | (ml_bs,env) -> ((FStar_List.rev ml_bs), env)
-
-let (mk_MLE_Seq :
+let mk_MLE_Seq:
   FStar_Extraction_ML_Syntax.mlexpr ->
-    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr')
+    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr'
   =
   fun e1  ->
     fun e2  ->
@@ -936,11 +857,10 @@ let (mk_MLE_Seq :
       | (uu____2732,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (e1 :: es2)
       | uu____2736 -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
-  
-let (mk_MLE_Let :
+let mk_MLE_Let:
   Prims.bool ->
     FStar_Extraction_ML_Syntax.mlletbinding ->
-      FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr')
+      FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr'
   =
   fun top_level  ->
     fun lbs  ->
@@ -971,17 +891,16 @@ let (mk_MLE_Let :
                           body)
              | uu____2766 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
         | uu____2769 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
-  
-let (resugar_pat :
+let resugar_pat:
   FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option ->
     FStar_Extraction_ML_Syntax.mlpattern ->
-      FStar_Extraction_ML_Syntax.mlpattern)
+      FStar_Extraction_ML_Syntax.mlpattern
   =
   fun q  ->
     fun p  ->
       match p with
       | FStar_Extraction_ML_Syntax.MLP_CTor (d,pats) ->
-          let uu____2786 = FStar_Extraction_ML_Util.is_xtuple d  in
+          let uu____2786 = FStar_Extraction_ML_Util.is_xtuple d in
           (match uu____2786 with
            | FStar_Pervasives_Native.Some n1 ->
                FStar_Extraction_ML_Syntax.MLP_Tuple pats
@@ -990,14 +909,12 @@ let (resugar_pat :
                 | FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Record_ctor (ty,fns)) ->
                     let path =
-                      FStar_List.map FStar_Ident.text_of_id ty.FStar_Ident.ns
-                       in
-                    let fs = record_fields fns pats  in
+                      FStar_List.map FStar_Ident.text_of_id ty.FStar_Ident.ns in
+                    let fs = record_fields fns pats in
                     FStar_Extraction_ML_Syntax.MLP_Record (path, fs)
                 | uu____2817 -> p))
       | uu____2820 -> p
-  
-let rec (extract_one_pat :
+let rec extract_one_pat:
   Prims.bool ->
     FStar_Extraction_ML_UEnv.env ->
       FStar_Syntax_Syntax.pat ->
@@ -1013,7 +930,7 @@ let rec (extract_one_pat :
                                               Prims.list)
                                             FStar_Pervasives_Native.tuple2
                                             FStar_Pervasives_Native.option,
-              Prims.bool) FStar_Pervasives_Native.tuple3)
+              Prims.bool) FStar_Pervasives_Native.tuple3
   =
   fun imp  ->
     fun g  ->
@@ -1024,29 +941,26 @@ let rec (extract_one_pat :
               match expected_topt with
               | FStar_Pervasives_Native.None  -> true
               | FStar_Pervasives_Native.Some t' ->
-                  let ok = type_leq g t t'  in
+                  let ok = type_leq g t t' in
                   (if Prims.op_Negation ok
                    then
                      FStar_Extraction_ML_UEnv.debug g
                        (fun uu____2900  ->
                           let uu____2901 =
                             FStar_Extraction_ML_Code.string_of_mlty
-                              g.FStar_Extraction_ML_UEnv.currentModule t'
-                             in
+                              g.FStar_Extraction_ML_UEnv.currentModule t' in
                           let uu____2902 =
                             FStar_Extraction_ML_Code.string_of_mlty
-                              g.FStar_Extraction_ML_UEnv.currentModule t
-                             in
+                              g.FStar_Extraction_ML_UEnv.currentModule t in
                           FStar_Util.print2
                             "Expected pattern type %s; got pattern type %s\n"
                             uu____2901 uu____2902)
                    else ();
-                   ok)
-               in
+                   ok) in
             match p.FStar_Syntax_Syntax.v with
             | FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_int
                 (c,swopt)) when
-                let uu____2932 = FStar_Options.codegen ()  in
+                let uu____2932 = FStar_Options.codegen () in
                 uu____2932 <> (FStar_Pervasives_Native.Some "Kremlin") ->
                 let uu____2937 =
                   match swopt with
@@ -1057,27 +971,23 @@ let rec (extract_one_pat :
                             FStar_Extraction_ML_Util.mlconst_of_const
                               p.FStar_Syntax_Syntax.p
                               (FStar_Const.Const_int
-                                 (c, FStar_Pervasives_Native.None))
-                             in
-                          FStar_Extraction_ML_Syntax.MLE_Const uu____2952  in
+                                 (c, FStar_Pervasives_Native.None)) in
+                          FStar_Extraction_ML_Syntax.MLE_Const uu____2952 in
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.ml_int_ty) uu____2951
-                         in
+                             FStar_Extraction_ML_Syntax.ml_int_ty) uu____2951 in
                       (uu____2950, FStar_Extraction_ML_Syntax.ml_int_ty)
                   | FStar_Pervasives_Native.Some sw ->
                       let source_term =
                         FStar_ToSyntax_ToSyntax.desugar_machine_integer
                           (g.FStar_Extraction_ML_UEnv.tcenv).FStar_TypeChecker_Env.dsenv
-                          c sw FStar_Range.dummyRange
-                         in
-                      let uu____2973 = term_as_mlexpr g source_term  in
+                          c sw FStar_Range.dummyRange in
+                      let uu____2973 = term_as_mlexpr g source_term in
                       (match uu____2973 with
-                       | (mlterm,uu____2985,mlty) -> (mlterm, mlty))
-                   in
+                       | (mlterm,uu____2985,mlty) -> (mlterm, mlty)) in
                 (match uu____2937 with
                  | (mlc,ml_ty) ->
-                     let x = FStar_Extraction_ML_Syntax.gensym ()  in
+                     let x = FStar_Extraction_ML_Syntax.gensym () in
                      let when_clause =
                        let uu____3005 =
                          let uu____3006 =
@@ -1085,18 +995,15 @@ let rec (extract_one_pat :
                              let uu____3016 =
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty ml_ty)
-                                 (FStar_Extraction_ML_Syntax.MLE_Var x)
-                                in
-                             [uu____3016; mlc]  in
+                                 (FStar_Extraction_ML_Syntax.MLE_Var x) in
+                             [uu____3016; mlc] in
                            (FStar_Extraction_ML_Util.prims_op_equality,
-                             uu____3013)
-                            in
-                         FStar_Extraction_ML_Syntax.MLE_App uu____3006  in
+                             uu____3013) in
+                         FStar_Extraction_ML_Syntax.MLE_App uu____3006 in
                        FStar_All.pipe_left
                          (FStar_Extraction_ML_Syntax.with_ty
-                            FStar_Extraction_ML_Syntax.ml_bool_ty) uu____3005
-                        in
-                     let uu____3019 = ok ml_ty  in
+                            FStar_Extraction_ML_Syntax.ml_bool_ty) uu____3005 in
+                     let uu____3019 = ok ml_ty in
                      (g,
                        (FStar_Pervasives_Native.Some
                           ((FStar_Extraction_ML_Syntax.MLP_Var x),
@@ -1104,29 +1011,26 @@ let rec (extract_one_pat :
             | FStar_Syntax_Syntax.Pat_constant s ->
                 let t =
                   FStar_TypeChecker_TcTerm.tc_constant
-                    g.FStar_Extraction_ML_UEnv.tcenv FStar_Range.dummyRange s
-                   in
-                let mlty = term_as_mlty g t  in
+                    g.FStar_Extraction_ML_UEnv.tcenv FStar_Range.dummyRange s in
+                let mlty = term_as_mlty g t in
                 let uu____3039 =
                   let uu____3048 =
                     let uu____3055 =
                       let uu____3056 =
                         FStar_Extraction_ML_Util.mlconst_of_const
-                          p.FStar_Syntax_Syntax.p s
-                         in
-                      FStar_Extraction_ML_Syntax.MLP_Const uu____3056  in
-                    (uu____3055, [])  in
-                  FStar_Pervasives_Native.Some uu____3048  in
-                let uu____3065 = ok mlty  in (g, uu____3039, uu____3065)
+                          p.FStar_Syntax_Syntax.p s in
+                      FStar_Extraction_ML_Syntax.MLP_Const uu____3056 in
+                    (uu____3055, []) in
+                  FStar_Pervasives_Native.Some uu____3048 in
+                let uu____3065 = ok mlty in (g, uu____3039, uu____3065)
             | FStar_Syntax_Syntax.Pat_var x ->
-                let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort  in
+                let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort in
                 let uu____3076 =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false
-                    false imp
-                   in
+                    false imp in
                 (match uu____3076 with
                  | (g1,x1) ->
-                     let uu____3099 = ok mlty  in
+                     let uu____3099 = ok mlty in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
@@ -1135,14 +1039,13 @@ let rec (extract_one_pat :
                             ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
                        uu____3099))
             | FStar_Syntax_Syntax.Pat_wild x ->
-                let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort  in
+                let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort in
                 let uu____3133 =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false
-                    false imp
-                   in
+                    false imp in
                 (match uu____3133 with
                  | (g1,x1) ->
-                     let uu____3156 = ok mlty  in
+                     let uu____3156 = ok mlty in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
@@ -1154,7 +1057,7 @@ let rec (extract_one_pat :
                 (g, FStar_Pervasives_Native.None, true)
             | FStar_Syntax_Syntax.Pat_cons (f,pats) ->
                 let uu____3227 =
-                  let uu____3232 = FStar_Extraction_ML_UEnv.lookup_fv g f  in
+                  let uu____3232 = FStar_Extraction_ML_UEnv.lookup_fv g f in
                   match uu____3232 with
                   | FStar_Util.Inr
                       (uu____3237,{
@@ -1165,13 +1068,12 @@ let rec (extract_one_pat :
                                     FStar_Extraction_ML_Syntax.loc =
                                       uu____3240;_},ttys,uu____3242)
                       -> (n1, ttys)
-                  | uu____3255 -> failwith "Expected a constructor"  in
+                  | uu____3255 -> failwith "Expected a constructor" in
                 (match uu____3227 with
                  | (d,tys) ->
                      let nTyVars =
-                       FStar_List.length (FStar_Pervasives_Native.fst tys)
-                        in
-                     let uu____3277 = FStar_Util.first_N nTyVars pats  in
+                       FStar_List.length (FStar_Pervasives_Native.fst tys) in
+                     let uu____3277 = FStar_Util.first_N nTyVars pats in
                      (match uu____3277 with
                       | (tysVarPats,restPats) ->
                           let f_ty_opt =
@@ -1193,25 +1095,20 @@ let rec (extract_one_pat :
                                                     (fun uu____3433  ->
                                                        let uu____3434 =
                                                          FStar_Syntax_Print.pat_to_string
-                                                           p1
-                                                          in
+                                                           p1 in
                                                        FStar_Util.print1
                                                          "Pattern %s is not extractable"
                                                          uu____3434);
                                                   FStar_Exn.raise
-                                                    Un_extractable))))
-                                 in
+                                                    Un_extractable)))) in
                               let f_ty =
-                                FStar_Extraction_ML_Util.subst tys mlty_args
-                                 in
+                                FStar_Extraction_ML_Util.subst tys mlty_args in
                               let uu____3436 =
                                 FStar_Extraction_ML_Util.uncurry_mlty_fun
-                                  f_ty
-                                 in
+                                  f_ty in
                               FStar_Pervasives_Native.Some uu____3436
                             with
-                            | Un_extractable  -> FStar_Pervasives_Native.None
-                             in
+                            | Un_extractable  -> FStar_Pervasives_Native.None in
                           let uu____3465 =
                             FStar_Util.fold_map
                               (fun g1  ->
@@ -1221,12 +1118,10 @@ let rec (extract_one_pat :
                                        let uu____3520 =
                                          extract_one_pat true g1 p1
                                            FStar_Pervasives_Native.None
-                                           term_as_mlexpr
-                                          in
+                                           term_as_mlexpr in
                                        (match uu____3520 with
                                         | (g2,p2,uu____3549) -> (g2, p2))) g
-                              tysVarPats
-                             in
+                              tysVarPats in
                           (match uu____3465 with
                            | (g1,tyMLPats) ->
                                let uu____3610 =
@@ -1245,20 +1140,17 @@ let rec (extract_one_pat :
                                                        hd1))
                                               | uu____3828 ->
                                                   (FStar_Pervasives_Native.None,
-                                                    FStar_Pervasives_Native.None)
-                                               in
+                                                    FStar_Pervasives_Native.None) in
                                             (match uu____3768 with
                                              | (f_ty_opt2,expected_ty) ->
                                                  let uu____3899 =
                                                    extract_one_pat false g2
                                                      p1 expected_ty
-                                                     term_as_mlexpr
-                                                    in
+                                                     term_as_mlexpr in
                                                  (match uu____3899 with
                                                   | (g3,p2,uu____3940) ->
                                                       ((g3, f_ty_opt2), p2))))
-                                   (g1, f_ty_opt) restPats
-                                  in
+                                   (g1, f_ty_opt) restPats in
                                (match uu____3610 with
                                 | ((g2,f_ty_opt1),restMLPats) ->
                                     let uu____4058 =
@@ -1271,38 +1163,32 @@ let rec (extract_one_pat :
                                                 match uu___62_4120 with
                                                 | FStar_Pervasives_Native.Some
                                                     x -> [x]
-                                                | uu____4162 -> []))
-                                         in
+                                                | uu____4162 -> [])) in
                                       FStar_All.pipe_right uu____4069
-                                        FStar_List.split
-                                       in
+                                        FStar_List.split in
                                     (match uu____4058 with
                                      | (mlPats,when_clauses) ->
                                          let pat_ty_compat =
                                            match f_ty_opt1 with
                                            | FStar_Pervasives_Native.Some
                                                ([],t) -> ok t
-                                           | uu____4235 -> false  in
+                                           | uu____4235 -> false in
                                          let uu____4244 =
                                            let uu____4253 =
                                              let uu____4260 =
                                                resugar_pat
                                                  f.FStar_Syntax_Syntax.fv_qual
                                                  (FStar_Extraction_ML_Syntax.MLP_CTor
-                                                    (d, mlPats))
-                                                in
+                                                    (d, mlPats)) in
                                              let uu____4263 =
                                                FStar_All.pipe_right
                                                  when_clauses
-                                                 FStar_List.flatten
-                                                in
-                                             (uu____4260, uu____4263)  in
+                                                 FStar_List.flatten in
+                                             (uu____4260, uu____4263) in
                                            FStar_Pervasives_Native.Some
-                                             uu____4253
-                                            in
+                                             uu____4253 in
                                          (g2, uu____4244, pat_ty_compat))))))
-  
-let (extract_pat :
+let extract_pat:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.pat ->
       FStar_Extraction_ML_Syntax.mlty ->
@@ -1317,7 +1203,7 @@ let (extract_pat :
                                             FStar_Pervasives_Native.option)
                                           FStar_Pervasives_Native.tuple2
                                           Prims.list,Prims.bool)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun g  ->
     fun p  ->
@@ -1325,36 +1211,31 @@ let (extract_pat :
         fun term_as_mlexpr  ->
           let extract_one_pat1 g1 p1 expected_t1 =
             let uu____4376 =
-              extract_one_pat false g1 p1 expected_t1 term_as_mlexpr  in
+              extract_one_pat false g1 p1 expected_t1 term_as_mlexpr in
             match uu____4376 with
             | (g2,FStar_Pervasives_Native.Some (x,v1),b) -> (g2, (x, v1), b)
             | uu____4433 ->
-                failwith "Impossible: Unable to translate pattern"
-             in
+                failwith "Impossible: Unable to translate pattern" in
           let mk_when_clause whens =
             match whens with
             | [] -> FStar_Pervasives_Native.None
             | hd1::tl1 ->
                 let uu____4476 =
                   FStar_List.fold_left FStar_Extraction_ML_Util.conjoin hd1
-                    tl1
-                   in
-                FStar_Pervasives_Native.Some uu____4476
-             in
+                    tl1 in
+                FStar_Pervasives_Native.Some uu____4476 in
           let uu____4477 =
-            extract_one_pat1 g p (FStar_Pervasives_Native.Some expected_t)
-             in
+            extract_one_pat1 g p (FStar_Pervasives_Native.Some expected_t) in
           match uu____4477 with
           | (g1,(p1,whens),b) ->
-              let when_clause = mk_when_clause whens  in
+              let when_clause = mk_when_clause whens in
               (g1, [(p1, when_clause)], b)
-  
-let (maybe_eta_data_and_project_record :
+let maybe_eta_data_and_project_record:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option ->
       FStar_Extraction_ML_Syntax.mlty ->
         FStar_Extraction_ML_Syntax.mlexpr ->
-          FStar_Extraction_ML_Syntax.mlexpr)
+          FStar_Extraction_ML_Syntax.mlexpr
   =
   fun g  ->
     fun qual  ->
@@ -1363,45 +1244,42 @@ let (maybe_eta_data_and_project_record :
           let rec eta_args more_args t =
             match t with
             | FStar_Extraction_ML_Syntax.MLTY_Fun (t0,uu____4615,t1) ->
-                let x = FStar_Extraction_ML_Syntax.gensym ()  in
+                let x = FStar_Extraction_ML_Syntax.gensym () in
                 let uu____4618 =
                   let uu____4629 =
                     let uu____4638 =
                       FStar_All.pipe_left
                         (FStar_Extraction_ML_Syntax.with_ty t0)
-                        (FStar_Extraction_ML_Syntax.MLE_Var x)
-                       in
-                    ((x, t0), uu____4638)  in
-                  uu____4629 :: more_args  in
+                        (FStar_Extraction_ML_Syntax.MLE_Var x) in
+                    ((x, t0), uu____4638) in
+                  uu____4629 :: more_args in
                 eta_args uu____4618 t1
             | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4651,uu____4652)
                 -> ((FStar_List.rev more_args), t)
-            | uu____4675 -> failwith "Impossible: Head type is not an arrow"
-             in
+            | uu____4675 -> failwith "Impossible: Head type is not an arrow" in
           let as_record qual1 e =
             match ((e.FStar_Extraction_ML_Syntax.expr), qual1) with
             | (FStar_Extraction_ML_Syntax.MLE_CTor
                (uu____4703,args),FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Record_ctor (tyname,fields))) ->
                 let path =
-                  FStar_List.map FStar_Ident.text_of_id tyname.FStar_Ident.ns
-                   in
-                let fields1 = record_fields fields args  in
+                  FStar_List.map FStar_Ident.text_of_id tyname.FStar_Ident.ns in
+                let fields1 = record_fields fields args in
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      e.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_Record (path, fields1))
-            | uu____4735 -> e  in
+            | uu____4735 -> e in
           let resugar_and_maybe_eta qual1 e =
-            let uu____4753 = eta_args [] residualType  in
+            let uu____4753 = eta_args [] residualType in
             match uu____4753 with
             | (eargs,tres) ->
                 (match eargs with
                  | [] ->
-                     let uu____4806 = as_record qual1 e  in
+                     let uu____4806 = as_record qual1 e in
                      FStar_Extraction_ML_Util.resugar_exp uu____4806
                  | uu____4807 ->
-                     let uu____4818 = FStar_List.unzip eargs  in
+                     let uu____4818 = FStar_List.unzip eargs in
                      (match uu____4818 with
                       | (binders,eargs1) ->
                           (match e.FStar_Extraction_ML_Syntax.expr with
@@ -1415,23 +1293,19 @@ let (maybe_eta_data_and_project_record :
                                           tres)
                                        (FStar_Extraction_ML_Syntax.MLE_CTor
                                           (head1,
-                                            (FStar_List.append args eargs1)))
-                                      in
+                                            (FStar_List.append args eargs1))) in
                                    FStar_All.pipe_left (as_record qual1)
-                                     uu____4861
-                                    in
+                                     uu____4861 in
                                  FStar_All.pipe_left
                                    FStar_Extraction_ML_Util.resugar_exp
-                                   uu____4860
-                                  in
+                                   uu____4860 in
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     e.FStar_Extraction_ML_Syntax.mlty)
                                  (FStar_Extraction_ML_Syntax.MLE_Fun
                                     (binders, body))
                            | uu____4870 ->
-                               failwith "Impossible: Not a constructor")))
-             in
+                               failwith "Impossible: Not a constructor"))) in
           match ((mlAppExpr.FStar_Extraction_ML_Syntax.expr), qual) with
           | (uu____4873,FStar_Pervasives_Native.None ) -> mlAppExpr
           | (FStar_Extraction_ML_Syntax.MLE_App
@@ -1443,10 +1317,9 @@ let (maybe_eta_data_and_project_record :
              (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
               let f1 =
                 FStar_Ident.lid_of_ids
-                  (FStar_List.append constrname.FStar_Ident.ns [f])
-                 in
-              let fn = FStar_Extraction_ML_Util.mlpath_of_lid f1  in
-              let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn)  in
+                  (FStar_List.append constrname.FStar_Ident.ns [f]) in
+              let fn = FStar_Extraction_ML_Util.mlpath_of_lid f1 in
+              let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn) in
               let e =
                 match args with
                 | [] -> proj
@@ -1455,11 +1328,9 @@ let (maybe_eta_data_and_project_record :
                       let uu____4915 =
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top) proj
-                         in
-                      (uu____4915, args)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____4908
-                 in
+                             FStar_Extraction_ML_Syntax.MLTY_Top) proj in
+                      (uu____4915, args) in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____4908 in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
           | (FStar_Extraction_ML_Syntax.MLE_App
@@ -1476,10 +1347,9 @@ let (maybe_eta_data_and_project_record :
              (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
               let f1 =
                 FStar_Ident.lid_of_ids
-                  (FStar_List.append constrname.FStar_Ident.ns [f])
-                 in
-              let fn = FStar_Extraction_ML_Util.mlpath_of_lid f1  in
-              let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn)  in
+                  (FStar_List.append constrname.FStar_Ident.ns [f]) in
+              let fn = FStar_Extraction_ML_Util.mlpath_of_lid f1 in
+              let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn) in
               let e =
                 match args with
                 | [] -> proj
@@ -1488,11 +1358,9 @@ let (maybe_eta_data_and_project_record :
                       let uu____4964 =
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top) proj
-                         in
-                      (uu____4964, args)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____4957
-                 in
+                             FStar_Extraction_ML_Syntax.MLTY_Top) proj in
+                      (uu____4964, args) in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____4957 in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
           | (FStar_Extraction_ML_Syntax.MLE_App
@@ -1506,8 +1374,7 @@ let (maybe_eta_data_and_project_record :
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
-                 in
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
               FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____4977
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
@@ -1520,8 +1387,7 @@ let (maybe_eta_data_and_project_record :
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
-                 in
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
               FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____4997
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
@@ -1539,8 +1405,7 @@ let (maybe_eta_data_and_project_record :
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
-                 in
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
               FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____5017
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
@@ -1558,8 +1423,7 @@ let (maybe_eta_data_and_project_record :
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
-                 in
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
               FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____5044
           | (FStar_Extraction_ML_Syntax.MLE_Name
              mlp,FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor
@@ -1568,8 +1432,7 @@ let (maybe_eta_data_and_project_record :
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
-                 in
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
               FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____5050
           | (FStar_Extraction_ML_Syntax.MLE_Name
              mlp,FStar_Pervasives_Native.Some
@@ -1578,8 +1441,7 @@ let (maybe_eta_data_and_project_record :
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
-                 in
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
               FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____5063
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
@@ -1592,8 +1454,7 @@ let (maybe_eta_data_and_project_record :
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
-                 in
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
               FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____5076
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
@@ -1606,15 +1467,13 @@ let (maybe_eta_data_and_project_record :
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
-                 in
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
               FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____5096
           | uu____5099 -> mlAppExpr
-  
-let (maybe_downgrade_eff :
+let maybe_downgrade_eff:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Extraction_ML_Syntax.e_tag ->
-      FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.e_tag)
+      FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.e_tag
   =
   fun g  ->
     fun f  ->
@@ -1622,8 +1481,7 @@ let (maybe_downgrade_eff :
         let rec non_informative1 t1 =
           let uu____5119 =
             (type_leq g t1 FStar_Extraction_ML_Syntax.ml_unit_ty) ||
-              (erasableType g t1)
-             in
+              (erasableType g t1) in
           if uu____5119
           then true
           else
@@ -1634,86 +1492,77 @@ let (maybe_downgrade_eff :
              | FStar_Extraction_ML_Syntax.MLTY_Fun
                  (uu____5123,FStar_Extraction_ML_Syntax.E_GHOST ,t2) ->
                  non_informative1 t2
-             | uu____5125 -> false)
-           in
+             | uu____5125 -> false) in
         let uu____5126 =
-          (f = FStar_Extraction_ML_Syntax.E_GHOST) && (non_informative1 t)
-           in
+          (f = FStar_Extraction_ML_Syntax.E_GHOST) && (non_informative1 t) in
         if uu____5126 then FStar_Extraction_ML_Syntax.E_PURE else f
-  
-let rec (term_as_mlexpr :
+let rec term_as_mlexpr:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Extraction_ML_Syntax.mlexpr,FStar_Extraction_ML_Syntax.e_tag,
-        FStar_Extraction_ML_Syntax.mlty) FStar_Pervasives_Native.tuple3)
+        FStar_Extraction_ML_Syntax.mlty) FStar_Pervasives_Native.tuple3
   =
   fun g  ->
     fun t  ->
-      let uu____5180 = term_as_mlexpr' g t  in
+      let uu____5180 = term_as_mlexpr' g t in
       match uu____5180 with
       | (e,tag,ty) ->
-          let tag1 = maybe_downgrade_eff g tag ty  in
+          let tag1 = maybe_downgrade_eff g tag ty in
           (FStar_Extraction_ML_UEnv.debug g
              (fun u  ->
                 let uu____5201 =
-                  let uu____5202 = FStar_Syntax_Print.tag_of_term t  in
-                  let uu____5203 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____5202 = FStar_Syntax_Print.tag_of_term t in
+                  let uu____5203 = FStar_Syntax_Print.term_to_string t in
                   let uu____5204 =
                     FStar_Extraction_ML_Code.string_of_mlty
-                      g.FStar_Extraction_ML_UEnv.currentModule ty
-                     in
+                      g.FStar_Extraction_ML_UEnv.currentModule ty in
                   FStar_Util.format4
                     "term_as_mlexpr (%s) :  %s has ML type %s and effect %s\n"
                     uu____5202 uu____5203 uu____5204
-                    (FStar_Extraction_ML_Util.eff_to_string tag1)
-                   in
+                    (FStar_Extraction_ML_Util.eff_to_string tag1) in
                 FStar_Util.print_string uu____5201);
            erase g e ty tag1)
-
-and (check_term_as_mlexpr :
+and check_term_as_mlexpr:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Extraction_ML_Syntax.e_tag ->
         FStar_Extraction_ML_Syntax.mlty ->
           (FStar_Extraction_ML_Syntax.mlexpr,FStar_Extraction_ML_Syntax.mlty)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun t  ->
       fun f  ->
         fun ty  ->
-          let uu____5213 = check_term_as_mlexpr' g t f ty  in
+          let uu____5213 = check_term_as_mlexpr' g t f ty in
           match uu____5213 with
           | (e,t1) ->
-              let uu____5224 = erase g e t1 f  in
+              let uu____5224 = erase g e t1 f in
               (match uu____5224 with | (r,uu____5236,t2) -> (r, t2))
-
-and (check_term_as_mlexpr' :
+and check_term_as_mlexpr':
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Extraction_ML_Syntax.e_tag ->
         FStar_Extraction_ML_Syntax.mlty ->
           (FStar_Extraction_ML_Syntax.mlexpr,FStar_Extraction_ML_Syntax.mlty)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun e0  ->
       fun f  ->
         fun ty  ->
-          let uu____5246 = term_as_mlexpr g e0  in
+          let uu____5246 = term_as_mlexpr g e0 in
           match uu____5246 with
           | (e,tag,t) ->
-              let tag1 = maybe_downgrade_eff g tag t  in
+              let tag1 = maybe_downgrade_eff g tag t in
               if FStar_Extraction_ML_Util.eff_leq tag1 f
-              then
-                let uu____5265 = maybe_coerce g e t ty  in (uu____5265, ty)
+              then let uu____5265 = maybe_coerce g e t ty in (uu____5265, ty)
               else err_unexpected_eff e0 f tag1
-
-and (term_as_mlexpr' :
+and term_as_mlexpr':
   FStar_Extraction_ML_UEnv.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Extraction_ML_Syntax.mlexpr,FStar_Extraction_ML_Syntax.e_tag,
-        FStar_Extraction_ML_Syntax.mlty) FStar_Pervasives_Native.tuple3)
+        FStar_Extraction_ML_Syntax.mlty) FStar_Pervasives_Native.tuple3
   =
   fun g  ->
     fun top  ->
@@ -1721,38 +1570,33 @@ and (term_as_mlexpr' :
         (fun u  ->
            let uu____5283 =
              let uu____5284 =
-               FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos  in
-             let uu____5285 = FStar_Syntax_Print.tag_of_term top  in
-             let uu____5286 = FStar_Syntax_Print.term_to_string top  in
+               FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos in
+             let uu____5285 = FStar_Syntax_Print.tag_of_term top in
+             let uu____5286 = FStar_Syntax_Print.term_to_string top in
              FStar_Util.format3 "%s: term_as_mlexpr' (%s) :  %s \n"
-               uu____5284 uu____5285 uu____5286
-              in
+               uu____5284 uu____5285 uu____5286 in
            FStar_Util.print_string uu____5283);
-      (let t = FStar_Syntax_Subst.compress top  in
+      (let t = FStar_Syntax_Subst.compress top in
        match t.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Tm_unknown  ->
            let uu____5294 =
-             let uu____5295 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____5295
-              in
+             let uu____5295 = FStar_Syntax_Print.tag_of_term t in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____5295 in
            failwith uu____5294
        | FStar_Syntax_Syntax.Tm_delayed uu____5302 ->
            let uu____5327 =
-             let uu____5328 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____5328
-              in
+             let uu____5328 = FStar_Syntax_Print.tag_of_term t in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____5328 in
            failwith uu____5327
        | FStar_Syntax_Syntax.Tm_uvar uu____5335 ->
            let uu____5352 =
-             let uu____5353 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____5353
-              in
+             let uu____5353 = FStar_Syntax_Print.tag_of_term t in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____5353 in
            failwith uu____5352
        | FStar_Syntax_Syntax.Tm_bvar uu____5360 ->
            let uu____5361 =
-             let uu____5362 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____5362
-              in
+             let uu____5362 = FStar_Syntax_Print.tag_of_term t in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____5362 in
            failwith uu____5361
        | FStar_Syntax_Syntax.Tm_type uu____5369 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
@@ -1775,24 +1619,22 @@ and (term_as_mlexpr' :
                "let-mutable no longer supported")
        | FStar_Syntax_Syntax.Tm_meta
            (t1,FStar_Syntax_Syntax.Meta_monadic (m,uu____5403)) ->
-           let t2 = FStar_Syntax_Subst.compress t1  in
+           let t2 = FStar_Syntax_Subst.compress t1 in
            (match t2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) when
                 FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname ->
                 let uu____5433 =
                   let uu____5440 =
                     FStar_TypeChecker_Env.effect_decl_opt
-                      g.FStar_Extraction_ML_UEnv.tcenv m
-                     in
-                  FStar_Util.must uu____5440  in
+                      g.FStar_Extraction_ML_UEnv.tcenv m in
+                  FStar_Util.must uu____5440 in
                 (match uu____5433 with
                  | (ed,qualifiers) ->
                      let uu____5467 =
                        let uu____5468 =
                          FStar_All.pipe_right qualifiers
-                           (FStar_List.contains FStar_Syntax_Syntax.Reifiable)
-                          in
-                       FStar_All.pipe_right uu____5468 Prims.op_Negation  in
+                           (FStar_List.contains FStar_Syntax_Syntax.Reifiable) in
+                       FStar_All.pipe_right uu____5468 Prims.op_Negation in
                      if uu____5467
                      then term_as_mlexpr' g t2
                      else
@@ -1804,27 +1646,25 @@ and (term_as_mlexpr' :
        | FStar_Syntax_Syntax.Tm_constant c ->
            let uu____5498 =
              FStar_TypeChecker_TcTerm.type_of_tot_term
-               g.FStar_Extraction_ML_UEnv.tcenv t
-              in
+               g.FStar_Extraction_ML_UEnv.tcenv t in
            (match uu____5498 with
             | (uu____5511,ty,uu____5513) ->
-                let ml_ty = term_as_mlty g ty  in
+                let ml_ty = term_as_mlty g ty in
                 let uu____5515 =
                   let uu____5516 =
                     FStar_Extraction_ML_Util.mlexpr_of_const
-                      t.FStar_Syntax_Syntax.pos c
-                     in
-                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____5516  in
+                      t.FStar_Syntax_Syntax.pos c in
+                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____5516 in
                 (uu____5515, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
        | FStar_Syntax_Syntax.Tm_name uu____5517 ->
-           let uu____5518 = is_type g t  in
+           let uu____5518 = is_type g t in
            if uu____5518
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____5526 = FStar_Extraction_ML_UEnv.lookup_term g t  in
+             (let uu____5526 = FStar_Extraction_ML_UEnv.lookup_term g t in
               match uu____5526 with
               | (FStar_Util.Inl uu____5539,uu____5540) ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
@@ -1838,18 +1678,18 @@ and (term_as_mlexpr' :
                          FStar_Extraction_ML_Syntax.E_PURE, t1)
                    | ([],t1) ->
                        let uu____5626 =
-                         maybe_eta_data_and_project_record g qual t1 x  in
+                         maybe_eta_data_and_project_record g qual t1 x in
                        (uu____5626, FStar_Extraction_ML_Syntax.E_PURE, t1)
                    | uu____5627 -> err_uninst g t mltys t))
        | FStar_Syntax_Syntax.Tm_fvar uu____5634 ->
-           let uu____5635 = is_type g t  in
+           let uu____5635 = is_type g t in
            if uu____5635
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____5643 = FStar_Extraction_ML_UEnv.lookup_term g t  in
+             (let uu____5643 = FStar_Extraction_ML_UEnv.lookup_term g t in
               match uu____5643 with
               | (FStar_Util.Inl uu____5656,uu____5657) ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
@@ -1863,14 +1703,14 @@ and (term_as_mlexpr' :
                          FStar_Extraction_ML_Syntax.E_PURE, t1)
                    | ([],t1) ->
                        let uu____5743 =
-                         maybe_eta_data_and_project_record g qual t1 x  in
+                         maybe_eta_data_and_project_record g qual t1 x in
                        (uu____5743, FStar_Extraction_ML_Syntax.E_PURE, t1)
                    | uu____5744 -> err_uninst g t mltys t))
        | FStar_Syntax_Syntax.Tm_abs (bs,body,copt) ->
-           let uu____5774 = FStar_Syntax_Subst.open_term bs body  in
+           let uu____5774 = FStar_Syntax_Subst.open_term bs body in
            (match uu____5774 with
             | (bs1,body1) ->
-                let uu____5787 = binders_as_ml_binders g bs1  in
+                let uu____5787 = binders_as_ml_binders g bs1 in
                 (match uu____5787 with
                  | (ml_bs,env) ->
                      let body2 =
@@ -1878,8 +1718,7 @@ and (term_as_mlexpr' :
                        | FStar_Pervasives_Native.Some c ->
                            let uu____5820 =
                              FStar_TypeChecker_Env.is_reifiable
-                               env.FStar_Extraction_ML_UEnv.tcenv c
-                              in
+                               env.FStar_Extraction_ML_UEnv.tcenv c in
                            if uu____5820
                            then
                              FStar_TypeChecker_Util.reify_body
@@ -1889,13 +1728,11 @@ and (term_as_mlexpr' :
                            (FStar_Extraction_ML_UEnv.debug g
                               (fun uu____5825  ->
                                  let uu____5826 =
-                                   FStar_Syntax_Print.term_to_string body1
-                                    in
+                                   FStar_Syntax_Print.term_to_string body1 in
                                  FStar_Util.print1
                                    "No computation type for: %s\n" uu____5826);
-                            body1)
-                        in
-                     let uu____5827 = term_as_mlexpr env body2  in
+                            body1) in
+                     let uu____5827 = term_as_mlexpr env body2 in
                      (match uu____5827 with
                       | (ml_body,f,t1) ->
                           let uu____5843 =
@@ -1906,16 +1743,14 @@ and (term_as_mlexpr' :
                                    | ((uu____5884,targ),(f1,t2)) ->
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          (FStar_Extraction_ML_Syntax.MLTY_Fun
-                                            (targ, f1, t2)))) ml_bs (f, t1)
-                             in
+                                            (targ, f1, t2)))) ml_bs (f, t1) in
                           (match uu____5843 with
                            | (f1,tfun) ->
                                let uu____5904 =
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty tfun)
                                    (FStar_Extraction_ML_Syntax.MLE_Fun
-                                      (ml_bs, ml_body))
-                                  in
+                                      (ml_bs, ml_body)) in
                                (uu____5904, f1, tfun)))))
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1926,16 +1761,14 @@ and (term_as_mlexpr' :
            ->
            let ty =
              let uu____5944 =
-               FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid  in
-             term_as_mlty g uu____5944  in
+               FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid in
+             term_as_mlty g uu____5944 in
            let uu____5945 =
              let uu____5946 =
                FStar_Extraction_ML_Util.mlexpr_of_range
-                 a1.FStar_Syntax_Syntax.pos
-                in
+                 a1.FStar_Syntax_Syntax.pos in
              FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty ty)
-               uu____5946
-              in
+               uu____5946 in
            (uu____5945, FStar_Extraction_ML_Syntax.E_PURE, ty)
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1955,55 +1788,48 @@ and (term_as_mlexpr' :
        | FStar_Syntax_Syntax.Tm_app (head1,uu____6022::(v1,uu____6024)::[])
            when (FStar_Syntax_Util.is_fstar_tactics_embed head1) && false ->
            let uu____6065 =
-             let uu____6068 = FStar_Syntax_Print.term_to_string v1  in
+             let uu____6068 = FStar_Syntax_Print.term_to_string v1 in
              FStar_Util.format2 "Trying to extract a quotation of %s"
-               uu____6068
-              in
+               uu____6068 in
            let s =
              let uu____6070 =
                let uu____6071 =
                  let uu____6072 =
-                   let uu____6075 = FStar_Util.marshal v1  in
-                   FStar_Util.bytes_of_string uu____6075  in
-                 FStar_Extraction_ML_Syntax.MLC_Bytes uu____6072  in
-               FStar_Extraction_ML_Syntax.MLE_Const uu____6071  in
+                   let uu____6075 = FStar_Util.marshal v1 in
+                   FStar_Util.bytes_of_string uu____6075 in
+                 FStar_Extraction_ML_Syntax.MLC_Bytes uu____6072 in
+               FStar_Extraction_ML_Syntax.MLE_Const uu____6071 in
              FStar_Extraction_ML_Syntax.with_ty
-               FStar_Extraction_ML_Syntax.ml_string_ty uu____6070
-              in
+               FStar_Extraction_ML_Syntax.ml_string_ty uu____6070 in
            let zero1 =
              FStar_Extraction_ML_Syntax.with_ty
                FStar_Extraction_ML_Syntax.ml_int_ty
                (FStar_Extraction_ML_Syntax.MLE_Const
                   (FStar_Extraction_ML_Syntax.MLC_Int
-                     ("0", FStar_Pervasives_Native.None)))
-              in
+                     ("0", FStar_Pervasives_Native.None))) in
            let term_ty =
              let uu____6090 =
                FStar_Syntax_Syntax.fvar
                  FStar_Parser_Const.fstar_syntax_syntax_term
                  FStar_Syntax_Syntax.Delta_constant
-                 FStar_Pervasives_Native.None
-                in
-             term_as_mlty g uu____6090  in
+                 FStar_Pervasives_Native.None in
+             term_as_mlty g uu____6090 in
            let marshal_from_string =
              let string_to_term_ty =
                FStar_Extraction_ML_Syntax.MLTY_Fun
                  (FStar_Extraction_ML_Syntax.ml_string_ty,
-                   FStar_Extraction_ML_Syntax.E_PURE, term_ty)
-                in
+                   FStar_Extraction_ML_Syntax.E_PURE, term_ty) in
              FStar_Extraction_ML_Syntax.with_ty string_to_term_ty
                (FStar_Extraction_ML_Syntax.MLE_Name
-                  (["Marshal"], "from_string"))
-              in
+                  (["Marshal"], "from_string")) in
            let uu____6095 =
              FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty term_ty)
                (FStar_Extraction_ML_Syntax.MLE_App
-                  (marshal_from_string, [s; zero1]))
-              in
+                  (marshal_from_string, [s; zero1])) in
            (uu____6095, FStar_Extraction_ML_Syntax.E_PURE, term_ty)
        | FStar_Syntax_Syntax.Tm_app (head1,uu____6099) when
            ((FStar_Syntax_Util.is_fstar_tactics_embed head1) &&
-              (let uu____6121 = FStar_Options.codegen ()  in
+              (let uu____6121 = FStar_Options.codegen () in
                uu____6121 = (FStar_Pervasives_Native.Some "tactics")))
              &&
              (let uu____6127 =
@@ -2011,10 +1837,9 @@ and (term_as_mlexpr' :
                   let uu____6129 =
                     FStar_All.pipe_right
                       g.FStar_Extraction_ML_UEnv.currentModule
-                      FStar_Extraction_ML_Syntax.string_of_mlpath
-                     in
-                  FStar_All.pipe_right uu____6129 FStar_Ident.lid_of_str  in
-                FStar_Syntax_Util.is_builtin_tactic uu____6128  in
+                      FStar_Extraction_ML_Syntax.string_of_mlpath in
+                  FStar_All.pipe_right uu____6129 FStar_Ident.lid_of_str in
+                FStar_Syntax_Util.is_builtin_tactic uu____6128 in
               Prims.op_Negation uu____6127)
            ->
            FStar_Errors.raise_error
@@ -2031,13 +1856,12 @@ and (term_as_mlexpr' :
                      (fun uu___63_6165  ->
                         match uu___63_6165 with
                         | FStar_Syntax_Syntax.TOTAL  -> true
-                        | uu____6166 -> false)))
-              in
+                        | uu____6166 -> false))) in
            let uu____6167 =
              let uu____6172 =
-               let uu____6173 = FStar_Syntax_Subst.compress head1  in
-               uu____6173.FStar_Syntax_Syntax.n  in
-             ((head1.FStar_Syntax_Syntax.n), uu____6172)  in
+               let uu____6173 = FStar_Syntax_Subst.compress head1 in
+               uu____6173.FStar_Syntax_Syntax.n in
+             ((head1.FStar_Syntax_Syntax.n), uu____6172) in
            (match uu____6167 with
             | (FStar_Syntax_Syntax.Tm_uvar uu____6182,uu____6183) ->
                 let t1 =
@@ -2047,8 +1871,7 @@ and (term_as_mlexpr' :
                     FStar_TypeChecker_Normalize.Zeta;
                     FStar_TypeChecker_Normalize.EraseUniverses;
                     FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                    g.FStar_Extraction_ML_UEnv.tcenv t
-                   in
+                    g.FStar_Extraction_ML_UEnv.tcenv t in
                 term_as_mlexpr' g t1
             | (uu____6201,FStar_Syntax_Syntax.Tm_abs
                (bs,uu____6203,FStar_Pervasives_Native.Some rc)) when
@@ -2060,25 +1883,21 @@ and (term_as_mlexpr' :
                     FStar_TypeChecker_Normalize.Zeta;
                     FStar_TypeChecker_Normalize.EraseUniverses;
                     FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                    g.FStar_Extraction_ML_UEnv.tcenv t
-                   in
+                    g.FStar_Extraction_ML_UEnv.tcenv t in
                 term_as_mlexpr' g t1
             | (uu____6224,FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_reify )) ->
                 let e =
-                  let uu____6226 = FStar_List.hd args  in
+                  let uu____6226 = FStar_List.hd args in
                   FStar_TypeChecker_Util.reify_body_with_arg
-                    g.FStar_Extraction_ML_UEnv.tcenv head1 uu____6226
-                   in
+                    g.FStar_Extraction_ML_UEnv.tcenv head1 uu____6226 in
                 let tm =
                   let uu____6236 =
-                    let uu____6237 = FStar_TypeChecker_Util.remove_reify e
-                       in
-                    let uu____6238 = FStar_List.tl args  in
-                    FStar_Syntax_Syntax.mk_Tm_app uu____6237 uu____6238  in
+                    let uu____6237 = FStar_TypeChecker_Util.remove_reify e in
+                    let uu____6238 = FStar_List.tl args in
+                    FStar_Syntax_Syntax.mk_Tm_app uu____6237 uu____6238 in
                   uu____6236 FStar_Pervasives_Native.None
-                    t.FStar_Syntax_Syntax.pos
-                   in
+                    t.FStar_Syntax_Syntax.pos in
                 term_as_mlexpr' g tm
             | uu____6247 ->
                 let rec extract_app is_data uu____6292 uu____6293 restArgs =
@@ -2098,8 +1917,7 @@ and (term_as_mlexpr' :
                                       ||
                                       (FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.op_Or)
-                                | uu____6405 -> false)
-                              in
+                                | uu____6405 -> false) in
                            let uu____6406 =
                              if evaluation_order_guaranteed
                              then
@@ -2107,8 +1925,7 @@ and (term_as_mlexpr' :
                                  FStar_All.pipe_right
                                    (FStar_List.rev mlargs_f)
                                    (FStar_List.map
-                                      FStar_Pervasives_Native.fst)
-                                  in
+                                      FStar_Pervasives_Native.fst) in
                                ([], uu____6431)
                              else
                                FStar_List.fold_left
@@ -2126,20 +1943,17 @@ and (term_as_mlexpr' :
                                           else
                                             (let x =
                                                FStar_Extraction_ML_Syntax.gensym
-                                                 ()
-                                                in
+                                                 () in
                                              let uu____6589 =
                                                let uu____6592 =
                                                  FStar_All.pipe_left
                                                    (FStar_Extraction_ML_Syntax.with_ty
                                                       arg.FStar_Extraction_ML_Syntax.mlty)
                                                    (FStar_Extraction_ML_Syntax.MLE_Var
-                                                      x)
-                                                  in
-                                               uu____6592 :: out_args  in
+                                                      x) in
+                                               uu____6592 :: out_args in
                                              (((x, arg) :: lbs), uu____6589)))
-                                 ([], []) mlargs_f
-                              in
+                                 ([], []) mlargs_f in
                            (match uu____6406 with
                             | (lbs,mlargs) ->
                                 let app =
@@ -2147,12 +1961,10 @@ and (term_as_mlexpr' :
                                     FStar_All.pipe_left
                                       (FStar_Extraction_ML_Syntax.with_ty t1)
                                       (FStar_Extraction_ML_Syntax.MLE_App
-                                         (mlhead, mlargs))
-                                     in
+                                         (mlhead, mlargs)) in
                                   FStar_All.pipe_left
                                     (maybe_eta_data_and_project_record g
-                                       is_data t1) uu____6642
-                                   in
+                                       is_data t1) uu____6642 in
                                 let l_app =
                                   FStar_List.fold_right
                                     (fun uu____6654  ->
@@ -2180,8 +1992,7 @@ and (term_as_mlexpr' :
                                                          = [];
                                                        FStar_Extraction_ML_Syntax.print_typ
                                                          = true
-                                                     }]) out)) lbs app
-                                   in
+                                                     }]) out)) lbs app in
                                 (l_app, f, t1))
                        | ((arg,uu____6673)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                           (formal_t,f',t2)) when
@@ -2192,9 +2003,8 @@ and (term_as_mlexpr' :
                            let uu____6704 =
                              let uu____6709 =
                                FStar_Extraction_ML_Util.join
-                                 arg.FStar_Syntax_Syntax.pos f f'
-                                in
-                             (uu____6709, t2)  in
+                                 arg.FStar_Syntax_Syntax.pos f f' in
+                             (uu____6709, t2) in
                            extract_app is_data
                              (mlhead,
                                ((FStar_Extraction_ML_Syntax.ml_unit,
@@ -2202,31 +2012,29 @@ and (term_as_mlexpr' :
                                mlargs_f)) uu____6704 rest
                        | ((e0,uu____6721)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                           (tExpected,f',t2)) ->
-                           let r = e0.FStar_Syntax_Syntax.pos  in
-                           let uu____6753 = term_as_mlexpr g e0  in
+                           let r = e0.FStar_Syntax_Syntax.pos in
+                           let uu____6753 = term_as_mlexpr g e0 in
                            (match uu____6753 with
                             | (e01,f0,tInferred) ->
                                 let e02 =
-                                  maybe_coerce g e01 tInferred tExpected  in
+                                  maybe_coerce g e01 tInferred tExpected in
                                 let uu____6770 =
                                   let uu____6775 =
                                     FStar_Extraction_ML_Util.join_l r
-                                      [f; f'; f0]
-                                     in
-                                  (uu____6775, t2)  in
+                                      [f; f'; f0] in
+                                  (uu____6775, t2) in
                                 extract_app is_data
                                   (mlhead, ((e02, f0) :: mlargs_f))
                                   uu____6770 rest)
                        | uu____6786 ->
                            let uu____6799 =
-                             FStar_Extraction_ML_Util.udelta_unfold g t1  in
+                             FStar_Extraction_ML_Util.udelta_unfold g t1 in
                            (match uu____6799 with
                             | FStar_Pervasives_Native.Some t2 ->
                                 extract_app is_data (mlhead, mlargs_f)
                                   (f, t2) restArgs
                             | FStar_Pervasives_Native.None  ->
-                                err_ill_typed_application g top restArgs t1))
-                   in
+                                err_ill_typed_application g top restArgs t1)) in
                 let extract_app_maybe_projector is_data mlhead uu____6856
                   args1 =
                   match uu____6856 with
@@ -2242,26 +2050,24 @@ and (term_as_mlexpr' :
                                 (uu____6968,f',t3)) ->
                                  let uu____7005 =
                                    FStar_Extraction_ML_Util.join
-                                     a0.FStar_Syntax_Syntax.pos f1 f'
-                                    in
+                                     a0.FStar_Syntax_Syntax.pos f1 f' in
                                  remove_implicits args3 uu____7005 t3
-                             | uu____7006 -> (args2, f1, t2)  in
-                           let uu____7031 = remove_implicits args1 f t1  in
+                             | uu____7006 -> (args2, f1, t2) in
+                           let uu____7031 = remove_implicits args1 f t1 in
                            (match uu____7031 with
                             | (args2,f1,t2) ->
                                 extract_app is_data (mlhead, []) (f1, t2)
                                   args2)
                        | uu____7087 ->
-                           extract_app is_data (mlhead, []) (f, t1) args1)
-                   in
-                let uu____7100 = is_type g t  in
+                           extract_app is_data (mlhead, []) (f, t1) args1) in
+                let uu____7100 = is_type g t in
                 if uu____7100
                 then
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
                 else
-                  (let head2 = FStar_Syntax_Util.un_uinst head1  in
+                  (let head2 = FStar_Syntax_Util.un_uinst head1 in
                    match head2.FStar_Syntax_Syntax.n with
                    | FStar_Syntax_Syntax.Tm_fvar fv when
                        (FStar_Syntax_Syntax.fv_eq_lid fv
@@ -2270,9 +2076,8 @@ and (term_as_mlexpr' :
                          (let uu____7117 =
                             let uu____7118 =
                               FStar_Extraction_ML_Syntax.string_of_mlpath
-                                g.FStar_Extraction_ML_UEnv.currentModule
-                               in
-                            uu____7118 = "FStar.Tactics.Builtins"  in
+                                g.FStar_Extraction_ML_UEnv.currentModule in
+                            uu____7118 = "FStar.Tactics.Builtins" in
                           Prims.op_Negation uu____7117)
                        ->
                        (match args with
@@ -2280,33 +2085,33 @@ and (term_as_mlexpr' :
                             term_as_mlexpr g (FStar_Pervasives_Native.fst a)
                         | uu____7159 ->
                             let uu____7168 =
-                              FStar_Syntax_Print.args_to_string args  in
+                              FStar_Syntax_Print.args_to_string args in
                             failwith uu____7168)
                    | FStar_Syntax_Syntax.Tm_name uu____7175 ->
                        let uu____7176 =
                          let uu____7189 =
-                           FStar_Extraction_ML_UEnv.lookup_term g head2  in
+                           FStar_Extraction_ML_UEnv.lookup_term g head2 in
                          match uu____7189 with
                          | (FStar_Util.Inr (uu____7208,x1,x2,x3),q) ->
                              ((x1, x2, x3), q)
-                         | uu____7253 -> failwith "FIXME Ty"  in
+                         | uu____7253 -> failwith "FIXME Ty" in
                        (match uu____7176 with
                         | ((head_ml,(vars,t1),inst_ok),qual) ->
                             let has_typ_apps =
                               match args with
                               | (a,uu____7303)::uu____7304 -> is_type g a
-                              | uu____7323 -> false  in
+                              | uu____7323 -> false in
                             let uu____7332 =
                               match vars with
                               | uu____7361::uu____7362 when
                                   (Prims.op_Negation has_typ_apps) && inst_ok
                                   -> (head_ml, t1, args)
                               | uu____7373 ->
-                                  let n1 = FStar_List.length vars  in
+                                  let n1 = FStar_List.length vars in
                                   if n1 <= (FStar_List.length args)
                                   then
                                     let uu____7401 =
-                                      FStar_Util.first_N n1 args  in
+                                      FStar_Util.first_N n1 args in
                                     (match uu____7401 with
                                      | (prefix1,rest) ->
                                          let prefixAsMLTypes =
@@ -2314,17 +2119,15 @@ and (term_as_mlexpr' :
                                              (fun uu____7490  ->
                                                 match uu____7490 with
                                                 | (x,uu____7496) ->
-                                                    term_as_mlty g x) prefix1
-                                            in
+                                                    term_as_mlty g x) prefix1 in
                                          let t2 =
                                            instantiate (vars, t1)
-                                             prefixAsMLTypes
-                                            in
+                                             prefixAsMLTypes in
                                          let mk_tapp e ty_args =
                                            match ty_args with
                                            | [] -> e
                                            | uu____7509 ->
-                                               let uu___67_7512 = e  in
+                                               let uu___67_7512 = e in
                                                {
                                                  FStar_Extraction_ML_Syntax.expr
                                                    =
@@ -2336,8 +2139,7 @@ and (term_as_mlexpr' :
                                                  FStar_Extraction_ML_Syntax.loc
                                                    =
                                                    (uu___67_7512.FStar_Extraction_ML_Syntax.loc)
-                                               }
-                                            in
+                                               } in
                                          let head3 =
                                            match head_ml.FStar_Extraction_ML_Syntax.expr
                                            with
@@ -2345,8 +2147,7 @@ and (term_as_mlexpr' :
                                                uu____7516 ->
                                                let uu___68_7517 =
                                                  mk_tapp head_ml
-                                                   prefixAsMLTypes
-                                                  in
+                                                   prefixAsMLTypes in
                                                {
                                                  FStar_Extraction_ML_Syntax.expr
                                                    =
@@ -2361,8 +2162,7 @@ and (term_as_mlexpr' :
                                                uu____7518 ->
                                                let uu___68_7519 =
                                                  mk_tapp head_ml
-                                                   prefixAsMLTypes
-                                                  in
+                                                   prefixAsMLTypes in
                                                {
                                                  FStar_Extraction_ML_Syntax.expr
                                                    =
@@ -2389,8 +2189,7 @@ and (term_as_mlexpr' :
                                                  (FStar_Extraction_ML_Syntax.MLE_App
                                                     ((let uu___69_7528 =
                                                         mk_tapp head3
-                                                          prefixAsMLTypes
-                                                         in
+                                                          prefixAsMLTypes in
                                                       {
                                                         FStar_Extraction_ML_Syntax.expr
                                                           =
@@ -2410,19 +2209,16 @@ and (term_as_mlexpr' :
                                                     t2)
                                            | uu____7529 ->
                                                failwith
-                                                 "Impossible: Unexpected head term"
-                                            in
+                                                 "Impossible: Unexpected head term" in
                                          (head3, t2, rest))
-                                  else err_uninst g head2 (vars, t1) top
-                               in
+                                  else err_uninst g head2 (vars, t1) top in
                             (match uu____7332 with
                              | (head_ml1,head_t,args1) ->
                                  (match args1 with
                                   | [] ->
                                       let uu____7590 =
                                         maybe_eta_data_and_project_record g
-                                          qual head_t head_ml1
-                                         in
+                                          qual head_t head_ml1 in
                                       (uu____7590,
                                         FStar_Extraction_ML_Syntax.E_PURE,
                                         head_t)
@@ -2434,28 +2230,28 @@ and (term_as_mlexpr' :
                    | FStar_Syntax_Syntax.Tm_fvar uu____7600 ->
                        let uu____7601 =
                          let uu____7614 =
-                           FStar_Extraction_ML_UEnv.lookup_term g head2  in
+                           FStar_Extraction_ML_UEnv.lookup_term g head2 in
                          match uu____7614 with
                          | (FStar_Util.Inr (uu____7633,x1,x2,x3),q) ->
                              ((x1, x2, x3), q)
-                         | uu____7678 -> failwith "FIXME Ty"  in
+                         | uu____7678 -> failwith "FIXME Ty" in
                        (match uu____7601 with
                         | ((head_ml,(vars,t1),inst_ok),qual) ->
                             let has_typ_apps =
                               match args with
                               | (a,uu____7728)::uu____7729 -> is_type g a
-                              | uu____7748 -> false  in
+                              | uu____7748 -> false in
                             let uu____7757 =
                               match vars with
                               | uu____7786::uu____7787 when
                                   (Prims.op_Negation has_typ_apps) && inst_ok
                                   -> (head_ml, t1, args)
                               | uu____7798 ->
-                                  let n1 = FStar_List.length vars  in
+                                  let n1 = FStar_List.length vars in
                                   if n1 <= (FStar_List.length args)
                                   then
                                     let uu____7826 =
-                                      FStar_Util.first_N n1 args  in
+                                      FStar_Util.first_N n1 args in
                                     (match uu____7826 with
                                      | (prefix1,rest) ->
                                          let prefixAsMLTypes =
@@ -2463,17 +2259,15 @@ and (term_as_mlexpr' :
                                              (fun uu____7915  ->
                                                 match uu____7915 with
                                                 | (x,uu____7921) ->
-                                                    term_as_mlty g x) prefix1
-                                            in
+                                                    term_as_mlty g x) prefix1 in
                                          let t2 =
                                            instantiate (vars, t1)
-                                             prefixAsMLTypes
-                                            in
+                                             prefixAsMLTypes in
                                          let mk_tapp e ty_args =
                                            match ty_args with
                                            | [] -> e
                                            | uu____7934 ->
-                                               let uu___67_7937 = e  in
+                                               let uu___67_7937 = e in
                                                {
                                                  FStar_Extraction_ML_Syntax.expr
                                                    =
@@ -2485,8 +2279,7 @@ and (term_as_mlexpr' :
                                                  FStar_Extraction_ML_Syntax.loc
                                                    =
                                                    (uu___67_7937.FStar_Extraction_ML_Syntax.loc)
-                                               }
-                                            in
+                                               } in
                                          let head3 =
                                            match head_ml.FStar_Extraction_ML_Syntax.expr
                                            with
@@ -2494,8 +2287,7 @@ and (term_as_mlexpr' :
                                                uu____7941 ->
                                                let uu___68_7942 =
                                                  mk_tapp head_ml
-                                                   prefixAsMLTypes
-                                                  in
+                                                   prefixAsMLTypes in
                                                {
                                                  FStar_Extraction_ML_Syntax.expr
                                                    =
@@ -2510,8 +2302,7 @@ and (term_as_mlexpr' :
                                                uu____7943 ->
                                                let uu___68_7944 =
                                                  mk_tapp head_ml
-                                                   prefixAsMLTypes
-                                                  in
+                                                   prefixAsMLTypes in
                                                {
                                                  FStar_Extraction_ML_Syntax.expr
                                                    =
@@ -2538,8 +2329,7 @@ and (term_as_mlexpr' :
                                                  (FStar_Extraction_ML_Syntax.MLE_App
                                                     ((let uu___69_7953 =
                                                         mk_tapp head3
-                                                          prefixAsMLTypes
-                                                         in
+                                                          prefixAsMLTypes in
                                                       {
                                                         FStar_Extraction_ML_Syntax.expr
                                                           =
@@ -2559,19 +2349,16 @@ and (term_as_mlexpr' :
                                                     t2)
                                            | uu____7954 ->
                                                failwith
-                                                 "Impossible: Unexpected head term"
-                                            in
+                                                 "Impossible: Unexpected head term" in
                                          (head3, t2, rest))
-                                  else err_uninst g head2 (vars, t1) top
-                               in
+                                  else err_uninst g head2 (vars, t1) top in
                             (match uu____7757 with
                              | (head_ml1,head_t,args1) ->
                                  (match args1 with
                                   | [] ->
                                       let uu____8015 =
                                         maybe_eta_data_and_project_record g
-                                          qual head_t head_ml1
-                                         in
+                                          qual head_t head_ml1 in
                                       (uu____8015,
                                         FStar_Extraction_ML_Syntax.E_PURE,
                                         head_t)
@@ -2581,7 +2368,7 @@ and (term_as_mlexpr' :
                                         (FStar_Extraction_ML_Syntax.E_PURE,
                                           head_t) args1)))
                    | uu____8025 ->
-                       let uu____8026 = term_as_mlexpr g head2  in
+                       let uu____8026 = term_as_mlexpr g head2 in
                        (match uu____8026 with
                         | (head3,f,t1) ->
                             extract_app_maybe_projector
@@ -2591,32 +2378,31 @@ and (term_as_mlexpr' :
              match tc with
              | FStar_Util.Inl t1 -> term_as_mlty g t1
              | FStar_Util.Inr c ->
-                 term_as_mlty g (FStar_Syntax_Util.comp_result c)
-              in
+                 term_as_mlty g (FStar_Syntax_Util.comp_result c) in
            let f1 =
              match f with
              | FStar_Pervasives_Native.None  ->
                  failwith "Ascription node with an empty effect label"
-             | FStar_Pervasives_Native.Some l -> effect_as_etag g l  in
-           let uu____8111 = check_term_as_mlexpr g e0 f1 t1  in
+             | FStar_Pervasives_Native.Some l -> effect_as_etag g l in
+           let uu____8111 = check_term_as_mlexpr g e0 f1 t1 in
            (match uu____8111 with | (e,t2) -> (e, f1, t2))
        | FStar_Syntax_Syntax.Tm_let ((is_rec,lbs),e') ->
-           let top_level = FStar_Syntax_Syntax.is_top_level lbs  in
+           let top_level = FStar_Syntax_Syntax.is_top_level lbs in
            let uu____8142 =
              if is_rec
              then FStar_Syntax_Subst.open_let_rec lbs e'
              else
-               (let uu____8156 = FStar_Syntax_Syntax.is_top_level lbs  in
+               (let uu____8156 = FStar_Syntax_Syntax.is_top_level lbs in
                 if uu____8156
                 then (lbs, e')
                 else
-                  (let lb = FStar_List.hd lbs  in
+                  (let lb = FStar_List.hd lbs in
                    let x =
                      let uu____8170 =
-                       FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                     FStar_Syntax_Syntax.freshen_bv uu____8170  in
+                       FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
+                     FStar_Syntax_Syntax.freshen_bv uu____8170 in
                    let lb1 =
-                     let uu___70_8172 = lb  in
+                     let uu___70_8172 = lb in
                      {
                        FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                        FStar_Syntax_Syntax.lbunivs =
@@ -2629,13 +2415,11 @@ and (term_as_mlexpr' :
                          (uu___70_8172.FStar_Syntax_Syntax.lbdef);
                        FStar_Syntax_Syntax.lbattrs =
                          (uu___70_8172.FStar_Syntax_Syntax.lbattrs)
-                     }  in
+                     } in
                    let e'1 =
                      FStar_Syntax_Subst.subst
-                       [FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x)] e'
-                      in
-                   ([lb1], e'1)))
-              in
+                       [FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x)] e' in
+                   ([lb1], e'1))) in
            (match uu____8142 with
             | (lbs1,e'1) ->
                 let lbs2 =
@@ -2652,11 +2436,9 @@ and (term_as_mlexpr' :
                                         g.FStar_Extraction_ML_UEnv.currentModule)
                                      [FStar_Pervasives_Native.snd
                                         g.FStar_Extraction_ML_UEnv.currentModule])
-                                  FStar_Range.dummyRange
-                                 in
+                                  FStar_Range.dummyRange in
                               FStar_TypeChecker_Env.set_current_module
-                                g.FStar_Extraction_ML_UEnv.tcenv uu____8204
-                               in
+                                g.FStar_Extraction_ML_UEnv.tcenv uu____8204 in
                             FStar_Extraction_ML_UEnv.debug g
                               (fun uu____8211  ->
                                  FStar_Options.set_option "debug_level"
@@ -2664,7 +2446,7 @@ and (term_as_mlexpr' :
                                       [FStar_Options.String "Norm";
                                       FStar_Options.String "Extraction"]));
                             (let lbdef =
-                               let uu____8215 = FStar_Options.ml_ish ()  in
+                               let uu____8215 = FStar_Options.ml_ish () in
                                if uu____8215
                                then lb.FStar_Syntax_Syntax.lbdef
                                else
@@ -2677,9 +2459,8 @@ and (term_as_mlexpr' :
                                      FStar_TypeChecker_Normalize.Zeta;
                                    FStar_TypeChecker_Normalize.PureSubtermsWithinComputations;
                                    FStar_TypeChecker_Normalize.Primops] tcenv
-                                   lb.FStar_Syntax_Syntax.lbdef
-                                in
-                             let uu___71_8219 = lb  in
+                                   lb.FStar_Syntax_Syntax.lbdef in
+                             let uu___71_8219 = lb in
                              {
                                FStar_Syntax_Syntax.lbname =
                                  (uu___71_8219.FStar_Syntax_Syntax.lbname);
@@ -2693,7 +2474,7 @@ and (term_as_mlexpr' :
                                FStar_Syntax_Syntax.lbattrs =
                                  (uu___71_8219.FStar_Syntax_Syntax.lbattrs)
                              })))
-                  else lbs1  in
+                  else lbs1 in
                 let maybe_generalize uu____8242 =
                   match uu____8242 with
                   | { FStar_Syntax_Syntax.lbname = lbname_;
@@ -2702,24 +2483,23 @@ and (term_as_mlexpr' :
                       FStar_Syntax_Syntax.lbeff = lbeff;
                       FStar_Syntax_Syntax.lbdef = e;
                       FStar_Syntax_Syntax.lbattrs = uu____8266;_} ->
-                      let f_e = effect_as_etag g lbeff  in
-                      let t2 = FStar_Syntax_Subst.compress t1  in
+                      let f_e = effect_as_etag g lbeff in
+                      let t2 = FStar_Syntax_Subst.compress t1 in
                       let no_gen uu____8340 =
-                        let expected_t = term_as_mlty g t2  in
+                        let expected_t = term_as_mlty g t2 in
                         (lbname_, f_e, (t2, ([], ([], expected_t))), false,
-                          e)
-                         in
+                          e) in
                       if Prims.op_Negation top_level
                       then no_gen ()
                       else
                         (match t2.FStar_Syntax_Syntax.n with
                          | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
-                             let uu____8457 = FStar_List.hd bs  in
+                             let uu____8457 = FStar_List.hd bs in
                              FStar_All.pipe_right uu____8457
                                (is_type_binder g)
                              ->
                              let uu____8470 =
-                               FStar_Syntax_Subst.open_comp bs c  in
+                               FStar_Syntax_Subst.open_comp bs c in
                              (match uu____8470 with
                               | (bs1,c1) ->
                                   let uu____8495 =
@@ -2727,9 +2507,8 @@ and (term_as_mlexpr' :
                                       FStar_Util.prefix_until
                                         (fun x  ->
                                            let uu____8538 =
-                                             is_type_binder g x  in
-                                           Prims.op_Negation uu____8538) bs1
-                                       in
+                                             is_type_binder g x in
+                                           Prims.op_Negation uu____8538) bs1 in
                                     match uu____8502 with
                                     | FStar_Pervasives_Native.None  ->
                                         (bs1,
@@ -2738,26 +2517,22 @@ and (term_as_mlexpr' :
                                         (bs2,b,rest) ->
                                         let uu____8626 =
                                           FStar_Syntax_Util.arrow (b :: rest)
-                                            c1
-                                           in
-                                        (bs2, uu____8626)
-                                     in
+                                            c1 in
+                                        (bs2, uu____8626) in
                                   (match uu____8495 with
                                    | (tbinders,tbody) ->
                                        let n_tbinders =
-                                         FStar_List.length tbinders  in
+                                         FStar_List.length tbinders in
                                        let e1 =
-                                         let uu____8671 = normalize_abs e  in
+                                         let uu____8671 = normalize_abs e in
                                          FStar_All.pipe_right uu____8671
-                                           FStar_Syntax_Util.unmeta
-                                          in
+                                           FStar_Syntax_Util.unmeta in
                                        (match e1.FStar_Syntax_Syntax.n with
                                         | FStar_Syntax_Syntax.Tm_abs
                                             (bs2,body,copt) ->
                                             let uu____8713 =
                                               FStar_Syntax_Subst.open_term
-                                                bs2 body
-                                               in
+                                                bs2 body in
                                             (match uu____8713 with
                                              | (bs3,body1) ->
                                                  if
@@ -2766,8 +2541,7 @@ and (term_as_mlexpr' :
                                                  then
                                                    let uu____8766 =
                                                      FStar_Util.first_N
-                                                       n_tbinders bs3
-                                                      in
+                                                       n_tbinders bs3 in
                                                    (match uu____8766 with
                                                     | (targs,rest_args) ->
                                                         let expected_source_ty
@@ -2792,17 +2566,14 @@ and (term_as_mlexpr' :
                                                                     let uu____8891
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
-                                                                    y  in
+                                                                    y in
                                                                     (x,
-                                                                    uu____8891)
-                                                                     in
+                                                                    uu____8891) in
                                                                     FStar_Syntax_Syntax.NT
                                                                     uu____8884)
-                                                              tbinders targs
-                                                             in
+                                                              tbinders targs in
                                                           FStar_Syntax_Subst.subst
-                                                            s tbody
-                                                           in
+                                                            s tbody in
                                                         let env =
                                                           FStar_List.fold_left
                                                             (fun env  ->
@@ -2815,12 +2586,10 @@ and (term_as_mlexpr' :
                                                                     FStar_Extraction_ML_UEnv.extend_ty
                                                                     env a
                                                                     FStar_Pervasives_Native.None)
-                                                            g targs
-                                                           in
+                                                            g targs in
                                                         let expected_t =
                                                           term_as_mlty env
-                                                            expected_source_ty
-                                                           in
+                                                            expected_source_ty in
                                                         let polytype =
                                                           let uu____8917 =
                                                             FStar_All.pipe_right
@@ -2835,11 +2604,9 @@ and (term_as_mlexpr' :
                                                                     (x,uu____8941)
                                                                     ->
                                                                     FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
-                                                                    x))
-                                                             in
+                                                                    x)) in
                                                           (uu____8917,
-                                                            expected_t)
-                                                           in
+                                                            expected_t) in
                                                         let add_unit =
                                                           match rest_args
                                                           with
@@ -2847,29 +2614,26 @@ and (term_as_mlexpr' :
                                                               let uu____8949
                                                                 =
                                                                 is_fstar_value
-                                                                  body1
-                                                                 in
+                                                                  body1 in
                                                               Prims.op_Negation
                                                                 uu____8949
                                                           | uu____8950 ->
-                                                              false
-                                                           in
+                                                              false in
                                                         let rest_args1 =
                                                           if add_unit
                                                           then unit_binder ::
                                                             rest_args
-                                                          else rest_args  in
+                                                          else rest_args in
                                                         let polytype1 =
                                                           if add_unit
                                                           then
                                                             FStar_Extraction_ML_Syntax.push_unit
                                                               polytype
-                                                          else polytype  in
+                                                          else polytype in
                                                         let body2 =
                                                           FStar_Syntax_Util.abs
                                                             rest_args1 body1
-                                                            copt
-                                                           in
+                                                            copt in
                                                         (lbname_, f_e,
                                                           (t2,
                                                             (targs,
@@ -2889,10 +2653,9 @@ and (term_as_mlexpr' :
                                                          FStar_Extraction_ML_UEnv.extend_ty
                                                            env a
                                                            FStar_Pervasives_Native.None)
-                                                g tbinders
-                                               in
+                                                g tbinders in
                                             let expected_t =
-                                              term_as_mlty env tbody  in
+                                              term_as_mlty env tbody in
                                             let polytype =
                                               let uu____9051 =
                                                 FStar_All.pipe_right tbinders
@@ -2901,9 +2664,8 @@ and (term_as_mlexpr' :
                                                         match uu____9063 with
                                                         | (x,uu____9069) ->
                                                             FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
-                                                              x))
-                                                 in
-                                              (uu____9051, expected_t)  in
+                                                              x)) in
+                                              (uu____9051, expected_t) in
                                             let args =
                                               FStar_All.pipe_right tbinders
                                                 (FStar_List.map
@@ -2912,19 +2674,16 @@ and (term_as_mlexpr' :
                                                       | (bv,uu____9091) ->
                                                           let uu____9092 =
                                                             FStar_Syntax_Syntax.bv_to_name
-                                                              bv
-                                                             in
+                                                              bv in
                                                           FStar_All.pipe_right
                                                             uu____9092
-                                                            FStar_Syntax_Syntax.as_arg))
-                                               in
+                                                            FStar_Syntax_Syntax.as_arg)) in
                                             let e2 =
                                               FStar_Syntax_Syntax.mk
                                                 (FStar_Syntax_Syntax.Tm_app
                                                    (e1, args))
                                                 FStar_Pervasives_Native.None
-                                                e1.FStar_Syntax_Syntax.pos
-                                               in
+                                                e1.FStar_Syntax_Syntax.pos in
                                             (lbname_, f_e,
                                               (t2, (tbinders, polytype)),
                                               false, e2)
@@ -2939,10 +2698,9 @@ and (term_as_mlexpr' :
                                                          FStar_Extraction_ML_UEnv.extend_ty
                                                            env a
                                                            FStar_Pervasives_Native.None)
-                                                g tbinders
-                                               in
+                                                g tbinders in
                                             let expected_t =
-                                              term_as_mlty env tbody  in
+                                              term_as_mlty env tbody in
                                             let polytype =
                                               let uu____9160 =
                                                 FStar_All.pipe_right tbinders
@@ -2951,9 +2709,8 @@ and (term_as_mlexpr' :
                                                         match uu____9172 with
                                                         | (x,uu____9178) ->
                                                             FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
-                                                              x))
-                                                 in
-                                              (uu____9160, expected_t)  in
+                                                              x)) in
+                                              (uu____9160, expected_t) in
                                             let args =
                                               FStar_All.pipe_right tbinders
                                                 (FStar_List.map
@@ -2962,19 +2719,16 @@ and (term_as_mlexpr' :
                                                       | (bv,uu____9200) ->
                                                           let uu____9201 =
                                                             FStar_Syntax_Syntax.bv_to_name
-                                                              bv
-                                                             in
+                                                              bv in
                                                           FStar_All.pipe_right
                                                             uu____9201
-                                                            FStar_Syntax_Syntax.as_arg))
-                                               in
+                                                            FStar_Syntax_Syntax.as_arg)) in
                                             let e2 =
                                               FStar_Syntax_Syntax.mk
                                                 (FStar_Syntax_Syntax.Tm_app
                                                    (e1, args))
                                                 FStar_Pervasives_Native.None
-                                                e1.FStar_Syntax_Syntax.pos
-                                               in
+                                                e1.FStar_Syntax_Syntax.pos in
                                             (lbname_, f_e,
                                               (t2, (tbinders, polytype)),
                                               false, e2)
@@ -2989,10 +2743,9 @@ and (term_as_mlexpr' :
                                                          FStar_Extraction_ML_UEnv.extend_ty
                                                            env a
                                                            FStar_Pervasives_Native.None)
-                                                g tbinders
-                                               in
+                                                g tbinders in
                                             let expected_t =
-                                              term_as_mlty env tbody  in
+                                              term_as_mlty env tbody in
                                             let polytype =
                                               let uu____9269 =
                                                 FStar_All.pipe_right tbinders
@@ -3001,9 +2754,8 @@ and (term_as_mlexpr' :
                                                         match uu____9281 with
                                                         | (x,uu____9287) ->
                                                             FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
-                                                              x))
-                                                 in
-                                              (uu____9269, expected_t)  in
+                                                              x)) in
+                                              (uu____9269, expected_t) in
                                             let args =
                                               FStar_All.pipe_right tbinders
                                                 (FStar_List.map
@@ -3012,26 +2764,22 @@ and (term_as_mlexpr' :
                                                       | (bv,uu____9309) ->
                                                           let uu____9310 =
                                                             FStar_Syntax_Syntax.bv_to_name
-                                                              bv
-                                                             in
+                                                              bv in
                                                           FStar_All.pipe_right
                                                             uu____9310
-                                                            FStar_Syntax_Syntax.as_arg))
-                                               in
+                                                            FStar_Syntax_Syntax.as_arg)) in
                                             let e2 =
                                               FStar_Syntax_Syntax.mk
                                                 (FStar_Syntax_Syntax.Tm_app
                                                    (e1, args))
                                                 FStar_Pervasives_Native.None
-                                                e1.FStar_Syntax_Syntax.pos
-                                               in
+                                                e1.FStar_Syntax_Syntax.pos in
                                             (lbname_, f_e,
                                               (t2, (tbinders, polytype)),
                                               false, e2)
                                         | uu____9352 ->
                                             err_value_restriction e1)))
-                         | uu____9371 -> no_gen ())
-                   in
+                         | uu____9371 -> no_gen ()) in
                 let check_lb env uu____9414 =
                   match uu____9414 with
                   | (nm,(lbname,f,(t1,(targs,polytype)),add_unit,e)) ->
@@ -3042,15 +2790,13 @@ and (term_as_mlexpr' :
                                match uu____9549 with
                                | (a,uu____9555) ->
                                    FStar_Extraction_ML_UEnv.extend_ty env1 a
-                                     FStar_Pervasives_Native.None) env targs
-                         in
-                      let expected_t = FStar_Pervasives_Native.snd polytype
-                         in
+                                     FStar_Pervasives_Native.None) env targs in
+                      let expected_t = FStar_Pervasives_Native.snd polytype in
                       let uu____9557 =
-                        check_term_as_mlexpr env1 e f expected_t  in
+                        check_term_as_mlexpr env1 e f expected_t in
                       (match uu____9557 with
                        | (e1,uu____9567) ->
-                           let f1 = maybe_downgrade_eff env1 f expected_t  in
+                           let f1 = maybe_downgrade_eff env1 f expected_t in
                            (f1,
                              {
                                FStar_Extraction_ML_Syntax.mllb_name = nm;
@@ -3061,105 +2807,93 @@ and (term_as_mlexpr' :
                                FStar_Extraction_ML_Syntax.mllb_def = e1;
                                FStar_Extraction_ML_Syntax.mllb_meta = [];
                                FStar_Extraction_ML_Syntax.print_typ = true
-                             }))
-                   in
+                             })) in
                 let lbs3 =
-                  FStar_All.pipe_right lbs2 (FStar_List.map maybe_generalize)
-                   in
+                  FStar_All.pipe_right lbs2 (FStar_List.map maybe_generalize) in
                 let uu____9634 =
                   FStar_List.fold_right
                     (fun lb  ->
                        fun uu____9725  ->
                          match uu____9725 with
                          | (env,lbs4) ->
-                             let uu____9850 = lb  in
+                             let uu____9850 = lb in
                              (match uu____9850 with
                               | (lbname,uu____9898,(t1,(uu____9900,polytype)),add_unit,uu____9903)
                                   ->
                                   let uu____9916 =
                                     FStar_Extraction_ML_UEnv.extend_lb env
-                                      lbname t1 polytype add_unit true
-                                     in
+                                      lbname t1 polytype add_unit true in
                                   (match uu____9916 with
                                    | (env1,nm) -> (env1, ((nm, lb) :: lbs4)))))
-                    lbs3 (g, [])
-                   in
+                    lbs3 (g, []) in
                 (match uu____9634 with
                  | (env_body,lbs4) ->
-                     let env_def = if is_rec then env_body else g  in
+                     let env_def = if is_rec then env_body else g in
                      let lbs5 =
                        FStar_All.pipe_right lbs4
-                         (FStar_List.map (check_lb env_def))
-                        in
-                     let e'_rng = e'1.FStar_Syntax_Syntax.pos  in
-                     let uu____10193 = term_as_mlexpr env_body e'1  in
+                         (FStar_List.map (check_lb env_def)) in
+                     let e'_rng = e'1.FStar_Syntax_Syntax.pos in
+                     let uu____10193 = term_as_mlexpr env_body e'1 in
                      (match uu____10193 with
                       | (e'2,f',t') ->
                           let f =
                             let uu____10210 =
                               let uu____10213 =
                                 FStar_List.map FStar_Pervasives_Native.fst
-                                  lbs5
-                                 in
-                              f' :: uu____10213  in
+                                  lbs5 in
+                              f' :: uu____10213 in
                             FStar_Extraction_ML_Util.join_l e'_rng
-                              uu____10210
-                             in
+                              uu____10210 in
                           let is_rec1 =
                             if is_rec = true
                             then FStar_Extraction_ML_Syntax.Rec
-                            else FStar_Extraction_ML_Syntax.NonRec  in
+                            else FStar_Extraction_ML_Syntax.NonRec in
                           let uu____10222 =
                             let uu____10223 =
                               let uu____10224 =
                                 let uu____10225 =
                                   FStar_List.map FStar_Pervasives_Native.snd
-                                    lbs5
-                                   in
-                                (is_rec1, uu____10225)  in
-                              mk_MLE_Let top_level uu____10224 e'2  in
+                                    lbs5 in
+                                (is_rec1, uu____10225) in
+                              mk_MLE_Let top_level uu____10224 e'2 in
                             let uu____10234 =
                               FStar_Extraction_ML_Util.mlloc_of_range
-                                t.FStar_Syntax_Syntax.pos
-                               in
+                                t.FStar_Syntax_Syntax.pos in
                             FStar_Extraction_ML_Syntax.with_ty_loc t'
-                              uu____10223 uu____10234
-                             in
+                              uu____10223 uu____10234 in
                           (uu____10222, f, t'))))
        | FStar_Syntax_Syntax.Tm_match (scrutinee,pats) ->
-           let uu____10273 = term_as_mlexpr g scrutinee  in
+           let uu____10273 = term_as_mlexpr g scrutinee in
            (match uu____10273 with
             | (e,f_e,t_e) ->
-                let uu____10289 = check_pats_for_ite pats  in
+                let uu____10289 = check_pats_for_ite pats in
                 (match uu____10289 with
                  | (b,then_e,else_e) ->
-                     let no_lift x t1 = x  in
+                     let no_lift x t1 = x in
                      if b
                      then
                        (match (then_e, else_e) with
                         | (FStar_Pervasives_Native.Some
                            then_e1,FStar_Pervasives_Native.Some else_e1) ->
-                            let uu____10346 = term_as_mlexpr g then_e1  in
+                            let uu____10346 = term_as_mlexpr g then_e1 in
                             (match uu____10346 with
                              | (then_mle,f_then,t_then) ->
-                                 let uu____10362 = term_as_mlexpr g else_e1
-                                    in
+                                 let uu____10362 = term_as_mlexpr g else_e1 in
                                  (match uu____10362 with
                                   | (else_mle,f_else,t_else) ->
                                       let uu____10378 =
                                         let uu____10387 =
-                                          type_leq g t_then t_else  in
+                                          type_leq g t_then t_else in
                                         if uu____10387
                                         then (t_else, no_lift)
                                         else
                                           (let uu____10401 =
-                                             type_leq g t_else t_then  in
+                                             type_leq g t_else t_then in
                                            if uu____10401
                                            then (t_then, no_lift)
                                            else
                                              (FStar_Extraction_ML_Syntax.MLTY_Top,
-                                               FStar_Extraction_ML_Syntax.apply_obj_repr))
-                                         in
+                                               FStar_Extraction_ML_Syntax.apply_obj_repr)) in
                                       (match uu____10378 with
                                        | (t_branch,maybe_lift1) ->
                                            let uu____10435 =
@@ -3167,31 +2901,24 @@ and (term_as_mlexpr' :
                                                let uu____10437 =
                                                  let uu____10446 =
                                                    maybe_lift1 then_mle
-                                                     t_then
-                                                    in
+                                                     t_then in
                                                  let uu____10447 =
                                                    let uu____10450 =
                                                      maybe_lift1 else_mle
-                                                       t_else
-                                                      in
+                                                       t_else in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____10450
-                                                    in
+                                                     uu____10450 in
                                                  (e, uu____10446,
-                                                   uu____10447)
-                                                  in
+                                                   uu____10447) in
                                                FStar_Extraction_ML_Syntax.MLE_If
-                                                 uu____10437
-                                                in
+                                                 uu____10437 in
                                              FStar_All.pipe_left
                                                (FStar_Extraction_ML_Syntax.with_ty
-                                                  t_branch) uu____10436
-                                              in
+                                                  t_branch) uu____10436 in
                                            let uu____10453 =
                                              FStar_Extraction_ML_Util.join
                                                then_e1.FStar_Syntax_Syntax.pos
-                                               f_then f_else
-                                              in
+                                               f_then f_else in
                                            (uu____10435, uu____10453,
                                              t_branch))))
                         | uu____10454 ->
@@ -3204,13 +2931,12 @@ and (term_as_mlexpr' :
                                (fun compat  ->
                                   fun br  ->
                                     let uu____10579 =
-                                      FStar_Syntax_Subst.open_branch br  in
+                                      FStar_Syntax_Subst.open_branch br in
                                     match uu____10579 with
                                     | (pat,when_opt,branch1) ->
                                         let uu____10623 =
                                           extract_pat g pat t_e
-                                            term_as_mlexpr
-                                           in
+                                            term_as_mlexpr in
                                         (match uu____10623 with
                                          | (env,p,pat_t_compat) ->
                                              let uu____10681 =
@@ -3222,23 +2948,20 @@ and (term_as_mlexpr' :
                                                | FStar_Pervasives_Native.Some
                                                    w ->
                                                    let uu____10703 =
-                                                     term_as_mlexpr env w  in
+                                                     term_as_mlexpr env w in
                                                    (match uu____10703 with
                                                     | (w1,f_w,t_w) ->
                                                         let w2 =
                                                           maybe_coerce env w1
                                                             t_w
-                                                            FStar_Extraction_ML_Syntax.ml_bool_ty
-                                                           in
+                                                            FStar_Extraction_ML_Syntax.ml_bool_ty in
                                                         ((FStar_Pervasives_Native.Some
-                                                            w2), f_w))
-                                                in
+                                                            w2), f_w)) in
                                              (match uu____10681 with
                                               | (when_opt1,f_when) ->
                                                   let uu____10752 =
                                                     term_as_mlexpr env
-                                                      branch1
-                                                     in
+                                                      branch1 in
                                                   (match uu____10752 with
                                                    | (mlbranch,f_branch,t_branch)
                                                        ->
@@ -3257,24 +2980,20 @@ and (term_as_mlexpr' :
                                                                     =
                                                                     FStar_Extraction_ML_Util.conjoin_opt
                                                                     wopt
-                                                                    when_opt1
-                                                                     in
+                                                                    when_opt1 in
                                                                     (p1,
                                                                     (when_clause,
                                                                     f_when),
                                                                     (mlbranch,
                                                                     f_branch,
-                                                                    t_branch))))
-                                                          in
+                                                                    t_branch)))) in
                                                        ((compat &&
                                                            pat_t_compat),
                                                          uu____10786)))))
-                               true)
-                           in
+                               true) in
                         match uu____10470 with
                         | (pat_t_compat,mlbranches) ->
-                            let mlbranches1 = FStar_List.flatten mlbranches
-                               in
+                            let mlbranches1 = FStar_List.flatten mlbranches in
                             let e1 =
                               if pat_t_compat
                               then e
@@ -3284,13 +3003,11 @@ and (term_as_mlexpr' :
                                       let uu____11029 =
                                         FStar_Extraction_ML_Code.string_of_mlexpr
                                           g.FStar_Extraction_ML_UEnv.currentModule
-                                          e
-                                         in
+                                          e in
                                       let uu____11030 =
                                         FStar_Extraction_ML_Code.string_of_mlty
                                           g.FStar_Extraction_ML_UEnv.currentModule
-                                          t_e
-                                         in
+                                          t_e in
                                       FStar_Util.print2
                                         "Coercing scrutinee %s from type %s because pattern type is incompatible\n"
                                         uu____11029 uu____11030);
@@ -3298,8 +3015,7 @@ and (term_as_mlexpr' :
                                    (FStar_Extraction_ML_Syntax.with_ty t_e)
                                    (FStar_Extraction_ML_Syntax.MLE_Coerce
                                       (e, t_e,
-                                        FStar_Extraction_ML_Syntax.MLTY_Top)))
-                               in
+                                        FStar_Extraction_ML_Syntax.MLTY_Top))) in
                             (match mlbranches1 with
                              | [] ->
                                  let uu____11055 =
@@ -3308,14 +3024,11 @@ and (term_as_mlexpr' :
                                        FStar_Syntax_Syntax.lid_as_fv
                                          FStar_Parser_Const.failwith_lid
                                          FStar_Syntax_Syntax.Delta_constant
-                                         FStar_Pervasives_Native.None
-                                        in
+                                         FStar_Pervasives_Native.None in
                                      FStar_Extraction_ML_UEnv.lookup_fv g
-                                       uu____11081
-                                      in
+                                       uu____11081 in
                                    FStar_All.pipe_left FStar_Util.right
-                                     uu____11064
-                                    in
+                                     uu____11064 in
                                  (match uu____11055 with
                                   | (uu____11124,fw,uu____11126,uu____11127)
                                       ->
@@ -3329,18 +3042,15 @@ and (term_as_mlexpr' :
                                                      FStar_Extraction_ML_Syntax.ml_string_ty)
                                                   (FStar_Extraction_ML_Syntax.MLE_Const
                                                      (FStar_Extraction_ML_Syntax.MLC_String
-                                                        "unreachable"))
-                                                 in
-                                              [uu____11140]  in
-                                            (fw, uu____11137)  in
+                                                        "unreachable")) in
+                                              [uu____11140] in
+                                            (fw, uu____11137) in
                                           FStar_Extraction_ML_Syntax.MLE_App
-                                            uu____11130
-                                           in
+                                            uu____11130 in
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              FStar_Extraction_ML_Syntax.ml_unit_ty)
-                                          uu____11129
-                                         in
+                                          uu____11129 in
                                       (uu____11128,
                                         FStar_Extraction_ML_Syntax.E_PURE,
                                         FStar_Extraction_ML_Syntax.ml_unit_ty))
@@ -3358,8 +3068,7 @@ and (term_as_mlexpr' :
                                               let f1 =
                                                 FStar_Extraction_ML_Util.join
                                                   top.FStar_Syntax_Syntax.pos
-                                                  f f_branch
-                                                 in
+                                                  f f_branch in
                                               let topt1 =
                                                 match topt with
                                                 | FStar_Pervasives_Native.None
@@ -3368,8 +3077,7 @@ and (term_as_mlexpr' :
                                                 | FStar_Pervasives_Native.Some
                                                     t1 ->
                                                     let uu____11363 =
-                                                      type_leq g t1 t_branch
-                                                       in
+                                                      type_leq g t1 t_branch in
                                                     if uu____11363
                                                     then
                                                       FStar_Pervasives_Native.Some
@@ -3377,19 +3085,16 @@ and (term_as_mlexpr' :
                                                     else
                                                       (let uu____11367 =
                                                          type_leq g t_branch
-                                                           t1
-                                                          in
+                                                           t1 in
                                                        if uu____11367
                                                        then
                                                          FStar_Pervasives_Native.Some
                                                            t1
                                                        else
-                                                         FStar_Pervasives_Native.None)
-                                                 in
+                                                         FStar_Pervasives_Native.None) in
                                               (topt1, f1))
                                      ((FStar_Pervasives_Native.Some t_first),
-                                       f_first) rest
-                                    in
+                                       f_first) rest in
                                  (match uu____11205 with
                                   | (topt,f_match) ->
                                       let mlbranches2 =
@@ -3406,30 +3111,25 @@ and (term_as_mlexpr' :
                                                           FStar_Extraction_ML_Syntax.apply_obj_repr
                                                             b1 t1
                                                       | FStar_Pervasives_Native.Some
-                                                          uu____11512 -> b1
-                                                       in
-                                                    (p, wopt, b2)))
-                                         in
+                                                          uu____11512 -> b1 in
+                                                    (p, wopt, b2))) in
                                       let t_match =
                                         match topt with
                                         | FStar_Pervasives_Native.None  ->
                                             FStar_Extraction_ML_Syntax.MLTY_Top
                                         | FStar_Pervasives_Native.Some t1 ->
-                                            t1
-                                         in
+                                            t1 in
                                       let uu____11517 =
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              t_match)
                                           (FStar_Extraction_ML_Syntax.MLE_Match
-                                             (e1, mlbranches2))
-                                         in
+                                             (e1, mlbranches2)) in
                                       (uu____11517, f_match, t_match)))))))
-
-let (ind_discriminator_body :
+let ind_discriminator_body:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Ident.lident ->
-      FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlmodule1)
+      FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlmodule1
   =
   fun env  ->
     fun discName  ->
@@ -3437,16 +3137,14 @@ let (ind_discriminator_body :
         let uu____11537 =
           let uu____11542 =
             FStar_TypeChecker_Env.lookup_lid
-              env.FStar_Extraction_ML_UEnv.tcenv discName
-             in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____11542  in
+              env.FStar_Extraction_ML_UEnv.tcenv discName in
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____11542 in
         match uu____11537 with
         | (uu____11567,fstar_disc_type) ->
             let wildcards =
               let uu____11576 =
-                let uu____11577 = FStar_Syntax_Subst.compress fstar_disc_type
-                   in
-                uu____11577.FStar_Syntax_Syntax.n  in
+                let uu____11577 = FStar_Syntax_Subst.compress fstar_disc_type in
+                uu____11577.FStar_Syntax_Syntax.n in
               match uu____11576 with
               | FStar_Syntax_Syntax.Tm_arrow (binders,uu____11587) ->
                   let uu____11604 =
@@ -3457,18 +3155,16 @@ let (ind_discriminator_body :
                             | (uu____11643,FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Implicit uu____11644)) ->
                                 true
-                            | uu____11647 -> false))
-                     in
+                            | uu____11647 -> false)) in
                   FStar_All.pipe_right uu____11604
                     (FStar_List.map
                        (fun uu____11680  ->
-                          let uu____11687 = fresh "_"  in
+                          let uu____11687 = fresh "_" in
                           (uu____11687, FStar_Extraction_ML_Syntax.MLTY_Top)))
-              | uu____11688 -> failwith "Discriminator must be a function"
-               in
-            let mlid = fresh "_discr_"  in
-            let targ = FStar_Extraction_ML_Syntax.MLTY_Top  in
-            let disc_ty = FStar_Extraction_ML_Syntax.MLTY_Top  in
+              | uu____11688 -> failwith "Discriminator must be a function" in
+            let mlid = fresh "_discr_" in
+            let targ = FStar_Extraction_ML_Syntax.MLTY_Top in
+            let disc_ty = FStar_Extraction_ML_Syntax.MLTY_Top in
             let discrBody =
               let uu____11699 =
                 let uu____11700 =
@@ -3478,31 +3174,25 @@ let (ind_discriminator_body :
                         let uu____11728 =
                           FStar_All.pipe_left
                             (FStar_Extraction_ML_Syntax.with_ty targ)
-                            (FStar_Extraction_ML_Syntax.MLE_Name ([], mlid))
-                           in
+                            (FStar_Extraction_ML_Syntax.MLE_Name ([], mlid)) in
                         let uu____11731 =
                           let uu____11742 =
                             let uu____11751 =
                               let uu____11752 =
                                 let uu____11759 =
                                   FStar_Extraction_ML_Syntax.mlpath_of_lident
-                                    constrName
-                                   in
+                                    constrName in
                                 (uu____11759,
-                                  [FStar_Extraction_ML_Syntax.MLP_Wild])
-                                 in
-                              FStar_Extraction_ML_Syntax.MLP_CTor uu____11752
-                               in
+                                  [FStar_Extraction_ML_Syntax.MLP_Wild]) in
+                              FStar_Extraction_ML_Syntax.MLP_CTor uu____11752 in
                             let uu____11762 =
                               FStar_All.pipe_left
                                 (FStar_Extraction_ML_Syntax.with_ty
                                    FStar_Extraction_ML_Syntax.ml_bool_ty)
                                 (FStar_Extraction_ML_Syntax.MLE_Const
-                                   (FStar_Extraction_ML_Syntax.MLC_Bool true))
-                               in
+                                   (FStar_Extraction_ML_Syntax.MLC_Bool true)) in
                             (uu____11751, FStar_Pervasives_Native.None,
-                              uu____11762)
-                             in
+                              uu____11762) in
                           let uu____11765 =
                             let uu____11776 =
                               let uu____11785 =
@@ -3511,32 +3201,26 @@ let (ind_discriminator_body :
                                      FStar_Extraction_ML_Syntax.ml_bool_ty)
                                   (FStar_Extraction_ML_Syntax.MLE_Const
                                      (FStar_Extraction_ML_Syntax.MLC_Bool
-                                        false))
-                                 in
+                                        false)) in
                               (FStar_Extraction_ML_Syntax.MLP_Wild,
-                                FStar_Pervasives_Native.None, uu____11785)
-                               in
-                            [uu____11776]  in
-                          uu____11742 :: uu____11765  in
-                        (uu____11728, uu____11731)  in
-                      FStar_Extraction_ML_Syntax.MLE_Match uu____11713  in
+                                FStar_Pervasives_Native.None, uu____11785) in
+                            [uu____11776] in
+                          uu____11742 :: uu____11765 in
+                        (uu____11728, uu____11731) in
+                      FStar_Extraction_ML_Syntax.MLE_Match uu____11713 in
                     FStar_All.pipe_left
                       (FStar_Extraction_ML_Syntax.with_ty
-                         FStar_Extraction_ML_Syntax.ml_bool_ty) uu____11712
-                     in
-                  ((FStar_List.append wildcards [(mlid, targ)]), uu____11711)
-                   in
-                FStar_Extraction_ML_Syntax.MLE_Fun uu____11700  in
+                         FStar_Extraction_ML_Syntax.ml_bool_ty) uu____11712 in
+                  ((FStar_List.append wildcards [(mlid, targ)]), uu____11711) in
+                FStar_Extraction_ML_Syntax.MLE_Fun uu____11700 in
               FStar_All.pipe_left
-                (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu____11699
-               in
+                (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu____11699 in
             let uu____11840 =
               let uu____11841 =
                 let uu____11844 =
                   let uu____11845 =
                     FStar_Extraction_ML_UEnv.convIdent
-                      discName.FStar_Ident.ident
-                     in
+                      discName.FStar_Ident.ident in
                   {
                     FStar_Extraction_ML_Syntax.mllb_name = uu____11845;
                     FStar_Extraction_ML_Syntax.mllb_tysc =
@@ -3545,8 +3229,7 @@ let (ind_discriminator_body :
                     FStar_Extraction_ML_Syntax.mllb_def = discrBody;
                     FStar_Extraction_ML_Syntax.mllb_meta = [];
                     FStar_Extraction_ML_Syntax.print_typ = false
-                  }  in
-                [uu____11844]  in
-              (FStar_Extraction_ML_Syntax.NonRec, uu____11841)  in
+                  } in
+                [uu____11844] in
+              (FStar_Extraction_ML_Syntax.NonRec, uu____11841) in
             FStar_Extraction_ML_Syntax.MLM_Let uu____11840
-  

--- a/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
@@ -8,91 +8,83 @@ type ty_or_exp_b =
                                       FStar_Pervasives_Native.tuple4)
     FStar_Util.either[@@deriving show]
 type binding =
-  | Bv of (FStar_Syntax_Syntax.bv,ty_or_exp_b) FStar_Pervasives_Native.tuple2
-  
-  | Fv of (FStar_Syntax_Syntax.fv,ty_or_exp_b) FStar_Pervasives_Native.tuple2 
+  | Bv of (FStar_Syntax_Syntax.bv,ty_or_exp_b)
+  FStar_Pervasives_Native.tuple2
+  | Fv of (FStar_Syntax_Syntax.fv,ty_or_exp_b) FStar_Pervasives_Native.tuple2
 [@@deriving show]
-let (uu___is_Bv : binding -> Prims.bool) =
-  fun projectee  -> match projectee with | Bv _0 -> true | uu____41 -> false 
-let (__proj__Bv__item___0 :
+let uu___is_Bv: binding -> Prims.bool =
+  fun projectee  -> match projectee with | Bv _0 -> true | uu____41 -> false
+let __proj__Bv__item___0:
   binding ->
-    (FStar_Syntax_Syntax.bv,ty_or_exp_b) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Bv _0 -> _0 
-let (uu___is_Fv : binding -> Prims.bool) =
-  fun projectee  -> match projectee with | Fv _0 -> true | uu____69 -> false 
-let (__proj__Fv__item___0 :
+    (FStar_Syntax_Syntax.bv,ty_or_exp_b) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Bv _0 -> _0
+let uu___is_Fv: binding -> Prims.bool =
+  fun projectee  -> match projectee with | Fv _0 -> true | uu____69 -> false
+let __proj__Fv__item___0:
   binding ->
-    (FStar_Syntax_Syntax.fv,ty_or_exp_b) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Fv _0 -> _0 
+    (FStar_Syntax_Syntax.fv,ty_or_exp_b) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Fv _0 -> _0
 type env =
   {
-  tcenv: FStar_TypeChecker_Env.env ;
-  gamma: binding Prims.list ;
+  tcenv: FStar_TypeChecker_Env.env;
+  gamma: binding Prims.list;
   tydefs:
     (FStar_Extraction_ML_Syntax.mlsymbol Prims.list,FStar_Extraction_ML_Syntax.mltydecl)
-      FStar_Pervasives_Native.tuple2 Prims.list
-    ;
-  type_names: FStar_Syntax_Syntax.fv Prims.list ;
-  currentModule: FStar_Extraction_ML_Syntax.mlpath }[@@deriving show]
-let (__proj__Mkenv__item__tcenv : env -> FStar_TypeChecker_Env.env) =
+      FStar_Pervasives_Native.tuple2 Prims.list;
+  type_names: FStar_Syntax_Syntax.fv Prims.list;
+  currentModule: FStar_Extraction_ML_Syntax.mlpath;}[@@deriving show]
+let __proj__Mkenv__item__tcenv: env -> FStar_TypeChecker_Env.env =
   fun projectee  ->
     match projectee with
     | { tcenv = __fname__tcenv; gamma = __fname__gamma;
         tydefs = __fname__tydefs; type_names = __fname__type_names;
         currentModule = __fname__currentModule;_} -> __fname__tcenv
-  
-let (__proj__Mkenv__item__gamma : env -> binding Prims.list) =
+let __proj__Mkenv__item__gamma: env -> binding Prims.list =
   fun projectee  ->
     match projectee with
     | { tcenv = __fname__tcenv; gamma = __fname__gamma;
         tydefs = __fname__tydefs; type_names = __fname__type_names;
         currentModule = __fname__currentModule;_} -> __fname__gamma
-  
-let (__proj__Mkenv__item__tydefs :
+let __proj__Mkenv__item__tydefs:
   env ->
     (FStar_Extraction_ML_Syntax.mlsymbol Prims.list,FStar_Extraction_ML_Syntax.mltydecl)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
     | { tcenv = __fname__tcenv; gamma = __fname__gamma;
         tydefs = __fname__tydefs; type_names = __fname__type_names;
         currentModule = __fname__currentModule;_} -> __fname__tydefs
-  
-let (__proj__Mkenv__item__type_names :
-  env -> FStar_Syntax_Syntax.fv Prims.list) =
+let __proj__Mkenv__item__type_names: env -> FStar_Syntax_Syntax.fv Prims.list
+  =
   fun projectee  ->
     match projectee with
     | { tcenv = __fname__tcenv; gamma = __fname__gamma;
         tydefs = __fname__tydefs; type_names = __fname__type_names;
         currentModule = __fname__currentModule;_} -> __fname__type_names
-  
-let (__proj__Mkenv__item__currentModule :
-  env -> FStar_Extraction_ML_Syntax.mlpath) =
+let __proj__Mkenv__item__currentModule:
+  env -> FStar_Extraction_ML_Syntax.mlpath =
   fun projectee  ->
     match projectee with
     | { tcenv = __fname__tcenv; gamma = __fname__gamma;
         tydefs = __fname__tydefs; type_names = __fname__type_names;
         currentModule = __fname__currentModule;_} -> __fname__currentModule
-  
-let (debug : env -> (Prims.unit -> Prims.unit) -> Prims.unit) =
+let debug: env -> (Prims.unit -> Prims.unit) -> Prims.unit =
   fun g  ->
     fun f  ->
-      let c = FStar_Extraction_ML_Syntax.string_of_mlpath g.currentModule  in
+      let c = FStar_Extraction_ML_Syntax.string_of_mlpath g.currentModule in
       let uu____257 =
-        FStar_Options.debug_at_level c (FStar_Options.Other "Extraction")  in
+        FStar_Options.debug_at_level c (FStar_Options.Other "Extraction") in
       if uu____257 then f () else ()
-  
-let (mkFvvar :
-  FStar_Ident.lident -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.fv) =
+let mkFvvar:
+  FStar_Ident.lident -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.fv =
   fun l  ->
     fun t  ->
       FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant
         FStar_Pervasives_Native.None
-  
-let (erasedContent : FStar_Extraction_ML_Syntax.mlty) =
-  FStar_Extraction_ML_Syntax.ml_unit_ty 
-let (erasableTypeNoDelta : FStar_Extraction_ML_Syntax.mlty -> Prims.bool) =
+let erasedContent: FStar_Extraction_ML_Syntax.mlty =
+  FStar_Extraction_ML_Syntax.ml_unit_ty
+let erasableTypeNoDelta: FStar_Extraction_ML_Syntax.mlty -> Prims.bool =
   fun t  ->
     if t = FStar_Extraction_ML_Syntax.ml_unit_ty
     then true
@@ -102,37 +94,32 @@ let (erasableTypeNoDelta : FStar_Extraction_ML_Syntax.mlty -> Prims.bool) =
            (uu____269,("FStar"::"Ghost"::[],"erased")) -> true
        | FStar_Extraction_ML_Syntax.MLTY_Named
            (uu____282,("FStar"::"Tactics"::"Effect"::[],"tactic")) ->
-           let uu____295 = FStar_Options.codegen ()  in
+           let uu____295 = FStar_Options.codegen () in
            uu____295 <> (FStar_Pervasives_Native.Some "tactics")
        | uu____300 -> false)
-  
-let (unknownType : FStar_Extraction_ML_Syntax.mlty) =
-  FStar_Extraction_ML_Syntax.MLTY_Top 
-let (prependTick : Prims.string -> Prims.string) =
-  fun x  -> if FStar_Util.starts_with x "'" then x else Prims.strcat "'A" x 
-let (removeTick : Prims.string -> Prims.string) =
+let unknownType: FStar_Extraction_ML_Syntax.mlty =
+  FStar_Extraction_ML_Syntax.MLTY_Top
+let prependTick: Prims.string -> Prims.string =
+  fun x  -> if FStar_Util.starts_with x "'" then x else Prims.strcat "'A" x
+let removeTick: Prims.string -> Prims.string =
   fun x  ->
     if FStar_Util.starts_with x "'"
     then FStar_Util.substring_from x (Prims.parse_int "1")
     else x
-  
-let (convRange : FStar_Range.range -> Prims.int) =
-  fun r  -> (Prims.parse_int "0") 
-let (convIdent : FStar_Ident.ident -> FStar_Extraction_ML_Syntax.mlident) =
-  fun id1  -> id1.FStar_Ident.idText 
-let (bv_as_ml_tyvar : FStar_Syntax_Syntax.bv -> Prims.string) =
+let convRange: FStar_Range.range -> Prims.int = fun r  -> Prims.parse_int "0"
+let convIdent: FStar_Ident.ident -> FStar_Extraction_ML_Syntax.mlident =
+  fun id1  -> id1.FStar_Ident.idText
+let bv_as_ml_tyvar: FStar_Syntax_Syntax.bv -> Prims.string =
   fun x  ->
-    let uu____318 = FStar_Extraction_ML_Syntax.bv_as_mlident x  in
+    let uu____318 = FStar_Extraction_ML_Syntax.bv_as_mlident x in
     prependTick uu____318
-  
-let (bv_as_ml_termvar : FStar_Syntax_Syntax.bv -> Prims.string) =
+let bv_as_ml_termvar: FStar_Syntax_Syntax.bv -> Prims.string =
   fun x  ->
-    let uu____322 = FStar_Extraction_ML_Syntax.bv_as_mlident x  in
+    let uu____322 = FStar_Extraction_ML_Syntax.bv_as_mlident x in
     removeTick uu____322
-  
-let rec (lookup_ty_local :
+let rec lookup_ty_local:
   binding Prims.list ->
-    FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty)
+    FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty
   =
   fun gamma  ->
     fun b  ->
@@ -153,8 +140,7 @@ let rec (lookup_ty_local :
           failwith
             (Prims.strcat "extraction: unbound type var "
                (b.FStar_Syntax_Syntax.ppname).FStar_Ident.idText)
-  
-let tyscheme_of_td :
+let tyscheme_of_td:
   'Auu____419 'Auu____420 'Auu____421 'Auu____422 .
     ('Auu____422,'Auu____421,'Auu____420,FStar_Extraction_ML_Syntax.mlidents,
       'Auu____419,FStar_Extraction_ML_Syntax.mltybody
@@ -170,11 +156,10 @@ let tyscheme_of_td :
              (FStar_Extraction_ML_Syntax.MLTD_Abbrev t) ->
              FStar_Pervasives_Native.Some (vars, t)
          | uu____476 -> FStar_Pervasives_Native.None)
-  
-let (lookup_ty_const :
+let lookup_ty_const:
   env ->
     FStar_Extraction_ML_Syntax.mlpath ->
-      FStar_Extraction_ML_Syntax.mltyscheme FStar_Pervasives_Native.option)
+      FStar_Extraction_ML_Syntax.mltyscheme FStar_Pervasives_Native.option
   =
   fun env  ->
     fun uu____486  ->
@@ -188,7 +173,7 @@ let (lookup_ty_const :
                    then
                      FStar_Util.find_map tds
                        (fun td  ->
-                          let uu____534 = td  in
+                          let uu____534 = td in
                           match uu____534 with
                           | (uu____537,n1,uu____539,uu____540,uu____541,uu____542)
                               ->
@@ -196,24 +181,21 @@ let (lookup_ty_const :
                               then tyscheme_of_td td
                               else FStar_Pervasives_Native.None)
                    else FStar_Pervasives_Native.None)
-  
-let (module_name_of_fv : FStar_Syntax_Syntax.fv -> Prims.string Prims.list) =
+let module_name_of_fv: FStar_Syntax_Syntax.fv -> Prims.string Prims.list =
   fun fv  ->
     FStar_All.pipe_right
       ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.ns
       (FStar_List.map (fun i  -> i.FStar_Ident.idText))
-  
-let (maybe_mangle_type_projector :
+let maybe_mangle_type_projector:
   env ->
     FStar_Syntax_Syntax.fv ->
-      FStar_Extraction_ML_Syntax.mlpath FStar_Pervasives_Native.option)
+      FStar_Extraction_ML_Syntax.mlpath FStar_Pervasives_Native.option
   =
   fun env  ->
     fun fv  ->
-      let mname = module_name_of_fv fv  in
+      let mname = module_name_of_fv fv in
       let ty_name =
-        (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.ident).FStar_Ident.idText
-         in
+        (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.ident).FStar_Ident.idText in
       FStar_Util.find_map env.tydefs
         (fun uu____597  ->
            match uu____597 with
@@ -231,16 +213,15 @@ let (maybe_mangle_type_projector :
                              | FStar_Pervasives_Native.None  ->
                                  FStar_Pervasives_Native.Some (m, n1)
                              | FStar_Pervasives_Native.Some mangled ->
-                                 let modul = m  in
+                                 let modul = m in
                                  FStar_Pervasives_Native.Some
                                    (modul, mangled)
                            else FStar_Pervasives_Native.None)
                         else FStar_Pervasives_Native.None))
-  
-let (lookup_tyvar :
-  env -> FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty) =
-  fun g  -> fun bt  -> lookup_ty_local g.gamma bt 
-let (lookup_fv_by_lid : env -> FStar_Ident.lident -> ty_or_exp_b) =
+let lookup_tyvar:
+  env -> FStar_Syntax_Syntax.bv -> FStar_Extraction_ML_Syntax.mlty =
+  fun g  -> fun bt  -> lookup_ty_local g.gamma bt
+let lookup_fv_by_lid: env -> FStar_Ident.lident -> ty_or_exp_b =
   fun g  ->
     fun lid  ->
       let x =
@@ -249,18 +230,15 @@ let (lookup_fv_by_lid : env -> FStar_Ident.lident -> ty_or_exp_b) =
              match uu___55_732 with
              | Fv (fv',x) when FStar_Syntax_Syntax.fv_eq_lid fv' lid ->
                  FStar_Pervasives_Native.Some x
-             | uu____737 -> FStar_Pervasives_Native.None)
-         in
+             | uu____737 -> FStar_Pervasives_Native.None) in
       match x with
       | FStar_Pervasives_Native.None  ->
           let uu____738 =
             FStar_Util.format1 "free Variable %s not found\n"
-              lid.FStar_Ident.nsstr
-             in
+              lid.FStar_Ident.nsstr in
           failwith uu____738
       | FStar_Pervasives_Native.Some y -> y
-  
-let (lookup_fv : env -> FStar_Syntax_Syntax.fv -> ty_or_exp_b) =
+let lookup_fv: env -> FStar_Syntax_Syntax.fv -> ty_or_exp_b =
   fun g  ->
     fun fv  ->
       let x =
@@ -269,26 +247,21 @@ let (lookup_fv : env -> FStar_Syntax_Syntax.fv -> ty_or_exp_b) =
              match uu___56_752 with
              | Fv (fv',t) when FStar_Syntax_Syntax.fv_eq fv fv' ->
                  FStar_Pervasives_Native.Some t
-             | uu____757 -> FStar_Pervasives_Native.None)
-         in
+             | uu____757 -> FStar_Pervasives_Native.None) in
       match x with
       | FStar_Pervasives_Native.None  ->
           let uu____758 =
             let uu____759 =
               FStar_Range.string_of_range
-                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.p
-               in
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.p in
             let uu____760 =
               FStar_Syntax_Print.lid_to_string
-                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-               in
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
             FStar_Util.format2 "(%s) free Variable %s not found\n" uu____759
-              uu____760
-             in
+              uu____760 in
           failwith uu____758
       | FStar_Pervasives_Native.Some y -> y
-  
-let (lookup_bv : env -> FStar_Syntax_Syntax.bv -> ty_or_exp_b) =
+let lookup_bv: env -> FStar_Syntax_Syntax.bv -> ty_or_exp_b =
   fun g  ->
     fun bv  ->
       let x =
@@ -297,43 +270,38 @@ let (lookup_bv : env -> FStar_Syntax_Syntax.bv -> ty_or_exp_b) =
              match uu___57_774 with
              | Bv (bv',r) when FStar_Syntax_Syntax.bv_eq bv bv' ->
                  FStar_Pervasives_Native.Some r
-             | uu____779 -> FStar_Pervasives_Native.None)
-         in
+             | uu____779 -> FStar_Pervasives_Native.None) in
       match x with
       | FStar_Pervasives_Native.None  ->
           let uu____780 =
             let uu____781 =
               FStar_Range.string_of_range
-                (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange
-               in
-            let uu____782 = FStar_Syntax_Print.bv_to_string bv  in
+                (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange in
+            let uu____782 = FStar_Syntax_Print.bv_to_string bv in
             FStar_Util.format2 "(%s) bound Variable %s not found\n" uu____781
-              uu____782
-             in
+              uu____782 in
           failwith uu____780
       | FStar_Pervasives_Native.Some y -> y
-  
-let (lookup :
+let lookup:
   env ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
       (ty_or_exp_b,FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun x  ->
       match x with
       | FStar_Util.Inl x1 ->
-          let uu____811 = lookup_bv g x1  in
+          let uu____811 = lookup_bv g x1 in
           (uu____811, FStar_Pervasives_Native.None)
       | FStar_Util.Inr x1 ->
-          let uu____815 = lookup_fv g x1  in
+          let uu____815 = lookup_fv g x1 in
           (uu____815, (x1.FStar_Syntax_Syntax.fv_qual))
-  
-let (lookup_term :
+let lookup_term:
   env ->
     FStar_Syntax_Syntax.term ->
       (ty_or_exp_b,FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun t  ->
@@ -341,25 +309,24 @@ let (lookup_term :
       | FStar_Syntax_Syntax.Tm_name x -> lookup g (FStar_Util.Inl x)
       | FStar_Syntax_Syntax.Tm_fvar x -> lookup g (FStar_Util.Inr x)
       | uu____838 -> failwith "Impossible: lookup_term for a non-name"
-  
-let (extend_ty :
+let extend_ty:
   env ->
     FStar_Syntax_Syntax.bv ->
-      FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option -> env)
+      FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option -> env
   =
   fun g  ->
     fun a  ->
       fun mapped_to  ->
-        let ml_a = bv_as_ml_tyvar a  in
+        let ml_a = bv_as_ml_tyvar a in
         let mapped_to1 =
           match mapped_to with
           | FStar_Pervasives_Native.None  ->
               FStar_Extraction_ML_Syntax.MLTY_Var ml_a
-          | FStar_Pervasives_Native.Some t -> t  in
+          | FStar_Pervasives_Native.Some t -> t in
         let gamma = (Bv (a, (FStar_Util.Inl (ml_a, mapped_to1)))) ::
-          (g.gamma)  in
-        let tcenv = FStar_TypeChecker_Env.push_bv g.tcenv a  in
-        let uu___59_893 = g  in
+          (g.gamma) in
+        let tcenv = FStar_TypeChecker_Env.push_bv g.tcenv a in
+        let uu___59_893 = g in
         {
           tcenv;
           gamma;
@@ -367,36 +334,31 @@ let (extend_ty :
           type_names = (uu___59_893.type_names);
           currentModule = (uu___59_893.currentModule)
         }
-  
-let (sanitize : Prims.string -> Prims.string) =
+let sanitize: Prims.string -> Prims.string =
   fun s  ->
-    let cs = FStar_String.list_of_string s  in
-    let valid c = ((FStar_Util.is_letter_or_digit c) || (c = 95)) || (c = 39)
-       in
+    let cs = FStar_String.list_of_string s in
+    let valid c = ((FStar_Util.is_letter_or_digit c) || (c = 95)) || (c = 39) in
     let cs' =
       FStar_List.fold_right
         (fun c  ->
            fun cs1  ->
              let uu____919 =
-               let uu____922 = valid c  in
-               if uu____922 then [c] else [95; 95]  in
-             FStar_List.append uu____919 cs1) cs []
-       in
+               let uu____922 = valid c in if uu____922 then [c] else [95; 95] in
+             FStar_List.append uu____919 cs1) cs [] in
     let cs'1 =
       match cs' with
       | c::cs1 when (FStar_Util.is_digit c) || (c = 39) -> 95 :: c :: cs1
-      | uu____945 -> cs  in
+      | uu____945 -> cs in
     FStar_String.string_of_list cs'1
-  
-let (find_uniq : binding Prims.list -> Prims.string -> Prims.string) =
+let find_uniq: binding Prims.list -> Prims.string -> Prims.string =
   fun gamma  ->
     fun mlident  ->
       let rec find_uniq mlident1 i =
         let suffix =
           if i = (Prims.parse_int "0")
           then ""
-          else FStar_Util.string_of_int i  in
-        let target_mlident = Prims.strcat mlident1 suffix  in
+          else FStar_Util.string_of_int i in
+        let target_mlident = Prims.strcat mlident1 suffix in
         let has_collision =
           FStar_List.existsb
             (fun uu___58_973  ->
@@ -412,15 +374,13 @@ let (find_uniq : binding Prims.list -> Prims.string -> Prims.string) =
                | Bv
                    (uu____1069,FStar_Util.Inr
                     (mlident',uu____1071,uu____1072,uu____1073))
-                   -> target_mlident = mlident') gamma
-           in
+                   -> target_mlident = mlident') gamma in
         if has_collision
         then find_uniq mlident1 (i + (Prims.parse_int "1"))
-        else target_mlident  in
-      let mlident1 = sanitize mlident  in
+        else target_mlident in
+      let mlident1 = sanitize mlident in
       find_uniq mlident1 (Prims.parse_int "0")
-  
-let (extend_bv :
+let extend_bv:
   env ->
     FStar_Syntax_Syntax.bv ->
       FStar_Extraction_ML_Syntax.mltyscheme ->
@@ -428,7 +388,7 @@ let (extend_bv :
           Prims.bool ->
             Prims.bool ->
               (env,FStar_Extraction_ML_Syntax.mlident)
-                FStar_Pervasives_Native.tuple2)
+                FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun x  ->
@@ -439,12 +399,11 @@ let (extend_bv :
               let ml_ty =
                 match t_x with
                 | ([],t) -> t
-                | uu____1134 -> FStar_Extraction_ML_Syntax.MLTY_Top  in
+                | uu____1134 -> FStar_Extraction_ML_Syntax.MLTY_Top in
               let mlident =
-                let uu____1136 = FStar_Extraction_ML_Syntax.bv_as_mlident x
-                   in
-                find_uniq g.gamma uu____1136  in
-              let mlx = FStar_Extraction_ML_Syntax.MLE_Var mlident  in
+                let uu____1136 = FStar_Extraction_ML_Syntax.bv_as_mlident x in
+                find_uniq g.gamma uu____1136 in
+              let mlx = FStar_Extraction_ML_Syntax.MLE_Var mlident in
               let mlx1 =
                 if mk_unit
                 then FStar_Extraction_ML_Syntax.ml_unit
@@ -458,19 +417,18 @@ let (extend_bv :
                          ((FStar_Extraction_ML_Syntax.with_ty
                              FStar_Extraction_ML_Syntax.MLTY_Top mlx),
                            [FStar_Extraction_ML_Syntax.ml_unit]))
-                  else FStar_Extraction_ML_Syntax.with_ty ml_ty mlx
-                 in
+                  else FStar_Extraction_ML_Syntax.with_ty ml_ty mlx in
               let t_x1 =
                 if add_unit
                 then FStar_Extraction_ML_Syntax.pop_unit t_x
-                else t_x  in
+                else t_x in
               let gamma =
                 (Bv (x, (FStar_Util.Inr (mlident, mlx1, t_x1, is_rec)))) ::
-                (g.gamma)  in
+                (g.gamma) in
               let tcenv =
-                let uu____1177 = FStar_Syntax_Syntax.binders_of_list [x]  in
-                FStar_TypeChecker_Env.push_binders g.tcenv uu____1177  in
-              ((let uu___60_1179 = g  in
+                let uu____1177 = FStar_Syntax_Syntax.binders_of_list [x] in
+                FStar_TypeChecker_Env.push_binders g.tcenv uu____1177 in
+              ((let uu___60_1179 = g in
                 {
                   tcenv;
                   gamma;
@@ -478,41 +436,36 @@ let (extend_bv :
                   type_names = (uu___60_1179.type_names);
                   currentModule = (uu___60_1179.currentModule)
                 }), mlident)
-  
-let rec (mltyFvars :
+let rec mltyFvars:
   FStar_Extraction_ML_Syntax.mlty ->
-    FStar_Extraction_ML_Syntax.mlident Prims.list)
+    FStar_Extraction_ML_Syntax.mlident Prims.list
   =
   fun t  ->
     match t with
     | FStar_Extraction_ML_Syntax.MLTY_Var x -> [x]
     | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,f,t2) ->
-        let uu____1191 = mltyFvars t1  in
-        let uu____1194 = mltyFvars t2  in
+        let uu____1191 = mltyFvars t1 in
+        let uu____1194 = mltyFvars t2 in
         FStar_List.append uu____1191 uu____1194
     | FStar_Extraction_ML_Syntax.MLTY_Named (args,path) ->
         FStar_List.collect mltyFvars args
     | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
         FStar_List.collect mltyFvars ts
     | FStar_Extraction_ML_Syntax.MLTY_Top  -> []
-  
-let rec (subsetMlidents :
+let rec subsetMlidents:
   FStar_Extraction_ML_Syntax.mlident Prims.list ->
-    FStar_Extraction_ML_Syntax.mlident Prims.list -> Prims.bool)
+    FStar_Extraction_ML_Syntax.mlident Prims.list -> Prims.bool
   =
   fun la  ->
     fun lb  ->
       match la with
       | h::tla -> (FStar_List.contains h lb) && (subsetMlidents tla lb)
       | [] -> true
-  
-let (tySchemeIsClosed : FStar_Extraction_ML_Syntax.mltyscheme -> Prims.bool)
-  =
+let tySchemeIsClosed: FStar_Extraction_ML_Syntax.mltyscheme -> Prims.bool =
   fun tys  ->
-    let uu____1227 = mltyFvars (FStar_Pervasives_Native.snd tys)  in
+    let uu____1227 = mltyFvars (FStar_Pervasives_Native.snd tys) in
     subsetMlidents uu____1227 (FStar_Pervasives_Native.fst tys)
-  
-let (extend_fv' :
+let extend_fv':
   env ->
     FStar_Syntax_Syntax.fv ->
       FStar_Extraction_ML_Syntax.mlpath ->
@@ -520,7 +473,7 @@ let (extend_fv' :
           Prims.bool ->
             Prims.bool ->
               (env,FStar_Extraction_ML_Syntax.mlident)
-                FStar_Pervasives_Native.tuple2)
+                FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun x  ->
@@ -528,24 +481,23 @@ let (extend_fv' :
         fun t_x  ->
           fun add_unit  ->
             fun is_rec  ->
-              let uu____1256 = tySchemeIsClosed t_x  in
+              let uu____1256 = tySchemeIsClosed t_x in
               if uu____1256
               then
                 let ml_ty =
                   match t_x with
                   | ([],t) -> t
-                  | uu____1265 -> FStar_Extraction_ML_Syntax.MLTY_Top  in
+                  | uu____1265 -> FStar_Extraction_ML_Syntax.MLTY_Top in
                 let uu____1266 =
-                  let uu____1277 = y  in
+                  let uu____1277 = y in
                   match uu____1277 with
                   | (ns,i) ->
                       let mlsymbol =
-                        FStar_Extraction_ML_Syntax.avoid_keyword i  in
-                      ((ns, mlsymbol), mlsymbol)
-                   in
+                        FStar_Extraction_ML_Syntax.avoid_keyword i in
+                      ((ns, mlsymbol), mlsymbol) in
                 match uu____1266 with
                 | (mlpath,mlsymbol) ->
-                    let mly = FStar_Extraction_ML_Syntax.MLE_Name mlpath  in
+                    let mly = FStar_Extraction_ML_Syntax.MLE_Name mlpath in
                     let mly1 =
                       if add_unit
                       then
@@ -556,16 +508,16 @@ let (extend_fv' :
                              ((FStar_Extraction_ML_Syntax.with_ty
                                  FStar_Extraction_ML_Syntax.MLTY_Top mly),
                                [FStar_Extraction_ML_Syntax.ml_unit]))
-                      else FStar_Extraction_ML_Syntax.with_ty ml_ty mly  in
+                      else FStar_Extraction_ML_Syntax.with_ty ml_ty mly in
                     let t_x1 =
                       if add_unit
                       then FStar_Extraction_ML_Syntax.pop_unit t_x
-                      else t_x  in
+                      else t_x in
                     let gamma =
                       (Fv
                          (x, (FStar_Util.Inr (mlsymbol, mly1, t_x1, is_rec))))
-                      :: (g.gamma)  in
-                    ((let uu___61_1360 = g  in
+                      :: (g.gamma) in
+                    ((let uu___61_1360 = g in
                       {
                         tcenv = (uu___61_1360.tcenv);
                         gamma;
@@ -574,15 +526,14 @@ let (extend_fv' :
                         currentModule = (uu___61_1360.currentModule)
                       }), mlsymbol)
               else failwith "freevars found"
-  
-let (extend_fv :
+let extend_fv:
   env ->
     FStar_Syntax_Syntax.fv ->
       FStar_Extraction_ML_Syntax.mltyscheme ->
         Prims.bool ->
           Prims.bool ->
             (env,FStar_Extraction_ML_Syntax.mlident)
-              FStar_Pervasives_Native.tuple2)
+              FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun x  ->
@@ -591,11 +542,9 @@ let (extend_fv :
           fun is_rec  ->
             let mlp =
               FStar_Extraction_ML_Syntax.mlpath_of_lident
-                (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-               in
+                (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
             extend_fv' g x mlp t_x add_unit is_rec
-  
-let (extend_lb :
+let extend_lb:
   env ->
     FStar_Syntax_Syntax.lbname ->
       FStar_Syntax_Syntax.typ ->
@@ -603,7 +552,7 @@ let (extend_lb :
           Prims.bool ->
             Prims.bool ->
               (env,FStar_Extraction_ML_Syntax.mlident)
-                FStar_Pervasives_Native.tuple2)
+                FStar_Pervasives_Native.tuple2
   =
   fun g  ->
     fun l  ->
@@ -616,19 +565,17 @@ let (extend_lb :
               | FStar_Util.Inr f ->
                   let uu____1418 =
                     FStar_Extraction_ML_Syntax.mlpath_of_lident
-                      (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                     in
+                      (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                   (match uu____1418 with
                    | (p,y) -> extend_fv' g f (p, y) t_x add_unit is_rec)
-  
-let (extend_tydef :
-  env -> FStar_Syntax_Syntax.fv -> FStar_Extraction_ML_Syntax.mltydecl -> env)
+let extend_tydef:
+  env -> FStar_Syntax_Syntax.fv -> FStar_Extraction_ML_Syntax.mltydecl -> env
   =
   fun g  ->
     fun fv  ->
       fun td  ->
-        let m = module_name_of_fv fv  in
-        let uu___62_1443 = g  in
+        let m = module_name_of_fv fv in
+        let uu___62_1443 = g in
         {
           tcenv = (uu___62_1443.tcenv);
           gamma = (uu___62_1443.gamma);
@@ -636,11 +583,10 @@ let (extend_tydef :
           type_names = (fv :: (g.type_names));
           currentModule = (uu___62_1443.currentModule)
         }
-  
-let (extend_type_name : env -> FStar_Syntax_Syntax.fv -> env) =
+let extend_type_name: env -> FStar_Syntax_Syntax.fv -> env =
   fun g  ->
     fun fv  ->
-      let uu___63_1458 = g  in
+      let uu___63_1458 = g in
       {
         tcenv = (uu___63_1458.tcenv);
         gamma = (uu___63_1458.gamma);
@@ -648,18 +594,16 @@ let (extend_type_name : env -> FStar_Syntax_Syntax.fv -> env) =
         type_names = (fv :: (g.type_names));
         currentModule = (uu___63_1458.currentModule)
       }
-  
-let (is_type_name : env -> FStar_Syntax_Syntax.fv -> Prims.bool) =
+let is_type_name: env -> FStar_Syntax_Syntax.fv -> Prims.bool =
   fun g  ->
     fun fv  ->
       FStar_All.pipe_right g.type_names
         (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq fv))
-  
-let (emptyMlPath :
+let emptyMlPath:
   (FStar_Extraction_ML_Syntax.mlsymbol Prims.list,Prims.string)
-    FStar_Pervasives_Native.tuple2)
-  = ([], "") 
-let (mkContext : FStar_TypeChecker_Env.env -> env) =
+    FStar_Pervasives_Native.tuple2
+  = ([], "")
+let mkContext: FStar_TypeChecker_Env.env -> env =
   fun e  ->
     let env =
       {
@@ -668,59 +612,50 @@ let (mkContext : FStar_TypeChecker_Env.env -> env) =
         tydefs = [];
         type_names = [];
         currentModule = emptyMlPath
-      }  in
-    let a = "'a"  in
+      } in
+    let a = "'a" in
     let failwith_ty =
       ([a],
         (FStar_Extraction_ML_Syntax.MLTY_Fun
            ((FStar_Extraction_ML_Syntax.MLTY_Named
                ([], (["Prims"], "string"))),
              FStar_Extraction_ML_Syntax.E_IMPURE,
-             (FStar_Extraction_ML_Syntax.MLTY_Var a))))
-       in
+             (FStar_Extraction_ML_Syntax.MLTY_Var a)))) in
     let uu____1505 =
       let uu____1510 =
         let uu____1511 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.failwith_lid
-            FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None
-           in
-        FStar_Util.Inr uu____1511  in
+            FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None in
+        FStar_Util.Inr uu____1511 in
       extend_lb env uu____1510 FStar_Syntax_Syntax.tun failwith_ty false
-        false
-       in
+        false in
     FStar_All.pipe_right uu____1505 FStar_Pervasives_Native.fst
-  
-let (monad_op_name :
+let monad_op_name:
   FStar_Syntax_Syntax.eff_decl ->
     Prims.string ->
       (FStar_Extraction_ML_Syntax.mlpath,FStar_Ident.lident)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun ed  ->
     fun nm  ->
       let lid =
         FStar_Syntax_Util.mk_field_projector_name_from_ident
-          ed.FStar_Syntax_Syntax.mname (FStar_Ident.id_of_text nm)
-         in
-      let uu____1527 = FStar_Extraction_ML_Syntax.mlpath_of_lident lid  in
+          ed.FStar_Syntax_Syntax.mname (FStar_Ident.id_of_text nm) in
+      let uu____1527 = FStar_Extraction_ML_Syntax.mlpath_of_lident lid in
       (uu____1527, lid)
-  
-let (action_name :
+let action_name:
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.action ->
       (FStar_Extraction_ML_Syntax.mlpath,FStar_Ident.lident)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun ed  ->
     fun a  ->
       let nm =
-        ((a.FStar_Syntax_Syntax.action_name).FStar_Ident.ident).FStar_Ident.idText
-         in
-      let module_name = (ed.FStar_Syntax_Syntax.mname).FStar_Ident.ns  in
+        ((a.FStar_Syntax_Syntax.action_name).FStar_Ident.ident).FStar_Ident.idText in
+      let module_name = (ed.FStar_Syntax_Syntax.mname).FStar_Ident.ns in
       let lid =
         FStar_Ident.lid_of_ids
-          (FStar_List.append module_name [FStar_Ident.id_of_text nm])
-         in
-      let uu____1543 = FStar_Extraction_ML_Syntax.mlpath_of_lident lid  in
+          (FStar_List.append module_name [FStar_Ident.id_of_text nm]) in
+      let uu____1543 = FStar_Extraction_ML_Syntax.mlpath_of_lident lid in
       (uu____1543, lid)
-  

--- a/src/ocaml-output/FStar_Extraction_ML_Util.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Util.ml
@@ -1,5 +1,5 @@
 open Prims
-let pruneNones :
+let pruneNones:
   'a . 'a FStar_Pervasives_Native.option Prims.list -> 'a Prims.list =
   fun l  ->
     FStar_List.fold_right
@@ -8,14 +8,12 @@ let pruneNones :
            match x with
            | FStar_Pervasives_Native.Some xs -> xs :: ll
            | FStar_Pervasives_Native.None  -> ll) l []
-  
-let (mk_range_mle : FStar_Extraction_ML_Syntax.mlexpr) =
+let mk_range_mle: FStar_Extraction_ML_Syntax.mlexpr =
   FStar_All.pipe_left
     (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
     (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "mk_range"))
-  
-let (mlconst_of_const' :
-  FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant) =
+let mlconst_of_const':
+  FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant =
   fun sctt  ->
     match sctt with
     | FStar_Const.Const_effect  -> failwith "Unsupported constant"
@@ -38,10 +36,9 @@ let (mlconst_of_const' :
         failwith "Unhandled constant: reify/reflect"
     | FStar_Const.Const_reflect uu____71 ->
         failwith "Unhandled constant: reify/reflect"
-  
-let (mlconst_of_const :
+let mlconst_of_const:
   FStar_Range.range ->
-    FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant)
+    FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant
   =
   fun p  ->
     fun c  ->
@@ -49,92 +46,84 @@ let (mlconst_of_const :
       with
       | uu____84 ->
           let uu____85 =
-            let uu____86 = FStar_Range.string_of_range p  in
-            let uu____87 = FStar_Syntax_Print.const_to_string c  in
+            let uu____86 = FStar_Range.string_of_range p in
+            let uu____87 = FStar_Syntax_Print.const_to_string c in
             FStar_Util.format2 "(%s) Failed to translate constant %s "
-              uu____86 uu____87
-             in
+              uu____86 uu____87 in
           failwith uu____85
-  
-let (mlexpr_of_range :
-  FStar_Range.range -> FStar_Extraction_ML_Syntax.mlexpr') =
+let mlexpr_of_range: FStar_Range.range -> FStar_Extraction_ML_Syntax.mlexpr'
+  =
   fun r  ->
     let cint i =
       let uu____95 =
         let uu____96 =
           let uu____97 =
-            let uu____108 = FStar_Util.string_of_int i  in
-            (uu____108, FStar_Pervasives_Native.None)  in
-          FStar_Extraction_ML_Syntax.MLC_Int uu____97  in
+            let uu____108 = FStar_Util.string_of_int i in
+            (uu____108, FStar_Pervasives_Native.None) in
+          FStar_Extraction_ML_Syntax.MLC_Int uu____97 in
         FStar_All.pipe_right uu____96
-          (fun _0_41  -> FStar_Extraction_ML_Syntax.MLE_Const _0_41)
-         in
+          (fun _0_41  -> FStar_Extraction_ML_Syntax.MLE_Const _0_41) in
       FStar_All.pipe_right uu____95
         (FStar_Extraction_ML_Syntax.with_ty
-           FStar_Extraction_ML_Syntax.ml_int_ty)
-       in
+           FStar_Extraction_ML_Syntax.ml_int_ty) in
     let cstr s =
       let uu____123 =
         FStar_All.pipe_right (FStar_Extraction_ML_Syntax.MLC_String s)
-          (fun _0_42  -> FStar_Extraction_ML_Syntax.MLE_Const _0_42)
-         in
+          (fun _0_42  -> FStar_Extraction_ML_Syntax.MLE_Const _0_42) in
       FStar_All.pipe_right uu____123
         (FStar_Extraction_ML_Syntax.with_ty
-           FStar_Extraction_ML_Syntax.ml_string_ty)
-       in
+           FStar_Extraction_ML_Syntax.ml_string_ty) in
     let uu____124 =
       let uu____131 =
         let uu____134 =
-          let uu____135 = FStar_Range.file_of_range r  in
-          FStar_All.pipe_right uu____135 cstr  in
+          let uu____135 = FStar_Range.file_of_range r in
+          FStar_All.pipe_right uu____135 cstr in
         let uu____136 =
           let uu____139 =
             let uu____140 =
-              let uu____141 = FStar_Range.start_of_range r  in
-              FStar_All.pipe_right uu____141 FStar_Range.line_of_pos  in
-            FStar_All.pipe_right uu____140 cint  in
+              let uu____141 = FStar_Range.start_of_range r in
+              FStar_All.pipe_right uu____141 FStar_Range.line_of_pos in
+            FStar_All.pipe_right uu____140 cint in
           let uu____142 =
             let uu____145 =
               let uu____146 =
-                let uu____147 = FStar_Range.start_of_range r  in
-                FStar_All.pipe_right uu____147 FStar_Range.col_of_pos  in
-              FStar_All.pipe_right uu____146 cint  in
+                let uu____147 = FStar_Range.start_of_range r in
+                FStar_All.pipe_right uu____147 FStar_Range.col_of_pos in
+              FStar_All.pipe_right uu____146 cint in
             let uu____148 =
               let uu____151 =
                 let uu____152 =
-                  let uu____153 = FStar_Range.end_of_range r  in
-                  FStar_All.pipe_right uu____153 FStar_Range.line_of_pos  in
-                FStar_All.pipe_right uu____152 cint  in
+                  let uu____153 = FStar_Range.end_of_range r in
+                  FStar_All.pipe_right uu____153 FStar_Range.line_of_pos in
+                FStar_All.pipe_right uu____152 cint in
               let uu____154 =
                 let uu____157 =
                   let uu____158 =
-                    let uu____159 = FStar_Range.end_of_range r  in
-                    FStar_All.pipe_right uu____159 FStar_Range.col_of_pos  in
-                  FStar_All.pipe_right uu____158 cint  in
-                [uu____157]  in
-              uu____151 :: uu____154  in
-            uu____145 :: uu____148  in
-          uu____139 :: uu____142  in
-        uu____134 :: uu____136  in
-      (mk_range_mle, uu____131)  in
+                    let uu____159 = FStar_Range.end_of_range r in
+                    FStar_All.pipe_right uu____159 FStar_Range.col_of_pos in
+                  FStar_All.pipe_right uu____158 cint in
+                [uu____157] in
+              uu____151 :: uu____154 in
+            uu____145 :: uu____148 in
+          uu____139 :: uu____142 in
+        uu____134 :: uu____136 in
+      (mk_range_mle, uu____131) in
     FStar_Extraction_ML_Syntax.MLE_App uu____124
-  
-let (mlexpr_of_const :
+let mlexpr_of_const:
   FStar_Range.range ->
-    FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlexpr')
+    FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlexpr'
   =
   fun p  ->
     fun c  ->
       match c with
       | FStar_Const.Const_range r -> mlexpr_of_range r
       | uu____169 ->
-          let uu____170 = mlconst_of_const p c  in
+          let uu____170 = mlconst_of_const p c in
           FStar_Extraction_ML_Syntax.MLE_Const uu____170
-  
-let rec (subst_aux :
+let rec subst_aux:
   (FStar_Extraction_ML_Syntax.mlident,FStar_Extraction_ML_Syntax.mlty)
     FStar_Pervasives_Native.tuple2 Prims.list ->
-    FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty)
+    FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty
   =
   fun subst1  ->
     fun t  ->
@@ -143,33 +132,30 @@ let rec (subst_aux :
           let uu____190 =
             FStar_Util.find_opt
               (fun uu____204  ->
-                 match uu____204 with | (y,uu____210) -> y = x) subst1
-             in
+                 match uu____204 with | (y,uu____210) -> y = x) subst1 in
           (match uu____190 with
            | FStar_Pervasives_Native.Some ts ->
                FStar_Pervasives_Native.snd ts
            | FStar_Pervasives_Native.None  -> t)
       | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,f,t2) ->
           let uu____227 =
-            let uu____234 = subst_aux subst1 t1  in
-            let uu____235 = subst_aux subst1 t2  in (uu____234, f, uu____235)
-             in
+            let uu____234 = subst_aux subst1 t1 in
+            let uu____235 = subst_aux subst1 t2 in (uu____234, f, uu____235) in
           FStar_Extraction_ML_Syntax.MLTY_Fun uu____227
       | FStar_Extraction_ML_Syntax.MLTY_Named (args,path) ->
           let uu____242 =
-            let uu____249 = FStar_List.map (subst_aux subst1) args  in
-            (uu____249, path)  in
+            let uu____249 = FStar_List.map (subst_aux subst1) args in
+            (uu____249, path) in
           FStar_Extraction_ML_Syntax.MLTY_Named uu____242
       | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-          let uu____257 = FStar_List.map (subst_aux subst1) ts  in
+          let uu____257 = FStar_List.map (subst_aux subst1) ts in
           FStar_Extraction_ML_Syntax.MLTY_Tuple uu____257
       | FStar_Extraction_ML_Syntax.MLTY_Top  ->
           FStar_Extraction_ML_Syntax.MLTY_Top
-  
-let (try_subst :
+let try_subst:
   FStar_Extraction_ML_Syntax.mltyscheme ->
     FStar_Extraction_ML_Syntax.mlty Prims.list ->
-      FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option)
+      FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option
   =
   fun uu____268  ->
     fun args  ->
@@ -179,61 +165,56 @@ let (try_subst :
           then FStar_Pervasives_Native.None
           else
             (let uu____279 =
-               let uu____280 = FStar_List.zip formals args  in
-               subst_aux uu____280 t  in
+               let uu____280 = FStar_List.zip formals args in
+               subst_aux uu____280 t in
              FStar_Pervasives_Native.Some uu____279)
-  
-let (subst :
+let subst:
   FStar_Extraction_ML_Syntax.mltyscheme ->
     FStar_Extraction_ML_Syntax.mlty Prims.list ->
-      FStar_Extraction_ML_Syntax.mlty)
+      FStar_Extraction_ML_Syntax.mlty
   =
   fun ts  ->
     fun args  ->
-      let uu____297 = try_subst ts args  in
+      let uu____297 = try_subst ts args in
       match uu____297 with
       | FStar_Pervasives_Native.None  ->
           failwith
             "Substitution must be fully applied (see GitHub issue #490)"
       | FStar_Pervasives_Native.Some t -> t
-  
-let (udelta_unfold :
+let udelta_unfold:
   FStar_Extraction_ML_UEnv.env ->
     FStar_Extraction_ML_Syntax.mlty ->
-      FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option)
+      FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option
   =
   fun g  ->
     fun uu___59_308  ->
       match uu___59_308 with
       | FStar_Extraction_ML_Syntax.MLTY_Named (args,n1) ->
-          let uu____317 = FStar_Extraction_ML_UEnv.lookup_ty_const g n1  in
+          let uu____317 = FStar_Extraction_ML_UEnv.lookup_ty_const g n1 in
           (match uu____317 with
            | FStar_Pervasives_Native.Some ts ->
-               let uu____323 = try_subst ts args  in
+               let uu____323 = try_subst ts args in
                (match uu____323 with
                 | FStar_Pervasives_Native.None  ->
                     let uu____328 =
                       let uu____329 =
-                        FStar_Extraction_ML_Syntax.string_of_mlpath n1  in
+                        FStar_Extraction_ML_Syntax.string_of_mlpath n1 in
                       let uu____330 =
-                        FStar_Util.string_of_int (FStar_List.length args)  in
+                        FStar_Util.string_of_int (FStar_List.length args) in
                       let uu____331 =
                         FStar_Util.string_of_int
-                          (FStar_List.length (FStar_Pervasives_Native.fst ts))
-                         in
+                          (FStar_List.length (FStar_Pervasives_Native.fst ts)) in
                       FStar_Util.format3
                         "Substitution must be fully applied; got an application of %s with %s args whereas %s were expected (see GitHub issue #490)"
-                        uu____329 uu____330 uu____331
-                       in
+                        uu____329 uu____330 uu____331 in
                     failwith uu____328
                 | FStar_Pervasives_Native.Some r ->
                     FStar_Pervasives_Native.Some r)
            | uu____335 -> FStar_Pervasives_Native.None)
       | uu____338 -> FStar_Pervasives_Native.None
-  
-let (eff_leq :
+let eff_leq:
   FStar_Extraction_ML_Syntax.e_tag ->
-    FStar_Extraction_ML_Syntax.e_tag -> Prims.bool)
+    FStar_Extraction_ML_Syntax.e_tag -> Prims.bool
   =
   fun f  ->
     fun f'  ->
@@ -244,18 +225,16 @@ let (eff_leq :
       | (FStar_Extraction_ML_Syntax.E_IMPURE
          ,FStar_Extraction_ML_Syntax.E_IMPURE ) -> true
       | uu____346 -> false
-  
-let (eff_to_string : FStar_Extraction_ML_Syntax.e_tag -> Prims.string) =
+let eff_to_string: FStar_Extraction_ML_Syntax.e_tag -> Prims.string =
   fun uu___60_353  ->
     match uu___60_353 with
     | FStar_Extraction_ML_Syntax.E_PURE  -> "Pure"
     | FStar_Extraction_ML_Syntax.E_GHOST  -> "Ghost"
     | FStar_Extraction_ML_Syntax.E_IMPURE  -> "Impure"
-  
-let (join :
+let join:
   FStar_Range.range ->
     FStar_Extraction_ML_Syntax.e_tag ->
-      FStar_Extraction_ML_Syntax.e_tag -> FStar_Extraction_ML_Syntax.e_tag)
+      FStar_Extraction_ML_Syntax.e_tag -> FStar_Extraction_ML_Syntax.e_tag
   =
   fun r  ->
     fun f  ->
@@ -284,23 +263,20 @@ let (join :
             FStar_Extraction_ML_Syntax.E_PURE
         | uu____363 ->
             let uu____368 =
-              let uu____369 = FStar_Range.string_of_range r  in
+              let uu____369 = FStar_Range.string_of_range r in
               FStar_Util.format3
                 "Impossible (%s): Inconsistent effects %s and %s" uu____369
-                (eff_to_string f) (eff_to_string f')
-               in
+                (eff_to_string f) (eff_to_string f') in
             failwith uu____368
-  
-let (join_l :
+let join_l:
   FStar_Range.range ->
     FStar_Extraction_ML_Syntax.e_tag Prims.list ->
-      FStar_Extraction_ML_Syntax.e_tag)
+      FStar_Extraction_ML_Syntax.e_tag
   =
   fun r  ->
     fun fs  ->
       FStar_List.fold_left (join r) FStar_Extraction_ML_Syntax.E_PURE fs
-  
-let mk_ty_fun :
+let mk_ty_fun:
   'Auu____383 .
     Prims.unit ->
       ('Auu____383,FStar_Extraction_ML_Syntax.mlty)
@@ -315,19 +291,18 @@ let mk_ty_fun :
            | (uu____409,t0) ->
                FStar_Extraction_ML_Syntax.MLTY_Fun
                  (t0, FStar_Extraction_ML_Syntax.E_PURE, t))
-  
 type unfold_t =
   FStar_Extraction_ML_Syntax.mlty ->
     FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option[@@deriving
                                                                     show]
-let rec (type_leq_c :
+let rec type_leq_c:
   unfold_t ->
     FStar_Extraction_ML_Syntax.mlexpr FStar_Pervasives_Native.option ->
       FStar_Extraction_ML_Syntax.mlty ->
         FStar_Extraction_ML_Syntax.mlty ->
           (Prims.bool,FStar_Extraction_ML_Syntax.mlexpr
                         FStar_Pervasives_Native.option)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun unfold_ty  ->
     fun e  ->
@@ -351,13 +326,10 @@ let rec (type_leq_c :
                           FStar_Extraction_ML_Syntax.MLE_Fun
                             ((FStar_List.append xs ys), body1)
                       | uu____528 ->
-                          FStar_Extraction_ML_Syntax.MLE_Fun (xs, body)
-                       in
+                          FStar_Extraction_ML_Syntax.MLE_Fun (xs, body) in
                     let uu____535 =
-                      (mk_ty_fun ()) xs body.FStar_Extraction_ML_Syntax.mlty
-                       in
-                    FStar_Extraction_ML_Syntax.with_ty uu____535 e1
-                 in
+                      (mk_ty_fun ()) xs body.FStar_Extraction_ML_Syntax.mlty in
+                    FStar_Extraction_ML_Syntax.with_ty uu____535 e1 in
               (match e with
                | FStar_Pervasives_Native.Some
                    {
@@ -367,21 +339,20 @@ let rec (type_leq_c :
                      FStar_Extraction_ML_Syntax.loc = uu____546;_}
                    ->
                    let uu____567 =
-                     (type_leq unfold_ty t1' t1) && (eff_leq f f')  in
+                     (type_leq unfold_ty t1' t1) && (eff_leq f f') in
                    if uu____567
                    then
                      (if
                         (f = FStar_Extraction_ML_Syntax.E_PURE) &&
                           (f' = FStar_Extraction_ML_Syntax.E_GHOST)
                       then
-                        let uu____583 = type_leq unfold_ty t2 t2'  in
+                        let uu____583 = type_leq unfold_ty t2 t2' in
                         (if uu____583
                          then
                            let body1 =
                              let uu____594 =
                                type_leq unfold_ty t2
-                                 FStar_Extraction_ML_Syntax.ml_unit_ty
-                                in
+                                 FStar_Extraction_ML_Syntax.ml_unit_ty in
                              if uu____594
                              then FStar_Extraction_ML_Syntax.ml_unit
                              else
@@ -390,50 +361,43 @@ let rec (type_leq_c :
                                  (FStar_Extraction_ML_Syntax.MLE_Coerce
                                     (FStar_Extraction_ML_Syntax.ml_unit,
                                       FStar_Extraction_ML_Syntax.ml_unit_ty,
-                                      t2'))
-                              in
+                                      t2')) in
                            let uu____599 =
                              let uu____602 =
                                let uu____603 =
                                  let uu____606 =
                                    (mk_ty_fun ()) [x]
-                                     body1.FStar_Extraction_ML_Syntax.mlty
-                                    in
-                                 FStar_Extraction_ML_Syntax.with_ty uu____606
-                                  in
+                                     body1.FStar_Extraction_ML_Syntax.mlty in
+                                 FStar_Extraction_ML_Syntax.with_ty uu____606 in
                                FStar_All.pipe_left uu____603
                                  (FStar_Extraction_ML_Syntax.MLE_Fun
-                                    ([x], body1))
-                                in
-                             FStar_Pervasives_Native.Some uu____602  in
+                                    ([x], body1)) in
+                             FStar_Pervasives_Native.Some uu____602 in
                            (true, uu____599)
                          else (false, FStar_Pervasives_Native.None))
                       else
                         (let uu____635 =
                            let uu____642 =
-                             let uu____645 = mk_fun xs body  in
+                             let uu____645 = mk_fun xs body in
                              FStar_All.pipe_left
                                (fun _0_43  ->
                                   FStar_Pervasives_Native.Some _0_43)
-                               uu____645
-                              in
-                           type_leq_c unfold_ty uu____642 t2 t2'  in
+                               uu____645 in
+                           type_leq_c unfold_ty uu____642 t2 t2' in
                          match uu____635 with
                          | (ok,body1) ->
                              let res =
                                match body1 with
                                | FStar_Pervasives_Native.Some body2 ->
-                                   let uu____669 = mk_fun [x] body2  in
+                                   let uu____669 = mk_fun [x] body2 in
                                    FStar_Pervasives_Native.Some uu____669
-                               | uu____678 -> FStar_Pervasives_Native.None
-                                in
+                               | uu____678 -> FStar_Pervasives_Native.None in
                              (ok, res)))
                    else (false, FStar_Pervasives_Native.None)
                | uu____686 ->
                    let uu____689 =
                      ((type_leq unfold_ty t1' t1) && (eff_leq f f')) &&
-                       (type_leq unfold_ty t2 t2')
-                      in
+                       (type_leq unfold_ty t2 t2') in
                    if uu____689
                    then (true, e)
                    else (false, FStar_Pervasives_Native.None))
@@ -443,17 +407,17 @@ let rec (type_leq_c :
               if path = path'
               then
                 let uu____725 =
-                  FStar_List.forall2 (type_leq unfold_ty) args args'  in
+                  FStar_List.forall2 (type_leq unfold_ty) args args' in
                 (if uu____725
                  then (true, e)
                  else (false, FStar_Pervasives_Native.None))
               else
-                (let uu____741 = unfold_ty t  in
+                (let uu____741 = unfold_ty t in
                  match uu____741 with
                  | FStar_Pervasives_Native.Some t1 ->
                      type_leq_c unfold_ty e t1 t'
                  | FStar_Pervasives_Native.None  ->
-                     let uu____755 = unfold_ty t'  in
+                     let uu____755 = unfold_ty t' in
                      (match uu____755 with
                       | FStar_Pervasives_Native.None  ->
                           (false, FStar_Pervasives_Native.None)
@@ -461,39 +425,36 @@ let rec (type_leq_c :
                           type_leq_c unfold_ty e t t'1))
           | (FStar_Extraction_ML_Syntax.MLTY_Tuple
              ts,FStar_Extraction_ML_Syntax.MLTY_Tuple ts') ->
-              let uu____777 = FStar_List.forall2 (type_leq unfold_ty) ts ts'
-                 in
+              let uu____777 = FStar_List.forall2 (type_leq unfold_ty) ts ts' in
               if uu____777
               then (true, e)
               else (false, FStar_Pervasives_Native.None)
           | (FStar_Extraction_ML_Syntax.MLTY_Top
              ,FStar_Extraction_ML_Syntax.MLTY_Top ) -> (true, e)
           | (FStar_Extraction_ML_Syntax.MLTY_Named uu____794,uu____795) ->
-              let uu____802 = unfold_ty t  in
+              let uu____802 = unfold_ty t in
               (match uu____802 with
                | FStar_Pervasives_Native.Some t1 ->
                    type_leq_c unfold_ty e t1 t'
                | uu____816 -> (false, FStar_Pervasives_Native.None))
           | (uu____821,FStar_Extraction_ML_Syntax.MLTY_Named uu____822) ->
-              let uu____829 = unfold_ty t'  in
+              let uu____829 = unfold_ty t' in
               (match uu____829 with
                | FStar_Pervasives_Native.Some t'1 ->
                    type_leq_c unfold_ty e t t'1
                | uu____843 -> (false, FStar_Pervasives_Native.None))
           | uu____848 -> (false, FStar_Pervasives_Native.None)
-
-and (type_leq :
+and type_leq:
   unfold_t ->
     FStar_Extraction_ML_Syntax.mlty ->
-      FStar_Extraction_ML_Syntax.mlty -> Prims.bool)
+      FStar_Extraction_ML_Syntax.mlty -> Prims.bool
   =
   fun g  ->
     fun t1  ->
       fun t2  ->
-        let uu____859 = type_leq_c g FStar_Pervasives_Native.None t1 t2  in
+        let uu____859 = type_leq_c g FStar_Pervasives_Native.None t1 t2 in
         FStar_All.pipe_right uu____859 FStar_Pervasives_Native.fst
-
-let is_type_abstraction :
+let is_type_abstraction:
   'Auu____881 'Auu____882 'Auu____883 .
     (('Auu____883,'Auu____882) FStar_Util.either,'Auu____881)
       FStar_Pervasives_Native.tuple2 Prims.list -> Prims.bool
@@ -502,32 +463,29 @@ let is_type_abstraction :
     match uu___61_897 with
     | (FStar_Util.Inl uu____908,uu____909)::uu____910 -> true
     | uu____933 -> false
-  
-let (is_xtuple :
+let is_xtuple:
   (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2 ->
-    Prims.int FStar_Pervasives_Native.option)
+    Prims.int FStar_Pervasives_Native.option
   =
   fun uu____954  ->
     match uu____954 with
     | (ns,n1) ->
         let uu____969 =
-          let uu____970 = FStar_Util.concat_l "." (FStar_List.append ns [n1])
-             in
-          FStar_Parser_Const.is_tuple_datacon_string uu____970  in
+          let uu____970 = FStar_Util.concat_l "." (FStar_List.append ns [n1]) in
+          FStar_Parser_Const.is_tuple_datacon_string uu____970 in
         if uu____969
         then
           let uu____973 =
-            let uu____974 = FStar_Util.char_at n1 (Prims.parse_int "7")  in
-            FStar_Util.int_of_char uu____974  in
+            let uu____974 = FStar_Util.char_at n1 (Prims.parse_int "7") in
+            FStar_Util.int_of_char uu____974 in
           FStar_Pervasives_Native.Some uu____973
         else FStar_Pervasives_Native.None
-  
-let (resugar_exp :
-  FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr) =
+let resugar_exp:
+  FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr =
   fun e  ->
     match e.FStar_Extraction_ML_Syntax.expr with
     | FStar_Extraction_ML_Syntax.MLE_CTor (mlp,args) ->
-        let uu____985 = is_xtuple mlp  in
+        let uu____985 = is_xtuple mlp in
         (match uu____985 with
          | FStar_Pervasives_Native.Some n1 ->
              FStar_All.pipe_left
@@ -536,20 +494,18 @@ let (resugar_exp :
                (FStar_Extraction_ML_Syntax.MLE_Tuple args)
          | uu____989 -> e)
     | uu____992 -> e
-  
-let (record_field_path :
-  FStar_Ident.lident Prims.list -> Prims.string Prims.list) =
+let record_field_path:
+  FStar_Ident.lident Prims.list -> Prims.string Prims.list =
   fun uu___62_999  ->
     match uu___62_999 with
     | f::uu____1005 ->
-        let uu____1008 = FStar_Util.prefix f.FStar_Ident.ns  in
+        let uu____1008 = FStar_Util.prefix f.FStar_Ident.ns in
         (match uu____1008 with
          | (ns,uu____1018) ->
              FStar_All.pipe_right ns
                (FStar_List.map (fun id1  -> id1.FStar_Ident.idText)))
     | uu____1029 -> failwith "impos"
-  
-let record_fields :
+let record_fields:
   'Auu____1037 .
     FStar_Ident.lident Prims.list ->
       'Auu____1037 Prims.list ->
@@ -560,84 +516,76 @@ let record_fields :
       FStar_List.map2
         (fun f  -> fun e  -> (((f.FStar_Ident.ident).FStar_Ident.idText), e))
         fs vs
-  
-let (is_xtuple_ty :
+let is_xtuple_ty:
   (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2 ->
-    Prims.int FStar_Pervasives_Native.option)
+    Prims.int FStar_Pervasives_Native.option
   =
   fun uu____1078  ->
     match uu____1078 with
     | (ns,n1) ->
         let uu____1093 =
           let uu____1094 =
-            FStar_Util.concat_l "." (FStar_List.append ns [n1])  in
-          FStar_Parser_Const.is_tuple_constructor_string uu____1094  in
+            FStar_Util.concat_l "." (FStar_List.append ns [n1]) in
+          FStar_Parser_Const.is_tuple_constructor_string uu____1094 in
         if uu____1093
         then
           let uu____1097 =
-            let uu____1098 = FStar_Util.char_at n1 (Prims.parse_int "5")  in
-            FStar_Util.int_of_char uu____1098  in
+            let uu____1098 = FStar_Util.char_at n1 (Prims.parse_int "5") in
+            FStar_Util.int_of_char uu____1098 in
           FStar_Pervasives_Native.Some uu____1097
         else FStar_Pervasives_Native.None
-  
-let (resugar_mlty :
-  FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty) =
+let resugar_mlty:
+  FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty =
   fun t  ->
     match t with
     | FStar_Extraction_ML_Syntax.MLTY_Named (args,mlp) ->
-        let uu____1109 = is_xtuple_ty mlp  in
+        let uu____1109 = is_xtuple_ty mlp in
         (match uu____1109 with
          | FStar_Pervasives_Native.Some n1 ->
              FStar_Extraction_ML_Syntax.MLTY_Tuple args
          | uu____1113 -> t)
     | uu____1116 -> t
-  
-let (flatten_ns : Prims.string Prims.list -> Prims.string) =
+let flatten_ns: Prims.string Prims.list -> Prims.string =
   fun ns  ->
-    let uu____1124 = FStar_Options.codegen_fsharp ()  in
+    let uu____1124 = FStar_Options.codegen_fsharp () in
     if uu____1124
     then FStar_String.concat "." ns
     else FStar_String.concat "_" ns
-  
-let (flatten_mlpath :
+let flatten_mlpath:
   (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2 ->
-    Prims.string)
+    Prims.string
   =
   fun uu____1134  ->
     match uu____1134 with
     | (ns,n1) ->
-        let uu____1147 = FStar_Options.codegen_fsharp ()  in
+        let uu____1147 = FStar_Options.codegen_fsharp () in
         if uu____1147
         then FStar_String.concat "." (FStar_List.append ns [n1])
         else FStar_String.concat "_" (FStar_List.append ns [n1])
-  
-let (mlpath_of_lid :
+let mlpath_of_lid:
   FStar_Ident.lident ->
-    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2)
+    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun l  ->
     let uu____1158 =
       FStar_All.pipe_right l.FStar_Ident.ns
-        (FStar_List.map (fun i  -> i.FStar_Ident.idText))
-       in
+        (FStar_List.map (fun i  -> i.FStar_Ident.idText)) in
     (uu____1158, ((l.FStar_Ident.ident).FStar_Ident.idText))
-  
-let rec (erasableType :
-  unfold_t -> FStar_Extraction_ML_Syntax.mlty -> Prims.bool) =
+let rec erasableType:
+  unfold_t -> FStar_Extraction_ML_Syntax.mlty -> Prims.bool =
   fun unfold_ty  ->
     fun t  ->
-      let uu____1178 = FStar_Extraction_ML_UEnv.erasableTypeNoDelta t  in
+      let uu____1178 = FStar_Extraction_ML_UEnv.erasableTypeNoDelta t in
       if uu____1178
       then true
       else
-        (let uu____1180 = unfold_ty t  in
+        (let uu____1180 = unfold_ty t in
          match uu____1180 with
          | FStar_Pervasives_Native.Some t1 -> erasableType unfold_ty t1
          | FStar_Pervasives_Native.None  -> false)
-  
-let rec (eraseTypeDeep :
+let rec eraseTypeDeep:
   unfold_t ->
-    FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty)
+    FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty
   =
   fun unfold_ty  ->
     fun t  ->
@@ -646,46 +594,41 @@ let rec (eraseTypeDeep :
           if etag = FStar_Extraction_ML_Syntax.E_PURE
           then
             let uu____1200 =
-              let uu____1207 = eraseTypeDeep unfold_ty tyd  in
-              let uu____1211 = eraseTypeDeep unfold_ty tycd  in
-              (uu____1207, etag, uu____1211)  in
+              let uu____1207 = eraseTypeDeep unfold_ty tyd in
+              let uu____1211 = eraseTypeDeep unfold_ty tycd in
+              (uu____1207, etag, uu____1211) in
             FStar_Extraction_ML_Syntax.MLTY_Fun uu____1200
           else t
       | FStar_Extraction_ML_Syntax.MLTY_Named (lty,mlp) ->
-          let uu____1222 = erasableType unfold_ty t  in
+          let uu____1222 = erasableType unfold_ty t in
           if uu____1222
           then FStar_Extraction_ML_UEnv.erasedContent
           else
             (let uu____1227 =
-               let uu____1234 = FStar_List.map (eraseTypeDeep unfold_ty) lty
-                  in
-               (uu____1234, mlp)  in
+               let uu____1234 = FStar_List.map (eraseTypeDeep unfold_ty) lty in
+               (uu____1234, mlp) in
              FStar_Extraction_ML_Syntax.MLTY_Named uu____1227)
       | FStar_Extraction_ML_Syntax.MLTY_Tuple lty ->
-          let uu____1245 = FStar_List.map (eraseTypeDeep unfold_ty) lty  in
+          let uu____1245 = FStar_List.map (eraseTypeDeep unfold_ty) lty in
           FStar_Extraction_ML_Syntax.MLTY_Tuple uu____1245
       | uu____1251 -> t
-  
-let (prims_op_equality : FStar_Extraction_ML_Syntax.mlexpr) =
+let prims_op_equality: FStar_Extraction_ML_Syntax.mlexpr =
   FStar_All.pipe_left
     (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
     (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_Equality"))
-  
-let (prims_op_amp_amp : FStar_Extraction_ML_Syntax.mlexpr) =
+let prims_op_amp_amp: FStar_Extraction_ML_Syntax.mlexpr =
   let uu____1254 =
     let uu____1257 =
       (mk_ty_fun ())
         [("x", FStar_Extraction_ML_Syntax.ml_bool_ty);
         ("y", FStar_Extraction_ML_Syntax.ml_bool_ty)]
-        FStar_Extraction_ML_Syntax.ml_bool_ty
-       in
-    FStar_Extraction_ML_Syntax.with_ty uu____1257  in
+        FStar_Extraction_ML_Syntax.ml_bool_ty in
+    FStar_Extraction_ML_Syntax.with_ty uu____1257 in
   FStar_All.pipe_left uu____1254
     (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_AmpAmp"))
-  
-let (conjoin :
+let conjoin:
   FStar_Extraction_ML_Syntax.mlexpr ->
-    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr)
+    FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr
   =
   fun e1  ->
     fun e2  ->
@@ -693,11 +636,10 @@ let (conjoin :
         (FStar_Extraction_ML_Syntax.with_ty
            FStar_Extraction_ML_Syntax.ml_bool_ty)
         (FStar_Extraction_ML_Syntax.MLE_App (prims_op_amp_amp, [e1; e2]))
-  
-let (conjoin_opt :
+let conjoin_opt:
   FStar_Extraction_ML_Syntax.mlexpr FStar_Pervasives_Native.option ->
     FStar_Extraction_ML_Syntax.mlexpr FStar_Pervasives_Native.option ->
-      FStar_Extraction_ML_Syntax.mlexpr FStar_Pervasives_Native.option)
+      FStar_Extraction_ML_Syntax.mlexpr FStar_Pervasives_Native.option
   =
   fun e1  ->
     fun e2  ->
@@ -709,165 +651,143 @@ let (conjoin_opt :
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some x) ->
           FStar_Pervasives_Native.Some x
       | (FStar_Pervasives_Native.Some x,FStar_Pervasives_Native.Some y) ->
-          let uu____1322 = conjoin x y  in
+          let uu____1322 = conjoin x y in
           FStar_Pervasives_Native.Some uu____1322
-  
-let (mlloc_of_range :
+let mlloc_of_range:
   FStar_Range.range ->
-    (Prims.int,Prims.string) FStar_Pervasives_Native.tuple2)
+    (Prims.int,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun r  ->
-    let pos = FStar_Range.start_of_range r  in
-    let line = FStar_Range.line_of_pos pos  in
-    let uu____1332 = FStar_Range.file_of_range r  in (line, uu____1332)
-  
-let rec (doms_and_cod :
+    let pos = FStar_Range.start_of_range r in
+    let line = FStar_Range.line_of_pos pos in
+    let uu____1332 = FStar_Range.file_of_range r in (line, uu____1332)
+let rec doms_and_cod:
   FStar_Extraction_ML_Syntax.mlty ->
     (FStar_Extraction_ML_Syntax.mlty Prims.list,FStar_Extraction_ML_Syntax.mlty)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     match t with
     | FStar_Extraction_ML_Syntax.MLTY_Fun (a,uu____1349,b) ->
-        let uu____1351 = doms_and_cod b  in
+        let uu____1351 = doms_and_cod b in
         (match uu____1351 with | (ds,c) -> ((a :: ds), c))
     | uu____1372 -> ([], t)
-  
-let (argTypes :
+let argTypes:
   FStar_Extraction_ML_Syntax.mlty ->
-    FStar_Extraction_ML_Syntax.mlty Prims.list)
+    FStar_Extraction_ML_Syntax.mlty Prims.list
   =
   fun t  ->
-    let uu____1382 = doms_and_cod t  in
-    FStar_Pervasives_Native.fst uu____1382
-  
-let rec (uncurry_mlty_fun :
+    let uu____1382 = doms_and_cod t in FStar_Pervasives_Native.fst uu____1382
+let rec uncurry_mlty_fun:
   FStar_Extraction_ML_Syntax.mlty ->
     (FStar_Extraction_ML_Syntax.mlty Prims.list,FStar_Extraction_ML_Syntax.mlty)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     match t with
     | FStar_Extraction_ML_Syntax.MLTY_Fun (a,uu____1407,b) ->
-        let uu____1409 = uncurry_mlty_fun b  in
+        let uu____1409 = uncurry_mlty_fun b in
         (match uu____1409 with | (args,res) -> ((a :: args), res))
     | uu____1430 -> ([], t)
-  
-let (not_implemented_warning :
-  FStar_Range.range -> Prims.string -> Prims.string -> Prims.unit) =
+let not_implemented_warning:
+  FStar_Range.range -> Prims.string -> Prims.string -> Prims.unit =
   fun r  ->
     fun t  ->
       fun msg  ->
         let uu____1442 =
           let uu____1447 =
             FStar_Util.format2
-              ". Tactic %s will not run natively because %s.\n" t msg
-             in
-          (FStar_Errors.Warning_CallNotImplementedAsWarning, uu____1447)  in
+              ". Tactic %s will not run natively because %s.\n" t msg in
+          (FStar_Errors.Warning_CallNotImplementedAsWarning, uu____1447) in
         FStar_Errors.log_issue r uu____1442
-  
 type emb_decl =
-  | Embed 
-  | Unembed [@@deriving show]
-let (uu___is_Embed : emb_decl -> Prims.bool) =
+  | Embed
+  | Unembed[@@deriving show]
+let uu___is_Embed: emb_decl -> Prims.bool =
   fun projectee  ->
     match projectee with | Embed  -> true | uu____1451 -> false
-  
-let (uu___is_Unembed : emb_decl -> Prims.bool) =
+let uu___is_Unembed: emb_decl -> Prims.bool =
   fun projectee  ->
     match projectee with | Unembed  -> true | uu____1455 -> false
-  
-let (lid_to_name : FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlexpr')
+let lid_to_name: FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlexpr' =
+  fun l  ->
+    let uu____1459 = FStar_Extraction_ML_Syntax.mlpath_of_lident l in
+    FStar_Extraction_ML_Syntax.MLE_Name uu____1459
+let lid_to_top_name: FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlexpr
   =
   fun l  ->
-    let uu____1459 = FStar_Extraction_ML_Syntax.mlpath_of_lident l  in
-    FStar_Extraction_ML_Syntax.MLE_Name uu____1459
-  
-let (lid_to_top_name :
-  FStar_Ident.lident -> FStar_Extraction_ML_Syntax.mlexpr) =
-  fun l  ->
     let uu____1463 =
-      let uu____1464 = FStar_Extraction_ML_Syntax.mlpath_of_lident l  in
-      FStar_Extraction_ML_Syntax.MLE_Name uu____1464  in
+      let uu____1464 = FStar_Extraction_ML_Syntax.mlpath_of_lident l in
+      FStar_Extraction_ML_Syntax.MLE_Name uu____1464 in
     FStar_All.pipe_left
       (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
       uu____1463
-  
-let (str_to_name : Prims.string -> FStar_Extraction_ML_Syntax.mlexpr') =
+let str_to_name: Prims.string -> FStar_Extraction_ML_Syntax.mlexpr' =
   fun s  ->
-    let uu____1468 = FStar_Ident.lid_of_str s  in lid_to_name uu____1468
-  
-let (str_to_top_name : Prims.string -> FStar_Extraction_ML_Syntax.mlexpr) =
+    let uu____1468 = FStar_Ident.lid_of_str s in lid_to_name uu____1468
+let str_to_top_name: Prims.string -> FStar_Extraction_ML_Syntax.mlexpr =
   fun s  ->
-    let uu____1472 = FStar_Ident.lid_of_str s  in lid_to_top_name uu____1472
-  
-let (fstar_syn_syn_prefix :
-  Prims.string -> FStar_Extraction_ML_Syntax.mlexpr') =
-  fun s  -> str_to_name (Prims.strcat "FStar_Syntax_Syntax." s) 
-let (fstar_tc_common_prefix :
-  Prims.string -> FStar_Extraction_ML_Syntax.mlexpr') =
-  fun s  -> str_to_name (Prims.strcat "FStar_TypeChecker_Common." s) 
-let (fstar_refl_basic_prefix :
-  Prims.string -> FStar_Extraction_ML_Syntax.mlexpr') =
-  fun s  -> str_to_name (Prims.strcat "FStar_Reflection_Basic." s) 
-let (fstar_refl_data_prefix :
-  Prims.string -> FStar_Extraction_ML_Syntax.mlexpr') =
-  fun s  -> str_to_name (Prims.strcat "FStar_Reflection_Data." s) 
-let (fstar_emb_basic_prefix :
-  Prims.string -> FStar_Extraction_ML_Syntax.mlexpr') =
-  fun s  -> str_to_name (Prims.strcat "FStar_Syntax_Embeddings." s) 
-let (mk_basic_embedding :
-  emb_decl -> Prims.string -> FStar_Extraction_ML_Syntax.mlexpr') =
+    let uu____1472 = FStar_Ident.lid_of_str s in lid_to_top_name uu____1472
+let fstar_syn_syn_prefix: Prims.string -> FStar_Extraction_ML_Syntax.mlexpr'
+  = fun s  -> str_to_name (Prims.strcat "FStar_Syntax_Syntax." s)
+let fstar_tc_common_prefix:
+  Prims.string -> FStar_Extraction_ML_Syntax.mlexpr' =
+  fun s  -> str_to_name (Prims.strcat "FStar_TypeChecker_Common." s)
+let fstar_refl_basic_prefix:
+  Prims.string -> FStar_Extraction_ML_Syntax.mlexpr' =
+  fun s  -> str_to_name (Prims.strcat "FStar_Reflection_Basic." s)
+let fstar_refl_data_prefix:
+  Prims.string -> FStar_Extraction_ML_Syntax.mlexpr' =
+  fun s  -> str_to_name (Prims.strcat "FStar_Reflection_Data." s)
+let fstar_emb_basic_prefix:
+  Prims.string -> FStar_Extraction_ML_Syntax.mlexpr' =
+  fun s  -> str_to_name (Prims.strcat "FStar_Syntax_Embeddings." s)
+let mk_basic_embedding:
+  emb_decl -> Prims.string -> FStar_Extraction_ML_Syntax.mlexpr' =
   fun m  ->
     fun s  ->
       match m with
       | Embed  -> fstar_emb_basic_prefix (Prims.strcat "embed_" s)
       | Unembed  -> fstar_emb_basic_prefix (Prims.strcat "unembed_" s)
-  
-let (mk_embedding :
-  emb_decl -> Prims.string -> FStar_Extraction_ML_Syntax.mlexpr') =
+let mk_embedding:
+  emb_decl -> Prims.string -> FStar_Extraction_ML_Syntax.mlexpr' =
   fun m  ->
     fun s  ->
       match m with
       | Embed  -> fstar_refl_basic_prefix (Prims.strcat "embed_" s)
       | Unembed  -> fstar_refl_basic_prefix (Prims.strcat "unembed_" s)
-  
-let (mk_tactic_unembedding :
+let mk_tactic_unembedding:
   FStar_Extraction_ML_Syntax.mlexpr' Prims.list ->
-    FStar_Extraction_ML_Syntax.mlexpr')
+    FStar_Extraction_ML_Syntax.mlexpr'
   =
   fun args  ->
-    let tac_arg = "t"  in
+    let tac_arg = "t" in
     let reify_tactic =
       let uu____1509 =
         let uu____1510 =
           let uu____1517 =
-            str_to_top_name "FStar_Tactics_Interpreter.reify_tactic"  in
+            str_to_top_name "FStar_Tactics_Interpreter.reify_tactic" in
           let uu____1518 =
-            let uu____1521 = str_to_top_name tac_arg  in [uu____1521]  in
-          (uu____1517, uu____1518)  in
-        FStar_Extraction_ML_Syntax.MLE_App uu____1510  in
+            let uu____1521 = str_to_top_name tac_arg in [uu____1521] in
+          (uu____1517, uu____1518) in
+        FStar_Extraction_ML_Syntax.MLE_App uu____1510 in
       FStar_All.pipe_left
         (FStar_Extraction_ML_Syntax.with_ty
-           FStar_Extraction_ML_Syntax.MLTY_Top) uu____1509
-       in
+           FStar_Extraction_ML_Syntax.MLTY_Top) uu____1509 in
     let from_tac =
       let uu____1525 =
         let uu____1526 =
           FStar_Util.string_of_int
-            ((FStar_List.length args) - (Prims.parse_int "1"))
-           in
-        Prims.strcat "FStar_Tactics_Builtins.from_tac_" uu____1526  in
-      str_to_top_name uu____1525  in
+            ((FStar_List.length args) - (Prims.parse_int "1")) in
+        Prims.strcat "FStar_Tactics_Builtins.from_tac_" uu____1526 in
+      str_to_top_name uu____1525 in
     let unembed_tactic =
       let uu____1528 =
         let uu____1529 =
           FStar_Util.string_of_int
-            ((FStar_List.length args) - (Prims.parse_int "1"))
-           in
-        Prims.strcat "FStar_Tactics_Interpreter.unembed_tactic_" uu____1529
-         in
-      str_to_top_name uu____1528  in
+            ((FStar_List.length args) - (Prims.parse_int "1")) in
+        Prims.strcat "FStar_Tactics_Interpreter.unembed_tactic_" uu____1529 in
+      str_to_top_name uu____1528 in
     let app =
       match FStar_List.length args with
       | _0_44 when _0_44 = (Prims.parse_int "1") ->
@@ -880,44 +800,39 @@ let (mk_tactic_unembedding :
                       let uu____1553 =
                         FStar_List.map
                           (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top) args
-                         in
-                      FStar_List.append uu____1553 [reify_tactic]  in
-                    (unembed_tactic, uu____1550)  in
-                  FStar_Extraction_ML_Syntax.MLE_App uu____1543  in
+                             FStar_Extraction_ML_Syntax.MLTY_Top) args in
+                      FStar_List.append uu____1553 [reify_tactic] in
+                    (unembed_tactic, uu____1550) in
+                  FStar_Extraction_ML_Syntax.MLE_App uu____1543 in
                 FStar_Extraction_ML_Syntax.with_ty
-                  FStar_Extraction_ML_Syntax.MLTY_Top uu____1542
-                 in
-              [uu____1541]  in
-            (from_tac, uu____1538)  in
+                  FStar_Extraction_ML_Syntax.MLTY_Top uu____1542 in
+              [uu____1541] in
+            (from_tac, uu____1538) in
           FStar_Extraction_ML_Syntax.MLE_App uu____1531
       | n1 ->
           let uu____1561 =
             let uu____1566 =
-              let uu____1567 = FStar_Util.string_of_int n1  in
+              let uu____1567 = FStar_Util.string_of_int n1 in
               FStar_Util.format1
                 "Unembedding not defined for tactics of %s arguments\n"
-                uu____1567
-               in
-            (FStar_Errors.Fatal_CallNotImplemented, uu____1566)  in
-          FStar_Errors.raise_err uu____1561
-       in
+                uu____1567 in
+            (FStar_Errors.Fatal_CallNotImplemented, uu____1566) in
+          FStar_Errors.raise_err uu____1561 in
     FStar_Extraction_ML_Syntax.MLE_Fun
       ([(tac_arg, FStar_Extraction_ML_Syntax.MLTY_Top);
        ("()", FStar_Extraction_ML_Syntax.MLTY_Top)],
         (FStar_Extraction_ML_Syntax.with_ty
            FStar_Extraction_ML_Syntax.MLTY_Top app))
-  
-let rec (mk_tac_param_type :
+let rec mk_tac_param_type:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlexpr')
+    FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlexpr'
   =
   fun tcenv  ->
     fun t  ->
       let rec try_mk t1 unrefined =
         let uu____1605 =
-          let uu____1606 = FStar_Syntax_Subst.compress t1  in
-          uu____1606.FStar_Syntax_Syntax.n  in
+          let uu____1606 = FStar_Syntax_Subst.compress t1 in
+          uu____1606.FStar_Syntax_Syntax.n in
         match uu____1605 with
         | FStar_Syntax_Syntax.Tm_fvar fv when
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.int_lid ->
@@ -933,104 +848,93 @@ let rec (mk_tac_param_type :
             fstar_syn_syn_prefix "t_string"
         | FStar_Syntax_Syntax.Tm_fvar fv when
             let uu____1614 =
-              FStar_Reflection_Data.fstar_refl_types_lid "binder"  in
+              FStar_Reflection_Data.fstar_refl_types_lid "binder" in
             FStar_Syntax_Syntax.fv_eq_lid fv uu____1614 ->
             fstar_refl_data_prefix "t_binder"
         | FStar_Syntax_Syntax.Tm_fvar fv when
             let uu____1616 =
-              FStar_Reflection_Data.fstar_refl_types_lid "term"  in
+              FStar_Reflection_Data.fstar_refl_types_lid "term" in
             FStar_Syntax_Syntax.fv_eq_lid fv uu____1616 ->
             fstar_refl_data_prefix "t_term"
         | FStar_Syntax_Syntax.Tm_fvar fv when
-            let uu____1618 = FStar_Reflection_Data.fstar_refl_types_lid "fv"
-               in
+            let uu____1618 = FStar_Reflection_Data.fstar_refl_types_lid "fv" in
             FStar_Syntax_Syntax.fv_eq_lid fv uu____1618 ->
             fstar_refl_data_prefix "t_fv"
         | FStar_Syntax_Syntax.Tm_fvar fv when
             let uu____1620 =
-              FStar_Reflection_Data.fstar_refl_syntax_lid "binder"  in
+              FStar_Reflection_Data.fstar_refl_syntax_lid "binder" in
             FStar_Syntax_Syntax.fv_eq_lid fv uu____1620 ->
             fstar_refl_data_prefix "t_binders"
         | FStar_Syntax_Syntax.Tm_fvar fv when
             let uu____1622 =
-              FStar_Reflection_Data.fstar_refl_syntax_lid "norm_step"  in
+              FStar_Reflection_Data.fstar_refl_syntax_lid "norm_step" in
             FStar_Syntax_Syntax.fv_eq_lid fv uu____1622 ->
             fstar_refl_data_prefix "t_norm_step"
         | FStar_Syntax_Syntax.Tm_app (h,args) ->
             let uu____1645 =
-              let uu____1646 = FStar_Syntax_Subst.compress h  in
-              uu____1646.FStar_Syntax_Syntax.n  in
+              let uu____1646 = FStar_Syntax_Subst.compress h in
+              uu____1646.FStar_Syntax_Syntax.n in
             (match uu____1645 with
              | FStar_Syntax_Syntax.Tm_uinst (h',uu____1650) ->
                  let uu____1655 =
-                   let uu____1656 = FStar_Syntax_Subst.compress h'  in
-                   uu____1656.FStar_Syntax_Syntax.n  in
+                   let uu____1656 = FStar_Syntax_Subst.compress h' in
+                   uu____1656.FStar_Syntax_Syntax.n in
                  (match uu____1655 with
                   | FStar_Syntax_Syntax.Tm_fvar fv when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.list_lid
                       ->
                       let arg_term =
-                        let uu____1663 = FStar_List.hd args  in
-                        FStar_Pervasives_Native.fst uu____1663  in
+                        let uu____1663 = FStar_List.hd args in
+                        FStar_Pervasives_Native.fst uu____1663 in
                       let uu____1678 =
                         let uu____1685 =
-                          let uu____1686 = fstar_tc_common_prefix "t_list_of"
-                             in
+                          let uu____1686 = fstar_tc_common_prefix "t_list_of" in
                           FStar_Extraction_ML_Syntax.with_ty
-                            FStar_Extraction_ML_Syntax.MLTY_Top uu____1686
-                           in
+                            FStar_Extraction_ML_Syntax.MLTY_Top uu____1686 in
                         let uu____1687 =
                           let uu____1690 =
-                            let uu____1693 = mk_tac_param_type tcenv arg_term
-                               in
-                            [uu____1693]  in
+                            let uu____1693 = mk_tac_param_type tcenv arg_term in
+                            [uu____1693] in
                           FStar_List.map
                             (FStar_Extraction_ML_Syntax.with_ty
                                FStar_Extraction_ML_Syntax.MLTY_Top)
-                            uu____1690
-                           in
-                        (uu____1685, uu____1687)  in
+                            uu____1690 in
+                        (uu____1685, uu____1687) in
                       FStar_Extraction_ML_Syntax.MLE_App uu____1678
                   | FStar_Syntax_Syntax.Tm_fvar fv when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.option_lid
                       ->
                       let arg_term =
-                        let uu____1700 = FStar_List.hd args  in
-                        FStar_Pervasives_Native.fst uu____1700  in
+                        let uu____1700 = FStar_List.hd args in
+                        FStar_Pervasives_Native.fst uu____1700 in
                       let uu____1715 =
                         let uu____1722 =
                           let uu____1723 =
-                            fstar_tc_common_prefix "t_option_of"  in
+                            fstar_tc_common_prefix "t_option_of" in
                           FStar_Extraction_ML_Syntax.with_ty
-                            FStar_Extraction_ML_Syntax.MLTY_Top uu____1723
-                           in
+                            FStar_Extraction_ML_Syntax.MLTY_Top uu____1723 in
                         let uu____1724 =
                           let uu____1727 =
-                            let uu____1730 = mk_tac_param_type tcenv arg_term
-                               in
-                            [uu____1730]  in
+                            let uu____1730 = mk_tac_param_type tcenv arg_term in
+                            [uu____1730] in
                           FStar_List.map
                             (FStar_Extraction_ML_Syntax.with_ty
                                FStar_Extraction_ML_Syntax.MLTY_Top)
-                            uu____1727
-                           in
-                        (uu____1722, uu____1724)  in
+                            uu____1727 in
+                        (uu____1722, uu____1724) in
                       FStar_Extraction_ML_Syntax.MLE_App uu____1715
                   | uu____1733 ->
                       let uu____1734 =
                         let uu____1739 =
                           let uu____1740 =
-                            let uu____1741 = FStar_Syntax_Subst.compress h'
-                               in
-                            FStar_Syntax_Print.term_to_string uu____1741  in
+                            let uu____1741 = FStar_Syntax_Subst.compress h' in
+                            FStar_Syntax_Print.term_to_string uu____1741 in
                           Prims.strcat
                             "Type term not defined for higher-order type"
-                            uu____1740
-                           in
-                        (FStar_Errors.Fatal_CallNotImplemented, uu____1739)
-                         in
+                            uu____1740 in
+                        (FStar_Errors.Fatal_CallNotImplemented, uu____1739) in
                       FStar_Errors.raise_err uu____1734)
              | uu____1742 ->
                  FStar_Errors.raise_err
@@ -1039,34 +943,31 @@ let rec (mk_tac_param_type :
             let t2 =
               FStar_TypeChecker_Normalize.normalize
                 [FStar_TypeChecker_Normalize.UnfoldUntil
-                   FStar_Syntax_Syntax.Delta_constant] tcenv t1
-               in
-            let uu____1745 = FStar_Syntax_Util.unrefine t2  in
+                   FStar_Syntax_Syntax.Delta_constant] tcenv t1 in
+            let uu____1745 = FStar_Syntax_Util.unrefine t2 in
             try_mk uu____1745 true
         | uu____1746 ->
             let uu____1747 =
               let uu____1752 =
                 let uu____1753 =
-                  let uu____1754 = FStar_Syntax_Subst.compress t1  in
-                  FStar_Syntax_Print.term_to_string uu____1754  in
-                Prims.strcat "Type term not defined for " uu____1753  in
-              (FStar_Errors.Fatal_CallNotImplemented, uu____1752)  in
-            FStar_Errors.raise_err uu____1747
-         in
+                  let uu____1754 = FStar_Syntax_Subst.compress t1 in
+                  FStar_Syntax_Print.term_to_string uu____1754 in
+                Prims.strcat "Type term not defined for " uu____1753 in
+              (FStar_Errors.Fatal_CallNotImplemented, uu____1752) in
+            FStar_Errors.raise_err uu____1747 in
       try_mk t false
-  
-let rec (mk_tac_embedding_path :
+let rec mk_tac_embedding_path:
   FStar_TypeChecker_Env.env ->
     emb_decl ->
-      FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlexpr')
+      FStar_Syntax_Syntax.term -> FStar_Extraction_ML_Syntax.mlexpr'
   =
   fun tcenv  ->
     fun m  ->
       fun t  ->
         let rec try_mk t1 unrefined =
           let uu____1771 =
-            let uu____1772 = FStar_Syntax_Subst.compress t1  in
-            uu____1772.FStar_Syntax_Syntax.n  in
+            let uu____1772 = FStar_Syntax_Subst.compress t1 in
+            uu____1772.FStar_Syntax_Syntax.n in
           match uu____1771 with
           | FStar_Syntax_Syntax.Tm_fvar fv when
               FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.int_lid ->
@@ -1082,105 +983,98 @@ let rec (mk_tac_embedding_path :
               -> mk_basic_embedding m "string"
           | FStar_Syntax_Syntax.Tm_fvar fv when
               let uu____1780 =
-                FStar_Reflection_Data.fstar_refl_types_lid "binder"  in
+                FStar_Reflection_Data.fstar_refl_types_lid "binder" in
               FStar_Syntax_Syntax.fv_eq_lid fv uu____1780 ->
               mk_embedding m "binder"
           | FStar_Syntax_Syntax.Tm_fvar fv when
               let uu____1782 =
-                FStar_Reflection_Data.fstar_refl_types_lid "term"  in
+                FStar_Reflection_Data.fstar_refl_types_lid "term" in
               FStar_Syntax_Syntax.fv_eq_lid fv uu____1782 ->
               mk_embedding m "term"
           | FStar_Syntax_Syntax.Tm_fvar fv when
               let uu____1784 =
-                FStar_Reflection_Data.fstar_refl_types_lid "fv"  in
+                FStar_Reflection_Data.fstar_refl_types_lid "fv" in
               FStar_Syntax_Syntax.fv_eq_lid fv uu____1784 ->
               mk_embedding m "fvar"
           | FStar_Syntax_Syntax.Tm_fvar fv when
               let uu____1786 =
-                FStar_Reflection_Data.fstar_refl_syntax_lid "binders"  in
+                FStar_Reflection_Data.fstar_refl_syntax_lid "binders" in
               FStar_Syntax_Syntax.fv_eq_lid fv uu____1786 ->
               mk_embedding m "binders"
           | FStar_Syntax_Syntax.Tm_fvar fv when
               let uu____1788 =
-                FStar_Reflection_Data.fstar_refl_syntax_lid "norm_step"  in
+                FStar_Reflection_Data.fstar_refl_syntax_lid "norm_step" in
               FStar_Syntax_Syntax.fv_eq_lid fv uu____1788 ->
               mk_embedding m "norm_step"
           | FStar_Syntax_Syntax.Tm_app (h,args) ->
               let uu____1811 =
-                let uu____1812 = FStar_Syntax_Subst.compress h  in
-                uu____1812.FStar_Syntax_Syntax.n  in
+                let uu____1812 = FStar_Syntax_Subst.compress h in
+                uu____1812.FStar_Syntax_Syntax.n in
               (match uu____1811 with
                | FStar_Syntax_Syntax.Tm_uinst (h',uu____1816) ->
                    let uu____1821 =
                      let uu____1832 =
-                       let uu____1833 = FStar_Syntax_Subst.compress h'  in
-                       uu____1833.FStar_Syntax_Syntax.n  in
+                       let uu____1833 = FStar_Syntax_Subst.compress h' in
+                       uu____1833.FStar_Syntax_Syntax.n in
                      match uu____1832 with
                      | FStar_Syntax_Syntax.Tm_fvar fv when
                          FStar_Syntax_Syntax.fv_eq_lid fv
                            FStar_Parser_Const.list_lid
                          ->
                          let arg_term =
-                           let uu____1850 = FStar_List.hd args  in
-                           FStar_Pervasives_Native.fst uu____1850  in
+                           let uu____1850 = FStar_List.hd args in
+                           FStar_Pervasives_Native.fst uu____1850 in
                          let uu____1865 =
                            let uu____1868 =
-                             mk_tac_embedding_path tcenv m arg_term  in
-                           [uu____1868]  in
-                         let uu____1869 = mk_tac_param_type tcenv arg_term
-                            in
+                             mk_tac_embedding_path tcenv m arg_term in
+                           [uu____1868] in
+                         let uu____1869 = mk_tac_param_type tcenv arg_term in
                          ("list", uu____1865, uu____1869, false)
                      | FStar_Syntax_Syntax.Tm_fvar fv when
                          FStar_Syntax_Syntax.fv_eq_lid fv
                            FStar_Parser_Const.option_lid
                          ->
                          let arg_term =
-                           let uu____1876 = FStar_List.hd args  in
-                           FStar_Pervasives_Native.fst uu____1876  in
+                           let uu____1876 = FStar_List.hd args in
+                           FStar_Pervasives_Native.fst uu____1876 in
                          let uu____1891 =
                            let uu____1894 =
-                             mk_tac_embedding_path tcenv m arg_term  in
-                           [uu____1894]  in
-                         let uu____1895 = mk_tac_param_type tcenv arg_term
-                            in
+                             mk_tac_embedding_path tcenv m arg_term in
+                           [uu____1894] in
+                         let uu____1895 = mk_tac_param_type tcenv arg_term in
                          ("option", uu____1891, uu____1895, false)
                      | FStar_Syntax_Syntax.Tm_fvar fv when
                          FStar_Syntax_Syntax.fv_eq_lid fv
                            FStar_Parser_Const.tactic_lid
                          ->
                          let arg_term =
-                           let uu____1902 = FStar_List.hd args  in
-                           FStar_Pervasives_Native.fst uu____1902  in
+                           let uu____1902 = FStar_List.hd args in
+                           FStar_Pervasives_Native.fst uu____1902 in
                          let uu____1917 =
                            let uu____1920 =
-                             mk_tac_embedding_path tcenv m arg_term  in
-                           [uu____1920]  in
-                         let uu____1921 = mk_tac_param_type tcenv arg_term
-                            in
+                             mk_tac_embedding_path tcenv m arg_term in
+                           [uu____1920] in
+                         let uu____1921 = mk_tac_param_type tcenv arg_term in
                          ("list", uu____1917, uu____1921, true)
                      | uu____1924 ->
                          let uu____1925 =
                            let uu____1930 =
                              let uu____1931 =
                                let uu____1932 =
-                                 FStar_Syntax_Subst.compress h'  in
-                               FStar_Syntax_Print.term_to_string uu____1932
-                                in
+                                 FStar_Syntax_Subst.compress h' in
+                               FStar_Syntax_Print.term_to_string uu____1932 in
                              Prims.strcat
                                "Embedding not defined for higher-order type "
-                               uu____1931
-                              in
+                               uu____1931 in
                            (FStar_Errors.Fatal_CallNotImplemented,
-                             uu____1930)
-                            in
-                         FStar_Errors.raise_err uu____1925
-                      in
+                             uu____1930) in
+                         FStar_Errors.raise_err uu____1925 in
                    (match uu____1821 with
                     | (ht,hargs,type_arg,is_tactic) ->
                         let hargs1 =
                           match m with
                           | Embed  -> FStar_List.append hargs [type_arg]
-                          | Unembed  -> hargs  in
+                          | Unembed  -> hargs in
                         if is_tactic
                         then
                           (match m with
@@ -1192,18 +1086,16 @@ let rec (mk_tac_embedding_path :
                         else
                           (let uu____1957 =
                              let uu____1964 =
-                               let uu____1965 = mk_basic_embedding m ht  in
+                               let uu____1965 = mk_basic_embedding m ht in
                                FStar_Extraction_ML_Syntax.with_ty
                                  FStar_Extraction_ML_Syntax.MLTY_Top
-                                 uu____1965
-                                in
+                                 uu____1965 in
                              let uu____1966 =
                                FStar_List.map
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     FStar_Extraction_ML_Syntax.MLTY_Top)
-                                 hargs1
-                                in
-                             (uu____1964, uu____1966)  in
+                                 hargs1 in
+                             (uu____1964, uu____1966) in
                            FStar_Extraction_ML_Syntax.MLE_App uu____1957))
                | uu____1971 ->
                    FStar_Errors.raise_err
@@ -1212,24 +1104,20 @@ let rec (mk_tac_embedding_path :
               let t2 =
                 FStar_TypeChecker_Normalize.normalize
                   [FStar_TypeChecker_Normalize.UnfoldUntil
-                     FStar_Syntax_Syntax.Delta_constant] tcenv t1
-                 in
-              let uu____1974 = FStar_Syntax_Util.unrefine t2  in
+                     FStar_Syntax_Syntax.Delta_constant] tcenv t1 in
+              let uu____1974 = FStar_Syntax_Util.unrefine t2 in
               try_mk uu____1974 true
           | uu____1975 ->
               let uu____1976 =
                 let uu____1981 =
                   let uu____1982 =
-                    let uu____1983 = FStar_Syntax_Subst.compress t1  in
-                    FStar_Syntax_Print.term_to_string uu____1983  in
-                  Prims.strcat "Embedding not defined for type " uu____1982
-                   in
-                (FStar_Errors.Fatal_CallNotImplemented, uu____1981)  in
-              FStar_Errors.raise_err uu____1976
-           in
+                    let uu____1983 = FStar_Syntax_Subst.compress t1 in
+                    FStar_Syntax_Print.term_to_string uu____1983 in
+                  Prims.strcat "Embedding not defined for type " uu____1982 in
+                (FStar_Errors.Fatal_CallNotImplemented, uu____1981) in
+              FStar_Errors.raise_err uu____1976 in
         try_mk t false
-  
-let mk_interpretation_fun :
+let mk_interpretation_fun:
   'Auu____1990 .
     FStar_TypeChecker_Env.env ->
       FStar_Ident.lident ->
@@ -1250,76 +1138,67 @@ let mk_interpretation_fun :
                 FStar_List.map
                   (fun x  ->
                      (FStar_Pervasives_Native.fst x).FStar_Syntax_Syntax.sort)
-                  bs
-                 in
-              let arity = FStar_List.length bs  in
+                  bs in
+              let arity = FStar_List.length bs in
               let h =
                 let uu____2062 =
-                  let uu____2063 = FStar_Util.string_of_int arity  in
+                  let uu____2063 = FStar_Util.string_of_int arity in
                   Prims.strcat
                     "FStar_Tactics_Interpreter.mk_tactic_interpretation_"
-                    uu____2063
-                   in
-                str_to_top_name uu____2062  in
+                    uu____2063 in
+                str_to_top_name uu____2062 in
               let tac_fun =
                 let uu____2071 =
                   let uu____2078 =
                     let uu____2079 =
-                      let uu____2080 = FStar_Util.string_of_int arity  in
+                      let uu____2080 = FStar_Util.string_of_int arity in
                       Prims.strcat "FStar_Tactics_Native.from_tactic_"
-                        uu____2080
-                       in
-                    str_to_top_name uu____2079  in
+                        uu____2080 in
+                    str_to_top_name uu____2079 in
                   let uu____2087 =
-                    let uu____2090 = lid_to_top_name tac_lid  in [uu____2090]
-                     in
-                  (uu____2078, uu____2087)  in
-                FStar_Extraction_ML_Syntax.MLE_App uu____2071  in
+                    let uu____2090 = lid_to_top_name tac_lid in [uu____2090] in
+                  (uu____2078, uu____2087) in
+                FStar_Extraction_ML_Syntax.MLE_App uu____2071 in
               let tac_lid_app =
                 let uu____2094 =
-                  let uu____2101 = str_to_top_name "FStar_Ident.lid_of_str"
-                     in
+                  let uu____2101 = str_to_top_name "FStar_Ident.lid_of_str" in
                   (uu____2101,
                     [FStar_Extraction_ML_Syntax.with_ty
-                       FStar_Extraction_ML_Syntax.MLTY_Top assm_lid])
-                   in
-                FStar_Extraction_ML_Syntax.MLE_App uu____2094  in
-              let psc = str_to_name "psc"  in
+                       FStar_Extraction_ML_Syntax.MLTY_Top assm_lid]) in
+                FStar_Extraction_ML_Syntax.MLE_App uu____2094 in
+              let psc = str_to_name "psc" in
               let args =
                 let uu____2108 =
                   let uu____2111 =
                     FStar_List.map (mk_tac_embedding_path tcenv Unembed)
-                      arg_types
-                     in
+                      arg_types in
                   let uu____2114 =
-                    let uu____2117 = mk_tac_embedding_path tcenv Embed t  in
+                    let uu____2117 = mk_tac_embedding_path tcenv Embed t in
                     let uu____2118 =
-                      let uu____2121 = mk_tac_param_type tcenv t  in
+                      let uu____2121 = mk_tac_param_type tcenv t in
                       let uu____2122 =
                         let uu____2125 =
                           let uu____2128 =
-                            let uu____2131 = str_to_name "args"  in
-                            [uu____2131]  in
-                          psc :: uu____2128  in
-                        tac_lid_app :: uu____2125  in
-                      uu____2121 :: uu____2122  in
-                    uu____2117 :: uu____2118  in
-                  FStar_List.append uu____2111 uu____2114  in
-                FStar_List.append [tac_fun] uu____2108  in
+                            let uu____2131 = str_to_name "args" in
+                            [uu____2131] in
+                          psc :: uu____2128 in
+                        tac_lid_app :: uu____2125 in
+                      uu____2121 :: uu____2122 in
+                    uu____2117 :: uu____2118 in
+                  FStar_List.append uu____2111 uu____2114 in
+                FStar_List.append [tac_fun] uu____2108 in
               let app =
                 let uu____2133 =
                   let uu____2134 =
                     let uu____2141 =
                       FStar_List.map
                         (FStar_Extraction_ML_Syntax.with_ty
-                           FStar_Extraction_ML_Syntax.MLTY_Top) args
-                       in
-                    (h, uu____2141)  in
-                  FStar_Extraction_ML_Syntax.MLE_App uu____2134  in
+                           FStar_Extraction_ML_Syntax.MLTY_Top) args in
+                    (h, uu____2141) in
+                  FStar_Extraction_ML_Syntax.MLE_App uu____2134 in
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
-                     FStar_Extraction_ML_Syntax.MLTY_Top) uu____2133
-                 in
+                     FStar_Extraction_ML_Syntax.MLTY_Top) uu____2133 in
               FStar_Pervasives_Native.Some
                 (FStar_Extraction_ML_Syntax.MLE_Fun
                    ([("psc", FStar_Extraction_ML_Syntax.MLTY_Top);
@@ -1327,8 +1206,7 @@ let mk_interpretation_fun :
             with
             | FStar_Errors.Error
                 (FStar_Errors.Fatal_CallNotImplemented ,msg,uu____2172) ->
-                ((let uu____2174 = FStar_Ident.string_of_lid tac_lid  in
+                ((let uu____2174 = FStar_Ident.string_of_lid tac_lid in
                   not_implemented_warning t.FStar_Syntax_Syntax.pos
                     uu____2174 msg);
                  FStar_Pervasives_Native.None)
-  

--- a/src/ocaml-output/FStar_Format.ml
+++ b/src/ocaml-output/FStar_Format.ml
@@ -1,48 +1,42 @@
 open Prims
 type doc =
-  | Doc of Prims.string [@@deriving show]
-let (uu___is_Doc : doc -> Prims.bool) = fun projectee  -> true 
-let (__proj__Doc__item___0 : doc -> Prims.string) =
-  fun projectee  -> match projectee with | Doc _0 -> _0 
-let (empty : doc) = Doc "" 
-let (hardline : doc) = Doc "\n" 
-let (text : Prims.string -> doc) = fun s  -> Doc s 
-let (num : Prims.int -> doc) = fun i  -> Doc (Prims.string_of_int i) 
-let (break_ : Prims.int -> doc) = fun i  -> Doc "" 
-let (break0 : doc) = break_ (Prims.parse_int "0") 
-let (break1 : doc) = text " " 
-let (enclose : doc -> doc -> doc -> doc) =
+  | Doc of Prims.string[@@deriving show]
+let uu___is_Doc: doc -> Prims.bool = fun projectee  -> true
+let __proj__Doc__item___0: doc -> Prims.string =
+  fun projectee  -> match projectee with | Doc _0 -> _0
+let empty: doc = Doc ""
+let hardline: doc = Doc "\n"
+let text: Prims.string -> doc = fun s  -> Doc s
+let num: Prims.int -> doc = fun i  -> Doc (Prims.string_of_int i)
+let break_: Prims.int -> doc = fun i  -> Doc ""
+let break0: doc = break_ (Prims.parse_int "0")
+let break1: doc = text " "
+let enclose: doc -> doc -> doc -> doc =
   fun uu____27  ->
     fun uu____28  ->
       fun uu____29  ->
         match (uu____27, uu____28, uu____29) with
         | (Doc l,Doc r,Doc x) -> Doc (Prims.strcat l (Prims.strcat x r))
-  
-let (brackets : doc -> doc) =
+let brackets: doc -> doc =
   fun uu____35  ->
     match uu____35 with | Doc d -> enclose (text "[") (text "]") (Doc d)
-  
-let (cbrackets : doc -> doc) =
+let cbrackets: doc -> doc =
   fun uu____39  ->
     match uu____39 with | Doc d -> enclose (text "{") (text "}") (Doc d)
-  
-let (parens : doc -> doc) =
+let parens: doc -> doc =
   fun uu____43  ->
     match uu____43 with | Doc d -> enclose (text "(") (text ")") (Doc d)
-  
-let (cat : doc -> doc -> doc) =
+let cat: doc -> doc -> doc =
   fun uu____49  ->
     fun uu____50  ->
       match (uu____49, uu____50) with
       | (Doc d1,Doc d2) -> Doc (Prims.strcat d1 d2)
-  
-let (reduce : doc Prims.list -> doc) =
-  fun docs  -> FStar_List.fold_left cat empty docs 
-let (group : doc -> doc) =
-  fun uu____62  -> match uu____62 with | Doc d -> Doc d 
-let (groups : doc Prims.list -> doc) =
-  fun docs  -> let uu____71 = reduce docs  in group uu____71 
-let (combine : doc -> doc Prims.list -> doc) =
+let reduce: doc Prims.list -> doc =
+  fun docs  -> FStar_List.fold_left cat empty docs
+let group: doc -> doc = fun uu____62  -> match uu____62 with | Doc d -> Doc d
+let groups: doc Prims.list -> doc =
+  fun docs  -> let uu____71 = reduce docs in group uu____71
+let combine: doc -> doc Prims.list -> doc =
   fun uu____78  ->
     fun docs  ->
       match uu____78 with
@@ -52,21 +46,17 @@ let (combine : doc -> doc Prims.list -> doc) =
             | Doc d ->
                 if d = ""
                 then FStar_Pervasives_Native.None
-                else FStar_Pervasives_Native.Some d
-             in
-          let docs1 = FStar_List.choose select docs  in
+                else FStar_Pervasives_Native.Some d in
+          let docs1 = FStar_List.choose select docs in
           Doc (FStar_String.concat sep docs1)
-  
-let (cat1 : doc -> doc -> doc) =
-  fun d1  -> fun d2  -> reduce [d1; break1; d2] 
-let (reduce1 : doc Prims.list -> doc) = fun docs  -> combine break1 docs 
-let (nest : Prims.int -> doc -> doc) =
-  fun i  -> fun uu____116  -> match uu____116 with | Doc d -> Doc d 
-let (align : doc Prims.list -> doc) =
+let cat1: doc -> doc -> doc = fun d1  -> fun d2  -> reduce [d1; break1; d2]
+let reduce1: doc Prims.list -> doc = fun docs  -> combine break1 docs
+let nest: Prims.int -> doc -> doc =
+  fun i  -> fun uu____116  -> match uu____116 with | Doc d -> Doc d
+let align: doc Prims.list -> doc =
   fun docs  ->
-    let uu____125 = combine hardline docs  in
+    let uu____125 = combine hardline docs in
     match uu____125 with | Doc doc -> Doc doc
-  
-let (hbox : doc -> doc) = fun d  -> d 
-let (pretty : Prims.int -> doc -> Prims.string) =
-  fun sz  -> fun uu____135  -> match uu____135 with | Doc doc -> doc 
+let hbox: doc -> doc = fun d  -> d
+let pretty: Prims.int -> doc -> Prims.string =
+  fun sz  -> fun uu____135  -> match uu____135 with | Doc doc -> doc

--- a/src/ocaml-output/FStar_Fsdoc_Generator.ml
+++ b/src/ocaml-output/FStar_Fsdoc_Generator.ml
@@ -1,8 +1,8 @@
 open Prims
-let (one_toplevel :
+let one_toplevel:
   FStar_Parser_AST.decl Prims.list ->
     (FStar_Parser_AST.decl,FStar_Parser_AST.decl Prims.list)
-      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun decls  ->
     let uu____16 =
@@ -10,33 +10,29 @@ let (one_toplevel :
         (fun d  ->
            match d.FStar_Parser_AST.d with
            | FStar_Parser_AST.TopLevelModule uu____28 -> true
-           | uu____29 -> false) decls
-       in
+           | uu____29 -> false) decls in
     match uu____16 with
     | (top,nontops) ->
         (match top with
          | t::[] -> FStar_Pervasives_Native.Some (t, nontops)
          | uu____65 -> FStar_Pervasives_Native.None)
-  
 type mforest =
-  | Leaf of (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 
-  | Branch of mforest FStar_Util.smap [@@deriving show]
-let (uu___is_Leaf : mforest -> Prims.bool) =
+  | Leaf of (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2
+  | Branch of mforest FStar_Util.smap[@@deriving show]
+let uu___is_Leaf: mforest -> Prims.bool =
   fun projectee  ->
     match projectee with | Leaf _0 -> true | uu____96 -> false
-  
-let (__proj__Leaf__item___0 :
-  mforest -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Leaf _0 -> _0 
-let (uu___is_Branch : mforest -> Prims.bool) =
+let __proj__Leaf__item___0:
+  mforest -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Leaf _0 -> _0
+let uu___is_Branch: mforest -> Prims.bool =
   fun projectee  ->
     match projectee with | Branch _0 -> true | uu____122 -> false
-  
-let (__proj__Branch__item___0 : mforest -> mforest FStar_Util.smap) =
-  fun projectee  -> match projectee with | Branch _0 -> _0 
-let (htree : mforest FStar_Util.smap) =
-  FStar_Util.smap_create (Prims.parse_int "50") 
-let string_of_optiont :
+let __proj__Branch__item___0: mforest -> mforest FStar_Util.smap =
+  fun projectee  -> match projectee with | Branch _0 -> _0
+let htree: mforest FStar_Util.smap =
+  FStar_Util.smap_create (Prims.parse_int "50")
+let string_of_optiont:
   'Auu____143 'Auu____144 .
     ('Auu____144 -> 'Auu____143) ->
       'Auu____143 ->
@@ -48,27 +44,25 @@ let string_of_optiont :
         match xo with
         | FStar_Pervasives_Native.Some x -> f x
         | FStar_Pervasives_Native.None  -> y
-  
-let (string_of_fsdoco :
+let string_of_fsdoco:
   (Prims.string,(Prims.string,Prims.string) FStar_Pervasives_Native.tuple2
                   Prims.list)
     FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option ->
-    Prims.string)
+    Prims.string
   =
   fun d  ->
     string_of_optiont
       (fun x  ->
          let uu____217 =
-           let uu____218 = FStar_Parser_AST.string_of_fsdoc x  in
-           Prims.strcat uu____218 "*)"  in
+           let uu____218 = FStar_Parser_AST.string_of_fsdoc x in
+           Prims.strcat uu____218 "*)" in
          Prims.strcat "(*" uu____217) "" d
-  
-let (string_of_termo :
-  FStar_Parser_AST.term FStar_Pervasives_Native.option -> Prims.string) =
-  fun t  -> string_of_optiont FStar_Parser_AST.term_to_string "" t 
-let (code_wrap : Prims.string -> Prims.string) =
-  fun s  -> Prims.strcat "```fsharp\n" (Prims.strcat s "\n```\n") 
-let (string_of_tycon : FStar_Parser_AST.tycon -> Prims.string) =
+let string_of_termo:
+  FStar_Parser_AST.term FStar_Pervasives_Native.option -> Prims.string =
+  fun t  -> string_of_optiont FStar_Parser_AST.term_to_string "" t
+let code_wrap: Prims.string -> Prims.string =
+  fun s  -> Prims.strcat "```fsharp\n" (Prims.strcat s "\n```\n")
+let string_of_tycon: FStar_Parser_AST.tycon -> Prims.string =
   fun tycon  ->
     match tycon with
     | FStar_Parser_AST.TyconAbstract uu____232 -> "abstract"
@@ -83,19 +77,17 @@ let (string_of_tycon : FStar_Parser_AST.tycon -> Prims.string) =
                      (fun uu____330  ->
                         match uu____330 with
                         | (id2,t,doco) ->
-                            let uu____376 = string_of_fsdoco doco  in
+                            let uu____376 = string_of_fsdoco doco in
                             let uu____377 =
                               let uu____378 =
                                 let uu____379 =
-                                  FStar_Parser_AST.term_to_string t  in
-                                Prims.strcat ":" uu____379  in
-                              Prims.strcat id2.FStar_Ident.idText uu____378
-                               in
-                            Prims.strcat uu____376 uu____377))
-                 in
-              FStar_All.pipe_right uu____291 (FStar_String.concat "; ")  in
-            Prims.strcat uu____290 " }"  in
-          Prims.strcat " = { " uu____289  in
+                                  FStar_Parser_AST.term_to_string t in
+                                Prims.strcat ":" uu____379 in
+                              Prims.strcat id2.FStar_Ident.idText uu____378 in
+                            Prims.strcat uu____376 uu____377)) in
+              FStar_All.pipe_right uu____291 (FStar_String.concat "; ") in
+            Prims.strcat uu____290 " }" in
+          Prims.strcat " = { " uu____289 in
         Prims.strcat id1.FStar_Ident.idText uu____288
     | FStar_Parser_AST.TyconVariant (id1,_bb,_ko,vars) ->
         let uu____422 =
@@ -106,22 +98,19 @@ let (string_of_tycon : FStar_Parser_AST.tycon -> Prims.string) =
                    (fun uu____472  ->
                       match uu____472 with
                       | (id2,trmo,doco,u) ->
-                          let uu____527 = string_of_fsdoco doco  in
+                          let uu____527 = string_of_fsdoco doco in
                           let uu____528 =
                             let uu____529 =
                               let uu____530 =
                                 string_of_optiont
-                                  FStar_Parser_AST.term_to_string "" trmo
-                                 in
-                              Prims.strcat ":" uu____530  in
-                            Prims.strcat id2.FStar_Ident.idText uu____529  in
-                          Prims.strcat uu____527 uu____528))
-               in
-            FStar_All.pipe_right uu____424 (FStar_String.concat " | ")  in
-          Prims.strcat " = " uu____423  in
+                                  FStar_Parser_AST.term_to_string "" trmo in
+                              Prims.strcat ":" uu____530 in
+                            Prims.strcat id2.FStar_Ident.idText uu____529 in
+                          Prims.strcat uu____527 uu____528)) in
+            FStar_All.pipe_right uu____424 (FStar_String.concat " | ") in
+          Prims.strcat " = " uu____423 in
         Prims.strcat id1.FStar_Ident.idText uu____422
-  
-let (string_of_decl' : FStar_Parser_AST.decl' -> Prims.string) =
+let string_of_decl': FStar_Parser_AST.decl' -> Prims.string =
   fun d  ->
     match d with
     | FStar_Parser_AST.TopLevelModule l ->
@@ -138,24 +127,22 @@ let (string_of_decl' : FStar_Parser_AST.decl' -> Prims.string) =
             (fun uu____575  ->
                match uu____575 with
                | (p,t) ->
-                   let uu____586 = FStar_Parser_AST.pat_to_string p  in
-                   let uu____587 = FStar_Parser_AST.term_to_string t  in
-                   (uu____586, uu____587)) pats
-           in
+                   let uu____586 = FStar_Parser_AST.pat_to_string p in
+                   let uu____587 = FStar_Parser_AST.term_to_string t in
+                   (uu____586, uu____587)) pats in
         let termty' =
           FStar_List.map
             (fun uu____598  ->
                match uu____598 with
-               | (p,t) -> Prims.strcat p (Prims.strcat ":" t)) termty
-           in
+               | (p,t) -> Prims.strcat p (Prims.strcat ":" t)) termty in
         Prims.strcat "let " (FStar_String.concat ", " termty')
     | FStar_Parser_AST.Main uu____605 -> "main ..."
     | FStar_Parser_AST.Assume (i,t) ->
         let uu____608 =
           let uu____609 =
-            let uu____610 = FStar_Parser_AST.term_to_string t  in
-            Prims.strcat ":" uu____610  in
-          Prims.strcat i.FStar_Ident.idText uu____609  in
+            let uu____610 = FStar_Parser_AST.term_to_string t in
+            Prims.strcat ":" uu____610 in
+          Prims.strcat i.FStar_Ident.idText uu____609 in
         Prims.strcat "assume " uu____608
     | FStar_Parser_AST.Tycon (uu____611,tys) ->
         let uu____629 =
@@ -165,20 +152,19 @@ let (string_of_decl' : FStar_Parser_AST.decl' -> Prims.string) =
                  (fun uu____664  ->
                     match uu____664 with
                     | (t,d1) ->
-                        let uu____707 = string_of_tycon t  in
+                        let uu____707 = string_of_tycon t in
                         let uu____708 =
-                          let uu____709 = string_of_fsdoco d1  in
-                          Prims.strcat " " uu____709  in
-                        Prims.strcat uu____707 uu____708))
-             in
-          FStar_All.pipe_right uu____630 (FStar_String.concat " and ")  in
+                          let uu____709 = string_of_fsdoco d1 in
+                          Prims.strcat " " uu____709 in
+                        Prims.strcat uu____707 uu____708)) in
+          FStar_All.pipe_right uu____630 (FStar_String.concat " and ") in
         Prims.strcat "type " uu____629
     | FStar_Parser_AST.Val (i,t) ->
         let uu____714 =
           let uu____715 =
-            let uu____716 = FStar_Parser_AST.term_to_string t  in
-            Prims.strcat ":" uu____716  in
-          Prims.strcat i.FStar_Ident.idText uu____715  in
+            let uu____716 = FStar_Parser_AST.term_to_string t in
+            Prims.strcat ":" uu____716 in
+          Prims.strcat i.FStar_Ident.idText uu____715 in
         Prims.strcat "val " uu____714
     | FStar_Parser_AST.Exception (i,uu____718) ->
         Prims.strcat "exception " i.FStar_Ident.idText
@@ -191,8 +177,7 @@ let (string_of_decl' : FStar_Parser_AST.decl' -> Prims.string) =
     | FStar_Parser_AST.SubEffect uu____742 -> "sub_effect"
     | FStar_Parser_AST.Pragma uu____743 -> "pragma"
     | FStar_Parser_AST.Fsdoc (comm,uu____745) -> comm
-  
-let (decl_documented : FStar_Parser_AST.decl -> Prims.bool) =
+let decl_documented: FStar_Parser_AST.decl -> Prims.bool =
   fun d  ->
     let tycon_documented tt =
       let tyconvars_documented tycon =
@@ -210,14 +195,12 @@ let (decl_documented : FStar_Parser_AST.decl -> Prims.bool) =
             FStar_List.existsb
               (fun uu____926  ->
                  match uu____926 with
-                 | (_id,_t,doco,_u) -> FStar_Util.is_some doco) vars
-         in
+                 | (_id,_t,doco,_u) -> FStar_Util.is_some doco) vars in
       FStar_List.existsb
         (fun uu____960  ->
            match uu____960 with
            | (tycon,doco) ->
-               (tyconvars_documented tycon) || (FStar_Util.is_some doco)) tt
-       in
+               (tyconvars_documented tycon) || (FStar_Util.is_some doco)) tt in
     match d.FStar_Parser_AST.doc with
     | FStar_Pervasives_Native.Some uu____973 -> true
     | uu____974 ->
@@ -225,22 +208,21 @@ let (decl_documented : FStar_Parser_AST.decl -> Prims.bool) =
          | FStar_Parser_AST.Fsdoc uu____977 -> true
          | FStar_Parser_AST.Tycon (uu____978,ty) -> tycon_documented ty
          | uu____996 -> false)
-  
-let (document_decl :
-  (Prims.string -> Prims.unit) -> FStar_Parser_AST.decl -> Prims.unit) =
+let document_decl:
+  (Prims.string -> Prims.unit) -> FStar_Parser_AST.decl -> Prims.unit =
   fun w  ->
     fun d  ->
       if decl_documented d
       then
-        let uu____1008 = d  in
+        let uu____1008 = d in
         match uu____1008 with
         | { FStar_Parser_AST.d = decl; FStar_Parser_AST.drange = uu____1010;
             FStar_Parser_AST.doc = fsdoc;
             FStar_Parser_AST.quals = uu____1012;
             FStar_Parser_AST.attrs = uu____1013;_} ->
             ((let uu____1017 =
-                let uu____1018 = string_of_decl' d.FStar_Parser_AST.d  in
-                code_wrap uu____1018  in
+                let uu____1018 = string_of_decl' d.FStar_Parser_AST.d in
+                code_wrap uu____1018 in
               w uu____1017);
              (match fsdoc with
               | FStar_Pervasives_Native.Some (doc1,_kw) ->
@@ -248,8 +230,7 @@ let (document_decl :
               | uu____1044 -> ());
              w "")
       else ()
-  
-let document_toplevel :
+let document_toplevel:
   'Auu____1051 .
     'Auu____1051 ->
       FStar_Parser_AST.decl ->
@@ -266,8 +247,7 @@ let document_toplevel :
                let uu____1101 =
                  FStar_List.tryFind
                    (fun uu____1115  ->
-                      match uu____1115 with | (k,v1) -> k = "summary") kw
-                  in
+                      match uu____1115 with | (k,v1) -> k = "summary") kw in
                (match uu____1101 with
                 | FStar_Pervasives_Native.None  ->
                     (FStar_Pervasives_Native.None,
@@ -280,45 +260,41 @@ let document_toplevel :
       | uu____1152 ->
           FStar_Errors.raise_err
             (FStar_Errors.Fatal_NotTopLevelModule, "Not Top-level Module")
-  
-let (document_module : FStar_Parser_AST.modul -> FStar_Ident.lid) =
+let document_module: FStar_Parser_AST.modul -> FStar_Ident.lid =
   fun m  ->
     let uu____1164 =
       match m with
       | FStar_Parser_AST.Module (n1,d) -> (n1, d, "module")
-      | FStar_Parser_AST.Interface (n1,d,uu____1191) -> (n1, d, "interface")
-       in
+      | FStar_Parser_AST.Interface (n1,d,uu____1191) -> (n1, d, "interface") in
     match uu____1164 with
     | (name,decls,_mt) ->
-        let uu____1205 = one_toplevel decls  in
+        let uu____1205 = one_toplevel decls in
         (match uu____1205 with
          | FStar_Pervasives_Native.Some (top_decl,other_decls) ->
              let on =
                FStar_Options.prepend_output_dir
-                 (Prims.strcat name.FStar_Ident.str ".md")
-                in
-             let fd = FStar_Util.open_file_for_writing on  in
-             let w = FStar_Util.append_to_file fd  in
-             let no_summary = "fsdoc: no-summary-found"  in
-             let no_comment = "fsdoc: no-comment-found"  in
-             let uu____1233 = document_toplevel name top_decl  in
+                 (Prims.strcat name.FStar_Ident.str ".md") in
+             let fd = FStar_Util.open_file_for_writing on in
+             let w = FStar_Util.append_to_file fd in
+             let no_summary = "fsdoc: no-summary-found" in
+             let no_comment = "fsdoc: no-comment-found" in
+             let uu____1233 = document_toplevel name top_decl in
              (match uu____1233 with
               | (summary,comment) ->
                   let summary1 =
                     match summary with
                     | FStar_Pervasives_Native.Some s -> s
-                    | FStar_Pervasives_Native.None  -> no_summary  in
+                    | FStar_Pervasives_Native.None  -> no_summary in
                   let comment1 =
                     match comment with
                     | FStar_Pervasives_Native.Some s -> s
-                    | FStar_Pervasives_Native.None  -> no_comment  in
+                    | FStar_Pervasives_Native.None  -> no_comment in
                   ((let uu____1257 =
-                      FStar_Util.format "# module %s" [name.FStar_Ident.str]
-                       in
+                      FStar_Util.format "# module %s" [name.FStar_Ident.str] in
                     w uu____1257);
-                   (let uu____1259 = FStar_Util.format "%s\n" [summary1]  in
+                   (let uu____1259 = FStar_Util.format "%s\n" [summary1] in
                     w uu____1259);
-                   (let uu____1261 = FStar_Util.format "%s\n" [comment1]  in
+                   (let uu____1261 = FStar_Util.format "%s\n" [comment1] in
                     w uu____1261);
                    FStar_List.iter (document_decl w) other_decls;
                    FStar_Util.close_file fd;
@@ -327,25 +303,21 @@ let (document_module : FStar_Parser_AST.modul -> FStar_Ident.lid) =
              let uu____1270 =
                let uu____1275 =
                  FStar_Util.format1 "No singleton toplevel in module %s"
-                   name.FStar_Ident.str
-                  in
-               (FStar_Errors.Fatal_NonSingletonTopLevel, uu____1275)  in
+                   name.FStar_Ident.str in
+               (FStar_Errors.Fatal_NonSingletonTopLevel, uu____1275) in
              FStar_Errors.raise_err uu____1270)
-  
-let (generate : Prims.string Prims.list -> Prims.unit) =
+let generate: Prims.string Prims.list -> Prims.unit =
   fun files  ->
     let modules =
       FStar_List.map
         (fun fn  ->
-           let uu____1289 = FStar_Parser_Driver.parse_file fn  in
-           FStar_Pervasives_Native.fst uu____1289) files
-       in
-    let mods = FStar_List.map document_module modules  in
-    let on = FStar_Options.prepend_output_dir "index.md"  in
-    let fd = FStar_Util.open_file_for_writing on  in
+           let uu____1289 = FStar_Parser_Driver.parse_file fn in
+           FStar_Pervasives_Native.fst uu____1289) files in
+    let mods = FStar_List.map document_module modules in
+    let on = FStar_Options.prepend_output_dir "index.md" in
+    let fd = FStar_Util.open_file_for_writing on in
     FStar_List.iter
       (fun m  ->
-         let uu____1315 = FStar_Util.format "%s\n" [m.FStar_Ident.str]  in
+         let uu____1315 = FStar_Util.format "%s\n" [m.FStar_Ident.str] in
          FStar_Util.append_to_file fd uu____1315) mods;
     FStar_Util.close_file fd
-  

--- a/src/ocaml-output/FStar_Ident.ml
+++ b/src/ocaml-output/FStar_Ident.ml
@@ -1,94 +1,85 @@
 open Prims
 type ident = {
-  idText: Prims.string ;
-  idRange: FStar_Range.range }[@@deriving show]
-let (__proj__Mkident__item__idText : ident -> Prims.string) =
+  idText: Prims.string;
+  idRange: FStar_Range.range;}[@@deriving show]
+let __proj__Mkident__item__idText: ident -> Prims.string =
   fun projectee  ->
     match projectee with
     | { idText = __fname__idText; idRange = __fname__idRange;_} ->
         __fname__idText
-  
-let (__proj__Mkident__item__idRange : ident -> FStar_Range.range) =
+let __proj__Mkident__item__idRange: ident -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { idText = __fname__idText; idRange = __fname__idRange;_} ->
         __fname__idRange
-  
 type path = Prims.string Prims.list[@@deriving show]
 type lident =
   {
-  ns: ident Prims.list ;
-  ident: ident ;
-  nsstr: Prims.string ;
-  str: Prims.string }[@@deriving show]
-let (__proj__Mklident__item__ns : lident -> ident Prims.list) =
+  ns: ident Prims.list;
+  ident: ident;
+  nsstr: Prims.string;
+  str: Prims.string;}[@@deriving show]
+let __proj__Mklident__item__ns: lident -> ident Prims.list =
   fun projectee  ->
     match projectee with
     | { ns = __fname__ns; ident = __fname__ident; nsstr = __fname__nsstr;
         str = __fname__str;_} -> __fname__ns
-  
-let (__proj__Mklident__item__ident : lident -> ident) =
+let __proj__Mklident__item__ident: lident -> ident =
   fun projectee  ->
     match projectee with
     | { ns = __fname__ns; ident = __fname__ident; nsstr = __fname__nsstr;
         str = __fname__str;_} -> __fname__ident
-  
-let (__proj__Mklident__item__nsstr : lident -> Prims.string) =
+let __proj__Mklident__item__nsstr: lident -> Prims.string =
   fun projectee  ->
     match projectee with
     | { ns = __fname__ns; ident = __fname__ident; nsstr = __fname__nsstr;
         str = __fname__str;_} -> __fname__nsstr
-  
-let (__proj__Mklident__item__str : lident -> Prims.string) =
+let __proj__Mklident__item__str: lident -> Prims.string =
   fun projectee  ->
     match projectee with
     | { ns = __fname__ns; ident = __fname__ident; nsstr = __fname__nsstr;
         str = __fname__str;_} -> __fname__str
-  
 type lid = lident[@@deriving show]
-let (mk_ident :
-  (Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple2 -> ident) =
+let mk_ident:
+  (Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple2 -> ident =
   fun uu____85  ->
     match uu____85 with | (text,range) -> { idText = text; idRange = range }
-  
-let (reserved_prefix : Prims.string) = "uu___" 
-let (gen : FStar_Range.range -> ident) =
-  let x = FStar_Util.mk_ref (Prims.parse_int "0")  in
+let reserved_prefix: Prims.string = "uu___"
+let gen: FStar_Range.range -> ident =
+  let x = FStar_Util.mk_ref (Prims.parse_int "0") in
   fun r  ->
     (let uu____99 =
-       let uu____100 = FStar_ST.op_Bang x  in
-       uu____100 + (Prims.parse_int "1")  in
+       let uu____100 = FStar_ST.op_Bang x in
+       uu____100 + (Prims.parse_int "1") in
      FStar_ST.op_Colon_Equals x uu____99);
     (let uu____183 =
        let uu____188 =
          let uu____189 =
-           let uu____190 = FStar_ST.op_Bang x  in
-           Prims.string_of_int uu____190  in
-         Prims.strcat reserved_prefix uu____189  in
-       (uu____188, r)  in
+           let uu____190 = FStar_ST.op_Bang x in
+           Prims.string_of_int uu____190 in
+         Prims.strcat reserved_prefix uu____189 in
+       (uu____188, r) in
      mk_ident uu____183)
-  
-let (id_of_text : Prims.string -> ident) =
-  fun str  -> mk_ident (str, FStar_Range.dummyRange) 
-let (text_of_id : ident -> Prims.string) = fun id1  -> id1.idText 
-let (text_of_path : Prims.string Prims.list -> Prims.string) =
-  fun path  -> FStar_Util.concat_l "." path 
-let (path_of_text : Prims.string -> Prims.string Prims.list) =
-  fun text  -> FStar_String.split [46] text 
-let (path_of_ns : ident Prims.list -> Prims.string Prims.list) =
-  fun ns  -> FStar_List.map text_of_id ns 
-let (path_of_lid : lident -> Prims.string Prims.list) =
+let id_of_text: Prims.string -> ident =
+  fun str  -> mk_ident (str, FStar_Range.dummyRange)
+let text_of_id: ident -> Prims.string = fun id1  -> id1.idText
+let text_of_path: Prims.string Prims.list -> Prims.string =
+  fun path  -> FStar_Util.concat_l "." path
+let path_of_text: Prims.string -> Prims.string Prims.list =
+  fun text  -> FStar_String.split [46] text
+let path_of_ns: ident Prims.list -> Prims.string Prims.list =
+  fun ns  -> FStar_List.map text_of_id ns
+let path_of_lid: lident -> Prims.string Prims.list =
   fun lid  ->
     FStar_List.map text_of_id (FStar_List.append lid.ns [lid.ident])
-  
-let (ids_of_lid : lident -> ident Prims.list) =
-  fun lid  -> FStar_List.append lid.ns [lid.ident] 
-let (lid_of_ns_and_id : ident Prims.list -> ident -> lident) =
+let ids_of_lid: lident -> ident Prims.list =
+  fun lid  -> FStar_List.append lid.ns [lid.ident]
+let lid_of_ns_and_id: ident Prims.list -> ident -> lident =
   fun ns  ->
     fun id1  ->
       let nsstr =
-        let uu____283 = FStar_List.map text_of_id ns  in
-        FStar_All.pipe_right uu____283 text_of_path  in
+        let uu____283 = FStar_List.map text_of_id ns in
+        FStar_All.pipe_right uu____283 text_of_path in
       {
         ns;
         ident = id1;
@@ -98,55 +89,47 @@ let (lid_of_ns_and_id : ident Prims.list -> ident -> lident) =
            then id1.idText
            else Prims.strcat nsstr (Prims.strcat "." id1.idText))
       }
-  
-let (lid_of_ids : ident Prims.list -> lident) =
+let lid_of_ids: ident Prims.list -> lident =
   fun ids  ->
-    let uu____296 = FStar_Util.prefix ids  in
+    let uu____296 = FStar_Util.prefix ids in
     match uu____296 with | (ns,id1) -> lid_of_ns_and_id ns id1
-  
-let (lid_of_str : Prims.string -> lident) =
+let lid_of_str: Prims.string -> lident =
   fun str  ->
-    let uu____312 = FStar_List.map id_of_text (FStar_Util.split str ".")  in
+    let uu____312 = FStar_List.map id_of_text (FStar_Util.split str ".") in
     lid_of_ids uu____312
-  
-let (lid_of_path : Prims.string Prims.list -> FStar_Range.range -> lident) =
+let lid_of_path: Prims.string Prims.list -> FStar_Range.range -> lident =
   fun path  ->
     fun pos  ->
-      let ids = FStar_List.map (fun s  -> mk_ident (s, pos)) path  in
+      let ids = FStar_List.map (fun s  -> mk_ident (s, pos)) path in
       lid_of_ids ids
-  
-let (text_of_lid : lident -> Prims.string) = fun lid  -> lid.str 
-let (lid_equals : lident -> lident -> Prims.bool) =
-  fun l1  -> fun l2  -> l1.str = l2.str 
-let (ident_equals : ident -> ident -> Prims.bool) =
-  fun id1  -> fun id2  -> id1.idText = id2.idText 
-let (range_of_lid : lid -> FStar_Range.range) =
-  fun lid  -> (lid.ident).idRange 
-let (set_lid_range : lident -> FStar_Range.range -> lident) =
+let text_of_lid: lident -> Prims.string = fun lid  -> lid.str
+let lid_equals: lident -> lident -> Prims.bool =
+  fun l1  -> fun l2  -> l1.str = l2.str
+let ident_equals: ident -> ident -> Prims.bool =
+  fun id1  -> fun id2  -> id1.idText = id2.idText
+let range_of_lid: lid -> FStar_Range.range = fun lid  -> (lid.ident).idRange
+let set_lid_range: lident -> FStar_Range.range -> lident =
   fun l  ->
     fun r  ->
-      let uu___23_354 = l  in
+      let uu___23_354 = l in
       {
         ns = (uu___23_354.ns);
         ident =
-          (let uu___24_356 = l.ident  in
+          (let uu___24_356 = l.ident in
            { idText = (uu___24_356.idText); idRange = r });
         nsstr = (uu___23_354.nsstr);
         str = (uu___23_354.str)
       }
-  
-let (lid_add_suffix : lident -> Prims.string -> lident) =
+let lid_add_suffix: lident -> Prims.string -> lident =
   fun l  ->
     fun s  ->
-      let path = path_of_lid l  in
+      let path = path_of_lid l in
       lid_of_path (FStar_List.append path [s]) (range_of_lid l)
-  
-let (ml_path_of_lid : lident -> Prims.string) =
+let ml_path_of_lid: lident -> Prims.string =
   fun lid  ->
     let uu____369 =
-      let uu____372 = path_of_ns lid.ns  in
-      FStar_List.append uu____372 [text_of_id lid.ident]  in
+      let uu____372 = path_of_ns lid.ns in
+      FStar_List.append uu____372 [text_of_id lid.ident] in
     FStar_All.pipe_left (FStar_String.concat "_") uu____369
-  
-let (string_of_lid : lident -> Prims.string) =
-  fun lid  -> let uu____380 = path_of_lid lid  in text_of_path uu____380 
+let string_of_lid: lident -> Prims.string =
+  fun lid  -> let uu____380 = path_of_lid lid in text_of_path uu____380

--- a/src/ocaml-output/FStar_Indent.ml
+++ b/src/ocaml-output/FStar_Indent.ml
@@ -1,37 +1,32 @@
 open Prims
-let (generate : FStar_Parser_ParseIt.filename Prims.list -> Prims.unit) =
+let generate: FStar_Parser_ParseIt.filename Prims.list -> Prims.unit =
   fun filenames  ->
     let parse_and_indent filename =
-      let uu____12 = FStar_Parser_Driver.parse_file filename  in
+      let uu____12 = FStar_Parser_Driver.parse_file filename in
       match uu____12 with
       | (modul,comments) ->
           let leftover_comments =
-            let comments1 = FStar_List.rev comments  in
+            let comments1 = FStar_List.rev comments in
             let uu____55 =
               FStar_Parser_ToDocument.modul_with_comments_to_document modul
-                comments1
-               in
+                comments1 in
             match uu____55 with
             | (doc1,comments2) ->
                 (FStar_Pprint.pretty_out_channel
                    (FStar_Util.float_of_string "1.0") (Prims.parse_int "100")
                    doc1 FStar_Util.stdout;
-                 comments2)
-             in
+                 comments2) in
           let left_over_doc =
             let uu____88 =
               let uu____91 =
                 let uu____94 =
                   let uu____97 =
                     FStar_Parser_ToDocument.comments_to_document
-                      leftover_comments
-                     in
-                  [uu____97]  in
-                FStar_Pprint.hardline :: uu____94  in
-              FStar_Pprint.hardline :: uu____91  in
-            FStar_Pprint.concat uu____88  in
+                      leftover_comments in
+                  [uu____97] in
+                FStar_Pprint.hardline :: uu____94 in
+              FStar_Pprint.hardline :: uu____91 in
+            FStar_Pprint.concat uu____88 in
           FStar_Pprint.pretty_out_channel (FStar_Util.float_of_string "1.0")
-            (Prims.parse_int "100") left_over_doc FStar_Util.stdout
-       in
+            (Prims.parse_int "100") left_over_doc FStar_Util.stdout in
     FStar_List.iter parse_and_indent filenames
-  

--- a/src/ocaml-output/FStar_Interactive_CompletionTable.ml
+++ b/src/ocaml-output/FStar_Interactive_CompletionTable.ml
@@ -1,22 +1,20 @@
 open Prims
-let (string_compare : Prims.string -> Prims.string -> Prims.int) =
-  fun s1  -> fun s2  -> FStar_String.compare s1 s2 
+let string_compare: Prims.string -> Prims.string -> Prims.int =
+  fun s1  -> fun s2  -> FStar_String.compare s1 s2
 type 'a heap =
-  | EmptyHeap 
-  | Heap of ('a,'a heap Prims.list) FStar_Pervasives_Native.tuple2 [@@deriving
+  | EmptyHeap
+  | Heap of ('a,'a heap Prims.list) FStar_Pervasives_Native.tuple2[@@deriving
                                                                     show]
-let uu___is_EmptyHeap : 'a . 'a heap -> Prims.bool =
+let uu___is_EmptyHeap: 'a . 'a heap -> Prims.bool =
   fun projectee  ->
     match projectee with | EmptyHeap  -> true | uu____37 -> false
-  
-let uu___is_Heap : 'a . 'a heap -> Prims.bool =
+let uu___is_Heap: 'a . 'a heap -> Prims.bool =
   fun projectee  ->
     match projectee with | Heap _0 -> true | uu____60 -> false
-  
-let __proj__Heap__item___0 :
+let __proj__Heap__item___0:
   'a . 'a heap -> ('a,'a heap Prims.list) FStar_Pervasives_Native.tuple2 =
-  fun projectee  -> match projectee with | Heap _0 -> _0 
-let heap_merge :
+  fun projectee  -> match projectee with | Heap _0 -> _0
+let heap_merge:
   'Auu____98 .
     ('Auu____98 -> 'Auu____98 -> Prims.int) ->
       'Auu____98 heap -> 'Auu____98 heap -> 'Auu____98 heap
@@ -29,18 +27,16 @@ let heap_merge :
         | (h,EmptyHeap ) -> h
         | (Heap (v1,hh1),Heap (v2,hh2)) ->
             let uu____173 =
-              let uu____174 = cmp v1 v2  in uu____174 < (Prims.parse_int "0")
-               in
+              let uu____174 = cmp v1 v2 in uu____174 < (Prims.parse_int "0") in
             if uu____173
             then Heap (v1, (h2 :: hh1))
             else Heap (v2, (h1 :: hh2))
-  
-let heap_insert :
+let heap_insert:
   'Auu____194 .
     ('Auu____194 -> 'Auu____194 -> Prims.int) ->
       'Auu____194 heap -> 'Auu____194 -> 'Auu____194 heap
-  = fun cmp  -> fun h  -> fun v1  -> heap_merge cmp (Heap (v1, [])) h 
-let rec heap_merge_pairs :
+  = fun cmp  -> fun h  -> fun v1  -> heap_merge cmp (Heap (v1, [])) h
+let rec heap_merge_pairs:
   'Auu____233 .
     ('Auu____233 -> 'Auu____233 -> Prims.int) ->
       'Auu____233 heap Prims.list -> 'Auu____233 heap
@@ -51,11 +47,10 @@ let rec heap_merge_pairs :
       | [] -> EmptyHeap
       | h::[] -> h
       | h1::h2::hh ->
-          let uu____286 = heap_merge cmp h1 h2  in
-          let uu____289 = heap_merge_pairs cmp hh  in
+          let uu____286 = heap_merge cmp h1 h2 in
+          let uu____289 = heap_merge_pairs cmp hh in
           heap_merge cmp uu____286 uu____289
-  
-let heap_peek :
+let heap_peek:
   'Auu____294 .
     'Auu____294 heap -> 'Auu____294 FStar_Pervasives_Native.option
   =
@@ -63,8 +58,7 @@ let heap_peek :
     match uu___30_302 with
     | EmptyHeap  -> FStar_Pervasives_Native.None
     | Heap (v1,uu____306) -> FStar_Pervasives_Native.Some v1
-  
-let heap_pop :
+let heap_pop:
   'Auu____318 .
     ('Auu____318 -> 'Auu____318 -> Prims.int) ->
       'Auu____318 heap ->
@@ -77,18 +71,16 @@ let heap_pop :
       | EmptyHeap  -> FStar_Pervasives_Native.None
       | Heap (v1,hh) ->
           let uu____365 =
-            let uu____372 = heap_merge_pairs cmp hh  in (v1, uu____372)  in
+            let uu____372 = heap_merge_pairs cmp hh in (v1, uu____372) in
           FStar_Pervasives_Native.Some uu____365
-  
-let heap_from_list :
+let heap_from_list:
   'Auu____386 .
     ('Auu____386 -> 'Auu____386 -> Prims.int) ->
       'Auu____386 Prims.list -> 'Auu____386 heap
   =
   fun cmp  ->
     fun values  -> FStar_List.fold_left (heap_insert cmp) EmptyHeap values
-  
-let push_nodup :
+let push_nodup:
   'Auu____417 .
     ('Auu____417 -> Prims.string) ->
       'Auu____417 -> 'Auu____417 Prims.list -> 'Auu____417 Prims.list
@@ -101,13 +93,12 @@ let push_nodup :
         | h::t ->
             let uu____445 =
               let uu____446 =
-                let uu____447 = key_fn x  in
-                let uu____448 = key_fn h  in
-                string_compare uu____447 uu____448  in
-              uu____446 = (Prims.parse_int "0")  in
+                let uu____447 = key_fn x in
+                let uu____448 = key_fn h in
+                string_compare uu____447 uu____448 in
+              uu____446 = (Prims.parse_int "0") in
             if uu____445 then h :: t else x :: h :: t
-  
-let rec add_priorities :
+let rec add_priorities:
   'Auu____457 .
     Prims.int ->
       (Prims.int,'Auu____457) FStar_Pervasives_Native.tuple2 Prims.list ->
@@ -121,8 +112,7 @@ let rec add_priorities :
         | [] -> acc
         | h::t ->
             add_priorities (n1 + (Prims.parse_int "1")) ((n1, h) :: acc) t
-  
-let merge_increasing_lists_rev :
+let merge_increasing_lists_rev:
   'a . ('a -> Prims.string) -> 'a Prims.list Prims.list -> 'a Prims.list =
   fun key_fn  ->
     fun lists  ->
@@ -132,50 +122,44 @@ let merge_increasing_lists_rev :
         | (uu____592,(uu____593,[])) -> failwith "impossible"
         | ((pr1,h1::uu____616),(pr2,h2::uu____619)) ->
             let cmp_h =
-              let uu____641 = key_fn h1  in
-              let uu____642 = key_fn h2  in
-              string_compare uu____641 uu____642  in
-            if cmp_h <> (Prims.parse_int "0") then cmp_h else pr1 - pr2
-         in
+              let uu____641 = key_fn h1 in
+              let uu____642 = key_fn h2 in string_compare uu____641 uu____642 in
+            if cmp_h <> (Prims.parse_int "0") then cmp_h else pr1 - pr2 in
       let rec aux lists1 acc =
-        let uu____673 = heap_pop cmp lists1  in
+        let uu____673 = heap_pop cmp lists1 in
         match uu____673 with
         | FStar_Pervasives_Native.None  -> acc
         | FStar_Pervasives_Native.Some ((pr,[]),uu____721) ->
             failwith "impossible"
         | FStar_Pervasives_Native.Some ((pr,v1::[]),lists2) ->
-            let uu____811 = push_nodup key_fn v1 acc  in aux lists2 uu____811
+            let uu____811 = push_nodup key_fn v1 acc in aux lists2 uu____811
         | FStar_Pervasives_Native.Some ((pr,v1::tl1),lists2) ->
-            let uu____862 = heap_insert cmp lists2 (pr, tl1)  in
-            let uu____879 = push_nodup key_fn v1 acc  in
-            aux uu____862 uu____879
-         in
-      let lists1 = FStar_List.filter (fun x  -> x <> []) lists  in
+            let uu____862 = heap_insert cmp lists2 (pr, tl1) in
+            let uu____879 = push_nodup key_fn v1 acc in
+            aux uu____862 uu____879 in
+      let lists1 = FStar_List.filter (fun x  -> x <> []) lists in
       match lists1 with
       | [] -> []
       | l::[] -> FStar_List.rev l
       | uu____906 ->
-          let lists2 = add_priorities (Prims.parse_int "0") [] lists1  in
-          let uu____928 = heap_from_list cmp lists2  in aux uu____928 []
-  
+          let lists2 = add_priorities (Prims.parse_int "0") [] lists1 in
+          let uu____928 = heap_from_list cmp lists2 in aux uu____928 []
 type 'a btree =
-  | StrEmpty 
+  | StrEmpty
   | StrBranch of (Prims.string,'a,'a btree,'a btree)
-  FStar_Pervasives_Native.tuple4 [@@deriving show]
-let uu___is_StrEmpty : 'a . 'a btree -> Prims.bool =
+  FStar_Pervasives_Native.tuple4[@@deriving show]
+let uu___is_StrEmpty: 'a . 'a btree -> Prims.bool =
   fun projectee  ->
     match projectee with | StrEmpty  -> true | uu____977 -> false
-  
-let uu___is_StrBranch : 'a . 'a btree -> Prims.bool =
+let uu___is_StrBranch: 'a . 'a btree -> Prims.bool =
   fun projectee  ->
     match projectee with | StrBranch _0 -> true | uu____1004 -> false
-  
-let __proj__StrBranch__item___0 :
+let __proj__StrBranch__item___0:
   'a .
     'a btree ->
       (Prims.string,'a,'a btree,'a btree) FStar_Pervasives_Native.tuple4
-  = fun projectee  -> match projectee with | StrBranch _0 -> _0 
-let rec btree_to_list_rev :
+  = fun projectee  -> match projectee with | StrBranch _0 -> _0
+let rec btree_to_list_rev:
   'Auu____1050 .
     'Auu____1050 btree ->
       (Prims.string,'Auu____1050) FStar_Pervasives_Native.tuple2 Prims.list
@@ -188,12 +172,10 @@ let rec btree_to_list_rev :
       | StrEmpty  -> acc
       | StrBranch (key,value,lbt,rbt) ->
           let uu____1093 =
-            let uu____1100 = btree_to_list_rev lbt acc  in (key, value) ::
-              uu____1100
-             in
+            let uu____1100 = btree_to_list_rev lbt acc in (key, value) ::
+              uu____1100 in
           btree_to_list_rev rbt uu____1093
-  
-let rec btree_from_list :
+let rec btree_from_list:
   'Auu____1115 .
     (Prims.string,'Auu____1115) FStar_Pervasives_Native.tuple2 Prims.list ->
       Prims.int ->
@@ -206,59 +188,56 @@ let rec btree_from_list :
       if size = (Prims.parse_int "0")
       then (StrEmpty, nodes)
       else
-        (let lbt_size = size / (Prims.parse_int "2")  in
-         let rbt_size = (size - lbt_size) - (Prims.parse_int "1")  in
-         let uu____1159 = btree_from_list nodes lbt_size  in
+        (let lbt_size = size / (Prims.parse_int "2") in
+         let rbt_size = (size - lbt_size) - (Prims.parse_int "1") in
+         let uu____1159 = btree_from_list nodes lbt_size in
          match uu____1159 with
          | (lbt,nodes_left) ->
              (match nodes_left with
               | [] -> failwith "Invalid size passed to btree_from_list"
               | (k,v1)::nodes_left1 ->
-                  let uu____1243 = btree_from_list nodes_left1 rbt_size  in
+                  let uu____1243 = btree_from_list nodes_left1 rbt_size in
                   (match uu____1243 with
                    | (rbt,nodes_left2) ->
                        ((StrBranch (k, v1, lbt, rbt)), nodes_left2))))
-  
-let rec btree_insert_replace :
-  'a . 'a btree -> Prims.string -> 'a -> 'a btree =
+let rec btree_insert_replace: 'a . 'a btree -> Prims.string -> 'a -> 'a btree
+  =
   fun bt  ->
     fun k  ->
       fun v1  ->
         match bt with
         | StrEmpty  -> StrBranch (k, v1, StrEmpty, StrEmpty)
         | StrBranch (k',v',lbt,rbt) ->
-            let cmp = string_compare k k'  in
+            let cmp = string_compare k k' in
             if cmp < (Prims.parse_int "0")
             then
               let uu____1341 =
-                let uu____1354 = btree_insert_replace lbt k v1  in
-                (k', v', uu____1354, rbt)  in
+                let uu____1354 = btree_insert_replace lbt k v1 in
+                (k', v', uu____1354, rbt) in
               StrBranch uu____1341
             else
               if cmp > (Prims.parse_int "0")
               then
                 (let uu____1364 =
-                   let uu____1377 = btree_insert_replace rbt k v1  in
-                   (k', v', lbt, uu____1377)  in
+                   let uu____1377 = btree_insert_replace rbt k v1 in
+                   (k', v', lbt, uu____1377) in
                  StrBranch uu____1364)
               else StrBranch (k', v1, lbt, rbt)
-  
-let rec btree_find_exact :
+let rec btree_find_exact:
   'a . 'a btree -> Prims.string -> 'a FStar_Pervasives_Native.option =
   fun bt  ->
     fun k  ->
       match bt with
       | StrEmpty  -> FStar_Pervasives_Native.None
       | StrBranch (k',v1,lbt,rbt) ->
-          let cmp = string_compare k k'  in
+          let cmp = string_compare k k' in
           if cmp < (Prims.parse_int "0")
           then btree_find_exact lbt k
           else
             if cmp > (Prims.parse_int "0")
             then btree_find_exact rbt k
             else FStar_Pervasives_Native.Some v1
-  
-let rec btree_extract_min :
+let rec btree_extract_min:
   'a .
     'a btree ->
       (Prims.string,'a,'a btree) FStar_Pervasives_Native.tuple3
@@ -271,77 +250,70 @@ let rec btree_extract_min :
         FStar_Pervasives_Native.Some (k, v1, rbt)
     | StrBranch (uu____1476,uu____1477,lbt,uu____1479) ->
         btree_extract_min lbt
-  
-let rec btree_remove : 'a . 'a btree -> Prims.string -> 'a btree =
+let rec btree_remove: 'a . 'a btree -> Prims.string -> 'a btree =
   fun bt  ->
     fun k  ->
       match bt with
       | StrEmpty  -> StrEmpty
       | StrBranch (k',v1,lbt,rbt) ->
-          let cmp = string_compare k k'  in
+          let cmp = string_compare k k' in
           if cmp < (Prims.parse_int "0")
           then
             let uu____1522 =
-              let uu____1535 = btree_remove lbt k  in
-              (k', v1, uu____1535, rbt)  in
+              let uu____1535 = btree_remove lbt k in
+              (k', v1, uu____1535, rbt) in
             StrBranch uu____1522
           else
             if cmp > (Prims.parse_int "0")
             then
               (let uu____1545 =
-                 let uu____1558 = btree_remove rbt k  in
-                 (k', v1, lbt, uu____1558)  in
+                 let uu____1558 = btree_remove rbt k in
+                 (k', v1, lbt, uu____1558) in
                StrBranch uu____1545)
             else
               (match lbt with
                | StrEmpty  -> bt
                | uu____1568 ->
-                   let uu____1571 = btree_extract_min rbt  in
+                   let uu____1571 = btree_extract_min rbt in
                    (match uu____1571 with
                     | FStar_Pervasives_Native.None  -> lbt
                     | FStar_Pervasives_Native.Some (rbt_min_k,rbt_min_v,rbt')
                         -> StrBranch (rbt_min_k, rbt_min_v, lbt, rbt')))
-  
 type prefix_match =
   {
-  prefix: Prims.string FStar_Pervasives_Native.option ;
-  completion: Prims.string }[@@deriving show]
-let (__proj__Mkprefix_match__item__prefix :
-  prefix_match -> Prims.string FStar_Pervasives_Native.option) =
+  prefix: Prims.string FStar_Pervasives_Native.option;
+  completion: Prims.string;}[@@deriving show]
+let __proj__Mkprefix_match__item__prefix:
+  prefix_match -> Prims.string FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { prefix = __fname__prefix; completion = __fname__completion;_} ->
         __fname__prefix
-  
-let (__proj__Mkprefix_match__item__completion : prefix_match -> Prims.string)
-  =
+let __proj__Mkprefix_match__item__completion: prefix_match -> Prims.string =
   fun projectee  ->
     match projectee with
     | { prefix = __fname__prefix; completion = __fname__completion;_} ->
         __fname__completion
-  
 type path_elem = {
-  imports: Prims.string Prims.list ;
-  segment: prefix_match }[@@deriving show]
-let (__proj__Mkpath_elem__item__imports :
-  path_elem -> Prims.string Prims.list) =
+  imports: Prims.string Prims.list;
+  segment: prefix_match;}[@@deriving show]
+let __proj__Mkpath_elem__item__imports: path_elem -> Prims.string Prims.list
+  =
   fun projectee  ->
     match projectee with
     | { imports = __fname__imports; segment = __fname__segment;_} ->
         __fname__imports
-  
-let (__proj__Mkpath_elem__item__segment : path_elem -> prefix_match) =
+let __proj__Mkpath_elem__item__segment: path_elem -> prefix_match =
   fun projectee  ->
     match projectee with
     | { imports = __fname__imports; segment = __fname__segment;_} ->
         __fname__segment
-  
-let (matched_prefix_of_path_elem :
-  path_elem -> Prims.string FStar_Pervasives_Native.option) =
-  fun elem  -> (elem.segment).prefix 
-let (mk_path_el : Prims.string Prims.list -> prefix_match -> path_elem) =
-  fun imports  -> fun segment  -> { imports; segment } 
-let rec btree_find_prefix :
+let matched_prefix_of_path_elem:
+  path_elem -> Prims.string FStar_Pervasives_Native.option =
+  fun elem  -> (elem.segment).prefix
+let mk_path_el: Prims.string Prims.list -> prefix_match -> path_elem =
+  fun imports  -> fun segment  -> { imports; segment }
+let rec btree_find_prefix:
   'a .
     'a btree ->
       Prims.string ->
@@ -353,13 +325,12 @@ let rec btree_find_prefix :
         match bt1 with
         | StrEmpty  -> acc
         | StrBranch (k,v1,lbt,rbt) ->
-            let cmp = string_compare k prefix2  in
-            let include_middle = FStar_Util.starts_with k prefix2  in
+            let cmp = string_compare k prefix2 in
+            let include_middle = FStar_Util.starts_with k prefix2 in
             let explore_right =
-              (cmp <= (Prims.parse_int "0")) || include_middle  in
-            let explore_left = cmp > (Prims.parse_int "0")  in
-            let matches = if explore_right then aux rbt prefix2 acc else acc
-               in
+              (cmp <= (Prims.parse_int "0")) || include_middle in
+            let explore_left = cmp > (Prims.parse_int "0") in
+            let matches = if explore_right then aux rbt prefix2 acc else acc in
             let matches1 =
               if include_middle
               then
@@ -368,14 +339,12 @@ let rec btree_find_prefix :
                    completion = k
                  }, v1)
                 :: matches
-              else matches  in
+              else matches in
             let matches2 =
-              if explore_left then aux lbt prefix2 matches1 else matches1  in
-            matches2
-         in
+              if explore_left then aux lbt prefix2 matches1 else matches1 in
+            matches2 in
       aux bt prefix1 []
-  
-let rec btree_fold :
+let rec btree_fold:
   'a 'b . 'a btree -> (Prims.string -> 'a -> 'b -> 'b) -> 'b -> 'b =
   fun bt  ->
     fun f  ->
@@ -384,52 +353,47 @@ let rec btree_fold :
         | StrEmpty  -> acc
         | StrBranch (k,v1,lbt,rbt) ->
             let uu____1861 =
-              let uu____1862 = btree_fold rbt f acc  in f k v1 uu____1862  in
+              let uu____1862 = btree_fold rbt f acc in f k v1 uu____1862 in
             btree_fold lbt f uu____1861
-  
 type path = path_elem Prims.list[@@deriving show]
 type query = Prims.string Prims.list[@@deriving show]
-let (query_to_string : Prims.string Prims.list -> Prims.string) =
-  fun q  -> FStar_String.concat "." q 
+let query_to_string: Prims.string Prims.list -> Prims.string =
+  fun q  -> FStar_String.concat "." q
 type 'a name_collection =
-  | Names of 'a btree 
+  | Names of 'a btree
   | ImportedNames of (Prims.string,'a name_collection Prims.list)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let uu___is_Names : 'a . 'a name_collection -> Prims.bool =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_Names: 'a . 'a name_collection -> Prims.bool =
   fun projectee  ->
     match projectee with | Names _0 -> true | uu____1913 -> false
-  
-let __proj__Names__item___0 : 'a . 'a name_collection -> 'a btree =
-  fun projectee  -> match projectee with | Names _0 -> _0 
-let uu___is_ImportedNames : 'a . 'a name_collection -> Prims.bool =
+let __proj__Names__item___0: 'a . 'a name_collection -> 'a btree =
+  fun projectee  -> match projectee with | Names _0 -> _0
+let uu___is_ImportedNames: 'a . 'a name_collection -> Prims.bool =
   fun projectee  ->
     match projectee with | ImportedNames _0 -> true | uu____1955 -> false
-  
-let __proj__ImportedNames__item___0 :
+let __proj__ImportedNames__item___0:
   'a .
     'a name_collection ->
       (Prims.string,'a name_collection Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun projectee  -> match projectee with | ImportedNames _0 -> _0 
+  = fun projectee  -> match projectee with | ImportedNames _0 -> _0
 type 'a names = 'a name_collection Prims.list[@@deriving show]
 type 'a trie = {
-  bindings: 'a names ;
-  namespaces: 'a trie names }[@@deriving show]
-let __proj__Mktrie__item__bindings : 'a . 'a trie -> 'a names =
+  bindings: 'a names;
+  namespaces: 'a trie names;}[@@deriving show]
+let __proj__Mktrie__item__bindings: 'a . 'a trie -> 'a names =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; namespaces = __fname__namespaces;_} ->
         __fname__bindings
-  
-let __proj__Mktrie__item__namespaces : 'a . 'a trie -> 'a trie names =
+let __proj__Mktrie__item__namespaces: 'a . 'a trie -> 'a trie names =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; namespaces = __fname__namespaces;_} ->
         __fname__namespaces
-  
-let trie_empty : 'Auu____2068 . Prims.unit -> 'Auu____2068 trie =
-  fun uu____2071  -> { bindings = []; namespaces = [] } 
-let rec names_find_exact :
+let trie_empty: 'Auu____2068 . Prims.unit -> 'Auu____2068 trie =
+  fun uu____2071  -> { bindings = []; namespaces = [] }
+let rec names_find_exact:
   'a . 'a names -> Prims.string -> 'a FStar_Pervasives_Native.option =
   fun names  ->
     fun ns  ->
@@ -437,31 +401,28 @@ let rec names_find_exact :
         match names with
         | [] -> (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (Names bt)::names1 ->
-            let uu____2150 = btree_find_exact bt ns  in
+            let uu____2150 = btree_find_exact bt ns in
             (uu____2150, (FStar_Pervasives_Native.Some names1))
         | (ImportedNames (uu____2165,names1))::more_names ->
-            let uu____2182 = names_find_exact names1 ns  in
-            (uu____2182, (FStar_Pervasives_Native.Some more_names))
-         in
+            let uu____2182 = names_find_exact names1 ns in
+            (uu____2182, (FStar_Pervasives_Native.Some more_names)) in
       match uu____2100 with
       | (result,names1) ->
           (match (result, names1) with
            | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some
               scopes) -> names_find_exact scopes ns
            | uu____2244 -> result)
-  
-let rec trie_descend_exact :
+let rec trie_descend_exact:
   'a . 'a trie -> query -> 'a trie FStar_Pervasives_Native.option =
   fun tr  ->
     fun query  ->
       match query with
       | [] -> FStar_Pervasives_Native.Some tr
       | ns::query1 ->
-          let uu____2284 = names_find_exact tr.namespaces ns  in
+          let uu____2284 = names_find_exact tr.namespaces ns in
           FStar_Util.bind_opt uu____2284
             (fun scope  -> trie_descend_exact scope query1)
-  
-let rec trie_find_exact :
+let rec trie_find_exact:
   'a . 'a trie -> query -> 'a FStar_Pervasives_Native.option =
   fun tr  ->
     fun query  ->
@@ -469,26 +430,24 @@ let rec trie_find_exact :
       | [] -> failwith "Empty query in trie_find_exact"
       | name::[] -> names_find_exact tr.bindings name
       | ns::query1 ->
-          let uu____2325 = names_find_exact tr.namespaces ns  in
+          let uu____2325 = names_find_exact tr.namespaces ns in
           FStar_Util.bind_opt uu____2325
             (fun scope  -> trie_find_exact scope query1)
-  
-let names_insert : 'a . 'a names -> Prims.string -> 'a -> 'a names =
+let names_insert: 'a . 'a names -> Prims.string -> 'a -> 'a names =
   fun name_collections  ->
     fun id1  ->
       fun v1  ->
         let uu____2365 =
           match name_collections with
           | (Names bt)::tl1 -> (bt, tl1)
-          | uu____2403 -> (StrEmpty, name_collections)  in
+          | uu____2403 -> (StrEmpty, name_collections) in
         match uu____2365 with
         | (bt,name_collections1) ->
             let uu____2428 =
-              let uu____2431 = btree_insert_replace bt id1 v1  in
-              Names uu____2431  in
+              let uu____2431 = btree_insert_replace bt id1 v1 in
+              Names uu____2431 in
             uu____2428 :: name_collections1
-  
-let rec namespaces_mutate :
+let rec namespaces_mutate:
   'a .
     'a trie names ->
       Prims.string ->
@@ -505,13 +464,11 @@ let rec namespaces_mutate :
           fun mut_node  ->
             fun mut_leaf  ->
               let trie =
-                let uu____2609 = names_find_exact namespaces ns  in
-                FStar_Util.dflt (trie_empty ()) uu____2609  in
-              let uu____2620 = trie_mutate trie q rev_acc1 mut_node mut_leaf
-                 in
+                let uu____2609 = names_find_exact namespaces ns in
+                FStar_Util.dflt (trie_empty ()) uu____2609 in
+              let uu____2620 = trie_mutate trie q rev_acc1 mut_node mut_leaf in
               names_insert namespaces ns uu____2620
-
-and trie_mutate :
+and trie_mutate:
   'a .
     'a trie ->
       query ->
@@ -530,11 +487,9 @@ and trie_mutate :
             | id1::q1 ->
                 let ns' =
                   namespaces_mutate tr.namespaces id1 q1 (id1 :: rev_acc1)
-                    mut_node mut_leaf
-                   in
+                    mut_node mut_leaf in
                 mut_node tr id1 q1 rev_acc1 ns'
-
-let trie_mutate_leaf :
+let trie_mutate_leaf:
   'a . 'a trie -> query -> ('a trie -> query -> 'a trie) -> 'a trie =
   fun tr  ->
     fun query  ->
@@ -544,10 +499,9 @@ let trie_mutate_leaf :
              fun uu____2710  ->
                fun uu____2711  ->
                  fun namespaces  ->
-                   let uu___35_2720 = tr1  in
+                   let uu___35_2720 = tr1 in
                    { bindings = (uu___35_2720.bindings); namespaces })
-  
-let trie_insert : 'a . 'a trie -> query -> Prims.string -> 'a -> 'a trie =
+let trie_insert: 'a . 'a trie -> query -> Prims.string -> 'a -> 'a trie =
   fun tr  ->
     fun ns_query  ->
       fun id1  ->
@@ -555,14 +509,13 @@ let trie_insert : 'a . 'a trie -> query -> Prims.string -> 'a -> 'a trie =
           trie_mutate_leaf tr ns_query
             (fun tr1  ->
                fun uu____2758  ->
-                 let uu___36_2761 = tr1  in
-                 let uu____2764 = names_insert tr1.bindings id1 v1  in
+                 let uu___36_2761 = tr1 in
+                 let uu____2764 = names_insert tr1.bindings id1 v1 in
                  {
                    bindings = uu____2764;
                    namespaces = (uu___36_2761.namespaces)
                  })
-  
-let trie_import :
+let trie_import:
   'a .
     'a trie ->
       query ->
@@ -572,14 +525,13 @@ let trie_import :
     fun host_query  ->
       fun included_query  ->
         fun mutator  ->
-          let label = query_to_string included_query  in
+          let label = query_to_string included_query in
           let included_trie =
-            let uu____2828 = trie_descend_exact tr included_query  in
-            FStar_Util.dflt (trie_empty ()) uu____2828  in
+            let uu____2828 = trie_descend_exact tr included_query in
+            FStar_Util.dflt (trie_empty ()) uu____2828 in
           trie_mutate_leaf tr host_query
             (fun tr1  -> fun uu____2838  -> mutator tr1 included_trie label)
-  
-let trie_include : 'a . 'a trie -> query -> query -> 'a trie =
+let trie_include: 'a . 'a trie -> query -> query -> 'a trie =
   fun tr  ->
     fun host_query  ->
       fun included_query  ->
@@ -587,14 +539,13 @@ let trie_include : 'a . 'a trie -> query -> query -> 'a trie =
           (fun tr1  ->
              fun inc  ->
                fun label  ->
-                 let uu___37_2875 = tr1  in
+                 let uu___37_2875 = tr1 in
                  {
                    bindings = ((ImportedNames (label, (inc.bindings))) ::
                      (tr1.bindings));
                    namespaces = (uu___37_2875.namespaces)
                  })
-  
-let trie_open_namespace : 'a . 'a trie -> query -> query -> 'a trie =
+let trie_open_namespace: 'a . 'a trie -> query -> query -> 'a trie =
   fun tr  ->
     fun host_query  ->
       fun included_query  ->
@@ -602,15 +553,14 @@ let trie_open_namespace : 'a . 'a trie -> query -> query -> 'a trie =
           (fun tr1  ->
              fun inc  ->
                fun label  ->
-                 let uu___38_2916 = tr1  in
+                 let uu___38_2916 = tr1 in
                  {
                    bindings = (uu___38_2916.bindings);
                    namespaces = ((ImportedNames (label, (inc.namespaces))) ::
                      (tr1.namespaces))
                  })
-  
-let trie_add_alias :
-  'a . 'a trie -> Prims.string -> query -> query -> 'a trie =
+let trie_add_alias: 'a . 'a trie -> Prims.string -> query -> query -> 'a trie
+  =
   fun tr  ->
     fun key  ->
       fun host_query  ->
@@ -627,8 +577,7 @@ let trie_add_alias :
                               [ImportedNames (label, (inc.bindings))];
                             namespaces = []
                           }))
-  
-let names_revmap :
+let names_revmap:
   'a 'b .
     ('a btree -> 'b) ->
       'a names ->
@@ -644,15 +593,13 @@ let names_revmap :
                match uu___34_3087 with
                | Names bt ->
                    let uu____3109 =
-                     let uu____3116 = fn bt  in (imports, uu____3116)  in
+                     let uu____3116 = fn bt in (imports, uu____3116) in
                    uu____3109 :: acc1
                | ImportedNames (nm,name_collections2) ->
                    aux acc1 (nm :: imports) name_collections2) acc
-          name_collections1
-         in
+          name_collections1 in
       aux [] [] name_collections
-  
-let btree_find_all :
+let btree_find_all:
   'a .
     Prims.string FStar_Pervasives_Native.option ->
       'a btree -> (prefix_match,'a) FStar_Pervasives_Native.tuple2 Prims.list
@@ -664,26 +611,22 @@ let btree_find_all :
            fun tr  ->
              fun acc  -> ({ prefix = prefix1; completion = k }, tr) :: acc)
         []
-  
 type name_search_term =
-  | NSTAll 
-  | NSTNone 
-  | NSTPrefix of Prims.string [@@deriving show]
-let (uu___is_NSTAll : name_search_term -> Prims.bool) =
+  | NSTAll
+  | NSTNone
+  | NSTPrefix of Prims.string[@@deriving show]
+let uu___is_NSTAll: name_search_term -> Prims.bool =
   fun projectee  ->
     match projectee with | NSTAll  -> true | uu____3204 -> false
-  
-let (uu___is_NSTNone : name_search_term -> Prims.bool) =
+let uu___is_NSTNone: name_search_term -> Prims.bool =
   fun projectee  ->
     match projectee with | NSTNone  -> true | uu____3208 -> false
-  
-let (uu___is_NSTPrefix : name_search_term -> Prims.bool) =
+let uu___is_NSTPrefix: name_search_term -> Prims.bool =
   fun projectee  ->
     match projectee with | NSTPrefix _0 -> true | uu____3213 -> false
-  
-let (__proj__NSTPrefix__item___0 : name_search_term -> Prims.string) =
-  fun projectee  -> match projectee with | NSTPrefix _0 -> _0 
-let names_find_rev :
+let __proj__NSTPrefix__item___0: name_search_term -> Prims.string =
+  fun projectee  -> match projectee with | NSTPrefix _0 -> _0
+let names_find_rev:
   'a .
     'a names ->
       name_search_term ->
@@ -700,8 +643,7 @@ let names_find_rev :
             names_revmap (btree_find_all (FStar_Pervasives_Native.Some ""))
               names
         | NSTPrefix id2 ->
-            names_revmap (fun bt  -> btree_find_prefix bt id2) names
-         in
+            names_revmap (fun bt  -> btree_find_prefix bt id2) names in
       let matching_values_per_collection =
         FStar_List.map
           (fun uu____3346  ->
@@ -711,15 +653,13 @@ let names_find_rev :
                    (fun uu____3394  ->
                       match uu____3394 with
                       | (segment,v1) -> ((mk_path_el imports segment), v1))
-                   matches) matching_values_per_collection_with_imports
-         in
+                   matches) matching_values_per_collection_with_imports in
       merge_increasing_lists_rev
         (fun uu____3412  ->
            match uu____3412 with
            | (path_el,uu____3418) -> (path_el.segment).completion)
         matching_values_per_collection
-  
-let rec trie_find_prefix' :
+let rec trie_find_prefix':
   'a .
     'a trie ->
       path ->
@@ -735,11 +675,11 @@ let rec trie_find_prefix' :
             match query with
             | [] -> (NSTAll, NSTAll, [])
             | id1::[] -> ((NSTPrefix id1), (NSTPrefix id1), [])
-            | ns::query1 -> ((NSTPrefix ns), NSTNone, query1)  in
+            | ns::query1 -> ((NSTPrefix ns), NSTNone, query1) in
           match uu____3464 with
           | (ns_search_term,bindings_search_term,query1) ->
               let matching_namespaces_rev =
-                names_find_rev tr.namespaces ns_search_term  in
+                names_find_rev tr.namespaces ns_search_term in
               let acc_with_recursive_bindings =
                 FStar_List.fold_left
                   (fun acc1  ->
@@ -747,137 +687,119 @@ let rec trie_find_prefix' :
                        match uu____3540 with
                        | (path_el,trie) ->
                            trie_find_prefix' trie (path_el :: path_acc)
-                             query1 acc1) acc matching_namespaces_rev
-                 in
+                             query1 acc1) acc matching_namespaces_rev in
               let matching_bindings_rev =
-                names_find_rev tr.bindings bindings_search_term  in
+                names_find_rev tr.bindings bindings_search_term in
               FStar_List.rev_map_onto
                 (fun uu____3585  ->
                    match uu____3585 with
                    | (path_el,v1) ->
                        ((FStar_List.rev (path_el :: path_acc)), v1))
                 matching_bindings_rev acc_with_recursive_bindings
-  
-let trie_find_prefix :
+let trie_find_prefix:
   'a .
     'a trie -> query -> (path,'a) FStar_Pervasives_Native.tuple2 Prims.list
-  = fun tr  -> fun query  -> trie_find_prefix' tr [] query [] 
+  = fun tr  -> fun query  -> trie_find_prefix' tr [] query []
 type ns_info = {
-  ns_name: Prims.string ;
-  ns_loaded: Prims.bool }[@@deriving show]
-let (__proj__Mkns_info__item__ns_name : ns_info -> Prims.string) =
+  ns_name: Prims.string;
+  ns_loaded: Prims.bool;}[@@deriving show]
+let __proj__Mkns_info__item__ns_name: ns_info -> Prims.string =
   fun projectee  ->
     match projectee with
     | { ns_name = __fname__ns_name; ns_loaded = __fname__ns_loaded;_} ->
         __fname__ns_name
-  
-let (__proj__Mkns_info__item__ns_loaded : ns_info -> Prims.bool) =
+let __proj__Mkns_info__item__ns_loaded: ns_info -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { ns_name = __fname__ns_name; ns_loaded = __fname__ns_loaded;_} ->
         __fname__ns_loaded
-  
 type mod_info =
   {
-  mod_name: Prims.string ;
-  mod_path: Prims.string ;
-  mod_loaded: Prims.bool }[@@deriving show]
-let (__proj__Mkmod_info__item__mod_name : mod_info -> Prims.string) =
+  mod_name: Prims.string;
+  mod_path: Prims.string;
+  mod_loaded: Prims.bool;}[@@deriving show]
+let __proj__Mkmod_info__item__mod_name: mod_info -> Prims.string =
   fun projectee  ->
     match projectee with
     | { mod_name = __fname__mod_name; mod_path = __fname__mod_path;
         mod_loaded = __fname__mod_loaded;_} -> __fname__mod_name
-  
-let (__proj__Mkmod_info__item__mod_path : mod_info -> Prims.string) =
+let __proj__Mkmod_info__item__mod_path: mod_info -> Prims.string =
   fun projectee  ->
     match projectee with
     | { mod_name = __fname__mod_name; mod_path = __fname__mod_path;
         mod_loaded = __fname__mod_loaded;_} -> __fname__mod_path
-  
-let (__proj__Mkmod_info__item__mod_loaded : mod_info -> Prims.bool) =
+let __proj__Mkmod_info__item__mod_loaded: mod_info -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { mod_name = __fname__mod_name; mod_path = __fname__mod_path;
         mod_loaded = __fname__mod_loaded;_} -> __fname__mod_loaded
-  
-let (mod_name : mod_info -> Prims.string) = fun md  -> md.mod_name 
+let mod_name: mod_info -> Prims.string = fun md  -> md.mod_name
 type mod_symbol =
-  | Module of mod_info 
-  | Namespace of ns_info [@@deriving show]
-let (uu___is_Module : mod_symbol -> Prims.bool) =
+  | Module of mod_info
+  | Namespace of ns_info[@@deriving show]
+let uu___is_Module: mod_symbol -> Prims.bool =
   fun projectee  ->
     match projectee with | Module _0 -> true | uu____3689 -> false
-  
-let (__proj__Module__item___0 : mod_symbol -> mod_info) =
-  fun projectee  -> match projectee with | Module _0 -> _0 
-let (uu___is_Namespace : mod_symbol -> Prims.bool) =
+let __proj__Module__item___0: mod_symbol -> mod_info =
+  fun projectee  -> match projectee with | Module _0 -> _0
+let uu___is_Namespace: mod_symbol -> Prims.bool =
   fun projectee  ->
     match projectee with | Namespace _0 -> true | uu____3701 -> false
-  
-let (__proj__Namespace__item___0 : mod_symbol -> ns_info) =
-  fun projectee  -> match projectee with | Namespace _0 -> _0 
+let __proj__Namespace__item___0: mod_symbol -> ns_info =
+  fun projectee  -> match projectee with | Namespace _0 -> _0
 type lid_symbol = FStar_Ident.lid[@@deriving show]
 type symbol =
-  | ModOrNs of mod_symbol 
-  | Lid of lid_symbol [@@deriving show]
-let (uu___is_ModOrNs : symbol -> Prims.bool) =
+  | ModOrNs of mod_symbol
+  | Lid of lid_symbol[@@deriving show]
+let uu___is_ModOrNs: symbol -> Prims.bool =
   fun projectee  ->
     match projectee with | ModOrNs _0 -> true | uu____3721 -> false
-  
-let (__proj__ModOrNs__item___0 : symbol -> mod_symbol) =
-  fun projectee  -> match projectee with | ModOrNs _0 -> _0 
-let (uu___is_Lid : symbol -> Prims.bool) =
+let __proj__ModOrNs__item___0: symbol -> mod_symbol =
+  fun projectee  -> match projectee with | ModOrNs _0 -> _0
+let uu___is_Lid: symbol -> Prims.bool =
   fun projectee  ->
     match projectee with | Lid _0 -> true | uu____3733 -> false
-  
-let (__proj__Lid__item___0 : symbol -> lid_symbol) =
-  fun projectee  -> match projectee with | Lid _0 -> _0 
+let __proj__Lid__item___0: symbol -> lid_symbol =
+  fun projectee  -> match projectee with | Lid _0 -> _0
 type table = {
-  tbl_lids: lid_symbol trie ;
-  tbl_mods: mod_symbol trie }[@@deriving show]
-let (__proj__Mktable__item__tbl_lids : table -> lid_symbol trie) =
+  tbl_lids: lid_symbol trie;
+  tbl_mods: mod_symbol trie;}[@@deriving show]
+let __proj__Mktable__item__tbl_lids: table -> lid_symbol trie =
   fun projectee  ->
     match projectee with
     | { tbl_lids = __fname__tbl_lids; tbl_mods = __fname__tbl_mods;_} ->
         __fname__tbl_lids
-  
-let (__proj__Mktable__item__tbl_mods : table -> mod_symbol trie) =
+let __proj__Mktable__item__tbl_mods: table -> mod_symbol trie =
   fun projectee  ->
     match projectee with
     | { tbl_lids = __fname__tbl_lids; tbl_mods = __fname__tbl_mods;_} ->
         __fname__tbl_mods
-  
-let (empty : table) =
-  { tbl_lids = (trie_empty ()); tbl_mods = (trie_empty ()) } 
-let (insert : table -> query -> Prims.string -> lid_symbol -> table) =
+let empty: table = { tbl_lids = (trie_empty ()); tbl_mods = (trie_empty ()) }
+let insert: table -> query -> Prims.string -> lid_symbol -> table =
   fun tbl  ->
     fun host_query  ->
       fun id1  ->
         fun c  ->
-          let uu___39_3791 = tbl  in
-          let uu____3792 = trie_insert tbl.tbl_lids host_query id1 c  in
+          let uu___39_3791 = tbl in
+          let uu____3792 = trie_insert tbl.tbl_lids host_query id1 c in
           { tbl_lids = uu____3792; tbl_mods = (uu___39_3791.tbl_mods) }
-  
-let (register_alias : table -> Prims.string -> query -> query -> table) =
+let register_alias: table -> Prims.string -> query -> query -> table =
   fun tbl  ->
     fun key  ->
       fun host_query  ->
         fun included_query  ->
-          let uu___40_3807 = tbl  in
+          let uu___40_3807 = tbl in
           let uu____3808 =
-            trie_add_alias tbl.tbl_lids key host_query included_query  in
+            trie_add_alias tbl.tbl_lids key host_query included_query in
           { tbl_lids = uu____3808; tbl_mods = (uu___40_3807.tbl_mods) }
-  
-let (register_include : table -> query -> query -> table) =
+let register_include: table -> query -> query -> table =
   fun tbl  ->
     fun host_query  ->
       fun included_query  ->
-        let uu___41_3820 = tbl  in
-        let uu____3821 = trie_include tbl.tbl_lids host_query included_query
-           in
+        let uu___41_3820 = tbl in
+        let uu____3821 = trie_include tbl.tbl_lids host_query included_query in
         { tbl_lids = uu____3821; tbl_mods = (uu___41_3820.tbl_mods) }
-  
-let (register_open : table -> Prims.bool -> query -> query -> table) =
+let register_open: table -> Prims.bool -> query -> query -> table =
   fun tbl  ->
     fun is_module  ->
       fun host_query  ->
@@ -885,21 +807,20 @@ let (register_open : table -> Prims.bool -> query -> query -> table) =
           if is_module
           then register_include tbl host_query included_query
           else
-            (let uu___42_3837 = tbl  in
+            (let uu___42_3837 = tbl in
              let uu____3838 =
-               trie_open_namespace tbl.tbl_lids host_query included_query  in
+               trie_open_namespace tbl.tbl_lids host_query included_query in
              { tbl_lids = uu____3838; tbl_mods = (uu___42_3837.tbl_mods) })
-  
-let (register_module_path :
-  table -> Prims.bool -> Prims.string -> query -> table) =
+let register_module_path:
+  table -> Prims.bool -> Prims.string -> query -> table =
   fun tbl  ->
     fun loaded  ->
       fun path  ->
         fun mod_query  ->
           let ins_ns id1 bindings full_name loaded1 =
             let uu____3874 =
-              let uu____3881 = names_find_exact bindings id1  in
-              (uu____3881, loaded1)  in
+              let uu____3881 = names_find_exact bindings id1 in
+              (uu____3881, loaded1) in
             match uu____3874 with
             | (FStar_Pervasives_Native.None ,uu____3890) ->
                 names_insert bindings id1
@@ -909,8 +830,7 @@ let (register_module_path :
                 names_insert bindings id1
                   (Namespace { ns_name = full_name; ns_loaded = loaded1 })
             | (FStar_Pervasives_Native.Some uu____3900,uu____3901) ->
-                bindings
-             in
+                bindings in
           let ins_mod id1 bindings full_name loaded1 =
             names_insert bindings id1
               (Module
@@ -918,16 +838,15 @@ let (register_module_path :
                    mod_name = full_name;
                    mod_path = path;
                    mod_loaded = loaded1
-                 })
-             in
+                 }) in
           let name_of_revq query =
-            FStar_String.concat "." (FStar_List.rev query)  in
+            FStar_String.concat "." (FStar_List.rev query) in
           let ins id1 q revq bindings loaded1 =
-            let name = name_of_revq (id1 :: revq)  in
+            let name = name_of_revq (id1 :: revq) in
             match q with
             | [] -> ins_mod id1 bindings name loaded1
-            | uu____3974 -> ins_ns id1 bindings name loaded1  in
-          let uu___43_3980 = tbl  in
+            | uu____3974 -> ins_ns id1 bindings name loaded1 in
+          let uu___43_3980 = tbl in
           let uu____3981 =
             trie_mutate tbl.tbl_mods mod_query []
               (fun tr  ->
@@ -935,142 +854,126 @@ let (register_module_path :
                    fun q  ->
                      fun revq  ->
                        fun namespaces  ->
-                         let uu___44_4003 = tr  in
-                         let uu____4006 = ins id1 q revq tr.bindings loaded
-                            in
+                         let uu___44_4003 = tr in
+                         let uu____4006 = ins id1 q revq tr.bindings loaded in
                          { bindings = uu____4006; namespaces })
-              (fun tr  -> fun uu____4017  -> tr)
-             in
+              (fun tr  -> fun uu____4017  -> tr) in
           { tbl_lids = (uu___43_3980.tbl_lids); tbl_mods = uu____3981 }
-  
-let (string_of_path : path -> Prims.string) =
+let string_of_path: path -> Prims.string =
   fun path  ->
-    let uu____4023 = FStar_List.map (fun el  -> (el.segment).completion) path
-       in
+    let uu____4023 = FStar_List.map (fun el  -> (el.segment).completion) path in
     FStar_String.concat "." uu____4023
-  
-let (match_length_of_path : path -> Prims.int) =
+let match_length_of_path: path -> Prims.int =
   fun path  ->
     let uu____4031 =
       FStar_List.fold_left
         (fun acc  ->
            fun elem  ->
-             let uu____4065 = acc  in
+             let uu____4065 = acc in
              match uu____4065 with
              | (acc_len,uu____4083) ->
                  (match (elem.segment).prefix with
                   | FStar_Pervasives_Native.Some prefix1 ->
                       let completion_len =
-                        FStar_String.length (elem.segment).completion  in
+                        FStar_String.length (elem.segment).completion in
                       (((acc_len + (Prims.parse_int "1")) + completion_len),
                         (prefix1, completion_len))
                   | FStar_Pervasives_Native.None  -> acc))
-        ((Prims.parse_int "0"), ("", (Prims.parse_int "0"))) path
-       in
+        ((Prims.parse_int "0"), ("", (Prims.parse_int "0"))) path in
     match uu____4031 with
     | (length1,(last_prefix,last_completion_length)) ->
         ((length1 - (Prims.parse_int "1")) - last_completion_length) +
           (FStar_String.length last_prefix)
-  
-let (first_import_of_path :
-  path -> Prims.string FStar_Pervasives_Native.option) =
+let first_import_of_path: path -> Prims.string FStar_Pervasives_Native.option
+  =
   fun path  ->
     match path with
     | [] -> FStar_Pervasives_Native.None
     | { imports; segment = uu____4137;_}::uu____4138 ->
         FStar_List.last imports
-  
-let (alist_of_ns_info :
+let alist_of_ns_info:
   ns_info ->
-    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list)
+    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun ns_info  ->
     [("name", (FStar_Util.JsonStr (ns_info.ns_name)));
     ("loaded", (FStar_Util.JsonBool (ns_info.ns_loaded)))]
-  
-let (alist_of_mod_info :
+let alist_of_mod_info:
   mod_info ->
-    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list)
+    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun mod_info  ->
     [("name", (FStar_Util.JsonStr (mod_info.mod_name)));
     ("path", (FStar_Util.JsonStr (mod_info.mod_path)));
     ("loaded", (FStar_Util.JsonBool (mod_info.mod_loaded)))]
-  
 type completion_result =
   {
-  completion_match_length: Prims.int ;
-  completion_candidate: Prims.string ;
-  completion_annotation: Prims.string }[@@deriving show]
-let (__proj__Mkcompletion_result__item__completion_match_length :
-  completion_result -> Prims.int) =
+  completion_match_length: Prims.int;
+  completion_candidate: Prims.string;
+  completion_annotation: Prims.string;}[@@deriving show]
+let __proj__Mkcompletion_result__item__completion_match_length:
+  completion_result -> Prims.int =
   fun projectee  ->
     match projectee with
     | { completion_match_length = __fname__completion_match_length;
         completion_candidate = __fname__completion_candidate;
         completion_annotation = __fname__completion_annotation;_} ->
         __fname__completion_match_length
-  
-let (__proj__Mkcompletion_result__item__completion_candidate :
-  completion_result -> Prims.string) =
+let __proj__Mkcompletion_result__item__completion_candidate:
+  completion_result -> Prims.string =
   fun projectee  ->
     match projectee with
     | { completion_match_length = __fname__completion_match_length;
         completion_candidate = __fname__completion_candidate;
         completion_annotation = __fname__completion_annotation;_} ->
         __fname__completion_candidate
-  
-let (__proj__Mkcompletion_result__item__completion_annotation :
-  completion_result -> Prims.string) =
+let __proj__Mkcompletion_result__item__completion_annotation:
+  completion_result -> Prims.string =
   fun projectee  ->
     match projectee with
     | { completion_match_length = __fname__completion_match_length;
         completion_candidate = __fname__completion_candidate;
         completion_annotation = __fname__completion_annotation;_} ->
         __fname__completion_annotation
-  
-let (json_of_completion_result : completion_result -> FStar_Util.json) =
+let json_of_completion_result: completion_result -> FStar_Util.json =
   fun result  ->
     FStar_Util.JsonList
       [FStar_Util.JsonInt (result.completion_match_length);
       FStar_Util.JsonStr (result.completion_annotation);
       FStar_Util.JsonStr (result.completion_candidate)]
-  
-let completion_result_of_lid :
+let completion_result_of_lid:
   'Auu____4224 .
     (path,'Auu____4224) FStar_Pervasives_Native.tuple2 -> completion_result
   =
   fun uu____4232  ->
     match uu____4232 with
     | (path,_lid) ->
-        let uu____4239 = match_length_of_path path  in
-        let uu____4240 = string_of_path path  in
+        let uu____4239 = match_length_of_path path in
+        let uu____4240 = string_of_path path in
         let uu____4241 =
-          let uu____4242 = first_import_of_path path  in
-          FStar_Util.dflt "" uu____4242  in
+          let uu____4242 = first_import_of_path path in
+          FStar_Util.dflt "" uu____4242 in
         {
           completion_match_length = uu____4239;
           completion_candidate = uu____4240;
           completion_annotation = uu____4241
         }
-  
-let (completion_result_of_mod :
-  Prims.string -> Prims.bool -> path -> completion_result) =
+let completion_result_of_mod:
+  Prims.string -> Prims.bool -> path -> completion_result =
   fun annot  ->
     fun loaded  ->
       fun path  ->
-        let uu____4254 = match_length_of_path path  in
-        let uu____4255 = string_of_path path  in
+        let uu____4254 = match_length_of_path path in
+        let uu____4255 = string_of_path path in
         let uu____4256 =
-          FStar_Util.format1 (if loaded then " %s " else "(%s)") annot  in
+          FStar_Util.format1 (if loaded then " %s " else "(%s)") annot in
         {
           completion_match_length = uu____4254;
           completion_candidate = uu____4255;
           completion_annotation = uu____4256
         }
-  
-let (completion_result_of_ns_or_mod :
-  (path,mod_symbol) FStar_Pervasives_Native.tuple2 -> completion_result) =
+let completion_result_of_ns_or_mod:
+  (path,mod_symbol) FStar_Pervasives_Native.tuple2 -> completion_result =
   fun uu____4264  ->
     match uu____4264 with
     | (path,symb) ->
@@ -1081,30 +984,27 @@ let (completion_result_of_ns_or_mod :
              -> completion_result_of_mod "mod" loaded path
          | Namespace { ns_name = uu____4274; ns_loaded = loaded;_} ->
              completion_result_of_mod "ns" loaded path)
-  
-let (find_module_or_ns :
-  table -> query -> mod_symbol FStar_Pervasives_Native.option) =
-  fun tbl  -> fun query  -> trie_find_exact tbl.tbl_mods query 
-let (autocomplete_lid : table -> query -> completion_result Prims.list) =
+let find_module_or_ns:
+  table -> query -> mod_symbol FStar_Pervasives_Native.option =
+  fun tbl  -> fun query  -> trie_find_exact tbl.tbl_mods query
+let autocomplete_lid: table -> query -> completion_result Prims.list =
   fun tbl  ->
     fun query  ->
-      let uu____4292 = trie_find_prefix tbl.tbl_lids query  in
+      let uu____4292 = trie_find_prefix tbl.tbl_lids query in
       FStar_List.map completion_result_of_lid uu____4292
-  
-let (autocomplete_mod_or_ns :
+let autocomplete_mod_or_ns:
   table ->
     query ->
       ((path,mod_symbol) FStar_Pervasives_Native.tuple2 ->
          (path,mod_symbol) FStar_Pervasives_Native.tuple2
            FStar_Pervasives_Native.option)
-        -> completion_result Prims.list)
+        -> completion_result Prims.list
   =
   fun tbl  ->
     fun query  ->
       fun filter1  ->
         let uu____4339 =
-          let uu____4346 = trie_find_prefix tbl.tbl_mods query  in
-          FStar_All.pipe_right uu____4346 (FStar_List.filter_map filter1)  in
+          let uu____4346 = trie_find_prefix tbl.tbl_mods query in
+          FStar_All.pipe_right uu____4346 (FStar_List.filter_map filter1) in
         FStar_All.pipe_right uu____4339
           (FStar_List.map completion_result_of_ns_or_mod)
-  

--- a/src/ocaml-output/FStar_Interactive_Ide.ml
+++ b/src/ocaml-output/FStar_Interactive_Ide.ml
@@ -1,47 +1,40 @@
 open Prims
-exception ExitREPL of Prims.int 
-let (uu___is_ExitREPL : Prims.exn -> Prims.bool) =
+exception ExitREPL of Prims.int
+let uu___is_ExitREPL: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | ExitREPL uu____7 -> true | uu____8 -> false
-  
-let (__proj__ExitREPL__item__uu___ : Prims.exn -> Prims.int) =
-  fun projectee  -> match projectee with | ExitREPL uu____15 -> uu____15 
-let (push :
-  FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
+let __proj__ExitREPL__item__uu___: Prims.exn -> Prims.int =
+  fun projectee  -> match projectee with | ExitREPL uu____15 -> uu____15
+let push:
+  FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env =
   fun env  ->
     fun msg  ->
-      let res = FStar_Universal.push_context env msg  in
+      let res = FStar_Universal.push_context env msg in
       FStar_Options.push (); res
-  
-let (pop : FStar_TypeChecker_Env.env -> Prims.string -> Prims.unit) =
+let pop: FStar_TypeChecker_Env.env -> Prims.string -> Prims.unit =
   fun env  ->
     fun msg  -> FStar_Universal.pop_context env msg; FStar_Options.pop ()
-  
 type push_kind =
-  | SyntaxCheck 
-  | LaxCheck 
-  | FullCheck [@@deriving show]
-let (uu___is_SyntaxCheck : push_kind -> Prims.bool) =
+  | SyntaxCheck
+  | LaxCheck
+  | FullCheck[@@deriving show]
+let uu___is_SyntaxCheck: push_kind -> Prims.bool =
   fun projectee  ->
     match projectee with | SyntaxCheck  -> true | uu____34 -> false
-  
-let (uu___is_LaxCheck : push_kind -> Prims.bool) =
+let uu___is_LaxCheck: push_kind -> Prims.bool =
   fun projectee  ->
     match projectee with | LaxCheck  -> true | uu____38 -> false
-  
-let (uu___is_FullCheck : push_kind -> Prims.bool) =
+let uu___is_FullCheck: push_kind -> Prims.bool =
   fun projectee  ->
     match projectee with | FullCheck  -> true | uu____42 -> false
-  
-let (set_check_kind :
-  FStar_TypeChecker_Env.env -> push_kind -> FStar_TypeChecker_Env.env) =
+let set_check_kind:
+  FStar_TypeChecker_Env.env -> push_kind -> FStar_TypeChecker_Env.env =
   fun env  ->
     fun check_kind  ->
-      let uu___86_49 = env  in
+      let uu___86_49 = env in
       let uu____50 =
         FStar_ToSyntax_Env.set_syntax_only env.FStar_TypeChecker_Env.dsenv
-          (check_kind = SyntaxCheck)
-         in
+          (check_kind = SyntaxCheck) in
       {
         FStar_TypeChecker_Env.solver =
           (uu___86_49.FStar_TypeChecker_Env.solver);
@@ -112,8 +105,7 @@ let (set_check_kind :
         FStar_TypeChecker_Env.dep_graph =
           (uu___86_49.FStar_TypeChecker_Env.dep_graph)
       }
-  
-let with_captured_errors' :
+let with_captured_errors':
   'Auu____54 .
     FStar_TypeChecker_Env.env ->
       (FStar_TypeChecker_Env.env -> 'Auu____54 FStar_Pervasives_Native.option)
@@ -131,9 +123,8 @@ let with_captured_errors' :
                     (Prims.strcat "F* may be in an inconsistent state.\n"
                        (Prims.strcat
                           "Please file a bug report, ideally with a "
-                          "minimized version of the program that triggered the error."))))
-             in
-          ((let uu____90 = FStar_TypeChecker_Env.get_range env  in
+                          "minimized version of the program that triggered the error.")))) in
+          ((let uu____90 = FStar_TypeChecker_Env.get_range env in
             FStar_Errors.log_issue uu____90
               (FStar_Errors.Error_IDEAssertionFailure, msg1));
            FStar_Pervasives_Native.None)
@@ -143,14 +134,13 @@ let with_captured_errors' :
       | FStar_Errors.Err (e,msg) ->
           ((let uu____110 =
               let uu____119 =
-                let uu____126 = FStar_TypeChecker_Env.get_range env  in
-                (e, msg, uu____126)  in
-              [uu____119]  in
+                let uu____126 = FStar_TypeChecker_Env.get_range env in
+                (e, msg, uu____126) in
+              [uu____119] in
             FStar_TypeChecker_Err.add_errors env uu____110);
            FStar_Pervasives_Native.None)
       | FStar_Errors.Stop  -> FStar_Pervasives_Native.None
-  
-let with_captured_errors :
+let with_captured_errors:
   'Auu____142 .
     FStar_TypeChecker_Env.env ->
       (FStar_TypeChecker_Env.env ->
@@ -159,136 +149,121 @@ let with_captured_errors :
   =
   fun env  ->
     fun f  ->
-      let uu____162 = FStar_Options.trace_error ()  in
+      let uu____162 = FStar_Options.trace_error () in
       if uu____162 then f env else with_captured_errors' env f
-  
 type timed_fname = {
-  tf_fname: Prims.string ;
-  tf_modtime: FStar_Util.time }[@@deriving show]
-let (__proj__Mktimed_fname__item__tf_fname : timed_fname -> Prims.string) =
+  tf_fname: Prims.string;
+  tf_modtime: FStar_Util.time;}[@@deriving show]
+let __proj__Mktimed_fname__item__tf_fname: timed_fname -> Prims.string =
   fun projectee  ->
     match projectee with
     | { tf_fname = __fname__tf_fname; tf_modtime = __fname__tf_modtime;_} ->
         __fname__tf_fname
-  
-let (__proj__Mktimed_fname__item__tf_modtime :
-  timed_fname -> FStar_Util.time) =
+let __proj__Mktimed_fname__item__tf_modtime: timed_fname -> FStar_Util.time =
   fun projectee  ->
     match projectee with
     | { tf_fname = __fname__tf_fname; tf_modtime = __fname__tf_modtime;_} ->
         __fname__tf_modtime
-  
-let (t0 : FStar_Util.time) = FStar_Util.now () 
-let (tf_of_fname : Prims.string -> timed_fname) =
+let t0: FStar_Util.time = FStar_Util.now ()
+let tf_of_fname: Prims.string -> timed_fname =
   fun fname  ->
     let uu____187 =
-      FStar_Parser_ParseIt.get_file_last_modification_time fname  in
+      FStar_Parser_ParseIt.get_file_last_modification_time fname in
     { tf_fname = fname; tf_modtime = uu____187 }
-  
-let (dummy_tf_of_fname : Prims.string -> timed_fname) =
-  fun fname  -> { tf_fname = fname; tf_modtime = t0 } 
-let (string_of_timed_fname : timed_fname -> Prims.string) =
+let dummy_tf_of_fname: Prims.string -> timed_fname =
+  fun fname  -> { tf_fname = fname; tf_modtime = t0 }
+let string_of_timed_fname: timed_fname -> Prims.string =
   fun uu____193  ->
     match uu____193 with
     | { tf_fname = fname; tf_modtime = modtime;_} ->
         if modtime = t0
         then FStar_Util.format1 "{ %s }" fname
         else
-          (let uu____197 = FStar_Util.string_of_time modtime  in
+          (let uu____197 = FStar_Util.string_of_time modtime in
            FStar_Util.format2 "{ %s; %s }" fname uu____197)
-  
 type push_query =
   {
-  push_kind: push_kind ;
-  push_code: Prims.string ;
-  push_line: Prims.int ;
-  push_column: Prims.int ;
-  push_peek_only: Prims.bool }[@@deriving show]
-let (__proj__Mkpush_query__item__push_kind : push_query -> push_kind) =
+  push_kind: push_kind;
+  push_code: Prims.string;
+  push_line: Prims.int;
+  push_column: Prims.int;
+  push_peek_only: Prims.bool;}[@@deriving show]
+let __proj__Mkpush_query__item__push_kind: push_query -> push_kind =
   fun projectee  ->
     match projectee with
     | { push_kind = __fname__push_kind; push_code = __fname__push_code;
         push_line = __fname__push_line; push_column = __fname__push_column;
         push_peek_only = __fname__push_peek_only;_} -> __fname__push_kind
-  
-let (__proj__Mkpush_query__item__push_code : push_query -> Prims.string) =
+let __proj__Mkpush_query__item__push_code: push_query -> Prims.string =
   fun projectee  ->
     match projectee with
     | { push_kind = __fname__push_kind; push_code = __fname__push_code;
         push_line = __fname__push_line; push_column = __fname__push_column;
         push_peek_only = __fname__push_peek_only;_} -> __fname__push_code
-  
-let (__proj__Mkpush_query__item__push_line : push_query -> Prims.int) =
+let __proj__Mkpush_query__item__push_line: push_query -> Prims.int =
   fun projectee  ->
     match projectee with
     | { push_kind = __fname__push_kind; push_code = __fname__push_code;
         push_line = __fname__push_line; push_column = __fname__push_column;
         push_peek_only = __fname__push_peek_only;_} -> __fname__push_line
-  
-let (__proj__Mkpush_query__item__push_column : push_query -> Prims.int) =
+let __proj__Mkpush_query__item__push_column: push_query -> Prims.int =
   fun projectee  ->
     match projectee with
     | { push_kind = __fname__push_kind; push_code = __fname__push_code;
         push_line = __fname__push_line; push_column = __fname__push_column;
         push_peek_only = __fname__push_peek_only;_} -> __fname__push_column
-  
-let (__proj__Mkpush_query__item__push_peek_only : push_query -> Prims.bool) =
+let __proj__Mkpush_query__item__push_peek_only: push_query -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { push_kind = __fname__push_kind; push_code = __fname__push_code;
         push_line = __fname__push_line; push_column = __fname__push_column;
         push_peek_only = __fname__push_peek_only;_} ->
         __fname__push_peek_only
-  
 type optmod_t = FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option
 [@@deriving show]
 type repl_task =
-  | LDInterleaved of (timed_fname,timed_fname) FStar_Pervasives_Native.tuple2
-  
-  | LDSingle of timed_fname 
-  | LDInterfaceOfCurrentFile of timed_fname 
-  | PushFragment of FStar_Parser_ParseIt.input_frag [@@deriving show]
-let (uu___is_LDInterleaved : repl_task -> Prims.bool) =
+  | LDInterleaved of (timed_fname,timed_fname)
+  FStar_Pervasives_Native.tuple2
+  | LDSingle of timed_fname
+  | LDInterfaceOfCurrentFile of timed_fname
+  | PushFragment of FStar_Parser_ParseIt.input_frag[@@deriving show]
+let uu___is_LDInterleaved: repl_task -> Prims.bool =
   fun projectee  ->
     match projectee with | LDInterleaved _0 -> true | uu____288 -> false
-  
-let (__proj__LDInterleaved__item___0 :
-  repl_task -> (timed_fname,timed_fname) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | LDInterleaved _0 -> _0 
-let (uu___is_LDSingle : repl_task -> Prims.bool) =
+let __proj__LDInterleaved__item___0:
+  repl_task -> (timed_fname,timed_fname) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | LDInterleaved _0 -> _0
+let uu___is_LDSingle: repl_task -> Prims.bool =
   fun projectee  ->
     match projectee with | LDSingle _0 -> true | uu____312 -> false
-  
-let (__proj__LDSingle__item___0 : repl_task -> timed_fname) =
-  fun projectee  -> match projectee with | LDSingle _0 -> _0 
-let (uu___is_LDInterfaceOfCurrentFile : repl_task -> Prims.bool) =
+let __proj__LDSingle__item___0: repl_task -> timed_fname =
+  fun projectee  -> match projectee with | LDSingle _0 -> _0
+let uu___is_LDInterfaceOfCurrentFile: repl_task -> Prims.bool =
   fun projectee  ->
     match projectee with
     | LDInterfaceOfCurrentFile _0 -> true
     | uu____324 -> false
-  
-let (__proj__LDInterfaceOfCurrentFile__item___0 : repl_task -> timed_fname) =
-  fun projectee  -> match projectee with | LDInterfaceOfCurrentFile _0 -> _0 
-let (uu___is_PushFragment : repl_task -> Prims.bool) =
+let __proj__LDInterfaceOfCurrentFile__item___0: repl_task -> timed_fname =
+  fun projectee  -> match projectee with | LDInterfaceOfCurrentFile _0 -> _0
+let uu___is_PushFragment: repl_task -> Prims.bool =
   fun projectee  ->
     match projectee with | PushFragment _0 -> true | uu____336 -> false
-  
-let (__proj__PushFragment__item___0 :
-  repl_task -> FStar_Parser_ParseIt.input_frag) =
-  fun projectee  -> match projectee with | PushFragment _0 -> _0 
+let __proj__PushFragment__item___0:
+  repl_task -> FStar_Parser_ParseIt.input_frag =
+  fun projectee  -> match projectee with | PushFragment _0 -> _0
 type env_t = FStar_TypeChecker_Env.env[@@deriving show]
 type repl_state =
   {
-  repl_line: Prims.int ;
-  repl_column: Prims.int ;
-  repl_fname: Prims.string ;
+  repl_line: Prims.int;
+  repl_column: Prims.int;
+  repl_fname: Prims.string;
   repl_deps_stack:
-    (repl_task,repl_state) FStar_Pervasives_Native.tuple2 Prims.list ;
-  repl_curmod: optmod_t ;
-  repl_env: env_t ;
-  repl_stdin: FStar_Util.stream_reader ;
-  repl_names: FStar_Interactive_CompletionTable.table }[@@deriving show]
-let (__proj__Mkrepl_state__item__repl_line : repl_state -> Prims.int) =
+    (repl_task,repl_state) FStar_Pervasives_Native.tuple2 Prims.list;
+  repl_curmod: optmod_t;
+  repl_env: env_t;
+  repl_stdin: FStar_Util.stream_reader;
+  repl_names: FStar_Interactive_CompletionTable.table;}[@@deriving show]
+let __proj__Mkrepl_state__item__repl_line: repl_state -> Prims.int =
   fun projectee  ->
     match projectee with
     | { repl_line = __fname__repl_line; repl_column = __fname__repl_column;
@@ -297,8 +272,7 @@ let (__proj__Mkrepl_state__item__repl_line : repl_state -> Prims.int) =
         repl_curmod = __fname__repl_curmod; repl_env = __fname__repl_env;
         repl_stdin = __fname__repl_stdin; repl_names = __fname__repl_names;_}
         -> __fname__repl_line
-  
-let (__proj__Mkrepl_state__item__repl_column : repl_state -> Prims.int) =
+let __proj__Mkrepl_state__item__repl_column: repl_state -> Prims.int =
   fun projectee  ->
     match projectee with
     | { repl_line = __fname__repl_line; repl_column = __fname__repl_column;
@@ -307,8 +281,7 @@ let (__proj__Mkrepl_state__item__repl_column : repl_state -> Prims.int) =
         repl_curmod = __fname__repl_curmod; repl_env = __fname__repl_env;
         repl_stdin = __fname__repl_stdin; repl_names = __fname__repl_names;_}
         -> __fname__repl_column
-  
-let (__proj__Mkrepl_state__item__repl_fname : repl_state -> Prims.string) =
+let __proj__Mkrepl_state__item__repl_fname: repl_state -> Prims.string =
   fun projectee  ->
     match projectee with
     | { repl_line = __fname__repl_line; repl_column = __fname__repl_column;
@@ -317,10 +290,9 @@ let (__proj__Mkrepl_state__item__repl_fname : repl_state -> Prims.string) =
         repl_curmod = __fname__repl_curmod; repl_env = __fname__repl_env;
         repl_stdin = __fname__repl_stdin; repl_names = __fname__repl_names;_}
         -> __fname__repl_fname
-  
-let (__proj__Mkrepl_state__item__repl_deps_stack :
+let __proj__Mkrepl_state__item__repl_deps_stack:
   repl_state ->
-    (repl_task,repl_state) FStar_Pervasives_Native.tuple2 Prims.list)
+    (repl_task,repl_state) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
@@ -330,8 +302,7 @@ let (__proj__Mkrepl_state__item__repl_deps_stack :
         repl_curmod = __fname__repl_curmod; repl_env = __fname__repl_env;
         repl_stdin = __fname__repl_stdin; repl_names = __fname__repl_names;_}
         -> __fname__repl_deps_stack
-  
-let (__proj__Mkrepl_state__item__repl_curmod : repl_state -> optmod_t) =
+let __proj__Mkrepl_state__item__repl_curmod: repl_state -> optmod_t =
   fun projectee  ->
     match projectee with
     | { repl_line = __fname__repl_line; repl_column = __fname__repl_column;
@@ -340,8 +311,7 @@ let (__proj__Mkrepl_state__item__repl_curmod : repl_state -> optmod_t) =
         repl_curmod = __fname__repl_curmod; repl_env = __fname__repl_env;
         repl_stdin = __fname__repl_stdin; repl_names = __fname__repl_names;_}
         -> __fname__repl_curmod
-  
-let (__proj__Mkrepl_state__item__repl_env : repl_state -> env_t) =
+let __proj__Mkrepl_state__item__repl_env: repl_state -> env_t =
   fun projectee  ->
     match projectee with
     | { repl_line = __fname__repl_line; repl_column = __fname__repl_column;
@@ -350,9 +320,8 @@ let (__proj__Mkrepl_state__item__repl_env : repl_state -> env_t) =
         repl_curmod = __fname__repl_curmod; repl_env = __fname__repl_env;
         repl_stdin = __fname__repl_stdin; repl_names = __fname__repl_names;_}
         -> __fname__repl_env
-  
-let (__proj__Mkrepl_state__item__repl_stdin :
-  repl_state -> FStar_Util.stream_reader) =
+let __proj__Mkrepl_state__item__repl_stdin:
+  repl_state -> FStar_Util.stream_reader =
   fun projectee  ->
     match projectee with
     | { repl_line = __fname__repl_line; repl_column = __fname__repl_column;
@@ -361,9 +330,8 @@ let (__proj__Mkrepl_state__item__repl_stdin :
         repl_curmod = __fname__repl_curmod; repl_env = __fname__repl_env;
         repl_stdin = __fname__repl_stdin; repl_names = __fname__repl_names;_}
         -> __fname__repl_stdin
-  
-let (__proj__Mkrepl_state__item__repl_names :
-  repl_state -> FStar_Interactive_CompletionTable.table) =
+let __proj__Mkrepl_state__item__repl_names:
+  repl_state -> FStar_Interactive_CompletionTable.table =
   fun projectee  ->
     match projectee with
     | { repl_line = __fname__repl_line; repl_column = __fname__repl_column;
@@ -372,124 +340,113 @@ let (__proj__Mkrepl_state__item__repl_names :
         repl_curmod = __fname__repl_curmod; repl_env = __fname__repl_env;
         repl_stdin = __fname__repl_stdin; repl_names = __fname__repl_names;_}
         -> __fname__repl_names
-  
 type completed_repl_task =
   (repl_task,repl_state) FStar_Pervasives_Native.tuple2[@@deriving show]
 type repl_stack_t =
   (repl_task,repl_state) FStar_Pervasives_Native.tuple2 Prims.list[@@deriving
                                                                     show]
-let (repl_stack :
+let repl_stack:
   (repl_task,repl_state) FStar_Pervasives_Native.tuple2 Prims.list
-    FStar_ST.ref)
-  = FStar_Util.mk_ref [] 
-let (pop_repl : repl_state -> repl_state) =
+    FStar_ST.ref
+  = FStar_Util.mk_ref []
+let pop_repl: repl_state -> repl_state =
   fun st  ->
-    let uu____572 = FStar_ST.op_Bang repl_stack  in
+    let uu____572 = FStar_ST.op_Bang repl_stack in
     match uu____572 with
     | [] -> failwith "Too many pops"
     | (uu____614,st')::stack ->
         (pop st.repl_env "#pop";
          FStar_ST.op_Colon_Equals repl_stack stack;
          st')
-  
-let (push_repl :
-  push_kind -> repl_task -> repl_state -> FStar_TypeChecker_Env.env) =
+let push_repl:
+  push_kind -> repl_task -> repl_state -> FStar_TypeChecker_Env.env =
   fun push_kind  ->
     fun task  ->
       fun st  ->
         (let uu____670 =
-           let uu____677 = FStar_ST.op_Bang repl_stack  in (task, st) ::
-             uu____677
-            in
+           let uu____677 = FStar_ST.op_Bang repl_stack in (task, st) ::
+             uu____677 in
          FStar_ST.op_Colon_Equals repl_stack uu____670);
-        (let uu____750 = set_check_kind st.repl_env push_kind  in
+        (let uu____750 = set_check_kind st.repl_env push_kind in
          push uu____750 "")
-  
-let (nothing_left_to_pop : repl_state -> Prims.bool) =
+let nothing_left_to_pop: repl_state -> Prims.bool =
   fun st  ->
     let uu____754 =
-      let uu____755 = FStar_ST.op_Bang repl_stack  in
-      FStar_List.length uu____755  in
+      let uu____755 = FStar_ST.op_Bang repl_stack in
+      FStar_List.length uu____755 in
     uu____754 = (FStar_List.length st.repl_deps_stack)
-  
 type name_tracking_event =
   | NTAlias of (FStar_Ident.lid,FStar_Ident.ident,FStar_Ident.lid)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | NTOpen of (FStar_Ident.lid,FStar_ToSyntax_Env.open_module_or_namespace)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | NTInclude of (FStar_Ident.lid,FStar_Ident.lid)
-  FStar_Pervasives_Native.tuple2 
-  | NTBinding of FStar_TypeChecker_Env.binding [@@deriving show]
-let (uu___is_NTAlias : name_tracking_event -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | NTBinding of FStar_TypeChecker_Env.binding[@@deriving show]
+let uu___is_NTAlias: name_tracking_event -> Prims.bool =
   fun projectee  ->
     match projectee with | NTAlias _0 -> true | uu____845 -> false
-  
-let (__proj__NTAlias__item___0 :
+let __proj__NTAlias__item___0:
   name_tracking_event ->
     (FStar_Ident.lid,FStar_Ident.ident,FStar_Ident.lid)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | NTAlias _0 -> _0 
-let (uu___is_NTOpen : name_tracking_event -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | NTAlias _0 -> _0
+let uu___is_NTOpen: name_tracking_event -> Prims.bool =
   fun projectee  ->
     match projectee with | NTOpen _0 -> true | uu____879 -> false
-  
-let (__proj__NTOpen__item___0 :
+let __proj__NTOpen__item___0:
   name_tracking_event ->
     (FStar_Ident.lid,FStar_ToSyntax_Env.open_module_or_namespace)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | NTOpen _0 -> _0 
-let (uu___is_NTInclude : name_tracking_event -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | NTOpen _0 -> _0
+let uu___is_NTInclude: name_tracking_event -> Prims.bool =
   fun projectee  ->
     match projectee with | NTInclude _0 -> true | uu____907 -> false
-  
-let (__proj__NTInclude__item___0 :
+let __proj__NTInclude__item___0:
   name_tracking_event ->
-    (FStar_Ident.lid,FStar_Ident.lid) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | NTInclude _0 -> _0 
-let (uu___is_NTBinding : name_tracking_event -> Prims.bool) =
+    (FStar_Ident.lid,FStar_Ident.lid) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | NTInclude _0 -> _0
+let uu___is_NTBinding: name_tracking_event -> Prims.bool =
   fun projectee  ->
     match projectee with | NTBinding _0 -> true | uu____931 -> false
-  
-let (__proj__NTBinding__item___0 :
-  name_tracking_event -> FStar_TypeChecker_Env.binding) =
-  fun projectee  -> match projectee with | NTBinding _0 -> _0 
-let (query_of_ids :
-  FStar_Ident.ident Prims.list -> FStar_Interactive_CompletionTable.query) =
-  fun ids  -> FStar_List.map FStar_Ident.text_of_id ids 
-let (query_of_lid :
-  FStar_Ident.lident -> FStar_Interactive_CompletionTable.query) =
+let __proj__NTBinding__item___0:
+  name_tracking_event -> FStar_TypeChecker_Env.binding =
+  fun projectee  -> match projectee with | NTBinding _0 -> _0
+let query_of_ids:
+  FStar_Ident.ident Prims.list -> FStar_Interactive_CompletionTable.query =
+  fun ids  -> FStar_List.map FStar_Ident.text_of_id ids
+let query_of_lid:
+  FStar_Ident.lident -> FStar_Interactive_CompletionTable.query =
   fun lid  ->
     query_of_ids
       (FStar_List.append lid.FStar_Ident.ns [lid.FStar_Ident.ident])
-  
-let (update_names_from_event :
+let update_names_from_event:
   Prims.string ->
     FStar_Interactive_CompletionTable.table ->
-      name_tracking_event -> FStar_Interactive_CompletionTable.table)
+      name_tracking_event -> FStar_Interactive_CompletionTable.table
   =
   fun cur_mod_str  ->
     fun table  ->
       fun evt  ->
-        let is_cur_mod lid = lid.FStar_Ident.str = cur_mod_str  in
+        let is_cur_mod lid = lid.FStar_Ident.str = cur_mod_str in
         match evt with
         | NTAlias (host,id1,included) ->
             if is_cur_mod host
             then
-              let uu____965 = query_of_lid included  in
+              let uu____965 = query_of_lid included in
               FStar_Interactive_CompletionTable.register_alias table
                 (FStar_Ident.text_of_id id1) [] uu____965
             else table
         | NTOpen (host,(included,kind)) ->
             if is_cur_mod host
             then
-              let uu____974 = query_of_lid included  in
+              let uu____974 = query_of_lid included in
               FStar_Interactive_CompletionTable.register_open table
                 (kind = FStar_ToSyntax_Env.Open_module) [] uu____974
             else table
         | NTInclude (host,included) ->
-            let uu____978 = if is_cur_mod host then [] else query_of_lid host
-               in
-            let uu____980 = query_of_lid included  in
+            let uu____978 = if is_cur_mod host then [] else query_of_lid host in
+            let uu____980 = query_of_lid included in
             FStar_Interactive_CompletionTable.register_include table
               uu____978 uu____980
         | NTBinding binding ->
@@ -499,23 +456,22 @@ let (update_names_from_event :
               | FStar_TypeChecker_Env.Binding_sig (lids,uu____990) -> lids
               | FStar_TypeChecker_Env.Binding_sig_inst
                   (lids,uu____996,uu____997) -> lids
-              | uu____1002 -> []  in
+              | uu____1002 -> [] in
             FStar_List.fold_left
               (fun tbl  ->
                  fun lid  ->
                    let ns_query =
                      if lid.FStar_Ident.nsstr = cur_mod_str
                      then []
-                     else query_of_ids lid.FStar_Ident.ns  in
+                     else query_of_ids lid.FStar_Ident.ns in
                    FStar_Interactive_CompletionTable.insert tbl ns_query
                      (FStar_Ident.text_of_id lid.FStar_Ident.ident) lid)
               table lids
-  
-let (commit_name_tracking' :
+let commit_name_tracking':
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     FStar_Interactive_CompletionTable.table ->
       name_tracking_event Prims.list ->
-        FStar_Interactive_CompletionTable.table)
+        FStar_Interactive_CompletionTable.table
   =
   fun cur_mod  ->
     fun names1  ->
@@ -524,19 +480,17 @@ let (commit_name_tracking' :
           match cur_mod with
           | FStar_Pervasives_Native.None  -> ""
           | FStar_Pervasives_Native.Some md ->
-              let uu____1033 = FStar_Syntax_Syntax.mod_name md  in
-              uu____1033.FStar_Ident.str
-           in
-        let updater = update_names_from_event cur_mod_str  in
+              let uu____1033 = FStar_Syntax_Syntax.mod_name md in
+              uu____1033.FStar_Ident.str in
+        let updater = update_names_from_event cur_mod_str in
         FStar_List.fold_left updater names1 name_events
-  
-let (commit_name_tracking :
-  repl_state -> name_tracking_event Prims.list -> repl_state) =
+let commit_name_tracking:
+  repl_state -> name_tracking_event Prims.list -> repl_state =
   fun st  ->
     fun name_events  ->
       let names1 =
-        commit_name_tracking' st.repl_curmod st.repl_names name_events  in
-      let uu___89_1050 = st  in
+        commit_name_tracking' st.repl_curmod st.repl_names name_events in
+      let uu___89_1050 = st in
       {
         repl_line = (uu___89_1050.repl_line);
         repl_column = (uu___89_1050.repl_column);
@@ -547,18 +501,17 @@ let (commit_name_tracking :
         repl_stdin = (uu___89_1050.repl_stdin);
         repl_names = names1
       }
-  
-let (fresh_name_tracking_hooks :
+let fresh_name_tracking_hooks:
   Prims.unit ->
     (name_tracking_event Prims.list FStar_ST.ref,FStar_ToSyntax_Env.dsenv_hooks,
-      FStar_TypeChecker_Env.tcenv_hooks) FStar_Pervasives_Native.tuple3)
+      FStar_TypeChecker_Env.tcenv_hooks) FStar_Pervasives_Native.tuple3
   =
   fun uu____1063  ->
-    let events = FStar_Util.mk_ref []  in
+    let events = FStar_Util.mk_ref [] in
     let push_event evt =
       let uu____1075 =
-        let uu____1078 = FStar_ST.op_Bang events  in evt :: uu____1078  in
-      FStar_ST.op_Colon_Equals events uu____1075  in
+        let uu____1078 = FStar_ST.op_Bang events in evt :: uu____1078 in
+      FStar_ST.op_Colon_Equals events uu____1075 in
     (events,
       {
         FStar_ToSyntax_Env.ds_push_open_hook =
@@ -566,20 +519,18 @@ let (fresh_name_tracking_hooks :
              fun op  ->
                let uu____1205 =
                  let uu____1206 =
-                   let uu____1211 = FStar_ToSyntax_Env.current_module dsenv
-                      in
-                   (uu____1211, op)  in
-                 NTOpen uu____1206  in
+                   let uu____1211 = FStar_ToSyntax_Env.current_module dsenv in
+                   (uu____1211, op) in
+                 NTOpen uu____1206 in
                push_event uu____1205);
         FStar_ToSyntax_Env.ds_push_include_hook =
           (fun dsenv  ->
              fun ns  ->
                let uu____1217 =
                  let uu____1218 =
-                   let uu____1223 = FStar_ToSyntax_Env.current_module dsenv
-                      in
-                   (uu____1223, ns)  in
-                 NTInclude uu____1218  in
+                   let uu____1223 = FStar_ToSyntax_Env.current_module dsenv in
+                   (uu____1223, ns) in
+                 NTInclude uu____1218 in
                push_event uu____1217);
         FStar_ToSyntax_Env.ds_push_module_abbrev_hook =
           (fun dsenv  ->
@@ -587,86 +538,78 @@ let (fresh_name_tracking_hooks :
                fun l  ->
                  let uu____1231 =
                    let uu____1232 =
-                     let uu____1239 = FStar_ToSyntax_Env.current_module dsenv
-                        in
-                     (uu____1239, x, l)  in
-                   NTAlias uu____1232  in
+                     let uu____1239 = FStar_ToSyntax_Env.current_module dsenv in
+                     (uu____1239, x, l) in
+                   NTAlias uu____1232 in
                  push_event uu____1231)
       },
       {
         FStar_TypeChecker_Env.tc_push_in_gamma_hook =
           (fun uu____1244  -> fun s  -> push_event (NTBinding s))
       })
-  
-let (track_name_changes :
+let track_name_changes:
   env_t ->
     (env_t,env_t ->
              (env_t,name_tracking_event Prims.list)
                FStar_Pervasives_Native.tuple2)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     let set_hooks dshooks tchooks env1 =
       let uu____1283 =
         FStar_Universal.with_tcenv env1
           (fun dsenv  ->
-             let uu____1291 = FStar_ToSyntax_Env.set_ds_hooks dsenv dshooks
-                in
-             ((), uu____1291))
-         in
+             let uu____1291 = FStar_ToSyntax_Env.set_ds_hooks dsenv dshooks in
+             ((), uu____1291)) in
       match uu____1283 with
-      | ((),tcenv') -> FStar_TypeChecker_Env.set_tc_hooks tcenv' tchooks  in
+      | ((),tcenv') -> FStar_TypeChecker_Env.set_tc_hooks tcenv' tchooks in
     let uu____1293 =
       let uu____1298 =
-        FStar_ToSyntax_Env.ds_hooks env.FStar_TypeChecker_Env.dsenv  in
-      let uu____1299 = FStar_TypeChecker_Env.tc_hooks env  in
-      (uu____1298, uu____1299)  in
+        FStar_ToSyntax_Env.ds_hooks env.FStar_TypeChecker_Env.dsenv in
+      let uu____1299 = FStar_TypeChecker_Env.tc_hooks env in
+      (uu____1298, uu____1299) in
     match uu____1293 with
     | (old_dshooks,old_tchooks) ->
-        let uu____1314 = fresh_name_tracking_hooks ()  in
+        let uu____1314 = fresh_name_tracking_hooks () in
         (match uu____1314 with
          | (events,new_dshooks,new_tchooks) ->
-             let uu____1348 = set_hooks new_dshooks new_tchooks env  in
+             let uu____1348 = set_hooks new_dshooks new_tchooks env in
              (uu____1348,
                ((fun env1  ->
-                   let uu____1361 = set_hooks old_dshooks old_tchooks env1
-                      in
+                   let uu____1361 = set_hooks old_dshooks old_tchooks env1 in
                    let uu____1362 =
-                     let uu____1365 = FStar_ST.op_Bang events  in
-                     FStar_List.rev uu____1365  in
+                     let uu____1365 = FStar_ST.op_Bang events in
+                     FStar_List.rev uu____1365 in
                    (uu____1361, uu____1362)))))
-  
-let (string_of_repl_task : repl_task -> Prims.string) =
+let string_of_repl_task: repl_task -> Prims.string =
   fun uu___71_1417  ->
     match uu___71_1417 with
     | LDInterleaved (intf,impl) ->
-        let uu____1420 = string_of_timed_fname intf  in
-        let uu____1421 = string_of_timed_fname impl  in
+        let uu____1420 = string_of_timed_fname intf in
+        let uu____1421 = string_of_timed_fname impl in
         FStar_Util.format2 "LDInterleaved (%s, %s)" uu____1420 uu____1421
     | LDSingle intf_or_impl ->
-        let uu____1423 = string_of_timed_fname intf_or_impl  in
+        let uu____1423 = string_of_timed_fname intf_or_impl in
         FStar_Util.format1 "LDSingle %s" uu____1423
     | LDInterfaceOfCurrentFile intf ->
-        let uu____1425 = string_of_timed_fname intf  in
+        let uu____1425 = string_of_timed_fname intf in
         FStar_Util.format1 "LDInterfaceOfCurrentFile %s" uu____1425
     | PushFragment frag ->
         FStar_Util.format1 "PushFragment { code = %s }"
           frag.FStar_Parser_ParseIt.frag_text
-  
-let (tc_one :
+let tc_one:
   FStar_TypeChecker_Env.env ->
     Prims.string FStar_Pervasives_Native.option ->
-      Prims.string -> FStar_TypeChecker_Env.env)
+      Prims.string -> FStar_TypeChecker_Env.env
   =
   fun env  ->
     fun intf_opt  ->
       fun modf  ->
-        let uu____1440 = FStar_Universal.tc_one_file env intf_opt modf  in
+        let uu____1440 = FStar_Universal.tc_one_file env intf_opt modf in
         match uu____1440 with | (uu____1449,env1) -> env1
-  
-let (run_repl_task :
+let run_repl_task:
   optmod_t ->
-    env_t -> repl_task -> (optmod_t,env_t) FStar_Pervasives_Native.tuple2)
+    env_t -> repl_task -> (optmod_t,env_t) FStar_Pervasives_Native.tuple2
   =
   fun curmod  ->
     fun env  ->
@@ -675,163 +618,147 @@ let (run_repl_task :
         | LDInterleaved (intf,impl) ->
             let uu____1478 =
               tc_one env (FStar_Pervasives_Native.Some (intf.tf_fname))
-                impl.tf_fname
-               in
+                impl.tf_fname in
             (curmod, uu____1478)
         | LDSingle intf_or_impl ->
             let uu____1480 =
-              tc_one env FStar_Pervasives_Native.None intf_or_impl.tf_fname
-               in
+              tc_one env FStar_Pervasives_Native.None intf_or_impl.tf_fname in
             (curmod, uu____1480)
         | LDInterfaceOfCurrentFile intf ->
             let uu____1482 =
-              FStar_Universal.load_interface_decls env intf.tf_fname  in
+              FStar_Universal.load_interface_decls env intf.tf_fname in
             (curmod, uu____1482)
         | PushFragment frag ->
             FStar_Universal.tc_one_fragment curmod env frag
-  
-let (repl_ld_tasks_of_deps :
-  Prims.string Prims.list -> repl_task Prims.list -> repl_task Prims.list) =
+let repl_ld_tasks_of_deps:
+  Prims.string Prims.list -> repl_task Prims.list -> repl_task Prims.list =
   fun deps  ->
     fun final_tasks  ->
-      let wrap = dummy_tf_of_fname  in
+      let wrap = dummy_tf_of_fname in
       let rec aux deps1 final_tasks1 =
         match deps1 with
         | intf::impl::deps' when FStar_Universal.needs_interleaving intf impl
             ->
-            let uu____1527 = aux deps' final_tasks1  in
+            let uu____1527 = aux deps' final_tasks1 in
             (LDInterleaved ((wrap intf), (wrap impl))) :: uu____1527
         | intf_or_impl::deps' ->
-            let uu____1534 = aux deps' final_tasks1  in
+            let uu____1534 = aux deps' final_tasks1 in
             (LDSingle (wrap intf_or_impl)) :: uu____1534
-        | [] -> final_tasks1  in
+        | [] -> final_tasks1 in
       aux deps final_tasks
-  
-let (deps_and_repl_ld_tasks_of_our_file :
+let deps_and_repl_ld_tasks_of_our_file:
   Prims.string ->
     (Prims.string Prims.list,repl_task Prims.list,FStar_Parser_Dep.deps)
-      FStar_Pervasives_Native.tuple3)
+      FStar_Pervasives_Native.tuple3
   =
   fun filename  ->
-    let get_mod_name fname = FStar_Parser_Dep.lowercase_module_name fname  in
-    let our_mod_name = get_mod_name filename  in
+    let get_mod_name fname = FStar_Parser_Dep.lowercase_module_name fname in
+    let our_mod_name = get_mod_name filename in
     let has_our_mod_name f =
-      let uu____1569 = get_mod_name f  in uu____1569 = our_mod_name  in
-    let uu____1570 = FStar_Dependencies.find_deps_if_needed [filename]  in
+      let uu____1569 = get_mod_name f in uu____1569 = our_mod_name in
+    let uu____1570 = FStar_Dependencies.find_deps_if_needed [filename] in
     match uu____1570 with
     | (deps,dep_graph1) ->
-        let uu____1593 = FStar_List.partition has_our_mod_name deps  in
+        let uu____1593 = FStar_List.partition has_our_mod_name deps in
         (match uu____1593 with
          | (same_name,real_deps) ->
              let intf_tasks =
                match same_name with
                | intf::impl::[] ->
                    ((let uu____1630 =
-                       let uu____1631 = FStar_Parser_Dep.is_interface intf
-                          in
-                       Prims.op_Negation uu____1631  in
+                       let uu____1631 = FStar_Parser_Dep.is_interface intf in
+                       Prims.op_Negation uu____1631 in
                      if uu____1630
                      then
                        let uu____1632 =
                          let uu____1637 =
                            FStar_Util.format1
-                             "Expecting an interface, got %s" intf
-                            in
-                         (FStar_Errors.Fatal_MissingInterface, uu____1637)
-                          in
+                             "Expecting an interface, got %s" intf in
+                         (FStar_Errors.Fatal_MissingInterface, uu____1637) in
                        FStar_Errors.raise_err uu____1632
                      else ());
                     (let uu____1640 =
                        let uu____1641 =
-                         FStar_Parser_Dep.is_implementation impl  in
-                       Prims.op_Negation uu____1641  in
+                         FStar_Parser_Dep.is_implementation impl in
+                       Prims.op_Negation uu____1641 in
                      if uu____1640
                      then
                        let uu____1642 =
                          let uu____1647 =
                            FStar_Util.format1
-                             "Expecting an implementation, got %s" impl
-                            in
+                             "Expecting an implementation, got %s" impl in
                          (FStar_Errors.Fatal_MissingImplementation,
-                           uu____1647)
-                          in
+                           uu____1647) in
                        FStar_Errors.raise_err uu____1642
                      else ());
                     [LDInterfaceOfCurrentFile (dummy_tf_of_fname intf)])
                | impl::[] -> []
                | uu____1650 ->
-                   let mods_str = FStar_String.concat " " same_name  in
-                   let message = "Too many or too few files matching %s: %s"
-                      in
+                   let mods_str = FStar_String.concat " " same_name in
+                   let message = "Too many or too few files matching %s: %s" in
                    ((let uu____1656 =
                        let uu____1661 =
-                         FStar_Util.format2 message our_mod_name mods_str  in
+                         FStar_Util.format2 message our_mod_name mods_str in
                        (FStar_Errors.Fatal_TooManyOrTooFewFileMatch,
-                         uu____1661)
-                        in
+                         uu____1661) in
                      FStar_Errors.raise_err uu____1656);
-                    [])
-                in
-             let tasks = repl_ld_tasks_of_deps real_deps intf_tasks  in
+                    []) in
+             let tasks = repl_ld_tasks_of_deps real_deps intf_tasks in
              (real_deps, tasks, dep_graph1))
-  
-let (update_task_timestamps : repl_task -> repl_task) =
+let update_task_timestamps: repl_task -> repl_task =
   fun uu___72_1671  ->
     match uu___72_1671 with
     | LDInterleaved (intf,impl) ->
         let uu____1674 =
-          let uu____1679 = tf_of_fname intf.tf_fname  in
-          let uu____1680 = tf_of_fname impl.tf_fname  in
-          (uu____1679, uu____1680)  in
+          let uu____1679 = tf_of_fname intf.tf_fname in
+          let uu____1680 = tf_of_fname impl.tf_fname in
+          (uu____1679, uu____1680) in
         LDInterleaved uu____1674
     | LDSingle intf_or_impl ->
-        let uu____1682 = tf_of_fname intf_or_impl.tf_fname  in
+        let uu____1682 = tf_of_fname intf_or_impl.tf_fname in
         LDSingle uu____1682
     | LDInterfaceOfCurrentFile intf ->
-        let uu____1684 = tf_of_fname intf.tf_fname  in
+        let uu____1684 = tf_of_fname intf.tf_fname in
         LDInterfaceOfCurrentFile uu____1684
     | PushFragment frag -> PushFragment frag
-  
-let (run_repl_transaction :
+let run_repl_transaction:
   repl_state ->
     push_kind ->
       Prims.bool ->
-        repl_task -> (Prims.bool,repl_state) FStar_Pervasives_Native.tuple2)
+        repl_task -> (Prims.bool,repl_state) FStar_Pervasives_Native.tuple2
   =
   fun st  ->
     fun push_kind  ->
       fun must_rollback  ->
         fun task  ->
-          let env = push_repl push_kind task st  in
-          let uu____1703 = track_name_changes env  in
+          let env = push_repl push_kind task st in
+          let uu____1703 = track_name_changes env in
           match uu____1703 with
           | (env1,finish_name_tracking) ->
               let check_success uu____1741 =
-                (let uu____1744 = FStar_Errors.get_err_count ()  in
+                (let uu____1744 = FStar_Errors.get_err_count () in
                  uu____1744 = (Prims.parse_int "0")) &&
-                  (Prims.op_Negation must_rollback)
-                 in
+                  (Prims.op_Negation must_rollback) in
               let uu____1745 =
                 let uu____1752 =
                   with_captured_errors env1
                     (fun env2  ->
                        let uu____1766 =
-                         run_repl_task st.repl_curmod env2 task  in
+                         run_repl_task st.repl_curmod env2 task in
                        FStar_All.pipe_left
                          (fun _0_40  -> FStar_Pervasives_Native.Some _0_40)
-                         uu____1766)
-                   in
+                         uu____1766) in
                 match uu____1752 with
                 | FStar_Pervasives_Native.Some (curmod,env2) when
                     check_success () -> (curmod, env2, true)
-                | uu____1797 -> ((st.repl_curmod), env1, false)  in
+                | uu____1797 -> ((st.repl_curmod), env1, false) in
               (match uu____1745 with
                | (curmod,env2,success) ->
-                   let uu____1811 = finish_name_tracking env2  in
+                   let uu____1811 = finish_name_tracking env2 in
                    (match uu____1811 with
                     | (env',name_events) ->
                         let st1 =
-                          let uu___90_1829 = st  in
+                          let uu___90_1829 = st in
                           {
                             repl_line = (uu___90_1829.repl_line);
                             repl_column = (uu___90_1829.repl_column);
@@ -841,56 +768,52 @@ let (run_repl_transaction :
                             repl_env = env2;
                             repl_stdin = (uu___90_1829.repl_stdin);
                             repl_names = (uu___90_1829.repl_names)
-                          }  in
+                          } in
                         let st2 =
                           if success
                           then commit_name_tracking st1 name_events
-                          else pop_repl st1  in
+                          else pop_repl st1 in
                         (success, st2)))
-  
-let (run_repl_ld_transactions :
+let run_repl_ld_transactions:
   repl_state ->
-    repl_task Prims.list -> (repl_state,repl_state) FStar_Util.either)
+    repl_task Prims.list -> (repl_state,repl_state) FStar_Util.either
   =
   fun st  ->
     fun tasks  ->
       let debug1 verb task =
-        let uu____1853 = FStar_Options.debug_any ()  in
+        let uu____1853 = FStar_Options.debug_any () in
         if uu____1853
         then
-          let uu____1854 = string_of_repl_task task  in
+          let uu____1854 = string_of_repl_task task in
           FStar_Util.print2 "%s %s" verb uu____1854
-        else ()  in
+        else () in
       let rec revert_many st1 uu___73_1868 =
         match uu___73_1868 with
         | [] -> st1
         | (task,_st')::entries ->
-            ((let uu____1893 = Obj.magic ()  in ());
+            ((let uu____1893 = Obj.magic () in ());
              debug1 "Reverting" task;
-             (let uu____1895 = pop_repl st1  in
-              revert_many uu____1895 entries))
-         in
+             (let uu____1895 = pop_repl st1 in revert_many uu____1895 entries)) in
       let rec aux st1 tasks1 previous =
         match (tasks1, previous) with
         | ([],[]) -> FStar_Util.Inl st1
         | (task::tasks2,[]) ->
             (debug1 "Loading" task;
-             (let uu____1940 = FStar_Options.restore_cmd_line_options false
-                 in
+             (let uu____1940 = FStar_Options.restore_cmd_line_options false in
               FStar_All.pipe_right uu____1940 FStar_Pervasives.ignore);
-             (let timestamped_task = update_task_timestamps task  in
+             (let timestamped_task = update_task_timestamps task in
               let push_kind =
-                let uu____1943 = FStar_Options.lax ()  in
-                if uu____1943 then LaxCheck else FullCheck  in
+                let uu____1943 = FStar_Options.lax () in
+                if uu____1943 then LaxCheck else FullCheck in
               let uu____1945 =
-                run_repl_transaction st1 push_kind false timestamped_task  in
+                run_repl_transaction st1 push_kind false timestamped_task in
               match uu____1945 with
               | (success,st2) ->
                   if success
                   then
                     let uu____1960 =
-                      let uu___91_1961 = st2  in
-                      let uu____1962 = FStar_ST.op_Bang repl_stack  in
+                      let uu___91_1961 = st2 in
+                      let uu____1962 = FStar_ST.op_Bang repl_stack in
                       {
                         repl_line = (uu___91_1961.repl_line);
                         repl_column = (uu___91_1961.repl_column);
@@ -900,64 +823,55 @@ let (run_repl_ld_transactions :
                         repl_env = (uu___91_1961.repl_env);
                         repl_stdin = (uu___91_1961.repl_stdin);
                         repl_names = (uu___91_1961.repl_names)
-                      }  in
+                      } in
                     aux uu____1960 tasks2 []
                   else FStar_Util.Inr st2))
         | (task::tasks2,prev::previous1) when
-            let uu____2013 = update_task_timestamps task  in
+            let uu____2013 = update_task_timestamps task in
             (FStar_Pervasives_Native.fst prev) = uu____2013 ->
             (debug1 "Skipping" task; aux st1 tasks2 previous1)
         | (tasks2,previous1) ->
-            let uu____2025 = revert_many st1 previous1  in
-            aux uu____2025 tasks2 []
-         in
+            let uu____2025 = revert_many st1 previous1 in
+            aux uu____2025 tasks2 [] in
       aux st tasks (FStar_List.rev st.repl_deps_stack)
-  
-let (json_to_str : FStar_Util.json -> Prims.string) =
+let json_to_str: FStar_Util.json -> Prims.string =
   fun uu___74_2032  ->
     match uu___74_2032 with
     | FStar_Util.JsonNull  -> "null"
     | FStar_Util.JsonBool b ->
         FStar_Util.format1 "bool (%s)" (if b then "true" else "false")
     | FStar_Util.JsonInt i ->
-        let uu____2036 = FStar_Util.string_of_int i  in
+        let uu____2036 = FStar_Util.string_of_int i in
         FStar_Util.format1 "int (%s)" uu____2036
     | FStar_Util.JsonStr s -> FStar_Util.format1 "string (%s)" s
     | FStar_Util.JsonList uu____2038 -> "list (...)"
     | FStar_Util.JsonAssoc uu____2041 -> "dictionary (...)"
-  
 exception UnexpectedJsonType of (Prims.string,FStar_Util.json)
-  FStar_Pervasives_Native.tuple2 
-let (uu___is_UnexpectedJsonType : Prims.exn -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+let uu___is_UnexpectedJsonType: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with
     | UnexpectedJsonType uu____2058 -> true
     | uu____2063 -> false
-  
-let (__proj__UnexpectedJsonType__item__uu___ :
-  Prims.exn -> (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2)
+let __proj__UnexpectedJsonType__item__uu___:
+  Prims.exn -> (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2
   =
   fun projectee  ->
     match projectee with | UnexpectedJsonType uu____2078 -> uu____2078
-  
-let js_fail : 'Auu____2086 . Prims.string -> FStar_Util.json -> 'Auu____2086
-  =
+let js_fail: 'Auu____2086 . Prims.string -> FStar_Util.json -> 'Auu____2086 =
   fun expected  ->
     fun got  -> FStar_Exn.raise (UnexpectedJsonType (expected, got))
-  
-let (js_int : FStar_Util.json -> Prims.int) =
+let js_int: FStar_Util.json -> Prims.int =
   fun uu___75_2097  ->
     match uu___75_2097 with
     | FStar_Util.JsonInt i -> i
     | other -> js_fail "int" other
-  
-let (js_str : FStar_Util.json -> Prims.string) =
+let js_str: FStar_Util.json -> Prims.string =
   fun uu___76_2102  ->
     match uu___76_2102 with
     | FStar_Util.JsonStr s -> s
     | other -> js_fail "string" other
-  
-let js_list :
+let js_list:
   'Auu____2108 .
     (FStar_Util.json -> 'Auu____2108) ->
       FStar_Util.json -> 'Auu____2108 Prims.list
@@ -967,29 +881,25 @@ let js_list :
       match uu___77_2121 with
       | FStar_Util.JsonList l -> FStar_List.map k l
       | other -> js_fail "list" other
-  
-let (js_assoc :
+let js_assoc:
   FStar_Util.json ->
-    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list)
+    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun uu___78_2138  ->
     match uu___78_2138 with
     | FStar_Util.JsonAssoc a -> a
     | other -> js_fail "dictionary" other
-  
-let (js_pushkind : FStar_Util.json -> push_kind) =
+let js_pushkind: FStar_Util.json -> push_kind =
   fun s  ->
-    let uu____2162 = js_str s  in
+    let uu____2162 = js_str s in
     match uu____2162 with
     | "syntax" -> SyntaxCheck
     | "lax" -> LaxCheck
     | "full" -> FullCheck
     | uu____2163 -> js_fail "push_kind" s
-  
-let (js_reductionrule : FStar_Util.json -> FStar_TypeChecker_Normalize.step)
-  =
+let js_reductionrule: FStar_Util.json -> FStar_TypeChecker_Normalize.step =
   fun s  ->
-    let uu____2167 = js_str s  in
+    let uu____2167 = js_str s in
     match uu____2167 with
     | "beta" -> FStar_TypeChecker_Normalize.Beta
     | "delta" ->
@@ -1001,39 +911,35 @@ let (js_reductionrule : FStar_Util.json -> FStar_TypeChecker_Normalize.step)
     | "pure-subterms" ->
         FStar_TypeChecker_Normalize.PureSubtermsWithinComputations
     | uu____2168 -> js_fail "reduction rule" s
-  
 type completion_context =
-  | CKCode 
-  | CKOption of Prims.bool 
+  | CKCode
+  | CKOption of Prims.bool
   | CKModuleOrNamespace of (Prims.bool,Prims.bool)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let (uu___is_CKCode : completion_context -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_CKCode: completion_context -> Prims.bool =
   fun projectee  ->
     match projectee with | CKCode  -> true | uu____2184 -> false
-  
-let (uu___is_CKOption : completion_context -> Prims.bool) =
+let uu___is_CKOption: completion_context -> Prims.bool =
   fun projectee  ->
     match projectee with | CKOption _0 -> true | uu____2189 -> false
-  
-let (__proj__CKOption__item___0 : completion_context -> Prims.bool) =
-  fun projectee  -> match projectee with | CKOption _0 -> _0 
-let (uu___is_CKModuleOrNamespace : completion_context -> Prims.bool) =
+let __proj__CKOption__item___0: completion_context -> Prims.bool =
+  fun projectee  -> match projectee with | CKOption _0 -> _0
+let uu___is_CKModuleOrNamespace: completion_context -> Prims.bool =
   fun projectee  ->
     match projectee with
     | CKModuleOrNamespace _0 -> true
     | uu____2205 -> false
-  
-let (__proj__CKModuleOrNamespace__item___0 :
+let __proj__CKModuleOrNamespace__item___0:
   completion_context ->
-    (Prims.bool,Prims.bool) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | CKModuleOrNamespace _0 -> _0 
-let (js_optional_completion_context :
-  FStar_Util.json FStar_Pervasives_Native.option -> completion_context) =
+    (Prims.bool,Prims.bool) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | CKModuleOrNamespace _0 -> _0
+let js_optional_completion_context:
+  FStar_Util.json FStar_Pervasives_Native.option -> completion_context =
   fun k  ->
     match k with
     | FStar_Pervasives_Native.None  -> CKCode
     | FStar_Pervasives_Native.Some k1 ->
-        let uu____2233 = js_str k1  in
+        let uu____2233 = js_str k1 in
         (match uu____2233 with
          | "symbol" -> CKCode
          | "code" -> CKCode
@@ -1047,35 +953,30 @@ let (js_optional_completion_context :
              js_fail
                "completion context (code, set-options, reset-options, open, let-open, include, module-alias)"
                k1)
-  
 type lookup_context =
-  | LKSymbolOnly 
-  | LKModule 
-  | LKOption 
-  | LKCode [@@deriving show]
-let (uu___is_LKSymbolOnly : lookup_context -> Prims.bool) =
+  | LKSymbolOnly
+  | LKModule
+  | LKOption
+  | LKCode[@@deriving show]
+let uu___is_LKSymbolOnly: lookup_context -> Prims.bool =
   fun projectee  ->
     match projectee with | LKSymbolOnly  -> true | uu____2238 -> false
-  
-let (uu___is_LKModule : lookup_context -> Prims.bool) =
+let uu___is_LKModule: lookup_context -> Prims.bool =
   fun projectee  ->
     match projectee with | LKModule  -> true | uu____2242 -> false
-  
-let (uu___is_LKOption : lookup_context -> Prims.bool) =
+let uu___is_LKOption: lookup_context -> Prims.bool =
   fun projectee  ->
     match projectee with | LKOption  -> true | uu____2246 -> false
-  
-let (uu___is_LKCode : lookup_context -> Prims.bool) =
+let uu___is_LKCode: lookup_context -> Prims.bool =
   fun projectee  ->
     match projectee with | LKCode  -> true | uu____2250 -> false
-  
-let (js_optional_lookup_context :
-  FStar_Util.json FStar_Pervasives_Native.option -> lookup_context) =
+let js_optional_lookup_context:
+  FStar_Util.json FStar_Pervasives_Native.option -> lookup_context =
   fun k  ->
     match k with
     | FStar_Pervasives_Native.None  -> LKSymbolOnly
     | FStar_Pervasives_Native.Some k1 ->
-        let uu____2259 = js_str k1  in
+        let uu____2259 = js_str k1 in
         (match uu____2259 with
          | "symbol-only" -> LKSymbolOnly
          | "code" -> LKCode
@@ -1089,124 +990,109 @@ let (js_optional_lookup_context :
              js_fail
                "lookup context (symbol-only, code, set-options, reset-options, open, let-open, include, module-alias)"
                k1)
-  
 type position =
   (Prims.string,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3[@@deriving
                                                                     show]
 type query' =
-  | Exit 
-  | DescribeProtocol 
-  | DescribeRepl 
-  | Segment of Prims.string 
-  | Pop 
-  | Push of push_query 
+  | Exit
+  | DescribeProtocol
+  | DescribeRepl
+  | Segment of Prims.string
+  | Pop
+  | Push of push_query
   | VfsAdd of (Prims.string FStar_Pervasives_Native.option,Prims.string)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | AutoComplete of (Prims.string,completion_context)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Lookup of
   (Prims.string,lookup_context,position FStar_Pervasives_Native.option,
-  Prims.string Prims.list) FStar_Pervasives_Native.tuple4 
+  Prims.string Prims.list) FStar_Pervasives_Native.tuple4
   | Compute of
   (Prims.string,FStar_TypeChecker_Normalize.step Prims.list
                   FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
-  | Search of Prims.string 
-  | GenericError of Prims.string 
-  | ProtocolViolation of Prims.string [@@deriving show]
+  FStar_Pervasives_Native.tuple2
+  | Search of Prims.string
+  | GenericError of Prims.string
+  | ProtocolViolation of Prims.string[@@deriving show]
 and query = {
-  qq: query' ;
-  qid: Prims.string }[@@deriving show]
-let (uu___is_Exit : query' -> Prims.bool) =
+  qq: query';
+  qid: Prims.string;}[@@deriving show]
+let uu___is_Exit: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | Exit  -> true | uu____2344 -> false
-  
-let (uu___is_DescribeProtocol : query' -> Prims.bool) =
+let uu___is_DescribeProtocol: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | DescribeProtocol  -> true | uu____2348 -> false
-  
-let (uu___is_DescribeRepl : query' -> Prims.bool) =
+let uu___is_DescribeRepl: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | DescribeRepl  -> true | uu____2352 -> false
-  
-let (uu___is_Segment : query' -> Prims.bool) =
+let uu___is_Segment: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | Segment _0 -> true | uu____2357 -> false
-  
-let (__proj__Segment__item___0 : query' -> Prims.string) =
-  fun projectee  -> match projectee with | Segment _0 -> _0 
-let (uu___is_Pop : query' -> Prims.bool) =
-  fun projectee  -> match projectee with | Pop  -> true | uu____2368 -> false 
-let (uu___is_Push : query' -> Prims.bool) =
+let __proj__Segment__item___0: query' -> Prims.string =
+  fun projectee  -> match projectee with | Segment _0 -> _0
+let uu___is_Pop: query' -> Prims.bool =
+  fun projectee  -> match projectee with | Pop  -> true | uu____2368 -> false
+let uu___is_Push: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | Push _0 -> true | uu____2373 -> false
-  
-let (__proj__Push__item___0 : query' -> push_query) =
-  fun projectee  -> match projectee with | Push _0 -> _0 
-let (uu___is_VfsAdd : query' -> Prims.bool) =
+let __proj__Push__item___0: query' -> push_query =
+  fun projectee  -> match projectee with | Push _0 -> _0
+let uu___is_VfsAdd: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | VfsAdd _0 -> true | uu____2391 -> false
-  
-let (__proj__VfsAdd__item___0 :
+let __proj__VfsAdd__item___0:
   query' ->
     (Prims.string FStar_Pervasives_Native.option,Prims.string)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | VfsAdd _0 -> _0 
-let (uu___is_AutoComplete : query' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | VfsAdd _0 -> _0
+let uu___is_AutoComplete: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | AutoComplete _0 -> true | uu____2425 -> false
-  
-let (__proj__AutoComplete__item___0 :
-  query' -> (Prims.string,completion_context) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | AutoComplete _0 -> _0 
-let (uu___is_Lookup : query' -> Prims.bool) =
+let __proj__AutoComplete__item___0:
+  query' -> (Prims.string,completion_context) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | AutoComplete _0 -> _0
+let uu___is_Lookup: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | Lookup _0 -> true | uu____2461 -> false
-  
-let (__proj__Lookup__item___0 :
+let __proj__Lookup__item___0:
   query' ->
     (Prims.string,lookup_context,position FStar_Pervasives_Native.option,
-      Prims.string Prims.list) FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | Lookup _0 -> _0 
-let (uu___is_Compute : query' -> Prims.bool) =
+      Prims.string Prims.list) FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | Lookup _0 -> _0
+let uu___is_Compute: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | Compute _0 -> true | uu____2517 -> false
-  
-let (__proj__Compute__item___0 :
+let __proj__Compute__item___0:
   query' ->
     (Prims.string,FStar_TypeChecker_Normalize.step Prims.list
                     FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Compute _0 -> _0 
-let (uu___is_Search : query' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Compute _0 -> _0
+let uu___is_Search: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | Search _0 -> true | uu____2553 -> false
-  
-let (__proj__Search__item___0 : query' -> Prims.string) =
-  fun projectee  -> match projectee with | Search _0 -> _0 
-let (uu___is_GenericError : query' -> Prims.bool) =
+let __proj__Search__item___0: query' -> Prims.string =
+  fun projectee  -> match projectee with | Search _0 -> _0
+let uu___is_GenericError: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | GenericError _0 -> true | uu____2565 -> false
-  
-let (__proj__GenericError__item___0 : query' -> Prims.string) =
-  fun projectee  -> match projectee with | GenericError _0 -> _0 
-let (uu___is_ProtocolViolation : query' -> Prims.bool) =
+let __proj__GenericError__item___0: query' -> Prims.string =
+  fun projectee  -> match projectee with | GenericError _0 -> _0
+let uu___is_ProtocolViolation: query' -> Prims.bool =
   fun projectee  ->
     match projectee with | ProtocolViolation _0 -> true | uu____2577 -> false
-  
-let (__proj__ProtocolViolation__item___0 : query' -> Prims.string) =
-  fun projectee  -> match projectee with | ProtocolViolation _0 -> _0 
-let (__proj__Mkquery__item__qq : query -> query') =
+let __proj__ProtocolViolation__item___0: query' -> Prims.string =
+  fun projectee  -> match projectee with | ProtocolViolation _0 -> _0
+let __proj__Mkquery__item__qq: query -> query' =
   fun projectee  ->
     match projectee with
     | { qq = __fname__qq; qid = __fname__qid;_} -> __fname__qq
-  
-let (__proj__Mkquery__item__qid : query -> Prims.string) =
+let __proj__Mkquery__item__qid: query -> Prims.string =
   fun projectee  ->
     match projectee with
     | { qq = __fname__qq; qid = __fname__qid;_} -> __fname__qid
-  
-let (query_needs_current_module : query' -> Prims.bool) =
+let query_needs_current_module: query' -> Prims.bool =
   fun uu___79_2597  ->
     match uu___79_2597 with
     | Exit  -> false
@@ -1227,9 +1113,8 @@ let (query_needs_current_module : query' -> Prims.bool) =
     | Lookup uu____2618 -> true
     | Compute uu____2631 -> true
     | Search uu____2640 -> true
-  
-let (interactive_protocol_vernum : Prims.int) = (Prims.parse_int "2") 
-let (interactive_protocol_features : Prims.string Prims.list) =
+let interactive_protocol_vernum: Prims.int = Prims.parse_int "2"
+let interactive_protocol_features: Prims.string Prims.list =
   ["autocomplete";
   "autocomplete/context";
   "compute";
@@ -1247,37 +1132,32 @@ let (interactive_protocol_features : Prims.string Prims.list) =
   "push";
   "search";
   "segment";
-  "vfs-add"] 
-exception InvalidQuery of Prims.string 
-let (uu___is_InvalidQuery : Prims.exn -> Prims.bool) =
+  "vfs-add"]
+exception InvalidQuery of Prims.string
+let uu___is_InvalidQuery: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with
     | InvalidQuery uu____2649 -> true
     | uu____2650 -> false
-  
-let (__proj__InvalidQuery__item__uu___ : Prims.exn -> Prims.string) =
+let __proj__InvalidQuery__item__uu___: Prims.exn -> Prims.string =
   fun projectee  ->
     match projectee with | InvalidQuery uu____2657 -> uu____2657
-  
 type query_status =
-  | QueryOK 
-  | QueryNOK 
-  | QueryViolatesProtocol [@@deriving show]
-let (uu___is_QueryOK : query_status -> Prims.bool) =
+  | QueryOK
+  | QueryNOK
+  | QueryViolatesProtocol[@@deriving show]
+let uu___is_QueryOK: query_status -> Prims.bool =
   fun projectee  ->
     match projectee with | QueryOK  -> true | uu____2661 -> false
-  
-let (uu___is_QueryNOK : query_status -> Prims.bool) =
+let uu___is_QueryNOK: query_status -> Prims.bool =
   fun projectee  ->
     match projectee with | QueryNOK  -> true | uu____2665 -> false
-  
-let (uu___is_QueryViolatesProtocol : query_status -> Prims.bool) =
+let uu___is_QueryViolatesProtocol: query_status -> Prims.bool =
   fun projectee  ->
     match projectee with
     | QueryViolatesProtocol  -> true
     | uu____2669 -> false
-  
-let try_assoc :
+let try_assoc:
   'Auu____2674 'Auu____2675 .
     'Auu____2675 ->
       ('Auu____2675,'Auu____2674) FStar_Pervasives_Native.tuple2 Prims.list
@@ -1288,55 +1168,50 @@ let try_assoc :
       let uu____2698 =
         FStar_Util.try_find
           (fun uu____2712  ->
-             match uu____2712 with | (k,uu____2718) -> k = key) a
-         in
+             match uu____2712 with | (k,uu____2718) -> k = key) a in
       FStar_Util.map_option FStar_Pervasives_Native.snd uu____2698
-  
-let (wrap_js_failure :
-  Prims.string -> Prims.string -> FStar_Util.json -> query) =
+let wrap_js_failure: Prims.string -> Prims.string -> FStar_Util.json -> query
+  =
   fun qid  ->
     fun expected  ->
       fun got  ->
         let uu____2732 =
           let uu____2733 =
-            let uu____2734 = json_to_str got  in
+            let uu____2734 = json_to_str got in
             FStar_Util.format2 "JSON decoding failed: expected %s, got %s"
-              expected uu____2734
-             in
-          ProtocolViolation uu____2733  in
+              expected uu____2734 in
+          ProtocolViolation uu____2733 in
         { qq = uu____2732; qid }
-  
-let (unpack_interactive_query : FStar_Util.json -> query) =
+let unpack_interactive_query: FStar_Util.json -> query =
   fun json  ->
     let assoc1 errloc key a =
-      let uu____2760 = try_assoc key a  in
+      let uu____2760 = try_assoc key a in
       match uu____2760 with
       | FStar_Pervasives_Native.Some v1 -> v1
       | FStar_Pervasives_Native.None  ->
           let uu____2764 =
             let uu____2765 =
-              FStar_Util.format2 "Missing key [%s] in %s." key errloc  in
-            InvalidQuery uu____2765  in
-          FStar_Exn.raise uu____2764
-       in
-    let request = FStar_All.pipe_right json js_assoc  in
+              FStar_Util.format2 "Missing key [%s] in %s." key errloc in
+            InvalidQuery uu____2765 in
+          FStar_Exn.raise uu____2764 in
+    let request = FStar_All.pipe_right json js_assoc in
     let qid =
-      let uu____2780 = assoc1 "query" "query-id" request  in
-      FStar_All.pipe_right uu____2780 js_str  in
+      let uu____2780 = assoc1 "query" "query-id" request in
+      FStar_All.pipe_right uu____2780 js_str in
     try
       let query =
-        let uu____2789 = assoc1 "query" "query" request  in
-        FStar_All.pipe_right uu____2789 js_str  in
+        let uu____2789 = assoc1 "query" "query" request in
+        FStar_All.pipe_right uu____2789 js_str in
       let args =
-        let uu____2797 = assoc1 "query" "args" request  in
-        FStar_All.pipe_right uu____2797 js_assoc  in
-      let arg k = assoc1 "[args]" k args  in
+        let uu____2797 = assoc1 "query" "args" request in
+        FStar_All.pipe_right uu____2797 js_assoc in
+      let arg k = assoc1 "[args]" k args in
       let try_arg k =
-        let uu____2814 = try_assoc k args  in
+        let uu____2814 = try_assoc k args in
         match uu____2814 with
         | FStar_Pervasives_Native.Some (FStar_Util.JsonNull ) ->
             FStar_Pervasives_Native.None
-        | other -> other  in
+        | other -> other in
       let uu____2822 =
         match query with
         | "exit" -> Exit
@@ -1345,148 +1220,137 @@ let (unpack_interactive_query : FStar_Util.json -> query) =
         | "describe-repl" -> DescribeRepl
         | "segment" ->
             let uu____2823 =
-              let uu____2824 = arg "code"  in
-              FStar_All.pipe_right uu____2824 js_str  in
+              let uu____2824 = arg "code" in
+              FStar_All.pipe_right uu____2824 js_str in
             Segment uu____2823
         | "peek" ->
             let uu____2825 =
               let uu____2826 =
-                let uu____2827 = arg "kind"  in
-                FStar_All.pipe_right uu____2827 js_pushkind  in
+                let uu____2827 = arg "kind" in
+                FStar_All.pipe_right uu____2827 js_pushkind in
               let uu____2828 =
-                let uu____2829 = arg "code"  in
-                FStar_All.pipe_right uu____2829 js_str  in
+                let uu____2829 = arg "code" in
+                FStar_All.pipe_right uu____2829 js_str in
               let uu____2830 =
-                let uu____2831 = arg "line"  in
-                FStar_All.pipe_right uu____2831 js_int  in
+                let uu____2831 = arg "line" in
+                FStar_All.pipe_right uu____2831 js_int in
               let uu____2832 =
-                let uu____2833 = arg "column"  in
-                FStar_All.pipe_right uu____2833 js_int  in
+                let uu____2833 = arg "column" in
+                FStar_All.pipe_right uu____2833 js_int in
               {
                 push_kind = uu____2826;
                 push_code = uu____2828;
                 push_line = uu____2830;
                 push_column = uu____2832;
                 push_peek_only = (query = "peek")
-              }  in
+              } in
             Push uu____2825
         | "push" ->
             let uu____2834 =
               let uu____2835 =
-                let uu____2836 = arg "kind"  in
-                FStar_All.pipe_right uu____2836 js_pushkind  in
+                let uu____2836 = arg "kind" in
+                FStar_All.pipe_right uu____2836 js_pushkind in
               let uu____2837 =
-                let uu____2838 = arg "code"  in
-                FStar_All.pipe_right uu____2838 js_str  in
+                let uu____2838 = arg "code" in
+                FStar_All.pipe_right uu____2838 js_str in
               let uu____2839 =
-                let uu____2840 = arg "line"  in
-                FStar_All.pipe_right uu____2840 js_int  in
+                let uu____2840 = arg "line" in
+                FStar_All.pipe_right uu____2840 js_int in
               let uu____2841 =
-                let uu____2842 = arg "column"  in
-                FStar_All.pipe_right uu____2842 js_int  in
+                let uu____2842 = arg "column" in
+                FStar_All.pipe_right uu____2842 js_int in
               {
                 push_kind = uu____2835;
                 push_code = uu____2837;
                 push_line = uu____2839;
                 push_column = uu____2841;
                 push_peek_only = (query = "peek")
-              }  in
+              } in
             Push uu____2834
         | "autocomplete" ->
             let uu____2843 =
               let uu____2848 =
-                let uu____2849 = arg "partial-symbol"  in
-                FStar_All.pipe_right uu____2849 js_str  in
+                let uu____2849 = arg "partial-symbol" in
+                FStar_All.pipe_right uu____2849 js_str in
               let uu____2850 =
-                let uu____2851 = try_arg "context"  in
+                let uu____2851 = try_arg "context" in
                 FStar_All.pipe_right uu____2851
-                  js_optional_completion_context
-                 in
-              (uu____2848, uu____2850)  in
+                  js_optional_completion_context in
+              (uu____2848, uu____2850) in
             AutoComplete uu____2843
         | "lookup" ->
             let uu____2856 =
               let uu____2869 =
-                let uu____2870 = arg "symbol"  in
-                FStar_All.pipe_right uu____2870 js_str  in
+                let uu____2870 = arg "symbol" in
+                FStar_All.pipe_right uu____2870 js_str in
               let uu____2871 =
-                let uu____2872 = try_arg "context"  in
-                FStar_All.pipe_right uu____2872 js_optional_lookup_context
-                 in
+                let uu____2872 = try_arg "context" in
+                FStar_All.pipe_right uu____2872 js_optional_lookup_context in
               let uu____2877 =
                 let uu____2886 =
-                  let uu____2895 = try_arg "location"  in
+                  let uu____2895 = try_arg "location" in
                   FStar_All.pipe_right uu____2895
-                    (FStar_Util.map_option js_assoc)
-                   in
+                    (FStar_Util.map_option js_assoc) in
                 FStar_All.pipe_right uu____2886
                   (FStar_Util.map_option
                      (fun loc  ->
                         let uu____2953 =
-                          let uu____2954 = assoc1 "[location]" "filename" loc
-                             in
-                          FStar_All.pipe_right uu____2954 js_str  in
+                          let uu____2954 = assoc1 "[location]" "filename" loc in
+                          FStar_All.pipe_right uu____2954 js_str in
                         let uu____2955 =
-                          let uu____2956 = assoc1 "[location]" "line" loc  in
-                          FStar_All.pipe_right uu____2956 js_int  in
+                          let uu____2956 = assoc1 "[location]" "line" loc in
+                          FStar_All.pipe_right uu____2956 js_int in
                         let uu____2957 =
-                          let uu____2958 = assoc1 "[location]" "column" loc
-                             in
-                          FStar_All.pipe_right uu____2958 js_int  in
-                        (uu____2953, uu____2955, uu____2957)))
-                 in
+                          let uu____2958 = assoc1 "[location]" "column" loc in
+                          FStar_All.pipe_right uu____2958 js_int in
+                        (uu____2953, uu____2955, uu____2957))) in
               let uu____2959 =
-                let uu____2962 = arg "requested-info"  in
-                FStar_All.pipe_right uu____2962 (js_list js_str)  in
-              (uu____2869, uu____2871, uu____2877, uu____2959)  in
+                let uu____2962 = arg "requested-info" in
+                FStar_All.pipe_right uu____2962 (js_list js_str) in
+              (uu____2869, uu____2871, uu____2877, uu____2959) in
             Lookup uu____2856
         | "compute" ->
             let uu____2975 =
               let uu____2984 =
-                let uu____2985 = arg "term"  in
-                FStar_All.pipe_right uu____2985 js_str  in
+                let uu____2985 = arg "term" in
+                FStar_All.pipe_right uu____2985 js_str in
               let uu____2986 =
-                let uu____2991 = try_arg "rules"  in
+                let uu____2991 = try_arg "rules" in
                 FStar_All.pipe_right uu____2991
-                  (FStar_Util.map_option (js_list js_reductionrule))
-                 in
-              (uu____2984, uu____2986)  in
+                  (FStar_Util.map_option (js_list js_reductionrule)) in
+              (uu____2984, uu____2986) in
             Compute uu____2975
         | "search" ->
             let uu____3006 =
-              let uu____3007 = arg "terms"  in
-              FStar_All.pipe_right uu____3007 js_str  in
+              let uu____3007 = arg "terms" in
+              FStar_All.pipe_right uu____3007 js_str in
             Search uu____3006
         | "vfs-add" ->
             let uu____3008 =
               let uu____3015 =
-                let uu____3018 = try_arg "filename"  in
+                let uu____3018 = try_arg "filename" in
                 FStar_All.pipe_right uu____3018
-                  (FStar_Util.map_option js_str)
-                 in
+                  (FStar_Util.map_option js_str) in
               let uu____3025 =
-                let uu____3026 = arg "contents"  in
-                FStar_All.pipe_right uu____3026 js_str  in
-              (uu____3015, uu____3025)  in
+                let uu____3026 = arg "contents" in
+                FStar_All.pipe_right uu____3026 js_str in
+              (uu____3015, uu____3025) in
             VfsAdd uu____3008
         | uu____3029 ->
-            let uu____3030 = FStar_Util.format1 "Unknown query '%s'" query
-               in
-            ProtocolViolation uu____3030
-         in
+            let uu____3030 = FStar_Util.format1 "Unknown query '%s'" query in
+            ProtocolViolation uu____3030 in
       { qq = uu____2822; qid }
     with | InvalidQuery msg -> { qq = (ProtocolViolation msg); qid }
     | UnexpectedJsonType (expected,got) -> wrap_js_failure qid expected got
-  
-let (read_interactive_query : FStar_Util.stream_reader -> query) =
+let read_interactive_query: FStar_Util.stream_reader -> query =
   fun stream  ->
     try
-      let uu____3043 = FStar_Util.read_line stream  in
+      let uu____3043 = FStar_Util.read_line stream in
       match uu____3043 with
       | FStar_Pervasives_Native.None  ->
           FStar_Exn.raise (ExitREPL (Prims.parse_int "0"))
       | FStar_Pervasives_Native.Some line ->
-          let uu____3047 = FStar_Util.json_of_string line  in
+          let uu____3047 = FStar_Util.json_of_string line in
           (match uu____3047 with
            | FStar_Pervasives_Native.None  ->
                { qq = (ProtocolViolation "Json parsing failed."); qid = "?" }
@@ -1494,63 +1358,57 @@ let (read_interactive_query : FStar_Util.stream_reader -> query) =
                unpack_interactive_query request)
     with | InvalidQuery msg -> { qq = (ProtocolViolation msg); qid = "?" }
     | UnexpectedJsonType (expected,got) -> wrap_js_failure "?" expected got
-  
-let json_of_opt :
+let json_of_opt:
   'Auu____3060 .
     ('Auu____3060 -> FStar_Util.json) ->
       'Auu____3060 FStar_Pervasives_Native.option -> FStar_Util.json
   =
   fun json_of_a  ->
     fun opt_a  ->
-      let uu____3078 = FStar_Util.map_option json_of_a opt_a  in
+      let uu____3078 = FStar_Util.map_option json_of_a opt_a in
       FStar_Util.dflt FStar_Util.JsonNull uu____3078
-  
-let (json_of_pos : FStar_Range.pos -> FStar_Util.json) =
+let json_of_pos: FStar_Range.pos -> FStar_Util.json =
   fun pos  ->
     let uu____3084 =
       let uu____3087 =
-        let uu____3088 = FStar_Range.line_of_pos pos  in
-        FStar_Util.JsonInt uu____3088  in
+        let uu____3088 = FStar_Range.line_of_pos pos in
+        FStar_Util.JsonInt uu____3088 in
       let uu____3089 =
         let uu____3092 =
-          let uu____3093 = FStar_Range.col_of_pos pos  in
-          FStar_Util.JsonInt uu____3093  in
-        [uu____3092]  in
-      uu____3087 :: uu____3089  in
+          let uu____3093 = FStar_Range.col_of_pos pos in
+          FStar_Util.JsonInt uu____3093 in
+        [uu____3092] in
+      uu____3087 :: uu____3089 in
     FStar_Util.JsonList uu____3084
-  
-let (json_of_range_fields :
-  Prims.string -> FStar_Range.pos -> FStar_Range.pos -> FStar_Util.json) =
+let json_of_range_fields:
+  Prims.string -> FStar_Range.pos -> FStar_Range.pos -> FStar_Util.json =
   fun file  ->
     fun b  ->
       fun e  ->
         let uu____3103 =
           let uu____3110 =
             let uu____3117 =
-              let uu____3122 = json_of_pos b  in ("beg", uu____3122)  in
+              let uu____3122 = json_of_pos b in ("beg", uu____3122) in
             let uu____3123 =
               let uu____3130 =
-                let uu____3135 = json_of_pos e  in ("end", uu____3135)  in
-              [uu____3130]  in
-            uu____3117 :: uu____3123  in
-          ("fname", (FStar_Util.JsonStr file)) :: uu____3110  in
+                let uu____3135 = json_of_pos e in ("end", uu____3135) in
+              [uu____3130] in
+            uu____3117 :: uu____3123 in
+          ("fname", (FStar_Util.JsonStr file)) :: uu____3110 in
         FStar_Util.JsonAssoc uu____3103
-  
-let (json_of_use_range : FStar_Range.range -> FStar_Util.json) =
+let json_of_use_range: FStar_Range.range -> FStar_Util.json =
   fun r  ->
-    let uu____3155 = FStar_Range.file_of_use_range r  in
-    let uu____3156 = FStar_Range.start_of_use_range r  in
-    let uu____3157 = FStar_Range.end_of_use_range r  in
+    let uu____3155 = FStar_Range.file_of_use_range r in
+    let uu____3156 = FStar_Range.start_of_use_range r in
+    let uu____3157 = FStar_Range.end_of_use_range r in
     json_of_range_fields uu____3155 uu____3156 uu____3157
-  
-let (json_of_def_range : FStar_Range.range -> FStar_Util.json) =
+let json_of_def_range: FStar_Range.range -> FStar_Util.json =
   fun r  ->
-    let uu____3161 = FStar_Range.file_of_range r  in
-    let uu____3162 = FStar_Range.start_of_range r  in
-    let uu____3163 = FStar_Range.end_of_range r  in
+    let uu____3161 = FStar_Range.file_of_range r in
+    let uu____3162 = FStar_Range.start_of_range r in
+    let uu____3163 = FStar_Range.end_of_range r in
     json_of_range_fields uu____3161 uu____3162 uu____3163
-  
-let (json_of_issue_level : FStar_Errors.issue_level -> FStar_Util.json) =
+let json_of_issue_level: FStar_Errors.issue_level -> FStar_Util.json =
   fun i  ->
     FStar_Util.JsonStr
       (match i with
@@ -1558,8 +1416,7 @@ let (json_of_issue_level : FStar_Errors.issue_level -> FStar_Util.json) =
        | FStar_Errors.EInfo  -> "info"
        | FStar_Errors.EWarning  -> "warning"
        | FStar_Errors.EError  -> "error")
-  
-let (json_of_issue : FStar_Errors.issue -> FStar_Util.json) =
+let json_of_issue: FStar_Errors.issue -> FStar_Util.json =
   fun issue  ->
     let uu____3170 =
       let uu____3177 =
@@ -1571,155 +1428,136 @@ let (json_of_issue : FStar_Errors.issue -> FStar_Util.json) =
                   match issue.FStar_Errors.issue_range with
                   | FStar_Pervasives_Native.None  -> []
                   | FStar_Pervasives_Native.Some r ->
-                      let uu____3206 = json_of_use_range r  in [uu____3206]
-                   in
+                      let uu____3206 = json_of_use_range r in [uu____3206] in
                 let uu____3207 =
                   match issue.FStar_Errors.issue_range with
                   | FStar_Pervasives_Native.Some r when
-                      let uu____3213 = FStar_Range.def_range r  in
-                      let uu____3214 = FStar_Range.use_range r  in
+                      let uu____3213 = FStar_Range.def_range r in
+                      let uu____3214 = FStar_Range.use_range r in
                       uu____3213 <> uu____3214 ->
-                      let uu____3215 = json_of_def_range r  in [uu____3215]
-                  | uu____3216 -> []  in
-                FStar_List.append uu____3200 uu____3207  in
-              FStar_Util.JsonList uu____3197  in
-            ("ranges", uu____3196)  in
-          [uu____3191]  in
+                      let uu____3215 = json_of_def_range r in [uu____3215]
+                  | uu____3216 -> [] in
+                FStar_List.append uu____3200 uu____3207 in
+              FStar_Util.JsonList uu____3197 in
+            ("ranges", uu____3196) in
+          [uu____3191] in
         ("message", (FStar_Util.JsonStr (issue.FStar_Errors.issue_message)))
-          :: uu____3184
-         in
+          :: uu____3184 in
       ("level", (json_of_issue_level issue.FStar_Errors.issue_level)) ::
-        uu____3177
-       in
+        uu____3177 in
     FStar_Util.JsonAssoc uu____3170
-  
 type symbol_lookup_result =
   {
-  slr_name: Prims.string ;
-  slr_def_range: FStar_Range.range FStar_Pervasives_Native.option ;
-  slr_typ: Prims.string FStar_Pervasives_Native.option ;
-  slr_doc: Prims.string FStar_Pervasives_Native.option ;
-  slr_def: Prims.string FStar_Pervasives_Native.option }[@@deriving show]
-let (__proj__Mksymbol_lookup_result__item__slr_name :
-  symbol_lookup_result -> Prims.string) =
+  slr_name: Prims.string;
+  slr_def_range: FStar_Range.range FStar_Pervasives_Native.option;
+  slr_typ: Prims.string FStar_Pervasives_Native.option;
+  slr_doc: Prims.string FStar_Pervasives_Native.option;
+  slr_def: Prims.string FStar_Pervasives_Native.option;}[@@deriving show]
+let __proj__Mksymbol_lookup_result__item__slr_name:
+  symbol_lookup_result -> Prims.string =
   fun projectee  ->
     match projectee with
     | { slr_name = __fname__slr_name; slr_def_range = __fname__slr_def_range;
         slr_typ = __fname__slr_typ; slr_doc = __fname__slr_doc;
         slr_def = __fname__slr_def;_} -> __fname__slr_name
-  
-let (__proj__Mksymbol_lookup_result__item__slr_def_range :
-  symbol_lookup_result -> FStar_Range.range FStar_Pervasives_Native.option) =
+let __proj__Mksymbol_lookup_result__item__slr_def_range:
+  symbol_lookup_result -> FStar_Range.range FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { slr_name = __fname__slr_name; slr_def_range = __fname__slr_def_range;
         slr_typ = __fname__slr_typ; slr_doc = __fname__slr_doc;
         slr_def = __fname__slr_def;_} -> __fname__slr_def_range
-  
-let (__proj__Mksymbol_lookup_result__item__slr_typ :
-  symbol_lookup_result -> Prims.string FStar_Pervasives_Native.option) =
+let __proj__Mksymbol_lookup_result__item__slr_typ:
+  symbol_lookup_result -> Prims.string FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { slr_name = __fname__slr_name; slr_def_range = __fname__slr_def_range;
         slr_typ = __fname__slr_typ; slr_doc = __fname__slr_doc;
         slr_def = __fname__slr_def;_} -> __fname__slr_typ
-  
-let (__proj__Mksymbol_lookup_result__item__slr_doc :
-  symbol_lookup_result -> Prims.string FStar_Pervasives_Native.option) =
+let __proj__Mksymbol_lookup_result__item__slr_doc:
+  symbol_lookup_result -> Prims.string FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { slr_name = __fname__slr_name; slr_def_range = __fname__slr_def_range;
         slr_typ = __fname__slr_typ; slr_doc = __fname__slr_doc;
         slr_def = __fname__slr_def;_} -> __fname__slr_doc
-  
-let (__proj__Mksymbol_lookup_result__item__slr_def :
-  symbol_lookup_result -> Prims.string FStar_Pervasives_Native.option) =
+let __proj__Mksymbol_lookup_result__item__slr_def:
+  symbol_lookup_result -> Prims.string FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { slr_name = __fname__slr_name; slr_def_range = __fname__slr_def_range;
         slr_typ = __fname__slr_typ; slr_doc = __fname__slr_doc;
         slr_def = __fname__slr_def;_} -> __fname__slr_def
-  
-let (alist_of_symbol_lookup_result :
+let alist_of_symbol_lookup_result:
   symbol_lookup_result ->
-    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list)
+    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun lr  ->
     let uu____3368 =
       let uu____3375 =
-        let uu____3380 = json_of_opt json_of_def_range lr.slr_def_range  in
-        ("defined-at", uu____3380)  in
+        let uu____3380 = json_of_opt json_of_def_range lr.slr_def_range in
+        ("defined-at", uu____3380) in
       let uu____3381 =
         let uu____3388 =
           let uu____3393 =
-            json_of_opt (fun _0_41  -> FStar_Util.JsonStr _0_41) lr.slr_typ
-             in
-          ("type", uu____3393)  in
+            json_of_opt (fun _0_41  -> FStar_Util.JsonStr _0_41) lr.slr_typ in
+          ("type", uu____3393) in
         let uu____3394 =
           let uu____3401 =
             let uu____3406 =
-              json_of_opt (fun _0_42  -> FStar_Util.JsonStr _0_42) lr.slr_doc
-               in
-            ("documentation", uu____3406)  in
+              json_of_opt (fun _0_42  -> FStar_Util.JsonStr _0_42) lr.slr_doc in
+            ("documentation", uu____3406) in
           let uu____3407 =
             let uu____3414 =
               let uu____3419 =
                 json_of_opt (fun _0_43  -> FStar_Util.JsonStr _0_43)
-                  lr.slr_def
-                 in
-              ("definition", uu____3419)  in
-            [uu____3414]  in
-          uu____3401 :: uu____3407  in
-        uu____3388 :: uu____3394  in
-      uu____3375 :: uu____3381  in
+                  lr.slr_def in
+              ("definition", uu____3419) in
+            [uu____3414] in
+          uu____3401 :: uu____3407 in
+        uu____3388 :: uu____3394 in
+      uu____3375 :: uu____3381 in
     ("name", (FStar_Util.JsonStr (lr.slr_name))) :: uu____3368
-  
-let (alist_of_protocol_info :
-  (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list) =
-  let js_version = FStar_Util.JsonInt interactive_protocol_vernum  in
+let alist_of_protocol_info:
+  (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list =
+  let js_version = FStar_Util.JsonInt interactive_protocol_vernum in
   let js_features =
     let uu____3452 =
       FStar_List.map (fun _0_44  -> FStar_Util.JsonStr _0_44)
-        interactive_protocol_features
-       in
-    FStar_All.pipe_left (fun _0_45  -> FStar_Util.JsonList _0_45) uu____3452
-     in
-  [("version", js_version); ("features", js_features)] 
+        interactive_protocol_features in
+    FStar_All.pipe_left (fun _0_45  -> FStar_Util.JsonList _0_45) uu____3452 in
+  [("version", js_version); ("features", js_features)]
 type fstar_option_permission_level =
-  | OptSet 
-  | OptReset 
-  | OptReadOnly [@@deriving show]
-let (uu___is_OptSet : fstar_option_permission_level -> Prims.bool) =
+  | OptSet
+  | OptReset
+  | OptReadOnly[@@deriving show]
+let uu___is_OptSet: fstar_option_permission_level -> Prims.bool =
   fun projectee  ->
     match projectee with | OptSet  -> true | uu____3472 -> false
-  
-let (uu___is_OptReset : fstar_option_permission_level -> Prims.bool) =
+let uu___is_OptReset: fstar_option_permission_level -> Prims.bool =
   fun projectee  ->
     match projectee with | OptReset  -> true | uu____3476 -> false
-  
-let (uu___is_OptReadOnly : fstar_option_permission_level -> Prims.bool) =
+let uu___is_OptReadOnly: fstar_option_permission_level -> Prims.bool =
   fun projectee  ->
     match projectee with | OptReadOnly  -> true | uu____3480 -> false
-  
-let (string_of_option_permission_level :
-  fstar_option_permission_level -> Prims.string) =
+let string_of_option_permission_level:
+  fstar_option_permission_level -> Prims.string =
   fun uu___80_3483  ->
     match uu___80_3483 with
     | OptSet  -> ""
     | OptReset  -> "requires #reset-options"
     | OptReadOnly  -> "read-only"
-  
 type fstar_option =
   {
-  opt_name: Prims.string ;
-  opt_sig: Prims.string ;
-  opt_value: FStar_Options.option_val ;
-  opt_default: FStar_Options.option_val ;
-  opt_type: FStar_Options.opt_type ;
-  opt_snippets: Prims.string Prims.list ;
-  opt_documentation: Prims.string FStar_Pervasives_Native.option ;
-  opt_permission_level: fstar_option_permission_level }[@@deriving show]
-let (__proj__Mkfstar_option__item__opt_name : fstar_option -> Prims.string) =
+  opt_name: Prims.string;
+  opt_sig: Prims.string;
+  opt_value: FStar_Options.option_val;
+  opt_default: FStar_Options.option_val;
+  opt_type: FStar_Options.opt_type;
+  opt_snippets: Prims.string Prims.list;
+  opt_documentation: Prims.string FStar_Pervasives_Native.option;
+  opt_permission_level: fstar_option_permission_level;}[@@deriving show]
+let __proj__Mkfstar_option__item__opt_name: fstar_option -> Prims.string =
   fun projectee  ->
     match projectee with
     | { opt_name = __fname__opt_name; opt_sig = __fname__opt_sig;
@@ -1728,8 +1566,7 @@ let (__proj__Mkfstar_option__item__opt_name : fstar_option -> Prims.string) =
         opt_documentation = __fname__opt_documentation;
         opt_permission_level = __fname__opt_permission_level;_} ->
         __fname__opt_name
-  
-let (__proj__Mkfstar_option__item__opt_sig : fstar_option -> Prims.string) =
+let __proj__Mkfstar_option__item__opt_sig: fstar_option -> Prims.string =
   fun projectee  ->
     match projectee with
     | { opt_name = __fname__opt_name; opt_sig = __fname__opt_sig;
@@ -1738,9 +1575,8 @@ let (__proj__Mkfstar_option__item__opt_sig : fstar_option -> Prims.string) =
         opt_documentation = __fname__opt_documentation;
         opt_permission_level = __fname__opt_permission_level;_} ->
         __fname__opt_sig
-  
-let (__proj__Mkfstar_option__item__opt_value :
-  fstar_option -> FStar_Options.option_val) =
+let __proj__Mkfstar_option__item__opt_value:
+  fstar_option -> FStar_Options.option_val =
   fun projectee  ->
     match projectee with
     | { opt_name = __fname__opt_name; opt_sig = __fname__opt_sig;
@@ -1749,9 +1585,8 @@ let (__proj__Mkfstar_option__item__opt_value :
         opt_documentation = __fname__opt_documentation;
         opt_permission_level = __fname__opt_permission_level;_} ->
         __fname__opt_value
-  
-let (__proj__Mkfstar_option__item__opt_default :
-  fstar_option -> FStar_Options.option_val) =
+let __proj__Mkfstar_option__item__opt_default:
+  fstar_option -> FStar_Options.option_val =
   fun projectee  ->
     match projectee with
     | { opt_name = __fname__opt_name; opt_sig = __fname__opt_sig;
@@ -1760,9 +1595,8 @@ let (__proj__Mkfstar_option__item__opt_default :
         opt_documentation = __fname__opt_documentation;
         opt_permission_level = __fname__opt_permission_level;_} ->
         __fname__opt_default
-  
-let (__proj__Mkfstar_option__item__opt_type :
-  fstar_option -> FStar_Options.opt_type) =
+let __proj__Mkfstar_option__item__opt_type:
+  fstar_option -> FStar_Options.opt_type =
   fun projectee  ->
     match projectee with
     | { opt_name = __fname__opt_name; opt_sig = __fname__opt_sig;
@@ -1771,9 +1605,8 @@ let (__proj__Mkfstar_option__item__opt_type :
         opt_documentation = __fname__opt_documentation;
         opt_permission_level = __fname__opt_permission_level;_} ->
         __fname__opt_type
-  
-let (__proj__Mkfstar_option__item__opt_snippets :
-  fstar_option -> Prims.string Prims.list) =
+let __proj__Mkfstar_option__item__opt_snippets:
+  fstar_option -> Prims.string Prims.list =
   fun projectee  ->
     match projectee with
     | { opt_name = __fname__opt_name; opt_sig = __fname__opt_sig;
@@ -1782,9 +1615,8 @@ let (__proj__Mkfstar_option__item__opt_snippets :
         opt_documentation = __fname__opt_documentation;
         opt_permission_level = __fname__opt_permission_level;_} ->
         __fname__opt_snippets
-  
-let (__proj__Mkfstar_option__item__opt_documentation :
-  fstar_option -> Prims.string FStar_Pervasives_Native.option) =
+let __proj__Mkfstar_option__item__opt_documentation:
+  fstar_option -> Prims.string FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { opt_name = __fname__opt_name; opt_sig = __fname__opt_sig;
@@ -1793,9 +1625,8 @@ let (__proj__Mkfstar_option__item__opt_documentation :
         opt_documentation = __fname__opt_documentation;
         opt_permission_level = __fname__opt_permission_level;_} ->
         __fname__opt_documentation
-  
-let (__proj__Mkfstar_option__item__opt_permission_level :
-  fstar_option -> fstar_option_permission_level) =
+let __proj__Mkfstar_option__item__opt_permission_level:
+  fstar_option -> fstar_option_permission_level =
   fun projectee  ->
     match projectee with
     | { opt_name = __fname__opt_name; opt_sig = __fname__opt_sig;
@@ -1804,9 +1635,7 @@ let (__proj__Mkfstar_option__item__opt_permission_level :
         opt_documentation = __fname__opt_documentation;
         opt_permission_level = __fname__opt_permission_level;_} ->
         __fname__opt_permission_level
-  
-let rec (kind_of_fstar_option_type : FStar_Options.opt_type -> Prims.string)
-  =
+let rec kind_of_fstar_option_type: FStar_Options.opt_type -> Prims.string =
   fun uu___81_3650  ->
     match uu___81_3650 with
     | FStar_Options.Const uu____3651 -> "flag"
@@ -1822,18 +1651,16 @@ let rec (kind_of_fstar_option_type : FStar_Options.opt_type -> Prims.string)
     | FStar_Options.ReverseAccumulated typ -> kind_of_fstar_option_type typ
     | FStar_Options.WithSideEffect (uu____3673,typ) ->
         kind_of_fstar_option_type typ
-  
-let rec (snippets_of_fstar_option :
-  Prims.string -> FStar_Options.opt_type -> Prims.string Prims.list) =
+let rec snippets_of_fstar_option:
+  Prims.string -> FStar_Options.opt_type -> Prims.string Prims.list =
   fun name  ->
     fun typ  ->
       let mk_field field_name =
-        Prims.strcat "${" (Prims.strcat field_name "}")  in
+        Prims.strcat "${" (Prims.strcat field_name "}") in
       let mk_snippet name1 argstring =
         Prims.strcat "--"
           (Prims.strcat name1
-             (if argstring <> "" then Prims.strcat " " argstring else ""))
-         in
+             (if argstring <> "" then Prims.strcat " " argstring else "")) in
       let rec arg_snippets_of_type typ1 =
         match typ1 with
         | FStar_Options.Const uu____3707 -> [""]
@@ -1851,13 +1678,11 @@ let rec (snippets_of_fstar_option :
         | FStar_Options.ReverseAccumulated elem_spec ->
             arg_snippets_of_type elem_spec
         | FStar_Options.WithSideEffect (uu____3728,elem_spec) ->
-            arg_snippets_of_type elem_spec
-         in
-      let uu____3734 = arg_snippets_of_type typ  in
+            arg_snippets_of_type elem_spec in
+      let uu____3734 = arg_snippets_of_type typ in
       FStar_List.map (mk_snippet name) uu____3734
-  
-let rec (json_of_fstar_option_value :
-  FStar_Options.option_val -> FStar_Util.json) =
+let rec json_of_fstar_option_value:
+  FStar_Options.option_val -> FStar_Util.json =
   fun uu___82_3739  ->
     match uu___82_3739 with
     | FStar_Options.Bool b -> FStar_Util.JsonBool b
@@ -1865,80 +1690,72 @@ let rec (json_of_fstar_option_value :
     | FStar_Options.Path s -> FStar_Util.JsonStr s
     | FStar_Options.Int n1 -> FStar_Util.JsonInt n1
     | FStar_Options.List vs ->
-        let uu____3747 = FStar_List.map json_of_fstar_option_value vs  in
+        let uu____3747 = FStar_List.map json_of_fstar_option_value vs in
         FStar_Util.JsonList uu____3747
     | FStar_Options.Unset  -> FStar_Util.JsonNull
-  
-let (alist_of_fstar_option :
+let alist_of_fstar_option:
   fstar_option ->
-    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list)
+    (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun opt  ->
     let uu____3759 =
       let uu____3766 =
         let uu____3773 =
-          let uu____3778 = json_of_fstar_option_value opt.opt_value  in
-          ("value", uu____3778)  in
+          let uu____3778 = json_of_fstar_option_value opt.opt_value in
+          ("value", uu____3778) in
         let uu____3779 =
           let uu____3786 =
-            let uu____3791 = json_of_fstar_option_value opt.opt_default  in
-            ("default", uu____3791)  in
+            let uu____3791 = json_of_fstar_option_value opt.opt_default in
+            ("default", uu____3791) in
           let uu____3792 =
             let uu____3799 =
               let uu____3804 =
                 json_of_opt (fun _0_46  -> FStar_Util.JsonStr _0_46)
-                  opt.opt_documentation
-                 in
-              ("documentation", uu____3804)  in
+                  opt.opt_documentation in
+              ("documentation", uu____3804) in
             let uu____3805 =
               let uu____3812 =
                 let uu____3817 =
-                  let uu____3818 = kind_of_fstar_option_type opt.opt_type  in
-                  FStar_Util.JsonStr uu____3818  in
-                ("type", uu____3817)  in
+                  let uu____3818 = kind_of_fstar_option_type opt.opt_type in
+                  FStar_Util.JsonStr uu____3818 in
+                ("type", uu____3817) in
               [uu____3812;
               ("permission-level",
                 (FStar_Util.JsonStr
                    (string_of_option_permission_level
-                      opt.opt_permission_level)))]
-               in
-            uu____3799 :: uu____3805  in
-          uu____3786 :: uu____3792  in
-        uu____3773 :: uu____3779  in
-      ("signature", (FStar_Util.JsonStr (opt.opt_sig))) :: uu____3766  in
+                      opt.opt_permission_level)))] in
+            uu____3799 :: uu____3805 in
+          uu____3786 :: uu____3792 in
+        uu____3773 :: uu____3779 in
+      ("signature", (FStar_Util.JsonStr (opt.opt_sig))) :: uu____3766 in
     ("name", (FStar_Util.JsonStr (opt.opt_name))) :: uu____3759
-  
-let (json_of_fstar_option : fstar_option -> FStar_Util.json) =
+let json_of_fstar_option: fstar_option -> FStar_Util.json =
   fun opt  ->
-    let uu____3854 = alist_of_fstar_option opt  in
+    let uu____3854 = alist_of_fstar_option opt in
     FStar_Util.JsonAssoc uu____3854
-  
-let (write_json : FStar_Util.json -> Prims.unit) =
+let write_json: FStar_Util.json -> Prims.unit =
   fun json  ->
-    (let uu____3865 = FStar_Util.string_of_json json  in
+    (let uu____3865 = FStar_Util.string_of_json json in
      FStar_Util.print_raw uu____3865);
     FStar_Util.print_raw "\n"
-  
-let (write_response :
-  Prims.string -> query_status -> FStar_Util.json -> Prims.unit) =
+let write_response:
+  Prims.string -> query_status -> FStar_Util.json -> Prims.unit =
   fun qid  ->
     fun status  ->
       fun response  ->
-        let qid1 = FStar_Util.JsonStr qid  in
+        let qid1 = FStar_Util.JsonStr qid in
         let status1 =
           match status with
           | QueryOK  -> FStar_Util.JsonStr "success"
           | QueryNOK  -> FStar_Util.JsonStr "failure"
-          | QueryViolatesProtocol  -> FStar_Util.JsonStr "protocol-violation"
-           in
+          | QueryViolatesProtocol  -> FStar_Util.JsonStr "protocol-violation" in
         write_json
           (FStar_Util.JsonAssoc
              [("kind", (FStar_Util.JsonStr "response"));
              ("query-id", qid1);
              ("status", status1);
              ("response", response)])
-  
-let (write_message : Prims.string -> FStar_Util.json -> Prims.unit) =
+let write_message: Prims.string -> FStar_Util.json -> Prims.unit =
   fun level  ->
     fun contents  ->
       write_json
@@ -1946,55 +1763,48 @@ let (write_message : Prims.string -> FStar_Util.json -> Prims.unit) =
            [("kind", (FStar_Util.JsonStr "message"));
            ("level", (FStar_Util.JsonStr level));
            ("contents", contents)])
-  
-let (write_hello : Prims.unit -> Prims.unit) =
+let write_hello: Prims.unit -> Prims.unit =
   fun uu____3921  ->
-    let js_version = FStar_Util.JsonInt interactive_protocol_vernum  in
+    let js_version = FStar_Util.JsonInt interactive_protocol_vernum in
     let js_features =
       let uu____3924 =
         FStar_List.map (fun _0_47  -> FStar_Util.JsonStr _0_47)
-          interactive_protocol_features
-         in
-      FStar_Util.JsonList uu____3924  in
+          interactive_protocol_features in
+      FStar_Util.JsonList uu____3924 in
     write_json
       (FStar_Util.JsonAssoc (("kind", (FStar_Util.JsonStr "protocol-info"))
          :: alist_of_protocol_info))
-  
-let (sig_of_fstar_option :
-  Prims.string -> FStar_Options.opt_type -> Prims.string) =
+let sig_of_fstar_option:
+  Prims.string -> FStar_Options.opt_type -> Prims.string =
   fun name  ->
     fun typ  ->
-      let flag = Prims.strcat "--" name  in
-      let uu____3938 = FStar_Options.desc_of_opt_type typ  in
+      let flag = Prims.strcat "--" name in
+      let uu____3938 = FStar_Options.desc_of_opt_type typ in
       match uu____3938 with
       | FStar_Pervasives_Native.None  -> flag
       | FStar_Pervasives_Native.Some arg_sig ->
           Prims.strcat flag (Prims.strcat " " arg_sig)
-  
-let (fstar_options_list_cache : fstar_option Prims.list) =
-  let defaults1 = FStar_Util.smap_of_list FStar_Options.defaults  in
+let fstar_options_list_cache: fstar_option Prims.list =
+  let defaults1 = FStar_Util.smap_of_list FStar_Options.defaults in
   let uu____3947 =
     FStar_All.pipe_right FStar_Options.all_specs_with_types
       (FStar_List.filter_map
          (fun uu____3976  ->
             match uu____3976 with
             | (_shortname,name,typ,doc1) ->
-                let uu____3991 = FStar_Util.smap_try_find defaults1 name  in
+                let uu____3991 = FStar_Util.smap_try_find defaults1 name in
                 FStar_All.pipe_right uu____3991
                   (FStar_Util.map_option
                      (fun default_value  ->
-                        let uu____4003 = sig_of_fstar_option name typ  in
-                        let uu____4004 = snippets_of_fstar_option name typ
-                           in
+                        let uu____4003 = sig_of_fstar_option name typ in
+                        let uu____4004 = snippets_of_fstar_option name typ in
                         let uu____4007 =
-                          let uu____4008 = FStar_Options.settable name  in
+                          let uu____4008 = FStar_Options.settable name in
                           if uu____4008
                           then OptSet
                           else
-                            (let uu____4010 = FStar_Options.resettable name
-                                in
-                             if uu____4010 then OptReset else OptReadOnly)
-                           in
+                            (let uu____4010 = FStar_Options.resettable name in
+                             if uu____4010 then OptReset else OptReadOnly) in
                         {
                           opt_name = name;
                           opt_sig = uu____4003;
@@ -2007,24 +1817,22 @@ let (fstar_options_list_cache : fstar_option Prims.list) =
                              then FStar_Pervasives_Native.None
                              else FStar_Pervasives_Native.Some doc1);
                           opt_permission_level = uu____4007
-                        }))))
-     in
+                        })))) in
   FStar_All.pipe_right uu____3947
     (FStar_List.sortWith
        (fun o1  ->
           fun o2  ->
             FStar_String.compare (FStar_String.lowercase o1.opt_name)
               (FStar_String.lowercase o2.opt_name)))
-  
-let (fstar_options_map_cache : fstar_option FStar_Util.smap) =
-  let cache = FStar_Util.smap_create (Prims.parse_int "50")  in
+let fstar_options_map_cache: fstar_option FStar_Util.smap =
+  let cache = FStar_Util.smap_create (Prims.parse_int "50") in
   FStar_List.iter (fun opt  -> FStar_Util.smap_add cache opt.opt_name opt)
     fstar_options_list_cache;
-  cache 
-let (update_option : fstar_option -> fstar_option) =
+  cache
+let update_option: fstar_option -> fstar_option =
   fun opt  ->
-    let uu___96_4034 = opt  in
-    let uu____4035 = FStar_Options.get_option opt.opt_name  in
+    let uu___96_4034 = opt in
+    let uu____4035 = FStar_Options.get_option opt.opt_name in
     {
       opt_name = (uu___96_4034.opt_name);
       opt_sig = (uu___96_4034.opt_sig);
@@ -2035,27 +1843,23 @@ let (update_option : fstar_option -> fstar_option) =
       opt_documentation = (uu___96_4034.opt_documentation);
       opt_permission_level = (uu___96_4034.opt_permission_level)
     }
-  
-let (current_fstar_options :
-  (fstar_option -> Prims.bool) -> fstar_option Prims.list) =
+let current_fstar_options:
+  (fstar_option -> Prims.bool) -> fstar_option Prims.list =
   fun filter1  ->
-    let uu____4046 = FStar_List.filter filter1 fstar_options_list_cache  in
+    let uu____4046 = FStar_List.filter filter1 fstar_options_list_cache in
     FStar_List.map update_option uu____4046
-  
-let (trim_option_name :
-  Prims.string -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2)
+let trim_option_name:
+  Prims.string -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun opt_name  ->
-    let opt_prefix = "--"  in
+    let opt_prefix = "--" in
     if FStar_Util.starts_with opt_name opt_prefix
     then
       let uu____4061 =
-        FStar_Util.substring_from opt_name (FStar_String.length opt_prefix)
-         in
+        FStar_Util.substring_from opt_name (FStar_String.length opt_prefix) in
       (opt_prefix, uu____4061)
     else ("", opt_name)
-  
-let (json_of_repl_state : repl_state -> FStar_Util.json) =
+let json_of_repl_state: repl_state -> FStar_Util.json =
   fun st  ->
     let filenames uu____4075 =
       match uu____4075 with
@@ -2064,33 +1868,30 @@ let (json_of_repl_state : repl_state -> FStar_Util.json) =
            | LDInterleaved (intf,impl) -> [intf.tf_fname; impl.tf_fname]
            | LDSingle intf_or_impl -> [intf_or_impl.tf_fname]
            | LDInterfaceOfCurrentFile intf -> [intf.tf_fname]
-           | PushFragment uu____4090 -> [])
-       in
+           | PushFragment uu____4090 -> []) in
     let uu____4091 =
       let uu____4098 =
         let uu____4103 =
           let uu____4104 =
             let uu____4107 =
-              FStar_List.concatMap filenames st.repl_deps_stack  in
+              FStar_List.concatMap filenames st.repl_deps_stack in
             FStar_List.map (fun _0_48  -> FStar_Util.JsonStr _0_48)
-              uu____4107
-             in
-          FStar_Util.JsonList uu____4104  in
-        ("loaded-dependencies", uu____4103)  in
+              uu____4107 in
+          FStar_Util.JsonList uu____4104 in
+        ("loaded-dependencies", uu____4103) in
       let uu____4114 =
         let uu____4121 =
           let uu____4126 =
             let uu____4127 =
               let uu____4130 =
-                current_fstar_options (fun uu____4135  -> true)  in
-              FStar_List.map json_of_fstar_option uu____4130  in
-            FStar_Util.JsonList uu____4127  in
-          ("options", uu____4126)  in
-        [uu____4121]  in
-      uu____4098 :: uu____4114  in
+                current_fstar_options (fun uu____4135  -> true) in
+              FStar_List.map json_of_fstar_option uu____4130 in
+            FStar_Util.JsonList uu____4127 in
+          ("options", uu____4126) in
+        [uu____4121] in
+      uu____4098 :: uu____4114 in
     FStar_Util.JsonAssoc uu____4091
-  
-let with_printed_effect_args :
+let with_printed_effect_args:
   'Auu____4150 . (Prims.unit -> 'Auu____4150) -> 'Auu____4150 =
   fun k  ->
     FStar_Options.with_saved_options
@@ -2098,21 +1899,18 @@ let with_printed_effect_args :
          FStar_Options.set_option "print_effect_args"
            (FStar_Options.Bool true);
          k ())
-  
-let (term_to_string :
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.string) =
+let term_to_string:
+  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.string =
   fun tcenv  ->
     fun t  ->
       with_printed_effect_args
         (fun uu____4171  ->
            FStar_TypeChecker_Normalize.term_to_string tcenv t)
-  
-let (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
+let sigelt_to_string: FStar_Syntax_Syntax.sigelt -> Prims.string =
   fun se  ->
     with_printed_effect_args
       (fun uu____4176  -> FStar_Syntax_Print.sigelt_to_string se)
-  
-let run_exit :
+let run_exit:
   'Auu____4180 'Auu____4181 .
     'Auu____4181 ->
       ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
@@ -2121,8 +1919,7 @@ let run_exit :
   =
   fun st  ->
     ((QueryOK, FStar_Util.JsonNull), (FStar_Util.Inr (Prims.parse_int "0")))
-  
-let run_describe_protocol :
+let run_describe_protocol:
   'Auu____4209 'Auu____4210 .
     'Auu____4210 ->
       ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
@@ -2132,8 +1929,7 @@ let run_describe_protocol :
   fun st  ->
     ((QueryOK, (FStar_Util.JsonAssoc alist_of_protocol_info)),
       (FStar_Util.Inl st))
-  
-let run_describe_repl :
+let run_describe_repl:
   'Auu____4237 .
     repl_state ->
       ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
@@ -2142,10 +1938,9 @@ let run_describe_repl :
   =
   fun st  ->
     let uu____4254 =
-      let uu____4259 = json_of_repl_state st  in (QueryOK, uu____4259)  in
+      let uu____4259 = json_of_repl_state st in (QueryOK, uu____4259) in
     (uu____4254, (FStar_Util.Inl st))
-  
-let run_protocol_violation :
+let run_protocol_violation:
   'Auu____4272 'Auu____4273 .
     'Auu____4273 ->
       Prims.string ->
@@ -2157,8 +1952,7 @@ let run_protocol_violation :
     fun message  ->
       ((QueryViolatesProtocol, (FStar_Util.JsonStr message)),
         (FStar_Util.Inl st))
-  
-let run_generic_error :
+let run_generic_error:
   'Auu____4306 'Auu____4307 .
     'Auu____4307 ->
       Prims.string ->
@@ -2169,12 +1963,10 @@ let run_generic_error :
   fun st  ->
     fun message  ->
       ((QueryNOK, (FStar_Util.JsonStr message)), (FStar_Util.Inl st))
-  
-let (collect_errors : Prims.unit -> FStar_Errors.issue Prims.list) =
+let collect_errors: Prims.unit -> FStar_Errors.issue Prims.list =
   fun uu____4340  ->
-    let errors = FStar_Errors.report_all ()  in FStar_Errors.clear (); errors
-  
-let run_segment :
+    let errors = FStar_Errors.report_all () in FStar_Errors.clear (); errors
+let run_segment:
   'Auu____4348 .
     repl_state ->
       Prims.string ->
@@ -2189,49 +1981,44 @@ let run_segment :
           FStar_Parser_ParseIt.frag_text = code;
           FStar_Parser_ParseIt.frag_line = (Prims.parse_int "1");
           FStar_Parser_ParseIt.frag_col = (Prims.parse_int "0")
-        }  in
+        } in
       let collect_decls uu____4375 =
-        let uu____4376 = FStar_Parser_Driver.parse_fragment frag  in
+        let uu____4376 = FStar_Parser_Driver.parse_fragment frag in
         match uu____4376 with
         | FStar_Parser_Driver.Empty  -> []
         | FStar_Parser_Driver.Decls decls -> decls
         | FStar_Parser_Driver.Modul (FStar_Parser_AST.Module
             (uu____4382,decls)) -> decls
         | FStar_Parser_Driver.Modul (FStar_Parser_AST.Interface
-            (uu____4388,decls,uu____4390)) -> decls
-         in
+            (uu____4388,decls,uu____4390)) -> decls in
       let uu____4395 =
         with_captured_errors st.repl_env
           (fun uu____4404  ->
-             let uu____4405 = collect_decls ()  in
+             let uu____4405 = collect_decls () in
              FStar_All.pipe_left
-               (fun _0_49  -> FStar_Pervasives_Native.Some _0_49) uu____4405)
-         in
+               (fun _0_49  -> FStar_Pervasives_Native.Some _0_49) uu____4405) in
       match uu____4395 with
       | FStar_Pervasives_Native.None  ->
           let errors =
-            let uu____4433 = collect_errors ()  in
-            FStar_All.pipe_right uu____4433 (FStar_List.map json_of_issue)
-             in
+            let uu____4433 = collect_errors () in
+            FStar_All.pipe_right uu____4433 (FStar_List.map json_of_issue) in
           ((QueryNOK, (FStar_Util.JsonList errors)), (FStar_Util.Inl st))
       | FStar_Pervasives_Native.Some decls ->
           let json_of_decl decl =
             let uu____4457 =
               let uu____4464 =
                 let uu____4469 =
-                  json_of_def_range (FStar_Parser_AST.decl_drange decl)  in
-                ("def_range", uu____4469)  in
-              [uu____4464]  in
-            FStar_Util.JsonAssoc uu____4457  in
+                  json_of_def_range (FStar_Parser_AST.decl_drange decl) in
+                ("def_range", uu____4469) in
+              [uu____4464] in
+            FStar_Util.JsonAssoc uu____4457 in
           let js_decls =
-            let uu____4479 = FStar_List.map json_of_decl decls  in
+            let uu____4479 = FStar_List.map json_of_decl decls in
             FStar_All.pipe_left (fun _0_50  -> FStar_Util.JsonList _0_50)
-              uu____4479
-             in
+              uu____4479 in
           ((QueryOK, (FStar_Util.JsonAssoc [("decls", js_decls)])),
             (FStar_Util.Inl st))
-  
-let run_vfs_add :
+let run_vfs_add:
   'Auu____4504 .
     repl_state ->
       Prims.string FStar_Pervasives_Native.option ->
@@ -2243,11 +2030,10 @@ let run_vfs_add :
   fun st  ->
     fun opt_fname  ->
       fun contents  ->
-        let fname = FStar_Util.dflt st.repl_fname opt_fname  in
+        let fname = FStar_Util.dflt st.repl_fname opt_fname in
         FStar_Parser_ParseIt.add_vfs_entry fname contents;
         ((QueryOK, FStar_Util.JsonNull), (FStar_Util.Inl st))
-  
-let run_pop :
+let run_pop:
   'Auu____4545 .
     repl_state ->
       ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
@@ -2255,35 +2041,32 @@ let run_pop :
         FStar_Pervasives_Native.tuple2
   =
   fun st  ->
-    let uu____4562 = nothing_left_to_pop st  in
+    let uu____4562 = nothing_left_to_pop st in
     if uu____4562
     then
       ((QueryNOK, (FStar_Util.JsonStr "Too many pops")), (FStar_Util.Inl st))
     else
-      (let st' = pop_repl st  in
+      (let st' = pop_repl st in
        ((QueryOK, FStar_Util.JsonNull), (FStar_Util.Inl st')))
-  
-let (load_deps :
+let load_deps:
   repl_state ->
     ((repl_state,Prims.string Prims.list) FStar_Pervasives_Native.tuple2,
-      repl_state) FStar_Util.either)
+      repl_state) FStar_Util.either
   =
   fun st  ->
     let uu____4606 =
       with_captured_errors st.repl_env
         (fun _env  ->
-           let uu____4632 = deps_and_repl_ld_tasks_of_our_file st.repl_fname
-              in
+           let uu____4632 = deps_and_repl_ld_tasks_of_our_file st.repl_fname in
            FStar_All.pipe_left
-             (fun _0_51  -> FStar_Pervasives_Native.Some _0_51) uu____4632)
-       in
+             (fun _0_51  -> FStar_Pervasives_Native.Some _0_51) uu____4632) in
     match uu____4606 with
     | FStar_Pervasives_Native.None  -> FStar_Util.Inr st
     | FStar_Pervasives_Native.Some (deps,tasks,dep_graph1) ->
         let st1 =
-          let uu___97_4723 = st  in
+          let uu___97_4723 = st in
           let uu____4724 =
-            FStar_TypeChecker_Env.set_dep_graph st.repl_env dep_graph1  in
+            FStar_TypeChecker_Env.set_dep_graph st.repl_env dep_graph1 in
           {
             repl_line = (uu___97_4723.repl_line);
             repl_column = (uu___97_4723.repl_column);
@@ -2293,27 +2076,24 @@ let (load_deps :
             repl_env = uu____4724;
             repl_stdin = (uu___97_4723.repl_stdin);
             repl_names = (uu___97_4723.repl_names)
-          }  in
-        let uu____4725 = run_repl_ld_transactions st1 tasks  in
+          } in
+        let uu____4725 = run_repl_ld_transactions st1 tasks in
         (match uu____4725 with
          | FStar_Util.Inr st2 -> FStar_Util.Inr st2
          | FStar_Util.Inl st2 -> FStar_Util.Inl (st2, deps))
-  
-let (rephrase_dependency_error : FStar_Errors.issue -> FStar_Errors.issue) =
+let rephrase_dependency_error: FStar_Errors.issue -> FStar_Errors.issue =
   fun issue  ->
-    let uu___98_4759 = issue  in
+    let uu___98_4759 = issue in
     let uu____4760 =
       FStar_Util.format1 "Error while computing or loading dependencies:\n%s"
-        issue.FStar_Errors.issue_message
-       in
+        issue.FStar_Errors.issue_message in
     {
       FStar_Errors.issue_message = uu____4760;
       FStar_Errors.issue_level = (uu___98_4759.FStar_Errors.issue_level);
       FStar_Errors.issue_range = (uu___98_4759.FStar_Errors.issue_range);
       FStar_Errors.issue_number = (uu___98_4759.FStar_Errors.issue_number)
     }
-  
-let run_push_without_deps :
+let run_push_without_deps:
   'Auu____4764 .
     repl_state ->
       push_query ->
@@ -2324,7 +2104,7 @@ let run_push_without_deps :
   fun st  ->
     fun query  ->
       let set_nosynth_flag st1 flag =
-        let uu___99_4792 = st1  in
+        let uu___99_4792 = st1 in
         {
           repl_line = (uu___99_4792.repl_line);
           repl_column = (uu___99_4792.repl_column);
@@ -2332,7 +2112,7 @@ let run_push_without_deps :
           repl_deps_stack = (uu___99_4792.repl_deps_stack);
           repl_curmod = (uu___99_4792.repl_curmod);
           repl_env =
-            (let uu___100_4794 = st1.repl_env  in
+            (let uu___100_4794 = st1.repl_env in
              {
                FStar_TypeChecker_Env.solver =
                  (uu___100_4794.FStar_TypeChecker_Env.solver);
@@ -2406,8 +2186,8 @@ let run_push_without_deps :
              });
           repl_stdin = (uu___99_4792.repl_stdin);
           repl_names = (uu___99_4792.repl_names)
-        }  in
-      let uu____4795 = query  in
+        } in
+      let uu____4795 = query in
       match uu____4795 with
       | { push_kind; push_code = text; push_line = line;
           push_column = column; push_peek_only = peek_only;_} ->
@@ -2416,29 +2196,27 @@ let run_push_without_deps :
               FStar_Parser_ParseIt.frag_text = text;
               FStar_Parser_ParseIt.frag_line = line;
               FStar_Parser_ParseIt.frag_col = column
-            }  in
+            } in
           (FStar_TypeChecker_Env.toggle_id_info st.repl_env true;
-           (let st1 = set_nosynth_flag st peek_only  in
+           (let st1 = set_nosynth_flag st peek_only in
             let uu____4816 =
               run_repl_transaction st1 push_kind peek_only
-                (PushFragment frag)
-               in
+                (PushFragment frag) in
             match uu____4816 with
             | (success,st2) ->
-                let st3 = set_nosynth_flag st2 false  in
+                let st3 = set_nosynth_flag st2 false in
                 let status =
-                  if success || peek_only then QueryOK else QueryNOK  in
+                  if success || peek_only then QueryOK else QueryNOK in
                 let json_errors =
                   let uu____4839 =
-                    let uu____4842 = collect_errors ()  in
+                    let uu____4842 = collect_errors () in
                     FStar_All.pipe_right uu____4842
-                      (FStar_List.map json_of_issue)
-                     in
-                  FStar_Util.JsonList uu____4839  in
+                      (FStar_List.map json_of_issue) in
+                  FStar_Util.JsonList uu____4839 in
                 let st4 =
                   if success
                   then
-                    let uu___101_4850 = st3  in
+                    let uu___101_4850 = st3 in
                     {
                       repl_line = line;
                       repl_column = column;
@@ -2449,69 +2227,60 @@ let run_push_without_deps :
                       repl_stdin = (uu___101_4850.repl_stdin);
                       repl_names = (uu___101_4850.repl_names)
                     }
-                  else st3  in
+                  else st3 in
                 ((status, json_errors), (FStar_Util.Inl st4))))
-  
-let (capitalize : Prims.string -> Prims.string) =
+let capitalize: Prims.string -> Prims.string =
   fun str  ->
     if str = ""
     then str
     else
       (let first =
          FStar_String.substring str (Prims.parse_int "0")
-           (Prims.parse_int "1")
-          in
+           (Prims.parse_int "1") in
        let uu____4865 =
          FStar_String.substring str (Prims.parse_int "1")
-           ((FStar_String.length str) - (Prims.parse_int "1"))
-          in
+           ((FStar_String.length str) - (Prims.parse_int "1")) in
        Prims.strcat (FStar_String.uppercase first) uu____4865)
-  
-let (add_module_completions :
+let add_module_completions:
   Prims.string ->
     Prims.string Prims.list ->
       FStar_Interactive_CompletionTable.table ->
-        FStar_Interactive_CompletionTable.table)
+        FStar_Interactive_CompletionTable.table
   =
   fun this_fname  ->
     fun deps  ->
       fun table  ->
-        let mods = FStar_Parser_Dep.build_inclusion_candidates_list ()  in
+        let mods = FStar_Parser_Dep.build_inclusion_candidates_list () in
         let loaded_mods_set =
-          let uu____4889 = FStar_Util.psmap_empty ()  in
+          let uu____4889 = FStar_Util.psmap_empty () in
           let uu____4892 =
-            let uu____4895 = FStar_Options.prims ()  in uu____4895 :: deps
-             in
+            let uu____4895 = FStar_Options.prims () in uu____4895 :: deps in
           FStar_List.fold_left
             (fun acc  ->
                fun dep1  ->
-                 let uu____4905 = FStar_Parser_Dep.lowercase_module_name dep1
-                    in
+                 let uu____4905 = FStar_Parser_Dep.lowercase_module_name dep1 in
                  FStar_Util.psmap_add acc uu____4905 true) uu____4889
-            uu____4892
-           in
+            uu____4892 in
         let loaded modname =
-          FStar_Util.psmap_find_default loaded_mods_set modname false  in
-        let this_mod_key = FStar_Parser_Dep.lowercase_module_name this_fname
-           in
+          FStar_Util.psmap_find_default loaded_mods_set modname false in
+        let this_mod_key = FStar_Parser_Dep.lowercase_module_name this_fname in
         FStar_List.fold_left
           (fun table1  ->
              fun uu____4921  ->
                match uu____4921 with
                | (modname,mod_path) ->
-                   let mod_key = FStar_String.lowercase modname  in
+                   let mod_key = FStar_String.lowercase modname in
                    if this_mod_key = mod_key
                    then table1
                    else
                      (let ns_query =
-                        let uu____4933 = capitalize modname  in
-                        FStar_Util.split uu____4933 "."  in
-                      let uu____4934 = loaded mod_key  in
+                        let uu____4933 = capitalize modname in
+                        FStar_Util.split uu____4933 "." in
+                      let uu____4934 = loaded mod_key in
                       FStar_Interactive_CompletionTable.register_module_path
                         table1 uu____4934 mod_path ns_query)) table
           (FStar_List.rev mods)
-  
-let run_push_with_deps :
+let run_push_with_deps:
   'Auu____4942 .
     repl_state ->
       push_query ->
@@ -2521,29 +2290,28 @@ let run_push_with_deps :
   =
   fun st  ->
     fun query  ->
-      (let uu____4964 = FStar_Options.debug_any ()  in
+      (let uu____4964 = FStar_Options.debug_any () in
        if uu____4964
        then FStar_Util.print_string "Reloading dependencies"
        else ());
       FStar_TypeChecker_Env.toggle_id_info st.repl_env false;
-      (let uu____4967 = load_deps st  in
+      (let uu____4967 = load_deps st in
        match uu____4967 with
        | FStar_Util.Inr st1 ->
            let errors =
-             let uu____5000 = collect_errors ()  in
-             FStar_List.map rephrase_dependency_error uu____5000  in
+             let uu____5000 = collect_errors () in
+             FStar_List.map rephrase_dependency_error uu____5000 in
            let js_errors =
-             FStar_All.pipe_right errors (FStar_List.map json_of_issue)  in
+             FStar_All.pipe_right errors (FStar_List.map json_of_issue) in
            ((QueryNOK, (FStar_Util.JsonList js_errors)),
              (FStar_Util.Inl st1))
        | FStar_Util.Inl (st1,deps) ->
-           ((let uu____5031 = FStar_Options.restore_cmd_line_options false
-                in
+           ((let uu____5031 = FStar_Options.restore_cmd_line_options false in
              FStar_All.pipe_right uu____5031 FStar_Pervasives.ignore);
             (let names1 =
-               add_module_completions st1.repl_fname deps st1.repl_names  in
+               add_module_completions st1.repl_fname deps st1.repl_names in
              run_push_without_deps
-               (let uu___102_5034 = st1  in
+               (let uu___102_5034 = st1 in
                 {
                   repl_line = (uu___102_5034.repl_line);
                   repl_column = (uu___102_5034.repl_column);
@@ -2554,8 +2322,7 @@ let run_push_with_deps :
                   repl_stdin = (uu___102_5034.repl_stdin);
                   repl_names = names1
                 }) query)))
-  
-let run_push :
+let run_push:
   'Auu____5038 .
     repl_state ->
       push_query ->
@@ -2565,12 +2332,11 @@ let run_push :
   =
   fun st  ->
     fun query  ->
-      let uu____5059 = nothing_left_to_pop st  in
+      let uu____5059 = nothing_left_to_pop st in
       if uu____5059
       then run_push_with_deps st query
       else run_push_without_deps st query
-  
-let (run_symbol_lookup :
+let run_symbol_lookup:
   repl_state ->
     Prims.string ->
       (Prims.string,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3
@@ -2580,67 +2346,58 @@ let (run_symbol_lookup :
                                         FStar_Pervasives_Native.tuple2
                                         Prims.list)
                           FStar_Pervasives_Native.tuple2)
-            FStar_Util.either)
+            FStar_Util.either
   =
   fun st  ->
     fun symbol  ->
       fun pos_opt  ->
         fun requested_info  ->
-          let tcenv = st.repl_env  in
+          let tcenv = st.repl_env in
           let info_of_lid_str lid_str =
             let lid =
               let uu____5137 =
                 FStar_List.map FStar_Ident.id_of_text
-                  (FStar_Util.split lid_str ".")
-                 in
-              FStar_Ident.lid_of_ids uu____5137  in
+                  (FStar_Util.split lid_str ".") in
+              FStar_Ident.lid_of_ids uu____5137 in
             let lid1 =
               let uu____5141 =
                 FStar_ToSyntax_Env.resolve_to_fully_qualified_name
-                  tcenv.FStar_TypeChecker_Env.dsenv lid
-                 in
-              FStar_All.pipe_left (FStar_Util.dflt lid) uu____5141  in
-            let uu____5146 = FStar_TypeChecker_Env.try_lookup_lid tcenv lid1
-               in
+                  tcenv.FStar_TypeChecker_Env.dsenv lid in
+              FStar_All.pipe_left (FStar_Util.dflt lid) uu____5141 in
+            let uu____5146 = FStar_TypeChecker_Env.try_lookup_lid tcenv lid1 in
             FStar_All.pipe_right uu____5146
               (FStar_Util.map_option
                  (fun uu____5201  ->
                     match uu____5201 with
-                    | ((uu____5220,typ),r) -> ((FStar_Util.Inr lid1), typ, r)))
-             in
+                    | ((uu____5220,typ),r) -> ((FStar_Util.Inr lid1), typ, r))) in
           let docs_of_lid lid =
             let uu____5237 =
               FStar_ToSyntax_Env.try_lookup_doc
-                tcenv.FStar_TypeChecker_Env.dsenv lid
-               in
+                tcenv.FStar_TypeChecker_Env.dsenv lid in
             FStar_All.pipe_right uu____5237
-              (FStar_Util.map_option FStar_Pervasives_Native.fst)
-             in
+              (FStar_Util.map_option FStar_Pervasives_Native.fst) in
           let def_of_lid lid =
-            let uu____5266 = FStar_TypeChecker_Env.lookup_qname tcenv lid  in
+            let uu____5266 = FStar_TypeChecker_Env.lookup_qname tcenv lid in
             FStar_Util.bind_opt uu____5266
               (fun uu___83_5310  ->
                  match uu___83_5310 with
                  | (FStar_Util.Inr (se,uu____5332),uu____5333) ->
-                     let uu____5362 = sigelt_to_string se  in
+                     let uu____5362 = sigelt_to_string se in
                      FStar_Pervasives_Native.Some uu____5362
-                 | uu____5363 -> FStar_Pervasives_Native.None)
-             in
+                 | uu____5363 -> FStar_Pervasives_Native.None) in
           let info_at_pos_opt =
             FStar_Util.bind_opt pos_opt
               (fun uu____5415  ->
                  match uu____5415 with
                  | (file,row,col) ->
-                     FStar_TypeChecker_Err.info_at_pos tcenv file row col)
-             in
+                     FStar_TypeChecker_Err.info_at_pos tcenv file row col) in
           let info_opt =
             match info_at_pos_opt with
             | FStar_Pervasives_Native.Some uu____5462 -> info_at_pos_opt
             | FStar_Pervasives_Native.None  ->
                 if symbol = ""
                 then FStar_Pervasives_Native.None
-                else info_of_lid_str symbol
-             in
+                else info_of_lid_str symbol in
           let response =
             match info_opt with
             | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
@@ -2648,29 +2405,29 @@ let (run_symbol_lookup :
                 let name =
                   match name_or_lid with
                   | FStar_Util.Inl name -> name
-                  | FStar_Util.Inr lid -> FStar_Ident.string_of_lid lid  in
+                  | FStar_Util.Inr lid -> FStar_Ident.string_of_lid lid in
                 let typ_str =
                   if FStar_List.mem "type" requested_info
                   then
-                    let uu____5590 = term_to_string tcenv typ  in
+                    let uu____5590 = term_to_string tcenv typ in
                     FStar_Pervasives_Native.Some uu____5590
-                  else FStar_Pervasives_Native.None  in
+                  else FStar_Pervasives_Native.None in
                 let doc_str =
                   match name_or_lid with
                   | FStar_Util.Inr lid when
                       FStar_List.mem "documentation" requested_info ->
                       docs_of_lid lid
-                  | uu____5598 -> FStar_Pervasives_Native.None  in
+                  | uu____5598 -> FStar_Pervasives_Native.None in
                 let def_str =
                   match name_or_lid with
                   | FStar_Util.Inr lid when
                       FStar_List.mem "definition" requested_info ->
                       def_of_lid lid
-                  | uu____5609 -> FStar_Pervasives_Native.None  in
+                  | uu____5609 -> FStar_Pervasives_Native.None in
                 let def_range1 =
                   if FStar_List.mem "defined-at" requested_info
                   then FStar_Pervasives_Native.Some rng
-                  else FStar_Pervasives_Native.None  in
+                  else FStar_Pervasives_Native.None in
                 let result =
                   {
                     slr_name = name;
@@ -2678,56 +2435,52 @@ let (run_symbol_lookup :
                     slr_typ = typ_str;
                     slr_doc = doc_str;
                     slr_def = def_str
-                  }  in
+                  } in
                 let uu____5621 =
-                  let uu____5632 = alist_of_symbol_lookup_result result  in
-                  ("symbol", uu____5632)  in
-                FStar_Pervasives_Native.Some uu____5621
-             in
+                  let uu____5632 = alist_of_symbol_lookup_result result in
+                  ("symbol", uu____5632) in
+                FStar_Pervasives_Native.Some uu____5621 in
           match response with
           | FStar_Pervasives_Native.None  ->
               FStar_Util.Inl "Symbol not found"
           | FStar_Pervasives_Native.Some info -> FStar_Util.Inr info
-  
-let (run_option_lookup :
+let run_option_lookup:
   Prims.string ->
     (Prims.string,(Prims.string,(Prims.string,FStar_Util.json)
                                   FStar_Pervasives_Native.tuple2 Prims.list)
                     FStar_Pervasives_Native.tuple2)
-      FStar_Util.either)
+      FStar_Util.either
   =
   fun opt_name  ->
-    let uu____5737 = trim_option_name opt_name  in
+    let uu____5737 = trim_option_name opt_name in
     match uu____5737 with
     | (uu____5756,trimmed_name) ->
         let uu____5758 =
-          FStar_Util.smap_try_find fstar_options_map_cache trimmed_name  in
+          FStar_Util.smap_try_find fstar_options_map_cache trimmed_name in
         (match uu____5758 with
          | FStar_Pervasives_Native.None  ->
              FStar_Util.Inl (Prims.strcat "Unknown option:" opt_name)
          | FStar_Pervasives_Native.Some opt ->
              let uu____5786 =
                let uu____5797 =
-                 let uu____5804 = update_option opt  in
-                 alist_of_fstar_option uu____5804  in
-               ("option", uu____5797)  in
+                 let uu____5804 = update_option opt in
+                 alist_of_fstar_option uu____5804 in
+               ("option", uu____5797) in
              FStar_Util.Inr uu____5786)
-  
-let (run_module_lookup :
+let run_module_lookup:
   repl_state ->
     Prims.string ->
       (Prims.string,(Prims.string,(Prims.string,FStar_Util.json)
                                     FStar_Pervasives_Native.tuple2 Prims.list)
                       FStar_Pervasives_Native.tuple2)
-        FStar_Util.either)
+        FStar_Util.either
   =
   fun st  ->
     fun symbol  ->
-      let query = FStar_Util.split symbol "."  in
+      let query = FStar_Util.split symbol "." in
       let uu____5844 =
         FStar_Interactive_CompletionTable.find_module_or_ns st.repl_names
-          query
-         in
+          query in
       match uu____5844 with
       | FStar_Pervasives_Native.None  ->
           FStar_Util.Inl "No such module or namespace"
@@ -2735,19 +2488,17 @@ let (run_module_lookup :
           (FStar_Interactive_CompletionTable.Module mod_info) ->
           let uu____5872 =
             let uu____5883 =
-              FStar_Interactive_CompletionTable.alist_of_mod_info mod_info
-               in
-            ("module", uu____5883)  in
+              FStar_Interactive_CompletionTable.alist_of_mod_info mod_info in
+            ("module", uu____5883) in
           FStar_Util.Inr uu____5872
       | FStar_Pervasives_Native.Some
           (FStar_Interactive_CompletionTable.Namespace ns_info) ->
           let uu____5907 =
             let uu____5918 =
-              FStar_Interactive_CompletionTable.alist_of_ns_info ns_info  in
-            ("namespace", uu____5918)  in
+              FStar_Interactive_CompletionTable.alist_of_ns_info ns_info in
+            ("namespace", uu____5918) in
           FStar_Util.Inr uu____5907
-  
-let (run_code_lookup :
+let run_code_lookup:
   repl_state ->
     Prims.string ->
       (Prims.string,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3
@@ -2757,24 +2508,22 @@ let (run_code_lookup :
                                         FStar_Pervasives_Native.tuple2
                                         Prims.list)
                           FStar_Pervasives_Native.tuple2)
-            FStar_Util.either)
+            FStar_Util.either
   =
   fun st  ->
     fun symbol  ->
       fun pos_opt  ->
         fun requested_info  ->
-          let uu____5987 = run_symbol_lookup st symbol pos_opt requested_info
-             in
+          let uu____5987 = run_symbol_lookup st symbol pos_opt requested_info in
           match uu____5987 with
           | FStar_Util.Inr alist -> FStar_Util.Inr alist
           | FStar_Util.Inl uu____6047 ->
-              let uu____6058 = run_module_lookup st symbol  in
+              let uu____6058 = run_module_lookup st symbol in
               (match uu____6058 with
                | FStar_Util.Inr alist -> FStar_Util.Inr alist
                | FStar_Util.Inl err_msg ->
                    FStar_Util.Inl "No such symbol, module, or namespace.")
-  
-let (run_lookup' :
+let run_lookup':
   repl_state ->
     Prims.string ->
       lookup_context ->
@@ -2785,7 +2534,7 @@ let (run_lookup' :
                                           FStar_Pervasives_Native.tuple2
                                           Prims.list)
                             FStar_Pervasives_Native.tuple2)
-              FStar_Util.either)
+              FStar_Util.either
   =
   fun st  ->
     fun symbol  ->
@@ -2798,8 +2547,7 @@ let (run_lookup' :
             | LKModule  -> run_module_lookup st symbol
             | LKOption  -> run_option_lookup symbol
             | LKCode  -> run_code_lookup st symbol pos_opt requested_info
-  
-let run_lookup :
+let run_lookup:
   'Auu____6208 .
     repl_state ->
       Prims.string ->
@@ -2817,7 +2565,7 @@ let run_lookup :
         fun pos_opt  ->
           fun requested_info  ->
             let uu____6261 =
-              run_lookup' st symbol context pos_opt requested_info  in
+              run_lookup' st symbol context pos_opt requested_info in
             match uu____6261 with
             | FStar_Util.Inl err_msg ->
                 ((QueryNOK, (FStar_Util.JsonStr err_msg)),
@@ -2826,8 +2574,7 @@ let run_lookup :
                 ((QueryOK,
                    (FStar_Util.JsonAssoc (("kind", (FStar_Util.JsonStr kind))
                       :: info))), (FStar_Util.Inl st))
-  
-let code_autocomplete_mod_filter :
+let code_autocomplete_mod_filter:
   'Auu____6345 .
     ('Auu____6345,FStar_Interactive_CompletionTable.mod_symbol)
       FStar_Pervasives_Native.tuple2 ->
@@ -2847,23 +2594,22 @@ let code_autocomplete_mod_filter :
         let uu____6379 =
           let uu____6384 =
             let uu____6385 =
-              let uu___103_6386 = md  in
+              let uu___103_6386 = md in
               let uu____6387 =
                 let uu____6388 =
-                  FStar_Interactive_CompletionTable.mod_name md  in
-                Prims.strcat uu____6388 "."  in
+                  FStar_Interactive_CompletionTable.mod_name md in
+                Prims.strcat uu____6388 "." in
               {
                 FStar_Interactive_CompletionTable.mod_name = uu____6387;
                 FStar_Interactive_CompletionTable.mod_path =
                   (uu___103_6386.FStar_Interactive_CompletionTable.mod_path);
                 FStar_Interactive_CompletionTable.mod_loaded =
                   (uu___103_6386.FStar_Interactive_CompletionTable.mod_loaded)
-              }  in
-            FStar_Interactive_CompletionTable.Module uu____6385  in
-          (pth, uu____6384)  in
+              } in
+            FStar_Interactive_CompletionTable.Module uu____6385 in
+          (pth, uu____6384) in
         FStar_Pervasives_Native.Some uu____6379
-  
-let run_code_autocomplete :
+let run_code_autocomplete:
   'Auu____6396 .
     repl_state ->
       Prims.string ->
@@ -2873,23 +2619,19 @@ let run_code_autocomplete :
   =
   fun st  ->
     fun search_term  ->
-      let needle = FStar_Util.split search_term "."  in
+      let needle = FStar_Util.split search_term "." in
       let mods_and_nss =
         FStar_Interactive_CompletionTable.autocomplete_mod_or_ns
-          st.repl_names needle code_autocomplete_mod_filter
-         in
+          st.repl_names needle code_autocomplete_mod_filter in
       let lids =
         FStar_Interactive_CompletionTable.autocomplete_lid st.repl_names
-          needle
-         in
+          needle in
       let json =
         FStar_List.map
           FStar_Interactive_CompletionTable.json_of_completion_result
-          (FStar_List.append lids mods_and_nss)
-         in
+          (FStar_List.append lids mods_and_nss) in
       ((QueryOK, (FStar_Util.JsonList json)), (FStar_Util.Inl st))
-  
-let run_module_autocomplete :
+let run_module_autocomplete:
   'Auu____6444 'Auu____6445 'Auu____6446 .
     repl_state ->
       Prims.string ->
@@ -2903,24 +2645,21 @@ let run_module_autocomplete :
     fun search_term  ->
       fun modules1  ->
         fun namespaces  ->
-          let needle = FStar_Util.split search_term "."  in
+          let needle = FStar_Util.split search_term "." in
           let mods_and_nss =
             FStar_Interactive_CompletionTable.autocomplete_mod_or_ns
               st.repl_names needle
-              (fun _0_52  -> FStar_Pervasives_Native.Some _0_52)
-             in
+              (fun _0_52  -> FStar_Pervasives_Native.Some _0_52) in
           let json =
             FStar_List.map
               FStar_Interactive_CompletionTable.json_of_completion_result
-              mods_and_nss
-             in
+              mods_and_nss in
           ((QueryOK, (FStar_Util.JsonList json)), (FStar_Util.Inl st))
-  
-let (candidates_of_fstar_option :
+let candidates_of_fstar_option:
   Prims.int ->
     Prims.bool ->
       fstar_option ->
-        FStar_Interactive_CompletionTable.completion_result Prims.list)
+        FStar_Interactive_CompletionTable.completion_result Prims.list
   =
   fun match_len  ->
     fun is_reset  ->
@@ -2929,18 +2668,17 @@ let (candidates_of_fstar_option :
           match opt.opt_permission_level with
           | OptSet  -> (true, "")
           | OptReset  -> (is_reset, "#reset-only")
-          | OptReadOnly  -> (false, "read-only")  in
+          | OptReadOnly  -> (false, "read-only") in
         match uu____6507 with
         | (may_set,explanation) ->
-            let opt_type = kind_of_fstar_option_type opt.opt_type  in
+            let opt_type = kind_of_fstar_option_type opt.opt_type in
             let annot =
               if may_set
               then opt_type
               else
                 Prims.strcat "("
                   (Prims.strcat explanation
-                     (Prims.strcat " " (Prims.strcat opt_type ")")))
-               in
+                     (Prims.strcat " " (Prims.strcat opt_type ")"))) in
             FStar_All.pipe_right opt.opt_snippets
               (FStar_List.map
                  (fun snippet  ->
@@ -2952,8 +2690,7 @@ let (candidates_of_fstar_option :
                       FStar_Interactive_CompletionTable.completion_annotation
                         = annot
                     }))
-  
-let run_option_autocomplete :
+let run_option_autocomplete:
   'Auu____6534 'Auu____6535 .
     'Auu____6535 ->
       Prims.string ->
@@ -2965,28 +2702,26 @@ let run_option_autocomplete :
   fun st  ->
     fun search_term  ->
       fun is_reset  ->
-        let uu____6560 = trim_option_name search_term  in
+        let uu____6560 = trim_option_name search_term in
         match uu____6560 with
         | ("--",trimmed_name) ->
             let matcher opt =
-              FStar_Util.starts_with opt.opt_name trimmed_name  in
-            let options = current_fstar_options matcher  in
-            let match_len = FStar_String.length search_term  in
+              FStar_Util.starts_with opt.opt_name trimmed_name in
+            let options = current_fstar_options matcher in
+            let match_len = FStar_String.length search_term in
             let collect_candidates =
-              candidates_of_fstar_option match_len is_reset  in
-            let results = FStar_List.concatMap collect_candidates options  in
+              candidates_of_fstar_option match_len is_reset in
+            let results = FStar_List.concatMap collect_candidates options in
             let json =
               FStar_List.map
                 FStar_Interactive_CompletionTable.json_of_completion_result
-                results
-               in
+                results in
             ((QueryOK, (FStar_Util.JsonList json)), (FStar_Util.Inl st))
         | (uu____6611,uu____6612) ->
             ((QueryNOK,
                (FStar_Util.JsonStr "Options should start with '--'")),
               (FStar_Util.Inl st))
-  
-let run_autocomplete :
+let run_autocomplete:
   'Auu____6625 .
     repl_state ->
       Prims.string ->
@@ -3004,8 +2739,7 @@ let run_autocomplete :
             run_option_autocomplete st search_term is_reset
         | CKModuleOrNamespace (modules1,namespaces) ->
             run_module_autocomplete st search_term modules1 namespaces
-  
-let run_and_rewind :
+let run_and_rewind:
   'Auu____6657 'Auu____6658 .
     repl_state ->
       (repl_state -> 'Auu____6658) ->
@@ -3014,18 +2748,17 @@ let run_and_rewind :
   =
   fun st  ->
     fun task  ->
-      let env' = push st.repl_env "#compute"  in
+      let env' = push st.repl_env "#compute" in
       let results =
         try
-          let uu____6697 = task st  in
+          let uu____6697 = task st in
           FStar_All.pipe_left (fun _0_53  -> FStar_Util.Inl _0_53) uu____6697
-        with | e -> FStar_Util.Inr e  in
+        with | e -> FStar_Util.Inr e in
       pop env' "#compute";
       (match results with
        | FStar_Util.Inl results1 -> (results1, (FStar_Util.Inl st))
        | FStar_Util.Inr e -> FStar_Exn.raise e)
-  
-let run_with_parsed_and_tc_term :
+let run_with_parsed_and_tc_term:
   'Auu____6741 'Auu____6742 'Auu____6743 .
     repl_state ->
       Prims.string ->
@@ -3047,12 +2780,12 @@ let run_with_parsed_and_tc_term :
           fun continuation  ->
             let dummy_let_fragment term1 =
               let dummy_decl =
-                FStar_Util.format1 "let __compute_dummy__ = (%s)" term1  in
+                FStar_Util.format1 "let __compute_dummy__ = (%s)" term1 in
               {
                 FStar_Parser_ParseIt.frag_text = dummy_decl;
                 FStar_Parser_ParseIt.frag_line = (Prims.parse_int "0");
                 FStar_Parser_ParseIt.frag_col = (Prims.parse_int "0")
-              }  in
+              } in
             let find_let_body ses =
               match ses with
               | {
@@ -3068,43 +2801,42 @@ let run_with_parsed_and_tc_term :
                   FStar_Syntax_Syntax.sigmeta = uu____6837;
                   FStar_Syntax_Syntax.sigattrs = uu____6838;_}::[] ->
                   FStar_Pervasives_Native.Some (univs1, def)
-              | uu____6881 -> FStar_Pervasives_Native.None  in
+              | uu____6881 -> FStar_Pervasives_Native.None in
             let parse1 frag =
               let uu____6900 =
                 FStar_Parser_ParseIt.parse
-                  (FStar_Parser_ParseIt.Toplevel frag)
-                 in
+                  (FStar_Parser_ParseIt.Toplevel frag) in
               match uu____6900 with
               | FStar_Parser_ParseIt.ASTFragment
                   (FStar_Util.Inr decls,uu____6906) ->
                   FStar_Pervasives_Native.Some decls
-              | uu____6931 -> FStar_Pervasives_Native.None  in
+              | uu____6931 -> FStar_Pervasives_Native.None in
             let desugar env decls =
               let uu____6945 =
                 let uu____6950 =
-                  FStar_ToSyntax_ToSyntax.decls_to_sigelts decls  in
-                uu____6950 env.FStar_TypeChecker_Env.dsenv  in
-              FStar_Pervasives_Native.fst uu____6945  in
+                  FStar_ToSyntax_ToSyntax.decls_to_sigelts decls in
+                uu____6950 env.FStar_TypeChecker_Env.dsenv in
+              FStar_Pervasives_Native.fst uu____6945 in
             let typecheck tcenv decls =
-              let uu____6968 = FStar_TypeChecker_Tc.tc_decls tcenv decls  in
-              match uu____6968 with | (ses,uu____6982,uu____6983) -> ses  in
+              let uu____6968 = FStar_TypeChecker_Tc.tc_decls tcenv decls in
+              match uu____6968 with | (ses,uu____6982,uu____6983) -> ses in
             run_and_rewind st
               (fun st1  ->
-                 let tcenv = st1.repl_env  in
-                 let frag = dummy_let_fragment term  in
+                 let tcenv = st1.repl_env in
+                 let frag = dummy_let_fragment term in
                  match st1.repl_curmod with
                  | FStar_Pervasives_Native.None  ->
                      (QueryNOK, (FStar_Util.JsonStr "Current module unset"))
                  | uu____7006 ->
-                     let uu____7007 = parse1 frag  in
+                     let uu____7007 = parse1 frag in
                      (match uu____7007 with
                       | FStar_Pervasives_Native.None  ->
                           (QueryNOK,
                             (FStar_Util.JsonStr "Could not parse this term"))
                       | FStar_Pervasives_Native.Some decls ->
                           let aux uu____7030 =
-                            let decls1 = desugar tcenv decls  in
-                            let ses = typecheck tcenv decls1  in
+                            let decls1 = desugar tcenv decls in
+                            let ses = typecheck tcenv decls1 in
                             match find_let_body ses with
                             | FStar_Pervasives_Native.None  ->
                                 (QueryNOK,
@@ -3113,17 +2845,14 @@ let run_with_parsed_and_tc_term :
                             | FStar_Pervasives_Native.Some (univs1,def) ->
                                 let uu____7065 =
                                   FStar_Syntax_Subst.open_univ_vars univs1
-                                    def
-                                   in
+                                    def in
                                 (match uu____7065 with
                                  | (univs2,def1) ->
                                      let tcenv1 =
                                        FStar_TypeChecker_Env.push_univ_vars
-                                         tcenv univs2
-                                        in
-                                     continuation tcenv1 def1)
-                             in
-                          let uu____7077 = FStar_Options.trace_error ()  in
+                                         tcenv univs2 in
+                                     continuation tcenv1 def1) in
+                          let uu____7077 = FStar_Options.trace_error () in
                           if uu____7077
                           then aux ()
                           else
@@ -3132,18 +2861,16 @@ let run_with_parsed_and_tc_term :
                              | e ->
                                  let uu____7102 =
                                    let uu____7103 =
-                                     FStar_Errors.issue_of_exn e  in
+                                     FStar_Errors.issue_of_exn e in
                                    match uu____7103 with
                                    | FStar_Pervasives_Native.Some issue ->
                                        let uu____7107 =
-                                         FStar_Errors.format_issue issue  in
+                                         FStar_Errors.format_issue issue in
                                        FStar_Util.JsonStr uu____7107
                                    | FStar_Pervasives_Native.None  ->
-                                       FStar_Exn.raise e
-                                    in
+                                       FStar_Exn.raise e in
                                  (QueryNOK, uu____7102))))
-  
-let run_compute :
+let run_compute:
   'Auu____7112 .
     repl_state ->
       Prims.string ->
@@ -3168,168 +2895,149 @@ let run_compute :
                    FStar_Syntax_Syntax.Delta_constant])
             [FStar_TypeChecker_Normalize.Inlining;
             FStar_TypeChecker_Normalize.Eager_unfolding;
-            FStar_TypeChecker_Normalize.Primops]
-           in
+            FStar_TypeChecker_Normalize.Primops] in
         let normalize_term1 tcenv rules2 t =
-          FStar_TypeChecker_Normalize.normalize rules2 tcenv t  in
+          FStar_TypeChecker_Normalize.normalize rules2 tcenv t in
         run_with_parsed_and_tc_term st term (Prims.parse_int "0")
           (Prims.parse_int "0")
           (fun tcenv  ->
              fun def  ->
-               let normalized = normalize_term1 tcenv rules1 def  in
+               let normalized = normalize_term1 tcenv rules1 def in
                let uu____7175 =
-                 let uu____7176 = term_to_string tcenv normalized  in
-                 FStar_Util.JsonStr uu____7176  in
+                 let uu____7176 = term_to_string tcenv normalized in
+                 FStar_Util.JsonStr uu____7176 in
                (QueryOK, uu____7175))
-  
 type search_term' =
-  | NameContainsStr of Prims.string 
-  | TypeContainsLid of FStar_Ident.lid [@@deriving show]
+  | NameContainsStr of Prims.string
+  | TypeContainsLid of FStar_Ident.lid[@@deriving show]
 and search_term = {
-  st_negate: Prims.bool ;
-  st_term: search_term' }[@@deriving show]
-let (uu___is_NameContainsStr : search_term' -> Prims.bool) =
+  st_negate: Prims.bool;
+  st_term: search_term';}[@@deriving show]
+let uu___is_NameContainsStr: search_term' -> Prims.bool =
   fun projectee  ->
     match projectee with | NameContainsStr _0 -> true | uu____7197 -> false
-  
-let (__proj__NameContainsStr__item___0 : search_term' -> Prims.string) =
-  fun projectee  -> match projectee with | NameContainsStr _0 -> _0 
-let (uu___is_TypeContainsLid : search_term' -> Prims.bool) =
+let __proj__NameContainsStr__item___0: search_term' -> Prims.string =
+  fun projectee  -> match projectee with | NameContainsStr _0 -> _0
+let uu___is_TypeContainsLid: search_term' -> Prims.bool =
   fun projectee  ->
     match projectee with | TypeContainsLid _0 -> true | uu____7209 -> false
-  
-let (__proj__TypeContainsLid__item___0 : search_term' -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | TypeContainsLid _0 -> _0 
-let (__proj__Mksearch_term__item__st_negate : search_term -> Prims.bool) =
+let __proj__TypeContainsLid__item___0: search_term' -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | TypeContainsLid _0 -> _0
+let __proj__Mksearch_term__item__st_negate: search_term -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { st_negate = __fname__st_negate; st_term = __fname__st_term;_} ->
         __fname__st_negate
-  
-let (__proj__Mksearch_term__item__st_term : search_term -> search_term') =
+let __proj__Mksearch_term__item__st_term: search_term -> search_term' =
   fun projectee  ->
     match projectee with
     | { st_negate = __fname__st_negate; st_term = __fname__st_term;_} ->
         __fname__st_term
-  
-let (st_cost : search_term' -> Prims.int) =
+let st_cost: search_term' -> Prims.int =
   fun uu___85_7229  ->
     match uu___85_7229 with
     | NameContainsStr str -> - (FStar_String.length str)
-    | TypeContainsLid lid -> (Prims.parse_int "1")
-  
+    | TypeContainsLid lid -> Prims.parse_int "1"
 type search_candidate =
   {
-  sc_lid: FStar_Ident.lid ;
-  sc_typ: FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option FStar_ST.ref ;
+  sc_lid: FStar_Ident.lid;
+  sc_typ:
+    FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option FStar_ST.ref;
   sc_fvars:
     FStar_Ident.lid FStar_Util.set FStar_Pervasives_Native.option
-      FStar_ST.ref
-    }[@@deriving show]
-let (__proj__Mksearch_candidate__item__sc_lid :
-  search_candidate -> FStar_Ident.lid) =
+      FStar_ST.ref;}[@@deriving show]
+let __proj__Mksearch_candidate__item__sc_lid:
+  search_candidate -> FStar_Ident.lid =
   fun projectee  ->
     match projectee with
     | { sc_lid = __fname__sc_lid; sc_typ = __fname__sc_typ;
         sc_fvars = __fname__sc_fvars;_} -> __fname__sc_lid
-  
-let (__proj__Mksearch_candidate__item__sc_typ :
+let __proj__Mksearch_candidate__item__sc_typ:
   search_candidate ->
-    FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option FStar_ST.ref)
+    FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option FStar_ST.ref
   =
   fun projectee  ->
     match projectee with
     | { sc_lid = __fname__sc_lid; sc_typ = __fname__sc_typ;
         sc_fvars = __fname__sc_fvars;_} -> __fname__sc_typ
-  
-let (__proj__Mksearch_candidate__item__sc_fvars :
+let __proj__Mksearch_candidate__item__sc_fvars:
   search_candidate ->
     FStar_Ident.lid FStar_Util.set FStar_Pervasives_Native.option
-      FStar_ST.ref)
+      FStar_ST.ref
   =
   fun projectee  ->
     match projectee with
     | { sc_lid = __fname__sc_lid; sc_typ = __fname__sc_typ;
         sc_fvars = __fname__sc_fvars;_} -> __fname__sc_fvars
-  
-let (sc_of_lid : FStar_Ident.lid -> search_candidate) =
+let sc_of_lid: FStar_Ident.lid -> search_candidate =
   fun lid  ->
-    let uu____7433 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-    let uu____7440 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+    let uu____7433 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+    let uu____7440 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
     { sc_lid = lid; sc_typ = uu____7433; sc_fvars = uu____7440 }
-  
-let (sc_typ :
-  FStar_TypeChecker_Env.env -> search_candidate -> FStar_Syntax_Syntax.typ) =
+let sc_typ:
+  FStar_TypeChecker_Env.env -> search_candidate -> FStar_Syntax_Syntax.typ =
   fun tcenv  ->
     fun sc  ->
-      let uu____7503 = FStar_ST.op_Bang sc.sc_typ  in
+      let uu____7503 = FStar_ST.op_Bang sc.sc_typ in
       match uu____7503 with
       | FStar_Pervasives_Native.Some t -> t
       | FStar_Pervasives_Native.None  ->
           let typ =
             let uu____7533 =
-              FStar_TypeChecker_Env.try_lookup_lid tcenv sc.sc_lid  in
+              FStar_TypeChecker_Env.try_lookup_lid tcenv sc.sc_lid in
             match uu____7533 with
             | FStar_Pervasives_Native.None  ->
                 FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
                   FStar_Pervasives_Native.None FStar_Range.dummyRange
             | FStar_Pervasives_Native.Some ((uu____7554,typ),uu____7556) ->
-                typ
-             in
+                typ in
           (FStar_ST.op_Colon_Equals sc.sc_typ
              (FStar_Pervasives_Native.Some typ);
            typ)
-  
-let (sc_fvars :
+let sc_fvars:
   FStar_TypeChecker_Env.env ->
-    search_candidate -> FStar_Ident.lid FStar_Util.set)
+    search_candidate -> FStar_Ident.lid FStar_Util.set
   =
   fun tcenv  ->
     fun sc  ->
-      let uu____7603 = FStar_ST.op_Bang sc.sc_fvars  in
+      let uu____7603 = FStar_ST.op_Bang sc.sc_fvars in
       match uu____7603 with
       | FStar_Pervasives_Native.Some fv -> fv
       | FStar_Pervasives_Native.None  ->
           let fv =
-            let uu____7647 = sc_typ tcenv sc  in
-            FStar_Syntax_Free.fvars uu____7647  in
+            let uu____7647 = sc_typ tcenv sc in
+            FStar_Syntax_Free.fvars uu____7647 in
           (FStar_ST.op_Colon_Equals sc.sc_fvars
              (FStar_Pervasives_Native.Some fv);
            fv)
-  
-let (json_of_search_result :
-  FStar_TypeChecker_Env.env -> search_candidate -> FStar_Util.json) =
+let json_of_search_result:
+  FStar_TypeChecker_Env.env -> search_candidate -> FStar_Util.json =
   fun tcenv  ->
     fun sc  ->
       let typ_str =
-        let uu____7685 = sc_typ tcenv sc  in term_to_string tcenv uu____7685
-         in
+        let uu____7685 = sc_typ tcenv sc in term_to_string tcenv uu____7685 in
       let uu____7686 =
         let uu____7693 =
           let uu____7698 =
             let uu____7699 =
               let uu____7700 =
                 FStar_ToSyntax_Env.shorten_lid
-                  tcenv.FStar_TypeChecker_Env.dsenv sc.sc_lid
-                 in
-              uu____7700.FStar_Ident.str  in
-            FStar_Util.JsonStr uu____7699  in
-          ("lid", uu____7698)  in
-        [uu____7693; ("type", (FStar_Util.JsonStr typ_str))]  in
+                  tcenv.FStar_TypeChecker_Env.dsenv sc.sc_lid in
+              uu____7700.FStar_Ident.str in
+            FStar_Util.JsonStr uu____7699 in
+          ("lid", uu____7698) in
+        [uu____7693; ("type", (FStar_Util.JsonStr typ_str))] in
       FStar_Util.JsonAssoc uu____7686
-  
-exception InvalidSearch of Prims.string 
-let (uu___is_InvalidSearch : Prims.exn -> Prims.bool) =
+exception InvalidSearch of Prims.string
+let uu___is_InvalidSearch: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with
     | InvalidSearch uu____7719 -> true
     | uu____7720 -> false
-  
-let (__proj__InvalidSearch__item__uu___ : Prims.exn -> Prims.string) =
+let __proj__InvalidSearch__item__uu___: Prims.exn -> Prims.string =
   fun projectee  ->
     match projectee with | InvalidSearch uu____7727 -> uu____7727
-  
-let run_search :
+let run_search:
   'Auu____7731 .
     repl_state ->
       Prims.string ->
@@ -3339,112 +3047,102 @@ let run_search :
   =
   fun st  ->
     fun search_str  ->
-      let tcenv = st.repl_env  in
-      let empty_fv_set = FStar_Syntax_Syntax.new_fv_set ()  in
+      let tcenv = st.repl_env in
+      let empty_fv_set = FStar_Syntax_Syntax.new_fv_set () in
       let st_matches candidate term =
         let found =
           match term.st_term with
           | NameContainsStr str ->
               FStar_Util.contains (candidate.sc_lid).FStar_Ident.str str
           | TypeContainsLid lid ->
-              let uu____7766 = sc_fvars tcenv candidate  in
-              FStar_Util.set_mem lid uu____7766
-           in
-        found <> term.st_negate  in
+              let uu____7766 = sc_fvars tcenv candidate in
+              FStar_Util.set_mem lid uu____7766 in
+        found <> term.st_negate in
       let parse1 search_str1 =
         let parse_one term =
-          let negate = FStar_Util.starts_with term "-"  in
+          let negate = FStar_Util.starts_with term "-" in
           let term1 =
             if negate
             then FStar_Util.substring_from term (Prims.parse_int "1")
-            else term  in
-          let beg_quote = FStar_Util.starts_with term1 "\""  in
-          let end_quote = FStar_Util.ends_with term1 "\""  in
+            else term in
+          let beg_quote = FStar_Util.starts_with term1 "\"" in
+          let end_quote = FStar_Util.ends_with term1 "\"" in
           let strip_quotes str =
             if (FStar_String.length str) < (Prims.parse_int "2")
             then FStar_Exn.raise (InvalidSearch "Empty search term")
             else
               FStar_Util.substring str (Prims.parse_int "1")
-                ((FStar_String.length term1) - (Prims.parse_int "2"))
-             in
+                ((FStar_String.length term1) - (Prims.parse_int "2")) in
           let parsed =
             if beg_quote <> end_quote
             then
               let uu____7790 =
                 let uu____7791 =
                   FStar_Util.format1 "Improperly quoted search term: %s"
-                    term1
-                   in
-                InvalidSearch uu____7791  in
+                    term1 in
+                InvalidSearch uu____7791 in
               FStar_Exn.raise uu____7790
             else
               if beg_quote
               then
-                (let uu____7793 = strip_quotes term1  in
+                (let uu____7793 = strip_quotes term1 in
                  NameContainsStr uu____7793)
               else
-                (let lid = FStar_Ident.lid_of_str term1  in
+                (let lid = FStar_Ident.lid_of_str term1 in
                  let uu____7796 =
                    FStar_ToSyntax_Env.resolve_to_fully_qualified_name
-                     tcenv.FStar_TypeChecker_Env.dsenv lid
-                    in
+                     tcenv.FStar_TypeChecker_Env.dsenv lid in
                  match uu____7796 with
                  | FStar_Pervasives_Native.None  ->
                      let uu____7799 =
                        let uu____7800 =
-                         FStar_Util.format1 "Unknown identifier: %s" term1
-                          in
-                       InvalidSearch uu____7800  in
+                         FStar_Util.format1 "Unknown identifier: %s" term1 in
+                       InvalidSearch uu____7800 in
                      FStar_Exn.raise uu____7799
-                 | FStar_Pervasives_Native.Some lid1 -> TypeContainsLid lid1)
-             in
-          { st_negate = negate; st_term = parsed }  in
+                 | FStar_Pervasives_Native.Some lid1 -> TypeContainsLid lid1) in
+          { st_negate = negate; st_term = parsed } in
         let terms =
-          FStar_List.map parse_one (FStar_Util.split search_str1 " ")  in
-        let cmp x y = (st_cost x.st_term) - (st_cost y.st_term)  in
-        FStar_Util.sort_with cmp terms  in
+          FStar_List.map parse_one (FStar_Util.split search_str1 " ") in
+        let cmp x y = (st_cost x.st_term) - (st_cost y.st_term) in
+        FStar_Util.sort_with cmp terms in
       let pprint_one term =
         let uu____7816 =
           match term.st_term with
           | NameContainsStr s -> FStar_Util.format1 "\"%s\"" s
-          | TypeContainsLid l -> FStar_Util.format1 "%s" l.FStar_Ident.str
-           in
-        Prims.strcat (if term.st_negate then "-" else "") uu____7816  in
+          | TypeContainsLid l -> FStar_Util.format1 "%s" l.FStar_Ident.str in
+        Prims.strcat (if term.st_negate then "-" else "") uu____7816 in
       let results =
         try
-          let terms = parse1 search_str  in
-          let all_lidents = FStar_TypeChecker_Env.lidents tcenv  in
-          let all_candidates = FStar_List.map sc_of_lid all_lidents  in
+          let terms = parse1 search_str in
+          let all_lidents = FStar_TypeChecker_Env.lidents tcenv in
+          let all_candidates = FStar_List.map sc_of_lid all_lidents in
           let matches_all candidate =
-            FStar_List.for_all (st_matches candidate) terms  in
+            FStar_List.for_all (st_matches candidate) terms in
           let cmp r1 r2 =
             FStar_Util.compare (r1.sc_lid).FStar_Ident.str
-              (r2.sc_lid).FStar_Ident.str
-             in
-          let results = FStar_List.filter matches_all all_candidates  in
-          let sorted1 = FStar_Util.sort_with cmp results  in
-          let js = FStar_List.map (json_of_search_result tcenv) sorted1  in
+              (r2.sc_lid).FStar_Ident.str in
+          let results = FStar_List.filter matches_all all_candidates in
+          let sorted1 = FStar_Util.sort_with cmp results in
+          let js = FStar_List.map (json_of_search_result tcenv) sorted1 in
           match results with
           | [] ->
               let kwds =
-                let uu____7879 = FStar_List.map pprint_one terms  in
-                FStar_Util.concat_l " " uu____7879  in
+                let uu____7879 = FStar_List.map pprint_one terms in
+                FStar_Util.concat_l " " uu____7879 in
               let uu____7882 =
                 let uu____7883 =
-                  FStar_Util.format1 "No results found for query [%s]" kwds
-                   in
-                InvalidSearch uu____7883  in
+                  FStar_Util.format1 "No results found for query [%s]" kwds in
+                InvalidSearch uu____7883 in
               FStar_Exn.raise uu____7882
           | uu____7888 -> (QueryOK, (FStar_Util.JsonList js))
-        with | InvalidSearch s -> (QueryNOK, (FStar_Util.JsonStr s))  in
+        with | InvalidSearch s -> (QueryNOK, (FStar_Util.JsonStr s)) in
       (results, (FStar_Util.Inl st))
-  
-let (run_query :
+let run_query:
   repl_state ->
     query' ->
       ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
         (repl_state,Prims.int) FStar_Util.either)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun st  ->
     fun q  ->
@@ -3464,8 +3162,7 @@ let (run_query :
           run_lookup st symbol context pos_opt rq_info
       | Compute (term,rules) -> run_compute st term rules
       | Search term -> run_search st term
-  
-let (validate_query : repl_state -> query -> query) =
+let validate_query: repl_state -> query -> query =
   fun st  ->
     fun q  ->
       match q.qq with
@@ -3486,49 +3183,45 @@ let (validate_query : repl_state -> query -> query) =
                query_needs_current_module q.qq ->
                { qq = (GenericError "Current module unset"); qid = (q.qid) }
            | uu____7982 -> q)
-  
-let rec (go : repl_state -> Prims.int) =
+let rec go: repl_state -> Prims.int =
   fun st  ->
     let rec loop st1 =
       let query =
-        let uu____7991 = read_interactive_query st1.repl_stdin  in
-        validate_query st1 uu____7991  in
-      let uu____7992 = run_query st1 query.qq  in
+        let uu____7991 = read_interactive_query st1.repl_stdin in
+        validate_query st1 uu____7991 in
+      let uu____7992 = run_query st1 query.qq in
       match uu____7992 with
       | ((status,response),state_opt) ->
           (write_response query.qid status response;
            (match state_opt with
             | FStar_Util.Inl st' -> loop st'
-            | FStar_Util.Inr exitcode -> FStar_Exn.raise (ExitREPL exitcode)))
-       in
-    let uu____8023 = FStar_Options.trace_error ()  in
+            | FStar_Util.Inr exitcode -> FStar_Exn.raise (ExitREPL exitcode))) in
+    let uu____8023 = FStar_Options.trace_error () in
     if uu____8023 then loop st else (try loop st with | ExitREPL n1 -> n1)
-  
-let (interactive_error_handler : FStar_Errors.error_handler) =
-  let issues = FStar_Util.mk_ref []  in
+let interactive_error_handler: FStar_Errors.error_handler =
+  let issues = FStar_Util.mk_ref [] in
   let add_one1 e =
     let uu____8042 =
-      let uu____8045 = FStar_ST.op_Bang issues  in e :: uu____8045  in
-    FStar_ST.op_Colon_Equals issues uu____8042  in
+      let uu____8045 = FStar_ST.op_Bang issues in e :: uu____8045 in
+    FStar_ST.op_Colon_Equals issues uu____8042 in
   let count_errors uu____8141 =
     let uu____8142 =
-      let uu____8145 = FStar_ST.op_Bang issues  in
+      let uu____8145 = FStar_ST.op_Bang issues in
       FStar_List.filter
         (fun e  -> e.FStar_Errors.issue_level = FStar_Errors.EError)
-        uu____8145
-       in
-    FStar_List.length uu____8142  in
+        uu____8145 in
+    FStar_List.length uu____8142 in
   let report uu____8200 =
-    let uu____8201 = FStar_ST.op_Bang issues  in
-    FStar_List.sortWith FStar_Errors.compare_issues uu____8201  in
-  let clear1 uu____8252 = FStar_ST.op_Colon_Equals issues []  in
+    let uu____8201 = FStar_ST.op_Bang issues in
+    FStar_List.sortWith FStar_Errors.compare_issues uu____8201 in
+  let clear1 uu____8252 = FStar_ST.op_Colon_Equals issues [] in
   {
     FStar_Errors.eh_add_one = add_one1;
     FStar_Errors.eh_count_errors = count_errors;
     FStar_Errors.eh_report = report;
     FStar_Errors.eh_clear = clear1
-  } 
-let (interactive_printer : FStar_Util.printer) =
+  }
+let interactive_printer: FStar_Util.printer =
   {
     FStar_Util.printer_prinfo =
       (fun s  -> write_message "info" (FStar_Util.JsonStr s));
@@ -3540,21 +3233,21 @@ let (interactive_printer : FStar_Util.printer) =
       (fun label  ->
          fun get_string  ->
            fun get_json  ->
-             let uu____8320 = get_json ()  in write_message label uu____8320)
-  } 
-let (initial_range : FStar_Range.range) =
+             let uu____8320 = get_json () in write_message label uu____8320)
+  }
+let initial_range: FStar_Range.range =
   let uu____8321 =
-    FStar_Range.mk_pos (Prims.parse_int "1") (Prims.parse_int "0")  in
+    FStar_Range.mk_pos (Prims.parse_int "1") (Prims.parse_int "0") in
   let uu____8322 =
-    FStar_Range.mk_pos (Prims.parse_int "1") (Prims.parse_int "0")  in
-  FStar_Range.mk_range "<input>" uu____8321 uu____8322 
-let (interactive_mode' : Prims.string -> Prims.unit) =
+    FStar_Range.mk_pos (Prims.parse_int "1") (Prims.parse_int "0") in
+  FStar_Range.mk_range "<input>" uu____8321 uu____8322
+let interactive_mode': Prims.string -> Prims.unit =
   fun filename  ->
     write_hello ();
-    (let env = FStar_Universal.init_env FStar_Parser_Dep.empty_deps  in
-     let env1 = FStar_TypeChecker_Env.set_range env initial_range  in
+    (let env = FStar_Universal.init_env FStar_Parser_Dep.empty_deps in
+     let env1 = FStar_TypeChecker_Env.set_range env initial_range in
      let init_st =
-       let uu____8330 = FStar_Util.open_stdin ()  in
+       let uu____8330 = FStar_Util.open_stdin () in
        {
          repl_line = (Prims.parse_int "1");
          repl_column = (Prims.parse_int "0");
@@ -3564,32 +3257,31 @@ let (interactive_mode' : Prims.string -> Prims.unit) =
          repl_env = env1;
          repl_stdin = uu____8330;
          repl_names = FStar_Interactive_CompletionTable.empty
-       }  in
+       } in
      let exit_code =
        let uu____8336 =
-         (FStar_Options.record_hints ()) || (FStar_Options.use_hints ())  in
+         (FStar_Options.record_hints ()) || (FStar_Options.use_hints ()) in
        if uu____8336
        then
          let uu____8337 =
-           let uu____8338 = FStar_Options.file_list ()  in
-           FStar_List.hd uu____8338  in
+           let uu____8338 = FStar_Options.file_list () in
+           FStar_List.hd uu____8338 in
          FStar_SMTEncoding_Solver.with_hints_db uu____8337 false
            (fun uu____8342  -> go init_st)
-       else go init_st  in
+       else go init_st in
      FStar_All.exit exit_code)
-  
-let (interactive_mode : Prims.string -> Prims.unit) =
+let interactive_mode: Prims.string -> Prims.unit =
   fun filename  ->
     FStar_Util.set_printer interactive_printer;
     (let uu____8349 =
-       let uu____8350 = FStar_Options.codegen ()  in
-       FStar_Option.isSome uu____8350  in
+       let uu____8350 = FStar_Options.codegen () in
+       FStar_Option.isSome uu____8350 in
      if uu____8349
      then
        FStar_Errors.log_issue FStar_Range.dummyRange
          (FStar_Errors.Warning_IDEIgnoreCodeGen, "--ide: ignoring --codegen")
      else ());
-    (let uu____8354 = FStar_Options.trace_error ()  in
+    (let uu____8354 = FStar_Options.trace_error () in
      if uu____8354
      then interactive_mode' filename
      else
@@ -3600,4 +3292,3 @@ let (interactive_mode : Prims.string -> Prims.unit) =
         | e ->
             (FStar_Errors.set_handler FStar_Errors.default_handler;
              FStar_Exn.raise e)))
-  

--- a/src/ocaml-output/FStar_Interactive_Legacy.ml
+++ b/src/ocaml-output/FStar_Interactive_Legacy.ml
@@ -1,11 +1,11 @@
 open Prims
-let (tc_one_file :
+let tc_one_file:
   Prims.string Prims.list ->
     FStar_TypeChecker_Env.env ->
       ((Prims.string FStar_Pervasives_Native.option,Prims.string)
          FStar_Pervasives_Native.tuple2,FStar_TypeChecker_Env.env,Prims.string
                                                                     Prims.list)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun remaining  ->
     fun env  ->
@@ -15,8 +15,7 @@ let (tc_one_file :
             FStar_Universal.needs_interleaving intf impl ->
             let uu____59 =
               FStar_Universal.tc_one_file env
-                (FStar_Pervasives_Native.Some intf) impl
-               in
+                (FStar_Pervasives_Native.Some intf) impl in
             (match uu____59 with
              | (uu____82,env1) ->
                  (((FStar_Pervasives_Native.Some intf), impl), env1,
@@ -24,35 +23,32 @@ let (tc_one_file :
         | intf_or_impl::remaining1 ->
             let uu____106 =
               FStar_Universal.tc_one_file env FStar_Pervasives_Native.None
-                intf_or_impl
-               in
+                intf_or_impl in
             (match uu____106 with
              | (uu____129,env1) ->
                  ((FStar_Pervasives_Native.None, intf_or_impl), env1,
                    remaining1))
-        | [] -> failwith "Impossible"  in
+        | [] -> failwith "Impossible" in
       match uu____25 with
       | ((intf,impl),env1,remaining1) -> ((intf, impl), env1, remaining1)
-  
 type env_t = FStar_TypeChecker_Env.env[@@deriving show]
 type modul_t = FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option
 [@@deriving show]
 type stack_t = (env_t,modul_t) FStar_Pervasives_Native.tuple2 Prims.list
 [@@deriving show]
-let (pop : FStar_TypeChecker_Env.env -> Prims.string -> Prims.unit) =
+let pop: FStar_TypeChecker_Env.env -> Prims.string -> Prims.unit =
   fun env  ->
     fun msg  -> FStar_Universal.pop_context env msg; FStar_Options.pop ()
-  
-let (push_with_kind :
+let push_with_kind:
   FStar_TypeChecker_Env.env ->
-    Prims.bool -> Prims.bool -> Prims.string -> FStar_TypeChecker_Env.env)
+    Prims.bool -> Prims.bool -> Prims.string -> FStar_TypeChecker_Env.env
   =
   fun env  ->
     fun lax1  ->
       fun restore_cmd_line_options1  ->
         fun msg  ->
           let env1 =
-            let uu___56_233 = env  in
+            let uu___56_233 = env in
             {
               FStar_TypeChecker_Env.solver =
                 (uu___56_233.FStar_TypeChecker_Env.solver);
@@ -123,201 +119,187 @@ let (push_with_kind :
                 (uu___56_233.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.dep_graph =
                 (uu___56_233.FStar_TypeChecker_Env.dep_graph)
-            }  in
-          let res = FStar_Universal.push_context env1 msg  in
+            } in
+          let res = FStar_Universal.push_context env1 msg in
           FStar_Options.push ();
           if restore_cmd_line_options1
           then
-            (let uu____237 = FStar_Options.restore_cmd_line_options false  in
+            (let uu____237 = FStar_Options.restore_cmd_line_options false in
              FStar_All.pipe_right uu____237 FStar_Pervasives.ignore)
           else ();
           res
-  
-let (check_frag :
+let check_frag:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
       FStar_Parser_ParseIt.input_frag ->
         (FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option,FStar_TypeChecker_Env.env,
           Prims.int) FStar_Pervasives_Native.tuple3
-          FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.option
   =
   fun env  ->
     fun curmod  ->
       fun frag  ->
         try
-          let uu____288 = FStar_Universal.tc_one_fragment curmod env frag  in
+          let uu____288 = FStar_Universal.tc_one_fragment curmod env frag in
           match uu____288 with
           | (m,env1) ->
               let uu____311 =
-                let uu____320 = FStar_Errors.get_err_count ()  in
-                (m, env1, uu____320)  in
+                let uu____320 = FStar_Errors.get_err_count () in
+                (m, env1, uu____320) in
               FStar_Pervasives_Native.Some uu____311
         with
         | FStar_Errors.Error (e,msg,r) when
-            let uu____350 = FStar_Options.trace_error ()  in
+            let uu____350 = FStar_Options.trace_error () in
             Prims.op_Negation uu____350 ->
             (FStar_TypeChecker_Err.add_errors env [(e, msg, r)];
              FStar_Pervasives_Native.None)
         | FStar_Errors.Err (e,msg) when
-            let uu____374 = FStar_Options.trace_error ()  in
+            let uu____374 = FStar_Options.trace_error () in
             Prims.op_Negation uu____374 ->
             ((let uu____376 =
                 let uu____385 =
-                  let uu____392 = FStar_TypeChecker_Env.get_range env  in
-                  (e, msg, uu____392)  in
-                [uu____385]  in
+                  let uu____392 = FStar_TypeChecker_Env.get_range env in
+                  (e, msg, uu____392) in
+                [uu____385] in
               FStar_TypeChecker_Err.add_errors env uu____376);
              FStar_Pervasives_Native.None)
-  
-let (report_fail : Prims.unit -> Prims.unit) =
+let report_fail: Prims.unit -> Prims.unit =
   fun uu____415  ->
-    (let uu____417 = FStar_Errors.report_all ()  in
+    (let uu____417 = FStar_Errors.report_all () in
      FStar_All.pipe_right uu____417 FStar_Pervasives.ignore);
     FStar_Errors.clear ()
-  
 type input_chunks =
-  | Push of (Prims.bool,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3 
-  | Pop of Prims.string 
+  | Push of (Prims.bool,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3
+  | Pop of Prims.string
   | Code of
   (Prims.string,(Prims.string,Prims.string) FStar_Pervasives_Native.tuple2)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Info of
   (Prims.string,Prims.bool,(Prims.string,Prims.int,Prims.int)
                              FStar_Pervasives_Native.tuple3
                              FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple3 
-  | Completions of Prims.string [@@deriving show]
-let (uu___is_Push : input_chunks -> Prims.bool) =
+  FStar_Pervasives_Native.tuple3
+  | Completions of Prims.string[@@deriving show]
+let uu___is_Push: input_chunks -> Prims.bool =
   fun projectee  ->
     match projectee with | Push _0 -> true | uu____482 -> false
-  
-let (__proj__Push__item___0 :
+let __proj__Push__item___0:
   input_chunks ->
-    (Prims.bool,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Push _0 -> _0 
-let (uu___is_Pop : input_chunks -> Prims.bool) =
+    (Prims.bool,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Push _0 -> _0
+let uu___is_Pop: input_chunks -> Prims.bool =
   fun projectee  ->
     match projectee with | Pop _0 -> true | uu____512 -> false
-  
-let (__proj__Pop__item___0 : input_chunks -> Prims.string) =
-  fun projectee  -> match projectee with | Pop _0 -> _0 
-let (uu___is_Code : input_chunks -> Prims.bool) =
+let __proj__Pop__item___0: input_chunks -> Prims.string =
+  fun projectee  -> match projectee with | Pop _0 -> _0
+let uu___is_Code: input_chunks -> Prims.bool =
   fun projectee  ->
     match projectee with | Code _0 -> true | uu____532 -> false
-  
-let (__proj__Code__item___0 :
+let __proj__Code__item___0:
   input_chunks ->
     (Prims.string,(Prims.string,Prims.string) FStar_Pervasives_Native.tuple2)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Code _0 -> _0 
-let (uu___is_Info : input_chunks -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Code _0 -> _0
+let uu___is_Info: input_chunks -> Prims.bool =
   fun projectee  ->
     match projectee with | Info _0 -> true | uu____582 -> false
-  
-let (__proj__Info__item___0 :
+let __proj__Info__item___0:
   input_chunks ->
     (Prims.string,Prims.bool,(Prims.string,Prims.int,Prims.int)
                                FStar_Pervasives_Native.tuple3
                                FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Info _0 -> _0 
-let (uu___is_Completions : input_chunks -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Info _0 -> _0
+let uu___is_Completions: input_chunks -> Prims.bool =
   fun projectee  ->
     match projectee with | Completions _0 -> true | uu____636 -> false
-  
-let (__proj__Completions__item___0 : input_chunks -> Prims.string) =
-  fun projectee  -> match projectee with | Completions _0 -> _0 
+let __proj__Completions__item___0: input_chunks -> Prims.string =
+  fun projectee  -> match projectee with | Completions _0 -> _0
 type interactive_state =
   {
-  chunk: FStar_Util.string_builder ;
-  stdin: FStar_Util.stream_reader FStar_Pervasives_Native.option FStar_ST.ref ;
-  buffer: input_chunks Prims.list FStar_ST.ref ;
-  log: FStar_Util.file_handle FStar_Pervasives_Native.option FStar_ST.ref }
+  chunk: FStar_Util.string_builder;
+  stdin:
+    FStar_Util.stream_reader FStar_Pervasives_Native.option FStar_ST.ref;
+  buffer: input_chunks Prims.list FStar_ST.ref;
+  log: FStar_Util.file_handle FStar_Pervasives_Native.option FStar_ST.ref;}
 [@@deriving show]
-let (__proj__Mkinteractive_state__item__chunk :
-  interactive_state -> FStar_Util.string_builder) =
+let __proj__Mkinteractive_state__item__chunk:
+  interactive_state -> FStar_Util.string_builder =
   fun projectee  ->
     match projectee with
     | { chunk = __fname__chunk; stdin = __fname__stdin;
         buffer = __fname__buffer; log = __fname__log;_} -> __fname__chunk
-  
-let (__proj__Mkinteractive_state__item__stdin :
+let __proj__Mkinteractive_state__item__stdin:
   interactive_state ->
-    FStar_Util.stream_reader FStar_Pervasives_Native.option FStar_ST.ref)
+    FStar_Util.stream_reader FStar_Pervasives_Native.option FStar_ST.ref
   =
   fun projectee  ->
     match projectee with
     | { chunk = __fname__chunk; stdin = __fname__stdin;
         buffer = __fname__buffer; log = __fname__log;_} -> __fname__stdin
-  
-let (__proj__Mkinteractive_state__item__buffer :
-  interactive_state -> input_chunks Prims.list FStar_ST.ref) =
+let __proj__Mkinteractive_state__item__buffer:
+  interactive_state -> input_chunks Prims.list FStar_ST.ref =
   fun projectee  ->
     match projectee with
     | { chunk = __fname__chunk; stdin = __fname__stdin;
         buffer = __fname__buffer; log = __fname__log;_} -> __fname__buffer
-  
-let (__proj__Mkinteractive_state__item__log :
+let __proj__Mkinteractive_state__item__log:
   interactive_state ->
-    FStar_Util.file_handle FStar_Pervasives_Native.option FStar_ST.ref)
+    FStar_Util.file_handle FStar_Pervasives_Native.option FStar_ST.ref
   =
   fun projectee  ->
     match projectee with
     | { chunk = __fname__chunk; stdin = __fname__stdin;
         buffer = __fname__buffer; log = __fname__log;_} -> __fname__log
-  
-let (the_interactive_state : interactive_state) =
-  let uu____934 = FStar_Util.new_string_builder ()  in
-  let uu____935 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-  let uu____942 = FStar_Util.mk_ref []  in
-  let uu____949 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+let the_interactive_state: interactive_state =
+  let uu____934 = FStar_Util.new_string_builder () in
+  let uu____935 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+  let uu____942 = FStar_Util.mk_ref [] in
+  let uu____949 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   { chunk = uu____934; stdin = uu____935; buffer = uu____942; log = uu____949
-  } 
-let rec (read_chunk : Prims.unit -> input_chunks) =
+  }
+let rec read_chunk: Prims.unit -> input_chunks =
   fun uu____1024  ->
-    let s = the_interactive_state  in
+    let s = the_interactive_state in
     let log1 =
-      let uu____1029 = FStar_Options.debug_any ()  in
+      let uu____1029 = FStar_Options.debug_any () in
       if uu____1029
       then
         let transcript =
-          let uu____1033 = FStar_ST.op_Bang s.log  in
+          let uu____1033 = FStar_ST.op_Bang s.log in
           match uu____1033 with
           | FStar_Pervasives_Native.Some transcript -> transcript
           | FStar_Pervasives_Native.None  ->
-              let transcript = FStar_Util.open_file_for_writing "transcript"
-                 in
+              let transcript = FStar_Util.open_file_for_writing "transcript" in
               (FStar_ST.op_Colon_Equals s.log
                  (FStar_Pervasives_Native.Some transcript);
-               transcript)
-           in
+               transcript) in
         fun line  ->
           (FStar_Util.append_to_file transcript line;
            FStar_Util.flush_file transcript)
-      else (fun uu____1088  -> ())  in
+      else (fun uu____1088  -> ()) in
     let stdin =
-      let uu____1090 = FStar_ST.op_Bang s.stdin  in
+      let uu____1090 = FStar_ST.op_Bang s.stdin in
       match uu____1090 with
       | FStar_Pervasives_Native.Some i -> i
       | FStar_Pervasives_Native.None  ->
-          let i = FStar_Util.open_stdin ()  in
+          let i = FStar_Util.open_stdin () in
           (FStar_ST.op_Colon_Equals s.stdin (FStar_Pervasives_Native.Some i);
-           i)
-       in
+           i) in
     let line =
-      let uu____1143 = FStar_Util.read_line stdin  in
+      let uu____1143 = FStar_Util.read_line stdin in
       match uu____1143 with
       | FStar_Pervasives_Native.None  -> FStar_All.exit (Prims.parse_int "0")
-      | FStar_Pervasives_Native.Some l -> l  in
+      | FStar_Pervasives_Native.Some l -> l in
     log1 line;
-    (let l = FStar_Util.trim_string line  in
+    (let l = FStar_Util.trim_string line in
      if FStar_Util.starts_with l "#end"
      then
        let responses =
          match FStar_Util.split l " " with
          | uu____1158::ok::fail1::[] -> (ok, fail1)
-         | uu____1161 -> ("ok", "fail")  in
-       let str = FStar_Util.string_of_string_builder s.chunk  in
+         | uu____1161 -> ("ok", "fail") in
+       let str = FStar_Util.string_of_string_builder s.chunk in
        (FStar_Util.clear_string_builder s.chunk; Code (str, responses))
      else
        if FStar_Util.starts_with l "#pop"
@@ -328,18 +310,17 @@ let rec (read_chunk : Prims.unit -> input_chunks) =
            (FStar_Util.clear_string_builder s.chunk;
             (let lc_lax =
                let uu____1175 =
-                 FStar_Util.substring_from l (FStar_String.length "#push")
-                  in
-               FStar_Util.trim_string uu____1175  in
+                 FStar_Util.substring_from l (FStar_String.length "#push") in
+               FStar_Util.trim_string uu____1175 in
              let lc =
                match FStar_Util.split lc_lax " " with
                | l1::c::"#lax"::[] ->
-                   let uu____1191 = FStar_Util.int_of_string l1  in
-                   let uu____1192 = FStar_Util.int_of_string c  in
+                   let uu____1191 = FStar_Util.int_of_string l1 in
+                   let uu____1192 = FStar_Util.int_of_string c in
                    (true, uu____1191, uu____1192)
                | l1::c::[] ->
-                   let uu____1195 = FStar_Util.int_of_string l1  in
-                   let uu____1196 = FStar_Util.int_of_string c  in
+                   let uu____1195 = FStar_Util.int_of_string l1 in
+                   let uu____1196 = FStar_Util.int_of_string c in
                    (false, uu____1195, uu____1196)
                | uu____1197 ->
                    (FStar_Errors.log_issue FStar_Range.dummyRange
@@ -347,8 +328,7 @@ let rec (read_chunk : Prims.unit -> input_chunks) =
                         (Prims.strcat
                            "Error locations may be wrong, unrecognized string after #push: "
                            lc_lax));
-                    (false, (Prims.parse_int "1"), (Prims.parse_int "0")))
-                in
+                    (false, (Prims.parse_int "1"), (Prims.parse_int "0"))) in
              Push lc))
          else
            if FStar_Util.starts_with l "#info "
@@ -362,11 +342,11 @@ let rec (read_chunk : Prims.unit -> input_chunks) =
                    (let uu____1225 =
                       let uu____1240 =
                         let uu____1249 =
-                          let uu____1256 = FStar_Util.int_of_string row  in
-                          let uu____1257 = FStar_Util.int_of_string col  in
-                          (file, uu____1256, uu____1257)  in
-                        FStar_Pervasives_Native.Some uu____1249  in
-                      (symbol, false, uu____1240)  in
+                          let uu____1256 = FStar_Util.int_of_string row in
+                          let uu____1257 = FStar_Util.int_of_string col in
+                          (file, uu____1256, uu____1257) in
+                        FStar_Pervasives_Native.Some uu____1249 in
+                      (symbol, false, uu____1240) in
                     Info uu____1225))
               | uu____1272 ->
                   (FStar_Errors.log_issue FStar_Range.dummyRange
@@ -393,65 +373,57 @@ let rec (read_chunk : Prims.unit -> input_chunks) =
                  (FStar_Util.string_builder_append s.chunk line;
                   FStar_Util.string_builder_append s.chunk "\n";
                   read_chunk ()))
-  
-let (shift_chunk : Prims.unit -> input_chunks) =
+let shift_chunk: Prims.unit -> input_chunks =
   fun uu____1290  ->
-    let s = the_interactive_state  in
-    let uu____1292 = FStar_ST.op_Bang s.buffer  in
+    let s = the_interactive_state in
+    let uu____1292 = FStar_ST.op_Bang s.buffer in
     match uu____1292 with
     | [] -> read_chunk ()
     | chunk::chunks -> (FStar_ST.op_Colon_Equals s.buffer chunks; chunk)
-  
-let (fill_buffer : Prims.unit -> Prims.unit) =
+let fill_buffer: Prims.unit -> Prims.unit =
   fun uu____1348  ->
-    let s = the_interactive_state  in
+    let s = the_interactive_state in
     let uu____1350 =
-      let uu____1353 = FStar_ST.op_Bang s.buffer  in
-      let uu____1379 = let uu____1382 = read_chunk ()  in [uu____1382]  in
-      FStar_List.append uu____1353 uu____1379  in
+      let uu____1353 = FStar_ST.op_Bang s.buffer in
+      let uu____1379 = let uu____1382 = read_chunk () in [uu____1382] in
+      FStar_List.append uu____1353 uu____1379 in
     FStar_ST.op_Colon_Equals s.buffer uu____1350
-  
-let (deps_of_our_file :
+let deps_of_our_file:
   Prims.string ->
     (Prims.string Prims.list,Prims.string FStar_Pervasives_Native.option,
-      FStar_Parser_Dep.deps) FStar_Pervasives_Native.tuple3)
+      FStar_Parser_Dep.deps) FStar_Pervasives_Native.tuple3
   =
   fun filename  ->
-    let uu____1419 = FStar_Dependencies.find_deps_if_needed [filename]  in
+    let uu____1419 = FStar_Dependencies.find_deps_if_needed [filename] in
     match uu____1419 with
     | (deps,dep_graph1) ->
         let uu____1442 =
           FStar_List.partition
             (fun x  ->
-               let uu____1455 = FStar_Parser_Dep.lowercase_module_name x  in
+               let uu____1455 = FStar_Parser_Dep.lowercase_module_name x in
                let uu____1456 =
-                 FStar_Parser_Dep.lowercase_module_name filename  in
-               uu____1455 <> uu____1456) deps
-           in
+                 FStar_Parser_Dep.lowercase_module_name filename in
+               uu____1455 <> uu____1456) deps in
         (match uu____1442 with
          | (deps1,same_name) ->
              let maybe_intf =
                match same_name with
                | intf::impl::[] ->
                    ((let uu____1485 =
-                       (let uu____1488 = FStar_Parser_Dep.is_interface intf
-                           in
+                       (let uu____1488 = FStar_Parser_Dep.is_interface intf in
                         Prims.op_Negation uu____1488) ||
                          (let uu____1490 =
-                            FStar_Parser_Dep.is_implementation impl  in
-                          Prims.op_Negation uu____1490)
-                        in
+                            FStar_Parser_Dep.is_implementation impl in
+                          Prims.op_Negation uu____1490) in
                      if uu____1485
                      then
                        let uu____1491 =
                          let uu____1496 =
                            FStar_Util.format2
                              "Found %s and %s but not an interface + implementation"
-                             intf impl
-                            in
+                             intf impl in
                          (FStar_Errors.Warning_MissingInterfaceOrImplementation,
-                           uu____1496)
-                          in
+                           uu____1496) in
                        FStar_Errors.log_issue FStar_Range.dummyRange
                          uu____1491
                      else ());
@@ -461,27 +433,24 @@ let (deps_of_our_file :
                    ((let uu____1503 =
                        let uu____1508 =
                          FStar_Util.format1 "Unexpected: ended up with %s"
-                           (FStar_String.concat " " same_name)
-                          in
-                       (FStar_Errors.Warning_UnexpectedFile, uu____1508)  in
+                           (FStar_String.concat " " same_name) in
+                       (FStar_Errors.Warning_UnexpectedFile, uu____1508) in
                      FStar_Errors.log_issue FStar_Range.dummyRange uu____1503);
-                    FStar_Pervasives_Native.None)
-                in
+                    FStar_Pervasives_Native.None) in
              (deps1, maybe_intf, dep_graph1))
-  
 type m_timestamps =
   (Prims.string FStar_Pervasives_Native.option,Prims.string,FStar_Util.time
                                                               FStar_Pervasives_Native.option,
     FStar_Util.time) FStar_Pervasives_Native.tuple4 Prims.list[@@deriving
                                                                 show]
-let rec (tc_deps :
+let rec tc_deps:
   modul_t ->
     stack_t ->
       FStar_TypeChecker_Env.env ->
         Prims.string Prims.list ->
           m_timestamps ->
             (stack_t,FStar_TypeChecker_Env.env,m_timestamps)
-              FStar_Pervasives_Native.tuple3)
+              FStar_Pervasives_Native.tuple3
   =
   fun m  ->
     fun stack  ->
@@ -491,11 +460,11 @@ let rec (tc_deps :
             match remaining with
             | [] -> (stack, env, ts)
             | uu____1558 ->
-                let stack1 = (env, m) :: stack  in
+                let stack1 = (env, m) :: stack in
                 let env1 =
-                  let uu____1573 = FStar_Options.lax ()  in
-                  push_with_kind env uu____1573 true "typecheck_modul"  in
-                let uu____1574 = tc_one_file remaining env1  in
+                  let uu____1573 = FStar_Options.lax () in
+                  push_with_kind env uu____1573 true "typecheck_modul" in
+                let uu____1574 = tc_one_file remaining env1 in
                 (match uu____1574 with
                  | ((intf,impl),env2,remaining1) ->
                      let uu____1613 =
@@ -504,29 +473,25 @@ let rec (tc_deps :
                          | FStar_Pervasives_Native.Some intf1 ->
                              let uu____1626 =
                                FStar_Parser_ParseIt.get_file_last_modification_time
-                                 intf1
-                                in
+                                 intf1 in
                              FStar_Pervasives_Native.Some uu____1626
                          | FStar_Pervasives_Native.None  ->
-                             FStar_Pervasives_Native.None
-                          in
+                             FStar_Pervasives_Native.None in
                        let impl_t =
                          FStar_Parser_ParseIt.get_file_last_modification_time
-                           impl
-                          in
-                       (intf_t, impl_t)  in
+                           impl in
+                       (intf_t, impl_t) in
                      (match uu____1613 with
                       | (intf_t,impl_t) ->
                           tc_deps m stack1 env2 remaining1
                             ((intf, impl, intf_t, impl_t) :: ts)))
-  
-let (update_deps :
+let update_deps:
   Prims.string ->
     modul_t ->
       stack_t ->
         env_t ->
           m_timestamps ->
-            (stack_t,env_t,m_timestamps) FStar_Pervasives_Native.tuple3)
+            (stack_t,env_t,m_timestamps) FStar_Pervasives_Native.tuple3
   =
   fun filename  ->
     fun m  ->
@@ -535,22 +500,20 @@ let (update_deps :
           fun ts  ->
             let is_stale intf impl intf_t impl_t =
               let impl_mt =
-                FStar_Parser_ParseIt.get_file_last_modification_time impl  in
+                FStar_Parser_ParseIt.get_file_last_modification_time impl in
               (FStar_Util.is_before impl_t impl_mt) ||
                 (match (intf, intf_t) with
                  | (FStar_Pervasives_Native.Some
                     intf1,FStar_Pervasives_Native.Some intf_t1) ->
                      let intf_mt =
                        FStar_Parser_ParseIt.get_file_last_modification_time
-                         intf1
-                        in
+                         intf1 in
                      FStar_Util.is_before intf_t1 intf_mt
                  | (FStar_Pervasives_Native.None
                     ,FStar_Pervasives_Native.None ) -> false
                  | (uu____1725,uu____1726) ->
                      failwith
-                       "Impossible, if the interface is None, the timestamp entry should also be None")
-               in
+                       "Impossible, if the interface is None, the timestamp entry should also be None") in
             let rec iterate depnames st env' ts1 good_stack good_ts =
               let match_dep depnames1 intf impl =
                 match intf with
@@ -567,82 +530,76 @@ let (update_deps :
                          if (depintf = intf1) && (dep1 = impl)
                          then (true, depnames')
                          else (false, depnames1)
-                     | uu____1849 -> (false, depnames1))
-                 in
+                     | uu____1849 -> (false, depnames1)) in
               let rec pop_tc_and_stack env1 stack ts2 =
                 match ts2 with
                 | [] -> env1
                 | uu____1916::ts3 ->
                     (pop env1 "";
                      (let uu____1957 =
-                        let uu____1972 = FStar_List.hd stack  in
-                        let uu____1981 = FStar_List.tl stack  in
-                        (uu____1972, uu____1981)  in
+                        let uu____1972 = FStar_List.hd stack in
+                        let uu____1981 = FStar_List.tl stack in
+                        (uu____1972, uu____1981) in
                       match uu____1957 with
                       | ((env2,uu____2003),stack1) ->
-                          pop_tc_and_stack env2 stack1 ts3))
-                 in
+                          pop_tc_and_stack env2 stack1 ts3)) in
               match ts1 with
               | ts_elt::ts' ->
-                  let uu____2067 = ts_elt  in
+                  let uu____2067 = ts_elt in
                   (match uu____2067 with
                    | (intf,impl,intf_t,impl_t) ->
-                       let uu____2098 = match_dep depnames intf impl  in
+                       let uu____2098 = match_dep depnames intf impl in
                        (match uu____2098 with
                         | (b,depnames') ->
                             let uu____2117 =
                               (Prims.op_Negation b) ||
-                                (is_stale intf impl intf_t impl_t)
-                               in
+                                (is_stale intf impl intf_t impl_t) in
                             if uu____2117
                             then
                               let env1 =
                                 pop_tc_and_stack env'
-                                  (FStar_List.rev_append st []) ts1
-                                 in
+                                  (FStar_List.rev_append st []) ts1 in
                               tc_deps m good_stack env1 depnames good_ts
                             else
                               (let uu____2134 =
-                                 let uu____2149 = FStar_List.hd st  in
-                                 let uu____2158 = FStar_List.tl st  in
-                                 (uu____2149, uu____2158)  in
+                                 let uu____2149 = FStar_List.hd st in
+                                 let uu____2158 = FStar_List.tl st in
+                                 (uu____2149, uu____2158) in
                                match uu____2134 with
                                | (stack_elt,st') ->
                                    iterate depnames' st' env' ts' (stack_elt
                                      :: good_stack) (ts_elt :: good_ts))))
-              | [] -> tc_deps m good_stack env' depnames good_ts  in
-            let uu____2235 = deps_of_our_file filename  in
+              | [] -> tc_deps m good_stack env' depnames good_ts in
+            let uu____2235 = deps_of_our_file filename in
             match uu____2235 with
             | (filenames,uu____2253,dep_graph1) ->
                 iterate filenames (FStar_List.rev_append stk []) env
                   (FStar_List.rev_append ts []) [] []
-  
-let (format_info :
+let format_info:
   FStar_TypeChecker_Env.env ->
     Prims.string ->
       FStar_Syntax_Syntax.term ->
         FStar_Range.range ->
-          Prims.string FStar_Pervasives_Native.option -> Prims.string)
+          Prims.string FStar_Pervasives_Native.option -> Prims.string
   =
   fun env  ->
     fun name  ->
       fun typ  ->
         fun range  ->
           fun doc1  ->
-            let uu____2330 = FStar_Range.string_of_range range  in
+            let uu____2330 = FStar_Range.string_of_range range in
             let uu____2331 =
-              FStar_TypeChecker_Normalize.term_to_string env typ  in
+              FStar_TypeChecker_Normalize.term_to_string env typ in
             let uu____2332 =
               match doc1 with
               | FStar_Pervasives_Native.Some docstring ->
                   FStar_Util.format1 "#doc %s" docstring
-              | FStar_Pervasives_Native.None  -> ""  in
+              | FStar_Pervasives_Native.None  -> "" in
             FStar_Util.format4 "(defined at %s) %s: %s%s" uu____2330 name
               uu____2331 uu____2332
-  
-let rec (go :
+let rec go:
   (Prims.int,Prims.int) FStar_Pervasives_Native.tuple2 ->
-    Prims.string -> stack_t -> modul_t -> env_t -> m_timestamps -> Prims.unit)
+    Prims.string -> stack_t -> modul_t -> env_t -> m_timestamps -> Prims.unit
   =
   fun line_col  ->
     fun filename  ->
@@ -650,7 +607,7 @@ let rec (go :
         fun curmod  ->
           fun env  ->
             fun ts  ->
-              let uu____2360 = shift_chunk ()  in
+              let uu____2360 = shift_chunk () in
               match uu____2360 with
               | Info (symbol,fqn_only,pos_opt) ->
                   let info_at_pos_opt =
@@ -658,8 +615,7 @@ let rec (go :
                     | FStar_Pervasives_Native.None  ->
                         FStar_Pervasives_Native.None
                     | FStar_Pervasives_Native.Some (file,row,col) ->
-                        FStar_TypeChecker_Err.info_at_pos env file row col
-                     in
+                        FStar_TypeChecker_Err.info_at_pos env file row col in
                   let info_opt =
                     match info_at_pos_opt with
                     | FStar_Pervasives_Native.Some uu____2455 ->
@@ -671,31 +627,26 @@ let rec (go :
                           (let lid =
                              let uu____2510 =
                                FStar_List.map FStar_Ident.id_of_text
-                                 (FStar_Util.split symbol ".")
-                                in
-                             FStar_Ident.lid_of_ids uu____2510  in
+                                 (FStar_Util.split symbol ".") in
+                             FStar_Ident.lid_of_ids uu____2510 in
                            let lid1 =
                              if fqn_only
                              then lid
                              else
                                (let uu____2515 =
                                   FStar_ToSyntax_Env.resolve_to_fully_qualified_name
-                                    env.FStar_TypeChecker_Env.dsenv lid
-                                   in
+                                    env.FStar_TypeChecker_Env.dsenv lid in
                                 match uu____2515 with
                                 | FStar_Pervasives_Native.None  -> lid
-                                | FStar_Pervasives_Native.Some lid1 -> lid1)
-                              in
+                                | FStar_Pervasives_Native.Some lid1 -> lid1) in
                            let uu____2519 =
-                             FStar_TypeChecker_Env.try_lookup_lid env lid1
-                              in
+                             FStar_TypeChecker_Env.try_lookup_lid env lid1 in
                            FStar_All.pipe_right uu____2519
                              (FStar_Util.map_option
                                 (fun uu____2574  ->
                                    match uu____2574 with
                                    | ((uu____2593,typ),r) ->
-                                       ((FStar_Util.Inr lid1), typ, r))))
-                     in
+                                       ((FStar_Util.Inr lid1), typ, r)))) in
                   ((match info_opt with
                     | FStar_Pervasives_Native.None  ->
                         FStar_Util.print_string "\n#done-nok\n"
@@ -705,23 +656,19 @@ let rec (go :
                           | FStar_Util.Inl name ->
                               (name, FStar_Pervasives_Native.None)
                           | FStar_Util.Inr lid ->
-                              let uu____2653 = FStar_Ident.string_of_lid lid
-                                 in
+                              let uu____2653 = FStar_Ident.string_of_lid lid in
                               let uu____2654 =
                                 let uu____2657 =
                                   FStar_ToSyntax_Env.try_lookup_doc
-                                    env.FStar_TypeChecker_Env.dsenv lid
-                                   in
+                                    env.FStar_TypeChecker_Env.dsenv lid in
                                 FStar_All.pipe_right uu____2657
                                   (FStar_Util.map_option
-                                     FStar_Pervasives_Native.fst)
-                                 in
-                              (uu____2653, uu____2654)
-                           in
+                                     FStar_Pervasives_Native.fst) in
+                              (uu____2653, uu____2654) in
                         (match uu____2636 with
                          | (name,doc1) ->
                              let uu____2688 =
-                               format_info env name typ rng doc1  in
+                               format_info env name typ rng doc1 in
                              FStar_Util.print1 "%s\n#done-ok\n" uu____2688));
                    go line_col filename stack curmod env ts)
               | Completions search_term ->
@@ -732,7 +679,7 @@ let rec (go :
                           ([], (Prims.parse_int "0"))
                     | (uu____2740,[]) -> FStar_Pervasives_Native.None
                     | (hs::ts1,hc::tc1) ->
-                        let hc_text = FStar_Ident.text_of_id hc  in
+                        let hc_text = FStar_Ident.text_of_id hc in
                         if FStar_Util.starts_with hc_text hs
                         then
                           (match ts1 with
@@ -741,7 +688,7 @@ let rec (go :
                                  (candidate, (FStar_String.length hs))
                            | uu____2790 ->
                                let uu____2793 =
-                                 measure_anchored_match ts1 tc1  in
+                                 measure_anchored_match ts1 tc1 in
                                FStar_All.pipe_right uu____2793
                                  (FStar_Util.map_option
                                     (fun uu____2833  ->
@@ -751,11 +698,9 @@ let rec (go :
                                              (((FStar_String.length hc_text)
                                                  + (Prims.parse_int "1"))
                                                 + len)))))
-                        else FStar_Pervasives_Native.None
-                     in
+                        else FStar_Pervasives_Native.None in
                   let rec locate_match needle candidate =
-                    let uu____2888 = measure_anchored_match needle candidate
-                       in
+                    let uu____2888 = measure_anchored_match needle candidate in
                     match uu____2888 with
                     | FStar_Pervasives_Native.Some (matched,n1) ->
                         FStar_Pervasives_Native.Some ([], matched, n1)
@@ -763,42 +708,38 @@ let rec (go :
                         (match candidate with
                          | [] -> FStar_Pervasives_Native.None
                          | hc::tc1 ->
-                             let uu____2967 = locate_match needle tc1  in
+                             let uu____2967 = locate_match needle tc1 in
                              FStar_All.pipe_right uu____2967
                                (FStar_Util.map_option
                                   (fun uu____3028  ->
                                      match uu____3028 with
                                      | (prefix1,matched,len) ->
-                                         ((hc :: prefix1), matched, len))))
-                     in
+                                         ((hc :: prefix1), matched, len)))) in
                   let str_of_ids ids =
                     let uu____3072 =
-                      FStar_List.map FStar_Ident.text_of_id ids  in
-                    FStar_Util.concat_l "." uu____3072  in
+                      FStar_List.map FStar_Ident.text_of_id ids in
+                    FStar_Util.concat_l "." uu____3072 in
                   let match_lident_against needle lident =
                     locate_match needle
                       (FStar_List.append lident.FStar_Ident.ns
-                         [lident.FStar_Ident.ident])
-                     in
+                         [lident.FStar_Ident.ident]) in
                   let shorten_namespace uu____3119 =
                     match uu____3119 with
                     | (prefix1,matched,match_len) ->
                         let naked_match =
                           match matched with
                           | uu____3150::[] -> true
-                          | uu____3151 -> false  in
+                          | uu____3151 -> false in
                         let uu____3154 =
                           FStar_ToSyntax_Env.shorten_module_path
                             env.FStar_TypeChecker_Env.dsenv prefix1
-                            naked_match
-                           in
+                            naked_match in
                         (match uu____3154 with
                          | (stripped_ns,shortened) ->
-                             let uu____3181 = str_of_ids shortened  in
-                             let uu____3182 = str_of_ids matched  in
-                             let uu____3183 = str_of_ids stripped_ns  in
-                             (uu____3181, uu____3182, uu____3183, match_len))
-                     in
+                             let uu____3181 = str_of_ids shortened in
+                             let uu____3182 = str_of_ids matched in
+                             let uu____3183 = str_of_ids stripped_ns in
+                             (uu____3181, uu____3182, uu____3183, match_len)) in
                   let prepare_candidate uu____3201 =
                     match uu____3201 with
                     | (prefix1,matched,stripped_ns,match_len) ->
@@ -808,25 +749,21 @@ let rec (go :
                           ((Prims.strcat prefix1 (Prims.strcat "." matched)),
                             stripped_ns,
                             (((FStar_String.length prefix1) + match_len) +
-                               (Prims.parse_int "1")))
-                     in
-                  let needle = FStar_Util.split search_term "."  in
-                  let all_lidents_in_env = FStar_TypeChecker_Env.lidents env
-                     in
+                               (Prims.parse_int "1"))) in
+                  let needle = FStar_Util.split search_term "." in
+                  let all_lidents_in_env = FStar_TypeChecker_Env.lidents env in
                   let matches =
                     let case_a_find_transitive_includes orig_ns m id1 =
                       let exported_names =
                         FStar_ToSyntax_Env.transitive_exported_ids
-                          env.FStar_TypeChecker_Env.dsenv m
-                         in
+                          env.FStar_TypeChecker_Env.dsenv m in
                       let matched_length =
                         FStar_List.fold_left
                           (fun out  ->
                              fun s  ->
                                ((FStar_String.length s) + out) +
                                  (Prims.parse_int "1"))
-                          (FStar_String.length id1) orig_ns
-                         in
+                          (FStar_String.length id1) orig_ns in
                       FStar_All.pipe_right exported_names
                         (FStar_List.filter_map
                            (fun n1  ->
@@ -835,31 +772,25 @@ let rec (go :
                                 let lid =
                                   FStar_Ident.lid_of_ns_and_id
                                     (FStar_Ident.ids_of_lid m)
-                                    (FStar_Ident.id_of_text n1)
-                                   in
+                                    (FStar_Ident.id_of_text n1) in
                                 let uu____3329 =
                                   FStar_ToSyntax_Env.resolve_to_fully_qualified_name
-                                    env.FStar_TypeChecker_Env.dsenv lid
-                                   in
+                                    env.FStar_TypeChecker_Env.dsenv lid in
                                 FStar_Option.map
                                   (fun fqn  ->
                                      let uu____3345 =
                                        let uu____3348 =
                                          FStar_List.map
-                                           FStar_Ident.id_of_text orig_ns
-                                          in
+                                           FStar_Ident.id_of_text orig_ns in
                                        FStar_List.append uu____3348
-                                         [fqn.FStar_Ident.ident]
-                                        in
+                                         [fqn.FStar_Ident.ident] in
                                      ([], uu____3345, matched_length))
                                   uu____3329
-                              else FStar_Pervasives_Native.None))
-                       in
+                              else FStar_Pervasives_Native.None)) in
                     let case_b_find_matches_in_env uu____3381 =
                       let matches =
                         FStar_List.filter_map (match_lident_against needle)
-                          all_lidents_in_env
-                         in
+                          all_lidents_in_env in
                       FStar_All.pipe_right matches
                         (FStar_List.filter
                            (fun uu____3456  ->
@@ -867,21 +798,18 @@ let rec (go :
                               | (ns,id1,uu____3469) ->
                                   let uu____3478 =
                                     let uu____3481 =
-                                      FStar_Ident.lid_of_ids id1  in
+                                      FStar_Ident.lid_of_ids id1 in
                                     FStar_ToSyntax_Env.resolve_to_fully_qualified_name
                                       env.FStar_TypeChecker_Env.dsenv
-                                      uu____3481
-                                     in
+                                      uu____3481 in
                                   (match uu____3478 with
                                    | FStar_Pervasives_Native.None  -> false
                                    | FStar_Pervasives_Native.Some l ->
                                        let uu____3483 =
                                          FStar_Ident.lid_of_ids
-                                           (FStar_List.append ns id1)
-                                          in
-                                       FStar_Ident.lid_equals l uu____3483)))
-                       in
-                    let uu____3484 = FStar_Util.prefix needle  in
+                                           (FStar_List.append ns id1) in
+                                       FStar_Ident.lid_equals l uu____3483))) in
+                    let uu____3484 = FStar_Util.prefix needle in
                     match uu____3484 with
                     | (ns,id1) ->
                         let matched_ids =
@@ -890,24 +818,20 @@ let rec (go :
                           | uu____3530 ->
                               let l =
                                 FStar_Ident.lid_of_path ns
-                                  FStar_Range.dummyRange
-                                 in
+                                  FStar_Range.dummyRange in
                               let uu____3534 =
                                 FStar_ToSyntax_Env.resolve_module_name
-                                  env.FStar_TypeChecker_Env.dsenv l true
-                                 in
+                                  env.FStar_TypeChecker_Env.dsenv l true in
                               (match uu____3534 with
                                | FStar_Pervasives_Native.None  ->
                                    case_b_find_matches_in_env ()
                                | FStar_Pervasives_Native.Some m ->
-                                   case_a_find_transitive_includes ns m id1)
-                           in
+                                   case_a_find_transitive_includes ns m id1) in
                         FStar_All.pipe_right matched_ids
                           (FStar_List.map
                              (fun x  ->
-                                let uu____3599 = shorten_namespace x  in
-                                prepare_candidate uu____3599))
-                     in
+                                let uu____3599 = shorten_namespace x in
+                                prepare_candidate uu____3599)) in
                   ((let uu____3609 =
                       FStar_Util.sort_with
                         (fun uu____3632  ->
@@ -917,14 +841,13 @@ let rec (go :
                                  (match FStar_String.compare cd1 cd2 with
                                   | _0_40 when _0_40 = (Prims.parse_int "0")
                                       -> FStar_String.compare ns1 ns2
-                                  | n1 -> n1)) matches
-                       in
+                                  | n1 -> n1)) matches in
                     FStar_List.iter
                       (fun uu____3688  ->
                          match uu____3688 with
                          | (candidate,ns,match_len) ->
                              let uu____3698 =
-                               FStar_Util.string_of_int match_len  in
+                               FStar_Util.string_of_int match_len in
                              FStar_Util.print3 "%s %s %s \n" uu____3698 ns
                                candidate) uu____3609);
                    FStar_Util.print_string "#done-ok\n";
@@ -938,7 +861,7 @@ let rec (go :
                              (FStar_Errors.Error_IDETooManyPops,
                                "too many pops");
                            FStar_All.exit (Prims.parse_int "1"))
-                      | hd1::tl1 -> (hd1, tl1)  in
+                      | hd1::tl1 -> (hd1, tl1) in
                     match uu____3702 with
                     | ((env1,curmod1),stack1) ->
                         go line_col filename stack1 curmod1 env1 ts))
@@ -947,22 +870,21 @@ let rec (go :
                     if (FStar_List.length stack) = (FStar_List.length ts)
                     then
                       let uu____3835 =
-                        update_deps filename curmod stack env ts  in
+                        update_deps filename curmod stack env ts in
                       (true, uu____3835)
-                    else (false, (stack, env, ts))  in
+                    else (false, (stack, env, ts)) in
                   (match uu____3798 with
                    | (restore_cmd_line_options1,(stack1,env1,ts1)) ->
-                       let stack2 = (env1, curmod) :: stack1  in
+                       let stack2 = (env1, curmod) :: stack1 in
                        let env2 =
                          push_with_kind env1 lax1 restore_cmd_line_options1
-                           "#push"
-                          in
+                           "#push" in
                        go (l, c) filename stack2 curmod env2 ts1)
               | Code (text,(ok,fail1)) ->
                   let fail2 curmod1 tcenv =
                     report_fail ();
                     FStar_Util.print1 "%s\n" fail1;
-                    go line_col filename stack curmod1 tcenv ts  in
+                    go line_col filename stack curmod1 tcenv ts in
                   let frag =
                     {
                       FStar_Parser_ParseIt.frag_text = text;
@@ -970,8 +892,8 @@ let rec (go :
                         (FStar_Pervasives_Native.fst line_col);
                       FStar_Parser_ParseIt.frag_col =
                         (FStar_Pervasives_Native.snd line_col)
-                    }  in
-                  let res = check_frag env curmod frag  in
+                    } in
+                  let res = check_frag env curmod frag in
                   (match res with
                    | FStar_Pervasives_Native.Some (curmod1,env1,n_errs) ->
                        if n_errs = (Prims.parse_int "0")
@@ -980,52 +902,47 @@ let rec (go :
                           go line_col filename stack curmod1 env1 ts)
                        else fail2 curmod1 env1
                    | uu____3922 -> fail2 curmod env)
-  
-let (interactive_mode : Prims.string -> Prims.unit) =
+let interactive_mode: Prims.string -> Prims.unit =
   fun filename  ->
     (let uu____3937 =
-       let uu____3938 = FStar_Options.codegen ()  in
-       FStar_Option.isSome uu____3938  in
+       let uu____3938 = FStar_Options.codegen () in
+       FStar_Option.isSome uu____3938 in
      if uu____3937
      then
        FStar_Errors.log_issue FStar_Range.dummyRange
          (FStar_Errors.Warning_IDEIgnoreCodeGen,
            "code-generation is not supported in interactive mode, ignoring the codegen flag")
      else ());
-    (let uu____3942 = deps_of_our_file filename  in
+    (let uu____3942 = deps_of_our_file filename in
      match uu____3942 with
      | (filenames,maybe_intf,dep_graph1) ->
-         let env = FStar_Universal.init_env dep_graph1  in
+         let env = FStar_Universal.init_env dep_graph1 in
          let uu____3965 =
-           tc_deps FStar_Pervasives_Native.None [] env filenames []  in
+           tc_deps FStar_Pervasives_Native.None [] env filenames [] in
          (match uu____3965 with
           | (stack,env1,ts) ->
               let initial_range =
                 let uu____3992 =
                   FStar_Range.mk_pos (Prims.parse_int "1")
-                    (Prims.parse_int "0")
-                   in
+                    (Prims.parse_int "0") in
                 let uu____3993 =
                   FStar_Range.mk_pos (Prims.parse_int "1")
-                    (Prims.parse_int "0")
-                   in
-                FStar_Range.mk_range "<input>" uu____3992 uu____3993  in
-              let env2 = FStar_TypeChecker_Env.set_range env1 initial_range
-                 in
+                    (Prims.parse_int "0") in
+                FStar_Range.mk_range "<input>" uu____3992 uu____3993 in
+              let env2 = FStar_TypeChecker_Env.set_range env1 initial_range in
               let env3 =
                 match maybe_intf with
                 | FStar_Pervasives_Native.Some intf ->
                     FStar_Universal.load_interface_decls env2 intf
-                | FStar_Pervasives_Native.None  -> env2  in
+                | FStar_Pervasives_Native.None  -> env2 in
               let uu____3997 =
                 (FStar_Options.record_hints ()) ||
-                  (FStar_Options.use_hints ())
-                 in
+                  (FStar_Options.use_hints ()) in
               if uu____3997
               then
                 let uu____3998 =
-                  let uu____3999 = FStar_Options.file_list ()  in
-                  FStar_List.hd uu____3999  in
+                  let uu____3999 = FStar_Options.file_list () in
+                  FStar_List.hd uu____3999 in
                 FStar_SMTEncoding_Solver.with_hints_db uu____3998 false
                   (fun uu____4003  ->
                      go ((Prims.parse_int "1"), (Prims.parse_int "0"))
@@ -1033,4 +950,3 @@ let (interactive_mode : Prims.string -> Prims.unit) =
               else
                 go ((Prims.parse_int "1"), (Prims.parse_int "0")) filename
                   stack FStar_Pervasives_Native.None env3 ts))
-  

--- a/src/ocaml-output/FStar_Main.ml
+++ b/src/ocaml-output/FStar_Main.ml
@@ -1,25 +1,24 @@
 open Prims
-let (uu___75 : Prims.unit) = FStar_Version.dummy () 
-let (process_args :
+let uu___75: Prims.unit = FStar_Version.dummy ()
+let process_args:
   Prims.unit ->
     (FStar_Getopt.parse_cmdline_res,Prims.string Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun uu____9  -> FStar_Options.parse_cmd_line () 
-let (cleanup : Prims.unit -> Prims.unit) =
-  fun uu____18  -> FStar_Util.kill_all () 
-let (finished_message :
+      FStar_Pervasives_Native.tuple2
+  = fun uu____9  -> FStar_Options.parse_cmd_line ()
+let cleanup: Prims.unit -> Prims.unit =
+  fun uu____18  -> FStar_Util.kill_all ()
+let finished_message:
   ((Prims.bool,FStar_Ident.lident) FStar_Pervasives_Native.tuple2,Prims.int)
-    FStar_Pervasives_Native.tuple2 Prims.list -> Prims.int -> Prims.unit)
+    FStar_Pervasives_Native.tuple2 Prims.list -> Prims.int -> Prims.unit
   =
   fun fmods  ->
     fun errs  ->
       let print_to =
         if errs > (Prims.parse_int "0")
         then FStar_Util.print_error
-        else FStar_Util.print_string  in
+        else FStar_Util.print_string in
       let uu____51 =
-        let uu____52 = FStar_Options.silent ()  in Prims.op_Negation uu____52
-         in
+        let uu____52 = FStar_Options.silent () in Prims.op_Negation uu____52 in
       if uu____51
       then
         (FStar_All.pipe_right fmods
@@ -28,28 +27,24 @@ let (finished_message :
                  match uu____79 with
                  | ((iface1,name),time) ->
                      let tag =
-                       if iface1 then "i'face (or impl+i'face)" else "module"
-                        in
+                       if iface1 then "i'face (or impl+i'face)" else "module" in
                      let uu____97 =
                        FStar_Options.should_print_message
-                         name.FStar_Ident.str
-                        in
+                         name.FStar_Ident.str in
                      if uu____97
                      then
                        (if time >= (Prims.parse_int "0")
                         then
                           let uu____98 =
-                            let uu____99 = FStar_Util.string_of_int time  in
+                            let uu____99 = FStar_Util.string_of_int time in
                             FStar_Util.format3
                               "Verified %s: %s (%s milliseconds)\n" tag
-                              (FStar_Ident.text_of_lid name) uu____99
-                             in
+                              (FStar_Ident.text_of_lid name) uu____99 in
                           print_to uu____98
                         else
                           (let uu____101 =
                              FStar_Util.format2 "Verified %s: %s\n" tag
-                               (FStar_Ident.text_of_lid name)
-                              in
+                               (FStar_Ident.text_of_lid name) in
                            print_to uu____101))
                      else ()));
          if errs > (Prims.parse_int "0")
@@ -57,93 +52,85 @@ let (finished_message :
            (if errs = (Prims.parse_int "1")
             then FStar_Util.print_error "1 error was reported (see above)\n"
             else
-              (let uu____104 = FStar_Util.string_of_int errs  in
+              (let uu____104 = FStar_Util.string_of_int errs in
                FStar_Util.print1_error
                  "%s errors were reported (see above)\n" uu____104))
          else
            (let uu____106 =
               FStar_Util.colorize_bold
-                "All verification conditions discharged successfully"
-               in
+                "All verification conditions discharged successfully" in
             FStar_Util.print1 "%s\n" uu____106))
       else ()
-  
-let (report_errors :
+let report_errors:
   ((Prims.bool,FStar_Ident.lident) FStar_Pervasives_Native.tuple2,Prims.int)
-    FStar_Pervasives_Native.tuple2 Prims.list -> Prims.unit)
+    FStar_Pervasives_Native.tuple2 Prims.list -> Prims.unit
   =
   fun fmods  ->
-    (let uu____132 = FStar_Errors.report_all ()  in
+    (let uu____132 = FStar_Errors.report_all () in
      FStar_All.pipe_right uu____132 FStar_Pervasives.ignore);
-    (let nerrs = FStar_Errors.get_err_count ()  in
+    (let nerrs = FStar_Errors.get_err_count () in
      if nerrs > (Prims.parse_int "0")
      then
        (finished_message fmods nerrs; FStar_All.exit (Prims.parse_int "1"))
      else ())
-  
-let (codegen :
+let codegen:
   (FStar_Syntax_Syntax.modul Prims.list,FStar_TypeChecker_Env.env)
-    FStar_Pervasives_Native.tuple2 -> Prims.unit)
+    FStar_Pervasives_Native.tuple2 -> Prims.unit
   =
   fun uu____150  ->
     match uu____150 with
     | (umods,env) ->
-        let opt = FStar_Options.codegen ()  in
+        let opt = FStar_Options.codegen () in
         if opt <> FStar_Pervasives_Native.None
         then
           let mllibs =
             let uu____173 =
-              let uu____182 = FStar_Extraction_ML_UEnv.mkContext env  in
+              let uu____182 = FStar_Extraction_ML_UEnv.mkContext env in
               FStar_Util.fold_map FStar_Extraction_ML_Modul.extract uu____182
-                umods
-               in
-            FStar_All.pipe_left FStar_Pervasives_Native.snd uu____173  in
-          let mllibs1 = FStar_List.flatten mllibs  in
+                umods in
+            FStar_All.pipe_left FStar_Pervasives_Native.snd uu____173 in
+          let mllibs1 = FStar_List.flatten mllibs in
           let ext =
             match opt with
             | FStar_Pervasives_Native.Some "FSharp" -> ".fs"
             | FStar_Pervasives_Native.Some "OCaml" -> ".ml"
             | FStar_Pervasives_Native.Some "tactics" -> ".ml"
             | FStar_Pervasives_Native.Some "Kremlin" -> ".krml"
-            | uu____205 -> failwith "Unrecognized option"  in
+            | uu____205 -> failwith "Unrecognized option" in
           (match opt with
            | FStar_Pervasives_Native.Some "FSharp" ->
-               let outdir = FStar_Options.output_dir ()  in
+               let outdir = FStar_Options.output_dir () in
                FStar_List.iter (FStar_Extraction_ML_PrintML.print outdir ext)
                  mllibs1
            | FStar_Pervasives_Native.Some "OCaml" ->
-               let outdir = FStar_Options.output_dir ()  in
+               let outdir = FStar_Options.output_dir () in
                FStar_List.iter (FStar_Extraction_ML_PrintML.print outdir ext)
                  mllibs1
            | FStar_Pervasives_Native.Some "tactics" ->
-               let outdir = FStar_Options.output_dir ()  in
+               let outdir = FStar_Options.output_dir () in
                FStar_List.iter (FStar_Extraction_ML_PrintML.print outdir ext)
                  mllibs1
            | FStar_Pervasives_Native.Some "Kremlin" ->
                let programs =
                  let uu____220 =
-                   FStar_List.map FStar_Extraction_Kremlin.translate mllibs1
-                    in
-                 FStar_List.flatten uu____220  in
-               let bin = (FStar_Extraction_Kremlin.current_version, programs)
-                  in
+                   FStar_List.map FStar_Extraction_Kremlin.translate mllibs1 in
+                 FStar_List.flatten uu____220 in
+               let bin = (FStar_Extraction_Kremlin.current_version, programs) in
                (match programs with
                 | (name,uu____231)::[] ->
                     let uu____240 =
                       FStar_Options.prepend_output_dir
-                        (Prims.strcat name ".krml")
-                       in
+                        (Prims.strcat name ".krml") in
                     FStar_Util.save_value_to_file uu____240 bin
                 | uu____241 ->
                     let uu____244 =
-                      FStar_Options.prepend_output_dir "out.krml"  in
+                      FStar_Options.prepend_output_dir "out.krml" in
                     FStar_Util.save_value_to_file uu____244 bin)
            | uu____245 -> failwith "Unrecognized option")
         else ()
-  
-let (gen_native_tactics :
+let gen_native_tactics:
   (FStar_Syntax_Syntax.modul Prims.list,FStar_TypeChecker_Env.env)
-    FStar_Pervasives_Native.tuple2 -> Prims.string -> Prims.unit)
+    FStar_Pervasives_Native.tuple2 -> Prims.string -> Prims.unit
   =
   fun uu____259  ->
     fun out_dir  ->
@@ -153,39 +140,34 @@ let (gen_native_tactics :
              (FStar_Options.String "tactics");
            (let mllibs =
               let uu____279 =
-                let uu____288 = FStar_Extraction_ML_UEnv.mkContext env  in
+                let uu____288 = FStar_Extraction_ML_UEnv.mkContext env in
                 FStar_Util.fold_map FStar_Extraction_ML_Modul.extract
-                  uu____288 umods
-                 in
-              FStar_All.pipe_left FStar_Pervasives_Native.snd uu____279  in
-            let mllibs1 = FStar_List.flatten mllibs  in
+                  uu____288 umods in
+              FStar_All.pipe_left FStar_Pervasives_Native.snd uu____279 in
+            let mllibs1 = FStar_List.flatten mllibs in
             FStar_List.iter
               (FStar_Extraction_ML_PrintML.print
                  (FStar_Pervasives_Native.Some out_dir) ".ml") mllibs1;
-            (let user_tactics_modules1 = FStar_Universal.user_tactics_modules
-                in
-             let uu____316 = FStar_ST.op_Bang user_tactics_modules1  in
+            (let user_tactics_modules1 = FStar_Universal.user_tactics_modules in
+             let uu____316 = FStar_ST.op_Bang user_tactics_modules1 in
              FStar_Tactics_Load.compile_modules out_dir uu____316)))
-  
-let (init_native_tactics : Prims.unit -> Prims.unit) =
+let init_native_tactics: Prims.unit -> Prims.unit =
   fun uu____366  ->
-    (let uu____368 = FStar_Options.load ()  in
+    (let uu____368 = FStar_Options.load () in
      FStar_Tactics_Load.load_tactics uu____368);
-    (let uu____371 = FStar_Options.use_native_tactics ()  in
+    (let uu____371 = FStar_Options.use_native_tactics () in
      match uu____371 with
      | FStar_Pervasives_Native.Some dir ->
          (FStar_Util.print1 "Using native tactics from %s\n" dir;
           FStar_Tactics_Load.load_tactics_dir dir)
      | FStar_Pervasives_Native.None  -> ())
-  
-let (init_warn_error : Prims.unit -> Prims.unit) =
+let init_warn_error: Prims.unit -> Prims.unit =
   fun uu____378  ->
-    let s = FStar_Options.warn_error ()  in
+    let s = FStar_Options.warn_error () in
     if s <> "" then FStar_Parser_ParseIt.parse_warn_error s else ()
-  
-let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
+let go: 'Auu____384 . 'Auu____384 -> Prims.unit =
   fun uu____388  ->
-    let uu____389 = process_args ()  in
+    let uu____389 = process_args () in
     match uu____389 with
     | (res,filenames) ->
         (match res with
@@ -199,11 +181,11 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
              (init_native_tactics ();
               init_warn_error ();
               (let uu____407 =
-                 let uu____408 = FStar_Options.dep ()  in
-                 uu____408 <> FStar_Pervasives_Native.None  in
+                 let uu____408 = FStar_Options.dep () in
+                 uu____408 <> FStar_Pervasives_Native.None in
                if uu____407
                then
-                 let uu____413 = FStar_Parser_Dep.collect filenames  in
+                 let uu____413 = FStar_Parser_Dep.collect filenames in
                  match uu____413 with
                  | (uu____420,deps) -> FStar_Parser_Dep.print deps
                else
@@ -211,8 +193,7 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                     ((FStar_Options.use_extracted_interfaces ()) ||
                        (FStar_Options.check_interface ()))
                       &&
-                      ((FStar_List.length filenames) > (Prims.parse_int "1"))
-                     in
+                      ((FStar_List.length filenames) > (Prims.parse_int "1")) in
                   if uu____427
                   then
                     FStar_Errors.raise_error
@@ -220,7 +201,7 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                         "Only one command line file is allowed if either --check_interface or --use_extracted_interfaces is set")
                       FStar_Range.dummyRange
                   else
-                    (let uu____429 = FStar_Options.interactive ()  in
+                    (let uu____429 = FStar_Options.interactive () in
                      if uu____429
                      then
                        match filenames with
@@ -235,8 +216,7 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                                 "--ide: Too many files in command line invocation\n");
                             FStar_All.exit (Prims.parse_int "1"))
                        | filename::[] ->
-                           let uu____438 = FStar_Options.check_interface ()
-                              in
+                           let uu____438 = FStar_Options.check_interface () in
                            (if uu____438
                             then
                               (FStar_Errors.log_issue FStar_Range.dummyRange
@@ -245,7 +225,7 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                                FStar_All.exit (Prims.parse_int "1"))
                             else
                               (let uu____441 =
-                                 FStar_Options.legacy_interactive ()  in
+                                 FStar_Options.legacy_interactive () in
                                if uu____441
                                then
                                  FStar_Interactive_Legacy.interactive_mode
@@ -254,11 +234,11 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                                  FStar_Interactive_Ide.interactive_mode
                                    filename))
                      else
-                       (let uu____444 = FStar_Options.doc ()  in
+                       (let uu____444 = FStar_Options.doc () in
                         if uu____444
                         then FStar_Fsdoc_Generator.generate filenames
                         else
-                          (let uu____446 = FStar_Options.indent ()  in
+                          (let uu____446 = FStar_Options.indent () in
                            if uu____446
                            then
                              (if FStar_Platform.is_fstar_compiler_using_ocaml
@@ -273,13 +253,11 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                              then
                                (let uu____449 =
                                   FStar_Dependencies.find_deps_if_needed
-                                    filenames
-                                   in
+                                    filenames in
                                 match uu____449 with
                                 | (filenames1,dep_graph1) ->
                                     ((let uu____463 =
-                                        FStar_Options.gen_native_tactics ()
-                                         in
+                                        FStar_Options.gen_native_tactics () in
                                       match uu____463 with
                                       | FStar_Pervasives_Native.Some dir ->
                                           (FStar_Util.print1
@@ -290,8 +268,7 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                                       | FStar_Pervasives_Native.None  -> ());
                                      (let uu____468 =
                                         FStar_Universal.batch_mode_tc
-                                          filenames1 dep_graph1
-                                         in
+                                          filenames1 dep_graph1 in
                                       match uu____468 with
                                       | (fmods,env) ->
                                           let module_names_and_times =
@@ -301,24 +278,21 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                                                     match uu____535 with
                                                     | (x,t) ->
                                                         ((FStar_Universal.module_or_interface_name
-                                                            x), t)))
-                                             in
+                                                            x), t))) in
                                           (report_errors
                                              module_names_and_times;
                                            (let uu____556 =
                                               let uu____563 =
                                                 FStar_All.pipe_right fmods
                                                   (FStar_List.map
-                                                     FStar_Pervasives_Native.fst)
-                                                 in
-                                              (uu____563, env)  in
+                                                     FStar_Pervasives_Native.fst) in
+                                              (uu____563, env) in
                                             codegen uu____556);
                                            report_errors
                                              module_names_and_times;
                                            (let uu____582 =
                                               FStar_Options.gen_native_tactics
-                                                ()
-                                               in
+                                                () in
                                             match uu____582 with
                                             | FStar_Pervasives_Native.Some
                                                 dir ->
@@ -327,9 +301,8 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                                                     FStar_All.pipe_right
                                                       fmods
                                                       (FStar_List.map
-                                                         FStar_Pervasives_Native.fst)
-                                                     in
-                                                  (uu____593, env)  in
+                                                         FStar_Pervasives_Native.fst) in
+                                                  (uu____593, env) in
                                                 gen_native_tactics uu____586
                                                   dir
                                             | FStar_Pervasives_Native.None 
@@ -343,38 +316,37 @@ let go : 'Auu____384 . 'Auu____384 -> Prims.unit =
                                FStar_Errors.log_issue FStar_Range.dummyRange
                                  (FStar_Errors.Error_MissingFileName,
                                    "no file provided\n"))))))))
-  
-let main : 'Auu____614 . Prims.unit -> 'Auu____614 =
+let main: 'Auu____614 . Prims.unit -> 'Auu____614 =
   fun uu____618  ->
     try
-      let uu____626 = FStar_Util.record_time go  in
+      let uu____626 = FStar_Util.record_time go in
       match uu____626 with
       | (uu____631,time) ->
-          ((let uu____634 = FStar_Options.query_stats ()  in
+          ((let uu____634 = FStar_Options.query_stats () in
             if uu____634
             then
-              let uu____635 = FStar_Util.string_of_int time  in
+              let uu____635 = FStar_Util.string_of_int time in
               let uu____636 =
-                let uu____637 = FStar_Getopt.cmdline ()  in
-                FStar_String.concat " " uu____637  in
+                let uu____637 = FStar_Getopt.cmdline () in
+                FStar_String.concat " " uu____637 in
               FStar_Util.print2 "TOTAL TIME %s ms: %s\n" uu____635 uu____636
             else ());
            cleanup ();
            FStar_All.exit (Prims.parse_int "0"))
     with
     | e ->
-        let trace = FStar_Util.trace_of_exn e  in
+        let trace = FStar_Util.trace_of_exn e in
         (if FStar_Errors.handleable e then FStar_Errors.err_exn e else ();
-         (let uu____654 = FStar_Options.trace_error ()  in
+         (let uu____654 = FStar_Options.trace_error () in
           if uu____654
           then
-            let uu____655 = FStar_Util.message_of_exn e  in
+            let uu____655 = FStar_Util.message_of_exn e in
             FStar_Util.print2_error "Unexpected error\n%s\n%s\n" uu____655
               trace
           else
             if Prims.op_Negation (FStar_Errors.handleable e)
             then
-              (let uu____657 = FStar_Util.message_of_exn e  in
+              (let uu____657 = FStar_Util.message_of_exn e in
                FStar_Util.print1_error
                  "Unexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.\n%s\n"
                  uu____657)
@@ -382,4 +354,3 @@ let main : 'Auu____614 . Prims.unit -> 'Auu____614 =
          cleanup ();
          report_errors [];
          FStar_All.exit (Prims.parse_int "1"))
-  

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -1,129 +1,113 @@
 open Prims
 type debug_level_t =
-  | Low 
-  | Medium 
-  | High 
-  | Extreme 
-  | Other of Prims.string [@@deriving show]
-let (uu___is_Low : debug_level_t -> Prims.bool) =
-  fun projectee  -> match projectee with | Low  -> true | uu____8 -> false 
-let (uu___is_Medium : debug_level_t -> Prims.bool) =
+  | Low
+  | Medium
+  | High
+  | Extreme
+  | Other of Prims.string[@@deriving show]
+let uu___is_Low: debug_level_t -> Prims.bool =
+  fun projectee  -> match projectee with | Low  -> true | uu____8 -> false
+let uu___is_Medium: debug_level_t -> Prims.bool =
   fun projectee  ->
     match projectee with | Medium  -> true | uu____12 -> false
-  
-let (uu___is_High : debug_level_t -> Prims.bool) =
-  fun projectee  -> match projectee with | High  -> true | uu____16 -> false 
-let (uu___is_Extreme : debug_level_t -> Prims.bool) =
+let uu___is_High: debug_level_t -> Prims.bool =
+  fun projectee  -> match projectee with | High  -> true | uu____16 -> false
+let uu___is_Extreme: debug_level_t -> Prims.bool =
   fun projectee  ->
     match projectee with | Extreme  -> true | uu____20 -> false
-  
-let (uu___is_Other : debug_level_t -> Prims.bool) =
+let uu___is_Other: debug_level_t -> Prims.bool =
   fun projectee  ->
     match projectee with | Other _0 -> true | uu____25 -> false
-  
-let (__proj__Other__item___0 : debug_level_t -> Prims.string) =
-  fun projectee  -> match projectee with | Other _0 -> _0 
+let __proj__Other__item___0: debug_level_t -> Prims.string =
+  fun projectee  -> match projectee with | Other _0 -> _0
 type option_val =
-  | Bool of Prims.bool 
-  | String of Prims.string 
-  | Path of Prims.string 
-  | Int of Prims.int 
-  | List of option_val Prims.list 
-  | Unset [@@deriving show]
-let (uu___is_Bool : option_val -> Prims.bool) =
+  | Bool of Prims.bool
+  | String of Prims.string
+  | Path of Prims.string
+  | Int of Prims.int
+  | List of option_val Prims.list
+  | Unset[@@deriving show]
+let uu___is_Bool: option_val -> Prims.bool =
   fun projectee  ->
     match projectee with | Bool _0 -> true | uu____59 -> false
-  
-let (__proj__Bool__item___0 : option_val -> Prims.bool) =
-  fun projectee  -> match projectee with | Bool _0 -> _0 
-let (uu___is_String : option_val -> Prims.bool) =
+let __proj__Bool__item___0: option_val -> Prims.bool =
+  fun projectee  -> match projectee with | Bool _0 -> _0
+let uu___is_String: option_val -> Prims.bool =
   fun projectee  ->
     match projectee with | String _0 -> true | uu____71 -> false
-  
-let (__proj__String__item___0 : option_val -> Prims.string) =
-  fun projectee  -> match projectee with | String _0 -> _0 
-let (uu___is_Path : option_val -> Prims.bool) =
+let __proj__String__item___0: option_val -> Prims.string =
+  fun projectee  -> match projectee with | String _0 -> _0
+let uu___is_Path: option_val -> Prims.bool =
   fun projectee  ->
     match projectee with | Path _0 -> true | uu____83 -> false
-  
-let (__proj__Path__item___0 : option_val -> Prims.string) =
-  fun projectee  -> match projectee with | Path _0 -> _0 
-let (uu___is_Int : option_val -> Prims.bool) =
-  fun projectee  -> match projectee with | Int _0 -> true | uu____95 -> false 
-let (__proj__Int__item___0 : option_val -> Prims.int) =
-  fun projectee  -> match projectee with | Int _0 -> _0 
-let (uu___is_List : option_val -> Prims.bool) =
+let __proj__Path__item___0: option_val -> Prims.string =
+  fun projectee  -> match projectee with | Path _0 -> _0
+let uu___is_Int: option_val -> Prims.bool =
+  fun projectee  -> match projectee with | Int _0 -> true | uu____95 -> false
+let __proj__Int__item___0: option_val -> Prims.int =
+  fun projectee  -> match projectee with | Int _0 -> _0
+let uu___is_List: option_val -> Prims.bool =
   fun projectee  ->
     match projectee with | List _0 -> true | uu____109 -> false
-  
-let (__proj__List__item___0 : option_val -> option_val Prims.list) =
-  fun projectee  -> match projectee with | List _0 -> _0 
-let (uu___is_Unset : option_val -> Prims.bool) =
+let __proj__List__item___0: option_val -> option_val Prims.list =
+  fun projectee  -> match projectee with | List _0 -> _0
+let uu___is_Unset: option_val -> Prims.bool =
   fun projectee  ->
     match projectee with | Unset  -> true | uu____126 -> false
-  
-let (mk_bool : Prims.bool -> option_val) = fun _0_27  -> Bool _0_27 
-let (mk_string : Prims.string -> option_val) = fun _0_28  -> String _0_28 
-let (mk_path : Prims.string -> option_val) = fun _0_29  -> Path _0_29 
-let (mk_int : Prims.int -> option_val) = fun _0_30  -> Int _0_30 
-let (mk_list : option_val Prims.list -> option_val) =
-  fun _0_31  -> List _0_31 
+let mk_bool: Prims.bool -> option_val = fun _0_27  -> Bool _0_27
+let mk_string: Prims.string -> option_val = fun _0_28  -> String _0_28
+let mk_path: Prims.string -> option_val = fun _0_29  -> Path _0_29
+let mk_int: Prims.int -> option_val = fun _0_30  -> Int _0_30
+let mk_list: option_val Prims.list -> option_val = fun _0_31  -> List _0_31
 type options =
-  | Set 
-  | Reset 
-  | Restore [@@deriving show]
-let (uu___is_Set : options -> Prims.bool) =
-  fun projectee  -> match projectee with | Set  -> true | uu____142 -> false 
-let (uu___is_Reset : options -> Prims.bool) =
+  | Set
+  | Reset
+  | Restore[@@deriving show]
+let uu___is_Set: options -> Prims.bool =
+  fun projectee  -> match projectee with | Set  -> true | uu____142 -> false
+let uu___is_Reset: options -> Prims.bool =
   fun projectee  ->
     match projectee with | Reset  -> true | uu____146 -> false
-  
-let (uu___is_Restore : options -> Prims.bool) =
+let uu___is_Restore: options -> Prims.bool =
   fun projectee  ->
     match projectee with | Restore  -> true | uu____150 -> false
-  
-let (__unit_tests__ : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false 
-let (__unit_tests : Prims.unit -> Prims.bool) =
-  fun uu____166  -> FStar_ST.op_Bang __unit_tests__ 
-let (__set_unit_tests : Prims.unit -> Prims.unit) =
-  fun uu____188  -> FStar_ST.op_Colon_Equals __unit_tests__ true 
-let (__clear_unit_tests : Prims.unit -> Prims.unit) =
-  fun uu____210  -> FStar_ST.op_Colon_Equals __unit_tests__ false 
-let (as_bool : option_val -> Prims.bool) =
+let __unit_tests__: Prims.bool FStar_ST.ref = FStar_Util.mk_ref false
+let __unit_tests: Prims.unit -> Prims.bool =
+  fun uu____166  -> FStar_ST.op_Bang __unit_tests__
+let __set_unit_tests: Prims.unit -> Prims.unit =
+  fun uu____188  -> FStar_ST.op_Colon_Equals __unit_tests__ true
+let __clear_unit_tests: Prims.unit -> Prims.unit =
+  fun uu____210  -> FStar_ST.op_Colon_Equals __unit_tests__ false
+let as_bool: option_val -> Prims.bool =
   fun uu___35_232  ->
     match uu___35_232 with
     | Bool b -> b
     | uu____234 -> failwith "Impos: expected Bool"
-  
-let (as_int : option_val -> Prims.int) =
+let as_int: option_val -> Prims.int =
   fun uu___36_237  ->
     match uu___36_237 with
     | Int b -> b
     | uu____239 -> failwith "Impos: expected Int"
-  
-let (as_string : option_val -> Prims.string) =
+let as_string: option_val -> Prims.string =
   fun uu___37_242  ->
     match uu___37_242 with
     | String b -> b
     | Path b -> FStar_Common.try_convert_file_name_to_mixed b
     | uu____245 -> failwith "Impos: expected String"
-  
-let (as_list' : option_val -> option_val Prims.list) =
+let as_list': option_val -> option_val Prims.list =
   fun uu___38_250  ->
     match uu___38_250 with
     | List ts -> ts
     | uu____256 -> failwith "Impos: expected List"
-  
-let as_list :
+let as_list:
   'Auu____262 .
     (option_val -> 'Auu____262) -> option_val -> 'Auu____262 Prims.list
   =
   fun as_t  ->
     fun x  ->
-      let uu____278 = as_list' x  in
+      let uu____278 = as_list' x in
       FStar_All.pipe_right uu____278 (FStar_List.map as_t)
-  
-let as_option :
+let as_option:
   'Auu____288 .
     (option_val -> 'Auu____288) ->
       option_val -> 'Auu____288 FStar_Pervasives_Native.option
@@ -133,62 +117,51 @@ let as_option :
       match uu___39_301 with
       | Unset  -> FStar_Pervasives_Native.None
       | v1 ->
-          let uu____305 = as_t v1  in FStar_Pervasives_Native.Some uu____305
-  
+          let uu____305 = as_t v1 in FStar_Pervasives_Native.Some uu____305
 type optionstate = option_val FStar_Util.smap[@@deriving show]
-let (fstar_options : optionstate Prims.list FStar_ST.ref) =
-  FStar_Util.mk_ref [] 
-let (peek : Prims.unit -> optionstate) =
+let fstar_options: optionstate Prims.list FStar_ST.ref = FStar_Util.mk_ref []
+let peek: Prims.unit -> optionstate =
   fun uu____327  ->
-    let uu____328 = FStar_ST.op_Bang fstar_options  in
-    FStar_List.hd uu____328
-  
-let (pop : Prims.unit -> Prims.unit) =
+    let uu____328 = FStar_ST.op_Bang fstar_options in FStar_List.hd uu____328
+let pop: Prims.unit -> Prims.unit =
   fun uu____356  ->
-    let uu____357 = FStar_ST.op_Bang fstar_options  in
+    let uu____357 = FStar_ST.op_Bang fstar_options in
     match uu____357 with
     | [] -> failwith "TOO MANY POPS!"
     | uu____383::[] -> failwith "TOO MANY POPS!"
     | uu____384::tl1 -> FStar_ST.op_Colon_Equals fstar_options tl1
-  
-let (push : Prims.unit -> Prims.unit) =
+let push: Prims.unit -> Prims.unit =
   fun uu____413  ->
     let uu____414 =
       let uu____417 =
-        let uu____420 = peek ()  in FStar_Util.smap_copy uu____420  in
-      let uu____423 = FStar_ST.op_Bang fstar_options  in uu____417 ::
-        uu____423
-       in
+        let uu____420 = peek () in FStar_Util.smap_copy uu____420 in
+      let uu____423 = FStar_ST.op_Bang fstar_options in uu____417 ::
+        uu____423 in
     FStar_ST.op_Colon_Equals fstar_options uu____414
-  
-let (set : optionstate -> Prims.unit) =
+let set: optionstate -> Prims.unit =
   fun o  ->
-    let uu____479 = FStar_ST.op_Bang fstar_options  in
+    let uu____479 = FStar_ST.op_Bang fstar_options in
     match uu____479 with
     | [] -> failwith "set on empty option stack"
     | uu____505::os -> FStar_ST.op_Colon_Equals fstar_options (o :: os)
-  
-let (set_option : Prims.string -> option_val -> Prims.unit) =
+let set_option: Prims.string -> option_val -> Prims.unit =
   fun k  ->
-    fun v1  -> let uu____538 = peek ()  in FStar_Util.smap_add uu____538 k v1
-  
-let (set_option' :
-  (Prims.string,option_val) FStar_Pervasives_Native.tuple2 -> Prims.unit) =
-  fun uu____547  -> match uu____547 with | (k,v1) -> set_option k v1 
-let with_saved_options : 'a . (Prims.unit -> 'a) -> 'a =
-  fun f  -> push (); (let retv = f ()  in pop (); retv) 
-let (light_off_files : Prims.string Prims.list FStar_ST.ref) =
-  FStar_Util.mk_ref [] 
-let (add_light_off_file : Prims.string -> Prims.unit) =
+    fun v1  -> let uu____538 = peek () in FStar_Util.smap_add uu____538 k v1
+let set_option':
+  (Prims.string,option_val) FStar_Pervasives_Native.tuple2 -> Prims.unit =
+  fun uu____547  -> match uu____547 with | (k,v1) -> set_option k v1
+let with_saved_options: 'a . (Prims.unit -> 'a) -> 'a =
+  fun f  -> push (); (let retv = f () in pop (); retv)
+let light_off_files: Prims.string Prims.list FStar_ST.ref =
+  FStar_Util.mk_ref []
+let add_light_off_file: Prims.string -> Prims.unit =
   fun filename  ->
     let uu____589 =
-      let uu____592 = FStar_ST.op_Bang light_off_files  in filename ::
-        uu____592
-       in
+      let uu____592 = FStar_ST.op_Bang light_off_files in filename ::
+        uu____592 in
     FStar_ST.op_Colon_Equals light_off_files uu____589
-  
-let (defaults :
-  (Prims.string,option_val) FStar_Pervasives_Native.tuple2 Prims.list) =
+let defaults:
+  (Prims.string,option_val) FStar_Pervasives_Native.tuple2 Prims.list =
   [("__temp_no_proj", (List []));
   ("__temp_fast_implicits", (Bool false));
   ("admit_smt_queries", (Bool false));
@@ -282,232 +255,223 @@ let (defaults :
   ("__ml_no_eta_expand_coertions", (Bool false));
   ("warn_error", (String ""));
   ("use_extracted_interfaces", (Bool false));
-  ("check_interface", (Bool false))] 
-let (init : Prims.unit -> Prims.unit) =
+  ("check_interface", (Bool false))]
+let init: Prims.unit -> Prims.unit =
   fun uu____1029  ->
-    let o = peek ()  in
+    let o = peek () in
     FStar_Util.smap_clear o;
     FStar_All.pipe_right defaults (FStar_List.iter set_option')
-  
-let (clear : Prims.unit -> Prims.unit) =
+let clear: Prims.unit -> Prims.unit =
   fun uu____1044  ->
-    let o = FStar_Util.smap_create (Prims.parse_int "50")  in
+    let o = FStar_Util.smap_create (Prims.parse_int "50") in
     FStar_ST.op_Colon_Equals fstar_options [o];
     FStar_ST.op_Colon_Equals light_off_files [];
     init ()
-  
-let (_run : Prims.unit) = clear () 
-let (get_option : Prims.string -> option_val) =
+let _run: Prims.unit = clear ()
+let get_option: Prims.string -> option_val =
   fun s  ->
     let uu____1103 =
-      let uu____1106 = peek ()  in FStar_Util.smap_try_find uu____1106 s  in
+      let uu____1106 = peek () in FStar_Util.smap_try_find uu____1106 s in
     match uu____1103 with
     | FStar_Pervasives_Native.None  ->
         failwith
           (Prims.strcat "Impossible: option " (Prims.strcat s " not found"))
     | FStar_Pervasives_Native.Some s1 -> s1
-  
-let lookup_opt :
+let lookup_opt:
   'Auu____1113 . Prims.string -> (option_val -> 'Auu____1113) -> 'Auu____1113
-  = fun s  -> fun c  -> c (get_option s) 
-let (get_admit_smt_queries : Prims.unit -> Prims.bool) =
-  fun uu____1129  -> lookup_opt "admit_smt_queries" as_bool 
-let (get_admit_except :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1134  -> lookup_opt "admit_except" (as_option as_string) 
-let (get_cache_checked_modules : Prims.unit -> Prims.bool) =
-  fun uu____1139  -> lookup_opt "cache_checked_modules" as_bool 
-let (get_cache_dir :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1144  -> lookup_opt "cache_dir" (as_option as_string) 
-let (get_codegen : Prims.unit -> Prims.string FStar_Pervasives_Native.option)
-  = fun uu____1151  -> lookup_opt "codegen" (as_option as_string) 
-let (get_codegen_lib : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1158  -> lookup_opt "codegen-lib" (as_list as_string) 
-let (get_debug : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1165  -> lookup_opt "debug" (as_list as_string) 
-let (get_debug_level : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1172  -> lookup_opt "debug_level" (as_list as_string) 
-let (get_dep : Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1179  -> lookup_opt "dep" (as_option as_string) 
-let (get_detail_errors : Prims.unit -> Prims.bool) =
-  fun uu____1184  -> lookup_opt "detail_errors" as_bool 
-let (get_detail_hint_replay : Prims.unit -> Prims.bool) =
-  fun uu____1187  -> lookup_opt "detail_hint_replay" as_bool 
-let (get_doc : Prims.unit -> Prims.bool) =
-  fun uu____1190  -> lookup_opt "doc" as_bool 
-let (get_dump_module : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1195  -> lookup_opt "dump_module" (as_list as_string) 
-let (get_eager_inference : Prims.unit -> Prims.bool) =
-  fun uu____1200  -> lookup_opt "eager_inference" as_bool 
-let (get_expose_interfaces : Prims.unit -> Prims.bool) =
-  fun uu____1203  -> lookup_opt "expose_interfaces" as_bool 
-let (get_extract :
-  Prims.unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
-  fun uu____1210  -> lookup_opt "extract" (as_option (as_list as_string)) 
-let (get_extract_module : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1221  -> lookup_opt "extract_module" (as_list as_string) 
-let (get_extract_namespace : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1228  -> lookup_opt "extract_namespace" (as_list as_string) 
-let (get_fs_typ_app : Prims.unit -> Prims.bool) =
-  fun uu____1233  -> lookup_opt "fs_typ_app" as_bool 
-let (get_fstar_home :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1238  -> lookup_opt "fstar_home" (as_option as_string) 
-let (get_gen_native_tactics :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1245  -> lookup_opt "gen_native_tactics" (as_option as_string) 
-let (get_hide_uvar_nums : Prims.unit -> Prims.bool) =
-  fun uu____1250  -> lookup_opt "hide_uvar_nums" as_bool 
-let (get_hint_info : Prims.unit -> Prims.bool) =
-  fun uu____1253  -> lookup_opt "hint_info" as_bool 
-let (get_hint_file :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1258  -> lookup_opt "hint_file" (as_option as_string) 
-let (get_in : Prims.unit -> Prims.bool) =
-  fun uu____1263  -> lookup_opt "in" as_bool 
-let (get_ide : Prims.unit -> Prims.bool) =
-  fun uu____1266  -> lookup_opt "ide" as_bool 
-let (get_include : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1271  -> lookup_opt "include" (as_list as_string) 
-let (get_indent : Prims.unit -> Prims.bool) =
-  fun uu____1276  -> lookup_opt "indent" as_bool 
-let (get_initial_fuel : Prims.unit -> Prims.int) =
-  fun uu____1279  -> lookup_opt "initial_fuel" as_int 
-let (get_initial_ifuel : Prims.unit -> Prims.int) =
-  fun uu____1282  -> lookup_opt "initial_ifuel" as_int 
-let (get_lax : Prims.unit -> Prims.bool) =
-  fun uu____1285  -> lookup_opt "lax" as_bool 
-let (get_load : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1290  -> lookup_opt "load" (as_list as_string) 
-let (get_log_queries : Prims.unit -> Prims.bool) =
-  fun uu____1295  -> lookup_opt "log_queries" as_bool 
-let (get_log_types : Prims.unit -> Prims.bool) =
-  fun uu____1298  -> lookup_opt "log_types" as_bool 
-let (get_max_fuel : Prims.unit -> Prims.int) =
-  fun uu____1301  -> lookup_opt "max_fuel" as_int 
-let (get_max_ifuel : Prims.unit -> Prims.int) =
-  fun uu____1304  -> lookup_opt "max_ifuel" as_int 
-let (get_min_fuel : Prims.unit -> Prims.int) =
-  fun uu____1307  -> lookup_opt "min_fuel" as_int 
-let (get_MLish : Prims.unit -> Prims.bool) =
-  fun uu____1310  -> lookup_opt "MLish" as_bool 
-let (get_n_cores : Prims.unit -> Prims.int) =
-  fun uu____1313  -> lookup_opt "n_cores" as_int 
-let (get_no_default_includes : Prims.unit -> Prims.bool) =
-  fun uu____1316  -> lookup_opt "no_default_includes" as_bool 
-let (get_no_extract : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1321  -> lookup_opt "no_extract" (as_list as_string) 
-let (get_no_location_info : Prims.unit -> Prims.bool) =
-  fun uu____1326  -> lookup_opt "no_location_info" as_bool 
-let (get_normalize_pure_terms_for_extraction : Prims.unit -> Prims.bool) =
-  fun uu____1329  -> lookup_opt "normalize_pure_terms_for_extraction" as_bool 
-let (get_odir : Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1334  -> lookup_opt "odir" (as_option as_string) 
-let (get_ugly : Prims.unit -> Prims.bool) =
-  fun uu____1339  -> lookup_opt "ugly" as_bool 
-let (get_prims : Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1344  -> lookup_opt "prims" (as_option as_string) 
-let (get_print_bound_var_types : Prims.unit -> Prims.bool) =
-  fun uu____1349  -> lookup_opt "print_bound_var_types" as_bool 
-let (get_print_effect_args : Prims.unit -> Prims.bool) =
-  fun uu____1352  -> lookup_opt "print_effect_args" as_bool 
-let (get_print_full_names : Prims.unit -> Prims.bool) =
-  fun uu____1355  -> lookup_opt "print_full_names" as_bool 
-let (get_print_implicits : Prims.unit -> Prims.bool) =
-  fun uu____1358  -> lookup_opt "print_implicits" as_bool 
-let (get_print_universes : Prims.unit -> Prims.bool) =
-  fun uu____1361  -> lookup_opt "print_universes" as_bool 
-let (get_print_z3_statistics : Prims.unit -> Prims.bool) =
-  fun uu____1364  -> lookup_opt "print_z3_statistics" as_bool 
-let (get_prn : Prims.unit -> Prims.bool) =
-  fun uu____1367  -> lookup_opt "prn" as_bool 
-let (get_query_stats : Prims.unit -> Prims.bool) =
-  fun uu____1370  -> lookup_opt "query_stats" as_bool 
-let (get_record_hints : Prims.unit -> Prims.bool) =
-  fun uu____1373  -> lookup_opt "record_hints" as_bool 
-let (get_reuse_hint_for :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1378  -> lookup_opt "reuse_hint_for" (as_option as_string) 
-let (get_silent : Prims.unit -> Prims.bool) =
-  fun uu____1383  -> lookup_opt "silent" as_bool 
-let (get_smt : Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1388  -> lookup_opt "smt" (as_option as_string) 
-let (get_smtencoding_elim_box : Prims.unit -> Prims.bool) =
-  fun uu____1393  -> lookup_opt "smtencoding.elim_box" as_bool 
-let (get_smtencoding_nl_arith_repr : Prims.unit -> Prims.string) =
-  fun uu____1396  -> lookup_opt "smtencoding.nl_arith_repr" as_string 
-let (get_smtencoding_l_arith_repr : Prims.unit -> Prims.string) =
-  fun uu____1399  -> lookup_opt "smtencoding.l_arith_repr" as_string 
-let (get_tactic_raw_binders : Prims.unit -> Prims.bool) =
-  fun uu____1402  -> lookup_opt "tactic_raw_binders" as_bool 
-let (get_tactic_trace : Prims.unit -> Prims.bool) =
-  fun uu____1405  -> lookup_opt "tactic_trace" as_bool 
-let (get_tactic_trace_d : Prims.unit -> Prims.int) =
-  fun uu____1408  -> lookup_opt "tactic_trace_d" as_int 
-let (get_timing : Prims.unit -> Prims.bool) =
-  fun uu____1411  -> lookup_opt "timing" as_bool 
-let (get_trace_error : Prims.unit -> Prims.bool) =
-  fun uu____1414  -> lookup_opt "trace_error" as_bool 
-let (get_unthrottle_inductives : Prims.unit -> Prims.bool) =
-  fun uu____1417  -> lookup_opt "unthrottle_inductives" as_bool 
-let (get_unsafe_tactic_exec : Prims.unit -> Prims.bool) =
-  fun uu____1420  -> lookup_opt "unsafe_tactic_exec" as_bool 
-let (get_use_eq_at_higher_order : Prims.unit -> Prims.bool) =
-  fun uu____1423  -> lookup_opt "use_eq_at_higher_order" as_bool 
-let (get_use_hints : Prims.unit -> Prims.bool) =
-  fun uu____1426  -> lookup_opt "use_hints" as_bool 
-let (get_use_hint_hashes : Prims.unit -> Prims.bool) =
-  fun uu____1429  -> lookup_opt "use_hint_hashes" as_bool 
-let (get_use_native_tactics :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____1434  -> lookup_opt "use_native_tactics" (as_option as_string) 
-let (get_use_tactics : Prims.unit -> Prims.bool) =
+  = fun s  -> fun c  -> c (get_option s)
+let get_admit_smt_queries: Prims.unit -> Prims.bool =
+  fun uu____1129  -> lookup_opt "admit_smt_queries" as_bool
+let get_admit_except:
+  Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____1134  -> lookup_opt "admit_except" (as_option as_string)
+let get_cache_checked_modules: Prims.unit -> Prims.bool =
+  fun uu____1139  -> lookup_opt "cache_checked_modules" as_bool
+let get_cache_dir: Prims.unit -> Prims.string FStar_Pervasives_Native.option
+  = fun uu____1144  -> lookup_opt "cache_dir" (as_option as_string)
+let get_codegen: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____1151  -> lookup_opt "codegen" (as_option as_string)
+let get_codegen_lib: Prims.unit -> Prims.string Prims.list =
+  fun uu____1158  -> lookup_opt "codegen-lib" (as_list as_string)
+let get_debug: Prims.unit -> Prims.string Prims.list =
+  fun uu____1165  -> lookup_opt "debug" (as_list as_string)
+let get_debug_level: Prims.unit -> Prims.string Prims.list =
+  fun uu____1172  -> lookup_opt "debug_level" (as_list as_string)
+let get_dep: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____1179  -> lookup_opt "dep" (as_option as_string)
+let get_detail_errors: Prims.unit -> Prims.bool =
+  fun uu____1184  -> lookup_opt "detail_errors" as_bool
+let get_detail_hint_replay: Prims.unit -> Prims.bool =
+  fun uu____1187  -> lookup_opt "detail_hint_replay" as_bool
+let get_doc: Prims.unit -> Prims.bool =
+  fun uu____1190  -> lookup_opt "doc" as_bool
+let get_dump_module: Prims.unit -> Prims.string Prims.list =
+  fun uu____1195  -> lookup_opt "dump_module" (as_list as_string)
+let get_eager_inference: Prims.unit -> Prims.bool =
+  fun uu____1200  -> lookup_opt "eager_inference" as_bool
+let get_expose_interfaces: Prims.unit -> Prims.bool =
+  fun uu____1203  -> lookup_opt "expose_interfaces" as_bool
+let get_extract:
+  Prims.unit -> Prims.string Prims.list FStar_Pervasives_Native.option =
+  fun uu____1210  -> lookup_opt "extract" (as_option (as_list as_string))
+let get_extract_module: Prims.unit -> Prims.string Prims.list =
+  fun uu____1221  -> lookup_opt "extract_module" (as_list as_string)
+let get_extract_namespace: Prims.unit -> Prims.string Prims.list =
+  fun uu____1228  -> lookup_opt "extract_namespace" (as_list as_string)
+let get_fs_typ_app: Prims.unit -> Prims.bool =
+  fun uu____1233  -> lookup_opt "fs_typ_app" as_bool
+let get_fstar_home: Prims.unit -> Prims.string FStar_Pervasives_Native.option
+  = fun uu____1238  -> lookup_opt "fstar_home" (as_option as_string)
+let get_gen_native_tactics:
+  Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____1245  -> lookup_opt "gen_native_tactics" (as_option as_string)
+let get_hide_uvar_nums: Prims.unit -> Prims.bool =
+  fun uu____1250  -> lookup_opt "hide_uvar_nums" as_bool
+let get_hint_info: Prims.unit -> Prims.bool =
+  fun uu____1253  -> lookup_opt "hint_info" as_bool
+let get_hint_file: Prims.unit -> Prims.string FStar_Pervasives_Native.option
+  = fun uu____1258  -> lookup_opt "hint_file" (as_option as_string)
+let get_in: Prims.unit -> Prims.bool =
+  fun uu____1263  -> lookup_opt "in" as_bool
+let get_ide: Prims.unit -> Prims.bool =
+  fun uu____1266  -> lookup_opt "ide" as_bool
+let get_include: Prims.unit -> Prims.string Prims.list =
+  fun uu____1271  -> lookup_opt "include" (as_list as_string)
+let get_indent: Prims.unit -> Prims.bool =
+  fun uu____1276  -> lookup_opt "indent" as_bool
+let get_initial_fuel: Prims.unit -> Prims.int =
+  fun uu____1279  -> lookup_opt "initial_fuel" as_int
+let get_initial_ifuel: Prims.unit -> Prims.int =
+  fun uu____1282  -> lookup_opt "initial_ifuel" as_int
+let get_lax: Prims.unit -> Prims.bool =
+  fun uu____1285  -> lookup_opt "lax" as_bool
+let get_load: Prims.unit -> Prims.string Prims.list =
+  fun uu____1290  -> lookup_opt "load" (as_list as_string)
+let get_log_queries: Prims.unit -> Prims.bool =
+  fun uu____1295  -> lookup_opt "log_queries" as_bool
+let get_log_types: Prims.unit -> Prims.bool =
+  fun uu____1298  -> lookup_opt "log_types" as_bool
+let get_max_fuel: Prims.unit -> Prims.int =
+  fun uu____1301  -> lookup_opt "max_fuel" as_int
+let get_max_ifuel: Prims.unit -> Prims.int =
+  fun uu____1304  -> lookup_opt "max_ifuel" as_int
+let get_min_fuel: Prims.unit -> Prims.int =
+  fun uu____1307  -> lookup_opt "min_fuel" as_int
+let get_MLish: Prims.unit -> Prims.bool =
+  fun uu____1310  -> lookup_opt "MLish" as_bool
+let get_n_cores: Prims.unit -> Prims.int =
+  fun uu____1313  -> lookup_opt "n_cores" as_int
+let get_no_default_includes: Prims.unit -> Prims.bool =
+  fun uu____1316  -> lookup_opt "no_default_includes" as_bool
+let get_no_extract: Prims.unit -> Prims.string Prims.list =
+  fun uu____1321  -> lookup_opt "no_extract" (as_list as_string)
+let get_no_location_info: Prims.unit -> Prims.bool =
+  fun uu____1326  -> lookup_opt "no_location_info" as_bool
+let get_normalize_pure_terms_for_extraction: Prims.unit -> Prims.bool =
+  fun uu____1329  -> lookup_opt "normalize_pure_terms_for_extraction" as_bool
+let get_odir: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____1334  -> lookup_opt "odir" (as_option as_string)
+let get_ugly: Prims.unit -> Prims.bool =
+  fun uu____1339  -> lookup_opt "ugly" as_bool
+let get_prims: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____1344  -> lookup_opt "prims" (as_option as_string)
+let get_print_bound_var_types: Prims.unit -> Prims.bool =
+  fun uu____1349  -> lookup_opt "print_bound_var_types" as_bool
+let get_print_effect_args: Prims.unit -> Prims.bool =
+  fun uu____1352  -> lookup_opt "print_effect_args" as_bool
+let get_print_full_names: Prims.unit -> Prims.bool =
+  fun uu____1355  -> lookup_opt "print_full_names" as_bool
+let get_print_implicits: Prims.unit -> Prims.bool =
+  fun uu____1358  -> lookup_opt "print_implicits" as_bool
+let get_print_universes: Prims.unit -> Prims.bool =
+  fun uu____1361  -> lookup_opt "print_universes" as_bool
+let get_print_z3_statistics: Prims.unit -> Prims.bool =
+  fun uu____1364  -> lookup_opt "print_z3_statistics" as_bool
+let get_prn: Prims.unit -> Prims.bool =
+  fun uu____1367  -> lookup_opt "prn" as_bool
+let get_query_stats: Prims.unit -> Prims.bool =
+  fun uu____1370  -> lookup_opt "query_stats" as_bool
+let get_record_hints: Prims.unit -> Prims.bool =
+  fun uu____1373  -> lookup_opt "record_hints" as_bool
+let get_reuse_hint_for:
+  Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____1378  -> lookup_opt "reuse_hint_for" (as_option as_string)
+let get_silent: Prims.unit -> Prims.bool =
+  fun uu____1383  -> lookup_opt "silent" as_bool
+let get_smt: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____1388  -> lookup_opt "smt" (as_option as_string)
+let get_smtencoding_elim_box: Prims.unit -> Prims.bool =
+  fun uu____1393  -> lookup_opt "smtencoding.elim_box" as_bool
+let get_smtencoding_nl_arith_repr: Prims.unit -> Prims.string =
+  fun uu____1396  -> lookup_opt "smtencoding.nl_arith_repr" as_string
+let get_smtencoding_l_arith_repr: Prims.unit -> Prims.string =
+  fun uu____1399  -> lookup_opt "smtencoding.l_arith_repr" as_string
+let get_tactic_raw_binders: Prims.unit -> Prims.bool =
+  fun uu____1402  -> lookup_opt "tactic_raw_binders" as_bool
+let get_tactic_trace: Prims.unit -> Prims.bool =
+  fun uu____1405  -> lookup_opt "tactic_trace" as_bool
+let get_tactic_trace_d: Prims.unit -> Prims.int =
+  fun uu____1408  -> lookup_opt "tactic_trace_d" as_int
+let get_timing: Prims.unit -> Prims.bool =
+  fun uu____1411  -> lookup_opt "timing" as_bool
+let get_trace_error: Prims.unit -> Prims.bool =
+  fun uu____1414  -> lookup_opt "trace_error" as_bool
+let get_unthrottle_inductives: Prims.unit -> Prims.bool =
+  fun uu____1417  -> lookup_opt "unthrottle_inductives" as_bool
+let get_unsafe_tactic_exec: Prims.unit -> Prims.bool =
+  fun uu____1420  -> lookup_opt "unsafe_tactic_exec" as_bool
+let get_use_eq_at_higher_order: Prims.unit -> Prims.bool =
+  fun uu____1423  -> lookup_opt "use_eq_at_higher_order" as_bool
+let get_use_hints: Prims.unit -> Prims.bool =
+  fun uu____1426  -> lookup_opt "use_hints" as_bool
+let get_use_hint_hashes: Prims.unit -> Prims.bool =
+  fun uu____1429  -> lookup_opt "use_hint_hashes" as_bool
+let get_use_native_tactics:
+  Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____1434  -> lookup_opt "use_native_tactics" (as_option as_string)
+let get_use_tactics: Prims.unit -> Prims.bool =
   fun uu____1439  ->
-    let uu____1440 = lookup_opt "no_tactics" as_bool  in
+    let uu____1440 = lookup_opt "no_tactics" as_bool in
     Prims.op_Negation uu____1440
-  
-let (get_using_facts_from :
-  Prims.unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
+let get_using_facts_from:
+  Prims.unit -> Prims.string Prims.list FStar_Pervasives_Native.option =
   fun uu____1447  ->
     lookup_opt "using_facts_from" (as_option (as_list as_string))
-  
-let (get_vcgen_optimize_bind_as_seq :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
+let get_vcgen_optimize_bind_as_seq:
+  Prims.unit -> Prims.string FStar_Pervasives_Native.option =
   fun uu____1458  ->
     lookup_opt "vcgen.optimize_bind_as_seq" (as_option as_string)
-  
-let (get_verify_module : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1465  -> lookup_opt "verify_module" (as_list as_string) 
-let (get___temp_no_proj : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1472  -> lookup_opt "__temp_no_proj" (as_list as_string) 
-let (get_version : Prims.unit -> Prims.bool) =
-  fun uu____1477  -> lookup_opt "version" as_bool 
-let (get_warn_default_effects : Prims.unit -> Prims.bool) =
-  fun uu____1480  -> lookup_opt "warn_default_effects" as_bool 
-let (get_z3cliopt : Prims.unit -> Prims.string Prims.list) =
-  fun uu____1485  -> lookup_opt "z3cliopt" (as_list as_string) 
-let (get_z3refresh : Prims.unit -> Prims.bool) =
-  fun uu____1490  -> lookup_opt "z3refresh" as_bool 
-let (get_z3rlimit : Prims.unit -> Prims.int) =
-  fun uu____1493  -> lookup_opt "z3rlimit" as_int 
-let (get_z3rlimit_factor : Prims.unit -> Prims.int) =
-  fun uu____1496  -> lookup_opt "z3rlimit_factor" as_int 
-let (get_z3seed : Prims.unit -> Prims.int) =
-  fun uu____1499  -> lookup_opt "z3seed" as_int 
-let (get_use_two_phase_tc : Prims.unit -> Prims.bool) =
-  fun uu____1502  -> lookup_opt "use_two_phase_tc" as_bool 
-let (get_no_positivity : Prims.unit -> Prims.bool) =
-  fun uu____1505  -> lookup_opt "__no_positivity" as_bool 
-let (get_ml_no_eta_expand_coertions : Prims.unit -> Prims.bool) =
-  fun uu____1508  -> lookup_opt "__ml_no_eta_expand_coertions" as_bool 
-let (get_warn_error : Prims.unit -> Prims.string) =
-  fun uu____1511  -> lookup_opt "warn_error" as_string 
-let (get_use_extracted_interfaces : Prims.unit -> Prims.bool) =
-  fun uu____1514  -> lookup_opt "use_extracted_interfaces" as_bool 
-let (get_check_interface : Prims.unit -> Prims.bool) =
-  fun uu____1517  -> lookup_opt "check_interface" as_bool 
-let (dlevel : Prims.string -> debug_level_t) =
+let get_verify_module: Prims.unit -> Prims.string Prims.list =
+  fun uu____1465  -> lookup_opt "verify_module" (as_list as_string)
+let get___temp_no_proj: Prims.unit -> Prims.string Prims.list =
+  fun uu____1472  -> lookup_opt "__temp_no_proj" (as_list as_string)
+let get_version: Prims.unit -> Prims.bool =
+  fun uu____1477  -> lookup_opt "version" as_bool
+let get_warn_default_effects: Prims.unit -> Prims.bool =
+  fun uu____1480  -> lookup_opt "warn_default_effects" as_bool
+let get_z3cliopt: Prims.unit -> Prims.string Prims.list =
+  fun uu____1485  -> lookup_opt "z3cliopt" (as_list as_string)
+let get_z3refresh: Prims.unit -> Prims.bool =
+  fun uu____1490  -> lookup_opt "z3refresh" as_bool
+let get_z3rlimit: Prims.unit -> Prims.int =
+  fun uu____1493  -> lookup_opt "z3rlimit" as_int
+let get_z3rlimit_factor: Prims.unit -> Prims.int =
+  fun uu____1496  -> lookup_opt "z3rlimit_factor" as_int
+let get_z3seed: Prims.unit -> Prims.int =
+  fun uu____1499  -> lookup_opt "z3seed" as_int
+let get_use_two_phase_tc: Prims.unit -> Prims.bool =
+  fun uu____1502  -> lookup_opt "use_two_phase_tc" as_bool
+let get_no_positivity: Prims.unit -> Prims.bool =
+  fun uu____1505  -> lookup_opt "__no_positivity" as_bool
+let get_ml_no_eta_expand_coertions: Prims.unit -> Prims.bool =
+  fun uu____1508  -> lookup_opt "__ml_no_eta_expand_coertions" as_bool
+let get_warn_error: Prims.unit -> Prims.string =
+  fun uu____1511  -> lookup_opt "warn_error" as_string
+let get_use_extracted_interfaces: Prims.unit -> Prims.bool =
+  fun uu____1514  -> lookup_opt "use_extracted_interfaces" as_bool
+let get_check_interface: Prims.unit -> Prims.bool =
+  fun uu____1517  -> lookup_opt "check_interface" as_bool
+let dlevel: Prims.string -> debug_level_t =
   fun uu___40_1520  ->
     match uu___40_1520 with
     | "Low" -> Low
@@ -515,8 +479,7 @@ let (dlevel : Prims.string -> debug_level_t) =
     | "High" -> High
     | "Extreme" -> Extreme
     | s -> Other s
-  
-let (one_debug_level_geq : debug_level_t -> debug_level_t -> Prims.bool) =
+let one_debug_level_geq: debug_level_t -> debug_level_t -> Prims.bool =
   fun l1  ->
     fun l2  ->
       match l1 with
@@ -526,35 +489,31 @@ let (one_debug_level_geq : debug_level_t -> debug_level_t -> Prims.bool) =
       | High  -> ((l2 = Low) || (l2 = Medium)) || (l2 = High)
       | Extreme  ->
           (((l2 = Low) || (l2 = Medium)) || (l2 = High)) || (l2 = Extreme)
-  
-let (debug_level_geq : debug_level_t -> Prims.bool) =
+let debug_level_geq: debug_level_t -> Prims.bool =
   fun l2  ->
-    let uu____1532 = get_debug_level ()  in
+    let uu____1532 = get_debug_level () in
     FStar_All.pipe_right uu____1532
       (FStar_Util.for_some (fun l1  -> one_debug_level_geq (dlevel l1) l2))
-  
-let (universe_include_path_base_dirs : Prims.string Prims.list) =
-  ["/ulib"; "/lib/fstar"] 
-let (_version : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
-let (_platform : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
-let (_compiler : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
-let (_date : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
-let (_commit : Prims.string FStar_ST.ref) = FStar_Util.mk_ref "" 
-let (display_version : Prims.unit -> Prims.unit) =
+let universe_include_path_base_dirs: Prims.string Prims.list =
+  ["/ulib"; "/lib/fstar"]
+let _version: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
+let _platform: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
+let _compiler: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
+let _date: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
+let _commit: Prims.string FStar_ST.ref = FStar_Util.mk_ref ""
+let display_version: Prims.unit -> Prims.unit =
   fun uu____1663  ->
     let uu____1664 =
-      let uu____1665 = FStar_ST.op_Bang _version  in
-      let uu____1685 = FStar_ST.op_Bang _platform  in
-      let uu____1705 = FStar_ST.op_Bang _compiler  in
-      let uu____1725 = FStar_ST.op_Bang _date  in
-      let uu____1745 = FStar_ST.op_Bang _commit  in
+      let uu____1665 = FStar_ST.op_Bang _version in
+      let uu____1685 = FStar_ST.op_Bang _platform in
+      let uu____1705 = FStar_ST.op_Bang _compiler in
+      let uu____1725 = FStar_ST.op_Bang _date in
+      let uu____1745 = FStar_ST.op_Bang _commit in
       FStar_Util.format5
         "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu____1665
-        uu____1685 uu____1705 uu____1725 uu____1745
-       in
+        uu____1685 uu____1705 uu____1725 uu____1745 in
     FStar_Util.print_string uu____1664
-  
-let display_usage_aux :
+let display_usage_aux:
   'Auu____1768 'Auu____1769 .
     ('Auu____1769,Prims.string,'Auu____1768 FStar_Getopt.opt_variant,
       Prims.string) FStar_Pervasives_Native.tuple4 Prims.list -> Prims.unit
@@ -570,70 +529,62 @@ let display_usage_aux :
                   if doc = ""
                   then
                     let uu____1838 =
-                      let uu____1839 = FStar_Util.colorize_bold flag  in
-                      FStar_Util.format1 "  --%s\n" uu____1839  in
+                      let uu____1839 = FStar_Util.colorize_bold flag in
+                      FStar_Util.format1 "  --%s\n" uu____1839 in
                     FStar_Util.print_string uu____1838
                   else
                     (let uu____1841 =
-                       let uu____1842 = FStar_Util.colorize_bold flag  in
-                       FStar_Util.format2 "  --%s  %s\n" uu____1842 doc  in
+                       let uu____1842 = FStar_Util.colorize_bold flag in
+                       FStar_Util.format2 "  --%s  %s\n" uu____1842 doc in
                      FStar_Util.print_string uu____1841)
               | FStar_Getopt.OneArg (uu____1843,argname) ->
                   if doc = ""
                   then
                     let uu____1849 =
-                      let uu____1850 = FStar_Util.colorize_bold flag  in
-                      let uu____1851 = FStar_Util.colorize_bold argname  in
-                      FStar_Util.format2 "  --%s %s\n" uu____1850 uu____1851
-                       in
+                      let uu____1850 = FStar_Util.colorize_bold flag in
+                      let uu____1851 = FStar_Util.colorize_bold argname in
+                      FStar_Util.format2 "  --%s %s\n" uu____1850 uu____1851 in
                     FStar_Util.print_string uu____1849
                   else
                     (let uu____1853 =
-                       let uu____1854 = FStar_Util.colorize_bold flag  in
-                       let uu____1855 = FStar_Util.colorize_bold argname  in
+                       let uu____1854 = FStar_Util.colorize_bold flag in
+                       let uu____1855 = FStar_Util.colorize_bold argname in
                        FStar_Util.format3 "  --%s %s  %s\n" uu____1854
-                         uu____1855 doc
-                        in
+                         uu____1855 doc in
                      FStar_Util.print_string uu____1853))) specs
-  
-let (mk_spec :
+let mk_spec:
   (FStar_BaseTypes.char,Prims.string,option_val FStar_Getopt.opt_variant,
-    Prims.string) FStar_Pervasives_Native.tuple4 -> FStar_Getopt.opt)
+    Prims.string) FStar_Pervasives_Native.tuple4 -> FStar_Getopt.opt
   =
   fun o  ->
-    let uu____1879 = o  in
+    let uu____1879 = o in
     match uu____1879 with
     | (ns,name,arg,desc) ->
         let arg1 =
           match arg with
           | FStar_Getopt.ZeroArgs f ->
               let g uu____1909 =
-                let uu____1910 = f ()  in set_option name uu____1910  in
+                let uu____1910 = f () in set_option name uu____1910 in
               FStar_Getopt.ZeroArgs g
           | FStar_Getopt.OneArg (f,d) ->
-              let g x = let uu____1921 = f x  in set_option name uu____1921
-                 in
-              FStar_Getopt.OneArg (g, d)
-           in
+              let g x = let uu____1921 = f x in set_option name uu____1921 in
+              FStar_Getopt.OneArg (g, d) in
         (ns, name, arg1, desc)
-  
-let (accumulated_option : Prims.string -> option_val -> option_val) =
+let accumulated_option: Prims.string -> option_val -> option_val =
   fun name  ->
     fun value  ->
       let prev_values =
-        let uu____1935 = lookup_opt name (as_option as_list')  in
-        FStar_Util.dflt [] uu____1935  in
+        let uu____1935 = lookup_opt name (as_option as_list') in
+        FStar_Util.dflt [] uu____1935 in
       mk_list (value :: prev_values)
-  
-let (reverse_accumulated_option : Prims.string -> option_val -> option_val) =
+let reverse_accumulated_option: Prims.string -> option_val -> option_val =
   fun name  ->
     fun value  ->
       let uu____1954 =
-        let uu____1957 = lookup_opt name as_list'  in
-        FStar_List.append uu____1957 [value]  in
+        let uu____1957 = lookup_opt name as_list' in
+        FStar_List.append uu____1957 [value] in
       mk_list uu____1954
-  
-let accumulate_string :
+let accumulate_string:
   'Auu____1966 .
     Prims.string ->
       ('Auu____1966 -> Prims.string) -> 'Auu____1966 -> Prims.unit
@@ -643,117 +594,102 @@ let accumulate_string :
       fun value  ->
         let uu____1984 =
           let uu____1985 =
-            let uu____1986 = post_processor value  in mk_string uu____1986
-             in
-          accumulated_option name uu____1985  in
+            let uu____1986 = post_processor value in mk_string uu____1986 in
+          accumulated_option name uu____1985 in
         set_option name uu____1984
-  
-let (add_extract_module : Prims.string -> Prims.unit) =
-  fun s  -> accumulate_string "extract_module" FStar_String.lowercase s 
-let (add_extract_namespace : Prims.string -> Prims.unit) =
-  fun s  -> accumulate_string "extract_namespace" FStar_String.lowercase s 
-let (add_verify_module : Prims.string -> Prims.unit) =
-  fun s  -> accumulate_string "verify_module" FStar_String.lowercase s 
+let add_extract_module: Prims.string -> Prims.unit =
+  fun s  -> accumulate_string "extract_module" FStar_String.lowercase s
+let add_extract_namespace: Prims.string -> Prims.unit =
+  fun s  -> accumulate_string "extract_namespace" FStar_String.lowercase s
+let add_verify_module: Prims.string -> Prims.unit =
+  fun s  -> accumulate_string "verify_module" FStar_String.lowercase s
 type opt_type =
-  | Const of option_val 
-  | IntStr of Prims.string 
-  | BoolStr 
-  | PathStr of Prims.string 
-  | SimpleStr of Prims.string 
-  | EnumStr of Prims.string Prims.list 
+  | Const of option_val
+  | IntStr of Prims.string
+  | BoolStr
+  | PathStr of Prims.string
+  | SimpleStr of Prims.string
+  | EnumStr of Prims.string Prims.list
   | OpenEnumStr of (Prims.string Prims.list,Prims.string)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | PostProcessed of (option_val -> option_val,opt_type)
-  FStar_Pervasives_Native.tuple2 
-  | Accumulated of opt_type 
-  | ReverseAccumulated of opt_type 
+  FStar_Pervasives_Native.tuple2
+  | Accumulated of opt_type
+  | ReverseAccumulated of opt_type
   | WithSideEffect of (Prims.unit -> Prims.unit,opt_type)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let (uu___is_Const : opt_type -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_Const: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | Const _0 -> true | uu____2064 -> false
-  
-let (__proj__Const__item___0 : opt_type -> option_val) =
-  fun projectee  -> match projectee with | Const _0 -> _0 
-let (uu___is_IntStr : opt_type -> Prims.bool) =
+let __proj__Const__item___0: opt_type -> option_val =
+  fun projectee  -> match projectee with | Const _0 -> _0
+let uu___is_IntStr: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | IntStr _0 -> true | uu____2076 -> false
-  
-let (__proj__IntStr__item___0 : opt_type -> Prims.string) =
-  fun projectee  -> match projectee with | IntStr _0 -> _0 
-let (uu___is_BoolStr : opt_type -> Prims.bool) =
+let __proj__IntStr__item___0: opt_type -> Prims.string =
+  fun projectee  -> match projectee with | IntStr _0 -> _0
+let uu___is_BoolStr: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | BoolStr  -> true | uu____2087 -> false
-  
-let (uu___is_PathStr : opt_type -> Prims.bool) =
+let uu___is_PathStr: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | PathStr _0 -> true | uu____2092 -> false
-  
-let (__proj__PathStr__item___0 : opt_type -> Prims.string) =
-  fun projectee  -> match projectee with | PathStr _0 -> _0 
-let (uu___is_SimpleStr : opt_type -> Prims.bool) =
+let __proj__PathStr__item___0: opt_type -> Prims.string =
+  fun projectee  -> match projectee with | PathStr _0 -> _0
+let uu___is_SimpleStr: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | SimpleStr _0 -> true | uu____2104 -> false
-  
-let (__proj__SimpleStr__item___0 : opt_type -> Prims.string) =
-  fun projectee  -> match projectee with | SimpleStr _0 -> _0 
-let (uu___is_EnumStr : opt_type -> Prims.bool) =
+let __proj__SimpleStr__item___0: opt_type -> Prims.string =
+  fun projectee  -> match projectee with | SimpleStr _0 -> _0
+let uu___is_EnumStr: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | EnumStr _0 -> true | uu____2118 -> false
-  
-let (__proj__EnumStr__item___0 : opt_type -> Prims.string Prims.list) =
-  fun projectee  -> match projectee with | EnumStr _0 -> _0 
-let (uu___is_OpenEnumStr : opt_type -> Prims.bool) =
+let __proj__EnumStr__item___0: opt_type -> Prims.string Prims.list =
+  fun projectee  -> match projectee with | EnumStr _0 -> _0
+let uu___is_OpenEnumStr: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | OpenEnumStr _0 -> true | uu____2142 -> false
-  
-let (__proj__OpenEnumStr__item___0 :
+let __proj__OpenEnumStr__item___0:
   opt_type ->
-    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | OpenEnumStr _0 -> _0 
-let (uu___is_PostProcessed : opt_type -> Prims.bool) =
+    (Prims.string Prims.list,Prims.string) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | OpenEnumStr _0 -> _0
+let uu___is_PostProcessed: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | PostProcessed _0 -> true | uu____2178 -> false
-  
-let (__proj__PostProcessed__item___0 :
+let __proj__PostProcessed__item___0:
   opt_type ->
-    (option_val -> option_val,opt_type) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | PostProcessed _0 -> _0 
-let (uu___is_Accumulated : opt_type -> Prims.bool) =
+    (option_val -> option_val,opt_type) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | PostProcessed _0 -> _0
+let uu___is_Accumulated: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | Accumulated _0 -> true | uu____2208 -> false
-  
-let (__proj__Accumulated__item___0 : opt_type -> opt_type) =
-  fun projectee  -> match projectee with | Accumulated _0 -> _0 
-let (uu___is_ReverseAccumulated : opt_type -> Prims.bool) =
+let __proj__Accumulated__item___0: opt_type -> opt_type =
+  fun projectee  -> match projectee with | Accumulated _0 -> _0
+let uu___is_ReverseAccumulated: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with
     | ReverseAccumulated _0 -> true
     | uu____2220 -> false
-  
-let (__proj__ReverseAccumulated__item___0 : opt_type -> opt_type) =
-  fun projectee  -> match projectee with | ReverseAccumulated _0 -> _0 
-let (uu___is_WithSideEffect : opt_type -> Prims.bool) =
+let __proj__ReverseAccumulated__item___0: opt_type -> opt_type =
+  fun projectee  -> match projectee with | ReverseAccumulated _0 -> _0
+let uu___is_WithSideEffect: opt_type -> Prims.bool =
   fun projectee  ->
     match projectee with | WithSideEffect _0 -> true | uu____2238 -> false
-  
-let (__proj__WithSideEffect__item___0 :
+let __proj__WithSideEffect__item___0:
   opt_type ->
-    (Prims.unit -> Prims.unit,opt_type) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | WithSideEffect _0 -> _0 
-exception InvalidArgument of Prims.string 
-let (uu___is_InvalidArgument : Prims.exn -> Prims.bool) =
+    (Prims.unit -> Prims.unit,opt_type) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | WithSideEffect _0 -> _0
+exception InvalidArgument of Prims.string
+let uu___is_InvalidArgument: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with
     | InvalidArgument uu____2270 -> true
     | uu____2271 -> false
-  
-let (__proj__InvalidArgument__item__uu___ : Prims.exn -> Prims.string) =
+let __proj__InvalidArgument__item__uu___: Prims.exn -> Prims.string =
   fun projectee  ->
     match projectee with | InvalidArgument uu____2278 -> uu____2278
-  
-let rec (parse_opt_val :
-  Prims.string -> opt_type -> Prims.string -> option_val) =
+let rec parse_opt_val: Prims.string -> opt_type -> Prims.string -> option_val
+  =
   fun opt_name  ->
     fun typ  ->
       fun str_val  ->
@@ -761,7 +697,7 @@ let rec (parse_opt_val :
           match typ with
           | Const c -> c
           | IntStr uu____2292 ->
-              let uu____2293 = FStar_Util.safe_int_of_string str_val  in
+              let uu____2293 = FStar_Util.safe_int_of_string str_val in
               (match uu____2293 with
                | FStar_Pervasives_Native.Some v1 -> mk_int v1
                | FStar_Pervasives_Native.None  ->
@@ -773,8 +709,7 @@ let rec (parse_opt_val :
                 else
                   if str_val = "false"
                   then false
-                  else FStar_Exn.raise (InvalidArgument opt_name)
-                 in
+                  else FStar_Exn.raise (InvalidArgument opt_name) in
               mk_bool uu____2297
           | PathStr uu____2300 -> mk_path str_val
           | SimpleStr uu____2301 -> mk_string str_val
@@ -784,29 +719,27 @@ let rec (parse_opt_val :
               else FStar_Exn.raise (InvalidArgument opt_name)
           | OpenEnumStr uu____2306 -> mk_string str_val
           | PostProcessed (pp,elem_spec) ->
-              let uu____2319 = parse_opt_val opt_name elem_spec str_val  in
+              let uu____2319 = parse_opt_val opt_name elem_spec str_val in
               pp uu____2319
           | Accumulated elem_spec ->
-              let v1 = parse_opt_val opt_name elem_spec str_val  in
+              let v1 = parse_opt_val opt_name elem_spec str_val in
               accumulated_option opt_name v1
           | ReverseAccumulated elem_spec ->
-              let v1 = parse_opt_val opt_name elem_spec str_val  in
+              let v1 = parse_opt_val opt_name elem_spec str_val in
               reverse_accumulated_option opt_name v1
           | WithSideEffect (side_effect,elem_spec) ->
               (side_effect (); parse_opt_val opt_name elem_spec str_val)
         with
         | InvalidArgument opt_name1 ->
             let uu____2336 =
-              FStar_Util.format1 "Invalid argument to --%s" opt_name1  in
+              FStar_Util.format1 "Invalid argument to --%s" opt_name1 in
             failwith uu____2336
-  
-let rec (desc_of_opt_type :
-  opt_type -> Prims.string FStar_Pervasives_Native.option) =
+let rec desc_of_opt_type:
+  opt_type -> Prims.string FStar_Pervasives_Native.option =
   fun typ  ->
     let desc_of_enum cases =
       FStar_Pervasives_Native.Some
-        (Prims.strcat "[" (Prims.strcat (FStar_String.concat "|" cases) "]"))
-       in
+        (Prims.strcat "[" (Prims.strcat (FStar_String.concat "|" cases) "]")) in
     match typ with
     | Const c -> FStar_Pervasives_Native.None
     | IntStr desc -> FStar_Pervasives_Native.Some desc
@@ -819,41 +752,36 @@ let rec (desc_of_opt_type :
     | Accumulated elem_spec -> desc_of_opt_type elem_spec
     | ReverseAccumulated elem_spec -> desc_of_opt_type elem_spec
     | WithSideEffect (uu____2377,elem_spec) -> desc_of_opt_type elem_spec
-  
-let rec (arg_spec_of_opt_type :
-  Prims.string -> opt_type -> option_val FStar_Getopt.opt_variant) =
+let rec arg_spec_of_opt_type:
+  Prims.string -> opt_type -> option_val FStar_Getopt.opt_variant =
   fun opt_name  ->
     fun typ  ->
-      let parser = parse_opt_val opt_name typ  in
-      let uu____2396 = desc_of_opt_type typ  in
+      let parser = parse_opt_val opt_name typ in
+      let uu____2396 = desc_of_opt_type typ in
       match uu____2396 with
       | FStar_Pervasives_Native.None  ->
           FStar_Getopt.ZeroArgs ((fun uu____2402  -> parser ""))
       | FStar_Pervasives_Native.Some desc ->
           FStar_Getopt.OneArg (parser, desc)
-  
-let (pp_validate_dir : option_val -> option_val) =
-  fun p  -> let pp = as_string p  in FStar_Util.mkdir false pp; p 
-let (pp_lowercase : option_val -> option_val) =
+let pp_validate_dir: option_val -> option_val =
+  fun p  -> let pp = as_string p in FStar_Util.mkdir false pp; p
+let pp_lowercase: option_val -> option_val =
   fun s  ->
     let uu____2414 =
-      let uu____2415 = as_string s  in FStar_String.lowercase uu____2415  in
+      let uu____2415 = as_string s in FStar_String.lowercase uu____2415 in
     mk_string uu____2414
-  
-let rec (specs_with_types :
+let rec specs_with_types:
   Prims.unit ->
     (FStar_BaseTypes.char,Prims.string,opt_type,Prims.string)
-      FStar_Pervasives_Native.tuple4 Prims.list)
+      FStar_Pervasives_Native.tuple4 Prims.list
   =
   fun uu____2432  ->
     let uu____2443 =
       let uu____2454 =
         let uu____2465 =
-          let uu____2474 = let uu____2475 = mk_bool true  in Const uu____2475
-             in
+          let uu____2474 = let uu____2475 = mk_bool true in Const uu____2475 in
           (FStar_Getopt.noshort, "cache_checked_modules", uu____2474,
-            "Write a '.checked' file for each module after verification and read from it if present, instead of re-verifying")
-           in
+            "Write a '.checked' file for each module after verification and read from it if present, instead of re-verifying") in
         let uu____2476 =
           let uu____2487 =
             let uu____2498 =
@@ -863,107 +791,92 @@ let rec (specs_with_types :
                     let uu____2542 =
                       let uu____2553 =
                         let uu____2562 =
-                          let uu____2563 = mk_bool true  in Const uu____2563
-                           in
+                          let uu____2563 = mk_bool true in Const uu____2563 in
                         (FStar_Getopt.noshort, "detail_errors", uu____2562,
-                          "Emit a detailed error report by asking the SMT solver many queries; will take longer;\n         implies n_cores=1")
-                         in
+                          "Emit a detailed error report by asking the SMT solver many queries; will take longer;\n         implies n_cores=1") in
                       let uu____2564 =
                         let uu____2575 =
                           let uu____2584 =
-                            let uu____2585 = mk_bool true  in
-                            Const uu____2585  in
+                            let uu____2585 = mk_bool true in Const uu____2585 in
                           (FStar_Getopt.noshort, "detail_hint_replay",
                             uu____2584,
-                            "Emit a detailed report for proof whose unsat core fails to replay;\n         implies n_cores=1")
-                           in
+                            "Emit a detailed report for proof whose unsat core fails to replay;\n         implies n_cores=1") in
                         let uu____2586 =
                           let uu____2597 =
                             let uu____2606 =
-                              let uu____2607 = mk_bool true  in
-                              Const uu____2607  in
+                              let uu____2607 = mk_bool true in
+                              Const uu____2607 in
                             (FStar_Getopt.noshort, "doc", uu____2606,
-                              "Extract Markdown documentation files for the input modules, as well as an index. Output is written to --odir directory.")
-                             in
+                              "Extract Markdown documentation files for the input modules, as well as an index. Output is written to --odir directory.") in
                           let uu____2608 =
                             let uu____2619 =
                               let uu____2630 =
                                 let uu____2639 =
-                                  let uu____2640 = mk_bool true  in
-                                  Const uu____2640  in
+                                  let uu____2640 = mk_bool true in
+                                  Const uu____2640 in
                                 (FStar_Getopt.noshort, "eager_inference",
                                   uu____2639,
-                                  "Solve all type-inference constraints eagerly; more efficient but at the cost of generality")
-                                 in
+                                  "Solve all type-inference constraints eagerly; more efficient but at the cost of generality") in
                               let uu____2641 =
                                 let uu____2652 =
                                   let uu____2663 =
                                     let uu____2674 =
                                       let uu____2685 =
                                         let uu____2694 =
-                                          let uu____2695 = mk_bool true  in
-                                          Const uu____2695  in
+                                          let uu____2695 = mk_bool true in
+                                          Const uu____2695 in
                                         (FStar_Getopt.noshort,
                                           "expose_interfaces", uu____2694,
-                                          "Explicitly break the abstraction imposed by the interface of any implementation file that appears on the command line (use with care!)")
-                                         in
+                                          "Explicitly break the abstraction imposed by the interface of any implementation file that appears on the command line (use with care!)") in
                                       let uu____2696 =
                                         let uu____2707 =
                                           let uu____2718 =
                                             let uu____2729 =
                                               let uu____2738 =
-                                                let uu____2739 = mk_bool true
-                                                   in
-                                                Const uu____2739  in
+                                                let uu____2739 = mk_bool true in
+                                                Const uu____2739 in
                                               (FStar_Getopt.noshort,
                                                 "hide_uvar_nums", uu____2738,
-                                                "Don't print unification variable numbers")
-                                               in
+                                                "Don't print unification variable numbers") in
                                             let uu____2740 =
                                               let uu____2751 =
                                                 let uu____2762 =
                                                   let uu____2771 =
                                                     let uu____2772 =
-                                                      mk_bool true  in
-                                                    Const uu____2772  in
+                                                      mk_bool true in
+                                                    Const uu____2772 in
                                                   (FStar_Getopt.noshort,
                                                     "hint_info", uu____2771,
-                                                    "Print information regarding hints (deprecated; use --query_stats instead)")
-                                                   in
+                                                    "Print information regarding hints (deprecated; use --query_stats instead)") in
                                                 let uu____2773 =
                                                   let uu____2784 =
                                                     let uu____2793 =
                                                       let uu____2794 =
-                                                        mk_bool true  in
-                                                      Const uu____2794  in
+                                                        mk_bool true in
+                                                      Const uu____2794 in
                                                     (FStar_Getopt.noshort,
                                                       "in", uu____2793,
-                                                      "Legacy interactive mode; reads input from stdin")
-                                                     in
+                                                      "Legacy interactive mode; reads input from stdin") in
                                                   let uu____2795 =
                                                     let uu____2806 =
                                                       let uu____2815 =
                                                         let uu____2816 =
-                                                          mk_bool true  in
-                                                        Const uu____2816  in
+                                                          mk_bool true in
+                                                        Const uu____2816 in
                                                       (FStar_Getopt.noshort,
                                                         "ide", uu____2815,
-                                                        "JSON-based interactive mode for IDEs")
-                                                       in
+                                                        "JSON-based interactive mode for IDEs") in
                                                     let uu____2817 =
                                                       let uu____2828 =
                                                         let uu____2839 =
                                                           let uu____2848 =
                                                             let uu____2849 =
-                                                              mk_bool true
-                                                               in
-                                                            Const uu____2849
-                                                             in
+                                                              mk_bool true in
+                                                            Const uu____2849 in
                                                           (FStar_Getopt.noshort,
                                                             "indent",
                                                             uu____2848,
-                                                            "Parses and outputs the files on the command line")
-                                                           in
+                                                            "Parses and outputs the files on the command line") in
                                                         let uu____2850 =
                                                           let uu____2861 =
                                                             let uu____2872 =
@@ -974,15 +887,13 @@ let rec (specs_with_types :
                                                                   let uu____2893
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                   Const
-                                                                    uu____2893
-                                                                   in
+                                                                    uu____2893 in
                                                                 (FStar_Getopt.noshort,
                                                                   "lax",
                                                                   uu____2892,
-                                                                  "Run the lax-type checker only (admit all verification conditions)")
-                                                                 in
+                                                                  "Run the lax-type checker only (admit all verification conditions)") in
                                                               let uu____2894
                                                                 =
                                                                 let uu____2905
@@ -994,15 +905,13 @@ let rec (specs_with_types :
                                                                     let uu____2926
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____2926
-                                                                     in
+                                                                    uu____2926 in
                                                                     (FStar_Getopt.noshort,
                                                                     "log_types",
                                                                     uu____2925,
-                                                                    "Print types computed for data/val/let-bindings")
-                                                                     in
+                                                                    "Print types computed for data/val/let-bindings") in
                                                                   let uu____2927
                                                                     =
                                                                     let uu____2938
@@ -1012,15 +921,13 @@ let rec (specs_with_types :
                                                                     let uu____2948
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____2948
-                                                                     in
+                                                                    uu____2948 in
                                                                     (FStar_Getopt.noshort,
                                                                     "log_queries",
                                                                     uu____2947,
-                                                                    "Log the Z3 queries in several queries-*.smt2 files, as we go")
-                                                                     in
+                                                                    "Log the Z3 queries in several queries-*.smt2 files, as we go") in
                                                                     let uu____2949
                                                                     =
                                                                     let uu____2960
@@ -1036,15 +943,13 @@ let rec (specs_with_types :
                                                                     let uu____3003
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3003
-                                                                     in
+                                                                    uu____3003 in
                                                                     (FStar_Getopt.noshort,
                                                                     "MLish",
                                                                     uu____3002,
-                                                                    "Trigger various specializations for compiling the F* compiler itself (not meant for user code)")
-                                                                     in
+                                                                    "Trigger various specializations for compiling the F* compiler itself (not meant for user code)") in
                                                                     let uu____3004
                                                                     =
                                                                     let uu____3015
@@ -1056,15 +961,13 @@ let rec (specs_with_types :
                                                                     let uu____3036
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3036
-                                                                     in
+                                                                    uu____3036 in
                                                                     (FStar_Getopt.noshort,
                                                                     "no_default_includes",
                                                                     uu____3035,
-                                                                    "Ignore the default module search paths")
-                                                                     in
+                                                                    "Ignore the default module search paths") in
                                                                     let uu____3037
                                                                     =
                                                                     let uu____3048
@@ -1076,15 +979,13 @@ let rec (specs_with_types :
                                                                     let uu____3069
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3069
-                                                                     in
+                                                                    uu____3069 in
                                                                     (FStar_Getopt.noshort,
                                                                     "no_location_info",
                                                                     uu____3068,
-                                                                    "Suppress location information in the generated OCaml output (only relevant with --codegen OCaml)")
-                                                                     in
+                                                                    "Suppress location information in the generated OCaml output (only relevant with --codegen OCaml)") in
                                                                     let uu____3070
                                                                     =
                                                                     let uu____3081
@@ -1094,15 +995,13 @@ let rec (specs_with_types :
                                                                     let uu____3091
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3091
-                                                                     in
+                                                                    uu____3091 in
                                                                     (FStar_Getopt.noshort,
                                                                     "normalize_pure_terms_for_extraction",
                                                                     uu____3090,
-                                                                    "Extract top-level pure terms after normalizing them. This can lead to very large code, but can result in more partial evaluation and compile-time specialization.")
-                                                                     in
+                                                                    "Extract top-level pure terms after normalizing them. This can lead to very large code, but can result in more partial evaluation and compile-time specialization.") in
                                                                     let uu____3092
                                                                     =
                                                                     let uu____3103
@@ -1116,15 +1015,13 @@ let rec (specs_with_types :
                                                                     let uu____3135
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3135
-                                                                     in
+                                                                    uu____3135 in
                                                                     (FStar_Getopt.noshort,
                                                                     "print_bound_var_types",
                                                                     uu____3134,
-                                                                    "Print the types of bound variables")
-                                                                     in
+                                                                    "Print the types of bound variables") in
                                                                     let uu____3136
                                                                     =
                                                                     let uu____3147
@@ -1134,15 +1031,13 @@ let rec (specs_with_types :
                                                                     let uu____3157
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3157
-                                                                     in
+                                                                    uu____3157 in
                                                                     (FStar_Getopt.noshort,
                                                                     "print_effect_args",
                                                                     uu____3156,
-                                                                    "Print inferred predicate transformers for all computation types")
-                                                                     in
+                                                                    "Print inferred predicate transformers for all computation types") in
                                                                     let uu____3158
                                                                     =
                                                                     let uu____3169
@@ -1152,15 +1047,13 @@ let rec (specs_with_types :
                                                                     let uu____3179
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3179
-                                                                     in
+                                                                    uu____3179 in
                                                                     (FStar_Getopt.noshort,
                                                                     "print_full_names",
                                                                     uu____3178,
-                                                                    "Print full names of variables")
-                                                                     in
+                                                                    "Print full names of variables") in
                                                                     let uu____3180
                                                                     =
                                                                     let uu____3191
@@ -1170,15 +1063,13 @@ let rec (specs_with_types :
                                                                     let uu____3201
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3201
-                                                                     in
+                                                                    uu____3201 in
                                                                     (FStar_Getopt.noshort,
                                                                     "print_implicits",
                                                                     uu____3200,
-                                                                    "Print implicit arguments")
-                                                                     in
+                                                                    "Print implicit arguments") in
                                                                     let uu____3202
                                                                     =
                                                                     let uu____3213
@@ -1188,15 +1079,13 @@ let rec (specs_with_types :
                                                                     let uu____3223
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3223
-                                                                     in
+                                                                    uu____3223 in
                                                                     (FStar_Getopt.noshort,
                                                                     "print_universes",
                                                                     uu____3222,
-                                                                    "Print universes")
-                                                                     in
+                                                                    "Print universes") in
                                                                     let uu____3224
                                                                     =
                                                                     let uu____3235
@@ -1206,15 +1095,13 @@ let rec (specs_with_types :
                                                                     let uu____3245
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3245
-                                                                     in
+                                                                    uu____3245 in
                                                                     (FStar_Getopt.noshort,
                                                                     "print_z3_statistics",
                                                                     uu____3244,
-                                                                    "Print Z3 statistics for each SMT query (deprecated; use --query_stats instead)")
-                                                                     in
+                                                                    "Print Z3 statistics for each SMT query (deprecated; use --query_stats instead)") in
                                                                     let uu____3246
                                                                     =
                                                                     let uu____3257
@@ -1224,15 +1111,13 @@ let rec (specs_with_types :
                                                                     let uu____3267
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3267
-                                                                     in
+                                                                    uu____3267 in
                                                                     (FStar_Getopt.noshort,
                                                                     "prn",
                                                                     uu____3266,
-                                                                    "Print full names (deprecated; use --print_full_names instead)")
-                                                                     in
+                                                                    "Print full names (deprecated; use --print_full_names instead)") in
                                                                     let uu____3268
                                                                     =
                                                                     let uu____3279
@@ -1242,15 +1127,13 @@ let rec (specs_with_types :
                                                                     let uu____3289
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3289
-                                                                     in
+                                                                    uu____3289 in
                                                                     (FStar_Getopt.noshort,
                                                                     "query_stats",
                                                                     uu____3288,
-                                                                    "Print SMT query statistics")
-                                                                     in
+                                                                    "Print SMT query statistics") in
                                                                     let uu____3290
                                                                     =
                                                                     let uu____3301
@@ -1260,15 +1143,13 @@ let rec (specs_with_types :
                                                                     let uu____3311
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3311
-                                                                     in
+                                                                    uu____3311 in
                                                                     (FStar_Getopt.noshort,
                                                                     "record_hints",
                                                                     uu____3310,
-                                                                    "Record a database of hints for efficient proof replay")
-                                                                     in
+                                                                    "Record a database of hints for efficient proof replay") in
                                                                     let uu____3312
                                                                     =
                                                                     let uu____3323
@@ -1280,14 +1161,13 @@ let rec (specs_with_types :
                                                                     let uu____3344
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3344
-                                                                     in
+                                                                    uu____3344 in
                                                                     (FStar_Getopt.noshort,
                                                                     "silent",
                                                                     uu____3343,
-                                                                    " ")  in
+                                                                    " ") in
                                                                     let uu____3345
                                                                     =
                                                                     let uu____3356
@@ -1305,15 +1185,13 @@ let rec (specs_with_types :
                                                                     let uu____3410
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3410
-                                                                     in
+                                                                    uu____3410 in
                                                                     (FStar_Getopt.noshort,
                                                                     "tactic_raw_binders",
                                                                     uu____3409,
-                                                                    "Do not use the lexical scope of tactics to improve binder names")
-                                                                     in
+                                                                    "Do not use the lexical scope of tactics to improve binder names") in
                                                                     let uu____3411
                                                                     =
                                                                     let uu____3422
@@ -1323,15 +1201,13 @@ let rec (specs_with_types :
                                                                     let uu____3432
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3432
-                                                                     in
+                                                                    uu____3432 in
                                                                     (FStar_Getopt.noshort,
                                                                     "tactic_trace",
                                                                     uu____3431,
-                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)")
-                                                                     in
+                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)") in
                                                                     let uu____3433
                                                                     =
                                                                     let uu____3444
@@ -1343,15 +1219,13 @@ let rec (specs_with_types :
                                                                     let uu____3465
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3465
-                                                                     in
+                                                                    uu____3465 in
                                                                     (FStar_Getopt.noshort,
                                                                     "timing",
                                                                     uu____3464,
-                                                                    "Print the time it takes to verify each top-level definition")
-                                                                     in
+                                                                    "Print the time it takes to verify each top-level definition") in
                                                                     let uu____3466
                                                                     =
                                                                     let uu____3477
@@ -1361,15 +1235,13 @@ let rec (specs_with_types :
                                                                     let uu____3487
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3487
-                                                                     in
+                                                                    uu____3487 in
                                                                     (FStar_Getopt.noshort,
                                                                     "trace_error",
                                                                     uu____3486,
-                                                                    "Don't print an error message; show an exception trace instead")
-                                                                     in
+                                                                    "Don't print an error message; show an exception trace instead") in
                                                                     let uu____3488
                                                                     =
                                                                     let uu____3499
@@ -1379,15 +1251,13 @@ let rec (specs_with_types :
                                                                     let uu____3509
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3509
-                                                                     in
+                                                                    uu____3509 in
                                                                     (FStar_Getopt.noshort,
                                                                     "ugly",
                                                                     uu____3508,
-                                                                    "Emit output formatted for debugging")
-                                                                     in
+                                                                    "Emit output formatted for debugging") in
                                                                     let uu____3510
                                                                     =
                                                                     let uu____3521
@@ -1397,15 +1267,13 @@ let rec (specs_with_types :
                                                                     let uu____3531
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3531
-                                                                     in
+                                                                    uu____3531 in
                                                                     (FStar_Getopt.noshort,
                                                                     "unthrottle_inductives",
                                                                     uu____3530,
-                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)")
-                                                                     in
+                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)") in
                                                                     let uu____3532
                                                                     =
                                                                     let uu____3543
@@ -1415,15 +1283,13 @@ let rec (specs_with_types :
                                                                     let uu____3553
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3553
-                                                                     in
+                                                                    uu____3553 in
                                                                     (FStar_Getopt.noshort,
                                                                     "unsafe_tactic_exec",
                                                                     uu____3552,
-                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects.")
-                                                                     in
+                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects.") in
                                                                     let uu____3554
                                                                     =
                                                                     let uu____3565
@@ -1433,15 +1299,13 @@ let rec (specs_with_types :
                                                                     let uu____3575
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3575
-                                                                     in
+                                                                    uu____3575 in
                                                                     (FStar_Getopt.noshort,
                                                                     "use_eq_at_higher_order",
                                                                     uu____3574,
-                                                                    "Use equality constraints when comparing higher-order types (Temporary)")
-                                                                     in
+                                                                    "Use equality constraints when comparing higher-order types (Temporary)") in
                                                                     let uu____3576
                                                                     =
                                                                     let uu____3587
@@ -1451,15 +1315,13 @@ let rec (specs_with_types :
                                                                     let uu____3597
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3597
-                                                                     in
+                                                                    uu____3597 in
                                                                     (FStar_Getopt.noshort,
                                                                     "use_hints",
                                                                     uu____3596,
-                                                                    "Use a previously recorded hints database for proof replay")
-                                                                     in
+                                                                    "Use a previously recorded hints database for proof replay") in
                                                                     let uu____3598
                                                                     =
                                                                     let uu____3609
@@ -1469,15 +1331,13 @@ let rec (specs_with_types :
                                                                     let uu____3619
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3619
-                                                                     in
+                                                                    uu____3619 in
                                                                     (FStar_Getopt.noshort,
                                                                     "use_hint_hashes",
                                                                     uu____3618,
-                                                                    "Admit queries if their hash matches the hash recorded in the hints database")
-                                                                     in
+                                                                    "Admit queries if their hash matches the hash recorded in the hints database") in
                                                                     let uu____3620
                                                                     =
                                                                     let uu____3631
@@ -1489,15 +1349,13 @@ let rec (specs_with_types :
                                                                     let uu____3652
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3652
-                                                                     in
+                                                                    uu____3652 in
                                                                     (FStar_Getopt.noshort,
                                                                     "no_tactics",
                                                                     uu____3651,
-                                                                    "Do not run the tactic engine before discharging a VC")
-                                                                     in
+                                                                    "Do not run the tactic engine before discharging a VC") in
                                                                     let uu____3653
                                                                     =
                                                                     let uu____3664
@@ -1513,15 +1371,13 @@ let rec (specs_with_types :
                                                                     let uu____3707
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3707
-                                                                     in
+                                                                    uu____3707 in
                                                                     (FStar_Getopt.noshort,
                                                                     "__temp_fast_implicits",
                                                                     uu____3706,
-                                                                    "Don't use this option yet")
-                                                                     in
+                                                                    "Don't use this option yet") in
                                                                     let uu____3708
                                                                     =
                                                                     let uu____3719
@@ -1535,27 +1391,24 @@ let rec (specs_with_types :
                                                                     let uu____3738
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3738
-                                                                     in
+                                                                    uu____3738 in
                                                                     ((fun
                                                                     uu____3743
                                                                      ->
                                                                     display_version
                                                                     ();
                                                                     FStar_All.exit
-                                                                    (Prims.parse_int "0")),
-                                                                    uu____3737)
-                                                                     in
+                                                                    (Prims.parse_int
+                                                                    "0")),
+                                                                    uu____3737) in
                                                                     WithSideEffect
-                                                                    uu____3730
-                                                                     in
+                                                                    uu____3730 in
                                                                     (118,
                                                                     "version",
                                                                     uu____3729,
-                                                                    "Display version number")
-                                                                     in
+                                                                    "Display version number") in
                                                                     let uu____3747
                                                                     =
                                                                     let uu____3759
@@ -1565,15 +1418,13 @@ let rec (specs_with_types :
                                                                     let uu____3769
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3769
-                                                                     in
+                                                                    uu____3769 in
                                                                     (FStar_Getopt.noshort,
                                                                     "warn_default_effects",
                                                                     uu____3768,
-                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)")
-                                                                     in
+                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)") in
                                                                     let uu____3770
                                                                     =
                                                                     let uu____3781
@@ -1585,15 +1436,13 @@ let rec (specs_with_types :
                                                                     let uu____3802
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3802
-                                                                     in
+                                                                    uu____3802 in
                                                                     (FStar_Getopt.noshort,
                                                                     "z3refresh",
                                                                     uu____3801,
-                                                                    "Restart Z3 after each query; useful for ensuring proof robustness")
-                                                                     in
+                                                                    "Restart Z3 after each query; useful for ensuring proof robustness") in
                                                                     let uu____3803
                                                                     =
                                                                     let uu____3814
@@ -1611,15 +1460,13 @@ let rec (specs_with_types :
                                                                     let uu____3868
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3868
-                                                                     in
+                                                                    uu____3868 in
                                                                     (FStar_Getopt.noshort,
                                                                     "__no_positivity",
                                                                     uu____3867,
-                                                                    "Don't check positivity of inductive types")
-                                                                     in
+                                                                    "Don't check positivity of inductive types") in
                                                                     let uu____3869
                                                                     =
                                                                     let uu____3880
@@ -1629,15 +1476,13 @@ let rec (specs_with_types :
                                                                     let uu____3890
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3890
-                                                                     in
+                                                                    uu____3890 in
                                                                     (FStar_Getopt.noshort,
                                                                     "__ml_no_eta_expand_coertions",
                                                                     uu____3889,
-                                                                    "Do not eta-expand coertions in generated OCaml")
-                                                                     in
+                                                                    "Do not eta-expand coertions in generated OCaml") in
                                                                     let uu____3891
                                                                     =
                                                                     let uu____3902
@@ -1649,15 +1494,13 @@ let rec (specs_with_types :
                                                                     let uu____3923
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3923
-                                                                     in
+                                                                    uu____3923 in
                                                                     (FStar_Getopt.noshort,
                                                                     "use_extracted_interfaces",
                                                                     uu____3922,
-                                                                    "Extract interfaces from the dependencies and use them for verification")
-                                                                     in
+                                                                    "Extract interfaces from the dependencies and use them for verification") in
                                                                     let uu____3924
                                                                     =
                                                                     let uu____3935
@@ -1667,15 +1510,13 @@ let rec (specs_with_types :
                                                                     let uu____3945
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3945
-                                                                     in
+                                                                    uu____3945 in
                                                                     (FStar_Getopt.noshort,
                                                                     "check_interface",
                                                                     uu____3944,
-                                                                    "Verify the extracted interface of the module. This flag automatically enables --use_extracted_interfaces also.")
-                                                                     in
+                                                                    "Verify the extracted interface of the module. This flag automatically enables --use_extracted_interfaces also.") in
                                                                     let uu____3946
                                                                     =
                                                                     let uu____3957
@@ -1689,93 +1530,78 @@ let rec (specs_with_types :
                                                                     let uu____3976
                                                                     =
                                                                     mk_bool
-                                                                    true  in
+                                                                    true in
                                                                     Const
-                                                                    uu____3976
-                                                                     in
+                                                                    uu____3976 in
                                                                     ((fun
                                                                     uu____3981
                                                                      ->
                                                                     (
                                                                     let uu____3983
                                                                     =
-                                                                    specs ()
-                                                                     in
+                                                                    specs () in
                                                                     display_usage_aux
                                                                     uu____3983);
                                                                     FStar_All.exit
-                                                                    (Prims.parse_int "0")),
-                                                                    uu____3975)
-                                                                     in
+                                                                    (Prims.parse_int
+                                                                    "0")),
+                                                                    uu____3975) in
                                                                     WithSideEffect
-                                                                    uu____3968
-                                                                     in
+                                                                    uu____3968 in
                                                                     (104,
                                                                     "help",
                                                                     uu____3967,
-                                                                    "Display this information")
-                                                                     in
-                                                                    [uu____3957]
-                                                                     in
+                                                                    "Display this information") in
+                                                                    [uu____3957] in
                                                                     uu____3935
                                                                     ::
-                                                                    uu____3946
-                                                                     in
+                                                                    uu____3946 in
                                                                     uu____3913
                                                                     ::
-                                                                    uu____3924
-                                                                     in
+                                                                    uu____3924 in
                                                                     (FStar_Getopt.noshort,
                                                                     "warn_error",
                                                                     (SimpleStr
                                                                     ""),
                                                                     "The [-warn_error] option follows the OCaml syntax, namely:\n\t\t- [r] is a range of warnings (either a number [n], or a range [n..n])\n\t\t- [-r] silences range [r]\n\t\t- [+r] enables range [r]\n\t\t- [@r] makes range [r] fatal.")
                                                                     ::
-                                                                    uu____3902
-                                                                     in
+                                                                    uu____3902 in
                                                                     uu____3880
                                                                     ::
-                                                                    uu____3891
-                                                                     in
+                                                                    uu____3891 in
                                                                     uu____3858
                                                                     ::
-                                                                    uu____3869
-                                                                     in
+                                                                    uu____3869 in
                                                                     (FStar_Getopt.noshort,
                                                                     "use_two_phase_tc",
                                                                     BoolStr,
                                                                     "Use the two phase typechecker (default 'false')")
                                                                     ::
-                                                                    uu____3847
-                                                                     in
+                                                                    uu____3847 in
                                                                     (FStar_Getopt.noshort,
                                                                     "z3seed",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     "Set the Z3 random seed (default 0)")
                                                                     ::
-                                                                    uu____3836
-                                                                     in
+                                                                    uu____3836 in
                                                                     (FStar_Getopt.noshort,
                                                                     "z3rlimit_factor",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     "Set the Z3 per-query resource limit multiplier. This is useful when, say, regenerating hints and you want to be more lax. (default 1)")
                                                                     ::
-                                                                    uu____3825
-                                                                     in
+                                                                    uu____3825 in
                                                                     (FStar_Getopt.noshort,
                                                                     "z3rlimit",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)")
                                                                     ::
-                                                                    uu____3814
-                                                                     in
+                                                                    uu____3814 in
                                                                     uu____3792
                                                                     ::
-                                                                    uu____3803
-                                                                     in
+                                                                    uu____3803 in
                                                                     (FStar_Getopt.noshort,
                                                                     "z3cliopt",
                                                                     (ReverseAccumulated
@@ -1783,20 +1609,16 @@ let rec (specs_with_types :
                                                                     "option")),
                                                                     "Z3 command line options")
                                                                     ::
-                                                                    uu____3781
-                                                                     in
+                                                                    uu____3781 in
                                                                     uu____3759
                                                                     ::
-                                                                    uu____3770
-                                                                     in
+                                                                    uu____3770 in
                                                                     uu____3719
                                                                     ::
-                                                                    uu____3747
-                                                                     in
+                                                                    uu____3747 in
                                                                     uu____3697
                                                                     ::
-                                                                    uu____3708
-                                                                     in
+                                                                    uu____3708 in
                                                                     (FStar_Getopt.noshort,
                                                                     "__temp_no_proj",
                                                                     (Accumulated
@@ -1804,8 +1626,7 @@ let rec (specs_with_types :
                                                                     "module_name")),
                                                                     "Don't generate projectors for this module")
                                                                     ::
-                                                                    uu____3686
-                                                                     in
+                                                                    uu____3686 in
                                                                     (FStar_Getopt.noshort,
                                                                     "vcgen.optimize_bind_as_seq",
                                                                     (EnumStr
@@ -1814,8 +1635,7 @@ let rec (specs_with_types :
                                                                     "with_type"]),
                                                                     "\n\t\tOptimize the generation of verification conditions, \n\t\t\tspecifically the construction of monadic `bind`,\n\t\t\tgenerating `seq` instead of `bind` when the first computation as a trivial post-condition.\n\t\t\tBy default, this optimization does not apply.\n\t\t\tWhen the `without_type` option is chosen, this imposes a cost on the SMT solver\n\t\t\tto reconstruct type information.\n\t\t\tWhen `with_type` is chosen, type information is provided to the SMT solver,\n\t\t\tbut at the cost of VC bloat, which may often be redundant.")
                                                                     ::
-                                                                    uu____3675
-                                                                     in
+                                                                    uu____3675 in
                                                                     (FStar_Getopt.noshort,
                                                                     "using_facts_from",
                                                                     (Accumulated
@@ -1823,68 +1643,54 @@ let rec (specs_with_types :
                                                                     "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
                                                                     "\n\t\tPrunes the context to include only the facts from the given namespace or fact id. \n\t\t\tFacts can be include or excluded using the [+|-] qualifier. \n\t\t\tFor example --using_facts_from '* -FStar.Reflection +FStar.List -FStar.List.Tot' will \n\t\t\t\tremove all facts from FStar.List.Tot.*, \n\t\t\t\tretain all remaining facts from FStar.List.*, \n\t\t\t\tremove all facts from FStar.Reflection.*, \n\t\t\t\tand retain all the rest.\n\t\tNote, the '+' is optional: --using_facts_from 'FStar.List' is equivalent to --using_facts_from '+FStar.List'. \n\t\tMultiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B.")
                                                                     ::
-                                                                    uu____3664
-                                                                     in
+                                                                    uu____3664 in
                                                                     uu____3642
                                                                     ::
-                                                                    uu____3653
-                                                                     in
+                                                                    uu____3653 in
                                                                     (FStar_Getopt.noshort,
                                                                     "use_native_tactics",
                                                                     (PathStr
                                                                     "path"),
                                                                     "Use compiled tactics from <path>")
                                                                     ::
-                                                                    uu____3631
-                                                                     in
+                                                                    uu____3631 in
                                                                     uu____3609
                                                                     ::
-                                                                    uu____3620
-                                                                     in
+                                                                    uu____3620 in
                                                                     uu____3587
                                                                     ::
-                                                                    uu____3598
-                                                                     in
+                                                                    uu____3598 in
                                                                     uu____3565
                                                                     ::
-                                                                    uu____3576
-                                                                     in
+                                                                    uu____3576 in
                                                                     uu____3543
                                                                     ::
-                                                                    uu____3554
-                                                                     in
+                                                                    uu____3554 in
                                                                     uu____3521
                                                                     ::
-                                                                    uu____3532
-                                                                     in
+                                                                    uu____3532 in
                                                                     uu____3499
                                                                     ::
-                                                                    uu____3510
-                                                                     in
+                                                                    uu____3510 in
                                                                     uu____3477
                                                                     ::
-                                                                    uu____3488
-                                                                     in
+                                                                    uu____3488 in
                                                                     uu____3455
                                                                     ::
-                                                                    uu____3466
-                                                                     in
+                                                                    uu____3466 in
                                                                     (FStar_Getopt.noshort,
                                                                     "tactic_trace_d",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     "Trace tactics up to a certain binding depth")
                                                                     ::
-                                                                    uu____3444
-                                                                     in
+                                                                    uu____3444 in
                                                                     uu____3422
                                                                     ::
-                                                                    uu____3433
-                                                                     in
+                                                                    uu____3433 in
                                                                     uu____3400
                                                                     ::
-                                                                    uu____3411
-                                                                     in
+                                                                    uu____3411 in
                                                                     (FStar_Getopt.noshort,
                                                                     "smtencoding.l_arith_repr",
                                                                     (EnumStr
@@ -1892,8 +1698,7 @@ let rec (specs_with_types :
                                                                     "boxwrap"]),
                                                                     "Toggle the representation of linear arithmetic functions in the SMT encoding:\n\t\ti.e., if 'boxwrap', use 'Prims.op_Addition, Prims.op_Subtraction, Prims.op_Minus'; \n\t\tif 'native', use '+, -, -'; \n\t\t(default 'boxwrap')")
                                                                     ::
-                                                                    uu____3389
-                                                                     in
+                                                                    uu____3389 in
                                                                     (FStar_Getopt.noshort,
                                                                     "smtencoding.nl_arith_repr",
                                                                     (EnumStr
@@ -1902,78 +1707,63 @@ let rec (specs_with_types :
                                                                     "boxwrap"]),
                                                                     "Control the representation of non-linear arithmetic functions in the SMT encoding:\n\t\ti.e., if 'boxwrap' use 'Prims.op_Multiply, Prims.op_Division, Prims.op_Modulus'; \n\t\tif 'native' use '*, div, mod';\n\t\tif 'wrapped' use '_mul, _div, _mod : Int*Int -> Int'; \n\t\t(default 'boxwrap')")
                                                                     ::
-                                                                    uu____3378
-                                                                     in
+                                                                    uu____3378 in
                                                                     (FStar_Getopt.noshort,
                                                                     "smtencoding.elim_box",
                                                                     BoolStr,
                                                                     "Toggle a peephole optimization that eliminates redundant uses of boxing/unboxing in the SMT encoding (default 'false')")
                                                                     ::
-                                                                    uu____3367
-                                                                     in
+                                                                    uu____3367 in
                                                                     (FStar_Getopt.noshort,
                                                                     "smt",
                                                                     (PathStr
                                                                     "path"),
                                                                     "Path to the Z3 SMT solver (we could eventually support other solvers)")
                                                                     ::
-                                                                    uu____3356
-                                                                     in
+                                                                    uu____3356 in
                                                                     uu____3334
                                                                     ::
-                                                                    uu____3345
-                                                                     in
+                                                                    uu____3345 in
                                                                     (FStar_Getopt.noshort,
                                                                     "reuse_hint_for",
                                                                     (SimpleStr
                                                                     "toplevel_name"),
                                                                     "Optimistically, attempt using the recorded hint for <toplevel_name> (a top-level name in the current module) when trying to verify some other term 'g'")
                                                                     ::
-                                                                    uu____3323
-                                                                     in
+                                                                    uu____3323 in
                                                                     uu____3301
                                                                     ::
-                                                                    uu____3312
-                                                                     in
+                                                                    uu____3312 in
                                                                     uu____3279
                                                                     ::
-                                                                    uu____3290
-                                                                     in
+                                                                    uu____3290 in
                                                                     uu____3257
                                                                     ::
-                                                                    uu____3268
-                                                                     in
+                                                                    uu____3268 in
                                                                     uu____3235
                                                                     ::
-                                                                    uu____3246
-                                                                     in
+                                                                    uu____3246 in
                                                                     uu____3213
                                                                     ::
-                                                                    uu____3224
-                                                                     in
+                                                                    uu____3224 in
                                                                     uu____3191
                                                                     ::
-                                                                    uu____3202
-                                                                     in
+                                                                    uu____3202 in
                                                                     uu____3169
                                                                     ::
-                                                                    uu____3180
-                                                                     in
+                                                                    uu____3180 in
                                                                     uu____3147
                                                                     ::
-                                                                    uu____3158
-                                                                     in
+                                                                    uu____3158 in
                                                                     uu____3125
                                                                     ::
-                                                                    uu____3136
-                                                                     in
+                                                                    uu____3136 in
                                                                     (FStar_Getopt.noshort,
                                                                     "prims",
                                                                     (PathStr
                                                                     "file"),
                                                                     "") ::
-                                                                    uu____3114
-                                                                     in
+                                                                    uu____3114 in
                                                                     (FStar_Getopt.noshort,
                                                                     "odir",
                                                                     (PostProcessed
@@ -1982,16 +1772,13 @@ let rec (specs_with_types :
                                                                     "dir"))),
                                                                     "Place output in directory <dir>")
                                                                     ::
-                                                                    uu____3103
-                                                                     in
+                                                                    uu____3103 in
                                                                     uu____3081
                                                                     ::
-                                                                    uu____3092
-                                                                     in
+                                                                    uu____3092 in
                                                                     uu____3059
                                                                     ::
-                                                                    uu____3070
-                                                                     in
+                                                                    uu____3070 in
                                                                     (FStar_Getopt.noshort,
                                                                     "no_extract",
                                                                     (Accumulated
@@ -1999,56 +1786,47 @@ let rec (specs_with_types :
                                                                     "module name")),
                                                                     "Deprecated: use --extract instead; Do not extract code from this module")
                                                                     ::
-                                                                    uu____3048
-                                                                     in
+                                                                    uu____3048 in
                                                                     uu____3026
                                                                     ::
-                                                                    uu____3037
-                                                                     in
+                                                                    uu____3037 in
                                                                     (FStar_Getopt.noshort,
                                                                     "n_cores",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     "Maximum number of cores to use for the solver (implies detail_errors = false) (default 1)")
                                                                     ::
-                                                                    uu____3015
-                                                                     in
+                                                                    uu____3015 in
                                                                     uu____2993
                                                                     ::
-                                                                    uu____3004
-                                                                     in
+                                                                    uu____3004 in
                                                                     (FStar_Getopt.noshort,
                                                                     "min_fuel",
                                                                     (IntStr
                                                                     "non-negative integer"),
                                                                     "Minimum number of unrolling of recursive functions to try (default 1)")
                                                                     ::
-                                                                    uu____2982
-                                                                     in
+                                                                    uu____2982 in
                                                                     (FStar_Getopt.noshort,
                                                                     "max_ifuel",
                                                                     (IntStr
                                                                     "non-negative integer"),
                                                                     "Number of unrolling of inductive datatypes to try at most (default 2)")
                                                                     ::
-                                                                    uu____2971
-                                                                     in
+                                                                    uu____2971 in
                                                                     (FStar_Getopt.noshort,
                                                                     "max_fuel",
                                                                     (IntStr
                                                                     "non-negative integer"),
                                                                     "Number of unrolling of recursive functions to try at most (default 8)")
                                                                     ::
-                                                                    uu____2960
-                                                                     in
+                                                                    uu____2960 in
                                                                     uu____2938
                                                                     ::
-                                                                    uu____2949
-                                                                     in
+                                                                    uu____2949 in
                                                                   uu____2916
                                                                     ::
-                                                                    uu____2927
-                                                                   in
+                                                                    uu____2927 in
                                                                 (FStar_Getopt.noshort,
                                                                   "load",
                                                                   (ReverseAccumulated
@@ -2056,59 +1834,48 @@ let rec (specs_with_types :
                                                                     "module")),
                                                                   "Load compiled module")
                                                                   ::
-                                                                  uu____2905
-                                                                 in
+                                                                  uu____2905 in
                                                               uu____2883 ::
-                                                                uu____2894
-                                                               in
+                                                                uu____2894 in
                                                             (FStar_Getopt.noshort,
                                                               "initial_ifuel",
                                                               (IntStr
                                                                  "non-negative integer"),
                                                               "Number of unrolling of inductive datatypes to try at first (default 1)")
-                                                              :: uu____2872
-                                                             in
+                                                              :: uu____2872 in
                                                           (FStar_Getopt.noshort,
                                                             "initial_fuel",
                                                             (IntStr
                                                                "non-negative integer"),
                                                             "Number of unrolling of recursive functions to try initially (default 2)")
-                                                            :: uu____2861
-                                                           in
+                                                            :: uu____2861 in
                                                         uu____2839 ::
-                                                          uu____2850
-                                                         in
+                                                          uu____2850 in
                                                       (FStar_Getopt.noshort,
                                                         "include",
                                                         (ReverseAccumulated
                                                            (PathStr "path")),
                                                         "A directory in which to search for files included on the command line")
-                                                        :: uu____2828
-                                                       in
-                                                    uu____2806 :: uu____2817
-                                                     in
-                                                  uu____2784 :: uu____2795
-                                                   in
-                                                uu____2762 :: uu____2773  in
+                                                        :: uu____2828 in
+                                                    uu____2806 :: uu____2817 in
+                                                  uu____2784 :: uu____2795 in
+                                                uu____2762 :: uu____2773 in
                                               (FStar_Getopt.noshort,
                                                 "hint_file",
                                                 (PathStr "path"),
                                                 "Read/write hints to <path> (instead of module-specific hints files)")
-                                                :: uu____2751
-                                               in
-                                            uu____2729 :: uu____2740  in
+                                                :: uu____2751 in
+                                            uu____2729 :: uu____2740 in
                                           (FStar_Getopt.noshort,
                                             "gen_native_tactics",
                                             (PathStr "[path]"),
                                             "Compile all user tactics used in the module in <path>")
-                                            :: uu____2718
-                                           in
+                                            :: uu____2718 in
                                         (FStar_Getopt.noshort, "fstar_home",
                                           (PathStr "dir"),
                                           "Set the FSTAR_HOME variable to <dir>")
-                                          :: uu____2707
-                                         in
-                                      uu____2685 :: uu____2696  in
+                                          :: uu____2707 in
+                                      uu____2685 :: uu____2696 in
                                     (FStar_Getopt.noshort,
                                       "extract_namespace",
                                       (Accumulated
@@ -2116,83 +1883,70 @@ let rec (specs_with_types :
                                             (pp_lowercase,
                                               (SimpleStr "namespace name")))),
                                       "Deprecated: use --extract instead; Only extract modules in the specified namespace")
-                                      :: uu____2674
-                                     in
+                                      :: uu____2674 in
                                   (FStar_Getopt.noshort, "extract_module",
                                     (Accumulated
                                        (PostProcessed
                                           (pp_lowercase,
                                             (SimpleStr "module_name")))),
                                     "Deprecated: use --extract instead; Only extract the specified modules (instead of the possibly-partial dependency graph)")
-                                    :: uu____2663
-                                   in
+                                    :: uu____2663 in
                                 (FStar_Getopt.noshort, "extract",
                                   (Accumulated
                                      (SimpleStr
                                         "One or more space-separated occurrences of '[+|-]( * | namespace | module)'")),
                                   "\n\t\tExtract only those modules whose names or namespaces match the provided options.\n\t\t\tModules can be extracted or not using the [+|-] qualifier. \n\t\t\tFor example --extract '* -FStar.Reflection +FStar.List -FStar.List.Tot' will \n\t\t\t\tnot extract FStar.List.Tot.*, \n\t\t\t\textract remaining modules from FStar.List.*, \n\t\t\t\tnot extract FStar.Reflection.*, \n\t\t\t\tand extract all the rest.\n\t\tNote, the '+' is optional: --extract '+A' and --extract 'A' mean the same thing.\n\t\tMultiple uses of this option accumulate, e.g., --extract A --extract B is interpreted as --extract 'A B'.")
-                                  :: uu____2652
-                                 in
-                              uu____2630 :: uu____2641  in
+                                  :: uu____2652 in
+                              uu____2630 :: uu____2641 in
                             (FStar_Getopt.noshort, "dump_module",
                               (Accumulated (SimpleStr "module_name")), "") ::
-                              uu____2619
-                             in
-                          uu____2597 :: uu____2608  in
-                        uu____2575 :: uu____2586  in
-                      uu____2553 :: uu____2564  in
+                              uu____2619 in
+                          uu____2597 :: uu____2608 in
+                        uu____2575 :: uu____2586 in
+                      uu____2553 :: uu____2564 in
                     (FStar_Getopt.noshort, "dep",
                       (EnumStr ["make"; "graph"; "full"]),
                       "Output the transitive closure of the full dependency graph in three formats:\n\t 'graph': a format suitable the 'dot' tool from 'GraphViz'\n\t 'full': a format suitable for 'make', including dependences for producing .ml and .krml files\n\t 'make': (deprecated) a format suitable for 'make', including only dependences among source files")
-                      :: uu____2542
-                     in
+                      :: uu____2542 in
                   (FStar_Getopt.noshort, "debug_level",
                     (Accumulated
                        (OpenEnumStr
                           (["Low"; "Medium"; "High"; "Extreme"], "..."))),
-                    "Control the verbosity of debugging info") :: uu____2531
-                   in
+                    "Control the verbosity of debugging info") :: uu____2531 in
                 (FStar_Getopt.noshort, "debug",
                   (Accumulated (SimpleStr "module_name")),
                   "Print lots of debugging information while checking module")
-                  :: uu____2520
-                 in
+                  :: uu____2520 in
               (FStar_Getopt.noshort, "codegen-lib",
                 (Accumulated (SimpleStr "namespace")),
                 "External runtime library (i.e. M.N.x extracts to M.N.X instead of M_N.x)")
-                :: uu____2509
-               in
+                :: uu____2509 in
             (FStar_Getopt.noshort, "codegen",
               (EnumStr ["OCaml"; "FSharp"; "Kremlin"; "tactics"]),
-              "Generate code for execution") :: uu____2498
-             in
+              "Generate code for execution") :: uu____2498 in
           (FStar_Getopt.noshort, "cache_dir",
             (PostProcessed (pp_validate_dir, (PathStr "dir"))),
             "Read and write .checked and .checked.lax in directory <dir>") ::
-            uu____2487
-           in
-        uu____2465 :: uu____2476  in
+            uu____2487 in
+        uu____2465 :: uu____2476 in
       (FStar_Getopt.noshort, "admit_except",
         (SimpleStr "[symbol|(symbol, id)]"),
         "Admit all queries, except those with label (<symbol>, <id>)) (e.g. --admit_except '(FStar.Fin.pigeonhole, 1)' or --admit_except FStar.Fin.pigeonhole)")
-        :: uu____2454
-       in
+        :: uu____2454 in
     (FStar_Getopt.noshort, "admit_smt_queries", BoolStr,
       "Admit SMT queries, unsafe! (default 'false')") :: uu____2443
-
-and (specs : Prims.unit -> FStar_Getopt.opt Prims.list) =
+and specs: Prims.unit -> FStar_Getopt.opt Prims.list =
   fun uu____4739  ->
-    let uu____4742 = specs_with_types ()  in
+    let uu____4742 = specs_with_types () in
     FStar_List.map
       (fun uu____4767  ->
          match uu____4767 with
          | (short,long,typ,doc) ->
              let uu____4780 =
-               let uu____4791 = arg_spec_of_opt_type long typ  in
-               (short, long, uu____4791, doc)  in
+               let uu____4791 = arg_spec_of_opt_type long typ in
+               (short, long, uu____4791, doc) in
              mk_spec uu____4780) uu____4742
-
-let (settable : Prims.string -> Prims.bool) =
+let settable: Prims.string -> Prims.bool =
   fun uu___41_4798  ->
     match uu___41_4798 with
     | "admit_smt_queries" -> true
@@ -2245,74 +1999,65 @@ let (settable : Prims.string -> Prims.bool) =
     | "use_two_phase_tc" -> true
     | "vcgen.optimize_bind_as_seq" -> true
     | uu____4799 -> false
-  
-let (resettable : Prims.string -> Prims.bool) =
+let resettable: Prims.string -> Prims.bool =
   fun s  ->
     (((settable s) || (s = "z3seed")) || (s = "z3cliopt")) ||
       (s = "using_facts_from")
-  
-let (all_specs : FStar_Getopt.opt Prims.list) = specs () 
-let (all_specs_with_types :
+let all_specs: FStar_Getopt.opt Prims.list = specs ()
+let all_specs_with_types:
   (FStar_BaseTypes.char,Prims.string,opt_type,Prims.string)
-    FStar_Pervasives_Native.tuple4 Prims.list)
-  = specs_with_types () 
-let (settable_specs :
+    FStar_Pervasives_Native.tuple4 Prims.list
+  = specs_with_types ()
+let settable_specs:
   (FStar_BaseTypes.char,Prims.string,Prims.unit FStar_Getopt.opt_variant,
-    Prims.string) FStar_Pervasives_Native.tuple4 Prims.list)
+    Prims.string) FStar_Pervasives_Native.tuple4 Prims.list
   =
   FStar_All.pipe_right all_specs
     (FStar_List.filter
        (fun uu____4856  ->
           match uu____4856 with
           | (uu____4867,x,uu____4869,uu____4870) -> settable x))
-  
-let (resettable_specs :
+let resettable_specs:
   (FStar_BaseTypes.char,Prims.string,Prims.unit FStar_Getopt.opt_variant,
-    Prims.string) FStar_Pervasives_Native.tuple4 Prims.list)
+    Prims.string) FStar_Pervasives_Native.tuple4 Prims.list
   =
   FStar_All.pipe_right all_specs
     (FStar_List.filter
        (fun uu____4916  ->
           match uu____4916 with
           | (uu____4927,x,uu____4929,uu____4930) -> resettable x))
-  
-let (display_usage : Prims.unit -> Prims.unit) =
+let display_usage: Prims.unit -> Prims.unit =
   fun uu____4937  ->
-    let uu____4938 = specs ()  in display_usage_aux uu____4938
-  
-let (fstar_home : Prims.unit -> Prims.string) =
+    let uu____4938 = specs () in display_usage_aux uu____4938
+let fstar_home: Prims.unit -> Prims.string =
   fun uu____4953  ->
-    let uu____4954 = get_fstar_home ()  in
+    let uu____4954 = get_fstar_home () in
     match uu____4954 with
     | FStar_Pervasives_Native.None  ->
-        let x = FStar_Util.get_exec_dir ()  in
-        let x1 = Prims.strcat x "/.."  in
+        let x = FStar_Util.get_exec_dir () in
+        let x1 = Prims.strcat x "/.." in
         ((let uu____4960 =
-            let uu____4965 = mk_string x1  in ("fstar_home", uu____4965)  in
+            let uu____4965 = mk_string x1 in ("fstar_home", uu____4965) in
           set_option' uu____4960);
          x1)
     | FStar_Pervasives_Native.Some x -> x
-  
-exception File_argument of Prims.string 
-let (uu___is_File_argument : Prims.exn -> Prims.bool) =
+exception File_argument of Prims.string
+let uu___is_File_argument: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with
     | File_argument uu____4973 -> true
     | uu____4974 -> false
-  
-let (__proj__File_argument__item__uu___ : Prims.exn -> Prims.string) =
+let __proj__File_argument__item__uu___: Prims.exn -> Prims.string =
   fun projectee  ->
     match projectee with | File_argument uu____4981 -> uu____4981
-  
-let (set_options : options -> Prims.string -> FStar_Getopt.parse_cmdline_res)
-  =
+let set_options: options -> Prims.string -> FStar_Getopt.parse_cmdline_res =
   fun o  ->
     fun s  ->
       let specs1 =
         match o with
         | Set  -> settable_specs
         | Reset  -> resettable_specs
-        | Restore  -> all_specs  in
+        | Restore  -> all_specs in
       try
         if s = ""
         then FStar_Getopt.Success
@@ -2322,111 +2067,95 @@ let (set_options : options -> Prims.string -> FStar_Getopt.parse_cmdline_res)
       with
       | File_argument s1 ->
           let uu____5025 =
-            FStar_Util.format1 "File %s is not a valid option" s1  in
+            FStar_Util.format1 "File %s is not a valid option" s1 in
           FStar_Getopt.Error uu____5025
-  
-let (file_list_ : Prims.string Prims.list FStar_ST.ref) =
-  FStar_Util.mk_ref [] 
-let (parse_cmd_line :
+let file_list_: Prims.string Prims.list FStar_ST.ref = FStar_Util.mk_ref []
+let parse_cmd_line:
   Prims.unit ->
     (FStar_Getopt.parse_cmdline_res,Prims.string Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun uu____5051  ->
     let res =
       FStar_Getopt.parse_cmdline all_specs
         (fun i  ->
            let uu____5056 =
-             let uu____5059 = FStar_ST.op_Bang file_list_  in
-             FStar_List.append uu____5059 [i]  in
-           FStar_ST.op_Colon_Equals file_list_ uu____5056)
-       in
+             let uu____5059 = FStar_ST.op_Bang file_list_ in
+             FStar_List.append uu____5059 [i] in
+           FStar_ST.op_Colon_Equals file_list_ uu____5056) in
     let uu____5108 =
-      let uu____5111 = FStar_ST.op_Bang file_list_  in
-      FStar_List.map FStar_Common.try_convert_file_name_to_mixed uu____5111
-       in
+      let uu____5111 = FStar_ST.op_Bang file_list_ in
+      FStar_List.map FStar_Common.try_convert_file_name_to_mixed uu____5111 in
     (res, uu____5108)
-  
-let (file_list : Prims.unit -> Prims.string Prims.list) =
-  fun uu____5143  -> FStar_ST.op_Bang file_list_ 
-let (restore_cmd_line_options : Prims.bool -> FStar_Getopt.parse_cmdline_res)
-  =
+let file_list: Prims.unit -> Prims.string Prims.list =
+  fun uu____5143  -> FStar_ST.op_Bang file_list_
+let restore_cmd_line_options: Prims.bool -> FStar_Getopt.parse_cmdline_res =
   fun should_clear  ->
-    let old_verify_module = get_verify_module ()  in
+    let old_verify_module = get_verify_module () in
     if should_clear then clear () else init ();
     (let r =
-       let uu____5176 = specs ()  in
-       FStar_Getopt.parse_cmdline uu____5176 (fun x  -> ())  in
+       let uu____5176 = specs () in
+       FStar_Getopt.parse_cmdline uu____5176 (fun x  -> ()) in
      (let uu____5182 =
         let uu____5187 =
-          let uu____5188 = FStar_List.map mk_string old_verify_module  in
-          List uu____5188  in
-        ("verify_module", uu____5187)  in
+          let uu____5188 = FStar_List.map mk_string old_verify_module in
+          List uu____5188 in
+        ("verify_module", uu____5187) in
       set_option' uu____5182);
      r)
-  
-let (module_name_of_file_name : Prims.string -> Prims.string) =
+let module_name_of_file_name: Prims.string -> Prims.string =
   fun f  ->
-    let f1 = FStar_Util.basename f  in
+    let f1 = FStar_Util.basename f in
     let f2 =
       let uu____5196 =
         let uu____5197 =
           let uu____5198 =
-            let uu____5199 = FStar_Util.get_file_extension f1  in
-            FStar_String.length uu____5199  in
-          (FStar_String.length f1) - uu____5198  in
-        uu____5197 - (Prims.parse_int "1")  in
-      FStar_String.substring f1 (Prims.parse_int "0") uu____5196  in
+            let uu____5199 = FStar_Util.get_file_extension f1 in
+            FStar_String.length uu____5199 in
+          (FStar_String.length f1) - uu____5198 in
+        uu____5197 - (Prims.parse_int "1") in
+      FStar_String.substring f1 (Prims.parse_int "0") uu____5196 in
     FStar_String.lowercase f2
-  
-let (should_verify : Prims.string -> Prims.bool) =
+let should_verify: Prims.string -> Prims.bool =
   fun m  ->
-    let uu____5203 = get_lax ()  in
+    let uu____5203 = get_lax () in
     if uu____5203
     then false
     else
-      (let l = get_verify_module ()  in
+      (let l = get_verify_module () in
        FStar_List.contains (FStar_String.lowercase m) l)
-  
-let (should_verify_file : Prims.string -> Prims.bool) =
+let should_verify_file: Prims.string -> Prims.bool =
   fun fn  ->
-    let uu____5211 = module_name_of_file_name fn  in should_verify uu____5211
-  
-let (dont_gen_projectors : Prims.string -> Prims.bool) =
+    let uu____5211 = module_name_of_file_name fn in should_verify uu____5211
+let dont_gen_projectors: Prims.string -> Prims.bool =
   fun m  ->
-    let uu____5215 = get___temp_no_proj ()  in
+    let uu____5215 = get___temp_no_proj () in
     FStar_List.contains m uu____5215
-  
-let (should_print_message : Prims.string -> Prims.bool) =
+let should_print_message: Prims.string -> Prims.bool =
   fun m  ->
-    let uu____5221 = should_verify m  in
+    let uu____5221 = should_verify m in
     if uu____5221 then m <> "Prims" else false
-  
-let (include_path : Prims.unit -> Prims.string Prims.list) =
+let include_path: Prims.unit -> Prims.string Prims.list =
   fun uu____5227  ->
-    let uu____5228 = get_no_default_includes ()  in
+    let uu____5228 = get_no_default_includes () in
     if uu____5228
     then get_include ()
     else
-      (let h = fstar_home ()  in
-       let defs = universe_include_path_base_dirs  in
+      (let h = fstar_home () in
+       let defs = universe_include_path_base_dirs in
        let uu____5236 =
          let uu____5239 =
            FStar_All.pipe_right defs
-             (FStar_List.map (fun x  -> Prims.strcat h x))
-            in
+             (FStar_List.map (fun x  -> Prims.strcat h x)) in
          FStar_All.pipe_right uu____5239
-           (FStar_List.filter FStar_Util.file_exists)
-          in
+           (FStar_List.filter FStar_Util.file_exists) in
        let uu____5252 =
-         let uu____5255 = get_include ()  in
-         FStar_List.append uu____5255 ["."]  in
+         let uu____5255 = get_include () in
+         FStar_List.append uu____5255 ["."] in
        FStar_List.append uu____5236 uu____5252)
-  
-let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
-  =
+let find_file: Prims.string -> Prims.string FStar_Pervasives_Native.option =
   fun filename  ->
-    let uu____5263 = FStar_Util.is_path_absolute filename  in
+    let uu____5263 = FStar_Util.is_path_absolute filename in
     if uu____5263
     then
       (if FStar_Util.file_exists filename
@@ -2434,90 +2163,78 @@ let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
        else FStar_Pervasives_Native.None)
     else
       (let uu____5270 =
-         let uu____5273 = include_path ()  in FStar_List.rev uu____5273  in
+         let uu____5273 = include_path () in FStar_List.rev uu____5273 in
        FStar_Util.find_map uu____5270
          (fun p  ->
             let path =
-              if p = "." then filename else FStar_Util.join_paths p filename
-               in
+              if p = "." then filename else FStar_Util.join_paths p filename in
             if FStar_Util.file_exists path
             then FStar_Pervasives_Native.Some path
             else FStar_Pervasives_Native.None))
-  
-let (prims : Prims.unit -> Prims.string) =
+let prims: Prims.unit -> Prims.string =
   fun uu____5286  ->
-    let uu____5287 = get_prims ()  in
+    let uu____5287 = get_prims () in
     match uu____5287 with
     | FStar_Pervasives_Native.None  ->
-        let filename = "prims.fst"  in
-        let uu____5291 = find_file filename  in
+        let filename = "prims.fst" in
+        let uu____5291 = find_file filename in
         (match uu____5291 with
          | FStar_Pervasives_Native.Some result -> result
          | FStar_Pervasives_Native.None  ->
              let uu____5295 =
                FStar_Util.format1
                  "unable to find required file \"%s\" in the module search path.\n"
-                 filename
-                in
+                 filename in
              failwith uu____5295)
     | FStar_Pervasives_Native.Some x -> x
-  
-let (prims_basename : Prims.unit -> Prims.string) =
+let prims_basename: Prims.unit -> Prims.string =
   fun uu____5299  ->
-    let uu____5300 = prims ()  in FStar_Util.basename uu____5300
-  
-let (pervasives : Prims.unit -> Prims.string) =
+    let uu____5300 = prims () in FStar_Util.basename uu____5300
+let pervasives: Prims.unit -> Prims.string =
   fun uu____5303  ->
-    let filename = "FStar.Pervasives.fst"  in
-    let uu____5305 = find_file filename  in
+    let filename = "FStar.Pervasives.fst" in
+    let uu____5305 = find_file filename in
     match uu____5305 with
     | FStar_Pervasives_Native.Some result -> result
     | FStar_Pervasives_Native.None  ->
         let uu____5309 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
-            filename
-           in
+            filename in
         failwith uu____5309
-  
-let (pervasives_basename : Prims.unit -> Prims.string) =
+let pervasives_basename: Prims.unit -> Prims.string =
   fun uu____5312  ->
-    let uu____5313 = pervasives ()  in FStar_Util.basename uu____5313
-  
-let (pervasives_native_basename : Prims.unit -> Prims.string) =
+    let uu____5313 = pervasives () in FStar_Util.basename uu____5313
+let pervasives_native_basename: Prims.unit -> Prims.string =
   fun uu____5316  ->
-    let filename = "FStar.Pervasives.Native.fst"  in
-    let uu____5318 = find_file filename  in
+    let filename = "FStar.Pervasives.Native.fst" in
+    let uu____5318 = find_file filename in
     match uu____5318 with
     | FStar_Pervasives_Native.Some result -> FStar_Util.basename result
     | FStar_Pervasives_Native.None  ->
         let uu____5322 =
           FStar_Util.format1
             "unable to find required file \"%s\" in the module search path.\n"
-            filename
-           in
+            filename in
         failwith uu____5322
-  
-let (prepend_output_dir : Prims.string -> Prims.string) =
+let prepend_output_dir: Prims.string -> Prims.string =
   fun fname  ->
-    let uu____5326 = get_odir ()  in
+    let uu____5326 = get_odir () in
     match uu____5326 with
     | FStar_Pervasives_Native.None  -> fname
     | FStar_Pervasives_Native.Some x -> FStar_Util.join_paths x fname
-  
-let (prepend_cache_dir : Prims.string -> Prims.string) =
+let prepend_cache_dir: Prims.string -> Prims.string =
   fun fpath  ->
-    let uu____5333 = get_cache_dir ()  in
+    let uu____5333 = get_cache_dir () in
     match uu____5333 with
     | FStar_Pervasives_Native.None  -> fpath
     | FStar_Pervasives_Native.Some x ->
-        let uu____5337 = FStar_Util.basename fpath  in
+        let uu____5337 = FStar_Util.basename fpath in
         FStar_Util.join_paths x uu____5337
-  
-let (parse_settings :
+let parse_settings:
   Prims.string Prims.list ->
     (Prims.string Prims.list,Prims.bool) FStar_Pervasives_Native.tuple2
-      Prims.list)
+      Prims.list
   =
   fun ns  ->
     let parse_one_setting s =
@@ -2528,324 +2245,292 @@ let (parse_settings :
         then
           (let path =
              let uu____5389 =
-               FStar_Util.substring_from s (Prims.parse_int "1")  in
-             FStar_Ident.path_of_text uu____5389  in
+               FStar_Util.substring_from s (Prims.parse_int "1") in
+             FStar_Ident.path_of_text uu____5389 in
            (path, false))
         else
           (let s1 =
              if FStar_Util.starts_with s "+"
              then FStar_Util.substring_from s (Prims.parse_int "1")
-             else s  in
-           ((FStar_Ident.path_of_text s1), true))
-       in
+             else s in
+           ((FStar_Ident.path_of_text s1), true)) in
     let uu____5397 =
       FStar_All.pipe_right ns
         (FStar_List.collect
            (fun s  ->
               FStar_All.pipe_right (FStar_Util.split s " ")
-                (FStar_List.map parse_one_setting)))
-       in
+                (FStar_List.map parse_one_setting))) in
     FStar_All.pipe_right uu____5397 FStar_List.rev
-  
-let (__temp_no_proj : Prims.string -> Prims.bool) =
+let __temp_no_proj: Prims.string -> Prims.bool =
   fun s  ->
-    let uu____5465 = get___temp_no_proj ()  in
+    let uu____5465 = get___temp_no_proj () in
     FStar_All.pipe_right uu____5465 (FStar_List.contains s)
-  
-let (__temp_fast_implicits : Prims.unit -> Prims.bool) =
-  fun uu____5472  -> lookup_opt "__temp_fast_implicits" as_bool 
-let (admit_smt_queries : Prims.unit -> Prims.bool) =
-  fun uu____5475  -> get_admit_smt_queries () 
-let (admit_except :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5480  -> get_admit_except () 
-let (cache_checked_modules : Prims.unit -> Prims.bool) =
-  fun uu____5483  -> get_cache_checked_modules () 
-let (codegen : Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5488  -> get_codegen () 
-let (codegen_libs : Prims.unit -> Prims.string Prims.list Prims.list) =
+let __temp_fast_implicits: Prims.unit -> Prims.bool =
+  fun uu____5472  -> lookup_opt "__temp_fast_implicits" as_bool
+let admit_smt_queries: Prims.unit -> Prims.bool =
+  fun uu____5475  -> get_admit_smt_queries ()
+let admit_except: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____5480  -> get_admit_except ()
+let cache_checked_modules: Prims.unit -> Prims.bool =
+  fun uu____5483  -> get_cache_checked_modules ()
+let codegen: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____5488  -> get_codegen ()
+let codegen_libs: Prims.unit -> Prims.string Prims.list Prims.list =
   fun uu____5495  ->
-    let uu____5496 = get_codegen_lib ()  in
+    let uu____5496 = get_codegen_lib () in
     FStar_All.pipe_right uu____5496
       (FStar_List.map (fun x  -> FStar_Util.split x "."))
-  
-let (debug_any : Prims.unit -> Prims.bool) =
-  fun uu____5511  -> let uu____5512 = get_debug ()  in uu____5512 <> [] 
-let (debug_at_level : Prims.string -> debug_level_t -> Prims.bool) =
+let debug_any: Prims.unit -> Prims.bool =
+  fun uu____5511  -> let uu____5512 = get_debug () in uu____5512 <> []
+let debug_at_level: Prims.string -> debug_level_t -> Prims.bool =
   fun modul  ->
     fun level  ->
-      (let uu____5525 = get_debug ()  in
+      (let uu____5525 = get_debug () in
        FStar_All.pipe_right uu____5525 (FStar_List.contains modul)) &&
         (debug_level_geq level)
-  
-let (dep : Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5534  -> get_dep () 
-let (detail_errors : Prims.unit -> Prims.bool) =
-  fun uu____5537  -> get_detail_errors () 
-let (detail_hint_replay : Prims.unit -> Prims.bool) =
-  fun uu____5540  -> get_detail_hint_replay () 
-let (doc : Prims.unit -> Prims.bool) = fun uu____5543  -> get_doc () 
-let (dump_module : Prims.string -> Prims.bool) =
+let dep: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____5534  -> get_dep ()
+let detail_errors: Prims.unit -> Prims.bool =
+  fun uu____5537  -> get_detail_errors ()
+let detail_hint_replay: Prims.unit -> Prims.bool =
+  fun uu____5540  -> get_detail_hint_replay ()
+let doc: Prims.unit -> Prims.bool = fun uu____5543  -> get_doc ()
+let dump_module: Prims.string -> Prims.bool =
   fun s  ->
-    let uu____5547 = get_dump_module ()  in
+    let uu____5547 = get_dump_module () in
     FStar_All.pipe_right uu____5547 (FStar_List.contains s)
-  
-let (eager_inference : Prims.unit -> Prims.bool) =
-  fun uu____5554  -> get_eager_inference () 
-let (expose_interfaces : Prims.unit -> Prims.bool) =
-  fun uu____5557  -> get_expose_interfaces () 
-let (fs_typ_app : Prims.string -> Prims.bool) =
+let eager_inference: Prims.unit -> Prims.bool =
+  fun uu____5554  -> get_eager_inference ()
+let expose_interfaces: Prims.unit -> Prims.bool =
+  fun uu____5557  -> get_expose_interfaces ()
+let fs_typ_app: Prims.string -> Prims.bool =
   fun filename  ->
-    let uu____5561 = FStar_ST.op_Bang light_off_files  in
+    let uu____5561 = FStar_ST.op_Bang light_off_files in
     FStar_List.contains filename uu____5561
-  
-let (gen_native_tactics :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5591  -> get_gen_native_tactics () 
-let (full_context_dependency : Prims.unit -> Prims.bool) =
-  fun uu____5594  -> true 
-let (hide_uvar_nums : Prims.unit -> Prims.bool) =
-  fun uu____5597  -> get_hide_uvar_nums () 
-let (hint_info : Prims.unit -> Prims.bool) =
-  fun uu____5600  -> (get_hint_info ()) || (get_query_stats ()) 
-let (hint_file : Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5605  -> get_hint_file () 
-let (ide : Prims.unit -> Prims.bool) = fun uu____5608  -> get_ide () 
-let (indent : Prims.unit -> Prims.bool) = fun uu____5611  -> get_indent () 
-let (initial_fuel : Prims.unit -> Prims.int) =
+let gen_native_tactics:
+  Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____5591  -> get_gen_native_tactics ()
+let full_context_dependency: Prims.unit -> Prims.bool =
+  fun uu____5594  -> true
+let hide_uvar_nums: Prims.unit -> Prims.bool =
+  fun uu____5597  -> get_hide_uvar_nums ()
+let hint_info: Prims.unit -> Prims.bool =
+  fun uu____5600  -> (get_hint_info ()) || (get_query_stats ())
+let hint_file: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____5605  -> get_hint_file ()
+let ide: Prims.unit -> Prims.bool = fun uu____5608  -> get_ide ()
+let indent: Prims.unit -> Prims.bool = fun uu____5611  -> get_indent ()
+let initial_fuel: Prims.unit -> Prims.int =
   fun uu____5614  ->
-    let uu____5615 = get_initial_fuel ()  in
-    let uu____5616 = get_max_fuel ()  in Prims.min uu____5615 uu____5616
-  
-let (initial_ifuel : Prims.unit -> Prims.int) =
+    let uu____5615 = get_initial_fuel () in
+    let uu____5616 = get_max_fuel () in Prims.min uu____5615 uu____5616
+let initial_ifuel: Prims.unit -> Prims.int =
   fun uu____5619  ->
-    let uu____5620 = get_initial_ifuel ()  in
-    let uu____5621 = get_max_ifuel ()  in Prims.min uu____5620 uu____5621
-  
-let (interactive : Prims.unit -> Prims.bool) =
-  fun uu____5624  -> (get_in ()) || (get_ide ()) 
-let (lax : Prims.unit -> Prims.bool) = fun uu____5627  -> get_lax () 
-let (load : Prims.unit -> Prims.string Prims.list) =
-  fun uu____5632  -> get_load () 
-let (legacy_interactive : Prims.unit -> Prims.bool) =
-  fun uu____5635  -> get_in () 
-let (log_queries : Prims.unit -> Prims.bool) =
-  fun uu____5638  -> get_log_queries () 
-let (log_types : Prims.unit -> Prims.bool) =
-  fun uu____5641  -> get_log_types () 
-let (max_fuel : Prims.unit -> Prims.int) = fun uu____5644  -> get_max_fuel () 
-let (max_ifuel : Prims.unit -> Prims.int) =
-  fun uu____5647  -> get_max_ifuel () 
-let (min_fuel : Prims.unit -> Prims.int) = fun uu____5650  -> get_min_fuel () 
-let (ml_ish : Prims.unit -> Prims.bool) = fun uu____5653  -> get_MLish () 
-let (set_ml_ish : Prims.unit -> Prims.unit) =
-  fun uu____5656  -> set_option "MLish" (Bool true) 
-let (n_cores : Prims.unit -> Prims.int) = fun uu____5659  -> get_n_cores () 
-let (no_default_includes : Prims.unit -> Prims.bool) =
-  fun uu____5662  -> get_no_default_includes () 
-let (no_extract : Prims.string -> Prims.bool) =
+    let uu____5620 = get_initial_ifuel () in
+    let uu____5621 = get_max_ifuel () in Prims.min uu____5620 uu____5621
+let interactive: Prims.unit -> Prims.bool =
+  fun uu____5624  -> (get_in ()) || (get_ide ())
+let lax: Prims.unit -> Prims.bool = fun uu____5627  -> get_lax ()
+let load: Prims.unit -> Prims.string Prims.list =
+  fun uu____5632  -> get_load ()
+let legacy_interactive: Prims.unit -> Prims.bool =
+  fun uu____5635  -> get_in ()
+let log_queries: Prims.unit -> Prims.bool =
+  fun uu____5638  -> get_log_queries ()
+let log_types: Prims.unit -> Prims.bool = fun uu____5641  -> get_log_types ()
+let max_fuel: Prims.unit -> Prims.int = fun uu____5644  -> get_max_fuel ()
+let max_ifuel: Prims.unit -> Prims.int = fun uu____5647  -> get_max_ifuel ()
+let min_fuel: Prims.unit -> Prims.int = fun uu____5650  -> get_min_fuel ()
+let ml_ish: Prims.unit -> Prims.bool = fun uu____5653  -> get_MLish ()
+let set_ml_ish: Prims.unit -> Prims.unit =
+  fun uu____5656  -> set_option "MLish" (Bool true)
+let n_cores: Prims.unit -> Prims.int = fun uu____5659  -> get_n_cores ()
+let no_default_includes: Prims.unit -> Prims.bool =
+  fun uu____5662  -> get_no_default_includes ()
+let no_extract: Prims.string -> Prims.bool =
   fun s  ->
-    let s1 = FStar_String.lowercase s  in
-    let uu____5667 = get_no_extract ()  in
+    let s1 = FStar_String.lowercase s in
+    let uu____5667 = get_no_extract () in
     FStar_All.pipe_right uu____5667
       (FStar_Util.for_some (fun f  -> (FStar_String.lowercase f) = s1))
-  
-let (normalize_pure_terms_for_extraction : Prims.unit -> Prims.bool) =
-  fun uu____5676  -> get_normalize_pure_terms_for_extraction () 
-let (no_location_info : Prims.unit -> Prims.bool) =
-  fun uu____5679  -> get_no_location_info () 
-let (output_dir : Prims.unit -> Prims.string FStar_Pervasives_Native.option)
-  = fun uu____5684  -> get_odir () 
-let (ugly : Prims.unit -> Prims.bool) = fun uu____5687  -> get_ugly () 
-let (print_bound_var_types : Prims.unit -> Prims.bool) =
-  fun uu____5690  -> get_print_bound_var_types () 
-let (print_effect_args : Prims.unit -> Prims.bool) =
-  fun uu____5693  -> get_print_effect_args () 
-let (print_implicits : Prims.unit -> Prims.bool) =
-  fun uu____5696  -> get_print_implicits () 
-let (print_real_names : Prims.unit -> Prims.bool) =
-  fun uu____5699  -> (get_prn ()) || (get_print_full_names ()) 
-let (print_universes : Prims.unit -> Prims.bool) =
-  fun uu____5702  -> get_print_universes () 
-let (print_z3_statistics : Prims.unit -> Prims.bool) =
-  fun uu____5705  -> (get_print_z3_statistics ()) || (get_query_stats ()) 
-let (query_stats : Prims.unit -> Prims.bool) =
-  fun uu____5708  -> get_query_stats () 
-let (record_hints : Prims.unit -> Prims.bool) =
-  fun uu____5711  -> get_record_hints () 
-let (reuse_hint_for :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5716  -> get_reuse_hint_for () 
-let (silent : Prims.unit -> Prims.bool) = fun uu____5719  -> get_silent () 
-let (smtencoding_elim_box : Prims.unit -> Prims.bool) =
-  fun uu____5722  -> get_smtencoding_elim_box () 
-let (smtencoding_nl_arith_native : Prims.unit -> Prims.bool) =
+let normalize_pure_terms_for_extraction: Prims.unit -> Prims.bool =
+  fun uu____5676  -> get_normalize_pure_terms_for_extraction ()
+let no_location_info: Prims.unit -> Prims.bool =
+  fun uu____5679  -> get_no_location_info ()
+let output_dir: Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____5684  -> get_odir ()
+let ugly: Prims.unit -> Prims.bool = fun uu____5687  -> get_ugly ()
+let print_bound_var_types: Prims.unit -> Prims.bool =
+  fun uu____5690  -> get_print_bound_var_types ()
+let print_effect_args: Prims.unit -> Prims.bool =
+  fun uu____5693  -> get_print_effect_args ()
+let print_implicits: Prims.unit -> Prims.bool =
+  fun uu____5696  -> get_print_implicits ()
+let print_real_names: Prims.unit -> Prims.bool =
+  fun uu____5699  -> (get_prn ()) || (get_print_full_names ())
+let print_universes: Prims.unit -> Prims.bool =
+  fun uu____5702  -> get_print_universes ()
+let print_z3_statistics: Prims.unit -> Prims.bool =
+  fun uu____5705  -> (get_print_z3_statistics ()) || (get_query_stats ())
+let query_stats: Prims.unit -> Prims.bool =
+  fun uu____5708  -> get_query_stats ()
+let record_hints: Prims.unit -> Prims.bool =
+  fun uu____5711  -> get_record_hints ()
+let reuse_hint_for: Prims.unit -> Prims.string FStar_Pervasives_Native.option
+  = fun uu____5716  -> get_reuse_hint_for ()
+let silent: Prims.unit -> Prims.bool = fun uu____5719  -> get_silent ()
+let smtencoding_elim_box: Prims.unit -> Prims.bool =
+  fun uu____5722  -> get_smtencoding_elim_box ()
+let smtencoding_nl_arith_native: Prims.unit -> Prims.bool =
   fun uu____5725  ->
-    let uu____5726 = get_smtencoding_nl_arith_repr ()  in
+    let uu____5726 = get_smtencoding_nl_arith_repr () in
     uu____5726 = "native"
-  
-let (smtencoding_nl_arith_wrapped : Prims.unit -> Prims.bool) =
+let smtencoding_nl_arith_wrapped: Prims.unit -> Prims.bool =
   fun uu____5729  ->
-    let uu____5730 = get_smtencoding_nl_arith_repr ()  in
+    let uu____5730 = get_smtencoding_nl_arith_repr () in
     uu____5730 = "wrapped"
-  
-let (smtencoding_nl_arith_default : Prims.unit -> Prims.bool) =
+let smtencoding_nl_arith_default: Prims.unit -> Prims.bool =
   fun uu____5733  ->
-    let uu____5734 = get_smtencoding_nl_arith_repr ()  in
+    let uu____5734 = get_smtencoding_nl_arith_repr () in
     uu____5734 = "boxwrap"
-  
-let (smtencoding_l_arith_native : Prims.unit -> Prims.bool) =
+let smtencoding_l_arith_native: Prims.unit -> Prims.bool =
   fun uu____5737  ->
-    let uu____5738 = get_smtencoding_l_arith_repr ()  in
-    uu____5738 = "native"
-  
-let (smtencoding_l_arith_default : Prims.unit -> Prims.bool) =
+    let uu____5738 = get_smtencoding_l_arith_repr () in uu____5738 = "native"
+let smtencoding_l_arith_default: Prims.unit -> Prims.bool =
   fun uu____5741  ->
-    let uu____5742 = get_smtencoding_l_arith_repr ()  in
+    let uu____5742 = get_smtencoding_l_arith_repr () in
     uu____5742 = "boxwrap"
-  
-let (tactic_raw_binders : Prims.unit -> Prims.bool) =
-  fun uu____5745  -> get_tactic_raw_binders () 
-let (tactic_trace : Prims.unit -> Prims.bool) =
-  fun uu____5748  -> get_tactic_trace () 
-let (tactic_trace_d : Prims.unit -> Prims.int) =
-  fun uu____5751  -> get_tactic_trace_d () 
-let (timing : Prims.unit -> Prims.bool) = fun uu____5754  -> get_timing () 
-let (trace_error : Prims.unit -> Prims.bool) =
-  fun uu____5757  -> get_trace_error () 
-let (unthrottle_inductives : Prims.unit -> Prims.bool) =
-  fun uu____5760  -> get_unthrottle_inductives () 
-let (unsafe_tactic_exec : Prims.unit -> Prims.bool) =
-  fun uu____5763  -> get_unsafe_tactic_exec () 
-let (use_eq_at_higher_order : Prims.unit -> Prims.bool) =
-  fun uu____5766  -> get_use_eq_at_higher_order () 
-let (use_hints : Prims.unit -> Prims.bool) =
-  fun uu____5769  -> get_use_hints () 
-let (use_hint_hashes : Prims.unit -> Prims.bool) =
-  fun uu____5772  -> get_use_hint_hashes () 
-let (use_native_tactics :
-  Prims.unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu____5777  -> get_use_native_tactics () 
-let (use_tactics : Prims.unit -> Prims.bool) =
-  fun uu____5780  -> get_use_tactics () 
-let (using_facts_from :
+let tactic_raw_binders: Prims.unit -> Prims.bool =
+  fun uu____5745  -> get_tactic_raw_binders ()
+let tactic_trace: Prims.unit -> Prims.bool =
+  fun uu____5748  -> get_tactic_trace ()
+let tactic_trace_d: Prims.unit -> Prims.int =
+  fun uu____5751  -> get_tactic_trace_d ()
+let timing: Prims.unit -> Prims.bool = fun uu____5754  -> get_timing ()
+let trace_error: Prims.unit -> Prims.bool =
+  fun uu____5757  -> get_trace_error ()
+let unthrottle_inductives: Prims.unit -> Prims.bool =
+  fun uu____5760  -> get_unthrottle_inductives ()
+let unsafe_tactic_exec: Prims.unit -> Prims.bool =
+  fun uu____5763  -> get_unsafe_tactic_exec ()
+let use_eq_at_higher_order: Prims.unit -> Prims.bool =
+  fun uu____5766  -> get_use_eq_at_higher_order ()
+let use_hints: Prims.unit -> Prims.bool = fun uu____5769  -> get_use_hints ()
+let use_hint_hashes: Prims.unit -> Prims.bool =
+  fun uu____5772  -> get_use_hint_hashes ()
+let use_native_tactics:
+  Prims.unit -> Prims.string FStar_Pervasives_Native.option =
+  fun uu____5777  -> get_use_native_tactics ()
+let use_tactics: Prims.unit -> Prims.bool =
+  fun uu____5780  -> get_use_tactics ()
+let using_facts_from:
   Prims.unit ->
-    (FStar_Ident.path,Prims.bool) FStar_Pervasives_Native.tuple2 Prims.list)
+    (FStar_Ident.path,Prims.bool) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun uu____5789  ->
-    let uu____5790 = get_using_facts_from ()  in
+    let uu____5790 = get_using_facts_from () in
     match uu____5790 with
     | FStar_Pervasives_Native.None  -> [([], true)]
     | FStar_Pervasives_Native.Some ns -> parse_settings ns
-  
-let (vcgen_optimize_bind_as_seq : Prims.unit -> Prims.bool) =
+let vcgen_optimize_bind_as_seq: Prims.unit -> Prims.bool =
   fun uu____5824  ->
-    let uu____5825 = get_vcgen_optimize_bind_as_seq ()  in
+    let uu____5825 = get_vcgen_optimize_bind_as_seq () in
     FStar_Option.isSome uu____5825
-  
-let (vcgen_decorate_with_type : Prims.unit -> Prims.bool) =
+let vcgen_decorate_with_type: Prims.unit -> Prims.bool =
   fun uu____5830  ->
-    let uu____5831 = get_vcgen_optimize_bind_as_seq ()  in
+    let uu____5831 = get_vcgen_optimize_bind_as_seq () in
     match uu____5831 with
     | FStar_Pervasives_Native.Some "with_type" -> true
     | uu____5834 -> false
-  
-let (warn_default_effects : Prims.unit -> Prims.bool) =
-  fun uu____5839  -> get_warn_default_effects () 
-let (z3_exe : Prims.unit -> Prims.string) =
+let warn_default_effects: Prims.unit -> Prims.bool =
+  fun uu____5839  -> get_warn_default_effects ()
+let z3_exe: Prims.unit -> Prims.string =
   fun uu____5842  ->
-    let uu____5843 = get_smt ()  in
+    let uu____5843 = get_smt () in
     match uu____5843 with
     | FStar_Pervasives_Native.None  -> FStar_Platform.exe "z3"
     | FStar_Pervasives_Native.Some s -> s
-  
-let (z3_cliopt : Prims.unit -> Prims.string Prims.list) =
-  fun uu____5851  -> get_z3cliopt () 
-let (z3_refresh : Prims.unit -> Prims.bool) =
-  fun uu____5854  -> get_z3refresh () 
-let (z3_rlimit : Prims.unit -> Prims.int) =
-  fun uu____5857  -> get_z3rlimit () 
-let (z3_rlimit_factor : Prims.unit -> Prims.int) =
-  fun uu____5860  -> get_z3rlimit_factor () 
-let (z3_seed : Prims.unit -> Prims.int) = fun uu____5863  -> get_z3seed () 
-let (use_two_phase_tc : Prims.unit -> Prims.bool) =
-  fun uu____5866  -> get_use_two_phase_tc () 
-let (no_positivity : Prims.unit -> Prims.bool) =
-  fun uu____5869  -> get_no_positivity () 
-let (ml_no_eta_expand_coertions : Prims.unit -> Prims.bool) =
-  fun uu____5872  -> get_ml_no_eta_expand_coertions () 
-let (warn_error : Prims.unit -> Prims.string) =
-  fun uu____5875  -> get_warn_error () 
-let (use_extracted_interfaces : Prims.unit -> Prims.bool) =
-  fun uu____5878  -> get_use_extracted_interfaces () 
-let (check_interface : Prims.unit -> Prims.bool) =
-  fun uu____5881  -> get_check_interface () 
-let (should_extract : Prims.string -> Prims.bool) =
+let z3_cliopt: Prims.unit -> Prims.string Prims.list =
+  fun uu____5851  -> get_z3cliopt ()
+let z3_refresh: Prims.unit -> Prims.bool =
+  fun uu____5854  -> get_z3refresh ()
+let z3_rlimit: Prims.unit -> Prims.int = fun uu____5857  -> get_z3rlimit ()
+let z3_rlimit_factor: Prims.unit -> Prims.int =
+  fun uu____5860  -> get_z3rlimit_factor ()
+let z3_seed: Prims.unit -> Prims.int = fun uu____5863  -> get_z3seed ()
+let use_two_phase_tc: Prims.unit -> Prims.bool =
+  fun uu____5866  -> get_use_two_phase_tc ()
+let no_positivity: Prims.unit -> Prims.bool =
+  fun uu____5869  -> get_no_positivity ()
+let ml_no_eta_expand_coertions: Prims.unit -> Prims.bool =
+  fun uu____5872  -> get_ml_no_eta_expand_coertions ()
+let warn_error: Prims.unit -> Prims.string =
+  fun uu____5875  -> get_warn_error ()
+let use_extracted_interfaces: Prims.unit -> Prims.bool =
+  fun uu____5878  -> get_use_extracted_interfaces ()
+let check_interface: Prims.unit -> Prims.bool =
+  fun uu____5881  -> get_check_interface ()
+let should_extract: Prims.string -> Prims.bool =
   fun m  ->
-    let m1 = FStar_String.lowercase m  in
-    let uu____5886 = get_extract ()  in
+    let m1 = FStar_String.lowercase m in
+    let uu____5886 = get_extract () in
     match uu____5886 with
     | FStar_Pervasives_Native.Some extract_setting ->
         ((let uu____5897 =
-            let uu____5910 = get_no_extract ()  in
-            let uu____5913 = get_extract_namespace ()  in
-            let uu____5916 = get_extract_module ()  in
-            (uu____5910, uu____5913, uu____5916)  in
+            let uu____5910 = get_no_extract () in
+            let uu____5913 = get_extract_namespace () in
+            let uu____5916 = get_extract_module () in
+            (uu____5910, uu____5913, uu____5916) in
           match uu____5897 with
           | ([],[],[]) -> ()
           | uu____5931 ->
               failwith
                 "Incompatible options: --extract cannot be used with --no_extract, --extract_namespace or --extract_module");
-         (let setting = parse_settings extract_setting  in
-          let m_components = FStar_Ident.path_of_text m1  in
+         (let setting = parse_settings extract_setting in
+          let m_components = FStar_Ident.path_of_text m1 in
           let rec matches_path m_components1 path =
             match (m_components1, path) with
             | (uu____5975,[]) -> true
             | (m2::ms,p::ps) ->
                 (m2 = (FStar_String.lowercase p)) && (matches_path ms ps)
-            | uu____5994 -> false  in
+            | uu____5994 -> false in
           let uu____6003 =
             FStar_All.pipe_right setting
               (FStar_Util.try_find
                  (fun uu____6037  ->
                     match uu____6037 with
-                    | (path,uu____6045) -> matches_path m_components path))
-             in
+                    | (path,uu____6045) -> matches_path m_components path)) in
           match uu____6003 with
           | FStar_Pervasives_Native.None  -> false
           | FStar_Pervasives_Native.Some (uu____6056,flag) -> flag))
     | FStar_Pervasives_Native.None  ->
         let should_extract_namespace m2 =
-          let uu____6074 = get_extract_namespace ()  in
+          let uu____6074 = get_extract_namespace () in
           match uu____6074 with
           | [] -> false
           | ns ->
               FStar_All.pipe_right ns
                 (FStar_Util.for_some
                    (fun n1  ->
-                      FStar_Util.starts_with m2 (FStar_String.lowercase n1)))
-           in
+                      FStar_Util.starts_with m2 (FStar_String.lowercase n1))) in
         let should_extract_module m2 =
-          let uu____6088 = get_extract_module ()  in
+          let uu____6088 = get_extract_module () in
           match uu____6088 with
           | [] -> false
           | l ->
               FStar_All.pipe_right l
                 (FStar_Util.for_some
-                   (fun n1  -> (FStar_String.lowercase n1) = m2))
-           in
-        (let uu____6100 = no_extract m1  in Prims.op_Negation uu____6100) &&
+                   (fun n1  -> (FStar_String.lowercase n1) = m2)) in
+        (let uu____6100 = no_extract m1 in Prims.op_Negation uu____6100) &&
           (let uu____6102 =
-             let uu____6111 = get_extract_namespace ()  in
-             let uu____6114 = get_extract_module ()  in
-             (uu____6111, uu____6114)  in
+             let uu____6111 = get_extract_namespace () in
+             let uu____6114 = get_extract_module () in
+             (uu____6111, uu____6114) in
            (match uu____6102 with
             | ([],[]) -> true
             | uu____6125 ->
                 (should_extract_namespace m1) || (should_extract_module m1)))
-  
-let (codegen_fsharp : Prims.unit -> Prims.bool) =
+let codegen_fsharp: Prims.unit -> Prims.bool =
   fun uu____6136  ->
-    let uu____6137 = codegen ()  in
+    let uu____6137 = codegen () in
     uu____6137 = (FStar_Pervasives_Native.Some "FSharp")
-  

--- a/src/ocaml-output/FStar_Order.ml
+++ b/src/ocaml-output/FStar_Order.ml
@@ -1,37 +1,35 @@
 open Prims
 type order =
-  | Lt 
-  | Eq 
-  | Gt [@@deriving show]
-let (uu___is_Lt : order -> Prims.bool) =
-  fun projectee  -> match projectee with | Lt  -> true | uu____4 -> false 
-let (uu___is_Eq : order -> Prims.bool) =
-  fun projectee  -> match projectee with | Eq  -> true | uu____8 -> false 
-let (uu___is_Gt : order -> Prims.bool) =
-  fun projectee  -> match projectee with | Gt  -> true | uu____12 -> false 
-let (ge : order -> Prims.bool) = fun o  -> o <> Lt 
-let (le : order -> Prims.bool) = fun o  -> o <> Gt 
-let (ne : order -> Prims.bool) = fun o  -> o <> Eq 
-let (gt : order -> Prims.bool) = fun o  -> o = Gt 
-let (lt : order -> Prims.bool) = fun o  -> o = Lt 
-let (eq : order -> Prims.bool) = fun o  -> o = Eq 
-let (lex : order -> (Prims.unit -> order) -> order) =
+  | Lt
+  | Eq
+  | Gt[@@deriving show]
+let uu___is_Lt: order -> Prims.bool =
+  fun projectee  -> match projectee with | Lt  -> true | uu____4 -> false
+let uu___is_Eq: order -> Prims.bool =
+  fun projectee  -> match projectee with | Eq  -> true | uu____8 -> false
+let uu___is_Gt: order -> Prims.bool =
+  fun projectee  -> match projectee with | Gt  -> true | uu____12 -> false
+let ge: order -> Prims.bool = fun o  -> o <> Lt
+let le: order -> Prims.bool = fun o  -> o <> Gt
+let ne: order -> Prims.bool = fun o  -> o <> Eq
+let gt: order -> Prims.bool = fun o  -> o = Gt
+let lt: order -> Prims.bool = fun o  -> o = Lt
+let eq: order -> Prims.bool = fun o  -> o = Eq
+let lex: order -> (Prims.unit -> order) -> order =
   fun o1  ->
     fun o2  ->
       match (o1, o2) with
       | (Lt ,uu____44) -> Lt
       | (Eq ,uu____49) -> o2 ()
       | (Gt ,uu____54) -> Gt
-  
-let (order_from_int : Prims.int -> order) =
+let order_from_int: Prims.int -> order =
   fun i  ->
     if i < (Prims.parse_int "0")
     then Lt
     else if i = (Prims.parse_int "0") then Eq else Gt
-  
-let (compare_int : Prims.int -> Prims.int -> order) =
-  fun i  -> fun j  -> order_from_int (i - j) 
-let rec compare_list :
+let compare_int: Prims.int -> Prims.int -> order =
+  fun i  -> fun j  -> order_from_int (i - j)
+let rec compare_list:
   'a . ('a -> 'a -> order) -> 'a Prims.list -> 'a Prims.list -> order =
   fun f  ->
     fun l1  ->
@@ -41,6 +39,5 @@ let rec compare_list :
         | ([],uu____114) -> Lt
         | (uu____121,[]) -> Gt
         | (x::xs,y::ys) ->
-            let uu____140 = f x y  in
+            let uu____140 = f x y in
             lex uu____140 (fun uu____142  -> compare_list f xs ys)
-  

--- a/src/ocaml-output/FStar_Parser_AST.ml
+++ b/src/ocaml-output/FStar_Parser_AST.ml
@@ -1,572 +1,505 @@
 open Prims
 type level =
-  | Un 
-  | Expr 
-  | Type_level 
-  | Kind 
-  | Formula [@@deriving show]
-let (uu___is_Un : level -> Prims.bool) =
-  fun projectee  -> match projectee with | Un  -> true | uu____4 -> false 
-let (uu___is_Expr : level -> Prims.bool) =
-  fun projectee  -> match projectee with | Expr  -> true | uu____8 -> false 
-let (uu___is_Type_level : level -> Prims.bool) =
+  | Un
+  | Expr
+  | Type_level
+  | Kind
+  | Formula[@@deriving show]
+let uu___is_Un: level -> Prims.bool =
+  fun projectee  -> match projectee with | Un  -> true | uu____4 -> false
+let uu___is_Expr: level -> Prims.bool =
+  fun projectee  -> match projectee with | Expr  -> true | uu____8 -> false
+let uu___is_Type_level: level -> Prims.bool =
   fun projectee  ->
     match projectee with | Type_level  -> true | uu____12 -> false
-  
-let (uu___is_Kind : level -> Prims.bool) =
-  fun projectee  -> match projectee with | Kind  -> true | uu____16 -> false 
-let (uu___is_Formula : level -> Prims.bool) =
+let uu___is_Kind: level -> Prims.bool =
+  fun projectee  -> match projectee with | Kind  -> true | uu____16 -> false
+let uu___is_Formula: level -> Prims.bool =
   fun projectee  ->
     match projectee with | Formula  -> true | uu____20 -> false
-  
 type imp =
-  | FsTypApp 
-  | Hash 
-  | UnivApp 
-  | Nothing [@@deriving show]
-let (uu___is_FsTypApp : imp -> Prims.bool) =
+  | FsTypApp
+  | Hash
+  | UnivApp
+  | Nothing[@@deriving show]
+let uu___is_FsTypApp: imp -> Prims.bool =
   fun projectee  ->
     match projectee with | FsTypApp  -> true | uu____24 -> false
-  
-let (uu___is_Hash : imp -> Prims.bool) =
-  fun projectee  -> match projectee with | Hash  -> true | uu____28 -> false 
-let (uu___is_UnivApp : imp -> Prims.bool) =
+let uu___is_Hash: imp -> Prims.bool =
+  fun projectee  -> match projectee with | Hash  -> true | uu____28 -> false
+let uu___is_UnivApp: imp -> Prims.bool =
   fun projectee  ->
     match projectee with | UnivApp  -> true | uu____32 -> false
-  
-let (uu___is_Nothing : imp -> Prims.bool) =
+let uu___is_Nothing: imp -> Prims.bool =
   fun projectee  ->
     match projectee with | Nothing  -> true | uu____36 -> false
-  
 type arg_qualifier =
-  | Implicit 
-  | Equality [@@deriving show]
-let (uu___is_Implicit : arg_qualifier -> Prims.bool) =
+  | Implicit
+  | Equality[@@deriving show]
+let uu___is_Implicit: arg_qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Implicit  -> true | uu____40 -> false
-  
-let (uu___is_Equality : arg_qualifier -> Prims.bool) =
+let uu___is_Equality: arg_qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Equality  -> true | uu____44 -> false
-  
 type aqual = arg_qualifier FStar_Pervasives_Native.option[@@deriving show]
 type let_qualifier =
-  | NoLetQualifier 
-  | Rec 
-  | Mutable [@@deriving show]
-let (uu___is_NoLetQualifier : let_qualifier -> Prims.bool) =
+  | NoLetQualifier
+  | Rec
+  | Mutable[@@deriving show]
+let uu___is_NoLetQualifier: let_qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | NoLetQualifier  -> true | uu____50 -> false
-  
-let (uu___is_Rec : let_qualifier -> Prims.bool) =
-  fun projectee  -> match projectee with | Rec  -> true | uu____54 -> false 
-let (uu___is_Mutable : let_qualifier -> Prims.bool) =
+let uu___is_Rec: let_qualifier -> Prims.bool =
+  fun projectee  -> match projectee with | Rec  -> true | uu____54 -> false
+let uu___is_Mutable: let_qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Mutable  -> true | uu____58 -> false
-  
 type term' =
-  | Wild 
-  | Const of FStar_Const.sconst 
+  | Wild
+  | Const of FStar_Const.sconst
   | Op of (FStar_Ident.ident,term Prims.list) FStar_Pervasives_Native.tuple2
-  
-  | Tvar of FStar_Ident.ident 
-  | Uvar of FStar_Ident.ident 
-  | Var of FStar_Ident.lid 
-  | Name of FStar_Ident.lid 
+  | Tvar of FStar_Ident.ident
+  | Uvar of FStar_Ident.ident
+  | Var of FStar_Ident.lid
+  | Name of FStar_Ident.lid
   | Projector of (FStar_Ident.lid,FStar_Ident.ident)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Construct of
   (FStar_Ident.lid,(term,imp) FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | Abs of (pattern Prims.list,term) FStar_Pervasives_Native.tuple2 
-  | App of (term,term,imp) FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple2
+  | Abs of (pattern Prims.list,term) FStar_Pervasives_Native.tuple2
+  | App of (term,term,imp) FStar_Pervasives_Native.tuple3
   | Let of
   (let_qualifier,(term Prims.list FStar_Pervasives_Native.option,(pattern,
                                                                    term)
                                                                    FStar_Pervasives_Native.tuple2)
                    FStar_Pervasives_Native.tuple2 Prims.list,term)
-  FStar_Pervasives_Native.tuple3 
-  | LetOpen of (FStar_Ident.lid,term) FStar_Pervasives_Native.tuple2 
-  | Seq of (term,term) FStar_Pervasives_Native.tuple2 
-  | Bind of (FStar_Ident.ident,term,term) FStar_Pervasives_Native.tuple3 
-  | If of (term,term,term) FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
+  | LetOpen of (FStar_Ident.lid,term) FStar_Pervasives_Native.tuple2
+  | Seq of (term,term) FStar_Pervasives_Native.tuple2
+  | Bind of (FStar_Ident.ident,term,term) FStar_Pervasives_Native.tuple3
+  | If of (term,term,term) FStar_Pervasives_Native.tuple3
   | Match of
   (term,(pattern,term FStar_Pervasives_Native.option,term)
           FStar_Pervasives_Native.tuple3 Prims.list)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | TryWith of
   (term,(pattern,term FStar_Pervasives_Native.option,term)
           FStar_Pervasives_Native.tuple3 Prims.list)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Ascribed of (term,term,term FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | Record of
   (term FStar_Pervasives_Native.option,(FStar_Ident.lid,term)
                                          FStar_Pervasives_Native.tuple2
                                          Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | Project of (term,FStar_Ident.lid) FStar_Pervasives_Native.tuple2 
-  | Product of (binder Prims.list,term) FStar_Pervasives_Native.tuple2 
-  | Sum of (binder Prims.list,term) FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
+  | Project of (term,FStar_Ident.lid) FStar_Pervasives_Native.tuple2
+  | Product of (binder Prims.list,term) FStar_Pervasives_Native.tuple2
+  | Sum of (binder Prims.list,term) FStar_Pervasives_Native.tuple2
   | QForall of (binder Prims.list,term Prims.list Prims.list,term)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | QExists of (binder Prims.list,term Prims.list Prims.list,term)
-  FStar_Pervasives_Native.tuple3 
-  | Refine of (binder,term) FStar_Pervasives_Native.tuple2 
-  | NamedTyp of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 
-  | Paren of term 
+  FStar_Pervasives_Native.tuple3
+  | Refine of (binder,term) FStar_Pervasives_Native.tuple2
+  | NamedTyp of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2
+  | Paren of term
   | Requires of (term,Prims.string FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Ensures of (term,Prims.string FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Labeled of (term,Prims.string,Prims.bool) FStar_Pervasives_Native.tuple3
-  
-  | Discrim of FStar_Ident.lid 
-  | Attributes of term Prims.list [@@deriving show]
+  | Discrim of FStar_Ident.lid
+  | Attributes of term Prims.list[@@deriving show]
 and term = {
-  tm: term' ;
-  range: FStar_Range.range ;
-  level: level }[@@deriving show]
+  tm: term';
+  range: FStar_Range.range;
+  level: level;}[@@deriving show]
 and binder' =
-  | Variable of FStar_Ident.ident 
-  | TVariable of FStar_Ident.ident 
-  | Annotated of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 
-  | TAnnotated of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 
-  | NoName of term [@@deriving show]
+  | Variable of FStar_Ident.ident
+  | TVariable of FStar_Ident.ident
+  | Annotated of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2
+  | TAnnotated of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2
+  | NoName of term[@@deriving show]
 and binder =
   {
-  b: binder' ;
-  brange: FStar_Range.range ;
-  blevel: level ;
-  aqual: aqual }[@@deriving show]
+  b: binder';
+  brange: FStar_Range.range;
+  blevel: level;
+  aqual: aqual;}[@@deriving show]
 and pattern' =
-  | PatWild 
-  | PatConst of FStar_Const.sconst 
-  | PatApp of (pattern,pattern Prims.list) FStar_Pervasives_Native.tuple2 
+  | PatWild
+  | PatConst of FStar_Const.sconst
+  | PatApp of (pattern,pattern Prims.list) FStar_Pervasives_Native.tuple2
   | PatVar of
   (FStar_Ident.ident,arg_qualifier FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
-  | PatName of FStar_Ident.lid 
+  FStar_Pervasives_Native.tuple2
+  | PatName of FStar_Ident.lid
   | PatTvar of
   (FStar_Ident.ident,arg_qualifier FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
-  | PatList of pattern Prims.list 
+  FStar_Pervasives_Native.tuple2
+  | PatList of pattern Prims.list
   | PatTuple of (pattern Prims.list,Prims.bool)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | PatRecord of (FStar_Ident.lid,pattern) FStar_Pervasives_Native.tuple2
-  Prims.list 
-  | PatAscribed of (pattern,term) FStar_Pervasives_Native.tuple2 
-  | PatOr of pattern Prims.list 
-  | PatOp of FStar_Ident.ident [@@deriving show]
+  Prims.list
+  | PatAscribed of (pattern,term) FStar_Pervasives_Native.tuple2
+  | PatOr of pattern Prims.list
+  | PatOp of FStar_Ident.ident[@@deriving show]
 and pattern = {
-  pat: pattern' ;
-  prange: FStar_Range.range }[@@deriving show]
-let (uu___is_Wild : term' -> Prims.bool) =
-  fun projectee  -> match projectee with | Wild  -> true | uu____524 -> false 
-let (uu___is_Const : term' -> Prims.bool) =
+  pat: pattern';
+  prange: FStar_Range.range;}[@@deriving show]
+let uu___is_Wild: term' -> Prims.bool =
+  fun projectee  -> match projectee with | Wild  -> true | uu____524 -> false
+let uu___is_Const: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Const _0 -> true | uu____529 -> false
-  
-let (__proj__Const__item___0 : term' -> FStar_Const.sconst) =
-  fun projectee  -> match projectee with | Const _0 -> _0 
-let (uu___is_Op : term' -> Prims.bool) =
-  fun projectee  -> match projectee with | Op _0 -> true | uu____547 -> false 
-let (__proj__Op__item___0 :
-  term' -> (FStar_Ident.ident,term Prims.list) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Op _0 -> _0 
-let (uu___is_Tvar : term' -> Prims.bool) =
+let __proj__Const__item___0: term' -> FStar_Const.sconst =
+  fun projectee  -> match projectee with | Const _0 -> _0
+let uu___is_Op: term' -> Prims.bool =
+  fun projectee  -> match projectee with | Op _0 -> true | uu____547 -> false
+let __proj__Op__item___0:
+  term' -> (FStar_Ident.ident,term Prims.list) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Op _0 -> _0
+let uu___is_Tvar: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tvar _0 -> true | uu____577 -> false
-  
-let (__proj__Tvar__item___0 : term' -> FStar_Ident.ident) =
-  fun projectee  -> match projectee with | Tvar _0 -> _0 
-let (uu___is_Uvar : term' -> Prims.bool) =
+let __proj__Tvar__item___0: term' -> FStar_Ident.ident =
+  fun projectee  -> match projectee with | Tvar _0 -> _0
+let uu___is_Uvar: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Uvar _0 -> true | uu____589 -> false
-  
-let (__proj__Uvar__item___0 : term' -> FStar_Ident.ident) =
-  fun projectee  -> match projectee with | Uvar _0 -> _0 
-let (uu___is_Var : term' -> Prims.bool) =
+let __proj__Uvar__item___0: term' -> FStar_Ident.ident =
+  fun projectee  -> match projectee with | Uvar _0 -> _0
+let uu___is_Var: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Var _0 -> true | uu____601 -> false
-  
-let (__proj__Var__item___0 : term' -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | Var _0 -> _0 
-let (uu___is_Name : term' -> Prims.bool) =
+let __proj__Var__item___0: term' -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | Var _0 -> _0
+let uu___is_Name: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Name _0 -> true | uu____613 -> false
-  
-let (__proj__Name__item___0 : term' -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | Name _0 -> _0 
-let (uu___is_Projector : term' -> Prims.bool) =
+let __proj__Name__item___0: term' -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | Name _0 -> _0
+let uu___is_Projector: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Projector _0 -> true | uu____629 -> false
-  
-let (__proj__Projector__item___0 :
-  term' -> (FStar_Ident.lid,FStar_Ident.ident) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Projector _0 -> _0 
-let (uu___is_Construct : term' -> Prims.bool) =
+let __proj__Projector__item___0:
+  term' -> (FStar_Ident.lid,FStar_Ident.ident) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Projector _0 -> _0
+let uu___is_Construct: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Construct _0 -> true | uu____663 -> false
-  
-let (__proj__Construct__item___0 :
+let __proj__Construct__item___0:
   term' ->
     (FStar_Ident.lid,(term,imp) FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Construct _0 -> _0 
-let (uu___is_Abs : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Construct _0 -> _0
+let uu___is_Abs: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Abs _0 -> true | uu____711 -> false
-  
-let (__proj__Abs__item___0 :
-  term' -> (pattern Prims.list,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Abs _0 -> _0 
-let (uu___is_App : term' -> Prims.bool) =
+let __proj__Abs__item___0:
+  term' -> (pattern Prims.list,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Abs _0 -> _0
+let uu___is_App: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | App _0 -> true | uu____747 -> false
-  
-let (__proj__App__item___0 :
-  term' -> (term,term,imp) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | App _0 -> _0 
-let (uu___is_Let : term' -> Prims.bool) =
+let __proj__App__item___0:
+  term' -> (term,term,imp) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | App _0 -> _0
+let uu___is_Let: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Let _0 -> true | uu____797 -> false
-  
-let (__proj__Let__item___0 :
+let __proj__Let__item___0:
   term' ->
     (let_qualifier,(term Prims.list FStar_Pervasives_Native.option,(pattern,
                                                                     term)
                                                                     FStar_Pervasives_Native.tuple2)
                      FStar_Pervasives_Native.tuple2 Prims.list,term)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Let _0 -> _0 
-let (uu___is_LetOpen : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Let _0 -> _0
+let uu___is_LetOpen: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | LetOpen _0 -> true | uu____873 -> false
-  
-let (__proj__LetOpen__item___0 :
-  term' -> (FStar_Ident.lid,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | LetOpen _0 -> _0 
-let (uu___is_Seq : term' -> Prims.bool) =
+let __proj__LetOpen__item___0:
+  term' -> (FStar_Ident.lid,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | LetOpen _0 -> _0
+let uu___is_Seq: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Seq _0 -> true | uu____901 -> false
-  
-let (__proj__Seq__item___0 :
-  term' -> (term,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Seq _0 -> _0 
-let (uu___is_Bind : term' -> Prims.bool) =
+let __proj__Seq__item___0:
+  term' -> (term,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Seq _0 -> _0
+let uu___is_Bind: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Bind _0 -> true | uu____931 -> false
-  
-let (__proj__Bind__item___0 :
-  term' -> (FStar_Ident.ident,term,term) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | Bind _0 -> _0 
-let (uu___is_If : term' -> Prims.bool) =
-  fun projectee  -> match projectee with | If _0 -> true | uu____967 -> false 
-let (__proj__If__item___0 :
-  term' -> (term,term,term) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | If _0 -> _0 
-let (uu___is_Match : term' -> Prims.bool) =
+let __proj__Bind__item___0:
+  term' -> (FStar_Ident.ident,term,term) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | Bind _0 -> _0
+let uu___is_If: term' -> Prims.bool =
+  fun projectee  -> match projectee with | If _0 -> true | uu____967 -> false
+let __proj__If__item___0:
+  term' -> (term,term,term) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | If _0 -> _0
+let uu___is_Match: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Match _0 -> true | uu____1011 -> false
-  
-let (__proj__Match__item___0 :
+let __proj__Match__item___0:
   term' ->
     (term,(pattern,term FStar_Pervasives_Native.option,term)
             FStar_Pervasives_Native.tuple3 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Match _0 -> _0 
-let (uu___is_TryWith : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Match _0 -> _0
+let uu___is_TryWith: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | TryWith _0 -> true | uu____1079 -> false
-  
-let (__proj__TryWith__item___0 :
+let __proj__TryWith__item___0:
   term' ->
     (term,(pattern,term FStar_Pervasives_Native.option,term)
             FStar_Pervasives_Native.tuple3 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | TryWith _0 -> _0 
-let (uu___is_Ascribed : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | TryWith _0 -> _0
+let uu___is_Ascribed: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Ascribed _0 -> true | uu____1141 -> false
-  
-let (__proj__Ascribed__item___0 :
+let __proj__Ascribed__item___0:
   term' ->
     (term,term,term FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Ascribed _0 -> _0 
-let (uu___is_Record : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Ascribed _0 -> _0
+let uu___is_Record: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Record _0 -> true | uu____1189 -> false
-  
-let (__proj__Record__item___0 :
+let __proj__Record__item___0:
   term' ->
     (term FStar_Pervasives_Native.option,(FStar_Ident.lid,term)
                                            FStar_Pervasives_Native.tuple2
                                            Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Record _0 -> _0 
-let (uu___is_Project : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Record _0 -> _0
+let uu___is_Project: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Project _0 -> true | uu____1241 -> false
-  
-let (__proj__Project__item___0 :
-  term' -> (term,FStar_Ident.lid) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Project _0 -> _0 
-let (uu___is_Product : term' -> Prims.bool) =
+let __proj__Project__item___0:
+  term' -> (term,FStar_Ident.lid) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Project _0 -> _0
+let uu___is_Product: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Product _0 -> true | uu____1271 -> false
-  
-let (__proj__Product__item___0 :
-  term' -> (binder Prims.list,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Product _0 -> _0 
-let (uu___is_Sum : term' -> Prims.bool) =
+let __proj__Product__item___0:
+  term' -> (binder Prims.list,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Product _0 -> _0
+let uu___is_Sum: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sum _0 -> true | uu____1307 -> false
-  
-let (__proj__Sum__item___0 :
-  term' -> (binder Prims.list,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Sum _0 -> _0 
-let (uu___is_QForall : term' -> Prims.bool) =
+let __proj__Sum__item___0:
+  term' -> (binder Prims.list,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Sum _0 -> _0
+let uu___is_QForall: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | QForall _0 -> true | uu____1349 -> false
-  
-let (__proj__QForall__item___0 :
+let __proj__QForall__item___0:
   term' ->
     (binder Prims.list,term Prims.list Prims.list,term)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | QForall _0 -> _0 
-let (uu___is_QExists : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | QForall _0 -> _0
+let uu___is_QExists: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | QExists _0 -> true | uu____1409 -> false
-  
-let (__proj__QExists__item___0 :
+let __proj__QExists__item___0:
   term' ->
     (binder Prims.list,term Prims.list Prims.list,term)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | QExists _0 -> _0 
-let (uu___is_Refine : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | QExists _0 -> _0
+let uu___is_Refine: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Refine _0 -> true | uu____1461 -> false
-  
-let (__proj__Refine__item___0 :
-  term' -> (binder,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Refine _0 -> _0 
-let (uu___is_NamedTyp : term' -> Prims.bool) =
+let __proj__Refine__item___0:
+  term' -> (binder,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Refine _0 -> _0
+let uu___is_NamedTyp: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | NamedTyp _0 -> true | uu____1489 -> false
-  
-let (__proj__NamedTyp__item___0 :
-  term' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | NamedTyp _0 -> _0 
-let (uu___is_Paren : term' -> Prims.bool) =
+let __proj__NamedTyp__item___0:
+  term' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | NamedTyp _0 -> _0
+let uu___is_Paren: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Paren _0 -> true | uu____1513 -> false
-  
-let (__proj__Paren__item___0 : term' -> term) =
-  fun projectee  -> match projectee with | Paren _0 -> _0 
-let (uu___is_Requires : term' -> Prims.bool) =
+let __proj__Paren__item___0: term' -> term =
+  fun projectee  -> match projectee with | Paren _0 -> _0
+let uu___is_Requires: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Requires _0 -> true | uu____1531 -> false
-  
-let (__proj__Requires__item___0 :
+let __proj__Requires__item___0:
   term' ->
     (term,Prims.string FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Requires _0 -> _0 
-let (uu___is_Ensures : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Requires _0 -> _0
+let uu___is_Ensures: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Ensures _0 -> true | uu____1567 -> false
-  
-let (__proj__Ensures__item___0 :
+let __proj__Ensures__item___0:
   term' ->
     (term,Prims.string FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Ensures _0 -> _0 
-let (uu___is_Labeled : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Ensures _0 -> _0
+let uu___is_Labeled: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Labeled _0 -> true | uu____1603 -> false
-  
-let (__proj__Labeled__item___0 :
-  term' -> (term,Prims.string,Prims.bool) FStar_Pervasives_Native.tuple3) =
-  fun projectee  -> match projectee with | Labeled _0 -> _0 
-let (uu___is_Discrim : term' -> Prims.bool) =
+let __proj__Labeled__item___0:
+  term' -> (term,Prims.string,Prims.bool) FStar_Pervasives_Native.tuple3 =
+  fun projectee  -> match projectee with | Labeled _0 -> _0
+let uu___is_Discrim: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Discrim _0 -> true | uu____1633 -> false
-  
-let (__proj__Discrim__item___0 : term' -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | Discrim _0 -> _0 
-let (uu___is_Attributes : term' -> Prims.bool) =
+let __proj__Discrim__item___0: term' -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | Discrim _0 -> _0
+let uu___is_Attributes: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Attributes _0 -> true | uu____1647 -> false
-  
-let (__proj__Attributes__item___0 : term' -> term Prims.list) =
-  fun projectee  -> match projectee with | Attributes _0 -> _0 
-let (__proj__Mkterm__item__tm : term -> term') =
+let __proj__Attributes__item___0: term' -> term Prims.list =
+  fun projectee  -> match projectee with | Attributes _0 -> _0
+let __proj__Mkterm__item__tm: term -> term' =
   fun projectee  ->
     match projectee with
     | { tm = __fname__tm; range = __fname__range; level = __fname__level;_}
         -> __fname__tm
-  
-let (__proj__Mkterm__item__range : term -> FStar_Range.range) =
+let __proj__Mkterm__item__range: term -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { tm = __fname__tm; range = __fname__range; level = __fname__level;_}
         -> __fname__range
-  
-let (__proj__Mkterm__item__level : term -> level) =
+let __proj__Mkterm__item__level: term -> level =
   fun projectee  ->
     match projectee with
     | { tm = __fname__tm; range = __fname__range; level = __fname__level;_}
         -> __fname__level
-  
-let (uu___is_Variable : binder' -> Prims.bool) =
+let uu___is_Variable: binder' -> Prims.bool =
   fun projectee  ->
     match projectee with | Variable _0 -> true | uu____1683 -> false
-  
-let (__proj__Variable__item___0 : binder' -> FStar_Ident.ident) =
-  fun projectee  -> match projectee with | Variable _0 -> _0 
-let (uu___is_TVariable : binder' -> Prims.bool) =
+let __proj__Variable__item___0: binder' -> FStar_Ident.ident =
+  fun projectee  -> match projectee with | Variable _0 -> _0
+let uu___is_TVariable: binder' -> Prims.bool =
   fun projectee  ->
     match projectee with | TVariable _0 -> true | uu____1695 -> false
-  
-let (__proj__TVariable__item___0 : binder' -> FStar_Ident.ident) =
-  fun projectee  -> match projectee with | TVariable _0 -> _0 
-let (uu___is_Annotated : binder' -> Prims.bool) =
+let __proj__TVariable__item___0: binder' -> FStar_Ident.ident =
+  fun projectee  -> match projectee with | TVariable _0 -> _0
+let uu___is_Annotated: binder' -> Prims.bool =
   fun projectee  ->
     match projectee with | Annotated _0 -> true | uu____1711 -> false
-  
-let (__proj__Annotated__item___0 :
-  binder' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Annotated _0 -> _0 
-let (uu___is_TAnnotated : binder' -> Prims.bool) =
+let __proj__Annotated__item___0:
+  binder' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Annotated _0 -> _0
+let uu___is_TAnnotated: binder' -> Prims.bool =
   fun projectee  ->
     match projectee with | TAnnotated _0 -> true | uu____1739 -> false
-  
-let (__proj__TAnnotated__item___0 :
-  binder' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | TAnnotated _0 -> _0 
-let (uu___is_NoName : binder' -> Prims.bool) =
+let __proj__TAnnotated__item___0:
+  binder' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | TAnnotated _0 -> _0
+let uu___is_NoName: binder' -> Prims.bool =
   fun projectee  ->
     match projectee with | NoName _0 -> true | uu____1763 -> false
-  
-let (__proj__NoName__item___0 : binder' -> term) =
-  fun projectee  -> match projectee with | NoName _0 -> _0 
-let (__proj__Mkbinder__item__b : binder -> binder') =
+let __proj__NoName__item___0: binder' -> term =
+  fun projectee  -> match projectee with | NoName _0 -> _0
+let __proj__Mkbinder__item__b: binder -> binder' =
   fun projectee  ->
     match projectee with
     | { b = __fname__b; brange = __fname__brange; blevel = __fname__blevel;
         aqual = __fname__aqual;_} -> __fname__b
-  
-let (__proj__Mkbinder__item__brange : binder -> FStar_Range.range) =
+let __proj__Mkbinder__item__brange: binder -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { b = __fname__b; brange = __fname__brange; blevel = __fname__blevel;
         aqual = __fname__aqual;_} -> __fname__brange
-  
-let (__proj__Mkbinder__item__blevel : binder -> level) =
+let __proj__Mkbinder__item__blevel: binder -> level =
   fun projectee  ->
     match projectee with
     | { b = __fname__b; brange = __fname__brange; blevel = __fname__blevel;
         aqual = __fname__aqual;_} -> __fname__blevel
-  
-let (__proj__Mkbinder__item__aqual : binder -> aqual) =
+let __proj__Mkbinder__item__aqual: binder -> aqual =
   fun projectee  ->
     match projectee with
     | { b = __fname__b; brange = __fname__brange; blevel = __fname__blevel;
         aqual = __fname__aqual;_} -> __fname__aqual
-  
-let (uu___is_PatWild : pattern' -> Prims.bool) =
+let uu___is_PatWild: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatWild  -> true | uu____1802 -> false
-  
-let (uu___is_PatConst : pattern' -> Prims.bool) =
+let uu___is_PatConst: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatConst _0 -> true | uu____1807 -> false
-  
-let (__proj__PatConst__item___0 : pattern' -> FStar_Const.sconst) =
-  fun projectee  -> match projectee with | PatConst _0 -> _0 
-let (uu___is_PatApp : pattern' -> Prims.bool) =
+let __proj__PatConst__item___0: pattern' -> FStar_Const.sconst =
+  fun projectee  -> match projectee with | PatConst _0 -> _0
+let uu___is_PatApp: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatApp _0 -> true | uu____1825 -> false
-  
-let (__proj__PatApp__item___0 :
-  pattern' -> (pattern,pattern Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | PatApp _0 -> _0 
-let (uu___is_PatVar : pattern' -> Prims.bool) =
+let __proj__PatApp__item___0:
+  pattern' -> (pattern,pattern Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | PatApp _0 -> _0
+let uu___is_PatVar: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatVar _0 -> true | uu____1861 -> false
-  
-let (__proj__PatVar__item___0 :
+let __proj__PatVar__item___0:
   pattern' ->
     (FStar_Ident.ident,arg_qualifier FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | PatVar _0 -> _0 
-let (uu___is_PatName : pattern' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | PatVar _0 -> _0
+let uu___is_PatName: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatName _0 -> true | uu____1891 -> false
-  
-let (__proj__PatName__item___0 : pattern' -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | PatName _0 -> _0 
-let (uu___is_PatTvar : pattern' -> Prims.bool) =
+let __proj__PatName__item___0: pattern' -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | PatName _0 -> _0
+let uu___is_PatTvar: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatTvar _0 -> true | uu____1909 -> false
-  
-let (__proj__PatTvar__item___0 :
+let __proj__PatTvar__item___0:
   pattern' ->
     (FStar_Ident.ident,arg_qualifier FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | PatTvar _0 -> _0 
-let (uu___is_PatList : pattern' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | PatTvar _0 -> _0
+let uu___is_PatList: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatList _0 -> true | uu____1941 -> false
-  
-let (__proj__PatList__item___0 : pattern' -> pattern Prims.list) =
-  fun projectee  -> match projectee with | PatList _0 -> _0 
-let (uu___is_PatTuple : pattern' -> Prims.bool) =
+let __proj__PatList__item___0: pattern' -> pattern Prims.list =
+  fun projectee  -> match projectee with | PatList _0 -> _0
+let uu___is_PatTuple: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatTuple _0 -> true | uu____1965 -> false
-  
-let (__proj__PatTuple__item___0 :
-  pattern' -> (pattern Prims.list,Prims.bool) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | PatTuple _0 -> _0 
-let (uu___is_PatRecord : pattern' -> Prims.bool) =
+let __proj__PatTuple__item___0:
+  pattern' -> (pattern Prims.list,Prims.bool) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | PatTuple _0 -> _0
+let uu___is_PatRecord: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatRecord _0 -> true | uu____2001 -> false
-  
-let (__proj__PatRecord__item___0 :
+let __proj__PatRecord__item___0:
   pattern' ->
-    (FStar_Ident.lid,pattern) FStar_Pervasives_Native.tuple2 Prims.list)
-  = fun projectee  -> match projectee with | PatRecord _0 -> _0 
-let (uu___is_PatAscribed : pattern' -> Prims.bool) =
+    (FStar_Ident.lid,pattern) FStar_Pervasives_Native.tuple2 Prims.list
+  = fun projectee  -> match projectee with | PatRecord _0 -> _0
+let uu___is_PatAscribed: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatAscribed _0 -> true | uu____2035 -> false
-  
-let (__proj__PatAscribed__item___0 :
-  pattern' -> (pattern,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | PatAscribed _0 -> _0 
-let (uu___is_PatOr : pattern' -> Prims.bool) =
+let __proj__PatAscribed__item___0:
+  pattern' -> (pattern,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | PatAscribed _0 -> _0
+let uu___is_PatOr: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatOr _0 -> true | uu____2061 -> false
-  
-let (__proj__PatOr__item___0 : pattern' -> pattern Prims.list) =
-  fun projectee  -> match projectee with | PatOr _0 -> _0 
-let (uu___is_PatOp : pattern' -> Prims.bool) =
+let __proj__PatOr__item___0: pattern' -> pattern Prims.list =
+  fun projectee  -> match projectee with | PatOr _0 -> _0
+let uu___is_PatOp: pattern' -> Prims.bool =
   fun projectee  ->
     match projectee with | PatOp _0 -> true | uu____2079 -> false
-  
-let (__proj__PatOp__item___0 : pattern' -> FStar_Ident.ident) =
-  fun projectee  -> match projectee with | PatOp _0 -> _0 
-let (__proj__Mkpattern__item__pat : pattern -> pattern') =
+let __proj__PatOp__item___0: pattern' -> FStar_Ident.ident =
+  fun projectee  -> match projectee with | PatOp _0 -> _0
+let __proj__Mkpattern__item__pat: pattern -> pattern' =
   fun projectee  ->
     match projectee with
     | { pat = __fname__pat; prange = __fname__prange;_} -> __fname__pat
-  
-let (__proj__Mkpattern__item__prange : pattern -> FStar_Range.range) =
+let __proj__Mkpattern__item__prange: pattern -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { pat = __fname__pat; prange = __fname__prange;_} -> __fname__prange
-  
 type attributes_ = term Prims.list[@@deriving show]
 type branch =
   (pattern,term FStar_Pervasives_Native.option,term)
@@ -581,462 +514,403 @@ type fsdoc =
 type tycon =
   | TyconAbstract of
   (FStar_Ident.ident,binder Prims.list,knd FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | TyconAbbrev of
   (FStar_Ident.ident,binder Prims.list,knd FStar_Pervasives_Native.option,
-  term) FStar_Pervasives_Native.tuple4 
+  term) FStar_Pervasives_Native.tuple4
   | TyconRecord of
   (FStar_Ident.ident,binder Prims.list,knd FStar_Pervasives_Native.option,
   (FStar_Ident.ident,term,fsdoc FStar_Pervasives_Native.option)
     FStar_Pervasives_Native.tuple3 Prims.list)
-  FStar_Pervasives_Native.tuple4 
+  FStar_Pervasives_Native.tuple4
   | TyconVariant of
   (FStar_Ident.ident,binder Prims.list,knd FStar_Pervasives_Native.option,
   (FStar_Ident.ident,term FStar_Pervasives_Native.option,fsdoc
                                                            FStar_Pervasives_Native.option,
     Prims.bool) FStar_Pervasives_Native.tuple4 Prims.list)
-  FStar_Pervasives_Native.tuple4 [@@deriving show]
-let (uu___is_TyconAbstract : tycon -> Prims.bool) =
+  FStar_Pervasives_Native.tuple4[@@deriving show]
+let uu___is_TyconAbstract: tycon -> Prims.bool =
   fun projectee  ->
     match projectee with | TyconAbstract _0 -> true | uu____2217 -> false
-  
-let (__proj__TyconAbstract__item___0 :
+let __proj__TyconAbstract__item___0:
   tycon ->
     (FStar_Ident.ident,binder Prims.list,knd FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | TyconAbstract _0 -> _0 
-let (uu___is_TyconAbbrev : tycon -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | TyconAbstract _0 -> _0
+let uu___is_TyconAbbrev: tycon -> Prims.bool =
   fun projectee  ->
     match projectee with | TyconAbbrev _0 -> true | uu____2271 -> false
-  
-let (__proj__TyconAbbrev__item___0 :
+let __proj__TyconAbbrev__item___0:
   tycon ->
     (FStar_Ident.ident,binder Prims.list,knd FStar_Pervasives_Native.option,
-      term) FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | TyconAbbrev _0 -> _0 
-let (uu___is_TyconRecord : tycon -> Prims.bool) =
+      term) FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | TyconAbbrev _0 -> _0
+let uu___is_TyconRecord: tycon -> Prims.bool =
   fun projectee  ->
     match projectee with | TyconRecord _0 -> true | uu____2341 -> false
-  
-let (__proj__TyconRecord__item___0 :
+let __proj__TyconRecord__item___0:
   tycon ->
     (FStar_Ident.ident,binder Prims.list,knd FStar_Pervasives_Native.option,
       (FStar_Ident.ident,term,fsdoc FStar_Pervasives_Native.option)
         FStar_Pervasives_Native.tuple3 Prims.list)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | TyconRecord _0 -> _0 
-let (uu___is_TyconVariant : tycon -> Prims.bool) =
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | TyconRecord _0 -> _0
+let uu___is_TyconVariant: tycon -> Prims.bool =
   fun projectee  ->
     match projectee with | TyconVariant _0 -> true | uu____2445 -> false
-  
-let (__proj__TyconVariant__item___0 :
+let __proj__TyconVariant__item___0:
   tycon ->
     (FStar_Ident.ident,binder Prims.list,knd FStar_Pervasives_Native.option,
       (FStar_Ident.ident,term FStar_Pervasives_Native.option,fsdoc
                                                                FStar_Pervasives_Native.option,
         Prims.bool) FStar_Pervasives_Native.tuple4 Prims.list)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | TyconVariant _0 -> _0 
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | TyconVariant _0 -> _0
 type qualifier =
-  | Private 
-  | Abstract 
-  | Noeq 
-  | Unopteq 
-  | Assumption 
-  | DefaultEffect 
-  | TotalEffect 
-  | Effect_qual 
-  | New 
-  | Inline 
-  | Visible 
-  | Unfold_for_unification_and_vcgen 
-  | Inline_for_extraction 
-  | Irreducible 
-  | NoExtract 
-  | Reifiable 
-  | Reflectable 
-  | Opaque 
-  | Logic [@@deriving show]
-let (uu___is_Private : qualifier -> Prims.bool) =
+  | Private
+  | Abstract
+  | Noeq
+  | Unopteq
+  | Assumption
+  | DefaultEffect
+  | TotalEffect
+  | Effect_qual
+  | New
+  | Inline
+  | Visible
+  | Unfold_for_unification_and_vcgen
+  | Inline_for_extraction
+  | Irreducible
+  | NoExtract
+  | Reifiable
+  | Reflectable
+  | Opaque
+  | Logic[@@deriving show]
+let uu___is_Private: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Private  -> true | uu____2534 -> false
-  
-let (uu___is_Abstract : qualifier -> Prims.bool) =
+let uu___is_Abstract: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Abstract  -> true | uu____2538 -> false
-  
-let (uu___is_Noeq : qualifier -> Prims.bool) =
+let uu___is_Noeq: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Noeq  -> true | uu____2542 -> false
-  
-let (uu___is_Unopteq : qualifier -> Prims.bool) =
+let uu___is_Unopteq: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Unopteq  -> true | uu____2546 -> false
-  
-let (uu___is_Assumption : qualifier -> Prims.bool) =
+let uu___is_Assumption: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Assumption  -> true | uu____2550 -> false
-  
-let (uu___is_DefaultEffect : qualifier -> Prims.bool) =
+let uu___is_DefaultEffect: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | DefaultEffect  -> true | uu____2554 -> false
-  
-let (uu___is_TotalEffect : qualifier -> Prims.bool) =
+let uu___is_TotalEffect: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | TotalEffect  -> true | uu____2558 -> false
-  
-let (uu___is_Effect_qual : qualifier -> Prims.bool) =
+let uu___is_Effect_qual: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Effect_qual  -> true | uu____2562 -> false
-  
-let (uu___is_New : qualifier -> Prims.bool) =
-  fun projectee  -> match projectee with | New  -> true | uu____2566 -> false 
-let (uu___is_Inline : qualifier -> Prims.bool) =
+let uu___is_New: qualifier -> Prims.bool =
+  fun projectee  -> match projectee with | New  -> true | uu____2566 -> false
+let uu___is_Inline: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Inline  -> true | uu____2570 -> false
-  
-let (uu___is_Visible : qualifier -> Prims.bool) =
+let uu___is_Visible: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Visible  -> true | uu____2574 -> false
-  
-let (uu___is_Unfold_for_unification_and_vcgen : qualifier -> Prims.bool) =
+let uu___is_Unfold_for_unification_and_vcgen: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Unfold_for_unification_and_vcgen  -> true
     | uu____2578 -> false
-  
-let (uu___is_Inline_for_extraction : qualifier -> Prims.bool) =
+let uu___is_Inline_for_extraction: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Inline_for_extraction  -> true
     | uu____2582 -> false
-  
-let (uu___is_Irreducible : qualifier -> Prims.bool) =
+let uu___is_Irreducible: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Irreducible  -> true | uu____2586 -> false
-  
-let (uu___is_NoExtract : qualifier -> Prims.bool) =
+let uu___is_NoExtract: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | NoExtract  -> true | uu____2590 -> false
-  
-let (uu___is_Reifiable : qualifier -> Prims.bool) =
+let uu___is_Reifiable: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Reifiable  -> true | uu____2594 -> false
-  
-let (uu___is_Reflectable : qualifier -> Prims.bool) =
+let uu___is_Reflectable: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Reflectable  -> true | uu____2598 -> false
-  
-let (uu___is_Opaque : qualifier -> Prims.bool) =
+let uu___is_Opaque: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Opaque  -> true | uu____2602 -> false
-  
-let (uu___is_Logic : qualifier -> Prims.bool) =
+let uu___is_Logic: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Logic  -> true | uu____2606 -> false
-  
 type qualifiers = qualifier Prims.list[@@deriving show]
 type decoration =
-  | Qualifier of qualifier 
-  | DeclAttributes of term Prims.list 
-  | Doc of fsdoc [@@deriving show]
-let (uu___is_Qualifier : decoration -> Prims.bool) =
+  | Qualifier of qualifier
+  | DeclAttributes of term Prims.list
+  | Doc of fsdoc[@@deriving show]
+let uu___is_Qualifier: decoration -> Prims.bool =
   fun projectee  ->
     match projectee with | Qualifier _0 -> true | uu____2627 -> false
-  
-let (__proj__Qualifier__item___0 : decoration -> qualifier) =
-  fun projectee  -> match projectee with | Qualifier _0 -> _0 
-let (uu___is_DeclAttributes : decoration -> Prims.bool) =
+let __proj__Qualifier__item___0: decoration -> qualifier =
+  fun projectee  -> match projectee with | Qualifier _0 -> _0
+let uu___is_DeclAttributes: decoration -> Prims.bool =
   fun projectee  ->
     match projectee with | DeclAttributes _0 -> true | uu____2641 -> false
-  
-let (__proj__DeclAttributes__item___0 : decoration -> term Prims.list) =
-  fun projectee  -> match projectee with | DeclAttributes _0 -> _0 
-let (uu___is_Doc : decoration -> Prims.bool) =
+let __proj__DeclAttributes__item___0: decoration -> term Prims.list =
+  fun projectee  -> match projectee with | DeclAttributes _0 -> _0
+let uu___is_Doc: decoration -> Prims.bool =
   fun projectee  ->
     match projectee with | Doc _0 -> true | uu____2659 -> false
-  
-let (__proj__Doc__item___0 : decoration -> fsdoc) =
-  fun projectee  -> match projectee with | Doc _0 -> _0 
+let __proj__Doc__item___0: decoration -> fsdoc =
+  fun projectee  -> match projectee with | Doc _0 -> _0
 type lift_op =
-  | NonReifiableLift of term 
-  | ReifiableLift of (term,term) FStar_Pervasives_Native.tuple2 
-  | LiftForFree of term [@@deriving show]
-let (uu___is_NonReifiableLift : lift_op -> Prims.bool) =
+  | NonReifiableLift of term
+  | ReifiableLift of (term,term) FStar_Pervasives_Native.tuple2
+  | LiftForFree of term[@@deriving show]
+let uu___is_NonReifiableLift: lift_op -> Prims.bool =
   fun projectee  ->
     match projectee with | NonReifiableLift _0 -> true | uu____2687 -> false
-  
-let (__proj__NonReifiableLift__item___0 : lift_op -> term) =
-  fun projectee  -> match projectee with | NonReifiableLift _0 -> _0 
-let (uu___is_ReifiableLift : lift_op -> Prims.bool) =
+let __proj__NonReifiableLift__item___0: lift_op -> term =
+  fun projectee  -> match projectee with | NonReifiableLift _0 -> _0
+let uu___is_ReifiableLift: lift_op -> Prims.bool =
   fun projectee  ->
     match projectee with | ReifiableLift _0 -> true | uu____2703 -> false
-  
-let (__proj__ReifiableLift__item___0 :
-  lift_op -> (term,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | ReifiableLift _0 -> _0 
-let (uu___is_LiftForFree : lift_op -> Prims.bool) =
+let __proj__ReifiableLift__item___0:
+  lift_op -> (term,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | ReifiableLift _0 -> _0
+let uu___is_LiftForFree: lift_op -> Prims.bool =
   fun projectee  ->
     match projectee with | LiftForFree _0 -> true | uu____2727 -> false
-  
-let (__proj__LiftForFree__item___0 : lift_op -> term) =
-  fun projectee  -> match projectee with | LiftForFree _0 -> _0 
+let __proj__LiftForFree__item___0: lift_op -> term =
+  fun projectee  -> match projectee with | LiftForFree _0 -> _0
 type lift =
   {
-  msource: FStar_Ident.lid ;
-  mdest: FStar_Ident.lid ;
-  lift_op: lift_op }[@@deriving show]
-let (__proj__Mklift__item__msource : lift -> FStar_Ident.lid) =
+  msource: FStar_Ident.lid;
+  mdest: FStar_Ident.lid;
+  lift_op: lift_op;}[@@deriving show]
+let __proj__Mklift__item__msource: lift -> FStar_Ident.lid =
   fun projectee  ->
     match projectee with
     | { msource = __fname__msource; mdest = __fname__mdest;
         lift_op = __fname__lift_op;_} -> __fname__msource
-  
-let (__proj__Mklift__item__mdest : lift -> FStar_Ident.lid) =
+let __proj__Mklift__item__mdest: lift -> FStar_Ident.lid =
   fun projectee  ->
     match projectee with
     | { msource = __fname__msource; mdest = __fname__mdest;
         lift_op = __fname__lift_op;_} -> __fname__mdest
-  
-let (__proj__Mklift__item__lift_op : lift -> lift_op) =
+let __proj__Mklift__item__lift_op: lift -> lift_op =
   fun projectee  ->
     match projectee with
     | { msource = __fname__msource; mdest = __fname__mdest;
         lift_op = __fname__lift_op;_} -> __fname__lift_op
-  
 type pragma =
-  | SetOptions of Prims.string 
-  | ResetOptions of Prims.string FStar_Pervasives_Native.option 
-  | LightOff [@@deriving show]
-let (uu___is_SetOptions : pragma -> Prims.bool) =
+  | SetOptions of Prims.string
+  | ResetOptions of Prims.string FStar_Pervasives_Native.option
+  | LightOff[@@deriving show]
+let uu___is_SetOptions: pragma -> Prims.bool =
   fun projectee  ->
     match projectee with | SetOptions _0 -> true | uu____2779 -> false
-  
-let (__proj__SetOptions__item___0 : pragma -> Prims.string) =
-  fun projectee  -> match projectee with | SetOptions _0 -> _0 
-let (uu___is_ResetOptions : pragma -> Prims.bool) =
+let __proj__SetOptions__item___0: pragma -> Prims.string =
+  fun projectee  -> match projectee with | SetOptions _0 -> _0
+let uu___is_ResetOptions: pragma -> Prims.bool =
   fun projectee  ->
     match projectee with | ResetOptions _0 -> true | uu____2793 -> false
-  
-let (__proj__ResetOptions__item___0 :
-  pragma -> Prims.string FStar_Pervasives_Native.option) =
-  fun projectee  -> match projectee with | ResetOptions _0 -> _0 
-let (uu___is_LightOff : pragma -> Prims.bool) =
+let __proj__ResetOptions__item___0:
+  pragma -> Prims.string FStar_Pervasives_Native.option =
+  fun projectee  -> match projectee with | ResetOptions _0 -> _0
+let uu___is_LightOff: pragma -> Prims.bool =
   fun projectee  ->
     match projectee with | LightOff  -> true | uu____2810 -> false
-  
 type decl' =
-  | TopLevelModule of FStar_Ident.lid 
-  | Open of FStar_Ident.lid 
-  | Include of FStar_Ident.lid 
+  | TopLevelModule of FStar_Ident.lid
+  | Open of FStar_Ident.lid
+  | Include of FStar_Ident.lid
   | ModuleAbbrev of (FStar_Ident.ident,FStar_Ident.lid)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | TopLevelLet of
   (let_qualifier,(pattern,term) FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | Main of term 
+  FStar_Pervasives_Native.tuple2
+  | Main of term
   | Tycon of
   (Prims.bool,(tycon,fsdoc FStar_Pervasives_Native.option)
                 FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | Val of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
+  | Val of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2
   | Exception of (FStar_Ident.ident,term FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
-  | NewEffect of effect_decl 
-  | SubEffect of lift 
-  | Pragma of pragma 
-  | Fsdoc of fsdoc 
-  | Assume of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
+  | NewEffect of effect_decl
+  | SubEffect of lift
+  | Pragma of pragma
+  | Fsdoc of fsdoc
+  | Assume of (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2
 [@@deriving show]
 and decl =
   {
-  d: decl' ;
-  drange: FStar_Range.range ;
-  doc: fsdoc FStar_Pervasives_Native.option ;
-  quals: qualifiers ;
-  attrs: attributes_ }[@@deriving show]
+  d: decl';
+  drange: FStar_Range.range;
+  doc: fsdoc FStar_Pervasives_Native.option;
+  quals: qualifiers;
+  attrs: attributes_;}[@@deriving show]
 and effect_decl =
   | DefineEffect of
   (FStar_Ident.ident,binder Prims.list,term,decl Prims.list)
-  FStar_Pervasives_Native.tuple4 
+  FStar_Pervasives_Native.tuple4
   | RedefineEffect of (FStar_Ident.ident,binder Prims.list,term)
-  FStar_Pervasives_Native.tuple3 [@@deriving show]
-let (uu___is_TopLevelModule : decl' -> Prims.bool) =
+  FStar_Pervasives_Native.tuple3[@@deriving show]
+let uu___is_TopLevelModule: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | TopLevelModule _0 -> true | uu____2961 -> false
-  
-let (__proj__TopLevelModule__item___0 : decl' -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | TopLevelModule _0 -> _0 
-let (uu___is_Open : decl' -> Prims.bool) =
+let __proj__TopLevelModule__item___0: decl' -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | TopLevelModule _0 -> _0
+let uu___is_Open: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | Open _0 -> true | uu____2973 -> false
-  
-let (__proj__Open__item___0 : decl' -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | Open _0 -> _0 
-let (uu___is_Include : decl' -> Prims.bool) =
+let __proj__Open__item___0: decl' -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | Open _0 -> _0
+let uu___is_Include: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | Include _0 -> true | uu____2985 -> false
-  
-let (__proj__Include__item___0 : decl' -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | Include _0 -> _0 
-let (uu___is_ModuleAbbrev : decl' -> Prims.bool) =
+let __proj__Include__item___0: decl' -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | Include _0 -> _0
+let uu___is_ModuleAbbrev: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | ModuleAbbrev _0 -> true | uu____3001 -> false
-  
-let (__proj__ModuleAbbrev__item___0 :
-  decl' -> (FStar_Ident.ident,FStar_Ident.lid) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | ModuleAbbrev _0 -> _0 
-let (uu___is_TopLevelLet : decl' -> Prims.bool) =
+let __proj__ModuleAbbrev__item___0:
+  decl' -> (FStar_Ident.ident,FStar_Ident.lid) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | ModuleAbbrev _0 -> _0
+let uu___is_TopLevelLet: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | TopLevelLet _0 -> true | uu____3035 -> false
-  
-let (__proj__TopLevelLet__item___0 :
+let __proj__TopLevelLet__item___0:
   decl' ->
     (let_qualifier,(pattern,term) FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | TopLevelLet _0 -> _0 
-let (uu___is_Main : decl' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | TopLevelLet _0 -> _0
+let uu___is_Main: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | Main _0 -> true | uu____3077 -> false
-  
-let (__proj__Main__item___0 : decl' -> term) =
-  fun projectee  -> match projectee with | Main _0 -> _0 
-let (uu___is_Tycon : decl' -> Prims.bool) =
+let __proj__Main__item___0: decl' -> term =
+  fun projectee  -> match projectee with | Main _0 -> _0
+let uu___is_Tycon: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tycon _0 -> true | uu____3101 -> false
-  
-let (__proj__Tycon__item___0 :
+let __proj__Tycon__item___0:
   decl' ->
     (Prims.bool,(tycon,fsdoc FStar_Pervasives_Native.option)
                   FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tycon _0 -> _0 
-let (uu___is_Val : decl' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tycon _0 -> _0
+let uu___is_Val: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | Val _0 -> true | uu____3153 -> false
-  
-let (__proj__Val__item___0 :
-  decl' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Val _0 -> _0 
-let (uu___is_Exception : decl' -> Prims.bool) =
+let __proj__Val__item___0:
+  decl' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Val _0 -> _0
+let uu___is_Exception: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | Exception _0 -> true | uu____3183 -> false
-  
-let (__proj__Exception__item___0 :
+let __proj__Exception__item___0:
   decl' ->
     (FStar_Ident.ident,term FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Exception _0 -> _0 
-let (uu___is_NewEffect : decl' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Exception _0 -> _0
+let uu___is_NewEffect: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | NewEffect _0 -> true | uu____3213 -> false
-  
-let (__proj__NewEffect__item___0 : decl' -> effect_decl) =
-  fun projectee  -> match projectee with | NewEffect _0 -> _0 
-let (uu___is_SubEffect : decl' -> Prims.bool) =
+let __proj__NewEffect__item___0: decl' -> effect_decl =
+  fun projectee  -> match projectee with | NewEffect _0 -> _0
+let uu___is_SubEffect: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | SubEffect _0 -> true | uu____3225 -> false
-  
-let (__proj__SubEffect__item___0 : decl' -> lift) =
-  fun projectee  -> match projectee with | SubEffect _0 -> _0 
-let (uu___is_Pragma : decl' -> Prims.bool) =
+let __proj__SubEffect__item___0: decl' -> lift =
+  fun projectee  -> match projectee with | SubEffect _0 -> _0
+let uu___is_Pragma: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | Pragma _0 -> true | uu____3237 -> false
-  
-let (__proj__Pragma__item___0 : decl' -> pragma) =
-  fun projectee  -> match projectee with | Pragma _0 -> _0 
-let (uu___is_Fsdoc : decl' -> Prims.bool) =
+let __proj__Pragma__item___0: decl' -> pragma =
+  fun projectee  -> match projectee with | Pragma _0 -> _0
+let uu___is_Fsdoc: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | Fsdoc _0 -> true | uu____3249 -> false
-  
-let (__proj__Fsdoc__item___0 : decl' -> fsdoc) =
-  fun projectee  -> match projectee with | Fsdoc _0 -> _0 
-let (uu___is_Assume : decl' -> Prims.bool) =
+let __proj__Fsdoc__item___0: decl' -> fsdoc =
+  fun projectee  -> match projectee with | Fsdoc _0 -> _0
+let uu___is_Assume: decl' -> Prims.bool =
   fun projectee  ->
     match projectee with | Assume _0 -> true | uu____3265 -> false
-  
-let (__proj__Assume__item___0 :
-  decl' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Assume _0 -> _0 
-let (__proj__Mkdecl__item__d : decl -> decl') =
+let __proj__Assume__item___0:
+  decl' -> (FStar_Ident.ident,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Assume _0 -> _0
+let __proj__Mkdecl__item__d: decl -> decl' =
   fun projectee  ->
     match projectee with
     | { d = __fname__d; drange = __fname__drange; doc = __fname__doc;
         quals = __fname__quals; attrs = __fname__attrs;_} -> __fname__d
-  
-let (__proj__Mkdecl__item__drange : decl -> FStar_Range.range) =
+let __proj__Mkdecl__item__drange: decl -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { d = __fname__d; drange = __fname__drange; doc = __fname__doc;
         quals = __fname__quals; attrs = __fname__attrs;_} -> __fname__drange
-  
-let (__proj__Mkdecl__item__doc :
-  decl -> fsdoc FStar_Pervasives_Native.option) =
+let __proj__Mkdecl__item__doc: decl -> fsdoc FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { d = __fname__d; drange = __fname__drange; doc = __fname__doc;
         quals = __fname__quals; attrs = __fname__attrs;_} -> __fname__doc
-  
-let (__proj__Mkdecl__item__quals : decl -> qualifiers) =
+let __proj__Mkdecl__item__quals: decl -> qualifiers =
   fun projectee  ->
     match projectee with
     | { d = __fname__d; drange = __fname__drange; doc = __fname__doc;
         quals = __fname__quals; attrs = __fname__attrs;_} -> __fname__quals
-  
-let (__proj__Mkdecl__item__attrs : decl -> attributes_) =
+let __proj__Mkdecl__item__attrs: decl -> attributes_ =
   fun projectee  ->
     match projectee with
     | { d = __fname__d; drange = __fname__drange; doc = __fname__doc;
         quals = __fname__quals; attrs = __fname__attrs;_} -> __fname__attrs
-  
-let (uu___is_DefineEffect : effect_decl -> Prims.bool) =
+let uu___is_DefineEffect: effect_decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DefineEffect _0 -> true | uu____3355 -> false
-  
-let (__proj__DefineEffect__item___0 :
+let __proj__DefineEffect__item___0:
   effect_decl ->
     (FStar_Ident.ident,binder Prims.list,term,decl Prims.list)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | DefineEffect _0 -> _0 
-let (uu___is_RedefineEffect : effect_decl -> Prims.bool) =
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | DefineEffect _0 -> _0
+let uu___is_RedefineEffect: effect_decl -> Prims.bool =
   fun projectee  ->
     match projectee with | RedefineEffect _0 -> true | uu____3411 -> false
-  
-let (__proj__RedefineEffect__item___0 :
+let __proj__RedefineEffect__item___0:
   effect_decl ->
-    (FStar_Ident.ident,binder Prims.list,term) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | RedefineEffect _0 -> _0 
+    (FStar_Ident.ident,binder Prims.list,term) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | RedefineEffect _0 -> _0
 type modul =
   | Module of (FStar_Ident.lid,decl Prims.list)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Interface of (FStar_Ident.lid,decl Prims.list,Prims.bool)
-  FStar_Pervasives_Native.tuple3 [@@deriving show]
-let (uu___is_Module : modul -> Prims.bool) =
+  FStar_Pervasives_Native.tuple3[@@deriving show]
+let uu___is_Module: modul -> Prims.bool =
   fun projectee  ->
     match projectee with | Module _0 -> true | uu____3475 -> false
-  
-let (__proj__Module__item___0 :
-  modul -> (FStar_Ident.lid,decl Prims.list) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Module _0 -> _0 
-let (uu___is_Interface : modul -> Prims.bool) =
+let __proj__Module__item___0:
+  modul -> (FStar_Ident.lid,decl Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Module _0 -> _0
+let uu___is_Interface: modul -> Prims.bool =
   fun projectee  ->
     match projectee with | Interface _0 -> true | uu____3513 -> false
-  
-let (__proj__Interface__item___0 :
+let __proj__Interface__item___0:
   modul ->
     (FStar_Ident.lid,decl Prims.list,Prims.bool)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Interface _0 -> _0 
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Interface _0 -> _0
 type file = modul[@@deriving show]
 type inputFragment = (file,decl Prims.list) FStar_Util.either[@@deriving
                                                                show]
-let (decl_drange : decl -> FStar_Range.range) = fun decl  -> decl.drange 
-let (check_id : FStar_Ident.ident -> Prims.unit) =
+let decl_drange: decl -> FStar_Range.range = fun decl  -> decl.drange
+let check_id: FStar_Ident.ident -> Prims.unit =
   fun id1  ->
     let first_char =
       FStar_String.substring id1.FStar_Ident.idText (Prims.parse_int "0")
-        (Prims.parse_int "1")
-       in
+        (Prims.parse_int "1") in
     if (FStar_String.lowercase first_char) = first_char
     then ()
     else
@@ -1044,12 +918,10 @@ let (check_id : FStar_Ident.ident -> Prims.unit) =
          let uu____3564 =
            FStar_Util.format1
              "Invalid identifer '%s'; expected a symbol that begins with a lower-case character"
-             id1.FStar_Ident.idText
-            in
-         (FStar_Errors.Fatal_InvalidIdentifier, uu____3564)  in
+             id1.FStar_Ident.idText in
+         (FStar_Errors.Fatal_InvalidIdentifier, uu____3564) in
        FStar_Errors.raise_error uu____3559 id1.FStar_Ident.idRange)
-  
-let at_most_one :
+let at_most_one:
   'Auu____3569 .
     Prims.string ->
       FStar_Range.range ->
@@ -1066,12 +938,10 @@ let at_most_one :
             let uu____3592 =
               let uu____3597 =
                 FStar_Util.format1
-                  "At most one %s is allowed on declarations" s
-                 in
-              (FStar_Errors.Fatal_MoreThanOneDeclaration, uu____3597)  in
+                  "At most one %s is allowed on declarations" s in
+              (FStar_Errors.Fatal_MoreThanOneDeclaration, uu____3597) in
             FStar_Errors.raise_error uu____3592 r
-  
-let (mk_decl : decl' -> FStar_Range.range -> decoration Prims.list -> decl) =
+let mk_decl: decl' -> FStar_Range.range -> decoration Prims.list -> decl =
   fun d  ->
     fun r  ->
       fun decorations  ->
@@ -1081,37 +951,32 @@ let (mk_decl : decl' -> FStar_Range.range -> decoration Prims.list -> decl) =
               (fun uu___36_3621  ->
                  match uu___36_3621 with
                  | Doc d1 -> FStar_Pervasives_Native.Some d1
-                 | uu____3625 -> FStar_Pervasives_Native.None) decorations
-             in
-          at_most_one "fsdoc" r uu____3616  in
+                 | uu____3625 -> FStar_Pervasives_Native.None) decorations in
+          at_most_one "fsdoc" r uu____3616 in
         let attributes_ =
           let uu____3631 =
             FStar_List.choose
               (fun uu___37_3640  ->
                  match uu___37_3640 with
                  | DeclAttributes a -> FStar_Pervasives_Native.Some a
-                 | uu____3650 -> FStar_Pervasives_Native.None) decorations
-             in
-          at_most_one "attribute set" r uu____3631  in
-        let attributes_1 = FStar_Util.dflt [] attributes_  in
+                 | uu____3650 -> FStar_Pervasives_Native.None) decorations in
+          at_most_one "attribute set" r uu____3631 in
+        let attributes_1 = FStar_Util.dflt [] attributes_ in
         let qualifiers =
           FStar_List.choose
             (fun uu___38_3665  ->
                match uu___38_3665 with
                | Qualifier q -> FStar_Pervasives_Native.Some q
-               | uu____3669 -> FStar_Pervasives_Native.None) decorations
-           in
+               | uu____3669 -> FStar_Pervasives_Native.None) decorations in
         { d; drange = r; doc = doc1; quals = qualifiers; attrs = attributes_1
         }
-  
-let (mk_binder : binder' -> FStar_Range.range -> level -> aqual -> binder) =
+let mk_binder: binder' -> FStar_Range.range -> level -> aqual -> binder =
   fun b  ->
     fun r  -> fun l  -> fun i  -> { b; brange = r; blevel = l; aqual = i }
-  
-let (mk_term : term' -> FStar_Range.range -> level -> term) =
-  fun t  -> fun r  -> fun l  -> { tm = t; range = r; level = l } 
-let (mk_uminus :
-  term -> FStar_Range.range -> FStar_Range.range -> level -> term) =
+let mk_term: term' -> FStar_Range.range -> level -> term =
+  fun t  -> fun r  -> fun l  -> { tm = t; range = r; level = l }
+let mk_uminus:
+  term -> FStar_Range.range -> FStar_Range.range -> level -> term =
   fun t  ->
     fun rminus  ->
       fun r  ->
@@ -1126,29 +991,25 @@ let (mk_uminus :
                      ((Prims.strcat "-" s),
                        (FStar_Pervasives_Native.Some
                           (FStar_Const.Signed, width))))
-            | uu____3726 -> Op ((FStar_Ident.mk_ident ("-", rminus)), [t])
-             in
+            | uu____3726 -> Op ((FStar_Ident.mk_ident ("-", rminus)), [t]) in
           mk_term t1 r l
-  
-let (mk_pattern : pattern' -> FStar_Range.range -> pattern) =
-  fun p  -> fun r  -> { pat = p; prange = r } 
-let (un_curry_abs : pattern Prims.list -> term -> term') =
+let mk_pattern: pattern' -> FStar_Range.range -> pattern =
+  fun p  -> fun r  -> { pat = p; prange = r }
+let un_curry_abs: pattern Prims.list -> term -> term' =
   fun ps  ->
     fun body  ->
       match body.tm with
       | Abs (p',body') -> Abs ((FStar_List.append ps p'), body')
       | uu____3753 -> Abs (ps, body)
-  
-let (mk_function :
+let mk_function:
   (pattern,term FStar_Pervasives_Native.option,term)
     FStar_Pervasives_Native.tuple3 Prims.list ->
-    FStar_Range.range -> FStar_Range.range -> term)
+    FStar_Range.range -> FStar_Range.range -> term
   =
   fun branches  ->
     fun r1  ->
       fun r2  ->
-        let x = let i = FStar_Parser_Const.next_id ()  in FStar_Ident.gen r1
-           in
+        let x = let i = FStar_Parser_Const.next_id () in FStar_Ident.gen r1 in
         let uu____3787 =
           let uu____3788 =
             let uu____3795 =
@@ -1156,23 +1017,21 @@ let (mk_function :
                 let uu____3797 =
                   let uu____3812 =
                     let uu____3813 =
-                      let uu____3814 = FStar_Ident.lid_of_ids [x]  in
-                      Var uu____3814  in
-                    mk_term uu____3813 r1 Expr  in
-                  (uu____3812, branches)  in
-                Match uu____3797  in
-              mk_term uu____3796 r2 Expr  in
+                      let uu____3814 = FStar_Ident.lid_of_ids [x] in
+                      Var uu____3814 in
+                    mk_term uu____3813 r1 Expr in
+                  (uu____3812, branches) in
+                Match uu____3797 in
+              mk_term uu____3796 r2 Expr in
             ([mk_pattern (PatVar (x, FStar_Pervasives_Native.None)) r1],
-              uu____3795)
-             in
-          Abs uu____3788  in
+              uu____3795) in
+          Abs uu____3788 in
         mk_term uu____3787 r2 Expr
-  
-let (un_function :
+let un_function:
   pattern ->
     term ->
       (pattern,term) FStar_Pervasives_Native.tuple2
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
   fun p  ->
     fun tm  ->
@@ -1181,22 +1040,19 @@ let (un_function :
           FStar_Pervasives_Native.Some
             ((mk_pattern (PatApp (p, pats)) p.prange), body)
       | uu____3866 -> FStar_Pervasives_Native.None
-  
-let (lid_with_range :
-  FStar_Ident.lident -> FStar_Range.range -> FStar_Ident.lident) =
+let lid_with_range:
+  FStar_Ident.lident -> FStar_Range.range -> FStar_Ident.lident =
   fun lid  ->
     fun r  ->
-      let uu____3881 = FStar_Ident.path_of_lid lid  in
+      let uu____3881 = FStar_Ident.path_of_lid lid in
       FStar_Ident.lid_of_path uu____3881 r
-  
-let (consPat : FStar_Range.range -> pattern -> pattern -> pattern') =
+let consPat: FStar_Range.range -> pattern -> pattern -> pattern' =
   fun r  ->
     fun hd1  ->
       fun tl1  ->
         PatApp
           ((mk_pattern (PatName FStar_Parser_Const.cons_lid) r), [hd1; tl1])
-  
-let (consTerm : FStar_Range.range -> term -> term -> term) =
+let consTerm: FStar_Range.range -> term -> term -> term =
   fun r  ->
     fun hd1  ->
       fun tl1  ->
@@ -1204,8 +1060,7 @@ let (consTerm : FStar_Range.range -> term -> term -> term) =
           (Construct
              (FStar_Parser_Const.cons_lid, [(hd1, Nothing); (tl1, Nothing)]))
           r Expr
-  
-let (lexConsTerm : FStar_Range.range -> term -> term -> term) =
+let lexConsTerm: FStar_Range.range -> term -> term -> term =
   fun r  ->
     fun hd1  ->
       fun tl1  ->
@@ -1213,37 +1068,30 @@ let (lexConsTerm : FStar_Range.range -> term -> term -> term) =
           (Construct
              (FStar_Parser_Const.lexcons_lid,
                [(hd1, Nothing); (tl1, Nothing)])) r Expr
-  
-let (mkConsList : FStar_Range.range -> term Prims.list -> term) =
+let mkConsList: FStar_Range.range -> term Prims.list -> term =
   fun r  ->
     fun elts  ->
-      let nil = mk_term (Construct (FStar_Parser_Const.nil_lid, [])) r Expr
-         in
+      let nil = mk_term (Construct (FStar_Parser_Const.nil_lid, [])) r Expr in
       FStar_List.fold_right (fun e  -> fun tl1  -> consTerm r e tl1) elts nil
-  
-let (mkLexList : FStar_Range.range -> term Prims.list -> term) =
+let mkLexList: FStar_Range.range -> term Prims.list -> term =
   fun r  ->
     fun elts  ->
       let nil =
-        mk_term (Construct (FStar_Parser_Const.lextop_lid, [])) r Expr  in
+        mk_term (Construct (FStar_Parser_Const.lextop_lid, [])) r Expr in
       FStar_List.fold_right (fun e  -> fun tl1  -> lexConsTerm r e tl1) elts
         nil
-  
-let (ml_comp : term -> term) =
+let ml_comp: term -> term =
   fun t  ->
-    let ml = mk_term (Name FStar_Parser_Const.effect_ML_lid) t.range Expr  in
-    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr  in t1
-  
-let (tot_comp : term -> term) =
+    let ml = mk_term (Name FStar_Parser_Const.effect_ML_lid) t.range Expr in
+    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr in t1
+let tot_comp: term -> term =
   fun t  ->
-    let ml = mk_term (Name FStar_Parser_Const.effect_Tot_lid) t.range Expr
-       in
-    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr  in t1
-  
-let (mkApp :
+    let ml = mk_term (Name FStar_Parser_Const.effect_Tot_lid) t.range Expr in
+    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr in t1
+let mkApp:
   term ->
     (term,imp) FStar_Pervasives_Native.tuple2 Prims.list ->
-      FStar_Range.range -> term)
+      FStar_Range.range -> term
   =
   fun t  ->
     fun args  ->
@@ -1259,35 +1107,30 @@ let (mkApp :
                       fun uu____4058  ->
                         match uu____4058 with
                         | (a,imp) -> mk_term (App (t1, a, imp)) r Un) t args)
-  
-let (mkRefSet : FStar_Range.range -> term Prims.list -> term) =
+let mkRefSet: FStar_Range.range -> term Prims.list -> term =
   fun r  ->
     fun elts  ->
       let uu____4075 =
         (FStar_Parser_Const.set_empty, FStar_Parser_Const.set_singleton,
-          FStar_Parser_Const.set_union, FStar_Parser_Const.heap_addr_of_lid)
-         in
+          FStar_Parser_Const.set_union, FStar_Parser_Const.heap_addr_of_lid) in
       match uu____4075 with
       | (empty_lid,singleton_lid,union_lid,addr_of_lid) ->
           let empty1 =
-            mk_term (Var (FStar_Ident.set_lid_range empty_lid r)) r Expr  in
+            mk_term (Var (FStar_Ident.set_lid_range empty_lid r)) r Expr in
           let addr_of1 =
-            mk_term (Var (FStar_Ident.set_lid_range addr_of_lid r)) r Expr
-             in
+            mk_term (Var (FStar_Ident.set_lid_range addr_of_lid r)) r Expr in
           let singleton1 =
-            mk_term (Var (FStar_Ident.set_lid_range singleton_lid r)) r Expr
-             in
+            mk_term (Var (FStar_Ident.set_lid_range singleton_lid r)) r Expr in
           let union1 =
-            mk_term (Var (FStar_Ident.set_lid_range union_lid r)) r Expr  in
+            mk_term (Var (FStar_Ident.set_lid_range union_lid r)) r Expr in
           FStar_List.fold_right
             (fun e  ->
                fun tl1  ->
-                 let e1 = mkApp addr_of1 [(e, Nothing)] r  in
-                 let single_e = mkApp singleton1 [(e1, Nothing)] r  in
+                 let e1 = mkApp addr_of1 [(e, Nothing)] r in
+                 let single_e = mkApp singleton1 [(e1, Nothing)] r in
                  mkApp union1 [(single_e, Nothing); (tl1, Nothing)] r) elts
             empty1
-  
-let (mkExplicitApp : term -> term Prims.list -> FStar_Range.range -> term) =
+let mkExplicitApp: term -> term Prims.list -> FStar_Range.range -> term =
   fun t  ->
     fun args  ->
       fun r  ->
@@ -1299,45 +1142,40 @@ let (mkExplicitApp : term -> term Prims.list -> FStar_Range.range -> term) =
                  let uu____4145 =
                    let uu____4146 =
                      let uu____4157 =
-                       FStar_List.map (fun a  -> (a, Nothing)) args  in
-                     (s, uu____4157)  in
-                   Construct uu____4146  in
+                       FStar_List.map (fun a  -> (a, Nothing)) args in
+                     (s, uu____4157) in
+                   Construct uu____4146 in
                  mk_term uu____4145 r Un
              | uu____4176 ->
                  FStar_List.fold_left
                    (fun t1  -> fun a  -> mk_term (App (t1, a, Nothing)) r Un)
                    t args)
-  
-let (mkAdmitMagic : FStar_Range.range -> term) =
+let mkAdmitMagic: FStar_Range.range -> term =
   fun r  ->
-    let unit_const = mk_term (Const FStar_Const.Const_unit) r Expr  in
+    let unit_const = mk_term (Const FStar_Const.Const_unit) r Expr in
     let admit1 =
       let admit_name =
         mk_term
           (Var (FStar_Ident.set_lid_range FStar_Parser_Const.admit_lid r)) r
-          Expr
-         in
-      mkExplicitApp admit_name [unit_const] r  in
+          Expr in
+      mkExplicitApp admit_name [unit_const] r in
     let magic1 =
       let magic_name =
         mk_term
           (Var (FStar_Ident.set_lid_range FStar_Parser_Const.magic_lid r)) r
-          Expr
-         in
-      mkExplicitApp magic_name [unit_const] r  in
-    let admit_magic = mk_term (Seq (admit1, magic1)) r Expr  in admit_magic
-  
-let mkWildAdmitMagic :
+          Expr in
+      mkExplicitApp magic_name [unit_const] r in
+    let admit_magic = mk_term (Seq (admit1, magic1)) r Expr in admit_magic
+let mkWildAdmitMagic:
   'Auu____4192 .
     FStar_Range.range ->
       (pattern,'Auu____4192 FStar_Pervasives_Native.option,term)
         FStar_Pervasives_Native.tuple3
   =
   fun r  ->
-    let uu____4205 = mkAdmitMagic r  in
+    let uu____4205 = mkAdmitMagic r in
     ((mk_pattern PatWild r), FStar_Pervasives_Native.None, uu____4205)
-  
-let focusBranches :
+let focusBranches:
   'Auu____4211 .
     (Prims.bool,(pattern,'Auu____4211 FStar_Pervasives_Native.option,
                   term) FStar_Pervasives_Native.tuple3)
@@ -1349,25 +1187,23 @@ let focusBranches :
   fun branches  ->
     fun r  ->
       let should_filter =
-        FStar_Util.for_some FStar_Pervasives_Native.fst branches  in
+        FStar_Util.for_some FStar_Pervasives_Native.fst branches in
       if should_filter
       then
         (FStar_Errors.log_issue r
            (FStar_Errors.Warning_Filtered, "Focusing on only some cases");
          (let focussed =
             let uu____4301 =
-              FStar_List.filter FStar_Pervasives_Native.fst branches  in
+              FStar_List.filter FStar_Pervasives_Native.fst branches in
             FStar_All.pipe_right uu____4301
-              (FStar_List.map FStar_Pervasives_Native.snd)
-             in
+              (FStar_List.map FStar_Pervasives_Native.snd) in
           let uu____4388 =
-            let uu____4399 = mkWildAdmitMagic r  in [uu____4399]  in
+            let uu____4399 = mkWildAdmitMagic r in [uu____4399] in
           FStar_List.append focussed uu____4388))
       else
         FStar_All.pipe_right branches
           (FStar_List.map FStar_Pervasives_Native.snd)
-  
-let focusLetBindings :
+let focusLetBindings:
   'Auu____4488 .
     (Prims.bool,('Auu____4488,term) FStar_Pervasives_Native.tuple2)
       FStar_Pervasives_Native.tuple2 Prims.list ->
@@ -1376,8 +1212,7 @@ let focusLetBindings :
   =
   fun lbs  ->
     fun r  ->
-      let should_filter = FStar_Util.for_some FStar_Pervasives_Native.fst lbs
-         in
+      let should_filter = FStar_Util.for_some FStar_Pervasives_Native.fst lbs in
       if should_filter
       then
         (FStar_Errors.log_issue r
@@ -1390,12 +1225,11 @@ let focusLetBindings :
                   if f
                   then lb
                   else
-                    (let uu____4586 = mkAdmitMagic r  in
+                    (let uu____4586 = mkAdmitMagic r in
                      ((FStar_Pervasives_Native.fst lb), uu____4586))) lbs)
       else
         FStar_All.pipe_right lbs (FStar_List.map FStar_Pervasives_Native.snd)
-  
-let focusAttrLetBindings :
+let focusAttrLetBindings:
   'Auu____4624 'Auu____4625 .
     ('Auu____4625,(Prims.bool,('Auu____4624,term)
                                 FStar_Pervasives_Native.tuple2)
@@ -1410,8 +1244,7 @@ let focusAttrLetBindings :
       let should_filter =
         FStar_Util.for_some
           (fun uu____4689  ->
-             match uu____4689 with | (attr,(focus,uu____4704)) -> focus) lbs
-         in
+             match uu____4689 with | (attr,(focus,uu____4704)) -> focus) lbs in
       if should_filter
       then
         (FStar_Errors.log_issue r
@@ -1425,44 +1258,40 @@ let focusAttrLetBindings :
                   then (attr, lb)
                   else
                     (let uu____4809 =
-                       let uu____4814 = mkAdmitMagic r  in
-                       ((FStar_Pervasives_Native.fst lb), uu____4814)  in
+                       let uu____4814 = mkAdmitMagic r in
+                       ((FStar_Pervasives_Native.fst lb), uu____4814) in
                      (attr, uu____4809))) lbs)
       else
         FStar_All.pipe_right lbs
           (FStar_List.map
              (fun uu____4868  ->
                 match uu____4868 with | (attr,(uu____4890,lb)) -> (attr, lb)))
-  
-let (mkFsTypApp : term -> term Prims.list -> FStar_Range.range -> term) =
+let mkFsTypApp: term -> term Prims.list -> FStar_Range.range -> term =
   fun t  ->
     fun args  ->
       fun r  ->
-        let uu____4925 = FStar_List.map (fun a  -> (a, FsTypApp)) args  in
+        let uu____4925 = FStar_List.map (fun a  -> (a, FsTypApp)) args in
         mkApp t uu____4925 r
-  
-let (mkTuple : term Prims.list -> FStar_Range.range -> term) =
+let mkTuple: term Prims.list -> FStar_Range.range -> term =
   fun args  ->
     fun r  ->
       let cons1 =
-        FStar_Parser_Const.mk_tuple_data_lid (FStar_List.length args) r  in
-      let uu____4949 = FStar_List.map (fun x  -> (x, Nothing)) args  in
+        FStar_Parser_Const.mk_tuple_data_lid (FStar_List.length args) r in
+      let uu____4949 = FStar_List.map (fun x  -> (x, Nothing)) args in
       mkApp (mk_term (Name cons1) r Expr) uu____4949 r
-  
-let (mkDTuple : term Prims.list -> FStar_Range.range -> term) =
+let mkDTuple: term Prims.list -> FStar_Range.range -> term =
   fun args  ->
     fun r  ->
       let cons1 =
-        FStar_Parser_Const.mk_dtuple_data_lid (FStar_List.length args) r  in
-      let uu____4973 = FStar_List.map (fun x  -> (x, Nothing)) args  in
+        FStar_Parser_Const.mk_dtuple_data_lid (FStar_List.length args) r in
+      let uu____4973 = FStar_List.map (fun x  -> (x, Nothing)) args in
       mkApp (mk_term (Name cons1) r Expr) uu____4973 r
-  
-let (mkRefinedBinder :
+let mkRefinedBinder:
   FStar_Ident.ident ->
     term ->
       Prims.bool ->
         term FStar_Pervasives_Native.option ->
-          FStar_Range.range -> aqual -> binder)
+          FStar_Range.range -> aqual -> binder
   =
   fun id1  ->
     fun t  ->
@@ -1470,8 +1299,7 @@ let (mkRefinedBinder :
         fun refopt  ->
           fun m  ->
             fun implicit  ->
-              let b = mk_binder (Annotated (id1, t)) m Type_level implicit
-                 in
+              let b = mk_binder (Annotated (id1, t)) m Type_level implicit in
               match refopt with
               | FStar_Pervasives_Native.None  -> b
               | FStar_Pervasives_Native.Some phi ->
@@ -1482,20 +1310,19 @@ let (mkRefinedBinder :
                          (id1, (mk_term (Refine (b, phi)) m Type_level))) m
                       Type_level implicit
                   else
-                    (let x = FStar_Ident.gen t.range  in
+                    (let x = FStar_Ident.gen t.range in
                      let b1 =
-                       mk_binder (Annotated (x, t)) m Type_level implicit  in
+                       mk_binder (Annotated (x, t)) m Type_level implicit in
                      mk_binder
                        (Annotated
                           (id1, (mk_term (Refine (b1, phi)) m Type_level))) m
                        Type_level implicit)
-  
-let (mkRefinedPattern :
+let mkRefinedPattern:
   pattern ->
     term ->
       Prims.bool ->
         term FStar_Pervasives_Native.option ->
-          FStar_Range.range -> FStar_Range.range -> pattern)
+          FStar_Range.range -> FStar_Range.range -> pattern
   =
   fun pat  ->
     fun t  ->
@@ -1517,51 +1344,45 @@ let (mkRefinedPattern :
                                     Type_level FStar_Pervasives_Native.None),
                                   phi)) range Type_level
                        | uu____5043 ->
-                           let x = FStar_Ident.gen t_range  in
+                           let x = FStar_Ident.gen t_range in
                            let phi1 =
                              let x_var =
                                let uu____5047 =
-                                 let uu____5048 = FStar_Ident.lid_of_ids [x]
-                                    in
-                                 Var uu____5048  in
-                               mk_term uu____5047 phi.range Formula  in
+                                 let uu____5048 = FStar_Ident.lid_of_ids [x] in
+                                 Var uu____5048 in
+                               mk_term uu____5047 phi.range Formula in
                              let pat_branch =
-                               (pat, FStar_Pervasives_Native.None, phi)  in
+                               (pat, FStar_Pervasives_Native.None, phi) in
                              let otherwise_branch =
                                let uu____5069 =
                                  let uu____5070 =
                                    let uu____5071 =
                                      FStar_Ident.lid_of_path ["False"]
-                                       phi.range
-                                      in
-                                   Name uu____5071  in
-                                 mk_term uu____5070 phi.range Formula  in
+                                       phi.range in
+                                   Name uu____5071 in
+                                 mk_term uu____5070 phi.range Formula in
                                ((mk_pattern PatWild phi.range),
-                                 FStar_Pervasives_Native.None, uu____5069)
-                                in
+                                 FStar_Pervasives_Native.None, uu____5069) in
                              mk_term
                                (Match (x_var, [pat_branch; otherwise_branch]))
-                               phi.range Formula
-                              in
+                               phi.range Formula in
                            mk_term
                              (Refine
                                 ((mk_binder (Annotated (x, t)) t_range
                                     Type_level FStar_Pervasives_Native.None),
                                   phi1)) range Type_level)
                     else
-                      (let x = FStar_Ident.gen t.range  in
+                      (let x = FStar_Ident.gen t.range in
                        mk_term
                          (Refine
                             ((mk_binder (Annotated (x, t)) t_range Type_level
                                 FStar_Pervasives_Native.None), phi)) range
-                         Type_level)
-                 in
+                         Type_level) in
               mk_pattern (PatAscribed (pat, t1)) range
-  
-let rec (extract_named_refinement :
+let rec extract_named_refinement:
   term ->
     (FStar_Ident.ident,term,term FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option
   =
   fun t1  ->
     match t1.tm with
@@ -1575,14 +1396,13 @@ let rec (extract_named_refinement :
           (x, t, (FStar_Pervasives_Native.Some t'))
     | Paren t -> extract_named_refinement t
     | uu____5162 -> FStar_Pervasives_Native.None
-  
-let rec (as_mlist :
+let rec as_mlist:
   ((FStar_Ident.lid,decl) FStar_Pervasives_Native.tuple2,decl Prims.list)
-    FStar_Pervasives_Native.tuple2 -> decl Prims.list -> modul)
+    FStar_Pervasives_Native.tuple2 -> decl Prims.list -> modul
   =
   fun cur  ->
     fun ds  ->
-      let uu____5201 = cur  in
+      let uu____5201 = cur in
       match uu____5201 with
       | ((m_name,m_decl),cur1) ->
           (match ds with
@@ -1594,16 +1414,15 @@ let rec (as_mlist :
                       (FStar_Errors.Fatal_UnexpectedModuleDeclaration,
                         "Unexpected module declaration") d.drange
                 | uu____5230 -> as_mlist ((m_name, m_decl), (d :: cur1)) ds1))
-  
-let (as_frag :
-  Prims.bool -> FStar_Range.range -> decl Prims.list -> inputFragment) =
+let as_frag:
+  Prims.bool -> FStar_Range.range -> decl Prims.list -> inputFragment =
   fun is_light  ->
     fun light_range  ->
       fun ds  ->
         let uu____5250 =
           match ds with
           | d::ds1 -> (d, ds1)
-          | [] -> FStar_Exn.raise FStar_Errors.Empty_frag  in
+          | [] -> FStar_Exn.raise FStar_Errors.Empty_frag in
         match uu____5250 with
         | (d,ds1) ->
             (match d.d with
@@ -1612,12 +1431,12 @@ let (as_frag :
                    if is_light
                    then
                      let uu____5287 =
-                       mk_decl (Pragma LightOff) light_range []  in
+                       mk_decl (Pragma LightOff) light_range [] in
                      uu____5287 :: ds1
-                   else ds1  in
-                 let m1 = as_mlist ((m, d), []) ds2  in FStar_Util.Inl m1
+                   else ds1 in
+                 let m1 = as_mlist ((m, d), []) ds2 in FStar_Util.Inl m1
              | uu____5298 ->
-                 let ds2 = d :: ds1  in
+                 let ds2 = d :: ds1 in
                  (FStar_List.iter
                     (fun uu___39_5309  ->
                        match uu___39_5309 with
@@ -1629,9 +1448,8 @@ let (as_frag :
                                "Unexpected module declaration") r
                        | uu____5317 -> ()) ds2;
                   FStar_Util.Inr ds2))
-  
-let (compile_op :
-  Prims.int -> Prims.string -> FStar_Range.range -> Prims.string) =
+let compile_op:
+  Prims.int -> Prims.string -> FStar_Range.range -> Prims.string =
   fun arity  ->
     fun s  ->
       fun r  ->
@@ -1662,8 +1480,7 @@ let (compile_op :
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnexpectedOperatorSymbol,
                   (Prims.strcat "Unexpected operator symbol: '"
-                     (Prims.strcat (FStar_Util.string_of_char c) "'"))) r
-           in
+                     (Prims.strcat (FStar_Util.string_of_char c) "'"))) r in
         match s with
         | ".[]<-" -> "op_String_Assignment"
         | ".()<-" -> "op_Array_Assignment"
@@ -1676,17 +1493,16 @@ let (compile_op :
         | uu____5358 ->
             let uu____5359 =
               let uu____5360 =
-                let uu____5363 = FStar_String.list_of_string s  in
-                FStar_List.map name_of_char uu____5363  in
-              FStar_String.concat "_" uu____5360  in
+                let uu____5363 = FStar_String.list_of_string s in
+                FStar_List.map name_of_char uu____5363 in
+              FStar_String.concat "_" uu____5360 in
             Prims.strcat "op_" uu____5359
-  
-let (compile_op' : Prims.string -> FStar_Range.range -> Prims.string) =
-  fun s  -> fun r  -> compile_op (~- (Prims.parse_int "1")) s r 
-let (string_of_fsdoc :
+let compile_op': Prims.string -> FStar_Range.range -> Prims.string =
+  fun s  -> fun r  -> compile_op (- (Prims.parse_int "1")) s r
+let string_of_fsdoc:
   (Prims.string,(Prims.string,Prims.string) FStar_Pervasives_Native.tuple2
                   Prims.list)
-    FStar_Pervasives_Native.tuple2 -> Prims.string)
+    FStar_Pervasives_Native.tuple2 -> Prims.string
   =
   fun uu____5386  ->
     match uu____5386 with
@@ -1696,19 +1512,16 @@ let (string_of_fsdoc :
             FStar_List.map
               (fun uu____5422  ->
                  match uu____5422 with
-                 | (k,v1) -> Prims.strcat k (Prims.strcat "->" v1)) keywords
-             in
-          FStar_String.concat "," uu____5412  in
+                 | (k,v1) -> Prims.strcat k (Prims.strcat "->" v1)) keywords in
+          FStar_String.concat "," uu____5412 in
         Prims.strcat comment uu____5411
-  
-let (string_of_let_qualifier : let_qualifier -> Prims.string) =
+let string_of_let_qualifier: let_qualifier -> Prims.string =
   fun uu___41_5431  ->
     match uu___41_5431 with
     | NoLetQualifier  -> ""
     | Rec  -> "rec"
     | Mutable  -> "mutable"
-  
-let to_string_l :
+let to_string_l:
   'Auu____5436 .
     Prims.string ->
       ('Auu____5436 -> Prims.string) ->
@@ -1717,34 +1530,31 @@ let to_string_l :
   fun sep  ->
     fun f  ->
       fun l  ->
-        let uu____5458 = FStar_List.map f l  in
+        let uu____5458 = FStar_List.map f l in
         FStar_String.concat sep uu____5458
-  
-let (imp_to_string : imp -> Prims.string) =
+let imp_to_string: imp -> Prims.string =
   fun uu___42_5463  ->
     match uu___42_5463 with | Hash  -> "#" | uu____5464 -> ""
-  
-let rec (term_to_string : term -> Prims.string) =
+let rec term_to_string: term -> Prims.string =
   fun x  ->
     match x.tm with
     | Wild  -> "_"
     | Requires (t,uu____5481) ->
-        let uu____5486 = term_to_string t  in
+        let uu____5486 = term_to_string t in
         FStar_Util.format1 "(requires %s)" uu____5486
     | Ensures (t,uu____5488) ->
-        let uu____5493 = term_to_string t  in
+        let uu____5493 = term_to_string t in
         FStar_Util.format1 "(ensures %s)" uu____5493
     | Labeled (t,l,uu____5496) ->
-        let uu____5497 = term_to_string t  in
+        let uu____5497 = term_to_string t in
         FStar_Util.format2 "(labeled %s %s)" l uu____5497
     | Const c -> FStar_Parser_Const.const_to_string c
     | Op (s,xs) ->
         let uu____5505 =
           let uu____5506 =
             FStar_List.map
-              (fun x1  -> FStar_All.pipe_right x1 term_to_string) xs
-             in
-          FStar_String.concat ", " uu____5506  in
+              (fun x1  -> FStar_All.pipe_right x1 term_to_string) xs in
+          FStar_String.concat ", " uu____5506 in
         FStar_Util.format2 "%s(%s)" (FStar_Ident.text_of_id s) uu____5505
     | Tvar id1 -> id1.FStar_Ident.idText
     | Uvar id1 -> id1.FStar_Ident.idText
@@ -1756,99 +1566,92 @@ let rec (term_to_string : term -> Prims.string) =
             (fun uu____5538  ->
                match uu____5538 with
                | (a,imp) ->
-                   let uu____5545 = term_to_string a  in
+                   let uu____5545 = term_to_string a in
                    FStar_Util.format2 "%s%s" (imp_to_string imp) uu____5545)
-            args
-           in
+            args in
         FStar_Util.format2 "(%s %s)" l.FStar_Ident.str uu____5529
     | Abs (pats,t) ->
-        let uu____5552 = to_string_l " " pat_to_string pats  in
-        let uu____5553 = FStar_All.pipe_right t term_to_string  in
+        let uu____5552 = to_string_l " " pat_to_string pats in
+        let uu____5553 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format2 "(fun %s -> %s)" uu____5552 uu____5553
     | App (t1,t2,imp) ->
-        let uu____5557 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____5558 = FStar_All.pipe_right t2 term_to_string  in
+        let uu____5557 = FStar_All.pipe_right t1 term_to_string in
+        let uu____5558 = FStar_All.pipe_right t2 term_to_string in
         FStar_Util.format3 "%s %s%s" uu____5557 (imp_to_string imp)
           uu____5558
     | Let (Rec ,(a,(p,b))::lbs,body) ->
-        let uu____5616 = attrs_opt_to_string a  in
+        let uu____5616 = attrs_opt_to_string a in
         let uu____5617 =
-          let uu____5618 = FStar_All.pipe_right p pat_to_string  in
-          let uu____5619 = FStar_All.pipe_right b term_to_string  in
-          FStar_Util.format2 "%s=%s" uu____5618 uu____5619  in
+          let uu____5618 = FStar_All.pipe_right p pat_to_string in
+          let uu____5619 = FStar_All.pipe_right b term_to_string in
+          FStar_Util.format2 "%s=%s" uu____5618 uu____5619 in
         let uu____5620 =
           to_string_l " "
             (fun uu____5640  ->
                match uu____5640 with
                | (a1,(p1,b1)) ->
-                   let uu____5668 = attrs_opt_to_string a1  in
-                   let uu____5669 = FStar_All.pipe_right p1 pat_to_string  in
-                   let uu____5670 = FStar_All.pipe_right b1 term_to_string
-                      in
+                   let uu____5668 = attrs_opt_to_string a1 in
+                   let uu____5669 = FStar_All.pipe_right p1 pat_to_string in
+                   let uu____5670 = FStar_All.pipe_right b1 term_to_string in
                    FStar_Util.format3 "%sand %s=%s" uu____5668 uu____5669
-                     uu____5670) lbs
-           in
-        let uu____5671 = FStar_All.pipe_right body term_to_string  in
+                     uu____5670) lbs in
+        let uu____5671 = FStar_All.pipe_right body term_to_string in
         FStar_Util.format4 "%slet rec %s%s in %s" uu____5616 uu____5617
           uu____5620 uu____5671
     | Let (q,(attrs,(pat,tm))::[],body) ->
-        let uu____5727 = attrs_opt_to_string attrs  in
-        let uu____5728 = FStar_All.pipe_right pat pat_to_string  in
-        let uu____5729 = FStar_All.pipe_right tm term_to_string  in
-        let uu____5730 = FStar_All.pipe_right body term_to_string  in
+        let uu____5727 = attrs_opt_to_string attrs in
+        let uu____5728 = FStar_All.pipe_right pat pat_to_string in
+        let uu____5729 = FStar_All.pipe_right tm term_to_string in
+        let uu____5730 = FStar_All.pipe_right body term_to_string in
         FStar_Util.format5 "%slet %s %s = %s in %s" uu____5727
           (string_of_let_qualifier q) uu____5728 uu____5729 uu____5730
     | Seq (t1,t2) ->
-        let uu____5733 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____5734 = FStar_All.pipe_right t2 term_to_string  in
+        let uu____5733 = FStar_All.pipe_right t1 term_to_string in
+        let uu____5734 = FStar_All.pipe_right t2 term_to_string in
         FStar_Util.format2 "%s; %s" uu____5733 uu____5734
     | If (t1,t2,t3) ->
-        let uu____5738 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____5739 = FStar_All.pipe_right t2 term_to_string  in
-        let uu____5740 = FStar_All.pipe_right t3 term_to_string  in
+        let uu____5738 = FStar_All.pipe_right t1 term_to_string in
+        let uu____5739 = FStar_All.pipe_right t2 term_to_string in
+        let uu____5740 = FStar_All.pipe_right t3 term_to_string in
         FStar_Util.format3 "if %s then %s else %s" uu____5738 uu____5739
           uu____5740
     | Match (t,branches) ->
-        let uu____5763 = FStar_All.pipe_right t term_to_string  in
+        let uu____5763 = FStar_All.pipe_right t term_to_string in
         let uu____5764 =
           to_string_l " | "
             (fun uu____5780  ->
                match uu____5780 with
                | (p,w,e) ->
-                   let uu____5796 = FStar_All.pipe_right p pat_to_string  in
+                   let uu____5796 = FStar_All.pipe_right p pat_to_string in
                    let uu____5797 =
                      match w with
                      | FStar_Pervasives_Native.None  -> ""
                      | FStar_Pervasives_Native.Some e1 ->
-                         let uu____5799 = term_to_string e1  in
-                         FStar_Util.format1 "when %s" uu____5799
-                      in
-                   let uu____5800 = FStar_All.pipe_right e term_to_string  in
+                         let uu____5799 = term_to_string e1 in
+                         FStar_Util.format1 "when %s" uu____5799 in
+                   let uu____5800 = FStar_All.pipe_right e term_to_string in
                    FStar_Util.format3 "%s %s -> %s" uu____5796 uu____5797
-                     uu____5800) branches
-           in
+                     uu____5800) branches in
         FStar_Util.format2 "match %s with %s" uu____5763 uu____5764
     | Ascribed (t1,t2,FStar_Pervasives_Native.None ) ->
-        let uu____5805 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____5806 = FStar_All.pipe_right t2 term_to_string  in
+        let uu____5805 = FStar_All.pipe_right t1 term_to_string in
+        let uu____5806 = FStar_All.pipe_right t2 term_to_string in
         FStar_Util.format2 "(%s : %s)" uu____5805 uu____5806
     | Ascribed (t1,t2,FStar_Pervasives_Native.Some tac) ->
-        let uu____5812 = FStar_All.pipe_right t1 term_to_string  in
-        let uu____5813 = FStar_All.pipe_right t2 term_to_string  in
-        let uu____5814 = FStar_All.pipe_right tac term_to_string  in
+        let uu____5812 = FStar_All.pipe_right t1 term_to_string in
+        let uu____5813 = FStar_All.pipe_right t2 term_to_string in
+        let uu____5814 = FStar_All.pipe_right tac term_to_string in
         FStar_Util.format3 "(%s : %s by %s)" uu____5812 uu____5813 uu____5814
     | Record (FStar_Pervasives_Native.Some e,fields) ->
-        let uu____5831 = FStar_All.pipe_right e term_to_string  in
+        let uu____5831 = FStar_All.pipe_right e term_to_string in
         let uu____5832 =
           to_string_l " "
             (fun uu____5841  ->
                match uu____5841 with
                | (l,e1) ->
-                   let uu____5848 = FStar_All.pipe_right e1 term_to_string
-                      in
+                   let uu____5848 = FStar_All.pipe_right e1 term_to_string in
                    FStar_Util.format2 "%s=%s" l.FStar_Ident.str uu____5848)
-            fields
-           in
+            fields in
         FStar_Util.format2 "{%s with %s}" uu____5831 uu____5832
     | Record (FStar_Pervasives_Native.None ,fields) ->
         let uu____5864 =
@@ -1856,13 +1659,12 @@ let rec (term_to_string : term -> Prims.string) =
             (fun uu____5873  ->
                match uu____5873 with
                | (l,e) ->
-                   let uu____5880 = FStar_All.pipe_right e term_to_string  in
+                   let uu____5880 = FStar_All.pipe_right e term_to_string in
                    FStar_Util.format2 "%s=%s" l.FStar_Ident.str uu____5880)
-            fields
-           in
+            fields in
         FStar_Util.format1 "{%s}" uu____5864
     | Project (e,l) ->
-        let uu____5883 = FStar_All.pipe_right e term_to_string  in
+        let uu____5883 = FStar_All.pipe_right e term_to_string in
         FStar_Util.format2 "%s.%s" uu____5883 l.FStar_Ident.str
     | Product ([],t) -> term_to_string t
     | Product (b::hd1::tl1,t) ->
@@ -1872,102 +1674,98 @@ let rec (term_to_string : term -> Prims.string) =
                 ([b], (mk_term (Product ((hd1 :: tl1), t)) x.range x.level)))
              x.range x.level)
     | Product (b::[],t) when x.level = Type_level ->
-        let uu____5903 = FStar_All.pipe_right b binder_to_string  in
-        let uu____5904 = FStar_All.pipe_right t term_to_string  in
+        let uu____5903 = FStar_All.pipe_right b binder_to_string in
+        let uu____5904 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format2 "%s -> %s" uu____5903 uu____5904
     | Product (b::[],t) when x.level = Kind ->
-        let uu____5909 = FStar_All.pipe_right b binder_to_string  in
-        let uu____5910 = FStar_All.pipe_right t term_to_string  in
+        let uu____5909 = FStar_All.pipe_right b binder_to_string in
+        let uu____5910 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format2 "%s => %s" uu____5909 uu____5910
     | Sum (binders,t) ->
         let uu____5917 =
           let uu____5918 =
-            FStar_All.pipe_right binders (FStar_List.map binder_to_string)
-             in
-          FStar_All.pipe_right uu____5918 (FStar_String.concat " * ")  in
-        let uu____5927 = FStar_All.pipe_right t term_to_string  in
+            FStar_All.pipe_right binders (FStar_List.map binder_to_string) in
+          FStar_All.pipe_right uu____5918 (FStar_String.concat " * ") in
+        let uu____5927 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format2 "%s * %s" uu____5917 uu____5927
     | QForall (bs,pats,t) ->
-        let uu____5943 = to_string_l " " binder_to_string bs  in
+        let uu____5943 = to_string_l " " binder_to_string bs in
         let uu____5944 =
-          to_string_l " \\/ " (to_string_l "; " term_to_string) pats  in
-        let uu____5947 = FStar_All.pipe_right t term_to_string  in
+          to_string_l " \\/ " (to_string_l "; " term_to_string) pats in
+        let uu____5947 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format3 "forall %s.{:pattern %s} %s" uu____5943 uu____5944
           uu____5947
     | QExists (bs,pats,t) ->
-        let uu____5963 = to_string_l " " binder_to_string bs  in
+        let uu____5963 = to_string_l " " binder_to_string bs in
         let uu____5964 =
-          to_string_l " \\/ " (to_string_l "; " term_to_string) pats  in
-        let uu____5967 = FStar_All.pipe_right t term_to_string  in
+          to_string_l " \\/ " (to_string_l "; " term_to_string) pats in
+        let uu____5967 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format3 "exists %s.{:pattern %s} %s" uu____5963 uu____5964
           uu____5967
     | Refine (b,t) ->
-        let uu____5970 = FStar_All.pipe_right b binder_to_string  in
-        let uu____5971 = FStar_All.pipe_right t term_to_string  in
+        let uu____5970 = FStar_All.pipe_right b binder_to_string in
+        let uu____5971 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format2 "%s:{%s}" uu____5970 uu____5971
     | NamedTyp (x1,t) ->
-        let uu____5974 = FStar_All.pipe_right t term_to_string  in
+        let uu____5974 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format2 "%s:%s" x1.FStar_Ident.idText uu____5974
     | Paren t ->
-        let uu____5976 = FStar_All.pipe_right t term_to_string  in
+        let uu____5976 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format1 "(%s)" uu____5976
     | Product (bs,t) ->
         let uu____5983 =
           let uu____5984 =
-            FStar_All.pipe_right bs (FStar_List.map binder_to_string)  in
-          FStar_All.pipe_right uu____5984 (FStar_String.concat ",")  in
-        let uu____5993 = FStar_All.pipe_right t term_to_string  in
+            FStar_All.pipe_right bs (FStar_List.map binder_to_string) in
+          FStar_All.pipe_right uu____5984 (FStar_String.concat ",") in
+        let uu____5993 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format2 "Unidentified product: [%s] %s" uu____5983
           uu____5993
     | t -> "_"
-
-and (binder_to_string : binder -> Prims.string) =
+and binder_to_string: binder -> Prims.string =
   fun x  ->
     let s =
       match x.b with
       | Variable i -> i.FStar_Ident.idText
       | TVariable i -> FStar_Util.format1 "%s:_" i.FStar_Ident.idText
       | TAnnotated (i,t) ->
-          let uu____6001 = FStar_All.pipe_right t term_to_string  in
+          let uu____6001 = FStar_All.pipe_right t term_to_string in
           FStar_Util.format2 "%s:%s" i.FStar_Ident.idText uu____6001
       | Annotated (i,t) ->
-          let uu____6004 = FStar_All.pipe_right t term_to_string  in
+          let uu____6004 = FStar_All.pipe_right t term_to_string in
           FStar_Util.format2 "%s:%s" i.FStar_Ident.idText uu____6004
-      | NoName t -> FStar_All.pipe_right t term_to_string  in
-    let uu____6006 = aqual_to_string x.aqual  in
+      | NoName t -> FStar_All.pipe_right t term_to_string in
+    let uu____6006 = aqual_to_string x.aqual in
     FStar_Util.format2 "%s%s" uu____6006 s
-
-and (aqual_to_string : aqual -> Prims.string) =
+and aqual_to_string: aqual -> Prims.string =
   fun uu___43_6007  ->
     match uu___43_6007 with
     | FStar_Pervasives_Native.Some (Equality ) -> "$"
     | FStar_Pervasives_Native.Some (Implicit ) -> "#"
     | uu____6008 -> ""
-
-and (pat_to_string : pattern -> Prims.string) =
+and pat_to_string: pattern -> Prims.string =
   fun x  ->
     match x.pat with
     | PatWild  -> "_"
     | PatConst c -> FStar_Parser_Const.const_to_string c
     | PatApp (p,ps) ->
-        let uu____6017 = FStar_All.pipe_right p pat_to_string  in
-        let uu____6018 = to_string_l " " pat_to_string ps  in
+        let uu____6017 = FStar_All.pipe_right p pat_to_string in
+        let uu____6018 = to_string_l " " pat_to_string ps in
         FStar_Util.format2 "(%s %s)" uu____6017 uu____6018
     | PatTvar (i,aq) ->
-        let uu____6025 = aqual_to_string aq  in
+        let uu____6025 = aqual_to_string aq in
         FStar_Util.format2 "%s%s" uu____6025 i.FStar_Ident.idText
     | PatVar (i,aq) ->
-        let uu____6032 = aqual_to_string aq  in
+        let uu____6032 = aqual_to_string aq in
         FStar_Util.format2 "%s%s" uu____6032 i.FStar_Ident.idText
     | PatName l -> l.FStar_Ident.str
     | PatList l ->
-        let uu____6037 = to_string_l "; " pat_to_string l  in
+        let uu____6037 = to_string_l "; " pat_to_string l in
         FStar_Util.format1 "[%s]" uu____6037
     | PatTuple (l,false ) ->
-        let uu____6043 = to_string_l ", " pat_to_string l  in
+        let uu____6043 = to_string_l ", " pat_to_string l in
         FStar_Util.format1 "(%s)" uu____6043
     | PatTuple (l,true ) ->
-        let uu____6049 = to_string_l ", " pat_to_string l  in
+        let uu____6049 = to_string_l ", " pat_to_string l in
         FStar_Util.format1 "(|%s|)" uu____6049
     | PatRecord l ->
         let uu____6057 =
@@ -1975,39 +1773,35 @@ and (pat_to_string : pattern -> Prims.string) =
             (fun uu____6066  ->
                match uu____6066 with
                | (f,e) ->
-                   let uu____6073 = FStar_All.pipe_right e pat_to_string  in
-                   FStar_Util.format2 "%s=%s" f.FStar_Ident.str uu____6073) l
-           in
+                   let uu____6073 = FStar_All.pipe_right e pat_to_string in
+                   FStar_Util.format2 "%s=%s" f.FStar_Ident.str uu____6073) l in
         FStar_Util.format1 "{%s}" uu____6057
     | PatOr l -> to_string_l "|\n " pat_to_string l
     | PatOp op -> FStar_Util.format1 "(%s)" (FStar_Ident.text_of_id op)
     | PatAscribed (p,t) ->
-        let uu____6080 = FStar_All.pipe_right p pat_to_string  in
-        let uu____6081 = FStar_All.pipe_right t term_to_string  in
+        let uu____6080 = FStar_All.pipe_right p pat_to_string in
+        let uu____6081 = FStar_All.pipe_right t term_to_string in
         FStar_Util.format2 "(%s:%s)" uu____6080 uu____6081
-
-and (attrs_opt_to_string :
-  term Prims.list FStar_Pervasives_Native.option -> Prims.string) =
+and attrs_opt_to_string:
+  term Prims.list FStar_Pervasives_Native.option -> Prims.string =
   fun uu___44_6082  ->
     match uu___44_6082 with
     | FStar_Pervasives_Native.None  -> ""
     | FStar_Pervasives_Native.Some attrs ->
         let uu____6094 =
-          let uu____6095 = FStar_List.map term_to_string attrs  in
-          FStar_All.pipe_right uu____6095 (FStar_String.concat "; ")  in
+          let uu____6095 = FStar_List.map term_to_string attrs in
+          FStar_All.pipe_right uu____6095 (FStar_String.concat "; ") in
         FStar_Util.format1 "[@ %s]" uu____6094
-
-let rec (head_id_of_pat : pattern -> FStar_Ident.lid Prims.list) =
+let rec head_id_of_pat: pattern -> FStar_Ident.lid Prims.list =
   fun p  ->
     match p.pat with
     | PatName l -> [l]
     | PatVar (i,uu____6109) ->
-        let uu____6114 = FStar_Ident.lid_of_ids [i]  in [uu____6114]
+        let uu____6114 = FStar_Ident.lid_of_ids [i] in [uu____6114]
     | PatApp (p1,uu____6116) -> head_id_of_pat p1
     | PatAscribed (p1,uu____6122) -> head_id_of_pat p1
     | uu____6123 -> []
-  
-let lids_of_let :
+let lids_of_let:
   'Auu____6126 .
     (pattern,'Auu____6126) FStar_Pervasives_Native.tuple2 Prims.list ->
       FStar_Ident.lid Prims.list
@@ -2017,8 +1811,7 @@ let lids_of_let :
       (FStar_List.collect
          (fun uu____6160  ->
             match uu____6160 with | (p,uu____6168) -> head_id_of_pat p))
-  
-let (id_of_tycon : tycon -> Prims.string) =
+let id_of_tycon: tycon -> Prims.string =
   fun uu___45_6171  ->
     match uu___45_6171 with
     | TyconAbstract (i,uu____6173,uu____6174) -> i.FStar_Ident.idText
@@ -2028,8 +1821,7 @@ let (id_of_tycon : tycon -> Prims.string) =
         i.FStar_Ident.idText
     | TyconVariant (i,uu____6228,uu____6229,uu____6230) ->
         i.FStar_Ident.idText
-  
-let (decl_to_string : decl -> Prims.string) =
+let decl_to_string: decl -> Prims.string =
   fun d  ->
     match d.d with
     | TopLevelModule l -> Prims.strcat "module " l.FStar_Ident.str
@@ -2041,11 +1833,10 @@ let (decl_to_string : decl -> Prims.string) =
     | TopLevelLet (uu____6275,pats) ->
         let uu____6289 =
           let uu____6290 =
-            let uu____6293 = lids_of_let pats  in
+            let uu____6293 = lids_of_let pats in
             FStar_All.pipe_right uu____6293
-              (FStar_List.map (fun l  -> l.FStar_Ident.str))
-             in
-          FStar_All.pipe_right uu____6290 (FStar_String.concat ", ")  in
+              (FStar_List.map (fun l  -> l.FStar_Ident.str)) in
+          FStar_All.pipe_right uu____6290 (FStar_String.concat ", ") in
         Prims.strcat "let " uu____6289
     | Main uu____6304 -> "main ..."
     | Assume (i,uu____6306) -> Prims.strcat "assume " i.FStar_Ident.idText
@@ -2055,9 +1846,8 @@ let (decl_to_string : decl -> Prims.string) =
             FStar_All.pipe_right tys
               (FStar_List.map
                  (fun uu____6348  ->
-                    match uu____6348 with | (x,uu____6356) -> id_of_tycon x))
-             in
-          FStar_All.pipe_right uu____6326 (FStar_String.concat ", ")  in
+                    match uu____6348 with | (x,uu____6356) -> id_of_tycon x)) in
+          FStar_All.pipe_right uu____6326 (FStar_String.concat ", ") in
         Prims.strcat "type " uu____6325
     | Val (i,uu____6364) -> Prims.strcat "val " i.FStar_Ident.idText
     | Exception (i,uu____6366) ->
@@ -2069,16 +1859,14 @@ let (decl_to_string : decl -> Prims.string) =
     | SubEffect uu____6390 -> "sub_effect"
     | Pragma uu____6391 -> "pragma"
     | Fsdoc uu____6392 -> "fsdoc"
-  
-let (modul_to_string : modul -> Prims.string) =
+let modul_to_string: modul -> Prims.string =
   fun m  ->
     match m with
     | Module (uu____6396,decls) ->
         let uu____6402 =
-          FStar_All.pipe_right decls (FStar_List.map decl_to_string)  in
+          FStar_All.pipe_right decls (FStar_List.map decl_to_string) in
         FStar_All.pipe_right uu____6402 (FStar_String.concat "\n")
     | Interface (uu____6411,decls,uu____6413) ->
         let uu____6418 =
-          FStar_All.pipe_right decls (FStar_List.map decl_to_string)  in
+          FStar_All.pipe_right decls (FStar_List.map decl_to_string) in
         FStar_All.pipe_right uu____6418 (FStar_String.concat "\n")
-  

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -1,206 +1,197 @@
 open Prims
-let (p2l : Prims.string Prims.list -> FStar_Ident.lident) =
-  fun l  -> FStar_Ident.lid_of_path l FStar_Range.dummyRange 
-let (pconst : Prims.string -> FStar_Ident.lident) =
-  fun s  -> p2l ["Prims"; s] 
-let (psconst : Prims.string -> FStar_Ident.lident) =
-  fun s  -> p2l ["FStar"; "Pervasives"; s] 
-let (psnconst : Prims.string -> FStar_Ident.lident) =
-  fun s  -> p2l ["FStar"; "Pervasives"; "Native"; s] 
-let (prims_lid : FStar_Ident.lident) = p2l ["Prims"] 
-let (pervasives_lid : FStar_Ident.lident) = p2l ["FStar"; "Pervasives"] 
-let (fstar_ns_lid : FStar_Ident.lident) = p2l ["FStar"] 
-let (bool_lid : FStar_Ident.lident) = pconst "bool" 
-let (unit_lid : FStar_Ident.lident) = pconst "unit" 
-let (squash_lid : FStar_Ident.lident) = pconst "squash" 
-let (auto_squash_lid : FStar_Ident.lident) = pconst "auto_squash" 
-let (string_lid : FStar_Ident.lident) = pconst "string" 
-let (bytes_lid : FStar_Ident.lident) = pconst "bytes" 
-let (int_lid : FStar_Ident.lident) = pconst "int" 
-let (exn_lid : FStar_Ident.lident) = pconst "exn" 
-let (list_lid : FStar_Ident.lident) = pconst "list" 
-let (option_lid : FStar_Ident.lident) = psnconst "option" 
-let (either_lid : FStar_Ident.lident) = psconst "either" 
-let (pattern_lid : FStar_Ident.lident) = pconst "pattern" 
-let (precedes_lid : FStar_Ident.lident) = pconst "precedes" 
-let (lex_t_lid : FStar_Ident.lident) = pconst "lex_t" 
-let (lexcons_lid : FStar_Ident.lident) = pconst "LexCons" 
-let (lextop_lid : FStar_Ident.lident) = pconst "LexTop" 
-let (smtpat_lid : FStar_Ident.lident) = pconst "smt_pat" 
-let (smtpatOr_lid : FStar_Ident.lident) = pconst "smt_pat_or" 
-let (monadic_lid : FStar_Ident.lident) = pconst "M" 
-let (spinoff_lid : FStar_Ident.lident) = pconst "spinoff" 
-let (int8_lid : FStar_Ident.lident) = p2l ["FStar"; "Int8"; "t"] 
-let (uint8_lid : FStar_Ident.lident) = p2l ["FStar"; "UInt8"; "t"] 
-let (int16_lid : FStar_Ident.lident) = p2l ["FStar"; "Int16"; "t"] 
-let (uint16_lid : FStar_Ident.lident) = p2l ["FStar"; "UInt16"; "t"] 
-let (int32_lid : FStar_Ident.lident) = p2l ["FStar"; "Int32"; "t"] 
-let (uint32_lid : FStar_Ident.lident) = p2l ["FStar"; "UInt32"; "t"] 
-let (int64_lid : FStar_Ident.lident) = p2l ["FStar"; "Int64"; "t"] 
-let (uint64_lid : FStar_Ident.lident) = p2l ["FStar"; "UInt64"; "t"] 
-let (salloc_lid : FStar_Ident.lident) = p2l ["FStar"; "ST"; "salloc"] 
-let (swrite_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "ST"; "op_Colon_Equals"] 
-let (sread_lid : FStar_Ident.lident) = p2l ["FStar"; "ST"; "op_Bang"] 
-let (max_lid : FStar_Ident.lident) = p2l ["max"] 
-let (float_lid : FStar_Ident.lident) = p2l ["FStar"; "Float"; "float"] 
-let (char_lid : FStar_Ident.lident) = p2l ["FStar"; "Char"; "char"] 
-let (heap_lid : FStar_Ident.lident) = p2l ["FStar"; "Heap"; "heap"] 
-let (true_lid : FStar_Ident.lident) = pconst "l_True" 
-let (false_lid : FStar_Ident.lident) = pconst "l_False" 
-let (and_lid : FStar_Ident.lident) = pconst "l_and" 
-let (or_lid : FStar_Ident.lident) = pconst "l_or" 
-let (not_lid : FStar_Ident.lident) = pconst "l_not" 
-let (imp_lid : FStar_Ident.lident) = pconst "l_imp" 
-let (iff_lid : FStar_Ident.lident) = pconst "l_iff" 
-let (ite_lid : FStar_Ident.lident) = pconst "l_ITE" 
-let (exists_lid : FStar_Ident.lident) = pconst "l_Exists" 
-let (forall_lid : FStar_Ident.lident) = pconst "l_Forall" 
-let (haseq_lid : FStar_Ident.lident) = pconst "hasEq" 
-let (b2t_lid : FStar_Ident.lident) = pconst "b2t" 
-let (admit_lid : FStar_Ident.lident) = pconst "admit" 
-let (magic_lid : FStar_Ident.lident) = pconst "magic" 
-let (has_type_lid : FStar_Ident.lident) = pconst "has_type" 
-let (c_true_lid : FStar_Ident.lident) = pconst "c_True" 
-let (c_false_lid : FStar_Ident.lident) = pconst "c_False" 
-let (c_and_lid : FStar_Ident.lident) = pconst "c_and" 
-let (c_or_lid : FStar_Ident.lident) = pconst "c_or" 
-let (dtuple2_lid : FStar_Ident.lident) = pconst "dtuple2" 
-let (eq2_lid : FStar_Ident.lident) = pconst "eq2" 
-let (eq3_lid : FStar_Ident.lident) = pconst "eq3" 
-let (c_eq2_lid : FStar_Ident.lident) = pconst "equals" 
-let (c_eq3_lid : FStar_Ident.lident) = pconst "h_equals" 
-let (cons_lid : FStar_Ident.lident) = pconst "Cons" 
-let (nil_lid : FStar_Ident.lident) = pconst "Nil" 
-let (some_lid : FStar_Ident.lident) = psnconst "Some" 
-let (none_lid : FStar_Ident.lident) = psnconst "None" 
-let (assume_lid : FStar_Ident.lident) = pconst "_assume" 
-let (assert_lid : FStar_Ident.lident) = pconst "_assert" 
-let (list_append_lid : FStar_Ident.lident) = p2l ["FStar"; "List"; "append"] 
-let (list_tot_append_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "List"; "Tot"; "Base"; "append"] 
-let (strcat_lid : FStar_Ident.lident) = p2l ["Prims"; "strcat"] 
-let (strcat_lid' : FStar_Ident.lident) = p2l ["FStar"; "String"; "strcat"] 
-let (str_make_lid : FStar_Ident.lident) = p2l ["FStar"; "String"; "make"] 
-let (let_in_typ : FStar_Ident.lident) = p2l ["Prims"; "Let"] 
-let (string_of_int_lid : FStar_Ident.lident) = p2l ["Prims"; "string_of_int"] 
-let (string_of_bool_lid : FStar_Ident.lident) =
-  p2l ["Prims"; "string_of_bool"] 
-let (string_compare : FStar_Ident.lident) =
-  p2l ["FStar"; "String"; "compare"] 
-let (op_Eq : FStar_Ident.lident) = pconst "op_Equality" 
-let (op_notEq : FStar_Ident.lident) = pconst "op_disEquality" 
-let (op_LT : FStar_Ident.lident) = pconst "op_LessThan" 
-let (op_LTE : FStar_Ident.lident) = pconst "op_LessThanOrEqual" 
-let (op_GT : FStar_Ident.lident) = pconst "op_GreaterThan" 
-let (op_GTE : FStar_Ident.lident) = pconst "op_GreaterThanOrEqual" 
-let (op_Subtraction : FStar_Ident.lident) = pconst "op_Subtraction" 
-let (op_Minus : FStar_Ident.lident) = pconst "op_Minus" 
-let (op_Addition : FStar_Ident.lident) = pconst "op_Addition" 
-let (op_Multiply : FStar_Ident.lident) = pconst "op_Multiply" 
-let (op_Division : FStar_Ident.lident) = pconst "op_Division" 
-let (op_Modulus : FStar_Ident.lident) = pconst "op_Modulus" 
-let (op_And : FStar_Ident.lident) = pconst "op_AmpAmp" 
-let (op_Or : FStar_Ident.lident) = pconst "op_BarBar" 
-let (op_Negation : FStar_Ident.lident) = pconst "op_Negation" 
-let (bvconst : Prims.string -> FStar_Ident.lident) =
-  fun s  -> p2l ["FStar"; "BV"; s] 
-let (bv_t_lid : FStar_Ident.lident) = bvconst "bv_t" 
-let (nat_to_bv_lid : FStar_Ident.lident) = bvconst "int2bv" 
-let (bv_to_nat_lid : FStar_Ident.lident) = bvconst "bv2int" 
-let (bv_and_lid : FStar_Ident.lident) = bvconst "bvand" 
-let (bv_xor_lid : FStar_Ident.lident) = bvconst "bvxor" 
-let (bv_or_lid : FStar_Ident.lident) = bvconst "bvor" 
-let (bv_add_lid : FStar_Ident.lident) = bvconst "bvadd" 
-let (bv_sub_lid : FStar_Ident.lident) = bvconst "bvsub" 
-let (bv_shift_left_lid : FStar_Ident.lident) = bvconst "bvshl" 
-let (bv_shift_right_lid : FStar_Ident.lident) = bvconst "bvshr" 
-let (bv_udiv_lid : FStar_Ident.lident) = bvconst "bvdiv" 
-let (bv_mod_lid : FStar_Ident.lident) = bvconst "bvmod" 
-let (bv_mul_lid : FStar_Ident.lident) = bvconst "bvmul" 
-let (bv_ult_lid : FStar_Ident.lident) = bvconst "bvult" 
-let (bv_uext_lid : FStar_Ident.lident) = bvconst "bv_uext" 
-let (array_lid : FStar_Ident.lident) = p2l ["FStar"; "Array"; "array"] 
-let (array_mk_array_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "Array"; "mk_array"] 
-let (st_lid : FStar_Ident.lident) = p2l ["FStar"; "ST"] 
-let (write_lid : FStar_Ident.lident) = p2l ["FStar"; "ST"; "write"] 
-let (read_lid : FStar_Ident.lident) = p2l ["FStar"; "ST"; "read"] 
-let (alloc_lid : FStar_Ident.lident) = p2l ["FStar"; "ST"; "alloc"] 
-let (op_ColonEq : FStar_Ident.lident) =
-  p2l ["FStar"; "ST"; "op_Colon_Equals"] 
-let (ref_lid : FStar_Ident.lident) = p2l ["FStar"; "Heap"; "ref"] 
-let (heap_addr_of_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "Heap"; "addr_of"] 
-let (set_empty : FStar_Ident.lident) = p2l ["FStar"; "Set"; "empty"] 
-let (set_singleton : FStar_Ident.lident) = p2l ["FStar"; "Set"; "singleton"] 
-let (set_union : FStar_Ident.lident) = p2l ["FStar"; "Set"; "union"] 
-let (fstar_hyperheap_lid : FStar_Ident.lident) = p2l ["FStar"; "HyperHeap"] 
-let (rref_lid : FStar_Ident.lident) = p2l ["FStar"; "HyperHeap"; "rref"] 
-let (erased_lid : FStar_Ident.lident) = p2l ["FStar"; "Ghost"; "erased"] 
-let (effect_PURE_lid : FStar_Ident.lident) = pconst "PURE" 
-let (effect_Pure_lid : FStar_Ident.lident) = pconst "Pure" 
-let (effect_Tot_lid : FStar_Ident.lident) = pconst "Tot" 
-let (effect_Lemma_lid : FStar_Ident.lident) = pconst "Lemma" 
-let (effect_GTot_lid : FStar_Ident.lident) = pconst "GTot" 
-let (effect_GHOST_lid : FStar_Ident.lident) = pconst "GHOST" 
-let (effect_Ghost_lid : FStar_Ident.lident) = pconst "Ghost" 
-let (effect_DIV_lid : FStar_Ident.lident) = pconst "DIV" 
-let (all_lid : FStar_Ident.lident) = p2l ["FStar"; "All"] 
-let (effect_ALL_lid : FStar_Ident.lident) = p2l ["FStar"; "All"; "ALL"] 
-let (effect_ML_lid : FStar_Ident.lident) = p2l ["FStar"; "All"; "ML"] 
-let (failwith_lid : FStar_Ident.lident) = p2l ["FStar"; "All"; "failwith"] 
-let (pipe_right_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "All"; "pipe_right"] 
-let (pipe_left_lid : FStar_Ident.lident) = p2l ["FStar"; "All"; "pipe_left"] 
-let (try_with_lid : FStar_Ident.lident) = p2l ["FStar"; "All"; "try_with"] 
-let (as_requires : FStar_Ident.lident) = pconst "as_requires" 
-let (as_ensures : FStar_Ident.lident) = pconst "as_ensures" 
-let (decreases_lid : FStar_Ident.lident) = pconst "decreases" 
-let (term_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "Reflection"; "Types"; "term"] 
-let (range_lid : FStar_Ident.lident) = pconst "range" 
-let (range_of_lid : FStar_Ident.lident) = pconst "range_of" 
-let (labeled_lid : FStar_Ident.lident) = pconst "labeled" 
-let (range_0 : FStar_Ident.lident) = pconst "range_0" 
-let (guard_free : FStar_Ident.lident) = pconst "guard_free" 
-let (inversion_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "Pervasives"; "inversion"] 
-let (with_type_lid : FStar_Ident.lident) = pconst "with_type" 
-let (normalize : FStar_Ident.lident) = pconst "normalize" 
-let (normalize_term : FStar_Ident.lident) = pconst "normalize_term" 
-let (norm : FStar_Ident.lident) = pconst "norm" 
-let (steps_simpl : FStar_Ident.lident) = pconst "simplify" 
-let (steps_weak : FStar_Ident.lident) = pconst "weak" 
-let (steps_hnf : FStar_Ident.lident) = pconst "hnf" 
-let (steps_primops : FStar_Ident.lident) = pconst "primops" 
-let (steps_zeta : FStar_Ident.lident) = pconst "zeta" 
-let (steps_iota : FStar_Ident.lident) = pconst "iota" 
-let (steps_delta : FStar_Ident.lident) = pconst "delta" 
-let (steps_unfoldonly : FStar_Ident.lident) = pconst "delta_only" 
-let (steps_unfoldattr : FStar_Ident.lident) = pconst "delta_attr" 
-let (deprecated_attr : FStar_Ident.lident) =
-  p2l ["FStar"; "Pervasives"; "deprecated"] 
-let (inline_let_attr : FStar_Ident.lident) =
-  p2l ["FStar"; "Pervasives"; "inline_let"] 
-let (gen_reset :
+let p2l: Prims.string Prims.list -> FStar_Ident.lident =
+  fun l  -> FStar_Ident.lid_of_path l FStar_Range.dummyRange
+let pconst: Prims.string -> FStar_Ident.lident = fun s  -> p2l ["Prims"; s]
+let psconst: Prims.string -> FStar_Ident.lident =
+  fun s  -> p2l ["FStar"; "Pervasives"; s]
+let psnconst: Prims.string -> FStar_Ident.lident =
+  fun s  -> p2l ["FStar"; "Pervasives"; "Native"; s]
+let prims_lid: FStar_Ident.lident = p2l ["Prims"]
+let pervasives_lid: FStar_Ident.lident = p2l ["FStar"; "Pervasives"]
+let fstar_ns_lid: FStar_Ident.lident = p2l ["FStar"]
+let bool_lid: FStar_Ident.lident = pconst "bool"
+let unit_lid: FStar_Ident.lident = pconst "unit"
+let squash_lid: FStar_Ident.lident = pconst "squash"
+let auto_squash_lid: FStar_Ident.lident = pconst "auto_squash"
+let string_lid: FStar_Ident.lident = pconst "string"
+let bytes_lid: FStar_Ident.lident = pconst "bytes"
+let int_lid: FStar_Ident.lident = pconst "int"
+let exn_lid: FStar_Ident.lident = pconst "exn"
+let list_lid: FStar_Ident.lident = pconst "list"
+let option_lid: FStar_Ident.lident = psnconst "option"
+let either_lid: FStar_Ident.lident = psconst "either"
+let pattern_lid: FStar_Ident.lident = pconst "pattern"
+let precedes_lid: FStar_Ident.lident = pconst "precedes"
+let lex_t_lid: FStar_Ident.lident = pconst "lex_t"
+let lexcons_lid: FStar_Ident.lident = pconst "LexCons"
+let lextop_lid: FStar_Ident.lident = pconst "LexTop"
+let smtpat_lid: FStar_Ident.lident = pconst "smt_pat"
+let smtpatOr_lid: FStar_Ident.lident = pconst "smt_pat_or"
+let monadic_lid: FStar_Ident.lident = pconst "M"
+let spinoff_lid: FStar_Ident.lident = pconst "spinoff"
+let int8_lid: FStar_Ident.lident = p2l ["FStar"; "Int8"; "t"]
+let uint8_lid: FStar_Ident.lident = p2l ["FStar"; "UInt8"; "t"]
+let int16_lid: FStar_Ident.lident = p2l ["FStar"; "Int16"; "t"]
+let uint16_lid: FStar_Ident.lident = p2l ["FStar"; "UInt16"; "t"]
+let int32_lid: FStar_Ident.lident = p2l ["FStar"; "Int32"; "t"]
+let uint32_lid: FStar_Ident.lident = p2l ["FStar"; "UInt32"; "t"]
+let int64_lid: FStar_Ident.lident = p2l ["FStar"; "Int64"; "t"]
+let uint64_lid: FStar_Ident.lident = p2l ["FStar"; "UInt64"; "t"]
+let salloc_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "salloc"]
+let swrite_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "op_Colon_Equals"]
+let sread_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "op_Bang"]
+let max_lid: FStar_Ident.lident = p2l ["max"]
+let float_lid: FStar_Ident.lident = p2l ["FStar"; "Float"; "float"]
+let char_lid: FStar_Ident.lident = p2l ["FStar"; "Char"; "char"]
+let heap_lid: FStar_Ident.lident = p2l ["FStar"; "Heap"; "heap"]
+let true_lid: FStar_Ident.lident = pconst "l_True"
+let false_lid: FStar_Ident.lident = pconst "l_False"
+let and_lid: FStar_Ident.lident = pconst "l_and"
+let or_lid: FStar_Ident.lident = pconst "l_or"
+let not_lid: FStar_Ident.lident = pconst "l_not"
+let imp_lid: FStar_Ident.lident = pconst "l_imp"
+let iff_lid: FStar_Ident.lident = pconst "l_iff"
+let ite_lid: FStar_Ident.lident = pconst "l_ITE"
+let exists_lid: FStar_Ident.lident = pconst "l_Exists"
+let forall_lid: FStar_Ident.lident = pconst "l_Forall"
+let haseq_lid: FStar_Ident.lident = pconst "hasEq"
+let b2t_lid: FStar_Ident.lident = pconst "b2t"
+let admit_lid: FStar_Ident.lident = pconst "admit"
+let magic_lid: FStar_Ident.lident = pconst "magic"
+let has_type_lid: FStar_Ident.lident = pconst "has_type"
+let c_true_lid: FStar_Ident.lident = pconst "c_True"
+let c_false_lid: FStar_Ident.lident = pconst "c_False"
+let c_and_lid: FStar_Ident.lident = pconst "c_and"
+let c_or_lid: FStar_Ident.lident = pconst "c_or"
+let dtuple2_lid: FStar_Ident.lident = pconst "dtuple2"
+let eq2_lid: FStar_Ident.lident = pconst "eq2"
+let eq3_lid: FStar_Ident.lident = pconst "eq3"
+let c_eq2_lid: FStar_Ident.lident = pconst "equals"
+let c_eq3_lid: FStar_Ident.lident = pconst "h_equals"
+let cons_lid: FStar_Ident.lident = pconst "Cons"
+let nil_lid: FStar_Ident.lident = pconst "Nil"
+let some_lid: FStar_Ident.lident = psnconst "Some"
+let none_lid: FStar_Ident.lident = psnconst "None"
+let assume_lid: FStar_Ident.lident = pconst "_assume"
+let assert_lid: FStar_Ident.lident = pconst "_assert"
+let list_append_lid: FStar_Ident.lident = p2l ["FStar"; "List"; "append"]
+let list_tot_append_lid: FStar_Ident.lident =
+  p2l ["FStar"; "List"; "Tot"; "Base"; "append"]
+let strcat_lid: FStar_Ident.lident = p2l ["Prims"; "strcat"]
+let strcat_lid': FStar_Ident.lident = p2l ["FStar"; "String"; "strcat"]
+let str_make_lid: FStar_Ident.lident = p2l ["FStar"; "String"; "make"]
+let let_in_typ: FStar_Ident.lident = p2l ["Prims"; "Let"]
+let string_of_int_lid: FStar_Ident.lident = p2l ["Prims"; "string_of_int"]
+let string_of_bool_lid: FStar_Ident.lident = p2l ["Prims"; "string_of_bool"]
+let string_compare: FStar_Ident.lident = p2l ["FStar"; "String"; "compare"]
+let op_Eq: FStar_Ident.lident = pconst "op_Equality"
+let op_notEq: FStar_Ident.lident = pconst "op_disEquality"
+let op_LT: FStar_Ident.lident = pconst "op_LessThan"
+let op_LTE: FStar_Ident.lident = pconst "op_LessThanOrEqual"
+let op_GT: FStar_Ident.lident = pconst "op_GreaterThan"
+let op_GTE: FStar_Ident.lident = pconst "op_GreaterThanOrEqual"
+let op_Subtraction: FStar_Ident.lident = pconst "op_Subtraction"
+let op_Minus: FStar_Ident.lident = pconst "op_Minus"
+let op_Addition: FStar_Ident.lident = pconst "op_Addition"
+let op_Multiply: FStar_Ident.lident = pconst "op_Multiply"
+let op_Division: FStar_Ident.lident = pconst "op_Division"
+let op_Modulus: FStar_Ident.lident = pconst "op_Modulus"
+let op_And: FStar_Ident.lident = pconst "op_AmpAmp"
+let op_Or: FStar_Ident.lident = pconst "op_BarBar"
+let op_Negation: FStar_Ident.lident = pconst "op_Negation"
+let bvconst: Prims.string -> FStar_Ident.lident =
+  fun s  -> p2l ["FStar"; "BV"; s]
+let bv_t_lid: FStar_Ident.lident = bvconst "bv_t"
+let nat_to_bv_lid: FStar_Ident.lident = bvconst "int2bv"
+let bv_to_nat_lid: FStar_Ident.lident = bvconst "bv2int"
+let bv_and_lid: FStar_Ident.lident = bvconst "bvand"
+let bv_xor_lid: FStar_Ident.lident = bvconst "bvxor"
+let bv_or_lid: FStar_Ident.lident = bvconst "bvor"
+let bv_add_lid: FStar_Ident.lident = bvconst "bvadd"
+let bv_sub_lid: FStar_Ident.lident = bvconst "bvsub"
+let bv_shift_left_lid: FStar_Ident.lident = bvconst "bvshl"
+let bv_shift_right_lid: FStar_Ident.lident = bvconst "bvshr"
+let bv_udiv_lid: FStar_Ident.lident = bvconst "bvdiv"
+let bv_mod_lid: FStar_Ident.lident = bvconst "bvmod"
+let bv_mul_lid: FStar_Ident.lident = bvconst "bvmul"
+let bv_ult_lid: FStar_Ident.lident = bvconst "bvult"
+let bv_uext_lid: FStar_Ident.lident = bvconst "bv_uext"
+let array_lid: FStar_Ident.lident = p2l ["FStar"; "Array"; "array"]
+let array_mk_array_lid: FStar_Ident.lident =
+  p2l ["FStar"; "Array"; "mk_array"]
+let st_lid: FStar_Ident.lident = p2l ["FStar"; "ST"]
+let write_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "write"]
+let read_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "read"]
+let alloc_lid: FStar_Ident.lident = p2l ["FStar"; "ST"; "alloc"]
+let op_ColonEq: FStar_Ident.lident = p2l ["FStar"; "ST"; "op_Colon_Equals"]
+let ref_lid: FStar_Ident.lident = p2l ["FStar"; "Heap"; "ref"]
+let heap_addr_of_lid: FStar_Ident.lident = p2l ["FStar"; "Heap"; "addr_of"]
+let set_empty: FStar_Ident.lident = p2l ["FStar"; "Set"; "empty"]
+let set_singleton: FStar_Ident.lident = p2l ["FStar"; "Set"; "singleton"]
+let set_union: FStar_Ident.lident = p2l ["FStar"; "Set"; "union"]
+let fstar_hyperheap_lid: FStar_Ident.lident = p2l ["FStar"; "HyperHeap"]
+let rref_lid: FStar_Ident.lident = p2l ["FStar"; "HyperHeap"; "rref"]
+let erased_lid: FStar_Ident.lident = p2l ["FStar"; "Ghost"; "erased"]
+let effect_PURE_lid: FStar_Ident.lident = pconst "PURE"
+let effect_Pure_lid: FStar_Ident.lident = pconst "Pure"
+let effect_Tot_lid: FStar_Ident.lident = pconst "Tot"
+let effect_Lemma_lid: FStar_Ident.lident = pconst "Lemma"
+let effect_GTot_lid: FStar_Ident.lident = pconst "GTot"
+let effect_GHOST_lid: FStar_Ident.lident = pconst "GHOST"
+let effect_Ghost_lid: FStar_Ident.lident = pconst "Ghost"
+let effect_DIV_lid: FStar_Ident.lident = pconst "DIV"
+let all_lid: FStar_Ident.lident = p2l ["FStar"; "All"]
+let effect_ALL_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "ALL"]
+let effect_ML_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "ML"]
+let failwith_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "failwith"]
+let pipe_right_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "pipe_right"]
+let pipe_left_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "pipe_left"]
+let try_with_lid: FStar_Ident.lident = p2l ["FStar"; "All"; "try_with"]
+let as_requires: FStar_Ident.lident = pconst "as_requires"
+let as_ensures: FStar_Ident.lident = pconst "as_ensures"
+let decreases_lid: FStar_Ident.lident = pconst "decreases"
+let term_lid: FStar_Ident.lident =
+  p2l ["FStar"; "Reflection"; "Types"; "term"]
+let range_lid: FStar_Ident.lident = pconst "range"
+let range_of_lid: FStar_Ident.lident = pconst "range_of"
+let labeled_lid: FStar_Ident.lident = pconst "labeled"
+let range_0: FStar_Ident.lident = pconst "range_0"
+let guard_free: FStar_Ident.lident = pconst "guard_free"
+let inversion_lid: FStar_Ident.lident =
+  p2l ["FStar"; "Pervasives"; "inversion"]
+let with_type_lid: FStar_Ident.lident = pconst "with_type"
+let normalize: FStar_Ident.lident = pconst "normalize"
+let normalize_term: FStar_Ident.lident = pconst "normalize_term"
+let norm: FStar_Ident.lident = pconst "norm"
+let steps_simpl: FStar_Ident.lident = pconst "simplify"
+let steps_weak: FStar_Ident.lident = pconst "weak"
+let steps_hnf: FStar_Ident.lident = pconst "hnf"
+let steps_primops: FStar_Ident.lident = pconst "primops"
+let steps_zeta: FStar_Ident.lident = pconst "zeta"
+let steps_iota: FStar_Ident.lident = pconst "iota"
+let steps_delta: FStar_Ident.lident = pconst "delta"
+let steps_unfoldonly: FStar_Ident.lident = pconst "delta_only"
+let steps_unfoldattr: FStar_Ident.lident = pconst "delta_attr"
+let deprecated_attr: FStar_Ident.lident =
+  p2l ["FStar"; "Pervasives"; "deprecated"]
+let inline_let_attr: FStar_Ident.lident =
+  p2l ["FStar"; "Pervasives"; "inline_let"]
+let gen_reset:
   (Prims.unit -> Prims.int,Prims.unit -> Prims.unit)
-    FStar_Pervasives_Native.tuple2)
+    FStar_Pervasives_Native.tuple2
   =
-  let x = FStar_Util.mk_ref (Prims.parse_int "0")  in
-  let gen1 uu____34 = FStar_Util.incr x; FStar_Util.read x  in
-  let reset uu____94 = FStar_Util.write x (Prims.parse_int "0")  in
-  (gen1, reset) 
-let (next_id : Prims.unit -> Prims.int) =
-  FStar_Pervasives_Native.fst gen_reset 
-let (sli : FStar_Ident.lident -> Prims.string) =
+  let x = FStar_Util.mk_ref (Prims.parse_int "0") in
+  let gen1 uu____34 = FStar_Util.incr x; FStar_Util.read x in
+  let reset uu____94 = FStar_Util.write x (Prims.parse_int "0") in
+  (gen1, reset)
+let next_id: Prims.unit -> Prims.int = FStar_Pervasives_Native.fst gen_reset
+let sli: FStar_Ident.lident -> Prims.string =
   fun l  ->
-    let uu____130 = FStar_Options.print_real_names ()  in
+    let uu____130 = FStar_Options.print_real_names () in
     if uu____130
     then l.FStar_Ident.str
     else (l.FStar_Ident.ident).FStar_Ident.idText
-  
-let (const_to_string : FStar_Const.sconst -> Prims.string) =
+let const_to_string: FStar_Const.sconst -> Prims.string =
   fun x  ->
     match x with
     | FStar_Const.Const_effect  -> "Effect"
@@ -217,125 +208,107 @@ let (const_to_string : FStar_Const.sconst -> Prims.string) =
     | FStar_Const.Const_set_range_of  -> "set_range_of"
     | FStar_Const.Const_reify  -> "reify"
     | FStar_Const.Const_reflect l ->
-        let uu____164 = sli l  in
+        let uu____164 = sli l in
         FStar_Util.format1 "[[%s.reflect]]" uu____164
-  
-let (mk_tuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
+let mk_tuple_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____172 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "tuple%s" uu____172  in
-      let uu____173 = psnconst t  in FStar_Ident.set_lid_range uu____173 r
-  
-let (lid_tuple2 : FStar_Ident.lident) =
-  mk_tuple_lid (Prims.parse_int "2") FStar_Range.dummyRange 
-let (is_tuple_constructor_string : Prims.string -> Prims.bool) =
-  fun s  -> FStar_Util.starts_with s "FStar.Pervasives.Native.tuple" 
-let (is_tuple_constructor_lid : FStar_Ident.ident -> Prims.bool) =
-  fun lid  -> is_tuple_constructor_string (FStar_Ident.text_of_id lid) 
-let (mk_tuple_data_lid :
-  Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
+        let uu____172 = FStar_Util.string_of_int n1 in
+        FStar_Util.format1 "tuple%s" uu____172 in
+      let uu____173 = psnconst t in FStar_Ident.set_lid_range uu____173 r
+let lid_tuple2: FStar_Ident.lident =
+  mk_tuple_lid (Prims.parse_int "2") FStar_Range.dummyRange
+let is_tuple_constructor_string: Prims.string -> Prims.bool =
+  fun s  -> FStar_Util.starts_with s "FStar.Pervasives.Native.tuple"
+let is_tuple_constructor_lid: FStar_Ident.ident -> Prims.bool =
+  fun lid  -> is_tuple_constructor_string (FStar_Ident.text_of_id lid)
+let mk_tuple_data_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____187 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "Mktuple%s" uu____187  in
-      let uu____188 = psnconst t  in FStar_Ident.set_lid_range uu____188 r
-  
-let (lid_Mktuple2 : FStar_Ident.lident) =
-  mk_tuple_data_lid (Prims.parse_int "2") FStar_Range.dummyRange 
-let (is_tuple_datacon_string : Prims.string -> Prims.bool) =
-  fun s  -> FStar_Util.starts_with s "FStar.Pervasives.Native.Mktuple" 
-let (is_tuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
+        let uu____187 = FStar_Util.string_of_int n1 in
+        FStar_Util.format1 "Mktuple%s" uu____187 in
+      let uu____188 = psnconst t in FStar_Ident.set_lid_range uu____188 r
+let lid_Mktuple2: FStar_Ident.lident =
+  mk_tuple_data_lid (Prims.parse_int "2") FStar_Range.dummyRange
+let is_tuple_datacon_string: Prims.string -> Prims.bool =
+  fun s  -> FStar_Util.starts_with s "FStar.Pervasives.Native.Mktuple"
+let is_tuple_data_lid: FStar_Ident.lident -> Prims.int -> Prims.bool =
   fun f  ->
     fun n1  ->
-      let uu____198 = mk_tuple_data_lid n1 FStar_Range.dummyRange  in
+      let uu____198 = mk_tuple_data_lid n1 FStar_Range.dummyRange in
       FStar_Ident.lid_equals f uu____198
-  
-let (is_tuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
-  fun f  -> is_tuple_datacon_string f.FStar_Ident.str 
-let (mod_prefix_dtuple : Prims.int -> Prims.string -> FStar_Ident.lident) =
-  fun n1  -> if n1 = (Prims.parse_int "2") then pconst else psconst 
-let (mk_dtuple_lid : Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
+let is_tuple_data_lid': FStar_Ident.lident -> Prims.bool =
+  fun f  -> is_tuple_datacon_string f.FStar_Ident.str
+let mod_prefix_dtuple: Prims.int -> Prims.string -> FStar_Ident.lident =
+  fun n1  -> if n1 = (Prims.parse_int "2") then pconst else psconst
+let mk_dtuple_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____219 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "dtuple%s" uu____219  in
-      let uu____220 = let uu____221 = mod_prefix_dtuple n1  in uu____221 t
-         in
+        let uu____219 = FStar_Util.string_of_int n1 in
+        FStar_Util.format1 "dtuple%s" uu____219 in
+      let uu____220 = let uu____221 = mod_prefix_dtuple n1 in uu____221 t in
       FStar_Ident.set_lid_range uu____220 r
-  
-let (is_dtuple_constructor_string : Prims.string -> Prims.bool) =
+let is_dtuple_constructor_string: Prims.string -> Prims.bool =
   fun s  ->
     (s = "Prims.dtuple2") ||
       (FStar_Util.starts_with s "FStar.Pervasives.dtuple")
-  
-let (is_dtuple_constructor_lid : FStar_Ident.lident -> Prims.bool) =
-  fun lid  -> is_dtuple_constructor_string lid.FStar_Ident.str 
-let (mk_dtuple_data_lid :
-  Prims.int -> FStar_Range.range -> FStar_Ident.lident) =
+let is_dtuple_constructor_lid: FStar_Ident.lident -> Prims.bool =
+  fun lid  -> is_dtuple_constructor_string lid.FStar_Ident.str
+let mk_dtuple_data_lid: Prims.int -> FStar_Range.range -> FStar_Ident.lident
+  =
   fun n1  ->
     fun r  ->
       let t =
-        let uu____237 = FStar_Util.string_of_int n1  in
-        FStar_Util.format1 "Mkdtuple%s" uu____237  in
-      let uu____238 = let uu____239 = mod_prefix_dtuple n1  in uu____239 t
-         in
+        let uu____237 = FStar_Util.string_of_int n1 in
+        FStar_Util.format1 "Mkdtuple%s" uu____237 in
+      let uu____238 = let uu____239 = mod_prefix_dtuple n1 in uu____239 t in
       FStar_Ident.set_lid_range uu____238 r
-  
-let (is_dtuple_datacon_string : Prims.string -> Prims.bool) =
+let is_dtuple_datacon_string: Prims.string -> Prims.bool =
   fun s  ->
     (s = "Prims.Mkdtuple2") ||
       (FStar_Util.starts_with s "FStar.Pervasives.Mkdtuple")
-  
-let (is_dtuple_data_lid : FStar_Ident.lident -> Prims.int -> Prims.bool) =
+let is_dtuple_data_lid: FStar_Ident.lident -> Prims.int -> Prims.bool =
   fun f  ->
     fun n1  ->
-      let uu____251 = mk_dtuple_data_lid n1 FStar_Range.dummyRange  in
+      let uu____251 = mk_dtuple_data_lid n1 FStar_Range.dummyRange in
       FStar_Ident.lid_equals f uu____251
-  
-let (is_dtuple_data_lid' : FStar_Ident.lident -> Prims.bool) =
-  fun f  -> is_dtuple_datacon_string (FStar_Ident.text_of_lid f) 
-let (is_name : FStar_Ident.lident -> Prims.bool) =
+let is_dtuple_data_lid': FStar_Ident.lident -> Prims.bool =
+  fun f  -> is_dtuple_datacon_string (FStar_Ident.text_of_lid f)
+let is_name: FStar_Ident.lident -> Prims.bool =
   fun lid  ->
     let c =
       FStar_Util.char_at (lid.FStar_Ident.ident).FStar_Ident.idText
-        (Prims.parse_int "0")
-       in
+        (Prims.parse_int "0") in
     FStar_Util.is_upper c
-  
-let (fstar_tactics_lid' : Prims.string Prims.list -> FStar_Ident.lid) =
+let fstar_tactics_lid': Prims.string Prims.list -> FStar_Ident.lid =
   fun s  ->
     FStar_Ident.lid_of_path (FStar_List.append ["FStar"; "Tactics"] s)
       FStar_Range.dummyRange
-  
-let (fstar_tactics_lid : Prims.string -> FStar_Ident.lid) =
-  fun s  -> fstar_tactics_lid' [s] 
-let (tactic_lid : FStar_Ident.lid) = fstar_tactics_lid' ["Effect"; "tactic"] 
-let (u_tac_lid : FStar_Ident.lid) = fstar_tactics_lid' ["Effect"; "__tac"] 
-let (tac_effect_lid : FStar_Ident.lid) = fstar_tactics_lid' ["Effect"; "TAC"] 
-let (effect_Tac_lid : FStar_Ident.lid) = fstar_tactics_lid' ["Effect"; "Tac"] 
-let (by_tactic_lid : FStar_Ident.lid) =
-  fstar_tactics_lid' ["Effect"; "__by_tactic"] 
-let (synth_lid : FStar_Ident.lid) =
-  fstar_tactics_lid' ["Effect"; "synth_by_tactic"] 
-let (assert_by_tactic_lid : FStar_Ident.lid) =
-  fstar_tactics_lid' ["Effect"; "assert_by_tactic"] 
-let (reify_tactic_lid : FStar_Ident.lid) =
-  fstar_tactics_lid' ["Effect"; "reify_tactic"] 
-let (quote_lid : FStar_Ident.lident) =
+let fstar_tactics_lid: Prims.string -> FStar_Ident.lid =
+  fun s  -> fstar_tactics_lid' [s]
+let tactic_lid: FStar_Ident.lid = fstar_tactics_lid' ["Effect"; "tactic"]
+let u_tac_lid: FStar_Ident.lid = fstar_tactics_lid' ["Effect"; "__tac"]
+let tac_effect_lid: FStar_Ident.lid = fstar_tactics_lid' ["Effect"; "TAC"]
+let effect_Tac_lid: FStar_Ident.lid = fstar_tactics_lid' ["Effect"; "Tac"]
+let by_tactic_lid: FStar_Ident.lid =
+  fstar_tactics_lid' ["Effect"; "__by_tactic"]
+let synth_lid: FStar_Ident.lid =
+  fstar_tactics_lid' ["Effect"; "synth_by_tactic"]
+let assert_by_tactic_lid: FStar_Ident.lid =
+  fstar_tactics_lid' ["Effect"; "assert_by_tactic"]
+let reify_tactic_lid: FStar_Ident.lid =
+  fstar_tactics_lid' ["Effect"; "reify_tactic"]
+let quote_lid: FStar_Ident.lident =
   FStar_Ident.lid_of_path ["FStar"; "Tactics"; "Builtins"; "quote"]
     FStar_Range.dummyRange
-  
-let (fstar_refl_embed_lid : FStar_Ident.lident) =
+let fstar_refl_embed_lid: FStar_Ident.lident =
   FStar_Ident.lid_of_path ["FStar"; "Tactics"; "Builtins"; "__embed"]
     FStar_Range.dummyRange
-  
-let (fstar_syntax_syntax_term : FStar_Ident.lident) =
-  FStar_Ident.lid_of_str "FStar.Syntax.Syntax.term" 
-let (fstar_reflection_types_binder_lid : FStar_Ident.lident) =
+let fstar_syntax_syntax_term: FStar_Ident.lident =
+  FStar_Ident.lid_of_str "FStar.Syntax.Syntax.term"
+let fstar_reflection_types_binder_lid: FStar_Ident.lident =
   FStar_Ident.lid_of_path ["FStar"; "Reflection"; "Types"; "binder"]
     FStar_Range.dummyRange
-  

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -1,93 +1,82 @@
 open Prims
 type verify_mode =
-  | VerifyAll 
-  | VerifyUserList 
-  | VerifyFigureItOut [@@deriving show]
-let (uu___is_VerifyAll : verify_mode -> Prims.bool) =
+  | VerifyAll
+  | VerifyUserList
+  | VerifyFigureItOut[@@deriving show]
+let uu___is_VerifyAll: verify_mode -> Prims.bool =
   fun projectee  ->
     match projectee with | VerifyAll  -> true | uu____4 -> false
-  
-let (uu___is_VerifyUserList : verify_mode -> Prims.bool) =
+let uu___is_VerifyUserList: verify_mode -> Prims.bool =
   fun projectee  ->
     match projectee with | VerifyUserList  -> true | uu____8 -> false
-  
-let (uu___is_VerifyFigureItOut : verify_mode -> Prims.bool) =
+let uu___is_VerifyFigureItOut: verify_mode -> Prims.bool =
   fun projectee  ->
     match projectee with | VerifyFigureItOut  -> true | uu____12 -> false
-  
 type files_for_module_name =
   (Prims.string FStar_Pervasives_Native.option,Prims.string
                                                  FStar_Pervasives_Native.option)
     FStar_Pervasives_Native.tuple2 FStar_Util.smap[@@deriving show]
 type color =
-  | White 
-  | Gray 
-  | Black [@@deriving show]
-let (uu___is_White : color -> Prims.bool) =
-  fun projectee  -> match projectee with | White  -> true | uu____26 -> false 
-let (uu___is_Gray : color -> Prims.bool) =
-  fun projectee  -> match projectee with | Gray  -> true | uu____30 -> false 
-let (uu___is_Black : color -> Prims.bool) =
-  fun projectee  -> match projectee with | Black  -> true | uu____34 -> false 
+  | White
+  | Gray
+  | Black[@@deriving show]
+let uu___is_White: color -> Prims.bool =
+  fun projectee  -> match projectee with | White  -> true | uu____26 -> false
+let uu___is_Gray: color -> Prims.bool =
+  fun projectee  -> match projectee with | Gray  -> true | uu____30 -> false
+let uu___is_Black: color -> Prims.bool =
+  fun projectee  -> match projectee with | Black  -> true | uu____34 -> false
 type open_kind =
-  | Open_module 
-  | Open_namespace [@@deriving show]
-let (uu___is_Open_module : open_kind -> Prims.bool) =
+  | Open_module
+  | Open_namespace[@@deriving show]
+let uu___is_Open_module: open_kind -> Prims.bool =
   fun projectee  ->
     match projectee with | Open_module  -> true | uu____38 -> false
-  
-let (uu___is_Open_namespace : open_kind -> Prims.bool) =
+let uu___is_Open_namespace: open_kind -> Prims.bool =
   fun projectee  ->
     match projectee with | Open_namespace  -> true | uu____42 -> false
-  
-let (check_and_strip_suffix :
-  Prims.string -> Prims.string FStar_Pervasives_Native.option) =
+let check_and_strip_suffix:
+  Prims.string -> Prims.string FStar_Pervasives_Native.option =
   fun f  ->
-    let suffixes = [".fsti"; ".fst"; ".fsi"; ".fs"]  in
+    let suffixes = [".fsti"; ".fst"; ".fsi"; ".fs"] in
     let matches =
       FStar_List.map
         (fun ext  ->
-           let lext = FStar_String.length ext  in
-           let l = FStar_String.length f  in
+           let lext = FStar_String.length ext in
+           let l = FStar_String.length f in
            let uu____68 =
              (l > lext) &&
-               (let uu____80 = FStar_String.substring f (l - lext) lext  in
-                uu____80 = ext)
-              in
+               (let uu____80 = FStar_String.substring f (l - lext) lext in
+                uu____80 = ext) in
            if uu____68
            then
              let uu____97 =
-               FStar_String.substring f (Prims.parse_int "0") (l - lext)  in
+               FStar_String.substring f (Prims.parse_int "0") (l - lext) in
              FStar_Pervasives_Native.Some uu____97
-           else FStar_Pervasives_Native.None) suffixes
-       in
-    let uu____109 = FStar_List.filter FStar_Util.is_some matches  in
+           else FStar_Pervasives_Native.None) suffixes in
+    let uu____109 = FStar_List.filter FStar_Util.is_some matches in
     match uu____109 with
     | (FStar_Pervasives_Native.Some m)::uu____119 ->
         FStar_Pervasives_Native.Some m
     | uu____126 -> FStar_Pervasives_Native.None
-  
-let (is_interface : Prims.string -> Prims.bool) =
+let is_interface: Prims.string -> Prims.bool =
   fun f  ->
     let uu____134 =
-      FStar_String.get f ((FStar_String.length f) - (Prims.parse_int "1"))
-       in
+      FStar_String.get f ((FStar_String.length f) - (Prims.parse_int "1")) in
     uu____134 = 105
-  
-let (is_implementation : Prims.string -> Prims.bool) =
-  fun f  -> let uu____141 = is_interface f  in Prims.op_Negation uu____141 
-let (interface_filename : Prims.string -> Prims.string) =
+let is_implementation: Prims.string -> Prims.bool =
+  fun f  -> let uu____141 = is_interface f in Prims.op_Negation uu____141
+let interface_filename: Prims.string -> Prims.string =
   fun f  ->
-    let uu____145 = is_interface f  in
+    let uu____145 = is_interface f in
     if uu____145
     then f
     else
       (let uu____147 =
-         let uu____148 = check_and_strip_suffix f  in
-         FStar_All.pipe_right uu____148 FStar_Util.must  in
+         let uu____148 = check_and_strip_suffix f in
+         FStar_All.pipe_right uu____148 FStar_Util.must in
        FStar_All.pipe_right uu____147 (fun x  -> Prims.strcat x ".fsti"))
-  
-let list_of_option :
+let list_of_option:
   'Auu____157 .
     'Auu____157 FStar_Pervasives_Native.option -> 'Auu____157 Prims.list
   =
@@ -95,8 +84,7 @@ let list_of_option :
     match uu___53_165 with
     | FStar_Pervasives_Native.Some x -> [x]
     | FStar_Pervasives_Native.None  -> []
-  
-let list_of_pair :
+let list_of_pair:
   'Auu____171 .
     ('Auu____171 FStar_Pervasives_Native.option,'Auu____171
                                                   FStar_Pervasives_Native.option)
@@ -106,220 +94,196 @@ let list_of_pair :
     match uu____185 with
     | (intf,impl) ->
         FStar_List.append (list_of_option intf) (list_of_option impl)
-  
-let (module_name_of_file : Prims.string -> Prims.string) =
+let module_name_of_file: Prims.string -> Prims.string =
   fun f  ->
     let uu____207 =
-      let uu____210 = FStar_Util.basename f  in
-      check_and_strip_suffix uu____210  in
+      let uu____210 = FStar_Util.basename f in
+      check_and_strip_suffix uu____210 in
     match uu____207 with
     | FStar_Pervasives_Native.Some longname -> longname
     | FStar_Pervasives_Native.None  ->
         let uu____212 =
-          let uu____217 = FStar_Util.format1 "not a valid FStar file: %s\n" f
-             in
-          (FStar_Errors.Fatal_NotValidFStarFile, uu____217)  in
+          let uu____217 = FStar_Util.format1 "not a valid FStar file: %s\n" f in
+          (FStar_Errors.Fatal_NotValidFStarFile, uu____217) in
         FStar_Errors.raise_err uu____212
-  
-let (lowercase_module_name : Prims.string -> Prims.string) =
+let lowercase_module_name: Prims.string -> Prims.string =
   fun f  ->
-    let uu____221 = module_name_of_file f  in
-    FStar_String.lowercase uu____221
-  
-let (namespace_of_module :
-  Prims.string -> FStar_Ident.lident FStar_Pervasives_Native.option) =
+    let uu____221 = module_name_of_file f in FStar_String.lowercase uu____221
+let namespace_of_module:
+  Prims.string -> FStar_Ident.lident FStar_Pervasives_Native.option =
   fun f  ->
     let lid =
       FStar_Ident.lid_of_path (FStar_Ident.path_of_text f)
-        FStar_Range.dummyRange
-       in
+        FStar_Range.dummyRange in
     match lid.FStar_Ident.ns with
     | [] -> FStar_Pervasives_Native.None
     | uu____230 ->
-        let uu____233 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
+        let uu____233 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
         FStar_Pervasives_Native.Some uu____233
-  
 type file_name = Prims.string[@@deriving show]
 type module_name = Prims.string[@@deriving show]
 type dependence =
-  | UseInterface of module_name 
-  | PreferInterface of module_name 
-  | UseImplementation of module_name [@@deriving show]
-let (uu___is_UseInterface : dependence -> Prims.bool) =
+  | UseInterface of module_name
+  | PreferInterface of module_name
+  | UseImplementation of module_name[@@deriving show]
+let uu___is_UseInterface: dependence -> Prims.bool =
   fun projectee  ->
     match projectee with | UseInterface _0 -> true | uu____250 -> false
-  
-let (__proj__UseInterface__item___0 : dependence -> module_name) =
-  fun projectee  -> match projectee with | UseInterface _0 -> _0 
-let (uu___is_PreferInterface : dependence -> Prims.bool) =
+let __proj__UseInterface__item___0: dependence -> module_name =
+  fun projectee  -> match projectee with | UseInterface _0 -> _0
+let uu___is_PreferInterface: dependence -> Prims.bool =
   fun projectee  ->
     match projectee with | PreferInterface _0 -> true | uu____262 -> false
-  
-let (__proj__PreferInterface__item___0 : dependence -> module_name) =
-  fun projectee  -> match projectee with | PreferInterface _0 -> _0 
-let (uu___is_UseImplementation : dependence -> Prims.bool) =
+let __proj__PreferInterface__item___0: dependence -> module_name =
+  fun projectee  -> match projectee with | PreferInterface _0 -> _0
+let uu___is_UseImplementation: dependence -> Prims.bool =
   fun projectee  ->
     match projectee with | UseImplementation _0 -> true | uu____274 -> false
-  
-let (__proj__UseImplementation__item___0 : dependence -> module_name) =
-  fun projectee  -> match projectee with | UseImplementation _0 -> _0 
+let __proj__UseImplementation__item___0: dependence -> module_name =
+  fun projectee  -> match projectee with | UseImplementation _0 -> _0
 type dependences = dependence Prims.list[@@deriving show]
-let empty_dependences : 'Auu____285 . Prims.unit -> 'Auu____285 Prims.list =
-  fun uu____288  -> [] 
+let empty_dependences: 'Auu____285 . Prims.unit -> 'Auu____285 Prims.list =
+  fun uu____288  -> []
 type dependence_graph =
   | Deps of (dependences,color) FStar_Pervasives_Native.tuple2
-  FStar_Util.smap [@@deriving show]
-let (uu___is_Deps : dependence_graph -> Prims.bool) = fun projectee  -> true 
-let (__proj__Deps__item___0 :
+  FStar_Util.smap[@@deriving show]
+let uu___is_Deps: dependence_graph -> Prims.bool = fun projectee  -> true
+let __proj__Deps__item___0:
   dependence_graph ->
-    (dependences,color) FStar_Pervasives_Native.tuple2 FStar_Util.smap)
-  = fun projectee  -> match projectee with | Deps _0 -> _0 
+    (dependences,color) FStar_Pervasives_Native.tuple2 FStar_Util.smap
+  = fun projectee  -> match projectee with | Deps _0 -> _0
 type deps =
   | Mk of (dependence_graph,files_for_module_name,file_name Prims.list)
-  FStar_Pervasives_Native.tuple3 [@@deriving show]
-let (uu___is_Mk : deps -> Prims.bool) = fun projectee  -> true 
-let (__proj__Mk__item___0 :
+  FStar_Pervasives_Native.tuple3[@@deriving show]
+let uu___is_Mk: deps -> Prims.bool = fun projectee  -> true
+let __proj__Mk__item___0:
   deps ->
     (dependence_graph,files_for_module_name,file_name Prims.list)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Mk _0 -> _0 
-let (deps_try_find :
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Mk _0 -> _0
+let deps_try_find:
   dependence_graph ->
     Prims.string ->
       (dependences,color) FStar_Pervasives_Native.tuple2
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
   fun uu____377  ->
     fun k  -> match uu____377 with | Deps m -> FStar_Util.smap_try_find m k
-  
-let (deps_add_dep :
+let deps_add_dep:
   dependence_graph ->
     Prims.string ->
-      (dependences,color) FStar_Pervasives_Native.tuple2 -> Prims.unit)
+      (dependences,color) FStar_Pervasives_Native.tuple2 -> Prims.unit
   =
   fun uu____406  ->
     fun k  ->
       fun v1  -> match uu____406 with | Deps m -> FStar_Util.smap_add m k v1
-  
-let (deps_keys : dependence_graph -> Prims.string Prims.list) =
-  fun uu____428  -> match uu____428 with | Deps m -> FStar_Util.smap_keys m 
-let (deps_empty : Prims.unit -> dependence_graph) =
+let deps_keys: dependence_graph -> Prims.string Prims.list =
+  fun uu____428  -> match uu____428 with | Deps m -> FStar_Util.smap_keys m
+let deps_empty: Prims.unit -> dependence_graph =
   fun uu____444  ->
-    let uu____445 = FStar_Util.smap_create (Prims.parse_int "41")  in
+    let uu____445 = FStar_Util.smap_create (Prims.parse_int "41") in
     Deps uu____445
-  
-let (empty_deps : deps) =
+let empty_deps: deps =
   let uu____456 =
-    let uu____465 = deps_empty ()  in
-    let uu____466 = FStar_Util.smap_create (Prims.parse_int "0")  in
-    (uu____465, uu____466, [])  in
-  Mk uu____456 
-let (all_cmd_line_files : deps -> Prims.string Prims.list) =
+    let uu____465 = deps_empty () in
+    let uu____466 = FStar_Util.smap_create (Prims.parse_int "0") in
+    (uu____465, uu____466, []) in
+  Mk uu____456
+let all_cmd_line_files: deps -> Prims.string Prims.list =
   fun uu____501  ->
     match uu____501 with | Mk (uu____504,uu____505,fns) -> fns
-  
-let (module_name_of_dep : dependence -> module_name) =
+let module_name_of_dep: dependence -> module_name =
   fun uu___54_513  ->
     match uu___54_513 with
     | UseInterface m -> m
     | PreferInterface m -> m
     | UseImplementation m -> m
-  
-let (resolve_module_name :
+let resolve_module_name:
   files_for_module_name ->
-    module_name -> module_name FStar_Pervasives_Native.option)
+    module_name -> module_name FStar_Pervasives_Native.option
   =
   fun file_system_map  ->
     fun key  ->
-      let uu____527 = FStar_Util.smap_try_find file_system_map key  in
+      let uu____527 = FStar_Util.smap_try_find file_system_map key in
       match uu____527 with
       | FStar_Pervasives_Native.Some
           (FStar_Pervasives_Native.Some fn,uu____549) ->
-          let uu____564 = lowercase_module_name fn  in
+          let uu____564 = lowercase_module_name fn in
           FStar_Pervasives_Native.Some uu____564
       | FStar_Pervasives_Native.Some
           (uu____565,FStar_Pervasives_Native.Some fn) ->
-          let uu____581 = lowercase_module_name fn  in
+          let uu____581 = lowercase_module_name fn in
           FStar_Pervasives_Native.Some uu____581
       | uu____582 -> FStar_Pervasives_Native.None
-  
-let (interface_of :
+let interface_of:
   files_for_module_name ->
-    module_name -> file_name FStar_Pervasives_Native.option)
+    module_name -> file_name FStar_Pervasives_Native.option
   =
   fun file_system_map  ->
     fun key  ->
-      let uu____603 = FStar_Util.smap_try_find file_system_map key  in
+      let uu____603 = FStar_Util.smap_try_find file_system_map key in
       match uu____603 with
       | FStar_Pervasives_Native.Some
           (FStar_Pervasives_Native.Some iface,uu____625) ->
           FStar_Pervasives_Native.Some iface
       | uu____640 -> FStar_Pervasives_Native.None
-  
-let (implementation_of :
+let implementation_of:
   files_for_module_name ->
-    module_name -> file_name FStar_Pervasives_Native.option)
+    module_name -> file_name FStar_Pervasives_Native.option
   =
   fun file_system_map  ->
     fun key  ->
-      let uu____661 = FStar_Util.smap_try_find file_system_map key  in
+      let uu____661 = FStar_Util.smap_try_find file_system_map key in
       match uu____661 with
       | FStar_Pervasives_Native.Some
           (uu____682,FStar_Pervasives_Native.Some impl) ->
           FStar_Pervasives_Native.Some impl
       | uu____698 -> FStar_Pervasives_Native.None
-  
-let (has_interface : files_for_module_name -> module_name -> Prims.bool) =
+let has_interface: files_for_module_name -> module_name -> Prims.bool =
   fun file_system_map  ->
     fun key  ->
-      let uu____715 = interface_of file_system_map key  in
+      let uu____715 = interface_of file_system_map key in
       FStar_Option.isSome uu____715
-  
-let (has_implementation : files_for_module_name -> module_name -> Prims.bool)
-  =
+let has_implementation: files_for_module_name -> module_name -> Prims.bool =
   fun file_system_map  ->
     fun key  ->
-      let uu____724 = implementation_of file_system_map key  in
+      let uu____724 = implementation_of file_system_map key in
       FStar_Option.isSome uu____724
-  
-let (check_or_use_extracted_interface :
-  Prims.string Prims.list -> Prims.string -> Prims.bool) =
+let check_or_use_extracted_interface:
+  Prims.string Prims.list -> Prims.string -> Prims.bool =
   fun all_cmd_line_files1  ->
     fun fn  ->
-      let uu____737 = is_interface fn  in
+      let uu____737 = is_interface fn in
       if uu____737
       then false
       else
-        (let is_cmd_line_fn = FStar_List.contains fn all_cmd_line_files1  in
+        (let is_cmd_line_fn = FStar_List.contains fn all_cmd_line_files1 in
          (FStar_Options.check_interface ()) ||
            ((FStar_Options.use_extracted_interfaces ()) &&
               (Prims.op_Negation is_cmd_line_fn)))
-  
-let (cache_file_name :
-  Prims.string Prims.list -> Prims.string -> Prims.string) =
+let cache_file_name: Prims.string Prims.list -> Prims.string -> Prims.string
+  =
   fun all_cmd_line_files1  ->
     fun fn  ->
       let fn1 =
         let uu____751 =
-          let uu____752 = FStar_Options.dep ()  in
-          uu____752 <> FStar_Pervasives_Native.None  in
+          let uu____752 = FStar_Options.dep () in
+          uu____752 <> FStar_Pervasives_Native.None in
         if uu____751
         then fn
         else
           (let uu____758 =
-             check_or_use_extracted_interface all_cmd_line_files1 fn  in
-           if uu____758 then interface_filename fn else fn)
-         in
+             check_or_use_extracted_interface all_cmd_line_files1 fn in
+           if uu____758 then interface_filename fn else fn) in
       let uu____760 =
-        let uu____761 = FStar_Options.lax ()  in
+        let uu____761 = FStar_Options.lax () in
         if uu____761
         then Prims.strcat fn1 ".checked.lax"
-        else Prims.strcat fn1 ".checked"  in
+        else Prims.strcat fn1 ".checked" in
       FStar_Options.prepend_cache_dir uu____760
-  
-let (file_of_dep_aux :
+let file_of_dep_aux:
   Prims.bool ->
-    files_for_module_name -> file_name Prims.list -> dependence -> file_name)
+    files_for_module_name -> file_name Prims.list -> dependence -> file_name
   =
   fun use_checked_file  ->
     fun file_system_map  ->
@@ -330,33 +294,30 @@ let (file_of_dep_aux :
               (FStar_Util.for_some
                  (fun fn  ->
                     (is_implementation fn) &&
-                      (let uu____788 = lowercase_module_name fn  in
-                       key = uu____788)))
-             in
+                      (let uu____788 = lowercase_module_name fn in
+                       key = uu____788))) in
           let maybe_add_suffix f =
             if use_checked_file
             then
               let uu____793 =
                 let uu____794 =
-                  (let uu____797 = FStar_Options.dep ()  in
+                  (let uu____797 = FStar_Options.dep () in
                    uu____797 <> FStar_Pervasives_Native.None) &&
-                    (FStar_Options.use_extracted_interfaces ())
-                   in
-                if uu____794 then interface_filename f else f  in
+                    (FStar_Options.use_extracted_interfaces ()) in
+                if uu____794 then interface_filename f else f in
               cache_file_name all_cmd_line_files1 uu____793
-            else f  in
+            else f in
           match d with
           | UseInterface key ->
-              let uu____805 = interface_of file_system_map key  in
+              let uu____805 = interface_of file_system_map key in
               (match uu____805 with
                | FStar_Pervasives_Native.None  ->
                    let uu____811 =
                      let uu____816 =
                        FStar_Util.format1
                          "Expected an interface for module %s, but couldn't find one"
-                         key
-                        in
-                     (FStar_Errors.Fatal_MissingInterface, uu____816)  in
+                         key in
+                     (FStar_Errors.Fatal_MissingInterface, uu____816) in
                    FStar_Errors.raise_err uu____811
                | FStar_Pervasives_Native.Some f ->
                    if use_checked_file
@@ -367,126 +328,113 @@ let (file_of_dep_aux :
           | PreferInterface key when has_interface file_system_map key ->
               let uu____820 =
                 (cmd_line_has_impl key) &&
-                  (let uu____822 = FStar_Options.dep ()  in
-                   FStar_Option.isNone uu____822)
-                 in
+                  (let uu____822 = FStar_Options.dep () in
+                   FStar_Option.isNone uu____822) in
               if uu____820
               then
-                let uu____825 = FStar_Options.expose_interfaces ()  in
+                let uu____825 = FStar_Options.expose_interfaces () in
                 (if uu____825
                  then
                    let uu____826 =
-                     let uu____827 = implementation_of file_system_map key
-                        in
-                     FStar_Option.get uu____827  in
+                     let uu____827 = implementation_of file_system_map key in
+                     FStar_Option.get uu____827 in
                    maybe_add_suffix uu____826
                  else
                    (let uu____831 =
                       let uu____836 =
                         let uu____837 =
                           let uu____838 =
-                            implementation_of file_system_map key  in
-                          FStar_Option.get uu____838  in
+                            implementation_of file_system_map key in
+                          FStar_Option.get uu____838 in
                         let uu____841 =
-                          let uu____842 = interface_of file_system_map key
-                             in
-                          FStar_Option.get uu____842  in
+                          let uu____842 = interface_of file_system_map key in
+                          FStar_Option.get uu____842 in
                         FStar_Util.format2
                           "Invoking fstar with %s on the command line breaks the abstraction imposed by its interface %s; if you really want this behavior add the option '--expose_interfaces'"
-                          uu____837 uu____841
-                         in
+                          uu____837 uu____841 in
                       (FStar_Errors.Fatal_MissingExposeInterfacesOption,
-                        uu____836)
-                       in
+                        uu____836) in
                     FStar_Errors.raise_err uu____831))
               else
                 (let uu____846 =
-                   let uu____847 = interface_of file_system_map key  in
-                   FStar_Option.get uu____847  in
+                   let uu____847 = interface_of file_system_map key in
+                   FStar_Option.get uu____847 in
                  maybe_add_suffix uu____846)
           | PreferInterface key ->
-              let uu____851 = implementation_of file_system_map key  in
+              let uu____851 = implementation_of file_system_map key in
               (match uu____851 with
                | FStar_Pervasives_Native.None  ->
                    let uu____857 =
                      let uu____862 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
-                         key
-                        in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____862)
-                      in
+                         key in
+                     (FStar_Errors.Fatal_MissingImplementation, uu____862) in
                    FStar_Errors.raise_err uu____857
                | FStar_Pervasives_Native.Some f -> maybe_add_suffix f)
           | UseImplementation key ->
-              let uu____865 = implementation_of file_system_map key  in
+              let uu____865 = implementation_of file_system_map key in
               (match uu____865 with
                | FStar_Pervasives_Native.None  ->
                    let uu____871 =
                      let uu____876 =
                        FStar_Util.format1
                          "Expected an implementation of module %s, but couldn't find one"
-                         key
-                        in
-                     (FStar_Errors.Fatal_MissingImplementation, uu____876)
-                      in
+                         key in
+                     (FStar_Errors.Fatal_MissingImplementation, uu____876) in
                    FStar_Errors.raise_err uu____871
                | FStar_Pervasives_Native.Some f -> maybe_add_suffix f)
-  
-let (file_of_dep :
-  files_for_module_name -> file_name Prims.list -> dependence -> file_name) =
-  file_of_dep_aux false 
-let (dependences_of :
+let file_of_dep:
+  files_for_module_name -> file_name Prims.list -> dependence -> file_name =
+  file_of_dep_aux false
+let dependences_of:
   files_for_module_name ->
     dependence_graph ->
-      file_name Prims.list -> file_name -> file_name Prims.list)
+      file_name Prims.list -> file_name -> file_name Prims.list
   =
   fun file_system_map  ->
     fun deps  ->
       fun all_cmd_line_files1  ->
         fun fn  ->
-          let uu____906 = deps_try_find deps fn  in
+          let uu____906 = deps_try_find deps fn in
           match uu____906 with
           | FStar_Pervasives_Native.None  -> empty_dependences ()
           | FStar_Pervasives_Native.Some (deps1,uu____920) ->
               FStar_List.map
                 (file_of_dep file_system_map all_cmd_line_files1) deps1
-  
-let (add_dependence :
-  dependence_graph -> file_name -> file_name -> Prims.unit) =
+let add_dependence: dependence_graph -> file_name -> file_name -> Prims.unit
+  =
   fun deps  ->
     fun from  ->
       fun to_  ->
         let add_dep uu____951 to_1 =
           match uu____951 with
           | (d,color) ->
-              let uu____971 = is_interface to_1  in
+              let uu____971 = is_interface to_1 in
               if uu____971
               then
                 let uu____978 =
                   let uu____981 =
-                    let uu____982 = lowercase_module_name to_1  in
-                    PreferInterface uu____982  in
-                  uu____981 :: d  in
+                    let uu____982 = lowercase_module_name to_1 in
+                    PreferInterface uu____982 in
+                  uu____981 :: d in
                 (uu____978, color)
               else
                 (let uu____986 =
                    let uu____989 =
-                     let uu____990 = lowercase_module_name to_1  in
-                     UseImplementation uu____990  in
-                   uu____989 :: d  in
-                 (uu____986, color))
-           in
-        let uu____993 = deps_try_find deps from  in
+                     let uu____990 = lowercase_module_name to_1 in
+                     UseImplementation uu____990 in
+                   uu____989 :: d in
+                 (uu____986, color)) in
+        let uu____993 = deps_try_find deps from in
         match uu____993 with
         | FStar_Pervasives_Native.None  ->
-            let uu____1004 = add_dep ((empty_dependences ()), White) to_  in
+            let uu____1004 = add_dep ((empty_dependences ()), White) to_ in
             deps_add_dep deps from uu____1004
         | FStar_Pervasives_Native.Some key_deps ->
-            let uu____1020 = add_dep key_deps to_  in
+            let uu____1020 = add_dep key_deps to_ in
             deps_add_dep deps from uu____1020
-  
-let (print_graph : dependence_graph -> Prims.unit) =
+let print_graph: dependence_graph -> Prims.unit =
   fun graph  ->
     FStar_Util.print_endline
       "A DOT-format graph has been dumped in the current directory as dep.graph";
@@ -499,71 +447,65 @@ let (print_graph : dependence_graph -> Prims.unit) =
          let uu____1033 =
            let uu____1034 =
              let uu____1037 =
-               let uu____1040 = deps_keys graph  in
-               FStar_List.unique uu____1040  in
+               let uu____1040 = deps_keys graph in
+               FStar_List.unique uu____1040 in
              FStar_List.collect
                (fun k  ->
                   let deps =
                     let uu____1049 =
-                      let uu____1054 = deps_try_find graph k  in
-                      FStar_Util.must uu____1054  in
-                    FStar_Pervasives_Native.fst uu____1049  in
-                  let r s = FStar_Util.replace_char s 46 95  in
+                      let uu____1054 = deps_try_find graph k in
+                      FStar_Util.must uu____1054 in
+                    FStar_Pervasives_Native.fst uu____1049 in
+                  let r s = FStar_Util.replace_char s 46 95 in
                   let print7 dep1 =
                     FStar_Util.format2 " %s -> %s" (r k)
-                      (r (module_name_of_dep dep1))
-                     in
-                  FStar_List.map print7 deps) uu____1037
-              in
-           FStar_String.concat "\n" uu____1034  in
-         Prims.strcat uu____1033 "\n}\n"  in
-       Prims.strcat "digraph {\n" uu____1032  in
+                      (r (module_name_of_dep dep1)) in
+                  FStar_List.map print7 deps) uu____1037 in
+           FStar_String.concat "\n" uu____1034 in
+         Prims.strcat uu____1033 "\n}\n" in
+       Prims.strcat "digraph {\n" uu____1032 in
      FStar_Util.write_file "dep.graph" uu____1031)
-  
-let (build_inclusion_candidates_list :
+let build_inclusion_candidates_list:
   Prims.unit ->
-    (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list)
+    (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun uu____1083  ->
-    let include_directories = FStar_Options.include_path ()  in
+    let include_directories = FStar_Options.include_path () in
     let include_directories1 =
-      FStar_List.map FStar_Util.normalize_file_path include_directories  in
-    let include_directories2 = FStar_List.unique include_directories1  in
+      FStar_List.map FStar_Util.normalize_file_path include_directories in
+    let include_directories2 = FStar_List.unique include_directories1 in
     let cwd =
-      let uu____1100 = FStar_Util.getcwd ()  in
-      FStar_Util.normalize_file_path uu____1100  in
+      let uu____1100 = FStar_Util.getcwd () in
+      FStar_Util.normalize_file_path uu____1100 in
     FStar_List.concatMap
       (fun d  ->
          if FStar_Util.file_exists d
          then
-           let files = FStar_Util.readdir d  in
+           let files = FStar_Util.readdir d in
            FStar_List.filter_map
              (fun f  ->
-                let f1 = FStar_Util.basename f  in
-                let uu____1126 = check_and_strip_suffix f1  in
+                let f1 = FStar_Util.basename f in
+                let uu____1126 = check_and_strip_suffix f1 in
                 FStar_All.pipe_right uu____1126
                   (FStar_Util.map_option
                      (fun longname  ->
                         let full_path =
-                          if d = cwd then f1 else FStar_Util.join_paths d f1
-                           in
+                          if d = cwd then f1 else FStar_Util.join_paths d f1 in
                         (longname, full_path)))) files
          else
            (let uu____1147 =
               let uu____1152 =
-                FStar_Util.format1 "not a valid include directory: %s\n" d
-                 in
-              (FStar_Errors.Fatal_NotValidIncludeDirectory, uu____1152)  in
+                FStar_Util.format1 "not a valid include directory: %s\n" d in
+              (FStar_Errors.Fatal_NotValidIncludeDirectory, uu____1152) in
             FStar_Errors.raise_err uu____1147)) include_directories2
-  
-let (build_map : Prims.string Prims.list -> files_for_module_name) =
+let build_map: Prims.string Prims.list -> files_for_module_name =
   fun filenames  ->
-    let map1 = FStar_Util.smap_create (Prims.parse_int "41")  in
+    let map1 = FStar_Util.smap_create (Prims.parse_int "41") in
     let add_entry key full_path =
-      let uu____1192 = FStar_Util.smap_try_find map1 key  in
+      let uu____1192 = FStar_Util.smap_try_find map1 key in
       match uu____1192 with
       | FStar_Pervasives_Native.Some (intf,impl) ->
-          let uu____1229 = is_interface full_path  in
+          let uu____1229 = is_interface full_path in
           if uu____1229
           then
             FStar_Util.smap_add map1 key
@@ -572,7 +514,7 @@ let (build_map : Prims.string Prims.list -> files_for_module_name) =
             FStar_Util.smap_add map1 key
               (intf, (FStar_Pervasives_Native.Some full_path))
       | FStar_Pervasives_Native.None  ->
-          let uu____1263 = is_interface full_path  in
+          let uu____1263 = is_interface full_path in
           if uu____1263
           then
             FStar_Util.smap_add map1 key
@@ -581,9 +523,8 @@ let (build_map : Prims.string Prims.list -> files_for_module_name) =
           else
             FStar_Util.smap_add map1 key
               (FStar_Pervasives_Native.None,
-                (FStar_Pervasives_Native.Some full_path))
-       in
-    (let uu____1290 = build_inclusion_candidates_list ()  in
+                (FStar_Pervasives_Native.Some full_path)) in
+    (let uu____1290 = build_inclusion_candidates_list () in
      FStar_List.iter
        (fun uu____1304  ->
           match uu____1304 with
@@ -592,152 +533,139 @@ let (build_map : Prims.string Prims.list -> files_for_module_name) =
        uu____1290);
     FStar_List.iter
       (fun f  ->
-         let uu____1315 = lowercase_module_name f  in add_entry uu____1315 f)
+         let uu____1315 = lowercase_module_name f in add_entry uu____1315 f)
       filenames;
     map1
-  
-let (enter_namespace :
+let enter_namespace:
   files_for_module_name ->
-    files_for_module_name -> Prims.string -> Prims.bool)
+    files_for_module_name -> Prims.string -> Prims.bool
   =
   fun original_map  ->
     fun working_map  ->
       fun prefix1  ->
-        let found = FStar_Util.mk_ref false  in
-        let prefix2 = Prims.strcat prefix1 "."  in
+        let found = FStar_Util.mk_ref false in
+        let prefix2 = Prims.strcat prefix1 "." in
         (let uu____1330 =
-           let uu____1333 = FStar_Util.smap_keys original_map  in
-           FStar_List.unique uu____1333  in
+           let uu____1333 = FStar_Util.smap_keys original_map in
+           FStar_List.unique uu____1333 in
          FStar_List.iter
            (fun k  ->
               if FStar_Util.starts_with k prefix2
               then
                 let suffix =
                   FStar_String.substring k (FStar_String.length prefix2)
-                    ((FStar_String.length k) - (FStar_String.length prefix2))
-                   in
+                    ((FStar_String.length k) - (FStar_String.length prefix2)) in
                 let filename =
-                  let uu____1359 = FStar_Util.smap_try_find original_map k
-                     in
-                  FStar_Util.must uu____1359  in
+                  let uu____1359 = FStar_Util.smap_try_find original_map k in
+                  FStar_Util.must uu____1359 in
                 (FStar_Util.smap_add working_map suffix filename;
                  FStar_ST.op_Colon_Equals found true)
               else ()) uu____1330);
         FStar_ST.op_Bang found
-  
-let (string_of_lid : FStar_Ident.lident -> Prims.bool -> Prims.string) =
+let string_of_lid: FStar_Ident.lident -> Prims.bool -> Prims.string =
   fun l  ->
     fun last1  ->
       let suffix =
-        if last1 then [(l.FStar_Ident.ident).FStar_Ident.idText] else []  in
+        if last1 then [(l.FStar_Ident.ident).FStar_Ident.idText] else [] in
       let names =
         let uu____1493 =
-          FStar_List.map (fun x  -> x.FStar_Ident.idText) l.FStar_Ident.ns
-           in
-        FStar_List.append uu____1493 suffix  in
+          FStar_List.map (fun x  -> x.FStar_Ident.idText) l.FStar_Ident.ns in
+        FStar_List.append uu____1493 suffix in
       FStar_String.concat "." names
-  
-let (lowercase_join_longident :
-  FStar_Ident.lident -> Prims.bool -> Prims.string) =
+let lowercase_join_longident:
+  FStar_Ident.lident -> Prims.bool -> Prims.string =
   fun l  ->
     fun last1  ->
-      let uu____1504 = string_of_lid l last1  in
+      let uu____1504 = string_of_lid l last1 in
       FStar_String.lowercase uu____1504
-  
-let (namespace_of_lid : FStar_Ident.lident -> Prims.string) =
+let namespace_of_lid: FStar_Ident.lident -> Prims.string =
   fun l  ->
-    let uu____1508 = FStar_List.map FStar_Ident.text_of_id l.FStar_Ident.ns
-       in
+    let uu____1508 = FStar_List.map FStar_Ident.text_of_id l.FStar_Ident.ns in
     FStar_String.concat "_" uu____1508
-  
-let (check_module_declaration_against_filename :
-  FStar_Ident.lident -> Prims.string -> Prims.unit) =
+let check_module_declaration_against_filename:
+  FStar_Ident.lident -> Prims.string -> Prims.unit =
   fun lid  ->
     fun filename  ->
-      let k' = lowercase_join_longident lid true  in
+      let k' = lowercase_join_longident lid true in
       let uu____1518 =
         let uu____1519 =
           let uu____1520 =
             let uu____1521 =
-              let uu____1524 = FStar_Util.basename filename  in
-              check_and_strip_suffix uu____1524  in
-            FStar_Util.must uu____1521  in
-          FStar_String.lowercase uu____1520  in
-        uu____1519 <> k'  in
+              let uu____1524 = FStar_Util.basename filename in
+              check_and_strip_suffix uu____1524 in
+            FStar_Util.must uu____1521 in
+          FStar_String.lowercase uu____1520 in
+        uu____1519 <> k' in
       if uu____1518
       then
         let uu____1525 =
           let uu____1530 =
-            let uu____1531 = string_of_lid lid true  in
+            let uu____1531 = string_of_lid lid true in
             FStar_Util.format2
               "The module declaration \"module %s\" found in file %s does not match its filename. Dependencies will be incorrect and the module will not be verified.\n"
-              uu____1531 filename
-             in
-          (FStar_Errors.Error_ModuleFileNameMismatch, uu____1530)  in
+              uu____1531 filename in
+          (FStar_Errors.Error_ModuleFileNameMismatch, uu____1530) in
         FStar_Errors.log_issue (FStar_Ident.range_of_lid lid) uu____1525
       else ()
-  
-exception Exit 
-let (uu___is_Exit : Prims.exn -> Prims.bool) =
+exception Exit
+let uu___is_Exit: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | Exit  -> true | uu____1536 -> false
-  
-let (hard_coded_dependencies :
+let hard_coded_dependencies:
   Prims.string ->
-    (FStar_Ident.lident,open_kind) FStar_Pervasives_Native.tuple2 Prims.list)
+    (FStar_Ident.lident,open_kind) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun full_filename  ->
-    let filename = FStar_Util.basename full_filename  in
+    let filename = FStar_Util.basename full_filename in
     let corelibs =
-      let uu____1550 = FStar_Options.prims_basename ()  in
+      let uu____1550 = FStar_Options.prims_basename () in
       let uu____1551 =
-        let uu____1554 = FStar_Options.pervasives_basename ()  in
+        let uu____1554 = FStar_Options.pervasives_basename () in
         let uu____1555 =
-          let uu____1558 = FStar_Options.pervasives_native_basename ()  in
-          [uu____1558]  in
-        uu____1554 :: uu____1555  in
-      uu____1550 :: uu____1551  in
+          let uu____1558 = FStar_Options.pervasives_native_basename () in
+          [uu____1558] in
+        uu____1554 :: uu____1555 in
+      uu____1550 :: uu____1551 in
     if FStar_List.mem filename corelibs
     then []
     else
       (let implicit_deps =
          [(FStar_Parser_Const.fstar_ns_lid, Open_namespace);
          (FStar_Parser_Const.prims_lid, Open_module);
-         (FStar_Parser_Const.pervasives_lid, Open_module)]  in
+         (FStar_Parser_Const.pervasives_lid, Open_module)] in
        let uu____1593 =
-         let uu____1596 = lowercase_module_name full_filename  in
-         namespace_of_module uu____1596  in
+         let uu____1596 = lowercase_module_name full_filename in
+         namespace_of_module uu____1596 in
        match uu____1593 with
        | FStar_Pervasives_Native.None  -> implicit_deps
        | FStar_Pervasives_Native.Some ns ->
            FStar_List.append implicit_deps [(ns, Open_namespace)])
-  
-let (collect_one :
+let collect_one:
   files_for_module_name ->
     Prims.string ->
       (dependence Prims.list,dependence Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun original_map  ->
     fun filename  ->
-      let deps = FStar_Util.mk_ref []  in
-      let mo_roots = FStar_Util.mk_ref []  in
+      let deps = FStar_Util.mk_ref [] in
+      let mo_roots = FStar_Util.mk_ref [] in
       let add_dep deps1 d =
         let uu____1785 =
           let uu____1786 =
-            let uu____1787 = FStar_ST.op_Bang deps1  in
-            FStar_List.existsML (fun d'  -> d' = d) uu____1787  in
-          Prims.op_Negation uu____1786  in
+            let uu____1787 = FStar_ST.op_Bang deps1 in
+            FStar_List.existsML (fun d'  -> d' = d) uu____1787 in
+          Prims.op_Negation uu____1786 in
         if uu____1785
         then
           let uu____1857 =
-            let uu____1860 = FStar_ST.op_Bang deps1  in d :: uu____1860  in
+            let uu____1860 = FStar_ST.op_Bang deps1 in d :: uu____1860 in
           FStar_ST.op_Colon_Equals deps1 uu____1857
-        else ()  in
-      let working_map = FStar_Util.smap_copy original_map  in
+        else () in
+      let working_map = FStar_Util.smap_copy original_map in
       let add_dependence_edge original_or_working_map lid =
-        let key = lowercase_join_longident lid true  in
-        let uu____2021 = resolve_module_name original_or_working_map key  in
+        let key = lowercase_join_longident lid true in
+        let uu____2021 = resolve_module_name original_or_working_map key in
         match uu____2021 with
         | FStar_Pervasives_Native.Some module_name ->
             (add_dep deps (PreferInterface module_name);
@@ -745,20 +673,18 @@ let (collect_one :
                 ((has_interface original_or_working_map module_name) &&
                    (has_implementation original_or_working_map module_name))
                   &&
-                  (let uu____2062 = FStar_Options.dep ()  in
-                   uu____2062 = (FStar_Pervasives_Native.Some "full"))
-                 in
+                  (let uu____2062 = FStar_Options.dep () in
+                   uu____2062 = (FStar_Pervasives_Native.Some "full")) in
               if uu____2060
               then add_dep mo_roots (UseImplementation module_name)
               else ());
              true)
-        | uu____2101 -> false  in
+        | uu____2101 -> false in
       let record_open_module let_open lid =
         let uu____2111 =
           (let_open && (add_dependence_edge working_map lid)) ||
             ((Prims.op_Negation let_open) &&
-               (add_dependence_edge original_map lid))
-           in
+               (add_dependence_edge original_map lid)) in
         if uu____2111
         then true
         else
@@ -766,53 +692,47 @@ let (collect_one :
            then
              (let uu____2114 =
                 let uu____2119 =
-                  let uu____2120 = string_of_lid lid true  in
-                  FStar_Util.format1 "Module not found: %s" uu____2120  in
+                  let uu____2120 = string_of_lid lid true in
+                  FStar_Util.format1 "Module not found: %s" uu____2120 in
                 (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                  uu____2119)
-                 in
+                  uu____2119) in
               FStar_Errors.log_issue (FStar_Ident.range_of_lid lid)
                 uu____2114)
            else ();
-           false)
-         in
+           false) in
       let record_open_namespace lid =
-        let key = lowercase_join_longident lid true  in
-        let r = enter_namespace original_map working_map key  in
+        let key = lowercase_join_longident lid true in
+        let r = enter_namespace original_map working_map key in
         if Prims.op_Negation r
         then
           let uu____2128 =
             let uu____2133 =
-              let uu____2134 = string_of_lid lid true  in
+              let uu____2134 = string_of_lid lid true in
               FStar_Util.format1
                 "No modules in namespace %s and no file with that name either"
-                uu____2134
-               in
-            (FStar_Errors.Warning_ModuleOrFileNotFoundWarning, uu____2133)
-             in
+                uu____2134 in
+            (FStar_Errors.Warning_ModuleOrFileNotFoundWarning, uu____2133) in
           FStar_Errors.log_issue (FStar_Ident.range_of_lid lid) uu____2128
-        else ()  in
+        else () in
       let record_open let_open lid =
-        let uu____2143 = record_open_module let_open lid  in
+        let uu____2143 = record_open_module let_open lid in
         if uu____2143
         then ()
         else
           if Prims.op_Negation let_open
           then record_open_namespace lid
-          else ()
-         in
+          else () in
       let record_open_module_or_namespace uu____2153 =
         match uu____2153 with
         | (lid,kind) ->
             (match kind with
              | Open_namespace  -> record_open_namespace lid
              | Open_module  ->
-                 let uu____2160 = record_open_module false lid  in ())
-         in
+                 let uu____2160 = record_open_module false lid in ()) in
       let record_module_alias ident lid =
-        let key = FStar_String.lowercase (FStar_Ident.text_of_id ident)  in
-        let alias = lowercase_join_longident lid true  in
-        let uu____2170 = FStar_Util.smap_try_find original_map alias  in
+        let key = FStar_String.lowercase (FStar_Ident.text_of_id ident) in
+        let alias = lowercase_join_longident lid true in
+        let uu____2170 = FStar_Util.smap_try_find original_map alias in
         match uu____2170 with
         | FStar_Pervasives_Native.Some deps_of_aliased_module ->
             (FStar_Util.smap_add working_map key deps_of_aliased_module; true)
@@ -820,43 +740,36 @@ let (collect_one :
             ((let uu____2224 =
                 let uu____2229 =
                   FStar_Util.format1 "module not found in search path: %s\n"
-                    alias
-                   in
+                    alias in
                 (FStar_Errors.Warning_ModuleOrFileNotFoundWarning,
-                  uu____2229)
-                 in
+                  uu____2229) in
               FStar_Errors.log_issue (FStar_Ident.range_of_lid lid)
                 uu____2224);
-             false)
-         in
+             false) in
       let record_lid lid =
         match lid.FStar_Ident.ns with
         | [] -> ()
         | uu____2234 ->
-            let module_name = FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-            let uu____2238 = add_dependence_edge working_map module_name  in
+            let module_name = FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
+            let uu____2238 = add_dependence_edge working_map module_name in
             if uu____2238
             then ()
             else
-              (let uu____2240 = FStar_Options.debug_any ()  in
+              (let uu____2240 = FStar_Options.debug_any () in
                if uu____2240
                then
                  let uu____2241 =
                    let uu____2246 =
-                     let uu____2247 = FStar_Ident.string_of_lid module_name
-                        in
+                     let uu____2247 = FStar_Ident.string_of_lid module_name in
                      FStar_Util.format1 "Unbound module reference %s"
-                       uu____2247
-                      in
-                   (FStar_Errors.Warning_UnboundModuleReference, uu____2246)
-                    in
+                       uu____2247 in
+                   (FStar_Errors.Warning_UnboundModuleReference, uu____2246) in
                  FStar_Errors.log_issue (FStar_Ident.range_of_lid lid)
                    uu____2241
-               else ())
-         in
-      let auto_open = hard_coded_dependencies filename  in
+               else ()) in
+      let auto_open = hard_coded_dependencies filename in
       FStar_List.iter record_open_module_or_namespace auto_open;
-      (let num_of_toplevelmods = FStar_Util.mk_ref (Prims.parse_int "0")  in
+      (let num_of_toplevelmods = FStar_Util.mk_ref (Prims.parse_int "0") in
        let rec collect_module uu___55_2333 =
          match uu___55_2333 with
          | FStar_Parser_AST.Module (lid,decls) ->
@@ -866,8 +779,8 @@ let (collect_one :
                   (Prims.parse_int "0")
               then
                 (let uu____2342 =
-                   let uu____2343 = namespace_of_lid lid  in
-                   enter_namespace original_map working_map uu____2343  in
+                   let uu____2343 = namespace_of_lid lid in
+                   enter_namespace original_map working_map uu____2343 in
                  ())
               else ();
               collect_decls decls)
@@ -878,29 +791,27 @@ let (collect_one :
                   (Prims.parse_int "0")
               then
                 (let uu____2354 =
-                   let uu____2355 = namespace_of_lid lid  in
-                   enter_namespace original_map working_map uu____2355  in
+                   let uu____2355 = namespace_of_lid lid in
+                   enter_namespace original_map working_map uu____2355 in
                  ())
               else ();
               collect_decls decls)
-       
        and collect_decls decls =
          FStar_List.iter
            (fun x  ->
               collect_decl x.FStar_Parser_AST.d;
               FStar_List.iter collect_term x.FStar_Parser_AST.attrs) decls
-       
        and collect_decl uu___56_2364 =
          match uu___56_2364 with
          | FStar_Parser_AST.Include lid -> record_open false lid
          | FStar_Parser_AST.Open lid -> record_open false lid
          | FStar_Parser_AST.ModuleAbbrev (ident,lid) ->
-             let uu____2369 = record_module_alias ident lid  in
+             let uu____2369 = record_module_alias ident lid in
              if uu____2369
              then
                let uu____2370 =
-                 let uu____2371 = lowercase_join_longident lid true  in
-                 PreferInterface uu____2371  in
+                 let uu____2371 = lowercase_join_longident lid true in
+                 PreferInterface uu____2371 in
                add_dep deps uu____2370
              else ()
          | FStar_Parser_AST.TopLevelLet (uu____2406,patterms) ->
@@ -932,8 +843,7 @@ let (collect_one :
              let ts1 =
                FStar_List.map
                  (fun uu____2482  -> match uu____2482 with | (x,docnik) -> x)
-                 ts
-                in
+                 ts in
              FStar_List.iter collect_tycon ts1
          | FStar_Parser_AST.Exception (uu____2495,t) ->
              FStar_Util.iter_opt t collect_term
@@ -943,22 +853,20 @@ let (collect_one :
          | FStar_Parser_AST.TopLevelModule lid ->
              (FStar_Util.incr num_of_toplevelmods;
               (let uu____2539 =
-                 let uu____2540 = FStar_ST.op_Bang num_of_toplevelmods  in
-                 uu____2540 > (Prims.parse_int "1")  in
+                 let uu____2540 = FStar_ST.op_Bang num_of_toplevelmods in
+                 uu____2540 > (Prims.parse_int "1") in
                if uu____2539
                then
                  let uu____2582 =
                    let uu____2587 =
-                     let uu____2588 = string_of_lid lid true  in
+                     let uu____2588 = string_of_lid lid true in
                      FStar_Util.format1
                        "Automatic dependency analysis demands one module per file (module %s not supported)"
-                       uu____2588
-                      in
-                   (FStar_Errors.Fatal_OneModulePerFile, uu____2587)  in
+                       uu____2588 in
+                   (FStar_Errors.Fatal_OneModulePerFile, uu____2587) in
                  FStar_Errors.raise_error uu____2582
                    (FStar_Ident.range_of_lid lid)
                else ()))
-       
        and collect_tycon uu___57_2590 =
          match uu___57_2590 with
          | FStar_Parser_AST.TyconAbstract (uu____2591,binders,k) ->
@@ -982,16 +890,13 @@ let (collect_one :
                    match uu____2738 with
                    | (uu____2751,t,uu____2753,uu____2754) ->
                        FStar_Util.iter_opt t collect_term) identterms)
-       
        and collect_effect_decl uu___58_2763 =
          match uu___58_2763 with
          | FStar_Parser_AST.DefineEffect (uu____2764,binders,t,decls) ->
              (collect_binders binders; collect_term t; collect_decls decls)
          | FStar_Parser_AST.RedefineEffect (uu____2778,binders,t) ->
              (collect_binders binders; collect_term t)
-       
        and collect_binders binders = FStar_List.iter collect_binder binders
-       
        and collect_binder uu___59_2789 =
          match uu___59_2789 with
          | { FStar_Parser_AST.b = FStar_Parser_AST.Annotated (uu____2790,t);
@@ -1007,9 +912,7 @@ let (collect_one :
              FStar_Parser_AST.blevel = uu____2802;
              FStar_Parser_AST.aqual = uu____2803;_} -> collect_term t
          | uu____2804 -> ()
-       
        and collect_term t = collect_term' t.FStar_Parser_AST.tm
-       
        and collect_constant uu___60_2806 =
          match uu___60_2806 with
          | FStar_Const.Const_int
@@ -1017,23 +920,22 @@ let (collect_one :
              let u =
                match signedness with
                | FStar_Const.Unsigned  -> "u"
-               | FStar_Const.Signed  -> ""  in
+               | FStar_Const.Signed  -> "" in
              let w =
                match width with
                | FStar_Const.Int8  -> "8"
                | FStar_Const.Int16  -> "16"
                | FStar_Const.Int32  -> "32"
-               | FStar_Const.Int64  -> "64"  in
+               | FStar_Const.Int64  -> "64" in
              let uu____2822 =
-               let uu____2823 = FStar_Util.format2 "fstar.%sint%s" u w  in
-               PreferInterface uu____2823  in
+               let uu____2823 = FStar_Util.format2 "fstar.%sint%s" u w in
+               PreferInterface uu____2823 in
              add_dep deps uu____2822
          | FStar_Const.Const_char uu____2857 ->
              add_dep deps (PreferInterface "fstar.char")
          | FStar_Const.Const_float uu____2891 ->
              add_dep deps (PreferInterface "fstar.float")
          | uu____2925 -> ()
-       
        and collect_term' uu___61_2926 =
          match uu___61_2926 with
          | FStar_Parser_AST.Wild  -> ()
@@ -1045,9 +947,8 @@ let (collect_one :
                    let uu____2936 =
                      FStar_Ident.lid_of_path
                        (FStar_Ident.path_of_text "FStar.List.Tot.Base.append")
-                       FStar_Range.dummyRange
-                      in
-                   FStar_Parser_AST.Name uu____2936  in
+                       FStar_Range.dummyRange in
+                   FStar_Parser_AST.Name uu____2936 in
                  collect_term' uu____2935)
               else ();
               FStar_List.iter collect_term ts)
@@ -1076,8 +977,7 @@ let (collect_one :
                    | (attrs_opt,(pat,t1)) ->
                        ((let uu____3069 =
                            FStar_Util.map_opt attrs_opt
-                             (FStar_List.iter collect_term)
-                            in
+                             (FStar_List.iter collect_term) in
                          ());
                         collect_pattern pat;
                         collect_term t1)) patterms;
@@ -1126,11 +1026,8 @@ let (collect_one :
              collect_term t
          | FStar_Parser_AST.Attributes cattributes ->
              FStar_List.iter collect_term cattributes
-       
        and collect_patterns ps = FStar_List.iter collect_pattern ps
-       
        and collect_pattern p = collect_pattern' p.FStar_Parser_AST.pat
-       
        and collect_pattern' uu___62_3265 =
          match uu___62_3265 with
          | FStar_Parser_AST.PatWild  -> ()
@@ -1151,93 +1048,84 @@ let (collect_one :
                lidpats
          | FStar_Parser_AST.PatAscribed (p,t) ->
              (collect_pattern p; collect_term t)
-       
        and collect_branches bs = FStar_List.iter collect_branch bs
-       
        and collect_branch uu____3345 =
          match uu____3345 with
          | (pat,t1,t2) ->
              (collect_pattern pat;
               FStar_Util.iter_opt t1 collect_term;
-              collect_term t2)
-        in
-       let uu____3363 = FStar_Parser_Driver.parse_file filename  in
+              collect_term t2) in
+       let uu____3363 = FStar_Parser_Driver.parse_file filename in
        match uu____3363 with
        | (ast,uu____3383) ->
-           let mname = lowercase_module_name filename  in
+           let mname = lowercase_module_name filename in
            ((let uu____3398 =
                ((is_interface filename) &&
                   (has_implementation original_map mname))
                  &&
-                 (let uu____3400 = FStar_Options.dep ()  in
-                  uu____3400 = (FStar_Pervasives_Native.Some "full"))
-                in
+                 (let uu____3400 = FStar_Options.dep () in
+                  uu____3400 = (FStar_Pervasives_Native.Some "full")) in
              if uu____3398
              then add_dep mo_roots (UseImplementation mname)
              else ());
             collect_module ast;
-            (let uu____3440 = FStar_ST.op_Bang deps  in
-             let uu____3488 = FStar_ST.op_Bang mo_roots  in
+            (let uu____3440 = FStar_ST.op_Bang deps in
+             let uu____3488 = FStar_ST.op_Bang mo_roots in
              (uu____3440, uu____3488))))
-  
-let (collect :
+let collect:
   Prims.string Prims.list ->
-    (Prims.string Prims.list,deps) FStar_Pervasives_Native.tuple2)
+    (Prims.string Prims.list,deps) FStar_Pervasives_Native.tuple2
   =
   fun all_cmd_line_files1  ->
     let all_cmd_line_files2 =
       FStar_All.pipe_right all_cmd_line_files1
         (FStar_List.map
            (fun fn  ->
-              let uu____3570 = FStar_Options.find_file fn  in
+              let uu____3570 = FStar_Options.find_file fn in
               match uu____3570 with
               | FStar_Pervasives_Native.None  ->
                   let uu____3573 =
                     let uu____3578 =
-                      FStar_Util.format1 "File %s could not be found\n" fn
-                       in
-                    (FStar_Errors.Fatal_ModuleOrFileNotFound, uu____3578)  in
+                      FStar_Util.format1 "File %s could not be found\n" fn in
+                    (FStar_Errors.Fatal_ModuleOrFileNotFound, uu____3578) in
                   FStar_Errors.raise_err uu____3573
-              | FStar_Pervasives_Native.Some fn1 -> fn1))
-       in
-    let dep_graph = deps_empty ()  in
-    let file_system_map = build_map all_cmd_line_files2  in
+              | FStar_Pervasives_Native.Some fn1 -> fn1)) in
+    let dep_graph = deps_empty () in
+    let file_system_map = build_map all_cmd_line_files2 in
     let rec discover_one file_name =
       let uu____3586 =
-        let uu____3587 = deps_try_find dep_graph file_name  in
-        uu____3587 = FStar_Pervasives_Native.None  in
+        let uu____3587 = deps_try_find dep_graph file_name in
+        uu____3587 = FStar_Pervasives_Native.None in
       if uu____3586
       then
-        let uu____3604 = collect_one file_system_map file_name  in
+        let uu____3604 = collect_one file_system_map file_name in
         match uu____3604 with
         | (deps,mo_roots) ->
             let deps1 =
-              let module_name = lowercase_module_name file_name  in
+              let module_name = lowercase_module_name file_name in
               let uu____3627 =
                 (is_implementation file_name) &&
-                  (has_interface file_system_map module_name)
-                 in
+                  (has_interface file_system_map module_name) in
               if uu____3627
               then FStar_List.append deps [UseInterface module_name]
-              else deps  in
+              else deps in
             ((let uu____3632 =
-                let uu____3637 = FStar_List.unique deps1  in
-                (uu____3637, White)  in
+                let uu____3637 = FStar_List.unique deps1 in
+                (uu____3637, White) in
               deps_add_dep dep_graph file_name uu____3632);
              (let uu____3642 =
                 FStar_List.map
                   (file_of_dep file_system_map all_cmd_line_files2)
-                  (FStar_List.append deps1 mo_roots)
-                 in
+                  (FStar_List.append deps1 mo_roots) in
               FStar_List.iter discover_one uu____3642))
-      else ()  in
+      else () in
     FStar_List.iter discover_one all_cmd_line_files2;
     (let topological_dependences_of all_command_line_files =
-       let topologically_sorted = FStar_Util.mk_ref []  in
+       let topologically_sorted = FStar_Util.mk_ref [] in
        let rec aux cycle filename =
          let uu____3675 =
-           let uu____3680 = deps_try_find dep_graph filename  in
-           FStar_Util.must uu____3680  in
+           let uu____3680 = deps_try_find dep_graph filename in
+           FStar_Util.must uu____3680 in
          match uu____3675 with
          | (direct_deps,color) ->
              (match color with
@@ -1245,10 +1133,8 @@ let (collect :
                   ((let uu____3694 =
                       let uu____3699 =
                         FStar_Util.format1
-                          "Recursive dependency on module %s\n" filename
-                         in
-                      (FStar_Errors.Warning_RecursiveDependency, uu____3699)
-                       in
+                          "Recursive dependency on module %s\n" filename in
+                      (FStar_Errors.Warning_RecursiveDependency, uu____3699) in
                     FStar_Errors.log_issue FStar_Range.dummyRange uu____3694);
                    FStar_Util.print1
                      "The cycle contains a subset of the modules in:\n%s \n"
@@ -1261,96 +1147,86 @@ let (collect :
                   (deps_add_dep dep_graph filename (direct_deps, Gray);
                    (let uu____3705 =
                       dependences_of file_system_map dep_graph
-                        all_command_line_files filename
-                       in
+                        all_command_line_files filename in
                     FStar_List.iter (fun k  -> aux (k :: cycle) k) uu____3705);
                    deps_add_dep dep_graph filename (direct_deps, Black);
                    (let uu____3711 =
-                      let uu____3714 = FStar_ST.op_Bang topologically_sorted
-                         in
-                      filename :: uu____3714  in
-                    FStar_ST.op_Colon_Equals topologically_sorted uu____3711)))
-          in
+                      let uu____3714 = FStar_ST.op_Bang topologically_sorted in
+                      filename :: uu____3714 in
+                    FStar_ST.op_Colon_Equals topologically_sorted uu____3711))) in
        FStar_List.iter (aux []) all_command_line_files;
-       FStar_ST.op_Bang topologically_sorted  in
+       FStar_ST.op_Bang topologically_sorted in
      FStar_All.pipe_right all_cmd_line_files2
        (FStar_List.iter
           (fun f  ->
-             let m = lowercase_module_name f  in
+             let m = lowercase_module_name f in
              FStar_Options.add_verify_module m));
-     (let uu____3860 = topological_dependences_of all_cmd_line_files2  in
+     (let uu____3860 = topological_dependences_of all_cmd_line_files2 in
       (uu____3860, (Mk (dep_graph, file_system_map, all_cmd_line_files2)))))
-  
-let (deps_of : deps -> Prims.string -> Prims.string Prims.list) =
+let deps_of: deps -> Prims.string -> Prims.string Prims.list =
   fun uu____3873  ->
     fun f  ->
       match uu____3873 with
       | Mk (deps,file_system_map,all_cmd_line_files1) ->
           dependences_of file_system_map deps all_cmd_line_files1 f
-  
-let (hash_dependences :
+let hash_dependences:
   deps ->
     Prims.string ->
       (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
   fun uu____3898  ->
     fun fn  ->
       match uu____3898 with
       | Mk (deps,file_system_map,all_cmd_line_files1) ->
           let fn1 =
-            let uu____3916 = FStar_Options.find_file fn  in
+            let uu____3916 = FStar_Options.find_file fn in
             match uu____3916 with
             | FStar_Pervasives_Native.Some fn1 -> fn1
-            | uu____3920 -> fn  in
-          let cache_file = cache_file_name all_cmd_line_files1 fn1  in
+            | uu____3920 -> fn in
+          let cache_file = cache_file_name all_cmd_line_files1 fn1 in
           let digest_of_file1 fn2 =
-            (let uu____3929 = FStar_Options.debug_any ()  in
+            (let uu____3929 = FStar_Options.debug_any () in
              if uu____3929
              then
                FStar_Util.print2 "%s: contains digest of %s\n" cache_file fn2
              else ());
-            FStar_Util.digest_of_file fn2  in
-          let module_name = lowercase_module_name fn1  in
-          let source_hash = digest_of_file1 fn1  in
+            FStar_Util.digest_of_file fn2 in
+          let module_name = lowercase_module_name fn1 in
+          let source_hash = digest_of_file1 fn1 in
           let interface_hash =
             let uu____3940 =
               (is_implementation fn1) &&
-                (has_interface file_system_map module_name)
-               in
+                (has_interface file_system_map module_name) in
             if uu____3940
             then
               let uu____3947 =
                 let uu____3952 =
                   let uu____3953 =
-                    let uu____3954 = interface_of file_system_map module_name
-                       in
-                    FStar_Option.get uu____3954  in
-                  digest_of_file1 uu____3953  in
-                ("interface", uu____3952)  in
+                    let uu____3954 = interface_of file_system_map module_name in
+                    FStar_Option.get uu____3954 in
+                  digest_of_file1 uu____3953 in
+                ("interface", uu____3952) in
               [uu____3947]
-            else []  in
+            else [] in
           let binary_deps =
             let uu____3973 =
-              dependences_of file_system_map deps all_cmd_line_files1 fn1  in
+              dependences_of file_system_map deps all_cmd_line_files1 fn1 in
             FStar_All.pipe_right uu____3973
               (FStar_List.filter
                  (fun fn2  ->
                     let uu____3983 =
                       (is_interface fn2) &&
-                        (let uu____3985 = lowercase_module_name fn2  in
-                         uu____3985 = module_name)
-                       in
-                    Prims.op_Negation uu____3983))
-             in
+                        (let uu____3985 = lowercase_module_name fn2 in
+                         uu____3985 = module_name) in
+                    Prims.op_Negation uu____3983)) in
           let binary_deps1 =
             FStar_List.sortWith
               (fun fn11  ->
                  fun fn2  ->
-                   let uu____3995 = lowercase_module_name fn11  in
-                   let uu____3996 = lowercase_module_name fn2  in
-                   FStar_String.compare uu____3995 uu____3996) binary_deps
-             in
+                   let uu____3995 = lowercase_module_name fn11 in
+                   let uu____3996 = lowercase_module_name fn2 in
+                   FStar_String.compare uu____3995 uu____3996) binary_deps in
           let rec hash_deps out uu___63_4019 =
             match uu___63_4019 with
             | [] ->
@@ -1358,30 +1234,28 @@ let (hash_dependences :
                   (FStar_List.append (("source", source_hash) ::
                      interface_hash) out)
             | fn2::deps1 ->
-                let cache_fn = cache_file_name all_cmd_line_files1 fn2  in
+                let cache_fn = cache_file_name all_cmd_line_files1 fn2 in
                 if FStar_Util.file_exists cache_fn
                 then
                   let uu____4063 =
                     let uu____4070 =
-                      let uu____4075 = lowercase_module_name fn2  in
-                      let uu____4076 = digest_of_file1 cache_fn  in
-                      (uu____4075, uu____4076)  in
-                    uu____4070 :: out  in
+                      let uu____4075 = lowercase_module_name fn2 in
+                      let uu____4076 = digest_of_file1 cache_fn in
+                      (uu____4075, uu____4076) in
+                    uu____4070 :: out in
                   hash_deps uu____4063 deps1
                 else
-                  ((let uu____4083 = FStar_Options.debug_any ()  in
+                  ((let uu____4083 = FStar_Options.debug_any () in
                     if uu____4083
                     then
                       FStar_Util.print2 "%s: missed digest of file %s\n"
                         cache_file cache_fn
                     else ());
-                   FStar_Pervasives_Native.None)
-             in
+                   FStar_Pervasives_Native.None) in
           hash_deps [] binary_deps1
-  
-let (print_digest :
+let print_digest:
   (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list ->
-    Prims.string)
+    Prims.string
   =
   fun dig  ->
     let uu____4110 =
@@ -1390,74 +1264,63 @@ let (print_digest :
            (fun uu____4129  ->
               match uu____4129 with
               | (m,d) ->
-                  let uu____4136 = FStar_Util.base64_encode d  in
-                  FStar_Util.format2 "%s:%s" m uu____4136))
-       in
+                  let uu____4136 = FStar_Util.base64_encode d in
+                  FStar_Util.format2 "%s:%s" m uu____4136)) in
     FStar_All.pipe_right uu____4110 (FStar_String.concat "\n")
-  
-let (print_make : deps -> Prims.unit) =
+let print_make: deps -> Prims.unit =
   fun uu____4141  ->
     match uu____4141 with
     | Mk (deps,file_system_map,all_cmd_line_files1) ->
-        let keys = deps_keys deps  in
+        let keys = deps_keys deps in
         FStar_All.pipe_right keys
           (FStar_List.iter
              (fun f  ->
                 let uu____4161 =
-                  let uu____4166 = deps_try_find deps f  in
-                  FStar_All.pipe_right uu____4166 FStar_Option.get  in
+                  let uu____4166 = deps_try_find deps f in
+                  FStar_All.pipe_right uu____4166 FStar_Option.get in
                 match uu____4161 with
                 | (f_deps,uu____4188) ->
                     let files =
                       FStar_List.map
                         (file_of_dep file_system_map all_cmd_line_files1)
-                        f_deps
-                       in
+                        f_deps in
                     let files1 =
                       FStar_List.map
-                        (fun s  -> FStar_Util.replace_chars s 32 "\\ ") files
-                       in
+                        (fun s  -> FStar_Util.replace_chars s 32 "\\ ") files in
                     FStar_Util.print2 "%s: %s\n\n" f
                       (FStar_String.concat " " files1)))
-  
-let (print_full : deps -> Prims.unit) =
+let print_full: deps -> Prims.unit =
   fun uu____4200  ->
     match uu____4200 with
     | Mk (deps,file_system_map,all_cmd_line_files1) ->
         let sort_output_files orig_output_file_map =
-          let order = FStar_Util.mk_ref []  in
+          let order = FStar_Util.mk_ref [] in
           let remaining_output_files =
-            FStar_Util.smap_copy orig_output_file_map  in
+            FStar_Util.smap_copy orig_output_file_map in
           let visited_other_modules =
-            FStar_Util.smap_create (Prims.parse_int "41")  in
+            FStar_Util.smap_create (Prims.parse_int "41") in
           let should_visit lc_module_name =
             (let uu____4237 =
-               FStar_Util.smap_try_find remaining_output_files lc_module_name
-                in
+               FStar_Util.smap_try_find remaining_output_files lc_module_name in
              FStar_Option.isSome uu____4237) ||
               (let uu____4241 =
                  FStar_Util.smap_try_find visited_other_modules
-                   lc_module_name
-                  in
-               FStar_Option.isNone uu____4241)
-             in
+                   lc_module_name in
+               FStar_Option.isNone uu____4241) in
           let mark_visiting lc_module_name =
             let ml_file_opt =
-              FStar_Util.smap_try_find remaining_output_files lc_module_name
-               in
+              FStar_Util.smap_try_find remaining_output_files lc_module_name in
             FStar_Util.smap_remove remaining_output_files lc_module_name;
             FStar_Util.smap_add visited_other_modules lc_module_name true;
-            ml_file_opt  in
+            ml_file_opt in
           let emit_output_file_opt ml_file_opt =
             match ml_file_opt with
             | FStar_Pervasives_Native.None  -> ()
             | FStar_Pervasives_Native.Some ml_file ->
                 let uu____4264 =
-                  let uu____4267 = FStar_ST.op_Bang order  in ml_file ::
-                    uu____4267
-                   in
-                FStar_ST.op_Colon_Equals order uu____4264
-             in
+                  let uu____4267 = FStar_ST.op_Bang order in ml_file ::
+                    uu____4267 in
+                FStar_ST.op_Colon_Equals order uu____4264 in
           let rec aux uu___64_4365 =
             match uu___64_4365 with
             | [] -> ()
@@ -1466,14 +1329,13 @@ let (print_full : deps -> Prims.unit) =
                   match file_opt with
                   | FStar_Pervasives_Native.None  -> ()
                   | FStar_Pervasives_Native.Some file_name ->
-                      let uu____4381 = deps_try_find deps file_name  in
+                      let uu____4381 = deps_try_find deps file_name in
                       (match uu____4381 with
                        | FStar_Pervasives_Native.None  ->
                            let uu____4392 =
                              FStar_Util.format2
                                "Impossible: module %s: %s not found"
-                               lc_module_name file_name
-                              in
+                               lc_module_name file_name in
                            failwith uu____4392
                        | FStar_Pervasives_Native.Some
                            (immediate_deps,uu____4394) ->
@@ -1481,84 +1343,77 @@ let (print_full : deps -> Prims.unit) =
                              FStar_List.map
                                (fun x  ->
                                   FStar_String.lowercase
-                                    (module_name_of_dep x)) immediate_deps
-                              in
-                           aux immediate_deps1)
-                   in
-                ((let uu____4405 = should_visit lc_module_name  in
+                                    (module_name_of_dep x)) immediate_deps in
+                           aux immediate_deps1) in
+                ((let uu____4405 = should_visit lc_module_name in
                   if uu____4405
                   then
-                    let ml_file_opt = mark_visiting lc_module_name  in
+                    let ml_file_opt = mark_visiting lc_module_name in
                     ((let uu____4410 =
-                        implementation_of file_system_map lc_module_name  in
+                        implementation_of file_system_map lc_module_name in
                       visit_file uu____4410);
                      (let uu____4414 =
-                        interface_of file_system_map lc_module_name  in
+                        interface_of file_system_map lc_module_name in
                       visit_file uu____4414);
                      emit_output_file_opt ml_file_opt)
                   else ());
-                 aux modules_to_extract)
-             in
+                 aux modules_to_extract) in
           let all_extracted_modules =
-            FStar_Util.smap_keys orig_output_file_map  in
+            FStar_Util.smap_keys orig_output_file_map in
           aux all_extracted_modules;
-          (let uu____4422 = FStar_ST.op_Bang order  in
-           FStar_List.rev uu____4422)
-           in
-        let keys = deps_keys deps  in
+          (let uu____4422 = FStar_ST.op_Bang order in
+           FStar_List.rev uu____4422) in
+        let keys = deps_keys deps in
         let output_file ext fst_file =
           let ml_base_name =
             let uu____4481 =
               let uu____4482 =
-                let uu____4485 = FStar_Util.basename fst_file  in
-                check_and_strip_suffix uu____4485  in
-              FStar_Option.get uu____4482  in
-            FStar_Util.replace_chars uu____4481 46 "_"  in
-          FStar_Options.prepend_output_dir (Prims.strcat ml_base_name ext)
-           in
-        let norm_path s = FStar_Util.replace_chars s 92 "/"  in
+                let uu____4485 = FStar_Util.basename fst_file in
+                check_and_strip_suffix uu____4485 in
+              FStar_Option.get uu____4482 in
+            FStar_Util.replace_chars uu____4481 46 "_" in
+          FStar_Options.prepend_output_dir (Prims.strcat ml_base_name ext) in
+        let norm_path s = FStar_Util.replace_chars s 92 "/" in
         let output_ml_file f =
-          let uu____4496 = output_file ".ml" f  in norm_path uu____4496  in
+          let uu____4496 = output_file ".ml" f in norm_path uu____4496 in
         let output_krml_file f =
-          let uu____4501 = output_file ".krml" f  in norm_path uu____4501  in
+          let uu____4501 = output_file ".krml" f in norm_path uu____4501 in
         let output_cmx_file f =
-          let uu____4506 = output_file ".cmx" f  in norm_path uu____4506  in
+          let uu____4506 = output_file ".cmx" f in norm_path uu____4506 in
         let cache_file f =
-          let uu____4511 = cache_file_name all_cmd_line_files1 f  in
-          norm_path uu____4511  in
+          let uu____4511 = cache_file_name all_cmd_line_files1 f in
+          norm_path uu____4511 in
         (FStar_All.pipe_right keys
            (FStar_List.iter
               (fun f  ->
                  let uu____4534 =
-                   let uu____4539 = deps_try_find deps f  in
-                   FStar_All.pipe_right uu____4539 FStar_Option.get  in
+                   let uu____4539 = deps_try_find deps f in
+                   FStar_All.pipe_right uu____4539 FStar_Option.get in
                  match uu____4534 with
                  | (f_deps,uu____4561) ->
-                     let norm_f = norm_path f  in
+                     let norm_f = norm_path f in
                      let files =
                        FStar_List.map
                          (file_of_dep_aux true file_system_map
-                            all_cmd_line_files1) f_deps
-                        in
-                     let files1 = FStar_List.map norm_path files  in
+                            all_cmd_line_files1) f_deps in
+                     let files1 = FStar_List.map norm_path files in
                      let files2 =
                        FStar_List.map
                          (fun s  -> FStar_Util.replace_chars s 32 "\\ ")
-                         files1
-                        in
-                     let files3 = FStar_String.concat "\\\n\t" files2  in
-                     ((let uu____4577 = is_interface f  in
+                         files1 in
+                     let files3 = FStar_String.concat "\\\n\t" files2 in
+                     ((let uu____4577 = is_interface f in
                        if uu____4577
                        then
                          let uu____4578 =
                            let uu____4579 =
-                             FStar_Options.prepend_cache_dir norm_f  in
-                           norm_path uu____4579  in
+                             FStar_Options.prepend_cache_dir norm_f in
+                           norm_path uu____4579 in
                          FStar_Util.print3
                            "%s.source: %s \\\n\t%s\n\ttouch $@\n\n"
                            uu____4578 norm_f files3
                        else ());
-                      (let uu____4582 = cache_file f  in
+                      (let uu____4582 = cache_file f in
                        FStar_Util.print3 "%s: %s \\\n\t%s\n\n" uu____4582
                          norm_f files3);
                       (let uu____4584 =
@@ -1566,23 +1421,22 @@ let (print_full : deps -> Prims.unit) =
                             (is_implementation f))
                            &&
                            (let uu____4586 =
-                              let uu____4587 = lowercase_module_name f  in
-                              has_interface file_system_map uu____4587  in
-                            Prims.op_Negation uu____4586)
-                          in
+                              let uu____4587 = lowercase_module_name f in
+                              has_interface file_system_map uu____4587 in
+                            Prims.op_Negation uu____4586) in
                        if uu____4584
                        then
                          let uu____4588 =
-                           let uu____4589 = interface_filename f  in
-                           cache_file uu____4589  in
+                           let uu____4589 = interface_filename f in
+                           cache_file uu____4589 in
                          FStar_Util.print3 "%s: %s \\\n\t%s\n\n" uu____4588
                            norm_f files3
                        else ());
-                      (let uu____4591 = is_implementation f  in
+                      (let uu____4591 = is_implementation f in
                        if uu____4591
                        then
-                         ((let uu____4593 = output_ml_file f  in
-                           let uu____4594 = cache_file f  in
+                         ((let uu____4593 = output_ml_file f in
+                           let uu____4594 = cache_file f in
                            FStar_Util.print2 "%s: %s\n\n" uu____4593
                              uu____4594);
                           (let cmx_files =
@@ -1590,121 +1444,104 @@ let (print_full : deps -> Prims.unit) =
                                FStar_All.pipe_right f_deps
                                  (FStar_List.map
                                     (file_of_dep_aux false file_system_map
-                                       all_cmd_line_files1))
-                                in
+                                       all_cmd_line_files1)) in
                              let extracted_fst_files =
                                FStar_All.pipe_right fst_files
                                  (FStar_List.filter
                                     (fun df  ->
                                        (let uu____4616 =
-                                          lowercase_module_name df  in
+                                          lowercase_module_name df in
                                         let uu____4617 =
-                                          lowercase_module_name f  in
+                                          lowercase_module_name f in
                                         uu____4616 <> uu____4617) &&
                                          (let uu____4619 =
-                                            lowercase_module_name df  in
+                                            lowercase_module_name df in
                                           FStar_Options.should_extract
-                                            uu____4619)))
-                                in
+                                            uu____4619))) in
                              FStar_All.pipe_right extracted_fst_files
-                               (FStar_List.map output_cmx_file)
-                              in
+                               (FStar_List.map output_cmx_file) in
                            (let uu____4625 =
-                              let uu____4626 = lowercase_module_name f  in
-                              FStar_Options.should_extract uu____4626  in
+                              let uu____4626 = lowercase_module_name f in
+                              FStar_Options.should_extract uu____4626 in
                             if uu____4625
                             then
-                              let uu____4627 = output_cmx_file f  in
-                              let uu____4628 = output_ml_file f  in
+                              let uu____4627 = output_cmx_file f in
+                              let uu____4628 = output_ml_file f in
                               FStar_Util.print3 "%s: %s \\\n\t%s\n\n"
                                 uu____4627 uu____4628
                                 (FStar_String.concat "\\\n\t" cmx_files)
                             else ());
-                           (let uu____4630 = output_krml_file f  in
-                            let uu____4631 = cache_file f  in
+                           (let uu____4630 = output_krml_file f in
+                            let uu____4631 = cache_file f in
                             FStar_Util.print2 "%s: %s\n\n" uu____4630
                               uu____4631)))
                        else
                          (let uu____4633 =
                             (let uu____4636 =
-                               let uu____4637 = lowercase_module_name f  in
-                               has_implementation file_system_map uu____4637
-                                in
+                               let uu____4637 = lowercase_module_name f in
+                               has_implementation file_system_map uu____4637 in
                              Prims.op_Negation uu____4636) &&
-                              (is_interface f)
-                             in
+                              (is_interface f) in
                           if uu____4633
                           then
-                            let uu____4638 = output_krml_file f  in
-                            let uu____4639 = cache_file f  in
+                            let uu____4638 = output_krml_file f in
+                            let uu____4639 = cache_file f in
                             FStar_Util.print2 "%s: %s\n\n" uu____4638
                               uu____4639
                           else ())))));
          (let all_fst_files =
             let uu____4644 =
-              FStar_All.pipe_right keys (FStar_List.filter is_implementation)
-               in
+              FStar_All.pipe_right keys (FStar_List.filter is_implementation) in
             FStar_All.pipe_right uu____4644
-              (FStar_Util.sort_with FStar_String.compare)
-             in
+              (FStar_Util.sort_with FStar_String.compare) in
           let all_ml_files =
-            let ml_file_map = FStar_Util.smap_create (Prims.parse_int "41")
-               in
+            let ml_file_map = FStar_Util.smap_create (Prims.parse_int "41") in
             FStar_All.pipe_right all_fst_files
               (FStar_List.iter
                  (fun fst_file  ->
-                    let mname = lowercase_module_name fst_file  in
-                    let uu____4670 = FStar_Options.should_extract mname  in
+                    let mname = lowercase_module_name fst_file in
+                    let uu____4670 = FStar_Options.should_extract mname in
                     if uu____4670
                     then
-                      let uu____4671 = output_ml_file fst_file  in
+                      let uu____4671 = output_ml_file fst_file in
                       FStar_Util.smap_add ml_file_map mname uu____4671
                     else ()));
-            sort_output_files ml_file_map  in
+            sort_output_files ml_file_map in
           let all_krml_files =
-            let krml_file_map = FStar_Util.smap_create (Prims.parse_int "41")
-               in
+            let krml_file_map = FStar_Util.smap_create (Prims.parse_int "41") in
             FStar_All.pipe_right keys
               (FStar_List.iter
                  (fun fst_file  ->
-                    let mname = lowercase_module_name fst_file  in
-                    let uu____4687 = output_krml_file fst_file  in
+                    let mname = lowercase_module_name fst_file in
+                    let uu____4687 = output_krml_file fst_file in
                     FStar_Util.smap_add krml_file_map mname uu____4687));
-            sort_output_files krml_file_map  in
+            sort_output_files krml_file_map in
           (let uu____4689 =
              let uu____4690 =
-               FStar_All.pipe_right all_fst_files (FStar_List.map norm_path)
-                in
-             FStar_All.pipe_right uu____4690 (FStar_String.concat " \\\n\t")
-              in
+               FStar_All.pipe_right all_fst_files (FStar_List.map norm_path) in
+             FStar_All.pipe_right uu____4690 (FStar_String.concat " \\\n\t") in
            FStar_Util.print1 "ALL_FST_FILES=\\\n\t%s\n\n" uu____4689);
           (let uu____4700 =
              let uu____4701 =
-               FStar_All.pipe_right all_ml_files (FStar_List.map norm_path)
-                in
-             FStar_All.pipe_right uu____4701 (FStar_String.concat " \\\n\t")
-              in
+               FStar_All.pipe_right all_ml_files (FStar_List.map norm_path) in
+             FStar_All.pipe_right uu____4701 (FStar_String.concat " \\\n\t") in
            FStar_Util.print1 "ALL_ML_FILES=\\\n\t%s\n\n" uu____4700);
           (let uu____4710 =
              let uu____4711 =
-               FStar_All.pipe_right all_krml_files (FStar_List.map norm_path)
-                in
-             FStar_All.pipe_right uu____4711 (FStar_String.concat " \\\n\t")
-              in
+               FStar_All.pipe_right all_krml_files (FStar_List.map norm_path) in
+             FStar_All.pipe_right uu____4711 (FStar_String.concat " \\\n\t") in
            FStar_Util.print1 "ALL_KRML_FILES=\\\n\t%s\n" uu____4710)))
-  
-let (print : deps -> Prims.unit) =
+let print: deps -> Prims.unit =
   fun deps  ->
-    let uu____4723 = FStar_Options.dep ()  in
+    let uu____4723 = FStar_Options.dep () in
     match uu____4723 with
     | FStar_Pervasives_Native.Some "make" -> print_make deps
     | FStar_Pervasives_Native.Some "full" -> print_full deps
     | FStar_Pervasives_Native.Some "graph" ->
-        let uu____4726 = deps  in
+        let uu____4726 = deps in
         (match uu____4726 with
          | Mk (deps1,uu____4728,uu____4729) -> print_graph deps1)
     | FStar_Pervasives_Native.Some uu____4734 ->
         FStar_Errors.raise_err
           (FStar_Errors.Fatal_UnknownToolForDep, "unknown tool for --dep\n")
     | FStar_Pervasives_Native.None  -> ()
-  

--- a/src/ocaml-output/FStar_Parser_Driver.ml
+++ b/src/ocaml-output/FStar_Parser_Driver.ml
@@ -1,30 +1,27 @@
 open Prims
-let (is_cache_file : Prims.string -> Prims.bool) =
+let is_cache_file: Prims.string -> Prims.bool =
   fun fn  ->
-    let uu____4 = FStar_Util.get_file_extension fn  in uu____4 = ".cache"
-  
+    let uu____4 = FStar_Util.get_file_extension fn in uu____4 = ".cache"
 type fragment =
-  | Empty 
-  | Modul of FStar_Parser_AST.modul 
-  | Decls of FStar_Parser_AST.decl Prims.list [@@deriving show]
-let (uu___is_Empty : fragment -> Prims.bool) =
-  fun projectee  -> match projectee with | Empty  -> true | uu____18 -> false 
-let (uu___is_Modul : fragment -> Prims.bool) =
+  | Empty
+  | Modul of FStar_Parser_AST.modul
+  | Decls of FStar_Parser_AST.decl Prims.list[@@deriving show]
+let uu___is_Empty: fragment -> Prims.bool =
+  fun projectee  -> match projectee with | Empty  -> true | uu____18 -> false
+let uu___is_Modul: fragment -> Prims.bool =
   fun projectee  ->
     match projectee with | Modul _0 -> true | uu____23 -> false
-  
-let (__proj__Modul__item___0 : fragment -> FStar_Parser_AST.modul) =
-  fun projectee  -> match projectee with | Modul _0 -> _0 
-let (uu___is_Decls : fragment -> Prims.bool) =
+let __proj__Modul__item___0: fragment -> FStar_Parser_AST.modul =
+  fun projectee  -> match projectee with | Modul _0 -> _0
+let uu___is_Decls: fragment -> Prims.bool =
   fun projectee  ->
     match projectee with | Decls _0 -> true | uu____37 -> false
-  
-let (__proj__Decls__item___0 : fragment -> FStar_Parser_AST.decl Prims.list)
-  = fun projectee  -> match projectee with | Decls _0 -> _0 
-let (parse_fragment : FStar_Parser_ParseIt.input_frag -> fragment) =
+let __proj__Decls__item___0: fragment -> FStar_Parser_AST.decl Prims.list =
+  fun projectee  -> match projectee with | Decls _0 -> _0
+let parse_fragment: FStar_Parser_ParseIt.input_frag -> fragment =
   fun frag  ->
     let uu____54 =
-      FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Toplevel frag)  in
+      FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Toplevel frag) in
     match uu____54 with
     | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inl modul,uu____56) ->
         Modul modul
@@ -36,27 +33,25 @@ let (parse_fragment : FStar_Parser_ParseIt.input_frag -> fragment) =
     | FStar_Parser_ParseIt.Term uu____125 ->
         failwith
           "Impossible: parsing a Toplevel always results in an ASTFragment"
-  
-let (parse_file :
+let parse_file:
   FStar_Parser_ParseIt.filename ->
     (FStar_Parser_AST.file,(Prims.string,FStar_Range.range)
                              FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun fn  ->
     let uu____139 =
-      FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Filename fn)  in
+      FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Filename fn) in
     match uu____139 with
     | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inl ast,comments) ->
         (ast, comments)
     | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr uu____178,uu____179)
         ->
-        let msg = FStar_Util.format1 "%s: expected a module\n" fn  in
-        let r = FStar_Range.dummyRange  in
+        let msg = FStar_Util.format1 "%s: expected a module\n" fn in
+        let r = FStar_Range.dummyRange in
         FStar_Errors.raise_error (FStar_Errors.Fatal_ModuleExpected, msg) r
     | FStar_Parser_ParseIt.ParseError (e,msg,r) ->
         FStar_Errors.raise_error (e, msg) r
     | FStar_Parser_ParseIt.Term uu____227 ->
         failwith
           "Impossible: parsing a Filename always results in an ASTFragment"
-  

--- a/src/ocaml-output/FStar_Parser_ToDocument.ml
+++ b/src/ocaml-output/FStar_Parser_ToDocument.ml
@@ -1,21 +1,20 @@
 open Prims
-let (should_print_fs_typ_app : Prims.bool FStar_ST.ref) =
-  FStar_Util.mk_ref false 
-let with_fs_typ_app :
+let should_print_fs_typ_app: Prims.bool FStar_ST.ref =
+  FStar_Util.mk_ref false
+let with_fs_typ_app:
   'Auu____19 'Auu____20 .
     Prims.bool -> ('Auu____20 -> 'Auu____19) -> 'Auu____20 -> 'Auu____19
   =
   fun b  ->
     fun printer  ->
       fun t  ->
-        let b0 = FStar_ST.op_Bang should_print_fs_typ_app  in
+        let b0 = FStar_ST.op_Bang should_print_fs_typ_app in
         FStar_ST.op_Colon_Equals should_print_fs_typ_app b;
-        (let res = printer t  in
+        (let res = printer t in
          FStar_ST.op_Colon_Equals should_print_fs_typ_app b0; res)
-  
-let (str : Prims.string -> FStar_Pprint.document) =
-  fun s  -> FStar_Pprint.doc_of_string s 
-let default_or_map :
+let str: Prims.string -> FStar_Pprint.document =
+  fun s  -> FStar_Pprint.doc_of_string s
+let default_or_map:
   'Auu____107 'Auu____108 .
     'Auu____108 ->
       ('Auu____107 -> 'Auu____108) ->
@@ -27,32 +26,28 @@ let default_or_map :
         match x with
         | FStar_Pervasives_Native.None  -> n1
         | FStar_Pervasives_Native.Some x' -> f x'
-  
-let (prefix2 :
-  FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document) =
+let prefix2:
+  FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document =
   fun prefix_  ->
     fun body  ->
       FStar_Pprint.prefix (Prims.parse_int "2") (Prims.parse_int "1") prefix_
         body
-  
-let (op_Hat_Slash_Plus_Hat :
-  FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document) =
-  fun prefix_  -> fun body  -> prefix2 prefix_ body 
-let (jump2 : FStar_Pprint.document -> FStar_Pprint.document) =
+let op_Hat_Slash_Plus_Hat:
+  FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document =
+  fun prefix_  -> fun body  -> prefix2 prefix_ body
+let jump2: FStar_Pprint.document -> FStar_Pprint.document =
   fun body  ->
     FStar_Pprint.jump (Prims.parse_int "2") (Prims.parse_int "1") body
-  
-let (infix2 :
+let infix2:
   FStar_Pprint.document ->
-    FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document)
-  = FStar_Pprint.infix (Prims.parse_int "2") (Prims.parse_int "1") 
-let (infix0 :
+    FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document
+  = FStar_Pprint.infix (Prims.parse_int "2") (Prims.parse_int "1")
+let infix0:
   FStar_Pprint.document ->
-    FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document)
-  = FStar_Pprint.infix (Prims.parse_int "0") (Prims.parse_int "1") 
-let (break1 : FStar_Pprint.document) =
-  FStar_Pprint.break_ (Prims.parse_int "1") 
-let separate_break_map :
+    FStar_Pprint.document -> FStar_Pprint.document -> FStar_Pprint.document
+  = FStar_Pprint.infix (Prims.parse_int "0") (Prims.parse_int "1")
+let break1: FStar_Pprint.document = FStar_Pprint.break_ (Prims.parse_int "1")
+let separate_break_map:
   'Auu____162 .
     FStar_Pprint.document ->
       ('Auu____162 -> FStar_Pprint.document) ->
@@ -63,12 +58,11 @@ let separate_break_map :
       fun l  ->
         let uu____184 =
           let uu____185 =
-            let uu____186 = FStar_Pprint.op_Hat_Hat sep break1  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____186  in
-          FStar_Pprint.separate_map uu____185 f l  in
+            let uu____186 = FStar_Pprint.op_Hat_Hat sep break1 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____186 in
+          FStar_Pprint.separate_map uu____185 f l in
         FStar_Pprint.group uu____184
-  
-let precede_break_separate_map :
+let precede_break_separate_map:
   'Auu____192 .
     FStar_Pprint.document ->
       FStar_Pprint.document ->
@@ -80,26 +74,23 @@ let precede_break_separate_map :
       fun f  ->
         fun l  ->
           let uu____218 =
-            let uu____219 = FStar_Pprint.op_Hat_Hat prec FStar_Pprint.space
-               in
+            let uu____219 = FStar_Pprint.op_Hat_Hat prec FStar_Pprint.space in
             let uu____220 =
-              let uu____221 = FStar_List.hd l  in
-              FStar_All.pipe_right uu____221 f  in
-            FStar_Pprint.precede uu____219 uu____220  in
+              let uu____221 = FStar_List.hd l in
+              FStar_All.pipe_right uu____221 f in
+            FStar_Pprint.precede uu____219 uu____220 in
           let uu____222 =
-            let uu____223 = FStar_List.tl l  in
+            let uu____223 = FStar_List.tl l in
             FStar_Pprint.concat_map
               (fun x  ->
                  let uu____229 =
                    let uu____230 =
-                     let uu____231 = f x  in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____231  in
-                   FStar_Pprint.op_Hat_Hat sep uu____230  in
-                 FStar_Pprint.op_Hat_Hat break1 uu____229) uu____223
-             in
+                     let uu____231 = f x in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____231 in
+                   FStar_Pprint.op_Hat_Hat sep uu____230 in
+                 FStar_Pprint.op_Hat_Hat break1 uu____229) uu____223 in
           FStar_Pprint.op_Hat_Hat uu____218 uu____222
-  
-let concat_break_map :
+let concat_break_map:
   'Auu____235 .
     ('Auu____235 -> FStar_Pprint.document) ->
       'Auu____235 Prims.list -> FStar_Pprint.document
@@ -109,54 +100,44 @@ let concat_break_map :
       let uu____253 =
         FStar_Pprint.concat_map
           (fun x  ->
-             let uu____257 = f x  in FStar_Pprint.op_Hat_Hat uu____257 break1)
-          l
-         in
+             let uu____257 = f x in FStar_Pprint.op_Hat_Hat uu____257 break1)
+          l in
       FStar_Pprint.group uu____253
-  
-let (parens_with_nesting : FStar_Pprint.document -> FStar_Pprint.document) =
+let parens_with_nesting: FStar_Pprint.document -> FStar_Pprint.document =
   fun contents  ->
     FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
       FStar_Pprint.lparen contents FStar_Pprint.rparen
-  
-let (soft_parens_with_nesting :
-  FStar_Pprint.document -> FStar_Pprint.document) =
+let soft_parens_with_nesting: FStar_Pprint.document -> FStar_Pprint.document
+  =
   fun contents  ->
     FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "0")
       FStar_Pprint.lparen contents FStar_Pprint.rparen
-  
-let (braces_with_nesting : FStar_Pprint.document -> FStar_Pprint.document) =
+let braces_with_nesting: FStar_Pprint.document -> FStar_Pprint.document =
   fun contents  ->
     FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
       FStar_Pprint.lbrace contents FStar_Pprint.rbrace
-  
-let (soft_braces_with_nesting :
-  FStar_Pprint.document -> FStar_Pprint.document) =
-  fun contents  ->
-    FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1")
-      FStar_Pprint.lbrace contents FStar_Pprint.rbrace
-  
-let (brackets_with_nesting : FStar_Pprint.document -> FStar_Pprint.document)
+let soft_braces_with_nesting: FStar_Pprint.document -> FStar_Pprint.document
   =
   fun contents  ->
+    FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1")
+      FStar_Pprint.lbrace contents FStar_Pprint.rbrace
+let brackets_with_nesting: FStar_Pprint.document -> FStar_Pprint.document =
+  fun contents  ->
     FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
       FStar_Pprint.lbracket contents FStar_Pprint.rbracket
-  
-let (soft_brackets_with_nesting :
-  FStar_Pprint.document -> FStar_Pprint.document) =
+let soft_brackets_with_nesting:
+  FStar_Pprint.document -> FStar_Pprint.document =
   fun contents  ->
     FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1")
       FStar_Pprint.lbracket contents FStar_Pprint.rbracket
-  
-let (soft_begin_end_with_nesting :
-  FStar_Pprint.document -> FStar_Pprint.document) =
+let soft_begin_end_with_nesting:
+  FStar_Pprint.document -> FStar_Pprint.document =
   fun contents  ->
-    let uu____279 = str "begin"  in
-    let uu____280 = str "end"  in
+    let uu____279 = str "begin" in
+    let uu____280 = str "end" in
     FStar_Pprint.soft_surround (Prims.parse_int "2") (Prims.parse_int "1")
       uu____279 contents uu____280
-  
-let separate_map_last :
+let separate_map_last:
   'Auu____285 .
     FStar_Pprint.document ->
       (Prims.bool -> 'Auu____285 -> FStar_Pprint.document) ->
@@ -165,14 +146,12 @@ let separate_map_last :
   fun sep  ->
     fun f  ->
       fun es  ->
-        let l = FStar_List.length es  in
+        let l = FStar_List.length es in
         let es1 =
           FStar_List.mapi
-            (fun i  -> fun e  -> f (i <> (l - (Prims.parse_int "1"))) e) es
-           in
+            (fun i  -> fun e  -> f (i <> (l - (Prims.parse_int "1"))) e) es in
         FStar_Pprint.separate sep es1
-  
-let separate_break_map_last :
+let separate_break_map_last:
   'Auu____330 .
     FStar_Pprint.document ->
       (Prims.bool -> 'Auu____330 -> FStar_Pprint.document) ->
@@ -183,12 +162,11 @@ let separate_break_map_last :
       fun l  ->
         let uu____357 =
           let uu____358 =
-            let uu____359 = FStar_Pprint.op_Hat_Hat sep break1  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____359  in
-          separate_map_last uu____358 f l  in
+            let uu____359 = FStar_Pprint.op_Hat_Hat sep break1 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____359 in
+          separate_map_last uu____358 f l in
         FStar_Pprint.group uu____357
-  
-let separate_map_or_flow :
+let separate_map_or_flow:
   'Auu____364 .
     FStar_Pprint.document ->
       ('Auu____364 -> FStar_Pprint.document) ->
@@ -200,8 +178,7 @@ let separate_map_or_flow :
         if (FStar_List.length l) < (Prims.parse_int "10")
         then FStar_Pprint.separate_map sep f l
         else FStar_Pprint.flow_map sep f l
-  
-let flow_map_last :
+let flow_map_last:
   'Auu____391 .
     FStar_Pprint.document ->
       (Prims.bool -> 'Auu____391 -> FStar_Pprint.document) ->
@@ -210,14 +187,12 @@ let flow_map_last :
   fun sep  ->
     fun f  ->
       fun es  ->
-        let l = FStar_List.length es  in
+        let l = FStar_List.length es in
         let es1 =
           FStar_List.mapi
-            (fun i  -> fun e  -> f (i <> (l - (Prims.parse_int "1"))) e) es
-           in
+            (fun i  -> fun e  -> f (i <> (l - (Prims.parse_int "1"))) e) es in
         FStar_Pprint.flow sep es1
-  
-let separate_map_or_flow_last :
+let separate_map_or_flow_last:
   'Auu____436 .
     FStar_Pprint.document ->
       (Prims.bool -> 'Auu____436 -> FStar_Pprint.document) ->
@@ -229,8 +204,7 @@ let separate_map_or_flow_last :
         if (FStar_List.length l) < (Prims.parse_int "10")
         then separate_map_last sep f l
         else flow_map_last sep f l
-  
-let soft_surround_separate_map :
+let soft_surround_separate_map:
   'Auu____473 .
     Prims.int ->
       Prims.int ->
@@ -252,11 +226,10 @@ let soft_surround_separate_map :
                   if xs = []
                   then void_
                   else
-                    (let uu____518 = FStar_Pprint.separate_map sep f xs  in
+                    (let uu____518 = FStar_Pprint.separate_map sep f xs in
                      FStar_Pprint.soft_surround n1 b opening uu____518
                        closing)
-  
-let soft_surround_map_or_flow :
+let soft_surround_map_or_flow:
   'Auu____528 .
     Prims.int ->
       Prims.int ->
@@ -278,21 +251,20 @@ let soft_surround_map_or_flow :
                   if xs = []
                   then void_
                   else
-                    (let uu____573 = separate_map_or_flow sep f xs  in
+                    (let uu____573 = separate_map_or_flow sep f xs in
                      FStar_Pprint.soft_surround n1 b opening uu____573
                        closing)
-  
-let (doc_of_fsdoc :
+let doc_of_fsdoc:
   (Prims.string,(Prims.string,Prims.string) FStar_Pervasives_Native.tuple2
                   Prims.list)
-    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document)
+    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document
   =
   fun uu____586  ->
     match uu____586 with
     | (comment,keywords) ->
         let uu____611 =
           let uu____612 =
-            let uu____615 = str comment  in
+            let uu____615 = str comment in
             let uu____616 =
               let uu____619 =
                 let uu____622 =
@@ -301,42 +273,37 @@ let (doc_of_fsdoc :
                        match uu____631 with
                        | (k,v1) ->
                            let uu____638 =
-                             let uu____641 = str k  in
+                             let uu____641 = str k in
                              let uu____642 =
                                let uu____645 =
-                                 let uu____648 = str v1  in [uu____648]  in
-                               FStar_Pprint.rarrow :: uu____645  in
-                             uu____641 :: uu____642  in
-                           FStar_Pprint.concat uu____638) keywords
-                   in
-                [uu____622]  in
-              FStar_Pprint.space :: uu____619  in
-            uu____615 :: uu____616  in
-          FStar_Pprint.concat uu____612  in
+                                 let uu____648 = str v1 in [uu____648] in
+                               FStar_Pprint.rarrow :: uu____645 in
+                             uu____641 :: uu____642 in
+                           FStar_Pprint.concat uu____638) keywords in
+                [uu____622] in
+              FStar_Pprint.space :: uu____619 in
+            uu____615 :: uu____616 in
+          FStar_Pprint.concat uu____612 in
         FStar_Pprint.group uu____611
-  
-let (is_unit : FStar_Parser_AST.term -> Prims.bool) =
+let is_unit: FStar_Parser_AST.term -> Prims.bool =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Const (FStar_Const.Const_unit ) -> true
     | uu____652 -> false
-  
-let (matches_var : FStar_Parser_AST.term -> FStar_Ident.ident -> Prims.bool)
-  =
+let matches_var: FStar_Parser_AST.term -> FStar_Ident.ident -> Prims.bool =
   fun t  ->
     fun x  ->
       match t.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Var y ->
           x.FStar_Ident.idText = (FStar_Ident.text_of_lid y)
       | uu____660 -> false
-  
-let (is_tuple_constructor : FStar_Ident.lident -> Prims.bool) =
-  FStar_Parser_Const.is_tuple_data_lid' 
-let (is_dtuple_constructor : FStar_Ident.lident -> Prims.bool) =
-  FStar_Parser_Const.is_dtuple_data_lid' 
-let (is_list_structure :
+let is_tuple_constructor: FStar_Ident.lident -> Prims.bool =
+  FStar_Parser_Const.is_tuple_data_lid'
+let is_dtuple_constructor: FStar_Ident.lident -> Prims.bool =
+  FStar_Parser_Const.is_dtuple_data_lid'
+let is_list_structure:
   FStar_Ident.lident ->
-    FStar_Ident.lident -> FStar_Parser_AST.term -> Prims.bool)
+    FStar_Ident.lident -> FStar_Parser_AST.term -> Prims.bool
   =
   fun cons_lid1  ->
     fun nil_lid1  ->
@@ -346,31 +313,28 @@ let (is_list_structure :
             FStar_Ident.lid_equals lid nil_lid1
         | FStar_Parser_AST.Construct (lid,uu____689::(e2,uu____691)::[]) ->
             (FStar_Ident.lid_equals lid cons_lid1) && (aux e2)
-        | uu____714 -> false  in
+        | uu____714 -> false in
       aux
-  
-let (is_list : FStar_Parser_AST.term -> Prims.bool) =
-  is_list_structure FStar_Parser_Const.cons_lid FStar_Parser_Const.nil_lid 
-let (is_lex_list : FStar_Parser_AST.term -> Prims.bool) =
+let is_list: FStar_Parser_AST.term -> Prims.bool =
+  is_list_structure FStar_Parser_Const.cons_lid FStar_Parser_Const.nil_lid
+let is_lex_list: FStar_Parser_AST.term -> Prims.bool =
   is_list_structure FStar_Parser_Const.lexcons_lid
     FStar_Parser_Const.lextop_lid
-  
-let rec (extract_from_list :
-  FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list) =
+let rec extract_from_list:
+  FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Construct (uu____726,[]) -> []
     | FStar_Parser_AST.Construct
         (uu____737,(e1,FStar_Parser_AST.Nothing )::(e2,FStar_Parser_AST.Nothing
                                                     )::[])
-        -> let uu____758 = extract_from_list e2  in e1 :: uu____758
+        -> let uu____758 = extract_from_list e2 in e1 :: uu____758
     | uu____761 ->
         let uu____762 =
-          let uu____763 = FStar_Parser_AST.term_to_string e  in
-          FStar_Util.format1 "Not a list %s" uu____763  in
+          let uu____763 = FStar_Parser_AST.term_to_string e in
+          FStar_Util.format1 "Not a list %s" uu____763 in
         failwith uu____762
-  
-let (is_array : FStar_Parser_AST.term -> Prims.bool) =
+let is_array: FStar_Parser_AST.term -> Prims.bool =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.App
@@ -382,8 +346,7 @@ let (is_array : FStar_Parser_AST.term -> Prims.bool) =
         (FStar_Ident.lid_equals lid FStar_Parser_Const.array_mk_array_lid) &&
           (is_list l)
     | uu____773 -> false
-  
-let rec (is_ref_set : FStar_Parser_AST.term -> Prims.bool) =
+let rec is_ref_set: FStar_Parser_AST.term -> Prims.bool =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Var maybe_empty_lid ->
@@ -429,9 +392,8 @@ let rec (is_ref_set : FStar_Parser_AST.term -> Prims.bool) =
            && (is_ref_set e1))
           && (is_ref_set e2)
     | uu____794 -> false
-  
-let rec (extract_from_ref_set :
-  FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list) =
+let rec extract_from_ref_set:
+  FStar_Parser_AST.term -> FStar_Parser_AST.term Prims.list =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Var uu____802 -> []
@@ -467,85 +429,75 @@ let rec (extract_from_ref_set :
            FStar_Parser_AST.level = uu____817;_},e2,FStar_Parser_AST.Nothing
          )
         ->
-        let uu____819 = extract_from_ref_set e1  in
-        let uu____822 = extract_from_ref_set e2  in
+        let uu____819 = extract_from_ref_set e1 in
+        let uu____822 = extract_from_ref_set e2 in
         FStar_List.append uu____819 uu____822
     | uu____825 ->
         let uu____826 =
-          let uu____827 = FStar_Parser_AST.term_to_string e  in
-          FStar_Util.format1 "Not a ref set %s" uu____827  in
+          let uu____827 = FStar_Parser_AST.term_to_string e in
+          FStar_Util.format1 "Not a ref set %s" uu____827 in
         failwith uu____826
-  
-let (is_general_application : FStar_Parser_AST.term -> Prims.bool) =
+let is_general_application: FStar_Parser_AST.term -> Prims.bool =
   fun e  ->
-    let uu____833 = (is_array e) || (is_ref_set e)  in
+    let uu____833 = (is_array e) || (is_ref_set e) in
     Prims.op_Negation uu____833
-  
-let (is_general_construction : FStar_Parser_AST.term -> Prims.bool) =
+let is_general_construction: FStar_Parser_AST.term -> Prims.bool =
   fun e  ->
-    let uu____837 = (is_list e) || (is_lex_list e)  in
+    let uu____837 = (is_list e) || (is_lex_list e) in
     Prims.op_Negation uu____837
-  
-let (is_general_prefix_op : FStar_Ident.ident -> Prims.bool) =
+let is_general_prefix_op: FStar_Ident.ident -> Prims.bool =
   fun op  ->
     let op_starting_char =
-      FStar_Util.char_at (FStar_Ident.text_of_id op) (Prims.parse_int "0")
-       in
+      FStar_Util.char_at (FStar_Ident.text_of_id op) (Prims.parse_int "0") in
     ((op_starting_char = 33) || (op_starting_char = 63)) ||
       ((op_starting_char = 126) && ((FStar_Ident.text_of_id op) <> "~"))
-  
-let (head_and_args :
+let head_and_args:
   FStar_Parser_AST.term ->
     (FStar_Parser_AST.term,(FStar_Parser_AST.term,FStar_Parser_AST.imp)
                              FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun e  ->
     let rec aux e1 acc =
       match e1.FStar_Parser_AST.tm with
       | FStar_Parser_AST.App (head1,arg,imp) -> aux head1 ((arg, imp) :: acc)
-      | uu____904 -> (e1, acc)  in
+      | uu____904 -> (e1, acc) in
     aux e []
-  
 type associativity =
-  | Left 
-  | Right 
-  | NonAssoc [@@deriving show]
-let (uu___is_Left : associativity -> Prims.bool) =
-  fun projectee  -> match projectee with | Left  -> true | uu____918 -> false 
-let (uu___is_Right : associativity -> Prims.bool) =
+  | Left
+  | Right
+  | NonAssoc[@@deriving show]
+let uu___is_Left: associativity -> Prims.bool =
+  fun projectee  -> match projectee with | Left  -> true | uu____918 -> false
+let uu___is_Right: associativity -> Prims.bool =
   fun projectee  ->
     match projectee with | Right  -> true | uu____922 -> false
-  
-let (uu___is_NonAssoc : associativity -> Prims.bool) =
+let uu___is_NonAssoc: associativity -> Prims.bool =
   fun projectee  ->
     match projectee with | NonAssoc  -> true | uu____926 -> false
-  
 type token = (FStar_Char.char,Prims.string) FStar_Util.either[@@deriving
                                                                show]
 type associativity_level =
   (associativity,token Prims.list) FStar_Pervasives_Native.tuple2[@@deriving
                                                                    show]
-let (token_to_string :
-  (FStar_BaseTypes.char,Prims.string) FStar_Util.either -> Prims.string) =
+let token_to_string:
+  (FStar_BaseTypes.char,Prims.string) FStar_Util.either -> Prims.string =
   fun uu___51_944  ->
     match uu___51_944 with
     | FStar_Util.Inl c -> Prims.strcat (FStar_Util.string_of_char c) ".*"
     | FStar_Util.Inr s -> s
-  
-let (matches_token :
+let matches_token:
   Prims.string ->
-    (FStar_Char.char,Prims.string) FStar_Util.either -> Prims.bool)
+    (FStar_Char.char,Prims.string) FStar_Util.either -> Prims.bool
   =
   fun s  ->
     fun uu___52_961  ->
       match uu___52_961 with
       | FStar_Util.Inl c ->
-          let uu____970 = FStar_String.get s (Prims.parse_int "0")  in
+          let uu____970 = FStar_String.get s (Prims.parse_int "0") in
           uu____970 = c
       | FStar_Util.Inr s' -> s = s'
-  
-let matches_level :
+let matches_level:
   'Auu____978 .
     Prims.string ->
       ('Auu____978,(FStar_Char.char,Prims.string) FStar_Util.either
@@ -556,16 +508,15 @@ let matches_level :
     fun uu____997  ->
       match uu____997 with
       | (assoc_levels,tokens) ->
-          let uu____1025 = FStar_List.tryFind (matches_token s) tokens  in
+          let uu____1025 = FStar_List.tryFind (matches_token s) tokens in
           uu____1025 <> FStar_Pervasives_Native.None
-  
-let opinfix4 :
+let opinfix4:
   'Auu____1051 .
     Prims.unit ->
       (associativity,('Auu____1051,Prims.string) FStar_Util.either Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1062  -> (Right, [FStar_Util.Inr "**"]) 
-let opinfix3 :
+  = fun uu____1062  -> (Right, [FStar_Util.Inr "**"])
+let opinfix3:
   'Auu____1078 .
     Prims.unit ->
       (associativity,(FStar_Char.char,'Auu____1078) FStar_Util.either
@@ -574,41 +525,40 @@ let opinfix3 :
   =
   fun uu____1090  ->
     (Left, [FStar_Util.Inl 42; FStar_Util.Inl 47; FStar_Util.Inl 37])
-  
-let opinfix2 :
+let opinfix2:
   'Auu____1125 .
     Prims.unit ->
       (associativity,(FStar_Char.char,'Auu____1125) FStar_Util.either
                        Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1137  -> (Left, [FStar_Util.Inl 43; FStar_Util.Inl 45]) 
-let minus_lvl :
+  = fun uu____1137  -> (Left, [FStar_Util.Inl 43; FStar_Util.Inl 45])
+let minus_lvl:
   'Auu____1165 .
     Prims.unit ->
       (associativity,('Auu____1165,Prims.string) FStar_Util.either Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1176  -> (Left, [FStar_Util.Inr "-"]) 
-let opinfix1 :
+  = fun uu____1176  -> (Left, [FStar_Util.Inr "-"])
+let opinfix1:
   'Auu____1192 .
     Prims.unit ->
       (associativity,(FStar_Char.char,'Auu____1192) FStar_Util.either
                        Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1204  -> (Right, [FStar_Util.Inl 64; FStar_Util.Inl 94]) 
-let pipe_right :
+  = fun uu____1204  -> (Right, [FStar_Util.Inl 64; FStar_Util.Inl 94])
+let pipe_right:
   'Auu____1232 .
     Prims.unit ->
       (associativity,('Auu____1232,Prims.string) FStar_Util.either Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1243  -> (Left, [FStar_Util.Inr "|>"]) 
-let opinfix0d :
+  = fun uu____1243  -> (Left, [FStar_Util.Inr "|>"])
+let opinfix0d:
   'Auu____1259 .
     Prims.unit ->
       (associativity,(FStar_Char.char,'Auu____1259) FStar_Util.either
                        Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1271  -> (Left, [FStar_Util.Inl 36]) 
-let opinfix0c :
+  = fun uu____1271  -> (Left, [FStar_Util.Inl 36])
+let opinfix0c:
   'Auu____1292 .
     Prims.unit ->
       (associativity,(FStar_Char.char,'Auu____1292) FStar_Util.either
@@ -617,48 +567,47 @@ let opinfix0c :
   =
   fun uu____1304  ->
     (Left, [FStar_Util.Inl 61; FStar_Util.Inl 60; FStar_Util.Inl 62])
-  
-let equal :
+let equal:
   'Auu____1339 .
     Prims.unit ->
       (associativity,('Auu____1339,Prims.string) FStar_Util.either Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1350  -> (Left, [FStar_Util.Inr "="]) 
-let opinfix0b :
+  = fun uu____1350  -> (Left, [FStar_Util.Inr "="])
+let opinfix0b:
   'Auu____1366 .
     Prims.unit ->
       (associativity,(FStar_Char.char,'Auu____1366) FStar_Util.either
                        Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1378  -> (Left, [FStar_Util.Inl 38]) 
-let opinfix0a :
+  = fun uu____1378  -> (Left, [FStar_Util.Inl 38])
+let opinfix0a:
   'Auu____1399 .
     Prims.unit ->
       (associativity,(FStar_Char.char,'Auu____1399) FStar_Util.either
                        Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1411  -> (Left, [FStar_Util.Inl 124]) 
-let colon_equals :
+  = fun uu____1411  -> (Left, [FStar_Util.Inl 124])
+let colon_equals:
   'Auu____1432 .
     Prims.unit ->
       (associativity,('Auu____1432,Prims.string) FStar_Util.either Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1443  -> (NonAssoc, [FStar_Util.Inr ":="]) 
-let amp :
+  = fun uu____1443  -> (NonAssoc, [FStar_Util.Inr ":="])
+let amp:
   'Auu____1459 .
     Prims.unit ->
       (associativity,('Auu____1459,Prims.string) FStar_Util.either Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1470  -> (Right, [FStar_Util.Inr "&"]) 
-let colon_colon :
+  = fun uu____1470  -> (Right, [FStar_Util.Inr "&"])
+let colon_colon:
   'Auu____1486 .
     Prims.unit ->
       (associativity,('Auu____1486,Prims.string) FStar_Util.either Prims.list)
         FStar_Pervasives_Native.tuple2
-  = fun uu____1497  -> (Right, [FStar_Util.Inr "::"]) 
-let (level_associativity_spec :
+  = fun uu____1497  -> (Right, [FStar_Util.Inr "::"])
+let level_associativity_spec:
   (associativity,(FStar_Char.char,Prims.string) FStar_Util.either Prims.list)
-    FStar_Pervasives_Native.tuple2 Prims.list)
+    FStar_Pervasives_Native.tuple2 Prims.list
   =
   [opinfix4 ();
   opinfix3 ();
@@ -671,44 +620,41 @@ let (level_associativity_spec :
   opinfix0a ();
   colon_equals ();
   amp ();
-  colon_colon ()] 
-let (level_table :
+  colon_colon ()]
+let level_table:
   ((Prims.int,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3,(FStar_Char.char,
                                                                     Prims.string)
                                                                     FStar_Util.either
                                                                     Prims.list)
-    FStar_Pervasives_Native.tuple2 Prims.list)
+    FStar_Pervasives_Native.tuple2 Prims.list
   =
   let levels_from_associativity l uu___53_1704 =
     match uu___53_1704 with
     | Left  -> (l, l, (l - (Prims.parse_int "1")))
     | Right  -> ((l - (Prims.parse_int "1")), l, l)
     | NonAssoc  ->
-        ((l - (Prims.parse_int "1")), l, (l - (Prims.parse_int "1")))
-     in
+        ((l - (Prims.parse_int "1")), l, (l - (Prims.parse_int "1"))) in
   FStar_List.mapi
     (fun i  ->
        fun uu____1744  ->
          match uu____1744 with
          | (assoc1,tokens) -> ((levels_from_associativity i assoc1), tokens))
     level_associativity_spec
-  
-let (assign_levels :
+let assign_levels:
   associativity_level Prims.list ->
     Prims.string ->
-      (Prims.int,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3)
+      (Prims.int,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3
   =
   fun token_associativity_spec  ->
     fun s  ->
-      let uu____1824 = FStar_List.tryFind (matches_level s) level_table  in
+      let uu____1824 = FStar_List.tryFind (matches_level s) level_table in
       match uu____1824 with
       | FStar_Pervasives_Native.Some (assoc_levels,uu____1874) ->
           assoc_levels
       | uu____1918 -> failwith (Prims.strcat "Unrecognized operator " s)
-  
-let (max : Prims.int -> Prims.int -> Prims.int) =
-  fun k1  -> fun k2  -> if k1 > k2 then k1 else k2 
-let max_level :
+let max: Prims.int -> Prims.int -> Prims.int =
+  fun k1  -> fun k2  -> if k1 > k2 then k1 else k2
+let max_level:
   'Auu____1953 .
     ('Auu____1953,(FStar_Char.char,Prims.string) FStar_Util.either Prims.list)
       FStar_Pervasives_Native.tuple2 Prims.list -> Prims.int
@@ -720,8 +666,7 @@ let max_level :
           (fun uu____2053  ->
              match uu____2053 with
              | (uu____2071,tokens) ->
-                 tokens = (FStar_Pervasives_Native.snd level)) level_table
-         in
+                 tokens = (FStar_Pervasives_Native.snd level)) level_table in
       match uu____2013 with
       | FStar_Pervasives_Native.Some ((uu____2113,l1,uu____2115),uu____2116)
           -> max n1 l1
@@ -730,28 +675,23 @@ let max_level :
             let uu____2172 =
               let uu____2173 =
                 FStar_List.map token_to_string
-                  (FStar_Pervasives_Native.snd level)
-                 in
-              FStar_String.concat "," uu____2173  in
-            FStar_Util.format1 "Undefined associativity level %s" uu____2172
-             in
-          failwith uu____2171
-       in
+                  (FStar_Pervasives_Native.snd level) in
+              FStar_String.concat "," uu____2173 in
+            FStar_Util.format1 "Undefined associativity level %s" uu____2172 in
+          failwith uu____2171 in
     FStar_List.fold_left find_level_and_max (Prims.parse_int "0") l
-  
-let (levels :
+let levels:
   Prims.string ->
-    (Prims.int,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3)
+    (Prims.int,Prims.int,Prims.int) FStar_Pervasives_Native.tuple3
   =
   fun op  ->
-    let uu____2207 = assign_levels level_associativity_spec op  in
+    let uu____2207 = assign_levels level_associativity_spec op in
     match uu____2207 with
     | (left1,mine,right1) ->
         if op = "*"
         then ((left1 - (Prims.parse_int "1")), mine, right1)
         else (left1, mine, right1)
-  
-let operatorInfix0ad12 :
+let operatorInfix0ad12:
   'Auu____2231 .
     Prims.unit ->
       (associativity,(FStar_Char.char,'Auu____2231) FStar_Util.either
@@ -765,45 +705,40 @@ let operatorInfix0ad12 :
     opinfix0d ();
     opinfix1 ();
     opinfix2 ()]
-  
-let (is_operatorInfix0ad12 : FStar_Ident.ident -> Prims.bool) =
+let is_operatorInfix0ad12: FStar_Ident.ident -> Prims.bool =
   fun op  ->
     let uu____2326 =
       let uu____2340 =
-        FStar_All.pipe_left matches_level (FStar_Ident.text_of_id op)  in
-      FStar_List.tryFind uu____2340 (operatorInfix0ad12 ())  in
+        FStar_All.pipe_left matches_level (FStar_Ident.text_of_id op) in
+      FStar_List.tryFind uu____2340 (operatorInfix0ad12 ()) in
     uu____2326 <> FStar_Pervasives_Native.None
-  
-let (is_operatorInfix34 : FStar_Ident.ident -> Prims.bool) =
-  let opinfix34 = [opinfix3 (); opinfix4 ()]  in
+let is_operatorInfix34: FStar_Ident.ident -> Prims.bool =
+  let opinfix34 = [opinfix3 (); opinfix4 ()] in
   fun op  ->
     let uu____2453 =
       let uu____2467 =
-        FStar_All.pipe_left matches_level (FStar_Ident.text_of_id op)  in
-      FStar_List.tryFind uu____2467 opinfix34  in
+        FStar_All.pipe_left matches_level (FStar_Ident.text_of_id op) in
+      FStar_List.tryFind uu____2467 opinfix34 in
     uu____2453 <> FStar_Pervasives_Native.None
-  
-let (handleable_args_length : FStar_Ident.ident -> Prims.int) =
+let handleable_args_length: FStar_Ident.ident -> Prims.int =
   fun op  ->
-    let op_s = FStar_Ident.text_of_id op  in
+    let op_s = FStar_Ident.text_of_id op in
     let uu____2533 =
-      (is_general_prefix_op op) || (FStar_List.mem op_s ["-"; "~"])  in
+      (is_general_prefix_op op) || (FStar_List.mem op_s ["-"; "~"]) in
     if uu____2533
-    then (Prims.parse_int "1")
+    then Prims.parse_int "1"
     else
       (let uu____2535 =
          ((is_operatorInfix0ad12 op) || (is_operatorInfix34 op)) ||
            (FStar_List.mem op_s
-              ["<==>"; "==>"; "\\/"; "/\\"; "="; "|>"; ":="; ".()"; ".[]"])
-          in
+              ["<==>"; "==>"; "\\/"; "/\\"; "="; "|>"; ":="; ".()"; ".[]"]) in
        if uu____2535
-       then (Prims.parse_int "2")
+       then Prims.parse_int "2"
        else
          if FStar_List.mem op_s [".()<-"; ".[]<-"]
-         then (Prims.parse_int "3")
-         else (Prims.parse_int "0"))
-  
-let handleable_op :
+         then Prims.parse_int "3"
+         else Prims.parse_int "0")
+let handleable_op:
   'Auu____2541 . FStar_Ident.ident -> 'Auu____2541 Prims.list -> Prims.bool =
   fun op  ->
     fun args  ->
@@ -819,12 +754,11 @@ let handleable_op :
       | _0_30 when _0_30 = (Prims.parse_int "3") ->
           FStar_List.mem (FStar_Ident.text_of_id op) [".()<-"; ".[]<-"]
       | uu____2554 -> false
-  
-let (comment_stack :
+let comment_stack:
   (Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple2 Prims.list
-    FStar_ST.ref)
-  = FStar_Util.mk_ref [] 
-let with_comment :
+    FStar_ST.ref
+  = FStar_Util.mk_ref []
+let with_comment:
   'Auu____2588 .
     ('Auu____2588 -> FStar_Pprint.document) ->
       'Auu____2588 -> FStar_Range.range -> FStar_Pprint.document
@@ -833,57 +767,53 @@ let with_comment :
     fun tm  ->
       fun tmrange  ->
         let rec comments_before_pos acc print_pos lookahead_pos =
-          let uu____2620 = FStar_ST.op_Bang comment_stack  in
+          let uu____2620 = FStar_ST.op_Bang comment_stack in
           match uu____2620 with
           | [] -> (acc, false)
           | (comment,crange)::cs ->
-              let uu____2679 = FStar_Range.range_before_pos crange print_pos
-                 in
+              let uu____2679 = FStar_Range.range_before_pos crange print_pos in
               if uu____2679
               then
                 (FStar_ST.op_Colon_Equals comment_stack cs;
                  (let uu____2716 =
                     let uu____2717 =
-                      let uu____2718 = str comment  in
+                      let uu____2718 = str comment in
                       FStar_Pprint.op_Hat_Hat uu____2718
-                        FStar_Pprint.hardline
-                       in
-                    FStar_Pprint.op_Hat_Hat acc uu____2717  in
+                        FStar_Pprint.hardline in
+                    FStar_Pprint.op_Hat_Hat acc uu____2717 in
                   comments_before_pos uu____2716 print_pos lookahead_pos))
               else
                 (let uu____2720 =
-                   FStar_Range.range_before_pos crange lookahead_pos  in
-                 (acc, uu____2720))
-           in
+                   FStar_Range.range_before_pos crange lookahead_pos in
+                 (acc, uu____2720)) in
         let uu____2721 =
           let uu____2726 =
-            let uu____2727 = FStar_Range.start_of_range tmrange  in
-            FStar_Range.end_of_line uu____2727  in
-          let uu____2728 = FStar_Range.end_of_range tmrange  in
-          comments_before_pos FStar_Pprint.empty uu____2726 uu____2728  in
+            let uu____2727 = FStar_Range.start_of_range tmrange in
+            FStar_Range.end_of_line uu____2727 in
+          let uu____2728 = FStar_Range.end_of_range tmrange in
+          comments_before_pos FStar_Pprint.empty uu____2726 uu____2728 in
         match uu____2721 with
         | (comments,has_lookahead) ->
-            let printed_e = printer tm  in
+            let printed_e = printer tm in
             let comments1 =
               if has_lookahead
               then
-                let pos = FStar_Range.end_of_range tmrange  in
-                let uu____2734 = comments_before_pos comments pos pos  in
+                let pos = FStar_Range.end_of_range tmrange in
+                let uu____2734 = comments_before_pos comments pos pos in
                 FStar_Pervasives_Native.fst uu____2734
-              else comments  in
-            let uu____2740 = FStar_Pprint.op_Hat_Hat comments1 printed_e  in
+              else comments in
+            let uu____2740 = FStar_Pprint.op_Hat_Hat comments1 printed_e in
             FStar_Pprint.group uu____2740
-  
-let rec (place_comments_until_pos :
+let rec place_comments_until_pos:
   Prims.int ->
     Prims.int ->
-      FStar_Range.pos -> FStar_Pprint.document -> FStar_Pprint.document)
+      FStar_Range.pos -> FStar_Pprint.document -> FStar_Pprint.document
   =
   fun k  ->
     fun lbegin  ->
       fun pos_end  ->
         fun doc1  ->
-          let uu____2753 = FStar_ST.op_Bang comment_stack  in
+          let uu____2753 = FStar_ST.op_Bang comment_stack in
           match uu____2753 with
           | (comment,crange)::cs when
               FStar_Range.range_before_pos crange pos_end ->
@@ -891,33 +821,31 @@ let rec (place_comments_until_pos :
                (let lnum =
                   let uu____2837 =
                     let uu____2838 =
-                      let uu____2839 = FStar_Range.start_of_range crange  in
-                      FStar_Range.line_of_pos uu____2839  in
-                    uu____2838 - lbegin  in
-                  max k uu____2837  in
+                      let uu____2839 = FStar_Range.start_of_range crange in
+                      FStar_Range.line_of_pos uu____2839 in
+                    uu____2838 - lbegin in
+                  max k uu____2837 in
                 let doc2 =
                   let uu____2841 =
                     let uu____2842 =
-                      FStar_Pprint.repeat lnum FStar_Pprint.hardline  in
-                    let uu____2843 = str comment  in
-                    FStar_Pprint.op_Hat_Hat uu____2842 uu____2843  in
-                  FStar_Pprint.op_Hat_Hat doc1 uu____2841  in
+                      FStar_Pprint.repeat lnum FStar_Pprint.hardline in
+                    let uu____2843 = str comment in
+                    FStar_Pprint.op_Hat_Hat uu____2842 uu____2843 in
+                  FStar_Pprint.op_Hat_Hat doc1 uu____2841 in
                 let uu____2844 =
-                  let uu____2845 = FStar_Range.end_of_range crange  in
-                  FStar_Range.line_of_pos uu____2845  in
+                  let uu____2845 = FStar_Range.end_of_range crange in
+                  FStar_Range.line_of_pos uu____2845 in
                 place_comments_until_pos (Prims.parse_int "1") uu____2844
                   pos_end doc2))
           | uu____2846 ->
               let lnum =
                 let uu____2854 =
-                  let uu____2855 = FStar_Range.line_of_pos pos_end  in
-                  uu____2855 - lbegin  in
-                max (Prims.parse_int "1") uu____2854  in
-              let uu____2856 = FStar_Pprint.repeat lnum FStar_Pprint.hardline
-                 in
+                  let uu____2855 = FStar_Range.line_of_pos pos_end in
+                  uu____2855 - lbegin in
+                max (Prims.parse_int "1") uu____2854 in
+              let uu____2856 = FStar_Pprint.repeat lnum FStar_Pprint.hardline in
               FStar_Pprint.op_Hat_Hat doc1 uu____2856
-  
-let separate_map_with_comments :
+let separate_map_with_comments:
   'Auu____2863 .
     FStar_Pprint.document ->
       FStar_Pprint.document ->
@@ -933,74 +861,66 @@ let separate_map_with_comments :
             let fold_fun uu____2911 x =
               match uu____2911 with
               | (last_line,doc1) ->
-                  let r = extract_range x  in
+                  let r = extract_range x in
                   let doc2 =
-                    let uu____2925 = FStar_Range.start_of_range r  in
+                    let uu____2925 = FStar_Range.start_of_range r in
                     place_comments_until_pos (Prims.parse_int "1") last_line
-                      uu____2925 doc1
-                     in
+                      uu____2925 doc1 in
                   let uu____2926 =
-                    let uu____2927 = FStar_Range.end_of_range r  in
-                    FStar_Range.line_of_pos uu____2927  in
+                    let uu____2927 = FStar_Range.end_of_range r in
+                    FStar_Range.line_of_pos uu____2927 in
                   let uu____2928 =
                     let uu____2929 =
-                      let uu____2930 = f x  in
-                      FStar_Pprint.op_Hat_Hat sep uu____2930  in
-                    FStar_Pprint.op_Hat_Hat doc2 uu____2929  in
-                  (uu____2926, uu____2928)
-               in
+                      let uu____2930 = f x in
+                      FStar_Pprint.op_Hat_Hat sep uu____2930 in
+                    FStar_Pprint.op_Hat_Hat doc2 uu____2929 in
+                  (uu____2926, uu____2928) in
             let uu____2931 =
-              let uu____2938 = FStar_List.hd xs  in
-              let uu____2939 = FStar_List.tl xs  in (uu____2938, uu____2939)
-               in
+              let uu____2938 = FStar_List.hd xs in
+              let uu____2939 = FStar_List.tl xs in (uu____2938, uu____2939) in
             match uu____2931 with
             | (x,xs1) ->
                 let init1 =
                   let uu____2955 =
                     let uu____2956 =
-                      let uu____2957 = extract_range x  in
-                      FStar_Range.end_of_range uu____2957  in
-                    FStar_Range.line_of_pos uu____2956  in
+                      let uu____2957 = extract_range x in
+                      FStar_Range.end_of_range uu____2957 in
+                    FStar_Range.line_of_pos uu____2956 in
                   let uu____2958 =
-                    let uu____2959 = f x  in
-                    FStar_Pprint.op_Hat_Hat prefix1 uu____2959  in
-                  (uu____2955, uu____2958)  in
-                let uu____2960 = FStar_List.fold_left fold_fun init1 xs1  in
+                    let uu____2959 = f x in
+                    FStar_Pprint.op_Hat_Hat prefix1 uu____2959 in
+                  (uu____2955, uu____2958) in
+                let uu____2960 = FStar_List.fold_left fold_fun init1 xs1 in
                 FStar_Pervasives_Native.snd uu____2960
-  
-let rec (p_decl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
+let rec p_decl: FStar_Parser_AST.decl -> FStar_Pprint.document =
   fun d  ->
     let uu____3339 =
-      let uu____3340 = FStar_Pprint.optional p_fsdoc d.FStar_Parser_AST.doc
-         in
+      let uu____3340 = FStar_Pprint.optional p_fsdoc d.FStar_Parser_AST.doc in
       let uu____3341 =
-        let uu____3342 = p_attributes d.FStar_Parser_AST.attrs  in
+        let uu____3342 = p_attributes d.FStar_Parser_AST.attrs in
         let uu____3343 =
-          let uu____3344 = p_qualifiers d.FStar_Parser_AST.quals  in
+          let uu____3344 = p_qualifiers d.FStar_Parser_AST.quals in
           let uu____3345 =
-            let uu____3346 = p_rawDecl d  in
+            let uu____3346 = p_rawDecl d in
             FStar_Pprint.op_Hat_Hat
               (if d.FStar_Parser_AST.quals = []
                then FStar_Pprint.empty
-               else break1) uu____3346
-             in
-          FStar_Pprint.op_Hat_Hat uu____3344 uu____3345  in
-        FStar_Pprint.op_Hat_Hat uu____3342 uu____3343  in
-      FStar_Pprint.op_Hat_Hat uu____3340 uu____3341  in
+               else break1) uu____3346 in
+          FStar_Pprint.op_Hat_Hat uu____3344 uu____3345 in
+        FStar_Pprint.op_Hat_Hat uu____3342 uu____3343 in
+      FStar_Pprint.op_Hat_Hat uu____3340 uu____3341 in
     FStar_Pprint.group uu____3339
-
-and (p_attributes : FStar_Parser_AST.attributes_ -> FStar_Pprint.document) =
+and p_attributes: FStar_Parser_AST.attributes_ -> FStar_Pprint.document =
   fun attrs  ->
     let uu____3349 =
-      let uu____3350 = str "@"  in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu____3350  in
+      let uu____3350 = str "@" in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu____3350 in
     let uu____3351 =
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.rbracket FStar_Pprint.hardline  in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.rbracket FStar_Pprint.hardline in
     soft_surround_map_or_flow (Prims.parse_int "0") (Prims.parse_int "2")
       FStar_Pprint.empty uu____3349 FStar_Pprint.space uu____3351
       p_atomicTerm attrs
-
-and (p_fsdoc : FStar_Parser_AST.fsdoc -> FStar_Pprint.document) =
+and p_fsdoc: FStar_Parser_AST.fsdoc -> FStar_Pprint.document =
   fun uu____3352  ->
     match uu____3352 with
     | (doc1,kwd_args) ->
@@ -1011,107 +931,98 @@ and (p_fsdoc : FStar_Parser_AST.fsdoc -> FStar_Pprint.document) =
               let process_kwd_arg uu____3386 =
                 match uu____3386 with
                 | (kwd,arg) ->
-                    let uu____3393 = str "@"  in
+                    let uu____3393 = str "@" in
                     let uu____3394 =
-                      let uu____3395 = str kwd  in
+                      let uu____3395 = str kwd in
                       let uu____3396 =
-                        let uu____3397 = str arg  in
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3397
-                         in
-                      FStar_Pprint.op_Hat_Hat uu____3395 uu____3396  in
-                    FStar_Pprint.op_Hat_Hat uu____3393 uu____3394
-                 in
+                        let uu____3397 = str arg in
+                        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3397 in
+                      FStar_Pprint.op_Hat_Hat uu____3395 uu____3396 in
+                    FStar_Pprint.op_Hat_Hat uu____3393 uu____3394 in
               let uu____3398 =
                 let uu____3399 =
                   FStar_Pprint.separate_map FStar_Pprint.hardline
-                    process_kwd_arg kwd_args1
-                   in
-                FStar_Pprint.op_Hat_Hat uu____3399 FStar_Pprint.hardline  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____3398
-           in
+                    process_kwd_arg kwd_args1 in
+                FStar_Pprint.op_Hat_Hat uu____3399 FStar_Pprint.hardline in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____3398 in
         let uu____3404 =
           let uu____3405 =
             let uu____3406 =
               let uu____3407 =
-                let uu____3408 = str doc1  in
+                let uu____3408 = str doc1 in
                 let uu____3409 =
                   let uu____3410 =
                     let uu____3411 =
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.rparen
-                        FStar_Pprint.hardline
-                       in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____3411  in
-                  FStar_Pprint.op_Hat_Hat kwd_args_doc uu____3410  in
-                FStar_Pprint.op_Hat_Hat uu____3408 uu____3409  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____3407  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____3406  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____3405  in
+                        FStar_Pprint.hardline in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____3411 in
+                  FStar_Pprint.op_Hat_Hat kwd_args_doc uu____3410 in
+                FStar_Pprint.op_Hat_Hat uu____3408 uu____3409 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____3407 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.star uu____3406 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____3405 in
         FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu____3404
-
-and (p_justSig : FStar_Parser_AST.decl -> FStar_Pprint.document) =
+and p_justSig: FStar_Parser_AST.decl -> FStar_Pprint.document =
   fun d  ->
     match d.FStar_Parser_AST.d with
     | FStar_Parser_AST.Val (lid,t) ->
         let uu____3415 =
-          let uu____3416 = str "val"  in
+          let uu____3416 = str "val" in
           let uu____3417 =
             let uu____3418 =
-              let uu____3419 = p_lident lid  in
+              let uu____3419 = p_lident lid in
               let uu____3420 =
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon
-                 in
-              FStar_Pprint.op_Hat_Hat uu____3419 uu____3420  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3418  in
-          FStar_Pprint.op_Hat_Hat uu____3416 uu____3417  in
-        let uu____3421 = p_typ false false t  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon in
+              FStar_Pprint.op_Hat_Hat uu____3419 uu____3420 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3418 in
+          FStar_Pprint.op_Hat_Hat uu____3416 uu____3417 in
+        let uu____3421 = p_typ false false t in
         op_Hat_Slash_Plus_Hat uu____3415 uu____3421
     | FStar_Parser_AST.TopLevelLet (uu____3422,lbs) ->
         FStar_Pprint.separate_map FStar_Pprint.hardline
           (fun lb  ->
              let uu____3447 =
-               let uu____3448 = str "let"  in
-               let uu____3449 = p_letlhs lb  in
-               FStar_Pprint.op_Hat_Slash_Hat uu____3448 uu____3449  in
+               let uu____3448 = str "let" in
+               let uu____3449 = p_letlhs lb in
+               FStar_Pprint.op_Hat_Slash_Hat uu____3448 uu____3449 in
              FStar_Pprint.group uu____3447) lbs
     | uu____3450 -> FStar_Pprint.empty
-
-and (p_rawDecl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
+and p_rawDecl: FStar_Parser_AST.decl -> FStar_Pprint.document =
   fun d  ->
     match d.FStar_Parser_AST.d with
     | FStar_Parser_AST.Open uid ->
         let uu____3453 =
-          let uu____3454 = str "open"  in
-          let uu____3455 = p_quident uid  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____3454 uu____3455  in
+          let uu____3454 = str "open" in
+          let uu____3455 = p_quident uid in
+          FStar_Pprint.op_Hat_Slash_Hat uu____3454 uu____3455 in
         FStar_Pprint.group uu____3453
     | FStar_Parser_AST.Include uid ->
         let uu____3457 =
-          let uu____3458 = str "include"  in
-          let uu____3459 = p_quident uid  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____3458 uu____3459  in
+          let uu____3458 = str "include" in
+          let uu____3459 = p_quident uid in
+          FStar_Pprint.op_Hat_Slash_Hat uu____3458 uu____3459 in
         FStar_Pprint.group uu____3457
     | FStar_Parser_AST.ModuleAbbrev (uid1,uid2) ->
         let uu____3462 =
-          let uu____3463 = str "module"  in
+          let uu____3463 = str "module" in
           let uu____3464 =
             let uu____3465 =
-              let uu____3466 = p_uident uid1  in
+              let uu____3466 = p_uident uid1 in
               let uu____3467 =
                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                  FStar_Pprint.equals
-                 in
-              FStar_Pprint.op_Hat_Hat uu____3466 uu____3467  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3465  in
-          FStar_Pprint.op_Hat_Hat uu____3463 uu____3464  in
-        let uu____3468 = p_quident uid2  in
+                  FStar_Pprint.equals in
+              FStar_Pprint.op_Hat_Hat uu____3466 uu____3467 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3465 in
+          FStar_Pprint.op_Hat_Hat uu____3463 uu____3464 in
+        let uu____3468 = p_quident uid2 in
         op_Hat_Slash_Plus_Hat uu____3462 uu____3468
     | FStar_Parser_AST.TopLevelModule uid ->
         let uu____3470 =
-          let uu____3471 = str "module"  in
+          let uu____3471 = str "module" in
           let uu____3472 =
-            let uu____3473 = p_quident uid  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3473  in
-          FStar_Pprint.op_Hat_Hat uu____3471 uu____3472  in
+            let uu____3473 = p_quident uid in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3473 in
+          FStar_Pprint.op_Hat_Hat uu____3471 uu____3472 in
         FStar_Pprint.group uu____3470
     | FStar_Parser_AST.Tycon
         (true
@@ -1120,33 +1031,32 @@ and (p_rawDecl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
            )::[])
         ->
         let effect_prefix_doc =
-          let uu____3506 = str "effect"  in
+          let uu____3506 = str "effect" in
           let uu____3507 =
-            let uu____3508 = p_uident uid  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3508  in
-          FStar_Pprint.op_Hat_Hat uu____3506 uu____3507  in
+            let uu____3508 = p_uident uid in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3508 in
+          FStar_Pprint.op_Hat_Hat uu____3506 uu____3507 in
         let uu____3509 =
-          let uu____3510 = p_typars tpars  in
+          let uu____3510 = p_typars tpars in
           FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
-            effect_prefix_doc uu____3510 FStar_Pprint.equals
-           in
-        let uu____3511 = p_typ false false t  in
+            effect_prefix_doc uu____3510 FStar_Pprint.equals in
+        let uu____3511 = p_typ false false t in
         op_Hat_Slash_Plus_Hat uu____3509 uu____3511
     | FStar_Parser_AST.Tycon (false ,tcdefs) ->
-        let uu____3529 = str "type"  in
-        let uu____3530 = str "and"  in
+        let uu____3529 = str "type" in
+        let uu____3530 = str "and" in
         precede_break_separate_map uu____3529 uu____3530 p_fsdocTypeDeclPairs
           tcdefs
     | FStar_Parser_AST.TopLevelLet (q,lbs) ->
         let let_doc =
-          let uu____3552 = str "let"  in
+          let uu____3552 = str "let" in
           let uu____3553 =
-            let uu____3554 = p_letqualifier q  in
-            FStar_Pprint.op_Hat_Hat uu____3554 FStar_Pprint.space  in
-          FStar_Pprint.op_Hat_Hat uu____3552 uu____3553  in
+            let uu____3554 = p_letqualifier q in
+            FStar_Pprint.op_Hat_Hat uu____3554 FStar_Pprint.space in
+          FStar_Pprint.op_Hat_Hat uu____3552 uu____3553 in
         let uu____3555 =
-          let uu____3556 = str "and"  in
-          FStar_Pprint.op_Hat_Hat uu____3556 FStar_Pprint.space  in
+          let uu____3556 = str "and" in
+          FStar_Pprint.op_Hat_Hat uu____3556 FStar_Pprint.space in
         separate_map_with_comments let_doc uu____3555 p_letbinding lbs
           (fun uu____3564  ->
              match uu____3564 with
@@ -1155,153 +1065,139 @@ and (p_rawDecl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
                    t.FStar_Parser_AST.range)
     | FStar_Parser_AST.Val (lid,t) ->
         let uu____3573 =
-          let uu____3574 = str "val"  in
+          let uu____3574 = str "val" in
           let uu____3575 =
             let uu____3576 =
-              let uu____3577 = p_lident lid  in
+              let uu____3577 = p_lident lid in
               let uu____3578 =
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon
-                 in
-              FStar_Pprint.op_Hat_Hat uu____3577 uu____3578  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3576  in
-          FStar_Pprint.op_Hat_Hat uu____3574 uu____3575  in
-        let uu____3579 = p_typ false false t  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon in
+              FStar_Pprint.op_Hat_Hat uu____3577 uu____3578 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3576 in
+          FStar_Pprint.op_Hat_Hat uu____3574 uu____3575 in
+        let uu____3579 = p_typ false false t in
         op_Hat_Slash_Plus_Hat uu____3573 uu____3579
     | FStar_Parser_AST.Assume (id1,t) ->
         let decl_keyword =
           let uu____3583 =
             let uu____3584 =
-              FStar_Util.char_at id1.FStar_Ident.idText (Prims.parse_int "0")
-               in
-            FStar_All.pipe_right uu____3584 FStar_Util.is_upper  in
+              FStar_Util.char_at id1.FStar_Ident.idText (Prims.parse_int "0") in
+            FStar_All.pipe_right uu____3584 FStar_Util.is_upper in
           if uu____3583
           then FStar_Pprint.empty
           else
-            (let uu____3586 = str "val"  in
-             FStar_Pprint.op_Hat_Hat uu____3586 FStar_Pprint.space)
-           in
+            (let uu____3586 = str "val" in
+             FStar_Pprint.op_Hat_Hat uu____3586 FStar_Pprint.space) in
         let uu____3587 =
           let uu____3588 =
-            let uu____3589 = p_ident id1  in
+            let uu____3589 = p_ident id1 in
             let uu____3590 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon
-               in
-            FStar_Pprint.op_Hat_Hat uu____3589 uu____3590  in
-          FStar_Pprint.op_Hat_Hat decl_keyword uu____3588  in
-        let uu____3591 = p_typ false false t  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.colon in
+            FStar_Pprint.op_Hat_Hat uu____3589 uu____3590 in
+          FStar_Pprint.op_Hat_Hat decl_keyword uu____3588 in
+        let uu____3591 = p_typ false false t in
         op_Hat_Slash_Plus_Hat uu____3587 uu____3591
     | FStar_Parser_AST.Exception (uid,t_opt) ->
-        let uu____3598 = str "exception"  in
+        let uu____3598 = str "exception" in
         let uu____3599 =
           let uu____3600 =
-            let uu____3601 = p_uident uid  in
+            let uu____3601 = p_uident uid in
             let uu____3602 =
               FStar_Pprint.optional
                 (fun t  ->
                    let uu____3606 =
-                     let uu____3607 = str "of"  in
-                     let uu____3608 = p_typ false false t  in
-                     op_Hat_Slash_Plus_Hat uu____3607 uu____3608  in
-                   FStar_Pprint.op_Hat_Hat break1 uu____3606) t_opt
-               in
-            FStar_Pprint.op_Hat_Hat uu____3601 uu____3602  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3600  in
+                     let uu____3607 = str "of" in
+                     let uu____3608 = p_typ false false t in
+                     op_Hat_Slash_Plus_Hat uu____3607 uu____3608 in
+                   FStar_Pprint.op_Hat_Hat break1 uu____3606) t_opt in
+            FStar_Pprint.op_Hat_Hat uu____3601 uu____3602 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3600 in
         FStar_Pprint.op_Hat_Hat uu____3598 uu____3599
     | FStar_Parser_AST.NewEffect ne ->
-        let uu____3610 = str "new_effect"  in
+        let uu____3610 = str "new_effect" in
         let uu____3611 =
-          let uu____3612 = p_newEffect ne  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3612  in
+          let uu____3612 = p_newEffect ne in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3612 in
         FStar_Pprint.op_Hat_Hat uu____3610 uu____3611
     | FStar_Parser_AST.SubEffect se ->
-        let uu____3614 = str "sub_effect"  in
+        let uu____3614 = str "sub_effect" in
         let uu____3615 =
-          let uu____3616 = p_subEffect se  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3616  in
+          let uu____3616 = p_subEffect se in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3616 in
         FStar_Pprint.op_Hat_Hat uu____3614 uu____3615
     | FStar_Parser_AST.Pragma p -> p_pragma p
     | FStar_Parser_AST.Fsdoc doc1 ->
-        let uu____3619 = p_fsdoc doc1  in
+        let uu____3619 = p_fsdoc doc1 in
         FStar_Pprint.op_Hat_Hat uu____3619 FStar_Pprint.hardline
     | FStar_Parser_AST.Main uu____3620 ->
         failwith "*Main declaration* : Is that really still in use ??"
     | FStar_Parser_AST.Tycon (true ,uu____3621) ->
         failwith
           "Effect abbreviation is expected to be defined by an abbreviation"
-
-and (p_pragma : FStar_Parser_AST.pragma -> FStar_Pprint.document) =
+and p_pragma: FStar_Parser_AST.pragma -> FStar_Pprint.document =
   fun uu___54_3638  ->
     match uu___54_3638 with
     | FStar_Parser_AST.SetOptions s ->
-        let uu____3640 = str "#set-options"  in
+        let uu____3640 = str "#set-options" in
         let uu____3641 =
           let uu____3642 =
-            let uu____3643 = str s  in FStar_Pprint.dquotes uu____3643  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3642  in
+            let uu____3643 = str s in FStar_Pprint.dquotes uu____3643 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3642 in
         FStar_Pprint.op_Hat_Hat uu____3640 uu____3641
     | FStar_Parser_AST.ResetOptions s_opt ->
-        let uu____3647 = str "#reset-options"  in
+        let uu____3647 = str "#reset-options" in
         let uu____3648 =
           FStar_Pprint.optional
             (fun s  ->
                let uu____3652 =
-                 let uu____3653 = str s  in FStar_Pprint.dquotes uu____3653
-                  in
-               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3652) s_opt
-           in
+                 let uu____3653 = str s in FStar_Pprint.dquotes uu____3653 in
+               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3652) s_opt in
         FStar_Pprint.op_Hat_Hat uu____3647 uu____3648
     | FStar_Parser_AST.LightOff  ->
         (FStar_ST.op_Colon_Equals should_print_fs_typ_app true;
          str "#light \"off\"")
-
-and (p_typars : FStar_Parser_AST.binder Prims.list -> FStar_Pprint.document)
-  = fun bs  -> p_binders true bs
-
-and (p_fsdocTypeDeclPairs :
+and p_typars: FStar_Parser_AST.binder Prims.list -> FStar_Pprint.document =
+  fun bs  -> p_binders true bs
+and p_fsdocTypeDeclPairs:
   (FStar_Parser_AST.tycon,FStar_Parser_AST.fsdoc
                             FStar_Pervasives_Native.option)
-    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document)
+    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document
   =
   fun uu____3677  ->
     match uu____3677 with
     | (typedecl,fsdoc_opt) ->
-        let uu____3690 = FStar_Pprint.optional p_fsdoc fsdoc_opt  in
-        let uu____3691 = p_typeDecl typedecl  in
+        let uu____3690 = FStar_Pprint.optional p_fsdoc fsdoc_opt in
+        let uu____3691 = p_typeDecl typedecl in
         FStar_Pprint.op_Hat_Hat uu____3690 uu____3691
-
-and (p_typeDecl : FStar_Parser_AST.tycon -> FStar_Pprint.document) =
+and p_typeDecl: FStar_Parser_AST.tycon -> FStar_Pprint.document =
   fun uu___55_3692  ->
     match uu___55_3692 with
     | FStar_Parser_AST.TyconAbstract (lid,bs,typ_opt) ->
-        let empty' uu____3707 = FStar_Pprint.empty  in
+        let empty' uu____3707 = FStar_Pprint.empty in
         p_typeDeclPrefix lid bs typ_opt empty'
     | FStar_Parser_AST.TyconAbbrev (lid,bs,typ_opt,t) ->
         let f uu____3723 =
-          let uu____3724 = p_typ false false t  in
-          prefix2 FStar_Pprint.equals uu____3724  in
+          let uu____3724 = p_typ false false t in
+          prefix2 FStar_Pprint.equals uu____3724 in
         p_typeDeclPrefix lid bs typ_opt f
     | FStar_Parser_AST.TyconRecord (lid,bs,typ_opt,record_field_decls) ->
         let p_recordFieldAndComments ps uu____3771 =
           match uu____3771 with
           | (lid1,t,doc_opt) ->
               let uu____3787 =
-                FStar_Range.extend_to_end_of_line t.FStar_Parser_AST.range
-                 in
+                FStar_Range.extend_to_end_of_line t.FStar_Parser_AST.range in
               with_comment (p_recordFieldDecl ps) (lid1, t, doc_opt)
-                uu____3787
-           in
+                uu____3787 in
         let p_fields uu____3801 =
           let uu____3802 =
             let uu____3803 =
               let uu____3804 =
                 let uu____3805 =
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1  in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
                 separate_map_last uu____3805 p_recordFieldAndComments
-                  record_field_decls
-                 in
-              braces_with_nesting uu____3804  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3803  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.equals uu____3802  in
+                  record_field_decls in
+              braces_with_nesting uu____3804 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3803 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.equals uu____3802 in
         p_typeDeclPrefix lid bs typ_opt p_fields
     | FStar_Parser_AST.TyconVariant (lid,bs,typ_opt,ct_decls) ->
         let p_constructorBranchAndComments uu____3869 =
@@ -1311,36 +1207,32 @@ and (p_typeDecl : FStar_Parser_AST.tycon -> FStar_Pprint.document) =
                 let uu____3895 =
                   let uu____3896 =
                     FStar_Util.map_opt t_opt
-                      (fun t  -> t.FStar_Parser_AST.range)
-                     in
-                  FStar_Util.dflt uid.FStar_Ident.idRange uu____3896  in
-                FStar_Range.extend_to_end_of_line uu____3895  in
+                      (fun t  -> t.FStar_Parser_AST.range) in
+                  FStar_Util.dflt uid.FStar_Ident.idRange uu____3896 in
+                FStar_Range.extend_to_end_of_line uu____3895 in
               let p_constructorBranch decl =
                 let uu____3929 =
                   let uu____3930 =
-                    let uu____3931 = p_constructorDecl decl  in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3931  in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____3930  in
-                FStar_Pprint.group uu____3929  in
+                    let uu____3931 = p_constructorDecl decl in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3931 in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____3930 in
+                FStar_Pprint.group uu____3929 in
               with_comment p_constructorBranch (uid, t_opt, doc_opt, use_of)
-                range
-           in
+                range in
         let datacon_doc uu____3951 =
           let uu____3952 =
             FStar_Pprint.separate_map break1 p_constructorBranchAndComments
-              ct_decls
-             in
-          FStar_Pprint.group uu____3952  in
+              ct_decls in
+          FStar_Pprint.group uu____3952 in
         p_typeDeclPrefix lid bs typ_opt
           (fun uu____3967  ->
-             let uu____3968 = datacon_doc ()  in
+             let uu____3968 = datacon_doc () in
              prefix2 FStar_Pprint.equals uu____3968)
-
-and (p_typeDeclPrefix :
+and p_typeDeclPrefix:
   FStar_Ident.ident ->
     FStar_Parser_AST.binder Prims.list ->
       FStar_Parser_AST.knd FStar_Pervasives_Native.option ->
-        (Prims.unit -> FStar_Pprint.document) -> FStar_Pprint.document)
+        (Prims.unit -> FStar_Pprint.document) -> FStar_Pprint.document
   =
   fun lid  ->
     fun bs  ->
@@ -1348,83 +1240,76 @@ and (p_typeDeclPrefix :
         fun cont  ->
           if (bs = []) && (typ_opt = FStar_Pervasives_Native.None)
           then
-            let uu____3983 = p_ident lid  in
+            let uu____3983 = p_ident lid in
             let uu____3984 =
-              let uu____3985 = cont ()  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3985  in
+              let uu____3985 = cont () in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____3985 in
             FStar_Pprint.op_Hat_Hat uu____3983 uu____3984
           else
             (let binders_doc =
-               let uu____3988 = p_typars bs  in
+               let uu____3988 = p_typars bs in
                let uu____3989 =
                  FStar_Pprint.optional
                    (fun t  ->
                       let uu____3993 =
                         let uu____3994 =
-                          let uu____3995 = p_typ false false t  in
+                          let uu____3995 = p_typ false false t in
                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                            uu____3995
-                           in
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____3994
-                         in
-                      FStar_Pprint.op_Hat_Hat break1 uu____3993) typ_opt
-                  in
-               FStar_Pprint.op_Hat_Hat uu____3988 uu____3989  in
-             let uu____3996 = p_ident lid  in
-             let uu____3997 = cont ()  in
+                            uu____3995 in
+                        FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____3994 in
+                      FStar_Pprint.op_Hat_Hat break1 uu____3993) typ_opt in
+               FStar_Pprint.op_Hat_Hat uu____3988 uu____3989 in
+             let uu____3996 = p_ident lid in
+             let uu____3997 = cont () in
              FStar_Pprint.surround (Prims.parse_int "2")
                (Prims.parse_int "1") uu____3996 binders_doc uu____3997)
-
-and (p_recordFieldDecl :
+and p_recordFieldDecl:
   Prims.bool ->
     (FStar_Ident.ident,FStar_Parser_AST.term,FStar_Parser_AST.fsdoc
                                                FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3 -> FStar_Pprint.document)
+      FStar_Pervasives_Native.tuple3 -> FStar_Pprint.document
   =
   fun ps  ->
     fun uu____3999  ->
       match uu____3999 with
       | (lid,t,doc_opt) ->
           let uu____4015 =
-            let uu____4016 = FStar_Pprint.optional p_fsdoc doc_opt  in
+            let uu____4016 = FStar_Pprint.optional p_fsdoc doc_opt in
             let uu____4017 =
-              let uu____4018 = p_lident lid  in
+              let uu____4018 = p_lident lid in
               let uu____4019 =
-                let uu____4020 = p_typ ps false t  in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4020  in
-              FStar_Pprint.op_Hat_Hat uu____4018 uu____4019  in
-            FStar_Pprint.op_Hat_Hat uu____4016 uu____4017  in
+                let uu____4020 = p_typ ps false t in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4020 in
+              FStar_Pprint.op_Hat_Hat uu____4018 uu____4019 in
+            FStar_Pprint.op_Hat_Hat uu____4016 uu____4017 in
           FStar_Pprint.group uu____4015
-
-and (p_constructorDecl :
+and p_constructorDecl:
   (FStar_Ident.ident,FStar_Parser_AST.term FStar_Pervasives_Native.option,
     FStar_Parser_AST.fsdoc FStar_Pervasives_Native.option,Prims.bool)
-    FStar_Pervasives_Native.tuple4 -> FStar_Pprint.document)
+    FStar_Pervasives_Native.tuple4 -> FStar_Pprint.document
   =
   fun uu____4021  ->
     match uu____4021 with
     | (uid,t_opt,doc_opt,use_of) ->
-        let sep = if use_of then str "of" else FStar_Pprint.colon  in
-        let uid_doc = p_uident uid  in
-        let uu____4049 = FStar_Pprint.optional p_fsdoc doc_opt  in
+        let sep = if use_of then str "of" else FStar_Pprint.colon in
+        let uid_doc = p_uident uid in
+        let uu____4049 = FStar_Pprint.optional p_fsdoc doc_opt in
         let uu____4050 =
-          let uu____4051 = FStar_Pprint.break_ (Prims.parse_int "0")  in
+          let uu____4051 = FStar_Pprint.break_ (Prims.parse_int "0") in
           let uu____4052 =
             default_or_map uid_doc
               (fun t  ->
                  let uu____4057 =
                    let uu____4058 =
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space sep  in
-                   FStar_Pprint.op_Hat_Hat uid_doc uu____4058  in
-                 let uu____4059 = p_typ false false t  in
-                 op_Hat_Slash_Plus_Hat uu____4057 uu____4059) t_opt
-             in
-          FStar_Pprint.op_Hat_Hat uu____4051 uu____4052  in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space sep in
+                   FStar_Pprint.op_Hat_Hat uid_doc uu____4058 in
+                 let uu____4059 = p_typ false false t in
+                 op_Hat_Slash_Plus_Hat uu____4057 uu____4059) t_opt in
+          FStar_Pprint.op_Hat_Hat uu____4051 uu____4052 in
         FStar_Pprint.op_Hat_Hat uu____4049 uu____4050
-
-and (p_letlhs :
+and p_letlhs:
   (FStar_Parser_AST.pattern,FStar_Parser_AST.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document)
+    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document
   =
   fun uu____4060  ->
     match uu____4060 with
@@ -1436,14 +1321,13 @@ and (p_letlhs :
                 let uu____4079 =
                   let uu____4080 =
                     let uu____4081 =
-                      let uu____4082 = p_tmArrow p_tmNoEq t  in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4082
-                       in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4081  in
-                  FStar_Pprint.group uu____4080  in
-                FStar_Pprint.op_Hat_Hat break1 uu____4079  in
+                      let uu____4082 = p_tmArrow p_tmNoEq t in
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4082 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4081 in
+                  FStar_Pprint.group uu____4080 in
+                FStar_Pprint.op_Hat_Hat break1 uu____4079 in
               (pat1, uu____4078)
-          | uu____4083 -> (pat, FStar_Pprint.empty)  in
+          | uu____4083 -> (pat, FStar_Pprint.empty) in
         (match uu____4067 with
          | (pat1,ascr_doc) ->
              (match pat1.FStar_Parser_AST.pat with
@@ -1454,63 +1338,59 @@ and (p_letlhs :
                      FStar_Parser_AST.prange = uu____4088;_},pats)
                   ->
                   let uu____4098 =
-                    let uu____4099 = p_lident x  in
+                    let uu____4099 = p_lident x in
                     let uu____4100 =
                       let uu____4101 =
-                        separate_map_or_flow break1 p_atomicPattern pats  in
-                      FStar_Pprint.op_Hat_Hat uu____4101 ascr_doc  in
-                    FStar_Pprint.op_Hat_Slash_Hat uu____4099 uu____4100  in
+                        separate_map_or_flow break1 p_atomicPattern pats in
+                      FStar_Pprint.op_Hat_Hat uu____4101 ascr_doc in
+                    FStar_Pprint.op_Hat_Slash_Hat uu____4099 uu____4100 in
                   FStar_Pprint.group uu____4098
               | uu____4102 ->
                   let uu____4103 =
-                    let uu____4104 = p_tuplePattern pat1  in
-                    FStar_Pprint.op_Hat_Hat uu____4104 ascr_doc  in
+                    let uu____4104 = p_tuplePattern pat1 in
+                    FStar_Pprint.op_Hat_Hat uu____4104 ascr_doc in
                   FStar_Pprint.group uu____4103))
-
-and (p_letbinding :
+and p_letbinding:
   (FStar_Parser_AST.pattern,FStar_Parser_AST.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document)
+    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document
   =
   fun uu____4105  ->
     match uu____4105 with
     | (pat,e) ->
-        let pat_doc = p_letlhs (pat, e)  in
+        let pat_doc = p_letlhs (pat, e) in
         let uu____4113 =
           let uu____4114 =
-            FStar_Pprint.op_Hat_Slash_Hat pat_doc FStar_Pprint.equals  in
-          FStar_Pprint.group uu____4114  in
-        let uu____4115 = p_term false false e  in
+            FStar_Pprint.op_Hat_Slash_Hat pat_doc FStar_Pprint.equals in
+          FStar_Pprint.group uu____4114 in
+        let uu____4115 = p_term false false e in
         prefix2 uu____4113 uu____4115
-
-and (p_newEffect : FStar_Parser_AST.effect_decl -> FStar_Pprint.document) =
+and p_newEffect: FStar_Parser_AST.effect_decl -> FStar_Pprint.document =
   fun uu___56_4116  ->
     match uu___56_4116 with
     | FStar_Parser_AST.RedefineEffect (lid,bs,t) ->
         p_effectRedefinition lid bs t
     | FStar_Parser_AST.DefineEffect (lid,bs,t,eff_decls) ->
         p_effectDefinition lid bs t eff_decls
-
-and (p_effectRedefinition :
+and p_effectRedefinition:
   FStar_Ident.ident ->
     FStar_Parser_AST.binder Prims.list ->
-      FStar_Parser_AST.term -> FStar_Pprint.document)
+      FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun uid  ->
     fun bs  ->
       fun t  ->
-        let uu____4141 = p_uident uid  in
-        let uu____4142 = p_binders true bs  in
+        let uu____4141 = p_uident uid in
+        let uu____4142 = p_binders true bs in
         let uu____4143 =
-          let uu____4144 = p_simpleTerm false false t  in
-          prefix2 FStar_Pprint.equals uu____4144  in
+          let uu____4144 = p_simpleTerm false false t in
+          prefix2 FStar_Pprint.equals uu____4144 in
         FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
           uu____4141 uu____4142 uu____4143
-
-and (p_effectDefinition :
+and p_effectDefinition:
   FStar_Ident.ident ->
     FStar_Parser_AST.binder Prims.list ->
       FStar_Parser_AST.term ->
-        FStar_Parser_AST.decl Prims.list -> FStar_Pprint.document)
+        FStar_Parser_AST.decl Prims.list -> FStar_Pprint.document
   =
   fun uid  ->
     fun bs  ->
@@ -1519,27 +1399,24 @@ and (p_effectDefinition :
           let uu____4153 =
             let uu____4154 =
               let uu____4155 =
-                let uu____4156 = p_uident uid  in
-                let uu____4157 = p_binders true bs  in
+                let uu____4156 = p_uident uid in
+                let uu____4157 = p_binders true bs in
                 let uu____4158 =
-                  let uu____4159 = p_typ false false t  in
-                  prefix2 FStar_Pprint.colon uu____4159  in
+                  let uu____4159 = p_typ false false t in
+                  prefix2 FStar_Pprint.colon uu____4159 in
                 FStar_Pprint.surround (Prims.parse_int "2")
-                  (Prims.parse_int "1") uu____4156 uu____4157 uu____4158
-                 in
-              FStar_Pprint.group uu____4155  in
+                  (Prims.parse_int "1") uu____4156 uu____4157 uu____4158 in
+              FStar_Pprint.group uu____4155 in
             let uu____4160 =
-              let uu____4161 = str "with"  in
+              let uu____4161 = str "with" in
               let uu____4162 =
                 separate_break_map_last FStar_Pprint.semi p_effectDecl
-                  eff_decls
-                 in
-              prefix2 uu____4161 uu____4162  in
-            FStar_Pprint.op_Hat_Slash_Hat uu____4154 uu____4160  in
+                  eff_decls in
+              prefix2 uu____4161 uu____4162 in
+            FStar_Pprint.op_Hat_Slash_Hat uu____4154 uu____4160 in
           braces_with_nesting uu____4153
-
-and (p_effectDecl :
-  Prims.bool -> FStar_Parser_AST.decl -> FStar_Pprint.document) =
+and p_effectDecl:
+  Prims.bool -> FStar_Parser_AST.decl -> FStar_Pprint.document =
   fun ps  ->
     fun d  ->
       match d.FStar_Parser_AST.d with
@@ -1550,23 +1427,20 @@ and (p_effectDecl :
              )::[])
           ->
           let uu____4193 =
-            let uu____4194 = p_lident lid  in
+            let uu____4194 = p_lident lid in
             let uu____4195 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.equals
-               in
-            FStar_Pprint.op_Hat_Hat uu____4194 uu____4195  in
-          let uu____4196 = p_simpleTerm ps false e  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.equals in
+            FStar_Pprint.op_Hat_Hat uu____4194 uu____4195 in
+          let uu____4196 = p_simpleTerm ps false e in
           prefix2 uu____4193 uu____4196
       | uu____4197 ->
           let uu____4198 =
-            let uu____4199 = FStar_Parser_AST.decl_to_string d  in
+            let uu____4199 = FStar_Parser_AST.decl_to_string d in
             FStar_Util.format1
               "Not a declaration of an effect member... or at least I hope so : %s"
-              uu____4199
-             in
+              uu____4199 in
           failwith uu____4198
-
-and (p_subEffect : FStar_Parser_AST.lift -> FStar_Pprint.document) =
+and p_subEffect: FStar_Parser_AST.lift -> FStar_Pprint.document =
   fun lift  ->
     let lift_op_doc =
       let lifts =
@@ -1574,36 +1448,33 @@ and (p_subEffect : FStar_Parser_AST.lift -> FStar_Pprint.document) =
         | FStar_Parser_AST.NonReifiableLift t -> [("lift_wp", t)]
         | FStar_Parser_AST.ReifiableLift (t1,t2) ->
             [("lift_wp", t1); ("lift", t2)]
-        | FStar_Parser_AST.LiftForFree t -> [("lift", t)]  in
+        | FStar_Parser_AST.LiftForFree t -> [("lift", t)] in
       let p_lift ps uu____4257 =
         match uu____4257 with
         | (kwd,t) ->
             let uu____4264 =
-              let uu____4265 = str kwd  in
+              let uu____4265 = str kwd in
               let uu____4266 =
                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                  FStar_Pprint.equals
-                 in
-              FStar_Pprint.op_Hat_Hat uu____4265 uu____4266  in
-            let uu____4267 = p_simpleTerm ps false t  in
-            prefix2 uu____4264 uu____4267
-         in
-      separate_break_map_last FStar_Pprint.semi p_lift lifts  in
+                  FStar_Pprint.equals in
+              FStar_Pprint.op_Hat_Hat uu____4265 uu____4266 in
+            let uu____4267 = p_simpleTerm ps false t in
+            prefix2 uu____4264 uu____4267 in
+      separate_break_map_last FStar_Pprint.semi p_lift lifts in
     let uu____4272 =
       let uu____4273 =
-        let uu____4274 = p_quident lift.FStar_Parser_AST.msource  in
+        let uu____4274 = p_quident lift.FStar_Parser_AST.msource in
         let uu____4275 =
-          let uu____4276 = str "~>"  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4276  in
-        FStar_Pprint.op_Hat_Hat uu____4274 uu____4275  in
-      let uu____4277 = p_quident lift.FStar_Parser_AST.mdest  in
-      prefix2 uu____4273 uu____4277  in
+          let uu____4276 = str "~>" in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4276 in
+        FStar_Pprint.op_Hat_Hat uu____4274 uu____4275 in
+      let uu____4277 = p_quident lift.FStar_Parser_AST.mdest in
+      prefix2 uu____4273 uu____4277 in
     let uu____4278 =
-      let uu____4279 = braces_with_nesting lift_op_doc  in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4279  in
+      let uu____4279 = braces_with_nesting lift_op_doc in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4279 in
     FStar_Pprint.op_Hat_Hat uu____4272 uu____4278
-
-and (p_qualifier : FStar_Parser_AST.qualifier -> FStar_Pprint.document) =
+and p_qualifier: FStar_Parser_AST.qualifier -> FStar_Pprint.document =
   fun uu___57_4280  ->
     match uu___57_4280 with
     | FStar_Parser_AST.Private  -> str "private"
@@ -1625,57 +1496,47 @@ and (p_qualifier : FStar_Parser_AST.qualifier -> FStar_Pprint.document) =
     | FStar_Parser_AST.Reflectable  -> str "reflectable"
     | FStar_Parser_AST.Opaque  -> str "opaque"
     | FStar_Parser_AST.Logic  -> str "logic"
-
-and (p_qualifiers : FStar_Parser_AST.qualifiers -> FStar_Pprint.document) =
+and p_qualifiers: FStar_Parser_AST.qualifiers -> FStar_Pprint.document =
   fun qs  ->
-    let uu____4282 = FStar_Pprint.separate_map break1 p_qualifier qs  in
+    let uu____4282 = FStar_Pprint.separate_map break1 p_qualifier qs in
     FStar_Pprint.group uu____4282
-
-and (p_letqualifier :
-  FStar_Parser_AST.let_qualifier -> FStar_Pprint.document) =
+and p_letqualifier: FStar_Parser_AST.let_qualifier -> FStar_Pprint.document =
   fun uu___58_4283  ->
     match uu___58_4283 with
     | FStar_Parser_AST.Rec  ->
-        let uu____4284 = str "rec"  in
+        let uu____4284 = str "rec" in
         FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4284
     | FStar_Parser_AST.Mutable  ->
-        let uu____4285 = str "mutable"  in
+        let uu____4285 = str "mutable" in
         FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4285
     | FStar_Parser_AST.NoLetQualifier  -> FStar_Pprint.empty
-
-and (p_aqual : FStar_Parser_AST.arg_qualifier -> FStar_Pprint.document) =
+and p_aqual: FStar_Parser_AST.arg_qualifier -> FStar_Pprint.document =
   fun uu___59_4286  ->
     match uu___59_4286 with
     | FStar_Parser_AST.Implicit  -> str "#"
     | FStar_Parser_AST.Equality  -> str "$"
-
-and (p_disjunctivePattern :
-  FStar_Parser_AST.pattern -> FStar_Pprint.document) =
+and p_disjunctivePattern: FStar_Parser_AST.pattern -> FStar_Pprint.document =
   fun p  ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatOr pats ->
         let uu____4291 =
           let uu____4292 =
             let uu____4293 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.space  in
-            FStar_Pprint.op_Hat_Hat break1 uu____4293  in
-          FStar_Pprint.separate_map uu____4292 p_tuplePattern pats  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.space in
+            FStar_Pprint.op_Hat_Hat break1 uu____4293 in
+          FStar_Pprint.separate_map uu____4292 p_tuplePattern pats in
         FStar_Pprint.group uu____4291
     | uu____4294 -> p_tuplePattern p
-
-and (p_tuplePattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
+and p_tuplePattern: FStar_Parser_AST.pattern -> FStar_Pprint.document =
   fun p  ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatTuple (pats,false ) ->
         let uu____4301 =
-          let uu____4302 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
-             in
-          FStar_Pprint.separate_map uu____4302 p_constructorPattern pats  in
+          let uu____4302 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
+          FStar_Pprint.separate_map uu____4302 p_constructorPattern pats in
         FStar_Pprint.group uu____4301
     | uu____4303 -> p_constructorPattern p
-
-and (p_constructorPattern :
-  FStar_Parser_AST.pattern -> FStar_Pprint.document) =
+and p_constructorPattern: FStar_Parser_AST.pattern -> FStar_Pprint.document =
   fun p  ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatApp
@@ -1684,21 +1545,20 @@ and (p_constructorPattern :
         when
         FStar_Ident.lid_equals maybe_cons_lid FStar_Parser_Const.cons_lid ->
         let uu____4311 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.colon FStar_Pprint.colon  in
-        let uu____4312 = p_constructorPattern hd1  in
-        let uu____4313 = p_constructorPattern tl1  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.colon FStar_Pprint.colon in
+        let uu____4312 = p_constructorPattern hd1 in
+        let uu____4313 = p_constructorPattern tl1 in
         infix0 uu____4311 uu____4312 uu____4313
     | FStar_Parser_AST.PatApp
         ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uid;
            FStar_Parser_AST.prange = uu____4315;_},pats)
         ->
-        let uu____4321 = p_quident uid  in
+        let uu____4321 = p_quident uid in
         let uu____4322 =
-          FStar_Pprint.separate_map break1 p_atomicPattern pats  in
+          FStar_Pprint.separate_map break1 p_atomicPattern pats in
         prefix2 uu____4321 uu____4322
     | uu____4323 -> p_atomicPattern p
-
-and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
+and p_atomicPattern: FStar_Parser_AST.pattern -> FStar_Pprint.document =
   fun p  ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatAscribed (pat,t) ->
@@ -1710,8 +1570,8 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
                FStar_Parser_AST.aqual = uu____4333;_},phi))
              when lid.FStar_Ident.idText = lid'.FStar_Ident.idText ->
              let uu____4339 =
-               let uu____4340 = p_ident lid  in
-               p_refinement aqual uu____4340 t1 phi  in
+               let uu____4340 = p_ident lid in
+               p_refinement aqual uu____4340 t1 phi in
              soft_parens_with_nesting uu____4339
          | (FStar_Parser_AST.PatWild ,FStar_Parser_AST.Refine
             ({ FStar_Parser_AST.b = FStar_Parser_AST.NoName t1;
@@ -1721,62 +1581,58 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
              ->
              let uu____4346 =
                p_refinement FStar_Pervasives_Native.None
-                 FStar_Pprint.underscore t1 phi
-                in
+                 FStar_Pprint.underscore t1 phi in
              soft_parens_with_nesting uu____4346
          | uu____4347 ->
              let uu____4352 =
-               let uu____4353 = p_tuplePattern pat  in
+               let uu____4353 = p_tuplePattern pat in
                let uu____4354 =
-                 let uu____4355 = FStar_Pprint.break_ (Prims.parse_int "0")
-                    in
+                 let uu____4355 = FStar_Pprint.break_ (Prims.parse_int "0") in
                  let uu____4356 =
-                   let uu____4357 = p_tmEqNoRefinement t  in
-                   FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4357  in
-                 FStar_Pprint.op_Hat_Hat uu____4355 uu____4356  in
-               FStar_Pprint.op_Hat_Hat uu____4353 uu____4354  in
+                   let uu____4357 = p_tmEqNoRefinement t in
+                   FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4357 in
+                 FStar_Pprint.op_Hat_Hat uu____4355 uu____4356 in
+               FStar_Pprint.op_Hat_Hat uu____4353 uu____4354 in
              soft_parens_with_nesting uu____4352)
     | FStar_Parser_AST.PatList pats ->
         let uu____4361 =
-          separate_break_map FStar_Pprint.semi p_tuplePattern pats  in
+          separate_break_map FStar_Pprint.semi p_tuplePattern pats in
         FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
           FStar_Pprint.lbracket uu____4361 FStar_Pprint.rbracket
     | FStar_Parser_AST.PatRecord pats ->
         let p_recordFieldPat uu____4376 =
           match uu____4376 with
           | (lid,pat) ->
-              let uu____4383 = p_qlident lid  in
-              let uu____4384 = p_tuplePattern pat  in
-              infix2 FStar_Pprint.equals uu____4383 uu____4384
-           in
+              let uu____4383 = p_qlident lid in
+              let uu____4384 = p_tuplePattern pat in
+              infix2 FStar_Pprint.equals uu____4383 uu____4384 in
         let uu____4385 =
-          separate_break_map FStar_Pprint.semi p_recordFieldPat pats  in
+          separate_break_map FStar_Pprint.semi p_recordFieldPat pats in
         soft_braces_with_nesting uu____4385
     | FStar_Parser_AST.PatTuple (pats,true ) ->
         let uu____4395 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar in
         let uu____4396 =
-          separate_break_map FStar_Pprint.comma p_constructorPattern pats  in
+          separate_break_map FStar_Pprint.comma p_constructorPattern pats in
         let uu____4397 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen in
         FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
           uu____4395 uu____4396 uu____4397
     | FStar_Parser_AST.PatTvar (tv,arg_qualifier_opt) -> p_tvar tv
     | FStar_Parser_AST.PatOp op ->
         let uu____4408 =
           let uu____4409 =
-            let uu____4410 = str (FStar_Ident.text_of_id op)  in
+            let uu____4410 = str (FStar_Ident.text_of_id op) in
             let uu____4411 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen
-               in
-            FStar_Pprint.op_Hat_Hat uu____4410 uu____4411  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4409  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen in
+            FStar_Pprint.op_Hat_Hat uu____4410 uu____4411 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____4409 in
         FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____4408
     | FStar_Parser_AST.PatWild  -> FStar_Pprint.underscore
     | FStar_Parser_AST.PatConst c -> p_constant c
     | FStar_Parser_AST.PatVar (lid,aqual) ->
-        let uu____4419 = FStar_Pprint.optional p_aqual aqual  in
-        let uu____4420 = p_lident lid  in
+        let uu____4419 = FStar_Pprint.optional p_aqual aqual in
+        let uu____4420 = p_lident lid in
         FStar_Pprint.op_Hat_Hat uu____4419 uu____4420
     | FStar_Parser_AST.PatName uid -> p_quident uid
     | FStar_Parser_AST.PatOr uu____4422 -> failwith "Inner or pattern !"
@@ -1784,26 +1640,25 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
         ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uu____4425;
            FStar_Parser_AST.prange = uu____4426;_},uu____4427)
         ->
-        let uu____4432 = p_tuplePattern p  in
+        let uu____4432 = p_tuplePattern p in
         soft_parens_with_nesting uu____4432
     | FStar_Parser_AST.PatTuple (uu____4433,false ) ->
-        let uu____4438 = p_tuplePattern p  in
+        let uu____4438 = p_tuplePattern p in
         soft_parens_with_nesting uu____4438
     | uu____4439 ->
         let uu____4440 =
-          let uu____4441 = FStar_Parser_AST.pat_to_string p  in
-          FStar_Util.format1 "Invalid pattern %s" uu____4441  in
+          let uu____4441 = FStar_Parser_AST.pat_to_string p in
+          FStar_Util.format1 "Invalid pattern %s" uu____4441 in
         failwith uu____4440
-
-and (p_binder :
-  Prims.bool -> FStar_Parser_AST.binder -> FStar_Pprint.document) =
+and p_binder: Prims.bool -> FStar_Parser_AST.binder -> FStar_Pprint.document
+  =
   fun is_atomic  ->
     fun b  ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.Variable lid ->
           let uu____4445 =
-            FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual  in
-          let uu____4446 = p_lident lid  in
+            FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
+          let uu____4446 = p_lident lid in
           FStar_Pprint.op_Hat_Hat uu____4445 uu____4446
       | FStar_Parser_AST.TVariable lid -> p_lident lid
       | FStar_Parser_AST.Annotated (lid,t) ->
@@ -1815,29 +1670,28 @@ and (p_binder :
                    FStar_Parser_AST.blevel = uu____4454;
                    FStar_Parser_AST.aqual = uu____4455;_},phi)
                 when lid.FStar_Ident.idText = lid'.FStar_Ident.idText ->
-                let uu____4457 = p_ident lid  in
+                let uu____4457 = p_ident lid in
                 p_refinement b.FStar_Parser_AST.aqual uu____4457 t1 phi
             | uu____4458 ->
                 let uu____4459 =
-                  FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual  in
+                  FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
                 let uu____4460 =
-                  let uu____4461 = p_lident lid  in
+                  let uu____4461 = p_lident lid in
                   let uu____4462 =
                     let uu____4463 =
                       let uu____4464 =
-                        FStar_Pprint.break_ (Prims.parse_int "0")  in
-                      let uu____4465 = p_tmFormula t  in
-                      FStar_Pprint.op_Hat_Hat uu____4464 uu____4465  in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4463  in
-                  FStar_Pprint.op_Hat_Hat uu____4461 uu____4462  in
-                FStar_Pprint.op_Hat_Hat uu____4459 uu____4460
-             in
+                        FStar_Pprint.break_ (Prims.parse_int "0") in
+                      let uu____4465 = p_tmFormula t in
+                      FStar_Pprint.op_Hat_Hat uu____4464 uu____4465 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4463 in
+                  FStar_Pprint.op_Hat_Hat uu____4461 uu____4462 in
+                FStar_Pprint.op_Hat_Hat uu____4459 uu____4460 in
           if is_atomic
           then
             let uu____4466 =
               let uu____4467 =
-                FStar_Pprint.op_Hat_Hat doc1 FStar_Pprint.rparen  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____4467  in
+                FStar_Pprint.op_Hat_Hat doc1 FStar_Pprint.rparen in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____4467 in
             FStar_Pprint.group uu____4466
           else FStar_Pprint.group doc1
       | FStar_Parser_AST.TAnnotated uu____4469 ->
@@ -1856,79 +1710,64 @@ and (p_binder :
                    let uu____4481 =
                      let uu____4482 =
                        p_refinement b.FStar_Parser_AST.aqual
-                         FStar_Pprint.underscore t1 phi
-                        in
-                     FStar_Pprint.op_Hat_Hat uu____4482 FStar_Pprint.rparen
-                      in
-                   FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____4481  in
+                         FStar_Pprint.underscore t1 phi in
+                     FStar_Pprint.op_Hat_Hat uu____4482 FStar_Pprint.rparen in
+                   FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____4481 in
                  FStar_Pprint.group uu____4480
                else
                  (let uu____4484 =
                     p_refinement b.FStar_Parser_AST.aqual
-                      FStar_Pprint.underscore t1 phi
-                     in
+                      FStar_Pprint.underscore t1 phi in
                   FStar_Pprint.group uu____4484)
            | uu____4485 -> if is_atomic then p_atomicTerm t else p_appTerm t)
-
-and (p_refinement :
+and p_refinement:
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
     FStar_Pprint.document ->
-      FStar_Parser_AST.term -> FStar_Parser_AST.term -> FStar_Pprint.document)
+      FStar_Parser_AST.term -> FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun aqual_opt  ->
     fun binder  ->
       fun t  ->
         fun phi  ->
-          let uu____4493 = FStar_Pprint.optional p_aqual aqual_opt  in
+          let uu____4493 = FStar_Pprint.optional p_aqual aqual_opt in
           let uu____4494 =
             let uu____4495 =
               let uu____4496 =
-                let uu____4497 = p_appTerm t  in
+                let uu____4497 = p_appTerm t in
                 let uu____4498 =
-                  let uu____4499 = p_noSeqTerm false false phi  in
-                  soft_braces_with_nesting uu____4499  in
-                FStar_Pprint.op_Hat_Hat uu____4497 uu____4498  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4496  in
-            FStar_Pprint.op_Hat_Hat binder uu____4495  in
+                  let uu____4499 = p_noSeqTerm false false phi in
+                  soft_braces_with_nesting uu____4499 in
+                FStar_Pprint.op_Hat_Hat uu____4497 uu____4498 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____4496 in
+            FStar_Pprint.op_Hat_Hat binder uu____4495 in
           FStar_Pprint.op_Hat_Hat uu____4493 uu____4494
-
-and (p_binders :
-  Prims.bool -> FStar_Parser_AST.binder Prims.list -> FStar_Pprint.document)
-  =
+and p_binders:
+  Prims.bool -> FStar_Parser_AST.binder Prims.list -> FStar_Pprint.document =
   fun is_atomic  ->
     fun bs  -> separate_map_or_flow break1 (p_binder is_atomic) bs
-
-and (p_qlident : FStar_Ident.lid -> FStar_Pprint.document) =
+and p_qlident: FStar_Ident.lid -> FStar_Pprint.document =
   fun lid  -> str (FStar_Ident.text_of_lid lid)
-
-and (p_quident : FStar_Ident.lid -> FStar_Pprint.document) =
+and p_quident: FStar_Ident.lid -> FStar_Pprint.document =
   fun lid  -> str (FStar_Ident.text_of_lid lid)
-
-and (p_ident : FStar_Ident.ident -> FStar_Pprint.document) =
+and p_ident: FStar_Ident.ident -> FStar_Pprint.document =
   fun lid  -> str (FStar_Ident.text_of_id lid)
-
-and (p_lident : FStar_Ident.ident -> FStar_Pprint.document) =
+and p_lident: FStar_Ident.ident -> FStar_Pprint.document =
   fun lid  -> str (FStar_Ident.text_of_id lid)
-
-and (p_uident : FStar_Ident.ident -> FStar_Pprint.document) =
+and p_uident: FStar_Ident.ident -> FStar_Pprint.document =
   fun lid  -> str (FStar_Ident.text_of_id lid)
-
-and (p_tvar : FStar_Ident.ident -> FStar_Pprint.document) =
+and p_tvar: FStar_Ident.ident -> FStar_Pprint.document =
   fun lid  -> str (FStar_Ident.text_of_id lid)
-
-and (p_lidentOrUnderscore : FStar_Ident.ident -> FStar_Pprint.document) =
+and p_lidentOrUnderscore: FStar_Ident.ident -> FStar_Pprint.document =
   fun id1  ->
     if
       FStar_Util.starts_with FStar_Ident.reserved_prefix
         id1.FStar_Ident.idText
     then FStar_Pprint.underscore
     else p_lident id1
-
-and (paren_if : Prims.bool -> FStar_Pprint.document -> FStar_Pprint.document)
-  = fun b  -> if b then soft_parens_with_nesting else (fun x  -> x)
-
-and (p_term :
-  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
+and paren_if: Prims.bool -> FStar_Pprint.document -> FStar_Pprint.document =
+  fun b  -> if b then soft_parens_with_nesting else (fun x  -> x)
+and p_term:
+  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun ps  ->
     fun pb  ->
@@ -1937,45 +1776,41 @@ and (p_term :
         | FStar_Parser_AST.Seq (e1,e2) ->
             let uu____4522 =
               let uu____4523 =
-                let uu____4524 = p_noSeqTerm true false e1  in
-                FStar_Pprint.op_Hat_Hat uu____4524 FStar_Pprint.semi  in
-              FStar_Pprint.group uu____4523  in
-            let uu____4525 = p_term ps pb e2  in
+                let uu____4524 = p_noSeqTerm true false e1 in
+                FStar_Pprint.op_Hat_Hat uu____4524 FStar_Pprint.semi in
+              FStar_Pprint.group uu____4523 in
+            let uu____4525 = p_term ps pb e2 in
             FStar_Pprint.op_Hat_Slash_Hat uu____4522 uu____4525
         | FStar_Parser_AST.Bind (x,e1,e2) ->
             let uu____4529 =
               let uu____4530 =
                 let uu____4531 =
-                  let uu____4532 = p_lident x  in
+                  let uu____4532 = p_lident x in
                   let uu____4533 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                      FStar_Pprint.long_left_arrow
-                     in
-                  FStar_Pprint.op_Hat_Hat uu____4532 uu____4533  in
+                      FStar_Pprint.long_left_arrow in
+                  FStar_Pprint.op_Hat_Hat uu____4532 uu____4533 in
                 let uu____4534 =
-                  let uu____4535 = p_noSeqTerm true false e1  in
+                  let uu____4535 = p_noSeqTerm true false e1 in
                   let uu____4536 =
                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                      FStar_Pprint.semi
-                     in
-                  FStar_Pprint.op_Hat_Hat uu____4535 uu____4536  in
-                op_Hat_Slash_Plus_Hat uu____4531 uu____4534  in
-              FStar_Pprint.group uu____4530  in
-            let uu____4537 = p_term ps pb e2  in
+                      FStar_Pprint.semi in
+                  FStar_Pprint.op_Hat_Hat uu____4535 uu____4536 in
+                op_Hat_Slash_Plus_Hat uu____4531 uu____4534 in
+              FStar_Pprint.group uu____4530 in
+            let uu____4537 = p_term ps pb e2 in
             FStar_Pprint.op_Hat_Slash_Hat uu____4529 uu____4537
         | uu____4538 ->
-            let uu____4539 = p_noSeqTerm ps pb e  in
+            let uu____4539 = p_noSeqTerm ps pb e in
             FStar_Pprint.group uu____4539
-
-and (p_noSeqTerm :
-  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
+and p_noSeqTerm:
+  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun ps  ->
     fun pb  ->
       fun e  -> with_comment (p_noSeqTerm' ps pb) e e.FStar_Parser_AST.range
-
-and (p_noSeqTerm' :
-  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
+and p_noSeqTerm':
+  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun ps  ->
     fun pb  ->
@@ -1983,32 +1818,30 @@ and (p_noSeqTerm' :
         match e.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Ascribed (e1,t,FStar_Pervasives_Native.None ) ->
             let uu____4550 =
-              let uu____4551 = p_tmIff e1  in
+              let uu____4551 = p_tmIff e1 in
               let uu____4552 =
                 let uu____4553 =
-                  let uu____4554 = p_typ ps pb t  in
-                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____4554
-                   in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____4553  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____4551 uu____4552  in
+                  let uu____4554 = p_typ ps pb t in
+                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____4554 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____4553 in
+              FStar_Pprint.op_Hat_Slash_Hat uu____4551 uu____4552 in
             FStar_Pprint.group uu____4550
         | FStar_Parser_AST.Ascribed (e1,t,FStar_Pervasives_Native.Some tac)
             ->
             let uu____4560 =
-              let uu____4561 = p_tmIff e1  in
+              let uu____4561 = p_tmIff e1 in
               let uu____4562 =
                 let uu____4563 =
                   let uu____4564 =
-                    let uu____4565 = p_typ false false t  in
+                    let uu____4565 = p_typ false false t in
                     let uu____4566 =
-                      let uu____4567 = str "by"  in
-                      let uu____4568 = p_typ ps pb tac  in
-                      FStar_Pprint.op_Hat_Slash_Hat uu____4567 uu____4568  in
-                    FStar_Pprint.op_Hat_Slash_Hat uu____4565 uu____4566  in
-                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____4564
-                   in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____4563  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____4561 uu____4562  in
+                      let uu____4567 = str "by" in
+                      let uu____4568 = p_typ ps pb tac in
+                      FStar_Pprint.op_Hat_Slash_Hat uu____4567 uu____4568 in
+                    FStar_Pprint.op_Hat_Slash_Hat uu____4565 uu____4566 in
+                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____4564 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.langle uu____4563 in
+              FStar_Pprint.op_Hat_Slash_Hat uu____4561 uu____4562 in
             FStar_Pprint.group uu____4560
         | FStar_Parser_AST.Op
             ({ FStar_Ident.idText = ".()<-";
@@ -2017,24 +1850,22 @@ and (p_noSeqTerm' :
             let uu____4575 =
               let uu____4576 =
                 let uu____4577 =
-                  let uu____4578 = p_atomicTermNotQUident e1  in
+                  let uu____4578 = p_atomicTermNotQUident e1 in
                   let uu____4579 =
                     let uu____4580 =
                       let uu____4581 =
-                        let uu____4582 = p_term false false e2  in
-                        soft_parens_with_nesting uu____4582  in
+                        let uu____4582 = p_term false false e2 in
+                        soft_parens_with_nesting uu____4582 in
                       let uu____4583 =
                         FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                          FStar_Pprint.larrow
-                         in
-                      FStar_Pprint.op_Hat_Hat uu____4581 uu____4583  in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____4580  in
-                  FStar_Pprint.op_Hat_Hat uu____4578 uu____4579  in
-                FStar_Pprint.group uu____4577  in
+                          FStar_Pprint.larrow in
+                      FStar_Pprint.op_Hat_Hat uu____4581 uu____4583 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____4580 in
+                  FStar_Pprint.op_Hat_Hat uu____4578 uu____4579 in
+                FStar_Pprint.group uu____4577 in
               let uu____4584 =
-                let uu____4585 = p_noSeqTerm ps pb e3  in jump2 uu____4585
-                 in
-              FStar_Pprint.op_Hat_Hat uu____4576 uu____4584  in
+                let uu____4585 = p_noSeqTerm ps pb e3 in jump2 uu____4585 in
+              FStar_Pprint.op_Hat_Hat uu____4576 uu____4584 in
             FStar_Pprint.group uu____4575
         | FStar_Parser_AST.Op
             ({ FStar_Ident.idText = ".[]<-";
@@ -2043,162 +1874,154 @@ and (p_noSeqTerm' :
             let uu____4592 =
               let uu____4593 =
                 let uu____4594 =
-                  let uu____4595 = p_atomicTermNotQUident e1  in
+                  let uu____4595 = p_atomicTermNotQUident e1 in
                   let uu____4596 =
                     let uu____4597 =
                       let uu____4598 =
-                        let uu____4599 = p_term false false e2  in
-                        soft_brackets_with_nesting uu____4599  in
+                        let uu____4599 = p_term false false e2 in
+                        soft_brackets_with_nesting uu____4599 in
                       let uu____4600 =
                         FStar_Pprint.op_Hat_Hat FStar_Pprint.space
-                          FStar_Pprint.larrow
-                         in
-                      FStar_Pprint.op_Hat_Hat uu____4598 uu____4600  in
-                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____4597  in
-                  FStar_Pprint.op_Hat_Hat uu____4595 uu____4596  in
-                FStar_Pprint.group uu____4594  in
+                          FStar_Pprint.larrow in
+                      FStar_Pprint.op_Hat_Hat uu____4598 uu____4600 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____4597 in
+                  FStar_Pprint.op_Hat_Hat uu____4595 uu____4596 in
+                FStar_Pprint.group uu____4594 in
               let uu____4601 =
-                let uu____4602 = p_noSeqTerm ps pb e3  in jump2 uu____4602
-                 in
-              FStar_Pprint.op_Hat_Hat uu____4593 uu____4601  in
+                let uu____4602 = p_noSeqTerm ps pb e3 in jump2 uu____4602 in
+              FStar_Pprint.op_Hat_Hat uu____4593 uu____4601 in
             FStar_Pprint.group uu____4592
         | FStar_Parser_AST.Requires (e1,wtf) ->
             let uu____4612 =
-              let uu____4613 = str "requires"  in
-              let uu____4614 = p_typ ps pb e1  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____4613 uu____4614  in
+              let uu____4613 = str "requires" in
+              let uu____4614 = p_typ ps pb e1 in
+              FStar_Pprint.op_Hat_Slash_Hat uu____4613 uu____4614 in
             FStar_Pprint.group uu____4612
         | FStar_Parser_AST.Ensures (e1,wtf) ->
             let uu____4624 =
-              let uu____4625 = str "ensures"  in
-              let uu____4626 = p_typ ps pb e1  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____4625 uu____4626  in
+              let uu____4625 = str "ensures" in
+              let uu____4626 = p_typ ps pb e1 in
+              FStar_Pprint.op_Hat_Slash_Hat uu____4625 uu____4626 in
             FStar_Pprint.group uu____4624
         | FStar_Parser_AST.Attributes es ->
             let uu____4630 =
-              let uu____4631 = str "attributes"  in
+              let uu____4631 = str "attributes" in
               let uu____4632 =
-                FStar_Pprint.separate_map break1 p_atomicTerm es  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____4631 uu____4632  in
+                FStar_Pprint.separate_map break1 p_atomicTerm es in
+              FStar_Pprint.op_Hat_Slash_Hat uu____4631 uu____4632 in
             FStar_Pprint.group uu____4630
         | FStar_Parser_AST.If (e1,e2,e3) ->
             if is_unit e3
             then
               let uu____4636 =
                 let uu____4637 =
-                  let uu____4638 = str "if"  in
-                  let uu____4639 = p_noSeqTerm false false e1  in
-                  op_Hat_Slash_Plus_Hat uu____4638 uu____4639  in
+                  let uu____4638 = str "if" in
+                  let uu____4639 = p_noSeqTerm false false e1 in
+                  op_Hat_Slash_Plus_Hat uu____4638 uu____4639 in
                 let uu____4640 =
-                  let uu____4641 = str "then"  in
-                  let uu____4642 = p_noSeqTerm ps pb e2  in
-                  op_Hat_Slash_Plus_Hat uu____4641 uu____4642  in
-                FStar_Pprint.op_Hat_Slash_Hat uu____4637 uu____4640  in
+                  let uu____4641 = str "then" in
+                  let uu____4642 = p_noSeqTerm ps pb e2 in
+                  op_Hat_Slash_Plus_Hat uu____4641 uu____4642 in
+                FStar_Pprint.op_Hat_Slash_Hat uu____4637 uu____4640 in
               FStar_Pprint.group uu____4636
             else
               (let e2_doc =
                  match e2.FStar_Parser_AST.tm with
                  | FStar_Parser_AST.If (uu____4645,uu____4646,e31) when
                      is_unit e31 ->
-                     let uu____4648 = p_noSeqTerm false false e2  in
+                     let uu____4648 = p_noSeqTerm false false e2 in
                      soft_parens_with_nesting uu____4648
-                 | uu____4649 -> p_noSeqTerm false false e2  in
+                 | uu____4649 -> p_noSeqTerm false false e2 in
                let uu____4650 =
                  let uu____4651 =
-                   let uu____4652 = str "if"  in
-                   let uu____4653 = p_noSeqTerm false false e1  in
-                   op_Hat_Slash_Plus_Hat uu____4652 uu____4653  in
+                   let uu____4652 = str "if" in
+                   let uu____4653 = p_noSeqTerm false false e1 in
+                   op_Hat_Slash_Plus_Hat uu____4652 uu____4653 in
                  let uu____4654 =
                    let uu____4655 =
-                     let uu____4656 = str "then"  in
-                     op_Hat_Slash_Plus_Hat uu____4656 e2_doc  in
+                     let uu____4656 = str "then" in
+                     op_Hat_Slash_Plus_Hat uu____4656 e2_doc in
                    let uu____4657 =
-                     let uu____4658 = str "else"  in
-                     let uu____4659 = p_noSeqTerm ps pb e3  in
-                     op_Hat_Slash_Plus_Hat uu____4658 uu____4659  in
-                   FStar_Pprint.op_Hat_Slash_Hat uu____4655 uu____4657  in
-                 FStar_Pprint.op_Hat_Slash_Hat uu____4651 uu____4654  in
+                     let uu____4658 = str "else" in
+                     let uu____4659 = p_noSeqTerm ps pb e3 in
+                     op_Hat_Slash_Plus_Hat uu____4658 uu____4659 in
+                   FStar_Pprint.op_Hat_Slash_Hat uu____4655 uu____4657 in
+                 FStar_Pprint.op_Hat_Slash_Hat uu____4651 uu____4654 in
                FStar_Pprint.group uu____4650)
         | FStar_Parser_AST.TryWith (e1,branches) ->
             let uu____4682 =
               let uu____4683 =
                 let uu____4684 =
-                  let uu____4685 = str "try"  in
-                  let uu____4686 = p_noSeqTerm false false e1  in
-                  prefix2 uu____4685 uu____4686  in
+                  let uu____4685 = str "try" in
+                  let uu____4686 = p_noSeqTerm false false e1 in
+                  prefix2 uu____4685 uu____4686 in
                 let uu____4687 =
-                  let uu____4688 = str "with"  in
+                  let uu____4688 = str "with" in
                   let uu____4689 =
                     separate_map_last FStar_Pprint.hardline p_patternBranch
-                      branches
-                     in
-                  FStar_Pprint.op_Hat_Slash_Hat uu____4688 uu____4689  in
-                FStar_Pprint.op_Hat_Slash_Hat uu____4684 uu____4687  in
-              FStar_Pprint.group uu____4683  in
-            let uu____4698 = paren_if (ps || pb)  in uu____4698 uu____4682
+                      branches in
+                  FStar_Pprint.op_Hat_Slash_Hat uu____4688 uu____4689 in
+                FStar_Pprint.op_Hat_Slash_Hat uu____4684 uu____4687 in
+              FStar_Pprint.group uu____4683 in
+            let uu____4698 = paren_if (ps || pb) in uu____4698 uu____4682
         | FStar_Parser_AST.Match (e1,branches) ->
             let uu____4723 =
               let uu____4724 =
                 let uu____4725 =
-                  let uu____4726 = str "match"  in
-                  let uu____4727 = p_noSeqTerm false false e1  in
-                  let uu____4728 = str "with"  in
+                  let uu____4726 = str "match" in
+                  let uu____4727 = p_noSeqTerm false false e1 in
+                  let uu____4728 = str "with" in
                   FStar_Pprint.surround (Prims.parse_int "2")
-                    (Prims.parse_int "1") uu____4726 uu____4727 uu____4728
-                   in
+                    (Prims.parse_int "1") uu____4726 uu____4727 uu____4728 in
                 let uu____4729 =
                   separate_map_last FStar_Pprint.hardline p_patternBranch
-                    branches
-                   in
-                FStar_Pprint.op_Hat_Slash_Hat uu____4725 uu____4729  in
-              FStar_Pprint.group uu____4724  in
-            let uu____4738 = paren_if (ps || pb)  in uu____4738 uu____4723
+                    branches in
+                FStar_Pprint.op_Hat_Slash_Hat uu____4725 uu____4729 in
+              FStar_Pprint.group uu____4724 in
+            let uu____4738 = paren_if (ps || pb) in uu____4738 uu____4723
         | FStar_Parser_AST.LetOpen (uid,e1) ->
             let uu____4743 =
               let uu____4744 =
                 let uu____4745 =
-                  let uu____4746 = str "let open"  in
-                  let uu____4747 = p_quident uid  in
-                  let uu____4748 = str "in"  in
+                  let uu____4746 = str "let open" in
+                  let uu____4747 = p_quident uid in
+                  let uu____4748 = str "in" in
                   FStar_Pprint.surround (Prims.parse_int "2")
-                    (Prims.parse_int "1") uu____4746 uu____4747 uu____4748
-                   in
-                let uu____4749 = p_term false pb e1  in
-                FStar_Pprint.op_Hat_Slash_Hat uu____4745 uu____4749  in
-              FStar_Pprint.group uu____4744  in
-            let uu____4750 = paren_if ps  in uu____4750 uu____4743
+                    (Prims.parse_int "1") uu____4746 uu____4747 uu____4748 in
+                let uu____4749 = p_term false pb e1 in
+                FStar_Pprint.op_Hat_Slash_Hat uu____4745 uu____4749 in
+              FStar_Pprint.group uu____4744 in
+            let uu____4750 = paren_if ps in uu____4750 uu____4743
         | FStar_Parser_AST.Let (q,(a0,lb0)::attr_letbindings,e1) ->
             let let_first =
-              let uu____4815 = p_attrs_opt a0  in
+              let uu____4815 = p_attrs_opt a0 in
               let uu____4816 =
                 let uu____4817 =
-                  let uu____4818 = str "let"  in
+                  let uu____4818 = str "let" in
                   let uu____4819 =
-                    let uu____4820 = p_letqualifier q  in
-                    let uu____4821 = p_letbinding lb0  in
-                    FStar_Pprint.op_Hat_Slash_Hat uu____4820 uu____4821  in
-                  FStar_Pprint.op_Hat_Slash_Hat uu____4818 uu____4819  in
-                FStar_Pprint.group uu____4817  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____4815 uu____4816  in
+                    let uu____4820 = p_letqualifier q in
+                    let uu____4821 = p_letbinding lb0 in
+                    FStar_Pprint.op_Hat_Slash_Hat uu____4820 uu____4821 in
+                  FStar_Pprint.op_Hat_Slash_Hat uu____4818 uu____4819 in
+                FStar_Pprint.group uu____4817 in
+              FStar_Pprint.op_Hat_Slash_Hat uu____4815 uu____4816 in
             let let_rest =
               match attr_letbindings with
               | [] -> FStar_Pprint.empty
               | uu____4835 ->
                   let uu____4850 =
                     precede_break_separate_map FStar_Pprint.empty
-                      FStar_Pprint.empty p_attr_letbinding attr_letbindings
-                     in
-                  FStar_Pprint.group uu____4850
-               in
+                      FStar_Pprint.empty p_attr_letbinding attr_letbindings in
+                  FStar_Pprint.group uu____4850 in
             let uu____4863 =
               let uu____4864 =
                 let uu____4865 =
-                  let uu____4866 = str "in"  in
-                  let uu____4867 = p_term false pb e1  in
-                  FStar_Pprint.op_Hat_Slash_Hat uu____4866 uu____4867  in
-                FStar_Pprint.op_Hat_Slash_Hat let_rest uu____4865  in
-              FStar_Pprint.op_Hat_Slash_Hat let_first uu____4864  in
-            let uu____4868 = paren_if ps  in uu____4868 uu____4863
+                  let uu____4866 = str "in" in
+                  let uu____4867 = p_term false pb e1 in
+                  FStar_Pprint.op_Hat_Slash_Hat uu____4866 uu____4867 in
+                FStar_Pprint.op_Hat_Slash_Hat let_rest uu____4865 in
+              FStar_Pprint.op_Hat_Slash_Hat let_first uu____4864 in
+            let uu____4868 = paren_if ps in uu____4868 uu____4863
         | FStar_Parser_AST.Abs
             ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatVar (x,typ_opt);
                FStar_Parser_AST.prange = uu____4873;_}::[],{
@@ -2213,66 +2036,61 @@ and (p_noSeqTerm' :
             when matches_var maybe_x x ->
             let uu____4904 =
               let uu____4905 =
-                let uu____4906 = str "function"  in
+                let uu____4906 = str "function" in
                 let uu____4907 =
                   separate_map_last FStar_Pprint.hardline p_patternBranch
-                    branches
-                   in
-                FStar_Pprint.op_Hat_Slash_Hat uu____4906 uu____4907  in
-              FStar_Pprint.group uu____4905  in
-            let uu____4916 = paren_if (ps || pb)  in uu____4916 uu____4904
+                    branches in
+                FStar_Pprint.op_Hat_Slash_Hat uu____4906 uu____4907 in
+              FStar_Pprint.group uu____4905 in
+            let uu____4916 = paren_if (ps || pb) in uu____4916 uu____4904
         | uu____4919 -> p_typ ps pb e
-
-and (p_attrs_opt :
+and p_attrs_opt:
   FStar_Parser_AST.term Prims.list FStar_Pervasives_Native.option ->
-    FStar_Pprint.document)
+    FStar_Pprint.document
   =
   fun uu___60_4920  ->
     match uu___60_4920 with
     | FStar_Pervasives_Native.None  -> FStar_Pprint.empty
     | FStar_Pervasives_Native.Some terms ->
         let uu____4932 =
-          let uu____4933 = str "[@"  in
+          let uu____4933 = str "[@" in
           let uu____4934 =
             let uu____4935 =
-              FStar_Pprint.separate_map break1 p_atomicTerm terms  in
-            let uu____4936 = str "]"  in
-            FStar_Pprint.op_Hat_Slash_Hat uu____4935 uu____4936  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____4933 uu____4934  in
+              FStar_Pprint.separate_map break1 p_atomicTerm terms in
+            let uu____4936 = str "]" in
+            FStar_Pprint.op_Hat_Slash_Hat uu____4935 uu____4936 in
+          FStar_Pprint.op_Hat_Slash_Hat uu____4933 uu____4934 in
         FStar_Pprint.group uu____4932
-
-and (p_attr_letbinding :
+and p_attr_letbinding:
   (FStar_Parser_AST.term Prims.list FStar_Pervasives_Native.option,(FStar_Parser_AST.pattern,
                                                                     FStar_Parser_AST.term)
                                                                     FStar_Pervasives_Native.tuple2)
-    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document)
+    FStar_Pervasives_Native.tuple2 -> FStar_Pprint.document
   =
   fun uu____4937  ->
     match uu____4937 with
     | (a,(pat,e)) ->
-        let pat_doc = p_letlhs (pat, e)  in
+        let pat_doc = p_letlhs (pat, e) in
         let uu____4966 =
-          let uu____4967 = p_attrs_opt a  in
+          let uu____4967 = p_attrs_opt a in
           let uu____4968 =
             let uu____4969 =
-              let uu____4970 = str "and "  in
+              let uu____4970 = str "and " in
               let uu____4971 =
-                FStar_Pprint.op_Hat_Slash_Hat pat_doc FStar_Pprint.equals  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____4970 uu____4971  in
-            FStar_Pprint.group uu____4969  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____4967 uu____4968  in
-        let uu____4972 = p_term false false e  in
+                FStar_Pprint.op_Hat_Slash_Hat pat_doc FStar_Pprint.equals in
+              FStar_Pprint.op_Hat_Slash_Hat uu____4970 uu____4971 in
+            FStar_Pprint.group uu____4969 in
+          FStar_Pprint.op_Hat_Slash_Hat uu____4967 uu____4968 in
+        let uu____4972 = p_term false false e in
         prefix2 uu____4966 uu____4972
-
-and (p_typ :
-  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
+and p_typ:
+  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun ps  ->
     fun pb  ->
       fun e  -> with_comment (p_typ' ps pb) e e.FStar_Parser_AST.range
-
-and (p_typ' :
-  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
+and p_typ':
+  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun ps  ->
     fun pb  ->
@@ -2281,76 +2099,68 @@ and (p_typ' :
         | FStar_Parser_AST.QForall (bs,trigger,e1) ->
             let uu____4994 =
               let uu____4995 =
-                let uu____4996 = p_quantifier e  in
-                FStar_Pprint.op_Hat_Hat uu____4996 FStar_Pprint.space  in
-              let uu____4997 = p_binders true bs  in
+                let uu____4996 = p_quantifier e in
+                FStar_Pprint.op_Hat_Hat uu____4996 FStar_Pprint.space in
+              let uu____4997 = p_binders true bs in
               FStar_Pprint.soft_surround (Prims.parse_int "2")
-                (Prims.parse_int "0") uu____4995 uu____4997 FStar_Pprint.dot
-               in
+                (Prims.parse_int "0") uu____4995 uu____4997 FStar_Pprint.dot in
             let uu____4998 =
-              let uu____4999 = p_trigger trigger  in
-              let uu____5000 = p_noSeqTerm ps pb e1  in
-              FStar_Pprint.op_Hat_Hat uu____4999 uu____5000  in
+              let uu____4999 = p_trigger trigger in
+              let uu____5000 = p_noSeqTerm ps pb e1 in
+              FStar_Pprint.op_Hat_Hat uu____4999 uu____5000 in
             prefix2 uu____4994 uu____4998
         | FStar_Parser_AST.QExists (bs,trigger,e1) ->
             let uu____5016 =
               let uu____5017 =
-                let uu____5018 = p_quantifier e  in
-                FStar_Pprint.op_Hat_Hat uu____5018 FStar_Pprint.space  in
-              let uu____5019 = p_binders true bs  in
+                let uu____5018 = p_quantifier e in
+                FStar_Pprint.op_Hat_Hat uu____5018 FStar_Pprint.space in
+              let uu____5019 = p_binders true bs in
               FStar_Pprint.soft_surround (Prims.parse_int "2")
-                (Prims.parse_int "0") uu____5017 uu____5019 FStar_Pprint.dot
-               in
+                (Prims.parse_int "0") uu____5017 uu____5019 FStar_Pprint.dot in
             let uu____5020 =
-              let uu____5021 = p_trigger trigger  in
-              let uu____5022 = p_noSeqTerm ps pb e1  in
-              FStar_Pprint.op_Hat_Hat uu____5021 uu____5022  in
+              let uu____5021 = p_trigger trigger in
+              let uu____5022 = p_noSeqTerm ps pb e1 in
+              FStar_Pprint.op_Hat_Hat uu____5021 uu____5022 in
             prefix2 uu____5016 uu____5020
         | uu____5023 -> p_simpleTerm ps pb e
-
-and (p_quantifier : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_quantifier: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.QForall uu____5025 -> str "forall"
     | FStar_Parser_AST.QExists uu____5038 -> str "exists"
     | uu____5051 ->
         failwith "Imposible : p_quantifier called on a non-quantifier term"
-
-and (p_trigger :
-  FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document) =
+and p_trigger:
+  FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document =
   fun uu___61_5052  ->
     match uu___61_5052 with
     | [] -> FStar_Pprint.empty
     | pats ->
         let uu____5064 =
           let uu____5065 =
-            let uu____5066 = str "pattern"  in
+            let uu____5066 = str "pattern" in
             let uu____5067 =
               let uu____5068 =
-                let uu____5069 = p_disjunctivePats pats  in jump2 uu____5069
-                 in
+                let uu____5069 = p_disjunctivePats pats in jump2 uu____5069 in
               let uu____5070 =
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.rbrace break1  in
-              FStar_Pprint.op_Hat_Slash_Hat uu____5068 uu____5070  in
-            FStar_Pprint.op_Hat_Slash_Hat uu____5066 uu____5067  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5065  in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.rbrace break1 in
+              FStar_Pprint.op_Hat_Slash_Hat uu____5068 uu____5070 in
+            FStar_Pprint.op_Hat_Slash_Hat uu____5066 uu____5067 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5065 in
         FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu____5064
-
-and (p_disjunctivePats :
-  FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document) =
+and p_disjunctivePats:
+  FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document =
   fun pats  ->
-    let uu____5076 = str "\\/"  in
+    let uu____5076 = str "\\/" in
     FStar_Pprint.separate_map uu____5076 p_conjunctivePats pats
-
-and (p_conjunctivePats :
-  FStar_Parser_AST.term Prims.list -> FStar_Pprint.document) =
+and p_conjunctivePats:
+  FStar_Parser_AST.term Prims.list -> FStar_Pprint.document =
   fun pats  ->
     let uu____5082 =
-      FStar_Pprint.separate_map FStar_Pprint.semi p_appTerm pats  in
+      FStar_Pprint.separate_map FStar_Pprint.semi p_appTerm pats in
     FStar_Pprint.group uu____5082
-
-and (p_simpleTerm :
-  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
+and p_simpleTerm:
+  Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun ps  ->
     fun pb  ->
@@ -2359,27 +2169,24 @@ and (p_simpleTerm :
         | FStar_Parser_AST.Abs (pats,e1) ->
             let uu____5092 =
               let uu____5093 =
-                let uu____5094 = str "fun"  in
+                let uu____5094 = str "fun" in
                 let uu____5095 =
                   let uu____5096 =
-                    FStar_Pprint.separate_map break1 p_atomicPattern pats  in
+                    FStar_Pprint.separate_map break1 p_atomicPattern pats in
                   FStar_Pprint.op_Hat_Slash_Hat uu____5096
-                    FStar_Pprint.rarrow
-                   in
-                op_Hat_Slash_Plus_Hat uu____5094 uu____5095  in
-              let uu____5097 = p_term false pb e1  in
-              op_Hat_Slash_Plus_Hat uu____5093 uu____5097  in
-            let uu____5098 = paren_if ps  in uu____5098 uu____5092
+                    FStar_Pprint.rarrow in
+                op_Hat_Slash_Plus_Hat uu____5094 uu____5095 in
+              let uu____5097 = p_term false pb e1 in
+              op_Hat_Slash_Plus_Hat uu____5093 uu____5097 in
+            let uu____5098 = paren_if ps in uu____5098 uu____5092
         | uu____5101 -> p_tmIff e
-
-and (p_maybeFocusArrow : Prims.bool -> FStar_Pprint.document) =
+and p_maybeFocusArrow: Prims.bool -> FStar_Pprint.document =
   fun b  -> if b then str "~>" else FStar_Pprint.rarrow
-
-and (p_patternBranch :
+and p_patternBranch:
   Prims.bool ->
     (FStar_Parser_AST.pattern,FStar_Parser_AST.term
                                 FStar_Pervasives_Native.option,FStar_Parser_AST.term)
-      FStar_Pervasives_Native.tuple3 -> FStar_Pprint.document)
+      FStar_Pervasives_Native.tuple3 -> FStar_Pprint.document
   =
   fun pb  ->
     fun uu____5105  ->
@@ -2390,60 +2197,55 @@ and (p_patternBranch :
               let uu____5123 =
                 let uu____5124 =
                   let uu____5125 =
-                    let uu____5126 = p_disjunctivePattern pat  in
+                    let uu____5126 = p_disjunctivePattern pat in
                     let uu____5127 =
-                      let uu____5128 = p_maybeWhen when_opt  in
-                      FStar_Pprint.op_Hat_Hat uu____5128 FStar_Pprint.rarrow
-                       in
-                    op_Hat_Slash_Plus_Hat uu____5126 uu____5127  in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5125  in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____5124  in
-              FStar_Pprint.group uu____5123  in
-            let uu____5129 = p_term false pb e  in
-            op_Hat_Slash_Plus_Hat uu____5122 uu____5129  in
+                      let uu____5128 = p_maybeWhen when_opt in
+                      FStar_Pprint.op_Hat_Hat uu____5128 FStar_Pprint.rarrow in
+                    op_Hat_Slash_Plus_Hat uu____5126 uu____5127 in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5125 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu____5124 in
+              FStar_Pprint.group uu____5123 in
+            let uu____5129 = p_term false pb e in
+            op_Hat_Slash_Plus_Hat uu____5122 uu____5129 in
           FStar_Pprint.group uu____5121
-
-and (p_maybeWhen :
+and p_maybeWhen:
   FStar_Parser_AST.term FStar_Pervasives_Native.option ->
-    FStar_Pprint.document)
+    FStar_Pprint.document
   =
   fun uu___62_5130  ->
     match uu___62_5130 with
     | FStar_Pervasives_Native.None  -> FStar_Pprint.empty
     | FStar_Pervasives_Native.Some e ->
-        let uu____5134 = str "when"  in
+        let uu____5134 = str "when" in
         let uu____5135 =
-          let uu____5136 = p_tmFormula e  in
-          FStar_Pprint.op_Hat_Hat uu____5136 FStar_Pprint.space  in
+          let uu____5136 = p_tmFormula e in
+          FStar_Pprint.op_Hat_Hat uu____5136 FStar_Pprint.space in
         op_Hat_Slash_Plus_Hat uu____5134 uu____5135
-
-and (p_tmIff : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmIff: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op
         ({ FStar_Ident.idText = "<==>"; FStar_Ident.idRange = uu____5138;_},e1::e2::[])
         ->
-        let uu____5143 = str "<==>"  in
-        let uu____5144 = p_tmImplies e1  in
-        let uu____5145 = p_tmIff e2  in
+        let uu____5143 = str "<==>" in
+        let uu____5144 = p_tmImplies e1 in
+        let uu____5145 = p_tmIff e2 in
         infix0 uu____5143 uu____5144 uu____5145
     | uu____5146 -> p_tmImplies e
-
-and (p_tmImplies : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmImplies: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op
         ({ FStar_Ident.idText = "==>"; FStar_Ident.idRange = uu____5148;_},e1::e2::[])
         ->
-        let uu____5153 = str "==>"  in
-        let uu____5154 = p_tmArrow p_tmFormula e1  in
-        let uu____5155 = p_tmImplies e2  in
+        let uu____5153 = str "==>" in
+        let uu____5154 = p_tmArrow p_tmFormula e1 in
+        let uu____5155 = p_tmImplies e2 in
         infix0 uu____5153 uu____5154 uu____5155
     | uu____5156 -> p_tmArrow p_tmFormula e
-
-and (p_tmArrow :
+and p_tmArrow:
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    FStar_Parser_AST.term -> FStar_Pprint.document)
+    FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun p_Tm  ->
     fun e  ->
@@ -2453,59 +2255,51 @@ and (p_tmArrow :
             let uu____5168 =
               separate_map_or_flow FStar_Pprint.empty
                 (fun b  ->
-                   let uu____5173 = p_binder false b  in
+                   let uu____5173 = p_binder false b in
                    let uu____5174 =
                      let uu____5175 =
-                       FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow break1  in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5175
-                      in
-                   FStar_Pprint.op_Hat_Hat uu____5173 uu____5174) bs
-               in
-            let uu____5176 = p_tmArrow p_Tm tgt  in
-            FStar_Pprint.op_Hat_Hat uu____5168 uu____5176  in
+                       FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow break1 in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5175 in
+                   FStar_Pprint.op_Hat_Hat uu____5173 uu____5174) bs in
+            let uu____5176 = p_tmArrow p_Tm tgt in
+            FStar_Pprint.op_Hat_Hat uu____5168 uu____5176 in
           FStar_Pprint.group uu____5167
       | uu____5177 -> p_Tm e
-
-and (p_tmFormula : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmFormula: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op
         ({ FStar_Ident.idText = "\\/"; FStar_Ident.idRange = uu____5179;_},e1::e2::[])
         ->
-        let uu____5184 = str "\\/"  in
-        let uu____5185 = p_tmFormula e1  in
-        let uu____5186 = p_tmConjunction e2  in
+        let uu____5184 = str "\\/" in
+        let uu____5185 = p_tmFormula e1 in
+        let uu____5186 = p_tmConjunction e2 in
         infix0 uu____5184 uu____5185 uu____5186
     | uu____5187 -> p_tmConjunction e
-
-and (p_tmConjunction : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmConjunction: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op
         ({ FStar_Ident.idText = "/\\"; FStar_Ident.idRange = uu____5189;_},e1::e2::[])
         ->
-        let uu____5194 = str "/\\"  in
-        let uu____5195 = p_tmConjunction e1  in
-        let uu____5196 = p_tmTuple e2  in
+        let uu____5194 = str "/\\" in
+        let uu____5195 = p_tmConjunction e1 in
+        let uu____5196 = p_tmTuple e2 in
         infix0 uu____5194 uu____5195 uu____5196
     | uu____5197 -> p_tmTuple e
-
-and (p_tmTuple : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmTuple: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  -> with_comment p_tmTuple' e e.FStar_Parser_AST.range
-
-and (p_tmTuple' : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmTuple': FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Construct (lid,args) when is_tuple_constructor lid ->
-        let uu____5214 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
-           in
+        let uu____5214 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
         FStar_Pprint.separate_map uu____5214
           (fun uu____5222  ->
              match uu____5222 with | (e1,uu____5228) -> p_tmEq e1) args
     | uu____5229 -> p_tmEq e
-
-and (paren_if_gt :
-  Prims.int -> Prims.int -> FStar_Pprint.document -> FStar_Pprint.document) =
+and paren_if_gt:
+  Prims.int -> Prims.int -> FStar_Pprint.document -> FStar_Pprint.document =
   fun curr  ->
     fun mine  ->
       fun doc1  ->
@@ -2514,26 +2308,23 @@ and (paren_if_gt :
         else
           (let uu____5234 =
              let uu____5235 =
-               FStar_Pprint.op_Hat_Hat doc1 FStar_Pprint.rparen  in
-             FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____5235  in
+               FStar_Pprint.op_Hat_Hat doc1 FStar_Pprint.rparen in
+             FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____5235 in
            FStar_Pprint.group uu____5234)
-
-and (p_tmEqWith :
+and p_tmEqWith:
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    FStar_Parser_AST.term -> FStar_Pprint.document)
+    FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun p_X  ->
     fun e  ->
       let n1 =
         max_level
           (FStar_List.append [colon_equals (); pipe_right ()]
-             (operatorInfix0ad12 ()))
-         in
+             (operatorInfix0ad12 ())) in
       p_tmEqWith' p_X n1 e
-
-and (p_tmEqWith' :
+and p_tmEqWith':
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    Prims.int -> FStar_Parser_AST.term -> FStar_Pprint.document)
+    Prims.int -> FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun p_X  ->
     fun curr  ->
@@ -2544,53 +2335,50 @@ and (p_tmEqWith' :
                ((FStar_Ident.text_of_id op) = "="))
               || ((FStar_Ident.text_of_id op) = "|>")
             ->
-            let op1 = FStar_Ident.text_of_id op  in
-            let uu____5298 = levels op1  in
+            let op1 = FStar_Ident.text_of_id op in
+            let uu____5298 = levels op1 in
             (match uu____5298 with
              | (left1,mine,right1) ->
                  let uu____5308 =
-                   let uu____5309 = FStar_All.pipe_left str op1  in
-                   let uu____5310 = p_tmEqWith' p_X left1 e1  in
-                   let uu____5311 = p_tmEqWith' p_X right1 e2  in
-                   infix0 uu____5309 uu____5310 uu____5311  in
+                   let uu____5309 = FStar_All.pipe_left str op1 in
+                   let uu____5310 = p_tmEqWith' p_X left1 e1 in
+                   let uu____5311 = p_tmEqWith' p_X right1 e2 in
+                   infix0 uu____5309 uu____5310 uu____5311 in
                  paren_if_gt curr mine uu____5308)
         | FStar_Parser_AST.Op
             ({ FStar_Ident.idText = ":="; FStar_Ident.idRange = uu____5312;_},e1::e2::[])
             ->
             let uu____5317 =
-              let uu____5318 = p_tmEqWith p_X e1  in
+              let uu____5318 = p_tmEqWith p_X e1 in
               let uu____5319 =
                 let uu____5320 =
                   let uu____5321 =
-                    let uu____5322 = p_tmEqWith p_X e2  in
-                    op_Hat_Slash_Plus_Hat FStar_Pprint.equals uu____5322  in
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5321  in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5320  in
-              FStar_Pprint.op_Hat_Hat uu____5318 uu____5319  in
+                    let uu____5322 = p_tmEqWith p_X e2 in
+                    op_Hat_Slash_Plus_Hat FStar_Pprint.equals uu____5322 in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu____5321 in
+                FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5320 in
+              FStar_Pprint.op_Hat_Hat uu____5318 uu____5319 in
             FStar_Pprint.group uu____5317
         | FStar_Parser_AST.Op
             ({ FStar_Ident.idText = "-"; FStar_Ident.idRange = uu____5323;_},e1::[])
             ->
-            let uu____5327 = levels "-"  in
+            let uu____5327 = levels "-" in
             (match uu____5327 with
              | (left1,mine,right1) ->
-                 let uu____5337 = p_tmEqWith' p_X mine e1  in
+                 let uu____5337 = p_tmEqWith' p_X mine e1 in
                  FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.minus uu____5337)
         | uu____5338 -> p_tmNoEqWith p_X e
-
-and (p_tmNoEqWith :
+and p_tmNoEqWith:
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    FStar_Parser_AST.term -> FStar_Pprint.document)
+    FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun p_X  ->
     fun e  ->
-      let n1 = max_level [colon_colon (); amp (); opinfix3 (); opinfix4 ()]
-         in
+      let n1 = max_level [colon_colon (); amp (); opinfix3 (); opinfix4 ()] in
       p_tmNoEqWith' p_X n1 e
-
-and (p_tmNoEqWith' :
+and p_tmNoEqWith':
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    Prims.int -> FStar_Parser_AST.term -> FStar_Pprint.document)
+    Prims.int -> FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun p_X  ->
     fun curr  ->
@@ -2599,167 +2387,152 @@ and (p_tmNoEqWith' :
         | FStar_Parser_AST.Construct
             (lid,(e1,uu____5409)::(e2,uu____5411)::[]) when
             (FStar_Ident.lid_equals lid FStar_Parser_Const.cons_lid) &&
-              (let uu____5431 = is_list e  in Prims.op_Negation uu____5431)
+              (let uu____5431 = is_list e in Prims.op_Negation uu____5431)
             ->
-            let op = "::"  in
-            let uu____5433 = levels op  in
+            let op = "::" in
+            let uu____5433 = levels op in
             (match uu____5433 with
              | (left1,mine,right1) ->
                  let uu____5443 =
-                   let uu____5444 = str op  in
-                   let uu____5445 = p_tmNoEqWith' p_X left1 e1  in
-                   let uu____5446 = p_tmNoEqWith' p_X right1 e2  in
-                   infix0 uu____5444 uu____5445 uu____5446  in
+                   let uu____5444 = str op in
+                   let uu____5445 = p_tmNoEqWith' p_X left1 e1 in
+                   let uu____5446 = p_tmNoEqWith' p_X right1 e2 in
+                   infix0 uu____5444 uu____5445 uu____5446 in
                  paren_if_gt curr mine uu____5443)
         | FStar_Parser_AST.Sum (binders,res) ->
-            let op = "&"  in
-            let uu____5454 = levels op  in
+            let op = "&" in
+            let uu____5454 = levels op in
             (match uu____5454 with
              | (left1,mine,right1) ->
                  let p_dsumfst b =
-                   let uu____5468 = p_binder false b  in
+                   let uu____5468 = p_binder false b in
                    let uu____5469 =
                      let uu____5470 =
-                       let uu____5471 = str op  in
-                       FStar_Pprint.op_Hat_Hat uu____5471 break1  in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5470
-                      in
-                   FStar_Pprint.op_Hat_Hat uu____5468 uu____5469  in
+                       let uu____5471 = str op in
+                       FStar_Pprint.op_Hat_Hat uu____5471 break1 in
+                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5470 in
+                   FStar_Pprint.op_Hat_Hat uu____5468 uu____5469 in
                  let uu____5472 =
-                   let uu____5473 = FStar_Pprint.concat_map p_dsumfst binders
-                      in
-                   let uu____5474 = p_tmNoEqWith' p_X right1 res  in
-                   FStar_Pprint.op_Hat_Hat uu____5473 uu____5474  in
+                   let uu____5473 = FStar_Pprint.concat_map p_dsumfst binders in
+                   let uu____5474 = p_tmNoEqWith' p_X right1 res in
+                   FStar_Pprint.op_Hat_Hat uu____5473 uu____5474 in
                  paren_if_gt curr mine uu____5472)
         | FStar_Parser_AST.Op (op,e1::e2::[]) when is_operatorInfix34 op ->
-            let op1 = FStar_Ident.text_of_id op  in
-            let uu____5481 = levels op1  in
+            let op1 = FStar_Ident.text_of_id op in
+            let uu____5481 = levels op1 in
             (match uu____5481 with
              | (left1,mine,right1) ->
                  let uu____5491 =
-                   let uu____5492 = str op1  in
-                   let uu____5493 = p_tmNoEqWith' p_X left1 e1  in
-                   let uu____5494 = p_tmNoEqWith' p_X right1 e2  in
-                   infix0 uu____5492 uu____5493 uu____5494  in
+                   let uu____5492 = str op1 in
+                   let uu____5493 = p_tmNoEqWith' p_X left1 e1 in
+                   let uu____5494 = p_tmNoEqWith' p_X right1 e2 in
+                   infix0 uu____5492 uu____5493 uu____5494 in
                  paren_if_gt curr mine uu____5491)
         | FStar_Parser_AST.Record (with_opt,record_fields) ->
             let uu____5513 =
               let uu____5514 =
-                default_or_map FStar_Pprint.empty p_with_clause with_opt  in
+                default_or_map FStar_Pprint.empty p_with_clause with_opt in
               let uu____5515 =
                 let uu____5516 =
-                  FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1  in
-                separate_map_last uu____5516 p_simpleDef record_fields  in
-              FStar_Pprint.op_Hat_Hat uu____5514 uu____5515  in
+                  FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
+                separate_map_last uu____5516 p_simpleDef record_fields in
+              FStar_Pprint.op_Hat_Hat uu____5514 uu____5515 in
             braces_with_nesting uu____5513
         | FStar_Parser_AST.Op
             ({ FStar_Ident.idText = "~"; FStar_Ident.idRange = uu____5521;_},e1::[])
             ->
             let uu____5525 =
-              let uu____5526 = str "~"  in
-              let uu____5527 = p_atomicTerm e1  in
-              FStar_Pprint.op_Hat_Hat uu____5526 uu____5527  in
+              let uu____5526 = str "~" in
+              let uu____5527 = p_atomicTerm e1 in
+              FStar_Pprint.op_Hat_Hat uu____5526 uu____5527 in
             FStar_Pprint.group uu____5525
         | uu____5528 -> p_X e
-
-and (p_tmEqNoRefinement : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmEqNoRefinement: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  -> p_tmEqWith p_appTerm e
-
-and (p_tmEq : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmEq: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  -> p_tmEqWith p_tmRefinement e
-
-and (p_tmNoEq : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmNoEq: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  -> p_tmNoEqWith p_tmRefinement e
-
-and (p_tmRefinement : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_tmRefinement: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.NamedTyp (lid,e1) ->
         let uu____5535 =
-          let uu____5536 = p_lidentOrUnderscore lid  in
+          let uu____5536 = p_lidentOrUnderscore lid in
           let uu____5537 =
-            let uu____5538 = p_appTerm e1  in
-            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____5538  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____5536 uu____5537  in
+            let uu____5538 = p_appTerm e1 in
+            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu____5538 in
+          FStar_Pprint.op_Hat_Slash_Hat uu____5536 uu____5537 in
         FStar_Pprint.group uu____5535
     | FStar_Parser_AST.Refine (b,phi) -> p_refinedBinder b phi
     | uu____5541 -> p_appTerm e
-
-and (p_with_clause : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_with_clause: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
-    let uu____5543 = p_appTerm e  in
+    let uu____5543 = p_appTerm e in
     let uu____5544 =
       let uu____5545 =
-        let uu____5546 = str "with"  in
-        FStar_Pprint.op_Hat_Hat uu____5546 break1  in
-      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5545  in
+        let uu____5546 = str "with" in
+        FStar_Pprint.op_Hat_Hat uu____5546 break1 in
+      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5545 in
     FStar_Pprint.op_Hat_Hat uu____5543 uu____5544
-
-and (p_refinedBinder :
-  FStar_Parser_AST.binder -> FStar_Parser_AST.term -> FStar_Pprint.document)
-  =
+and p_refinedBinder:
+  FStar_Parser_AST.binder -> FStar_Parser_AST.term -> FStar_Pprint.document =
   fun b  ->
     fun phi  ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.Annotated (lid,t) ->
           let uu____5551 =
-            let uu____5552 = p_lident lid  in
-            p_refinement b.FStar_Parser_AST.aqual uu____5552 t phi  in
+            let uu____5552 = p_lident lid in
+            p_refinement b.FStar_Parser_AST.aqual uu____5552 t phi in
           soft_parens_with_nesting uu____5551
       | FStar_Parser_AST.TAnnotated uu____5553 ->
           failwith "Is this still used ?"
       | FStar_Parser_AST.Variable uu____5558 ->
           let uu____5559 =
-            let uu____5560 = FStar_Parser_AST.binder_to_string b  in
+            let uu____5560 = FStar_Parser_AST.binder_to_string b in
             FStar_Util.format1
               "Imposible : a refined binder ought to be annotated %s"
-              uu____5560
-             in
+              uu____5560 in
           failwith uu____5559
       | FStar_Parser_AST.TVariable uu____5561 ->
           let uu____5562 =
-            let uu____5563 = FStar_Parser_AST.binder_to_string b  in
+            let uu____5563 = FStar_Parser_AST.binder_to_string b in
             FStar_Util.format1
               "Imposible : a refined binder ought to be annotated %s"
-              uu____5563
-             in
+              uu____5563 in
           failwith uu____5562
       | FStar_Parser_AST.NoName uu____5564 ->
           let uu____5565 =
-            let uu____5566 = FStar_Parser_AST.binder_to_string b  in
+            let uu____5566 = FStar_Parser_AST.binder_to_string b in
             FStar_Util.format1
               "Imposible : a refined binder ought to be annotated %s"
-              uu____5566
-             in
+              uu____5566 in
           failwith uu____5565
-
-and (p_simpleDef :
+and p_simpleDef:
   Prims.bool ->
     (FStar_Ident.lid,FStar_Parser_AST.term) FStar_Pervasives_Native.tuple2 ->
-      FStar_Pprint.document)
+      FStar_Pprint.document
   =
   fun ps  ->
     fun uu____5568  ->
       match uu____5568 with
       | (lid,e) ->
           let uu____5575 =
-            let uu____5576 = p_qlident lid  in
+            let uu____5576 = p_qlident lid in
             let uu____5577 =
-              let uu____5578 = p_noSeqTerm ps false e  in
-              FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals uu____5578
-               in
-            FStar_Pprint.op_Hat_Slash_Hat uu____5576 uu____5577  in
+              let uu____5578 = p_noSeqTerm ps false e in
+              FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.equals uu____5578 in
+            FStar_Pprint.op_Hat_Slash_Hat uu____5576 uu____5577 in
           FStar_Pprint.group uu____5575
-
-and (p_appTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_appTerm: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.App uu____5580 when is_general_application e ->
-        let uu____5587 = head_and_args e  in
+        let uu____5587 = head_and_args e in
         (match uu____5587 with
          | (head1,args) ->
              let uu____5612 =
-               let uu____5623 = FStar_ST.op_Bang should_print_fs_typ_app  in
+               let uu____5623 = FStar_ST.op_Bang should_print_fs_typ_app in
                if uu____5623
                then
                  let uu____5653 =
@@ -2767,69 +2540,62 @@ and (p_appTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
                      (fun uu____5677  ->
                         match uu____5677 with
                         | (uu____5682,aq) -> aq = FStar_Parser_AST.FsTypApp)
-                     args
-                    in
+                     args in
                  match uu____5653 with
                  | (fs_typ_args,args1) ->
                      let uu____5720 =
-                       let uu____5721 = p_indexingTerm head1  in
+                       let uu____5721 = p_indexingTerm head1 in
                        let uu____5722 =
                          let uu____5723 =
-                           FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
-                            in
+                           FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
                          soft_surround_map_or_flow (Prims.parse_int "2")
                            (Prims.parse_int "0") FStar_Pprint.empty
                            FStar_Pprint.langle uu____5723 FStar_Pprint.rangle
-                           p_fsTypArg fs_typ_args
-                          in
-                       FStar_Pprint.op_Hat_Hat uu____5721 uu____5722  in
+                           p_fsTypArg fs_typ_args in
+                       FStar_Pprint.op_Hat_Hat uu____5721 uu____5722 in
                      (uu____5720, args1)
                else
-                 (let uu____5735 = p_indexingTerm head1  in
-                  (uu____5735, args))
-                in
+                 (let uu____5735 = p_indexingTerm head1 in (uu____5735, args)) in
              (match uu____5612 with
               | (head_doc,args1) ->
                   let uu____5756 =
                     let uu____5757 =
-                      FStar_Pprint.op_Hat_Hat head_doc FStar_Pprint.space  in
+                      FStar_Pprint.op_Hat_Hat head_doc FStar_Pprint.space in
                     soft_surround_map_or_flow (Prims.parse_int "2")
                       (Prims.parse_int "0") head_doc uu____5757 break1
-                      FStar_Pprint.empty p_argTerm args1
-                     in
+                      FStar_Pprint.empty p_argTerm args1 in
                   FStar_Pprint.group uu____5756))
     | FStar_Parser_AST.Construct (lid,args) when
         (is_general_construction e) &&
-          (let uu____5777 = is_dtuple_constructor lid  in
+          (let uu____5777 = is_dtuple_constructor lid in
            Prims.op_Negation uu____5777)
         ->
         (match args with
          | [] -> p_quident lid
          | arg::[] ->
              let uu____5795 =
-               let uu____5796 = p_quident lid  in
-               let uu____5797 = p_argTerm arg  in
-               FStar_Pprint.op_Hat_Slash_Hat uu____5796 uu____5797  in
+               let uu____5796 = p_quident lid in
+               let uu____5797 = p_argTerm arg in
+               FStar_Pprint.op_Hat_Slash_Hat uu____5796 uu____5797 in
              FStar_Pprint.group uu____5795
          | hd1::tl1 ->
              let uu____5814 =
                let uu____5815 =
                  let uu____5816 =
-                   let uu____5817 = p_quident lid  in
-                   let uu____5818 = p_argTerm hd1  in
-                   prefix2 uu____5817 uu____5818  in
-                 FStar_Pprint.group uu____5816  in
+                   let uu____5817 = p_quident lid in
+                   let uu____5818 = p_argTerm hd1 in
+                   prefix2 uu____5817 uu____5818 in
+                 FStar_Pprint.group uu____5816 in
                let uu____5819 =
                  let uu____5820 =
-                   FStar_Pprint.separate_map break1 p_argTerm tl1  in
-                 jump2 uu____5820  in
-               FStar_Pprint.op_Hat_Hat uu____5815 uu____5819  in
+                   FStar_Pprint.separate_map break1 p_argTerm tl1 in
+                 jump2 uu____5820 in
+               FStar_Pprint.op_Hat_Hat uu____5815 uu____5819 in
              FStar_Pprint.group uu____5814)
     | uu____5825 -> p_indexingTerm e
-
-and (p_argTerm :
+and p_argTerm:
   (FStar_Parser_AST.term,FStar_Parser_AST.imp) FStar_Pervasives_Native.tuple2
-    -> FStar_Pprint.document)
+    -> FStar_Pprint.document
   =
   fun arg_imp  ->
     match arg_imp with
@@ -2838,25 +2604,23 @@ and (p_argTerm :
         (FStar_Errors.log_issue e.FStar_Parser_AST.range
            (FStar_Errors.Warning_UnexpectedFsTypApp,
              "Unexpected FsTypApp, output might not be formatted correctly.");
-         (let uu____5834 = p_indexingTerm e  in
+         (let uu____5834 = p_indexingTerm e in
           FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
             FStar_Pprint.langle uu____5834 FStar_Pprint.rangle))
     | (e,FStar_Parser_AST.Hash ) ->
-        let uu____5836 = str "#"  in
-        let uu____5837 = p_indexingTerm e  in
+        let uu____5836 = str "#" in
+        let uu____5837 = p_indexingTerm e in
         FStar_Pprint.op_Hat_Hat uu____5836 uu____5837
     | (e,FStar_Parser_AST.Nothing ) -> p_indexingTerm e
-
-and (p_fsTypArg :
+and p_fsTypArg:
   (FStar_Parser_AST.term,FStar_Parser_AST.imp) FStar_Pervasives_Native.tuple2
-    -> FStar_Pprint.document)
+    -> FStar_Pprint.document
   =
   fun uu____5839  ->
     match uu____5839 with | (e,uu____5845) -> p_indexingTerm e
-
-and (p_indexingTerm_aux :
+and p_indexingTerm_aux:
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    FStar_Parser_AST.term -> FStar_Pprint.document)
+    FStar_Parser_AST.term -> FStar_Pprint.document
   =
   fun exit1  ->
     fun e  ->
@@ -2865,51 +2629,47 @@ and (p_indexingTerm_aux :
           ({ FStar_Ident.idText = ".()"; FStar_Ident.idRange = uu____5850;_},e1::e2::[])
           ->
           let uu____5855 =
-            let uu____5856 = p_indexingTerm_aux p_atomicTermNotQUident e1  in
+            let uu____5856 = p_indexingTerm_aux p_atomicTermNotQUident e1 in
             let uu____5857 =
               let uu____5858 =
-                let uu____5859 = p_term false false e2  in
-                soft_parens_with_nesting uu____5859  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5858  in
-            FStar_Pprint.op_Hat_Hat uu____5856 uu____5857  in
+                let uu____5859 = p_term false false e2 in
+                soft_parens_with_nesting uu____5859 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5858 in
+            FStar_Pprint.op_Hat_Hat uu____5856 uu____5857 in
           FStar_Pprint.group uu____5855
       | FStar_Parser_AST.Op
           ({ FStar_Ident.idText = ".[]"; FStar_Ident.idRange = uu____5860;_},e1::e2::[])
           ->
           let uu____5865 =
-            let uu____5866 = p_indexingTerm_aux p_atomicTermNotQUident e1  in
+            let uu____5866 = p_indexingTerm_aux p_atomicTermNotQUident e1 in
             let uu____5867 =
               let uu____5868 =
-                let uu____5869 = p_term false false e2  in
-                soft_brackets_with_nesting uu____5869  in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5868  in
-            FStar_Pprint.op_Hat_Hat uu____5866 uu____5867  in
+                let uu____5869 = p_term false false e2 in
+                soft_brackets_with_nesting uu____5869 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5868 in
+            FStar_Pprint.op_Hat_Hat uu____5866 uu____5867 in
           FStar_Pprint.group uu____5865
       | uu____5870 -> exit1 e
-
-and (p_indexingTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_indexingTerm: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  -> p_indexingTerm_aux p_atomicTerm e
-
-and (p_atomicTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_atomicTerm: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.LetOpen (lid,e1) ->
-        let uu____5875 = p_quident lid  in
+        let uu____5875 = p_quident lid in
         let uu____5876 =
           let uu____5877 =
-            let uu____5878 = p_term false false e1  in
-            soft_parens_with_nesting uu____5878  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5877  in
+            let uu____5878 = p_term false false e1 in
+            soft_parens_with_nesting uu____5878 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5877 in
         FStar_Pprint.op_Hat_Hat uu____5875 uu____5876
     | FStar_Parser_AST.Name lid -> p_quident lid
     | FStar_Parser_AST.Op (op,e1::[]) when is_general_prefix_op op ->
-        let uu____5884 = str (FStar_Ident.text_of_id op)  in
-        let uu____5885 = p_atomicTerm e1  in
+        let uu____5884 = str (FStar_Ident.text_of_id op) in
+        let uu____5885 = p_atomicTerm e1 in
         FStar_Pprint.op_Hat_Hat uu____5884 uu____5885
     | uu____5886 -> p_atomicTermNotQUident e
-
-and (p_atomicTermNotQUident : FStar_Parser_AST.term -> FStar_Pprint.document)
-  =
+and p_atomicTermNotQUident: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Wild  -> FStar_Pprint.underscore
@@ -2927,217 +2687,202 @@ and (p_atomicTermNotQUident : FStar_Parser_AST.term -> FStar_Pprint.document)
         FStar_Ident.lid_equals lid FStar_Parser_Const.false_lid ->
         str "False"
     | FStar_Parser_AST.Op (op,e1::[]) when is_general_prefix_op op ->
-        let uu____5900 = str (FStar_Ident.text_of_id op)  in
-        let uu____5901 = p_atomicTermNotQUident e1  in
+        let uu____5900 = str (FStar_Ident.text_of_id op) in
+        let uu____5901 = p_atomicTermNotQUident e1 in
         FStar_Pprint.op_Hat_Hat uu____5900 uu____5901
     | FStar_Parser_AST.Op (op,[]) ->
         let uu____5905 =
           let uu____5906 =
-            let uu____5907 = str (FStar_Ident.text_of_id op)  in
+            let uu____5907 = str (FStar_Ident.text_of_id op) in
             let uu____5908 =
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen
-               in
-            FStar_Pprint.op_Hat_Hat uu____5907 uu____5908  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5906  in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space FStar_Pprint.rparen in
+            FStar_Pprint.op_Hat_Hat uu____5907 uu____5908 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu____5906 in
         FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu____5905
     | FStar_Parser_AST.Construct (lid,args) when is_dtuple_constructor lid ->
         let uu____5923 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen FStar_Pprint.bar in
         let uu____5924 =
-          let uu____5925 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
-             in
-          let uu____5926 = FStar_List.map FStar_Pervasives_Native.fst args
-             in
-          FStar_Pprint.separate_map uu____5925 p_tmEq uu____5926  in
+          let uu____5925 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
+          let uu____5926 = FStar_List.map FStar_Pervasives_Native.fst args in
+          FStar_Pprint.separate_map uu____5925 p_tmEq uu____5926 in
         let uu____5933 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen in
         FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
           uu____5923 uu____5924 uu____5933
     | FStar_Parser_AST.Project (e1,lid) ->
         let uu____5936 =
-          let uu____5937 = p_atomicTermNotQUident e1  in
+          let uu____5937 = p_atomicTermNotQUident e1 in
           let uu____5938 =
-            let uu____5939 = p_qlident lid  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5939  in
+            let uu____5939 = p_qlident lid in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5939 in
           FStar_Pprint.prefix (Prims.parse_int "2") (Prims.parse_int "0")
-            uu____5937 uu____5938
-           in
+            uu____5937 uu____5938 in
         FStar_Pprint.group uu____5936
     | uu____5940 -> p_projectionLHS e
-
-and (p_projectionLHS : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_projectionLHS: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun e  ->
     match e.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Var lid -> p_qlident lid
     | FStar_Parser_AST.Projector (constr_lid,field_lid) ->
-        let uu____5945 = p_quident constr_lid  in
+        let uu____5945 = p_quident constr_lid in
         let uu____5946 =
           let uu____5947 =
-            let uu____5948 = p_lident field_lid  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5948  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____5947  in
+            let uu____5948 = p_lident field_lid in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____5948 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____5947 in
         FStar_Pprint.op_Hat_Hat uu____5945 uu____5946
     | FStar_Parser_AST.Discrim constr_lid ->
-        let uu____5950 = p_quident constr_lid  in
+        let uu____5950 = p_quident constr_lid in
         FStar_Pprint.op_Hat_Hat uu____5950 FStar_Pprint.qmark
     | FStar_Parser_AST.Paren e1 ->
-        let uu____5952 = p_term false false e1  in
+        let uu____5952 = p_term false false e1 in
         soft_parens_with_nesting uu____5952
     | uu____5953 when is_array e ->
-        let es = extract_from_list e  in
+        let es = extract_from_list e in
         let uu____5957 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket FStar_Pprint.bar  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket FStar_Pprint.bar in
         let uu____5958 =
-          let uu____5959 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1
-             in
+          let uu____5959 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
           separate_map_or_flow_last uu____5959
-            (fun ps  -> p_noSeqTerm ps false) es
-           in
+            (fun ps  -> p_noSeqTerm ps false) es in
         let uu____5962 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rbracket  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rbracket in
         FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
           uu____5957 uu____5958 uu____5962
     | uu____5963 when is_list e ->
         let uu____5964 =
-          let uu____5965 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1
-             in
-          let uu____5966 = extract_from_list e  in
+          let uu____5965 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
+          let uu____5966 = extract_from_list e in
           separate_map_or_flow_last uu____5965
-            (fun ps  -> p_noSeqTerm ps false) uu____5966
-           in
+            (fun ps  -> p_noSeqTerm ps false) uu____5966 in
         FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
           FStar_Pprint.lbracket uu____5964 FStar_Pprint.rbracket
     | uu____5971 when is_lex_list e ->
         let uu____5972 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.percent FStar_Pprint.lbracket
-           in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.percent FStar_Pprint.lbracket in
         let uu____5973 =
-          let uu____5974 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1
-             in
-          let uu____5975 = extract_from_list e  in
+          let uu____5974 = FStar_Pprint.op_Hat_Hat FStar_Pprint.semi break1 in
+          let uu____5975 = extract_from_list e in
           separate_map_or_flow_last uu____5974
-            (fun ps  -> p_noSeqTerm ps false) uu____5975
-           in
+            (fun ps  -> p_noSeqTerm ps false) uu____5975 in
         FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "1")
           uu____5972 uu____5973 FStar_Pprint.rbracket
     | uu____5980 when is_ref_set e ->
-        let es = extract_from_ref_set e  in
+        let es = extract_from_ref_set e in
         let uu____5984 =
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.bang FStar_Pprint.lbrace  in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.bang FStar_Pprint.lbrace in
         let uu____5985 =
-          let uu____5986 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1
-             in
-          separate_map_or_flow uu____5986 p_appTerm es  in
+          let uu____5986 = FStar_Pprint.op_Hat_Hat FStar_Pprint.comma break1 in
+          separate_map_or_flow uu____5986 p_appTerm es in
         FStar_Pprint.surround (Prims.parse_int "2") (Prims.parse_int "0")
           uu____5984 uu____5985 FStar_Pprint.rbrace
     | FStar_Parser_AST.Labeled (e1,s,b) ->
-        let uu____5990 = str (Prims.strcat "(*" (Prims.strcat s "*)"))  in
-        let uu____5991 = p_term false false e1  in
+        let uu____5990 = str (Prims.strcat "(*" (Prims.strcat s "*)")) in
+        let uu____5991 = p_term false false e1 in
         FStar_Pprint.op_Hat_Slash_Hat uu____5990 uu____5991
     | FStar_Parser_AST.Op (op,args) when
-        let uu____5998 = handleable_op op args  in
+        let uu____5998 = handleable_op op args in
         Prims.op_Negation uu____5998 ->
         let uu____5999 =
           let uu____6000 =
             let uu____6001 =
               let uu____6002 =
                 let uu____6003 =
-                  FStar_Util.string_of_int (FStar_List.length args)  in
+                  FStar_Util.string_of_int (FStar_List.length args) in
                 Prims.strcat uu____6003
-                  " arguments couldn't be handled by the pretty printer"
-                 in
-              Prims.strcat " with " uu____6002  in
-            Prims.strcat (FStar_Ident.text_of_id op) uu____6001  in
-          Prims.strcat "Operation " uu____6000  in
+                  " arguments couldn't be handled by the pretty printer" in
+              Prims.strcat " with " uu____6002 in
+            Prims.strcat (FStar_Ident.text_of_id op) uu____6001 in
+          Prims.strcat "Operation " uu____6000 in
         failwith uu____5999
     | FStar_Parser_AST.Uvar uu____6004 ->
         failwith "Unexpected universe variable out of universe context"
     | FStar_Parser_AST.Wild  ->
-        let uu____6005 = p_term false false e  in
+        let uu____6005 = p_term false false e in
         soft_parens_with_nesting uu____6005
     | FStar_Parser_AST.Const uu____6006 ->
-        let uu____6007 = p_term false false e  in
+        let uu____6007 = p_term false false e in
         soft_parens_with_nesting uu____6007
     | FStar_Parser_AST.Op uu____6008 ->
-        let uu____6015 = p_term false false e  in
+        let uu____6015 = p_term false false e in
         soft_parens_with_nesting uu____6015
     | FStar_Parser_AST.Tvar uu____6016 ->
-        let uu____6017 = p_term false false e  in
+        let uu____6017 = p_term false false e in
         soft_parens_with_nesting uu____6017
     | FStar_Parser_AST.Var uu____6018 ->
-        let uu____6019 = p_term false false e  in
+        let uu____6019 = p_term false false e in
         soft_parens_with_nesting uu____6019
     | FStar_Parser_AST.Name uu____6020 ->
-        let uu____6021 = p_term false false e  in
+        let uu____6021 = p_term false false e in
         soft_parens_with_nesting uu____6021
     | FStar_Parser_AST.Construct uu____6022 ->
-        let uu____6033 = p_term false false e  in
+        let uu____6033 = p_term false false e in
         soft_parens_with_nesting uu____6033
     | FStar_Parser_AST.Abs uu____6034 ->
-        let uu____6041 = p_term false false e  in
+        let uu____6041 = p_term false false e in
         soft_parens_with_nesting uu____6041
     | FStar_Parser_AST.App uu____6042 ->
-        let uu____6049 = p_term false false e  in
+        let uu____6049 = p_term false false e in
         soft_parens_with_nesting uu____6049
     | FStar_Parser_AST.Let uu____6050 ->
-        let uu____6071 = p_term false false e  in
+        let uu____6071 = p_term false false e in
         soft_parens_with_nesting uu____6071
     | FStar_Parser_AST.LetOpen uu____6072 ->
-        let uu____6077 = p_term false false e  in
+        let uu____6077 = p_term false false e in
         soft_parens_with_nesting uu____6077
     | FStar_Parser_AST.Seq uu____6078 ->
-        let uu____6083 = p_term false false e  in
+        let uu____6083 = p_term false false e in
         soft_parens_with_nesting uu____6083
     | FStar_Parser_AST.Bind uu____6084 ->
-        let uu____6091 = p_term false false e  in
+        let uu____6091 = p_term false false e in
         soft_parens_with_nesting uu____6091
     | FStar_Parser_AST.If uu____6092 ->
-        let uu____6099 = p_term false false e  in
+        let uu____6099 = p_term false false e in
         soft_parens_with_nesting uu____6099
     | FStar_Parser_AST.Match uu____6100 ->
-        let uu____6115 = p_term false false e  in
+        let uu____6115 = p_term false false e in
         soft_parens_with_nesting uu____6115
     | FStar_Parser_AST.TryWith uu____6116 ->
-        let uu____6131 = p_term false false e  in
+        let uu____6131 = p_term false false e in
         soft_parens_with_nesting uu____6131
     | FStar_Parser_AST.Ascribed uu____6132 ->
-        let uu____6141 = p_term false false e  in
+        let uu____6141 = p_term false false e in
         soft_parens_with_nesting uu____6141
     | FStar_Parser_AST.Record uu____6142 ->
-        let uu____6155 = p_term false false e  in
+        let uu____6155 = p_term false false e in
         soft_parens_with_nesting uu____6155
     | FStar_Parser_AST.Project uu____6156 ->
-        let uu____6161 = p_term false false e  in
+        let uu____6161 = p_term false false e in
         soft_parens_with_nesting uu____6161
     | FStar_Parser_AST.Product uu____6162 ->
-        let uu____6169 = p_term false false e  in
+        let uu____6169 = p_term false false e in
         soft_parens_with_nesting uu____6169
     | FStar_Parser_AST.Sum uu____6170 ->
-        let uu____6177 = p_term false false e  in
+        let uu____6177 = p_term false false e in
         soft_parens_with_nesting uu____6177
     | FStar_Parser_AST.QForall uu____6178 ->
-        let uu____6191 = p_term false false e  in
+        let uu____6191 = p_term false false e in
         soft_parens_with_nesting uu____6191
     | FStar_Parser_AST.QExists uu____6192 ->
-        let uu____6205 = p_term false false e  in
+        let uu____6205 = p_term false false e in
         soft_parens_with_nesting uu____6205
     | FStar_Parser_AST.Refine uu____6206 ->
-        let uu____6211 = p_term false false e  in
+        let uu____6211 = p_term false false e in
         soft_parens_with_nesting uu____6211
     | FStar_Parser_AST.NamedTyp uu____6212 ->
-        let uu____6217 = p_term false false e  in
+        let uu____6217 = p_term false false e in
         soft_parens_with_nesting uu____6217
     | FStar_Parser_AST.Requires uu____6218 ->
-        let uu____6225 = p_term false false e  in
+        let uu____6225 = p_term false false e in
         soft_parens_with_nesting uu____6225
     | FStar_Parser_AST.Ensures uu____6226 ->
-        let uu____6233 = p_term false false e  in
+        let uu____6233 = p_term false false e in
         soft_parens_with_nesting uu____6233
     | FStar_Parser_AST.Attributes uu____6234 ->
-        let uu____6237 = p_term false false e  in
+        let uu____6237 = p_term false false e in
         soft_parens_with_nesting uu____6237
-
-and (p_constant : FStar_Const.sconst -> FStar_Pprint.document) =
+and p_constant: FStar_Const.sconst -> FStar_Pprint.document =
   fun uu___65_6238  ->
     match uu___65_6238 with
     | FStar_Const.Const_effect  -> str "Effect"
@@ -3145,74 +2890,71 @@ and (p_constant : FStar_Const.sconst -> FStar_Pprint.document) =
     | FStar_Const.Const_bool b -> FStar_Pprint.doc_of_bool b
     | FStar_Const.Const_float x -> str (FStar_Util.string_of_float x)
     | FStar_Const.Const_char x ->
-        let uu____6242 = FStar_Pprint.doc_of_char x  in
+        let uu____6242 = FStar_Pprint.doc_of_char x in
         FStar_Pprint.squotes uu____6242
     | FStar_Const.Const_string (s,uu____6244) ->
-        let uu____6245 = str s  in FStar_Pprint.dquotes uu____6245
+        let uu____6245 = str s in FStar_Pprint.dquotes uu____6245
     | FStar_Const.Const_bytearray (bytes,uu____6247) ->
         let uu____6252 =
-          let uu____6253 = str (FStar_Util.string_of_bytes bytes)  in
-          FStar_Pprint.dquotes uu____6253  in
-        let uu____6254 = str "B"  in
+          let uu____6253 = str (FStar_Util.string_of_bytes bytes) in
+          FStar_Pprint.dquotes uu____6253 in
+        let uu____6254 = str "B" in
         FStar_Pprint.op_Hat_Hat uu____6252 uu____6254
     | FStar_Const.Const_int (repr,sign_width_opt) ->
         let signedness uu___63_6272 =
           match uu___63_6272 with
           | FStar_Const.Unsigned  -> str "u"
-          | FStar_Const.Signed  -> FStar_Pprint.empty  in
+          | FStar_Const.Signed  -> FStar_Pprint.empty in
         let width uu___64_6276 =
           match uu___64_6276 with
           | FStar_Const.Int8  -> str "y"
           | FStar_Const.Int16  -> str "s"
           | FStar_Const.Int32  -> str "l"
-          | FStar_Const.Int64  -> str "L"  in
+          | FStar_Const.Int64  -> str "L" in
         let ending =
           default_or_map FStar_Pprint.empty
             (fun uu____6287  ->
                match uu____6287 with
                | (s,w) ->
-                   let uu____6294 = signedness s  in
-                   let uu____6295 = width w  in
+                   let uu____6294 = signedness s in
+                   let uu____6295 = width w in
                    FStar_Pprint.op_Hat_Hat uu____6294 uu____6295)
-            sign_width_opt
-           in
-        let uu____6296 = str repr  in
+            sign_width_opt in
+        let uu____6296 = str repr in
         FStar_Pprint.op_Hat_Hat uu____6296 ending
     | FStar_Const.Const_range_of  -> str "range_of"
     | FStar_Const.Const_set_range_of  -> str "set_range_of"
     | FStar_Const.Const_range r ->
-        let uu____6298 = FStar_Range.string_of_range r  in str uu____6298
+        let uu____6298 = FStar_Range.string_of_range r in str uu____6298
     | FStar_Const.Const_reify  -> str "reify"
     | FStar_Const.Const_reflect lid ->
-        let uu____6300 = p_quident lid  in
+        let uu____6300 = p_quident lid in
         let uu____6301 =
           let uu____6302 =
-            let uu____6303 = str "reflect"  in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____6303  in
-          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____6302  in
+            let uu____6303 = str "reflect" in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.dot uu____6303 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.qmark uu____6302 in
         FStar_Pprint.op_Hat_Hat uu____6300 uu____6301
-
-and (p_universe : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_universe: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun u  ->
-    let uu____6305 = str "u#"  in
-    let uu____6306 = p_atomicUniverse u  in
+    let uu____6305 = str "u#" in
+    let uu____6306 = p_atomicUniverse u in
     FStar_Pprint.op_Hat_Hat uu____6305 uu____6306
-
-and (p_universeFrom : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_universeFrom: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun u  ->
     match u.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Op
         ({ FStar_Ident.idText = "+"; FStar_Ident.idRange = uu____6308;_},u1::u2::[])
         ->
         let uu____6313 =
-          let uu____6314 = p_universeFrom u1  in
+          let uu____6314 = p_universeFrom u1 in
           let uu____6315 =
-            let uu____6316 = p_universeFrom u2  in
-            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.plus uu____6316  in
-          FStar_Pprint.op_Hat_Slash_Hat uu____6314 uu____6315  in
+            let uu____6316 = p_universeFrom u2 in
+            FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.plus uu____6316 in
+          FStar_Pprint.op_Hat_Slash_Hat uu____6314 uu____6315 in
         FStar_Pprint.group uu____6313
     | FStar_Parser_AST.App uu____6317 ->
-        let uu____6324 = head_and_args u  in
+        let uu____6324 = head_and_args u in
         (match uu____6324 with
          | (head1,args) ->
              (match head1.FStar_Parser_AST.tm with
@@ -3221,25 +2963,22 @@ and (p_universeFrom : FStar_Parser_AST.term -> FStar_Pprint.document) =
                     FStar_Parser_Const.max_lid
                   ->
                   let uu____6350 =
-                    let uu____6351 = p_qlident FStar_Parser_Const.max_lid  in
+                    let uu____6351 = p_qlident FStar_Parser_Const.max_lid in
                     let uu____6352 =
                       FStar_Pprint.separate_map FStar_Pprint.space
                         (fun uu____6360  ->
                            match uu____6360 with
-                           | (u1,uu____6366) -> p_atomicUniverse u1) args
-                       in
-                    op_Hat_Slash_Plus_Hat uu____6351 uu____6352  in
+                           | (u1,uu____6366) -> p_atomicUniverse u1) args in
+                    op_Hat_Slash_Plus_Hat uu____6351 uu____6352 in
                   FStar_Pprint.group uu____6350
               | uu____6367 ->
                   let uu____6368 =
-                    let uu____6369 = FStar_Parser_AST.term_to_string u  in
+                    let uu____6369 = FStar_Parser_AST.term_to_string u in
                     FStar_Util.format1 "Invalid term in universe context %s"
-                      uu____6369
-                     in
+                      uu____6369 in
                   failwith uu____6368))
     | uu____6370 -> p_atomicUniverse u
-
-and (p_atomicUniverse : FStar_Parser_AST.term -> FStar_Pprint.document) =
+and p_atomicUniverse: FStar_Parser_AST.term -> FStar_Pprint.document =
   fun u  ->
     match u.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Wild  -> FStar_Pprint.underscore
@@ -3247,75 +2986,69 @@ and (p_atomicUniverse : FStar_Parser_AST.term -> FStar_Pprint.document) =
         p_constant (FStar_Const.Const_int (r, sw))
     | FStar_Parser_AST.Uvar id1 -> str (FStar_Ident.text_of_id id1)
     | FStar_Parser_AST.Paren u1 ->
-        let uu____6394 = p_universeFrom u1  in
+        let uu____6394 = p_universeFrom u1 in
         soft_parens_with_nesting uu____6394
     | FStar_Parser_AST.Op
         ({ FStar_Ident.idText = "+"; FStar_Ident.idRange = uu____6395;_},uu____6396::uu____6397::[])
         ->
-        let uu____6400 = p_universeFrom u  in
+        let uu____6400 = p_universeFrom u in
         soft_parens_with_nesting uu____6400
     | FStar_Parser_AST.App uu____6401 ->
-        let uu____6408 = p_universeFrom u  in
+        let uu____6408 = p_universeFrom u in
         soft_parens_with_nesting uu____6408
     | uu____6409 ->
         let uu____6410 =
-          let uu____6411 = FStar_Parser_AST.term_to_string u  in
-          FStar_Util.format1 "Invalid term in universe context %s" uu____6411
-           in
+          let uu____6411 = FStar_Parser_AST.term_to_string u in
+          FStar_Util.format1 "Invalid term in universe context %s" uu____6411 in
         failwith uu____6410
-
-let (term_to_document : FStar_Parser_AST.term -> FStar_Pprint.document) =
-  fun e  -> p_term false false e 
-let (signature_to_document : FStar_Parser_AST.decl -> FStar_Pprint.document)
-  = fun e  -> p_justSig e 
-let (decl_to_document : FStar_Parser_AST.decl -> FStar_Pprint.document) =
-  fun e  -> p_decl e 
-let (pat_to_document : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
-  fun p  -> p_disjunctivePattern p 
-let (binder_to_document : FStar_Parser_AST.binder -> FStar_Pprint.document) =
-  fun b  -> p_binder true b 
-let (modul_to_document : FStar_Parser_AST.modul -> FStar_Pprint.document) =
+let term_to_document: FStar_Parser_AST.term -> FStar_Pprint.document =
+  fun e  -> p_term false false e
+let signature_to_document: FStar_Parser_AST.decl -> FStar_Pprint.document =
+  fun e  -> p_justSig e
+let decl_to_document: FStar_Parser_AST.decl -> FStar_Pprint.document =
+  fun e  -> p_decl e
+let pat_to_document: FStar_Parser_AST.pattern -> FStar_Pprint.document =
+  fun p  -> p_disjunctivePattern p
+let binder_to_document: FStar_Parser_AST.binder -> FStar_Pprint.document =
+  fun b  -> p_binder true b
+let modul_to_document: FStar_Parser_AST.modul -> FStar_Pprint.document =
   fun m  ->
     FStar_ST.op_Colon_Equals should_print_fs_typ_app false;
     (let res =
        match m with
        | FStar_Parser_AST.Module (uu____6451,decls) ->
            let uu____6457 =
-             FStar_All.pipe_right decls (FStar_List.map decl_to_document)  in
+             FStar_All.pipe_right decls (FStar_List.map decl_to_document) in
            FStar_All.pipe_right uu____6457
              (FStar_Pprint.separate FStar_Pprint.hardline)
        | FStar_Parser_AST.Interface (uu____6466,decls,uu____6468) ->
            let uu____6473 =
-             FStar_All.pipe_right decls (FStar_List.map decl_to_document)  in
+             FStar_All.pipe_right decls (FStar_List.map decl_to_document) in
            FStar_All.pipe_right uu____6473
-             (FStar_Pprint.separate FStar_Pprint.hardline)
-        in
+             (FStar_Pprint.separate FStar_Pprint.hardline) in
      FStar_ST.op_Colon_Equals should_print_fs_typ_app false; res)
-  
-let (comments_to_document :
+let comments_to_document:
   (Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple2 Prims.list
-    -> FStar_Pprint.document)
+    -> FStar_Pprint.document
   =
   fun comments  ->
     FStar_Pprint.separate_map FStar_Pprint.hardline
       (fun uu____6524  ->
          match uu____6524 with | (comment,range) -> str comment) comments
-  
-let (modul_with_comments_to_document :
+let modul_with_comments_to_document:
   FStar_Parser_AST.modul ->
     (Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple2
       Prims.list ->
       (FStar_Pprint.document,(Prims.string,FStar_Range.range)
                                FStar_Pervasives_Native.tuple2 Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun m  ->
     fun comments  ->
       let decls =
         match m with
         | FStar_Parser_AST.Module (uu____6564,decls) -> decls
-        | FStar_Parser_AST.Interface (uu____6570,decls,uu____6572) -> decls
-         in
+        | FStar_Parser_AST.Interface (uu____6570,decls,uu____6572) -> decls in
       FStar_ST.op_Colon_Equals should_print_fs_typ_app false;
       (match decls with
        | [] -> (FStar_Pprint.empty, comments)
@@ -3329,33 +3062,28 @@ let (modul_with_comments_to_document :
                  FStar_Parser_AST.doc = uu____6631;
                  FStar_Parser_AST.quals = uu____6632;
                  FStar_Parser_AST.attrs = uu____6633;_}::uu____6634 ->
-                 let d0 = FStar_List.hd ds  in
+                 let d0 = FStar_List.hd ds in
                  let uu____6640 =
                    let uu____6643 =
-                     let uu____6646 = FStar_List.tl ds  in d :: uu____6646
-                      in
-                   d0 :: uu____6643  in
+                     let uu____6646 = FStar_List.tl ds in d :: uu____6646 in
+                   d0 :: uu____6643 in
                  (uu____6640, (d0.FStar_Parser_AST.drange))
-             | uu____6651 -> ((d :: ds), (d.FStar_Parser_AST.drange))  in
+             | uu____6651 -> ((d :: ds), (d.FStar_Parser_AST.drange)) in
            (match uu____6617 with
             | (decls1,first_range) ->
-                let extract_decl_range d1 = d1.FStar_Parser_AST.drange  in
+                let extract_decl_range d1 = d1.FStar_Parser_AST.drange in
                 (FStar_ST.op_Colon_Equals comment_stack comments;
                  (let initial_comment =
-                    let uu____6709 = FStar_Range.start_of_range first_range
-                       in
+                    let uu____6709 = FStar_Range.start_of_range first_range in
                     place_comments_until_pos (Prims.parse_int "0")
-                      (Prims.parse_int "1") uu____6709 FStar_Pprint.empty
-                     in
+                      (Prims.parse_int "1") uu____6709 FStar_Pprint.empty in
                   let doc1 =
                     separate_map_with_comments FStar_Pprint.empty
                       FStar_Pprint.empty decl_to_document decls1
-                      extract_decl_range
-                     in
-                  let comments1 = FStar_ST.op_Bang comment_stack  in
+                      extract_decl_range in
+                  let comments1 = FStar_ST.op_Bang comment_stack in
                   FStar_ST.op_Colon_Equals comment_stack [];
                   FStar_ST.op_Colon_Equals should_print_fs_typ_app false;
                   (let uu____6805 =
-                     FStar_Pprint.op_Hat_Hat initial_comment doc1  in
+                     FStar_Pprint.op_Hat_Hat initial_comment doc1 in
                    (uu____6805, comments1))))))
-  

--- a/src/ocaml-output/FStar_Pervasives.ml
+++ b/src/ocaml-output/FStar_Pervasives.ml
@@ -1,5 +1,5 @@
 open Prims
-let id : 'Aa . 'Aa -> 'Aa = fun x  -> x 
+let id: 'Aa . 'Aa -> 'Aa = fun x  -> x
 type 'Aheap st_pre_h = 'Aheap -> Obj.t[@@deriving show]
 type ('Aheap,'Aa,'Apre) st_post_h' = 'Aa -> 'Aheap -> Obj.t[@@deriving show]
 type ('Aheap,'Aa) st_post_h = ('Aheap,'Aa,Prims.unit) st_post_h'[@@deriving
@@ -18,23 +18,22 @@ type ('Aheap,'Aa,'Ap,'Awp,'Aq,'Ah) st_assume_p = Prims.unit[@@deriving show]
 type ('Aheap,'Aa,'Ap,'Ah) st_null_wp = Prims.unit[@@deriving show]
 type ('Aheap,'Aa,'Awp) st_trivial = Prims.unit[@@deriving show]
 type 'Aa result =
-  | V of 'Aa 
-  | E of Prims.exn 
-  | Err of Prims.string [@@deriving show]
-let uu___is_V : 'Aa . 'Aa result -> Prims.bool =
-  fun projectee  -> match projectee with | V v -> true | uu____602 -> false 
-let __proj__V__item__v : 'Aa . 'Aa result -> 'Aa =
-  fun projectee  -> match projectee with | V v -> v 
-let uu___is_E : 'Aa . 'Aa result -> Prims.bool =
-  fun projectee  -> match projectee with | E e -> true | uu____632 -> false 
-let __proj__E__item__e : 'Aa . 'Aa result -> Prims.exn =
-  fun projectee  -> match projectee with | E e -> e 
-let uu___is_Err : 'Aa . 'Aa result -> Prims.bool =
+  | V of 'Aa
+  | E of Prims.exn
+  | Err of Prims.string[@@deriving show]
+let uu___is_V: 'Aa . 'Aa result -> Prims.bool =
+  fun projectee  -> match projectee with | V v -> true | uu____602 -> false
+let __proj__V__item__v: 'Aa . 'Aa result -> 'Aa =
+  fun projectee  -> match projectee with | V v -> v
+let uu___is_E: 'Aa . 'Aa result -> Prims.bool =
+  fun projectee  -> match projectee with | E e -> true | uu____632 -> false
+let __proj__E__item__e: 'Aa . 'Aa result -> Prims.exn =
+  fun projectee  -> match projectee with | E e -> e
+let uu___is_Err: 'Aa . 'Aa result -> Prims.bool =
   fun projectee  ->
     match projectee with | Err msg -> true | uu____662 -> false
-  
-let __proj__Err__item__msg : 'Aa . 'Aa result -> Prims.string =
-  fun projectee  -> match projectee with | Err msg -> msg 
+let __proj__Err__item__msg: 'Aa . 'Aa result -> Prims.string =
+  fun projectee  -> match projectee with | Err msg -> msg
 type ex_pre = Obj.t[@@deriving show]
 type ('Aa,'Apre) ex_post' = 'Aa result -> Obj.t[@@deriving show]
 type 'Aa ex_post = ('Aa,Prims.unit) ex_post'[@@deriving show]
@@ -69,92 +68,85 @@ type ('Aheap,'Aa,'Ap,'Awp,'Aq,'Ah) all_assume_p = Prims.unit[@@deriving show]
 type ('Aheap,'Aa,'Ap,'Ah0) all_null_wp = Prims.unit[@@deriving show]
 type ('Aheap,'Aa,'Awp) all_trivial = Prims.unit[@@deriving show]
 type 'Aa inversion = Prims.unit[@@deriving show]
-let allow_inversion : 'Aa . Prims.unit = () 
-let invertOption : 'Aa . Prims.unit -> Prims.unit = fun uu____1689  -> () 
+let allow_inversion: 'Aa . Prims.unit = ()
+let invertOption: 'Aa . Prims.unit -> Prims.unit = fun uu____1689  -> ()
 type ('a,'b) either =
-  | Inl of 'a 
-  | Inr of 'b [@@deriving show]
-let uu___is_Inl : 'a 'b . ('a,'b) either -> Prims.bool =
+  | Inl of 'a
+  | Inr of 'b[@@deriving show]
+let uu___is_Inl: 'a 'b . ('a,'b) either -> Prims.bool =
   fun projectee  ->
     match projectee with | Inl v -> true | uu____1732 -> false
-  
-let __proj__Inl__item__v : 'a 'b . ('a,'b) either -> 'a =
-  fun projectee  -> match projectee with | Inl v -> v 
-let uu___is_Inr : 'a 'b . ('a,'b) either -> Prims.bool =
+let __proj__Inl__item__v: 'a 'b . ('a,'b) either -> 'a =
+  fun projectee  -> match projectee with | Inl v -> v
+let uu___is_Inr: 'a 'b . ('a,'b) either -> Prims.bool =
   fun projectee  ->
     match projectee with | Inr v -> true | uu____1776 -> false
-  
-let __proj__Inr__item__v : 'a 'b . ('a,'b) either -> 'b =
-  fun projectee  -> match projectee with | Inr v -> v 
-let dfst : 'Aa 'Ab . ('Aa,'Ab) Prims.dtuple2 -> 'Aa =
-  fun t  -> Prims.__proj__Mkdtuple2__item___1 t 
-let dsnd : 'Aa 'Ab . ('Aa,'Ab) Prims.dtuple2 -> 'Ab =
-  fun t  -> Prims.__proj__Mkdtuple2__item___2 t 
+let __proj__Inr__item__v: 'a 'b . ('a,'b) either -> 'b =
+  fun projectee  -> match projectee with | Inr v -> v
+let dfst: 'Aa 'Ab . ('Aa,'Ab) Prims.dtuple2 -> 'Aa =
+  fun t  -> Prims.__proj__Mkdtuple2__item___1 t
+let dsnd: 'Aa 'Ab . ('Aa,'Ab) Prims.dtuple2 -> 'Ab =
+  fun t  -> Prims.__proj__Mkdtuple2__item___2 t
 type ('Aa,'Ab,'Ac) dtuple3 =
-  | Mkdtuple3 of 'Aa * 'Ab * 'Ac [@@deriving show]
-let uu___is_Mkdtuple3 : 'Aa 'Ab 'Ac . ('Aa,'Ab,'Ac) dtuple3 -> Prims.bool =
-  fun projectee  -> true 
-let __proj__Mkdtuple3__item___1 : 'Aa 'Ab 'Ac . ('Aa,'Ab,'Ac) dtuple3 -> 'Aa
-  = fun projectee  -> match projectee with | Mkdtuple3 (_1,_2,_3) -> _1 
-let __proj__Mkdtuple3__item___2 : 'Aa 'Ab 'Ac . ('Aa,'Ab,'Ac) dtuple3 -> 'Ab
-  = fun projectee  -> match projectee with | Mkdtuple3 (_1,_2,_3) -> _2 
-let __proj__Mkdtuple3__item___3 : 'Aa 'Ab 'Ac . ('Aa,'Ab,'Ac) dtuple3 -> 'Ac
-  = fun projectee  -> match projectee with | Mkdtuple3 (_1,_2,_3) -> _3 
+  | Mkdtuple3 of 'Aa* 'Ab* 'Ac[@@deriving show]
+let uu___is_Mkdtuple3: 'Aa 'Ab 'Ac . ('Aa,'Ab,'Ac) dtuple3 -> Prims.bool =
+  fun projectee  -> true
+let __proj__Mkdtuple3__item___1: 'Aa 'Ab 'Ac . ('Aa,'Ab,'Ac) dtuple3 -> 'Aa =
+  fun projectee  -> match projectee with | Mkdtuple3 (_1,_2,_3) -> _1
+let __proj__Mkdtuple3__item___2: 'Aa 'Ab 'Ac . ('Aa,'Ab,'Ac) dtuple3 -> 'Ab =
+  fun projectee  -> match projectee with | Mkdtuple3 (_1,_2,_3) -> _2
+let __proj__Mkdtuple3__item___3: 'Aa 'Ab 'Ac . ('Aa,'Ab,'Ac) dtuple3 -> 'Ac =
+  fun projectee  -> match projectee with | Mkdtuple3 (_1,_2,_3) -> _3
 type ('Aa,'Ab,'Ac,'Ad) dtuple4 =
-  | Mkdtuple4 of 'Aa * 'Ab * 'Ac * 'Ad [@@deriving show]
-let uu___is_Mkdtuple4 :
+  | Mkdtuple4 of 'Aa* 'Ab* 'Ac* 'Ad[@@deriving show]
+let uu___is_Mkdtuple4:
   'Aa 'Ab 'Ac 'Ad . ('Aa,'Ab,'Ac,'Ad) dtuple4 -> Prims.bool =
-  fun projectee  -> true 
-let __proj__Mkdtuple4__item___1 :
+  fun projectee  -> true
+let __proj__Mkdtuple4__item___1:
   'Aa 'Ab 'Ac 'Ad . ('Aa,'Ab,'Ac,'Ad) dtuple4 -> 'Aa =
-  fun projectee  -> match projectee with | Mkdtuple4 (_1,_2,_3,_4) -> _1 
-let __proj__Mkdtuple4__item___2 :
+  fun projectee  -> match projectee with | Mkdtuple4 (_1,_2,_3,_4) -> _1
+let __proj__Mkdtuple4__item___2:
   'Aa 'Ab 'Ac 'Ad . ('Aa,'Ab,'Ac,'Ad) dtuple4 -> 'Ab =
-  fun projectee  -> match projectee with | Mkdtuple4 (_1,_2,_3,_4) -> _2 
-let __proj__Mkdtuple4__item___3 :
+  fun projectee  -> match projectee with | Mkdtuple4 (_1,_2,_3,_4) -> _2
+let __proj__Mkdtuple4__item___3:
   'Aa 'Ab 'Ac 'Ad . ('Aa,'Ab,'Ac,'Ad) dtuple4 -> 'Ac =
-  fun projectee  -> match projectee with | Mkdtuple4 (_1,_2,_3,_4) -> _3 
-let __proj__Mkdtuple4__item___4 :
+  fun projectee  -> match projectee with | Mkdtuple4 (_1,_2,_3,_4) -> _3
+let __proj__Mkdtuple4__item___4:
   'Aa 'Ab 'Ac 'Ad . ('Aa,'Ab,'Ac,'Ad) dtuple4 -> 'Ad =
-  fun projectee  -> match projectee with | Mkdtuple4 (_1,_2,_3,_4) -> _4 
-let ignore : 'Aa . 'Aa -> Prims.unit = fun x  -> () 
-let rec false_elim : 'Aa . Prims.unit -> 'Aa = fun u  -> false_elim () 
+  fun projectee  -> match projectee with | Mkdtuple4 (_1,_2,_3,_4) -> _4
+let ignore: 'Aa . 'Aa -> Prims.unit = fun x  -> ()
+let rec false_elim: 'Aa . Prims.unit -> 'Aa = fun u  -> false_elim ()
 type __internal_ocaml_attributes =
-  | PpxDerivingShow 
-  | PpxDerivingShowConstant of Prims.string 
-  | CInline 
-  | Substitute 
-  | Gc 
-  | Comment of Prims.string [@@deriving show]
-let (uu___is_PpxDerivingShow : __internal_ocaml_attributes -> Prims.bool) =
+  | PpxDerivingShow
+  | PpxDerivingShowConstant of Prims.string
+  | CInline
+  | Substitute
+  | Gc
+  | Comment of Prims.string[@@deriving show]
+let uu___is_PpxDerivingShow: __internal_ocaml_attributes -> Prims.bool =
   fun projectee  ->
     match projectee with | PpxDerivingShow  -> true | uu____2346 -> false
-  
-let (uu___is_PpxDerivingShowConstant :
-  __internal_ocaml_attributes -> Prims.bool) =
+let uu___is_PpxDerivingShowConstant:
+  __internal_ocaml_attributes -> Prims.bool =
   fun projectee  ->
     match projectee with
     | PpxDerivingShowConstant _0 -> true
     | uu____2351 -> false
-  
-let (__proj__PpxDerivingShowConstant__item___0 :
-  __internal_ocaml_attributes -> Prims.string) =
-  fun projectee  -> match projectee with | PpxDerivingShowConstant _0 -> _0 
-let (uu___is_CInline : __internal_ocaml_attributes -> Prims.bool) =
+let __proj__PpxDerivingShowConstant__item___0:
+  __internal_ocaml_attributes -> Prims.string =
+  fun projectee  -> match projectee with | PpxDerivingShowConstant _0 -> _0
+let uu___is_CInline: __internal_ocaml_attributes -> Prims.bool =
   fun projectee  ->
     match projectee with | CInline  -> true | uu____2362 -> false
-  
-let (uu___is_Substitute : __internal_ocaml_attributes -> Prims.bool) =
+let uu___is_Substitute: __internal_ocaml_attributes -> Prims.bool =
   fun projectee  ->
     match projectee with | Substitute  -> true | uu____2366 -> false
-  
-let (uu___is_Gc : __internal_ocaml_attributes -> Prims.bool) =
-  fun projectee  -> match projectee with | Gc  -> true | uu____2370 -> false 
-let (uu___is_Comment : __internal_ocaml_attributes -> Prims.bool) =
+let uu___is_Gc: __internal_ocaml_attributes -> Prims.bool =
+  fun projectee  -> match projectee with | Gc  -> true | uu____2370 -> false
+let uu___is_Comment: __internal_ocaml_attributes -> Prims.bool =
   fun projectee  ->
     match projectee with | Comment _0 -> true | uu____2375 -> false
-  
-let (__proj__Comment__item___0 : __internal_ocaml_attributes -> Prims.string)
-  = fun projectee  -> match projectee with | Comment _0 -> _0 
-let (deprecated : Prims.string -> Prims.unit) = fun s  -> () 
-let (inline_let : Prims.unit) = () 
+let __proj__Comment__item___0: __internal_ocaml_attributes -> Prims.string =
+  fun projectee  -> match projectee with | Comment _0 -> _0
+let deprecated: Prims.string -> Prims.unit = fun s  -> ()
+let inline_let: Prims.unit = ()

--- a/src/ocaml-output/FStar_Range.ml
+++ b/src/ocaml-output/FStar_Range.ml
@@ -1,104 +1,92 @@
 open Prims
 type file_name = Prims.string[@@deriving show]
 type pos = {
-  line: Prims.int ;
-  col: Prims.int }[@@deriving show]
-let (__proj__Mkpos__item__line : pos -> Prims.int) =
+  line: Prims.int;
+  col: Prims.int;}[@@deriving show]
+let __proj__Mkpos__item__line: pos -> Prims.int =
   fun projectee  ->
     match projectee with
     | { line = __fname__line; col = __fname__col;_} -> __fname__line
-  
-let (__proj__Mkpos__item__col : pos -> Prims.int) =
+let __proj__Mkpos__item__col: pos -> Prims.int =
   fun projectee  ->
     match projectee with
     | { line = __fname__line; col = __fname__col;_} -> __fname__col
-  
-let (max : Prims.int -> Prims.int -> Prims.int) =
-  fun i  -> fun j  -> if i < j then j else i 
-let (pos_geq : pos -> pos -> Prims.bool) =
+let max: Prims.int -> Prims.int -> Prims.int =
+  fun i  -> fun j  -> if i < j then j else i
+let pos_geq: pos -> pos -> Prims.bool =
   fun p1  ->
     fun p2  ->
       (p1.line >= p2.line) || ((p1.line = p2.line) && (p1.col >= p2.col))
-  
 type rng = {
-  file_name: file_name ;
-  start_pos: pos ;
-  end_pos: pos }[@@deriving show]
-let (__proj__Mkrng__item__file_name : rng -> file_name) =
+  file_name: file_name;
+  start_pos: pos;
+  end_pos: pos;}[@@deriving show]
+let __proj__Mkrng__item__file_name: rng -> file_name =
   fun projectee  ->
     match projectee with
     | { file_name = __fname__file_name; start_pos = __fname__start_pos;
         end_pos = __fname__end_pos;_} -> __fname__file_name
-  
-let (__proj__Mkrng__item__start_pos : rng -> pos) =
+let __proj__Mkrng__item__start_pos: rng -> pos =
   fun projectee  ->
     match projectee with
     | { file_name = __fname__file_name; start_pos = __fname__start_pos;
         end_pos = __fname__end_pos;_} -> __fname__start_pos
-  
-let (__proj__Mkrng__item__end_pos : rng -> pos) =
+let __proj__Mkrng__item__end_pos: rng -> pos =
   fun projectee  ->
     match projectee with
     | { file_name = __fname__file_name; start_pos = __fname__start_pos;
         end_pos = __fname__end_pos;_} -> __fname__end_pos
-  
 type range = {
-  def_range: rng ;
-  use_range: rng }[@@deriving show]
-let (__proj__Mkrange__item__def_range : range -> rng) =
+  def_range: rng;
+  use_range: rng;}[@@deriving show]
+let __proj__Mkrange__item__def_range: range -> rng =
   fun projectee  ->
     match projectee with
     | { def_range = __fname__def_range; use_range = __fname__use_range;_} ->
         __fname__def_range
-  
-let (__proj__Mkrange__item__use_range : range -> rng) =
+let __proj__Mkrange__item__use_range: range -> rng =
   fun projectee  ->
     match projectee with
     | { def_range = __fname__def_range; use_range = __fname__use_range;_} ->
         __fname__use_range
-  
-let (dummy_pos : pos) =
-  { line = (Prims.parse_int "0"); col = (Prims.parse_int "0") } 
-let (dummy_rng : rng) =
-  { file_name = "<dummy>"; start_pos = dummy_pos; end_pos = dummy_pos } 
-let (dummyRange : range) = { def_range = dummy_rng; use_range = dummy_rng } 
-let (use_range : range -> rng) = fun r  -> r.use_range 
-let (def_range : range -> rng) = fun r  -> r.def_range 
-let (range_of_rng : rng -> rng -> range) =
-  fun d  -> fun u  -> { def_range = d; use_range = u } 
-let (set_use_range : range -> rng -> range) =
+let dummy_pos: pos =
+  { line = (Prims.parse_int "0"); col = (Prims.parse_int "0") }
+let dummy_rng: rng =
+  { file_name = "<dummy>"; start_pos = dummy_pos; end_pos = dummy_pos }
+let dummyRange: range = { def_range = dummy_rng; use_range = dummy_rng }
+let use_range: range -> rng = fun r  -> r.use_range
+let def_range: range -> rng = fun r  -> r.def_range
+let range_of_rng: rng -> rng -> range =
+  fun d  -> fun u  -> { def_range = d; use_range = u }
+let set_use_range: range -> rng -> range =
   fun r2  ->
     fun use_rng  ->
       if use_rng <> dummy_rng
       then
-        let uu___23_98 = r2  in
+        let uu___23_98 = r2 in
         { def_range = (uu___23_98.def_range); use_range = use_rng }
       else r2
-  
-let (set_def_range : range -> rng -> range) =
+let set_def_range: range -> rng -> range =
   fun r2  ->
     fun def_rng  ->
       if def_rng <> dummy_rng
       then
-        let uu___24_106 = r2  in
+        let uu___24_106 = r2 in
         { def_range = def_rng; use_range = (uu___24_106.use_range) }
       else r2
-  
-let (mk_pos : Prims.int -> Prims.int -> pos) =
+let mk_pos: Prims.int -> Prims.int -> pos =
   fun l  ->
     fun c  ->
       {
         line = (max (Prims.parse_int "0") l);
         col = (max (Prims.parse_int "0") c)
       }
-  
-let (mk_rng : file_name -> pos -> pos -> rng) =
+let mk_rng: file_name -> pos -> pos -> rng =
   fun file_name  ->
     fun start_pos  -> fun end_pos  -> { file_name; start_pos; end_pos }
-  
-let (mk_range : Prims.string -> pos -> pos -> range) =
-  fun f  -> fun b  -> fun e  -> let r = mk_rng f b e  in range_of_rng r r 
-let (union_rng : rng -> rng -> rng) =
+let mk_range: Prims.string -> pos -> pos -> range =
+  fun f  -> fun b  -> fun e  -> let r = mk_rng f b e in range_of_rng r r
+let union_rng: rng -> rng -> rng =
   fun r1  ->
     fun r2  ->
       if r1.file_name <> r2.file_name
@@ -107,90 +95,77 @@ let (union_rng : rng -> rng -> rng) =
         (let start_pos =
            if pos_geq r1.start_pos r2.start_pos
            then r2.start_pos
-           else r1.start_pos  in
+           else r1.start_pos in
          let end_pos =
            if pos_geq r1.start_pos r2.start_pos
            then r1.start_pos
-           else r2.start_pos  in
+           else r2.start_pos in
          mk_rng r1.file_name start_pos end_pos)
-  
-let (union_ranges : range -> range -> range) =
+let union_ranges: range -> range -> range =
   fun r1  ->
     fun r2  ->
       {
         def_range = (union_rng r1.def_range r2.def_range);
         use_range = (union_rng r1.use_range r2.use_range)
       }
-  
-let (string_of_pos : pos -> Prims.string) =
+let string_of_pos: pos -> Prims.string =
   fun pos  ->
-    let uu____153 = FStar_Util.string_of_int pos.line  in
-    let uu____154 = FStar_Util.string_of_int pos.col  in
+    let uu____153 = FStar_Util.string_of_int pos.line in
+    let uu____154 = FStar_Util.string_of_int pos.col in
     FStar_Util.format2 "%s,%s" uu____153 uu____154
-  
-let (string_of_rng : rng -> Prims.string) =
+let string_of_rng: rng -> Prims.string =
   fun r  ->
-    let uu____158 = string_of_pos r.start_pos  in
-    let uu____159 = string_of_pos r.end_pos  in
+    let uu____158 = string_of_pos r.start_pos in
+    let uu____159 = string_of_pos r.end_pos in
     FStar_Util.format3 "%s(%s-%s)" r.file_name uu____158 uu____159
-  
-let (string_of_def_range : range -> Prims.string) =
-  fun r  -> string_of_rng r.def_range 
-let (string_of_use_range : range -> Prims.string) =
-  fun r  -> string_of_rng r.use_range 
-let (string_of_range : range -> Prims.string) =
-  fun r  -> string_of_def_range r 
-let (file_of_range : range -> Prims.string) =
-  fun r  -> (r.def_range).file_name 
-let (start_of_range : range -> pos) = fun r  -> (r.def_range).start_pos 
-let (end_of_range : range -> pos) = fun r  -> (r.def_range).end_pos 
-let (file_of_use_range : range -> Prims.string) =
-  fun r  -> (r.use_range).file_name 
-let (start_of_use_range : range -> pos) = fun r  -> (r.use_range).start_pos 
-let (end_of_use_range : range -> pos) = fun r  -> (r.use_range).end_pos 
-let (line_of_pos : pos -> Prims.int) = fun p  -> p.line 
-let (col_of_pos : pos -> Prims.int) = fun p  -> p.col 
-let (end_range : range -> range) =
+let string_of_def_range: range -> Prims.string =
+  fun r  -> string_of_rng r.def_range
+let string_of_use_range: range -> Prims.string =
+  fun r  -> string_of_rng r.use_range
+let string_of_range: range -> Prims.string = fun r  -> string_of_def_range r
+let file_of_range: range -> Prims.string = fun r  -> (r.def_range).file_name
+let start_of_range: range -> pos = fun r  -> (r.def_range).start_pos
+let end_of_range: range -> pos = fun r  -> (r.def_range).end_pos
+let file_of_use_range: range -> Prims.string =
+  fun r  -> (r.use_range).file_name
+let start_of_use_range: range -> pos = fun r  -> (r.use_range).start_pos
+let end_of_use_range: range -> pos = fun r  -> (r.use_range).end_pos
+let line_of_pos: pos -> Prims.int = fun p  -> p.line
+let col_of_pos: pos -> Prims.int = fun p  -> p.col
+let end_range: range -> range =
   fun r  ->
     mk_range (r.def_range).file_name (r.def_range).end_pos
       (r.def_range).end_pos
-  
-let (compare_rng : rng -> rng -> Prims.int) =
+let compare_rng: rng -> rng -> Prims.int =
   fun r1  ->
     fun r2  ->
-      let fcomp = FStar_String.compare r1.file_name r2.file_name  in
+      let fcomp = FStar_String.compare r1.file_name r2.file_name in
       if fcomp = (Prims.parse_int "0")
       then
-        let start1 = r1.start_pos  in
-        let start2 = r2.start_pos  in
-        let lcomp = start1.line - start2.line  in
+        let start1 = r1.start_pos in
+        let start2 = r2.start_pos in
+        let lcomp = start1.line - start2.line in
         (if lcomp = (Prims.parse_int "0")
          then start1.col - start2.col
          else lcomp)
       else fcomp
-  
-let (compare : range -> range -> Prims.int) =
-  fun r1  -> fun r2  -> compare_rng r1.def_range r2.def_range 
-let (compare_use_range : range -> range -> Prims.int) =
-  fun r1  -> fun r2  -> compare_rng r1.use_range r2.use_range 
-let (range_before_pos : range -> pos -> Prims.bool) =
-  fun m1  ->
-    fun p  -> let uu____226 = end_of_range m1  in pos_geq p uu____226
-  
-let (end_of_line : pos -> pos) =
+let compare: range -> range -> Prims.int =
+  fun r1  -> fun r2  -> compare_rng r1.def_range r2.def_range
+let compare_use_range: range -> range -> Prims.int =
+  fun r1  -> fun r2  -> compare_rng r1.use_range r2.use_range
+let range_before_pos: range -> pos -> Prims.bool =
+  fun m1  -> fun p  -> let uu____226 = end_of_range m1 in pos_geq p uu____226
+let end_of_line: pos -> pos =
   fun p  ->
-    let uu___25_230 = p  in
+    let uu___25_230 = p in
     { line = (uu___25_230.line); col = FStar_Util.max_int }
-  
-let (extend_to_end_of_line : range -> range) =
+let extend_to_end_of_line: range -> range =
   fun r  ->
-    let uu____234 = file_of_range r  in
-    let uu____235 = start_of_range r  in
-    let uu____236 = let uu____237 = end_of_range r  in end_of_line uu____237
-       in
+    let uu____234 = file_of_range r in
+    let uu____235 = start_of_range r in
+    let uu____236 = let uu____237 = end_of_range r in end_of_line uu____237 in
     mk_range uu____234 uu____235 uu____236
-  
-let (prims_to_fstar_range :
+let prims_to_fstar_range:
   ((Prims.string,(Prims.int,Prims.int) FStar_Pervasives_Native.tuple2,
      (Prims.int,Prims.int) FStar_Pervasives_Native.tuple2)
      FStar_Pervasives_Native.tuple3,(Prims.string,(Prims.int,Prims.int)
@@ -198,35 +173,30 @@ let (prims_to_fstar_range :
                                       (Prims.int,Prims.int)
                                         FStar_Pervasives_Native.tuple2)
                                       FStar_Pervasives_Native.tuple3)
-    FStar_Pervasives_Native.tuple2 -> range)
+    FStar_Pervasives_Native.tuple2 -> range
   =
   fun r  ->
-    let uu____305 = r  in
+    let uu____305 = r in
     match uu____305 with
     | (r1,r2) ->
-        let uu____396 = r1  in
+        let uu____396 = r1 in
         (match uu____396 with
          | (f1,s1,e1) ->
-             let uu____430 = r2  in
+             let uu____430 = r2 in
              (match uu____430 with
               | (f2,s2,e2) ->
                   let s11 =
                     mk_pos (FStar_Pervasives_Native.fst s1)
-                      (FStar_Pervasives_Native.snd s1)
-                     in
+                      (FStar_Pervasives_Native.snd s1) in
                   let e11 =
                     mk_pos (FStar_Pervasives_Native.fst e1)
-                      (FStar_Pervasives_Native.snd e1)
-                     in
+                      (FStar_Pervasives_Native.snd e1) in
                   let s21 =
                     mk_pos (FStar_Pervasives_Native.fst s2)
-                      (FStar_Pervasives_Native.snd s2)
-                     in
+                      (FStar_Pervasives_Native.snd s2) in
                   let e21 =
                     mk_pos (FStar_Pervasives_Native.fst e2)
-                      (FStar_Pervasives_Native.snd e2)
-                     in
-                  let r11 = mk_rng f1 s11 e11  in
-                  let r21 = mk_rng f2 s21 e21  in
+                      (FStar_Pervasives_Native.snd e2) in
+                  let r11 = mk_rng f1 s11 e11 in
+                  let r21 = mk_rng f2 s21 e21 in
                   { def_range = r11; use_range = r21 }))
-  

--- a/src/ocaml-output/FStar_Reflection_Basic.ml
+++ b/src/ocaml-output/FStar_Reflection_Basic.ml
@@ -1,45 +1,42 @@
 open Prims
-let (lid_as_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
+let lid_as_tm: FStar_Ident.lident -> FStar_Syntax_Syntax.term =
   fun l  ->
     let uu____4 =
       FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant
-        FStar_Pervasives_Native.None
-       in
+        FStar_Pervasives_Native.None in
     FStar_All.pipe_right uu____4 FStar_Syntax_Syntax.fv_to_tm
-  
-let (fstar_refl_embed : FStar_Syntax_Syntax.term) =
-  lid_as_tm FStar_Parser_Const.fstar_refl_embed_lid 
-let (protect_embedded_term :
+let fstar_refl_embed: FStar_Syntax_Syntax.term =
+  lid_as_tm FStar_Parser_Const.fstar_refl_embed_lid
+let protect_embedded_term:
   FStar_Syntax_Syntax.typ ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t  ->
     fun x  ->
       let uu____13 =
         let uu____14 =
-          let uu____15 = FStar_Syntax_Syntax.iarg t  in
+          let uu____15 = FStar_Syntax_Syntax.iarg t in
           let uu____16 =
-            let uu____19 = FStar_Syntax_Syntax.as_arg x  in [uu____19]  in
-          uu____15 :: uu____16  in
-        FStar_Syntax_Syntax.mk_Tm_app fstar_refl_embed uu____14  in
+            let uu____19 = FStar_Syntax_Syntax.as_arg x in [uu____19] in
+          uu____15 :: uu____16 in
+        FStar_Syntax_Syntax.mk_Tm_app fstar_refl_embed uu____14 in
       uu____13 FStar_Pervasives_Native.None x.FStar_Syntax_Syntax.pos
-  
-let (un_protect_embedded_term :
+let un_protect_embedded_term:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun t  ->
     let uu____29 =
-      let uu____44 = FStar_Syntax_Util.unmeta t  in
-      FStar_Syntax_Util.head_and_args uu____44  in
+      let uu____44 = FStar_Syntax_Util.unmeta t in
+      FStar_Syntax_Util.head_and_args uu____44 in
     match uu____29 with
     | (head1,args) ->
         let uu____69 =
           let uu____82 =
-            let uu____83 = FStar_Syntax_Util.un_uinst head1  in
-            uu____83.FStar_Syntax_Syntax.n  in
-          (uu____82, args)  in
+            let uu____83 = FStar_Syntax_Util.un_uinst head1 in
+            uu____83.FStar_Syntax_Syntax.n in
+          (uu____82, args) in
         (match uu____69 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,uu____97::(x,uu____99)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -48,164 +45,148 @@ let (un_protect_embedded_term :
          | uu____138 ->
              ((let uu____152 =
                  let uu____157 =
-                   let uu____158 = FStar_Syntax_Print.term_to_string t  in
-                   FStar_Util.format1 "Not an protected term: %s" uu____158
-                    in
-                 (FStar_Errors.Warning_UnprotectedTerm, uu____157)  in
+                   let uu____158 = FStar_Syntax_Print.term_to_string t in
+                   FStar_Util.format1 "Not an protected term: %s" uu____158 in
+                 (FStar_Errors.Warning_UnprotectedTerm, uu____157) in
                FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____152);
               FStar_Pervasives_Native.None))
-  
-let (embed_binder :
-  FStar_Range.range -> FStar_Syntax_Syntax.binder -> FStar_Syntax_Syntax.term)
+let embed_binder:
+  FStar_Range.range -> FStar_Syntax_Syntax.binder -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun b  ->
       FStar_Syntax_Util.mk_alien FStar_Reflection_Data.fstar_refl_binder b
         "reflection.embed_binder" (FStar_Pervasives_Native.Some rng)
-  
-let (unembed_binder :
+let unembed_binder:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option
   =
   fun t  ->
     try
       let uu____179 =
-        let uu____180 = FStar_Syntax_Util.un_alien t  in
-        FStar_All.pipe_right uu____180 FStar_Dyn.undyn  in
+        let uu____180 = FStar_Syntax_Util.un_alien t in
+        FStar_All.pipe_right uu____180 FStar_Dyn.undyn in
       FStar_Pervasives_Native.Some uu____179
     with
     | uu____187 ->
         ((let uu____189 =
             let uu____194 =
-              let uu____195 = FStar_Syntax_Print.term_to_string t  in
-              FStar_Util.format1 "Not an embedded binder: %s" uu____195  in
-            (FStar_Errors.Warning_NotEmbedded, uu____194)  in
+              let uu____195 = FStar_Syntax_Print.term_to_string t in
+              FStar_Util.format1 "Not an embedded binder: %s" uu____195 in
+            (FStar_Errors.Warning_NotEmbedded, uu____194) in
           FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____189);
          FStar_Pervasives_Native.None)
-  
-let (embed_binders :
+let embed_binders:
   FStar_Range.range ->
-    FStar_Syntax_Syntax.binder Prims.list -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.binder Prims.list -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun l  ->
       let uu____206 =
         FStar_Syntax_Embeddings.embed_list embed_binder
-          FStar_Reflection_Data.fstar_refl_binder
-         in
+          FStar_Reflection_Data.fstar_refl_binder in
       uu____206 rng l
-  
-let (unembed_binders :
+let unembed_binders:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.binder Prims.list FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.binder Prims.list FStar_Pervasives_Native.option
   =
   fun t  ->
-    let uu____221 = FStar_Syntax_Embeddings.unembed_list unembed_binder  in
+    let uu____221 = FStar_Syntax_Embeddings.unembed_list unembed_binder in
     uu____221 t
-  
-let (embed_term :
-  FStar_Range.range -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  =
+let embed_term:
+  FStar_Range.range -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun t  ->
-      let t1 = protect_embedded_term FStar_Syntax_Syntax.tun t  in
-      let uu___57_237 = t1  in
+      let t1 = protect_embedded_term FStar_Syntax_Syntax.tun t in
+      let uu___57_237 = t1 in
       {
         FStar_Syntax_Syntax.n = (uu___57_237.FStar_Syntax_Syntax.n);
         FStar_Syntax_Syntax.pos = rng;
         FStar_Syntax_Syntax.vars = (uu___57_237.FStar_Syntax_Syntax.vars)
       }
-  
-let (unembed_term :
+let unembed_term:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
-  = fun t  -> un_protect_embedded_term t 
-let (embed_fvar :
-  FStar_Range.range -> FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term) =
+    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
+  = fun t  -> un_protect_embedded_term t
+let embed_fvar:
+  FStar_Range.range -> FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun fv  ->
       FStar_Syntax_Util.mk_alien FStar_Reflection_Data.fstar_refl_fvar fv
         "reflection.embed_fvar" (FStar_Pervasives_Native.Some rng)
-  
-let (unembed_fvar :
+let unembed_fvar:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.fv FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.fv FStar_Pervasives_Native.option
   =
   fun t  ->
     try
       let uu____267 =
-        let uu____268 = FStar_Syntax_Util.un_alien t  in
-        FStar_All.pipe_right uu____268 FStar_Dyn.undyn  in
+        let uu____268 = FStar_Syntax_Util.un_alien t in
+        FStar_All.pipe_right uu____268 FStar_Dyn.undyn in
       FStar_Pervasives_Native.Some uu____267
     with
     | uu____275 ->
         ((let uu____277 =
             let uu____282 =
-              let uu____283 = FStar_Syntax_Print.term_to_string t  in
-              FStar_Util.format1 "Not an embedded fvar: %s" uu____283  in
-            (FStar_Errors.Warning_NotEmbedded, uu____282)  in
+              let uu____283 = FStar_Syntax_Print.term_to_string t in
+              FStar_Util.format1 "Not an embedded fvar: %s" uu____283 in
+            (FStar_Errors.Warning_NotEmbedded, uu____282) in
           FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____277);
          FStar_Pervasives_Native.None)
-  
-let (embed_comp :
-  FStar_Range.range -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.term)
-  =
+let embed_comp:
+  FStar_Range.range -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun c  ->
       FStar_Syntax_Util.mk_alien FStar_Reflection_Data.fstar_refl_comp c
         "reflection.embed_comp" (FStar_Pervasives_Native.Some rng)
-  
-let (unembed_comp :
+let unembed_comp:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.comp FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.comp FStar_Pervasives_Native.option
   =
   fun t  ->
     try
       let uu____304 =
-        let uu____305 = FStar_Syntax_Util.un_alien t  in
-        FStar_All.pipe_right uu____305 FStar_Dyn.undyn  in
+        let uu____305 = FStar_Syntax_Util.un_alien t in
+        FStar_All.pipe_right uu____305 FStar_Dyn.undyn in
       FStar_Pervasives_Native.Some uu____304
     with
     | uu____312 ->
         ((let uu____314 =
             let uu____319 =
-              let uu____320 = FStar_Syntax_Print.term_to_string t  in
-              FStar_Util.format1 "Not an embedded comp: %s" uu____320  in
-            (FStar_Errors.Warning_NotEmbedded, uu____319)  in
+              let uu____320 = FStar_Syntax_Print.term_to_string t in
+              FStar_Util.format1 "Not an embedded comp: %s" uu____320 in
+            (FStar_Errors.Warning_NotEmbedded, uu____319) in
           FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____314);
          FStar_Pervasives_Native.None)
-  
-let (embed_env :
-  FStar_Range.range -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term)
+let embed_env:
+  FStar_Range.range -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun env  ->
       FStar_Syntax_Util.mk_alien FStar_Reflection_Data.fstar_refl_env env
         "tactics_embed_env" (FStar_Pervasives_Native.Some rng)
-  
-let (unembed_env :
+let unembed_env:
   FStar_Syntax_Syntax.term ->
-    FStar_TypeChecker_Env.env FStar_Pervasives_Native.option)
+    FStar_TypeChecker_Env.env FStar_Pervasives_Native.option
   =
   fun t  ->
     try
       let uu____341 =
-        let uu____342 = FStar_Syntax_Util.un_alien t  in
-        FStar_All.pipe_right uu____342 FStar_Dyn.undyn  in
+        let uu____342 = FStar_Syntax_Util.un_alien t in
+        FStar_All.pipe_right uu____342 FStar_Dyn.undyn in
       FStar_Pervasives_Native.Some uu____341
     with
     | uu____349 ->
         ((let uu____351 =
             let uu____356 =
-              let uu____357 = FStar_Syntax_Print.term_to_string t  in
-              FStar_Util.format1 "Not an embedded env: %s" uu____357  in
-            (FStar_Errors.Warning_NotEmbedded, uu____356)  in
+              let uu____357 = FStar_Syntax_Print.term_to_string t in
+              FStar_Util.format1 "Not an embedded env: %s" uu____357 in
+            (FStar_Errors.Warning_NotEmbedded, uu____356) in
           FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____351);
          FStar_Pervasives_Native.None)
-  
-let (embed_const :
+let embed_const:
   FStar_Range.range ->
-    FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.term)
+    FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun c  ->
@@ -219,48 +200,43 @@ let (embed_const :
               let uu____367 =
                 let uu____368 =
                   let uu____369 =
-                    let uu____370 = FStar_BigInt.string_of_big_int i  in
-                    FStar_Syntax_Util.exp_int uu____370  in
-                  FStar_Syntax_Syntax.as_arg uu____369  in
-                [uu____368]  in
+                    let uu____370 = FStar_BigInt.string_of_big_int i in
+                    FStar_Syntax_Util.exp_int uu____370 in
+                  FStar_Syntax_Syntax.as_arg uu____369 in
+                [uu____368] in
               FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_C_Int
-                uu____367
-               in
+                uu____367 in
             uu____366 FStar_Pervasives_Native.None FStar_Range.dummyRange
         | FStar_Reflection_Data.C_String s ->
             let uu____374 =
               let uu____375 =
                 let uu____376 =
-                  let uu____377 = FStar_Syntax_Embeddings.embed_string rng s
-                     in
-                  FStar_Syntax_Syntax.as_arg uu____377  in
-                [uu____376]  in
+                  let uu____377 = FStar_Syntax_Embeddings.embed_string rng s in
+                  FStar_Syntax_Syntax.as_arg uu____377 in
+                [uu____376] in
               FStar_Syntax_Syntax.mk_Tm_app
-                FStar_Reflection_Data.ref_C_String uu____375
-               in
-            uu____374 FStar_Pervasives_Native.None FStar_Range.dummyRange
-         in
-      let uu___64_380 = r  in
+                FStar_Reflection_Data.ref_C_String uu____375 in
+            uu____374 FStar_Pervasives_Native.None FStar_Range.dummyRange in
+      let uu___64_380 = r in
       {
         FStar_Syntax_Syntax.n = (uu___64_380.FStar_Syntax_Syntax.n);
         FStar_Syntax_Syntax.pos = rng;
         FStar_Syntax_Syntax.vars = (uu___64_380.FStar_Syntax_Syntax.vars)
       }
-  
-let (unembed_const :
+let unembed_const:
   FStar_Syntax_Syntax.term ->
-    FStar_Reflection_Data.vconst FStar_Pervasives_Native.option)
+    FStar_Reflection_Data.vconst FStar_Pervasives_Native.option
   =
   fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____389 = FStar_Syntax_Util.head_and_args t1  in
+    let t1 = FStar_Syntax_Util.unascribe t in
+    let uu____389 = FStar_Syntax_Util.head_and_args t1 in
     match uu____389 with
     | (hd1,args) ->
         let uu____428 =
           let uu____441 =
-            let uu____442 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____442.FStar_Syntax_Syntax.n  in
-          (uu____441, args)  in
+            let uu____442 = FStar_Syntax_Util.un_uinst hd1 in
+            uu____442.FStar_Syntax_Syntax.n in
+          (uu____441, args) in
         (match uu____428 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -278,7 +254,7 @@ let (unembed_const :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Int_lid
              ->
-             let uu____527 = FStar_Syntax_Embeddings.unembed_int i  in
+             let uu____527 = FStar_Syntax_Embeddings.unembed_int i in
              FStar_Util.bind_opt uu____527
                (fun i1  ->
                   FStar_All.pipe_left
@@ -288,7 +264,7 @@ let (unembed_const :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_String_lid
              ->
-             let uu____561 = FStar_Syntax_Embeddings.unembed_string s  in
+             let uu____561 = FStar_Syntax_Embeddings.unembed_string s in
              FStar_Util.bind_opt uu____561
                (fun s1  ->
                   FStar_All.pipe_left
@@ -297,16 +273,14 @@ let (unembed_const :
          | uu____568 ->
              ((let uu____582 =
                  let uu____587 =
-                   let uu____588 = FStar_Syntax_Print.term_to_string t1  in
-                   FStar_Util.format1 "Not an embedded vconst: %s" uu____588
-                    in
-                 (FStar_Errors.Warning_NotEmbedded, uu____587)  in
+                   let uu____588 = FStar_Syntax_Print.term_to_string t1 in
+                   FStar_Util.format1 "Not an embedded vconst: %s" uu____588 in
+                 (FStar_Errors.Warning_NotEmbedded, uu____587) in
                FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____582);
               FStar_Pervasives_Native.None))
-  
-let rec (embed_pattern :
+let rec embed_pattern:
   FStar_Range.range ->
-    FStar_Reflection_Data.pattern -> FStar_Syntax_Syntax.term)
+    FStar_Reflection_Data.pattern -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun p  ->
@@ -315,81 +289,75 @@ let rec (embed_pattern :
           let uu____596 =
             let uu____597 =
               let uu____598 =
-                let uu____599 = embed_const rng c  in
-                FStar_Syntax_Syntax.as_arg uu____599  in
-              [uu____598]  in
+                let uu____599 = embed_const rng c in
+                FStar_Syntax_Syntax.as_arg uu____599 in
+              [uu____598] in
             FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Pat_Constant uu____597
-             in
+              FStar_Reflection_Data.ref_Pat_Constant uu____597 in
           uu____596 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
           let uu____608 =
             let uu____609 =
               let uu____610 =
-                let uu____611 = embed_fvar rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____611  in
+                let uu____611 = embed_fvar rng fv in
+                FStar_Syntax_Syntax.as_arg uu____611 in
               let uu____612 =
                 let uu____615 =
                   let uu____616 =
                     let uu____617 =
                       FStar_Syntax_Embeddings.embed_list embed_pattern
-                        FStar_Reflection_Data.fstar_refl_pattern
-                       in
-                    uu____617 rng ps  in
-                  FStar_Syntax_Syntax.as_arg uu____616  in
-                [uu____615]  in
-              uu____610 :: uu____612  in
+                        FStar_Reflection_Data.fstar_refl_pattern in
+                    uu____617 rng ps in
+                  FStar_Syntax_Syntax.as_arg uu____616 in
+                [uu____615] in
+              uu____610 :: uu____612 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Pat_Cons
-              uu____609
-             in
+              uu____609 in
           uu____608 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Var bv ->
           let uu____628 =
             let uu____629 =
               let uu____630 =
                 let uu____631 =
-                  let uu____632 = FStar_Syntax_Syntax.mk_binder bv  in
-                  embed_binder rng uu____632  in
-                FStar_Syntax_Syntax.as_arg uu____631  in
-              [uu____630]  in
+                  let uu____632 = FStar_Syntax_Syntax.mk_binder bv in
+                  embed_binder rng uu____632 in
+                FStar_Syntax_Syntax.as_arg uu____631 in
+              [uu____630] in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Pat_Var
-              uu____629
-             in
+              uu____629 in
           uu____628 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Pat_Wild bv ->
           let uu____636 =
             let uu____637 =
               let uu____638 =
                 let uu____639 =
-                  let uu____640 = FStar_Syntax_Syntax.mk_binder bv  in
-                  embed_binder rng uu____640  in
-                FStar_Syntax_Syntax.as_arg uu____639  in
-              [uu____638]  in
+                  let uu____640 = FStar_Syntax_Syntax.mk_binder bv in
+                  embed_binder rng uu____640 in
+                FStar_Syntax_Syntax.as_arg uu____639 in
+              [uu____638] in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Pat_Wild
-              uu____637
-             in
+              uu____637 in
           uu____636 FStar_Pervasives_Native.None rng
-  
-let rec (unembed_pattern :
+let rec unembed_pattern:
   FStar_Syntax_Syntax.term ->
-    FStar_Reflection_Data.pattern FStar_Pervasives_Native.option)
+    FStar_Reflection_Data.pattern FStar_Pervasives_Native.option
   =
   fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____651 = FStar_Syntax_Util.head_and_args t1  in
+    let t1 = FStar_Syntax_Util.unascribe t in
+    let uu____651 = FStar_Syntax_Util.head_and_args t1 in
     match uu____651 with
     | (hd1,args) ->
         let uu____690 =
           let uu____703 =
-            let uu____704 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____704.FStar_Syntax_Syntax.n  in
-          (uu____703, args)  in
+            let uu____704 = FStar_Syntax_Util.un_uinst hd1 in
+            uu____704.FStar_Syntax_Syntax.n in
+          (uu____703, args) in
         (match uu____690 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____719)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Pat_Constant_lid
              ->
-             let uu____744 = unembed_const c  in
+             let uu____744 = unembed_const c in
              FStar_Util.bind_opt uu____744
                (fun c1  ->
                   FStar_All.pipe_left
@@ -400,14 +368,13 @@ let rec (unembed_pattern :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Pat_Cons_lid
              ->
-             let uu____790 = unembed_fvar f  in
+             let uu____790 = unembed_fvar f in
              FStar_Util.bind_opt uu____790
                (fun f1  ->
                   let uu____796 =
                     let uu____801 =
-                      FStar_Syntax_Embeddings.unembed_list unembed_pattern
-                       in
-                    uu____801 ps  in
+                      FStar_Syntax_Embeddings.unembed_list unembed_pattern in
+                    uu____801 ps in
                   FStar_Util.bind_opt uu____796
                     (fun ps1  ->
                        FStar_All.pipe_left
@@ -417,7 +384,7 @@ let rec (unembed_pattern :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Pat_Var_lid
              ->
-             let uu____845 = unembed_binder b  in
+             let uu____845 = unembed_binder b in
              FStar_Util.bind_opt uu____845
                (fun uu____851  ->
                   match uu____851 with
@@ -429,7 +396,7 @@ let rec (unembed_pattern :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Pat_Wild_lid
              ->
-             let uu____885 = unembed_binder b  in
+             let uu____885 = unembed_binder b in
              FStar_Util.bind_opt uu____885
                (fun uu____891  ->
                   match uu____891 with
@@ -440,28 +407,25 @@ let rec (unembed_pattern :
          | uu____898 ->
              ((let uu____912 =
                  let uu____917 =
-                   let uu____918 = FStar_Syntax_Print.term_to_string t1  in
-                   FStar_Util.format1 "Not an embedded pattern: %s" uu____918
-                    in
-                 (FStar_Errors.Warning_NotEmbedded, uu____917)  in
+                   let uu____918 = FStar_Syntax_Print.term_to_string t1 in
+                   FStar_Util.format1 "Not an embedded pattern: %s" uu____918 in
+                 (FStar_Errors.Warning_NotEmbedded, uu____917) in
                FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____912);
               FStar_Pervasives_Native.None))
-  
-let (embed_branch :
+let embed_branch:
   (FStar_Reflection_Data.pattern,FStar_Syntax_Syntax.term)
-    FStar_Pervasives_Native.tuple2 FStar_Syntax_Embeddings.embedder)
+    FStar_Pervasives_Native.tuple2 FStar_Syntax_Embeddings.embedder
   =
   FStar_Syntax_Embeddings.embed_pair embed_pattern
     FStar_Reflection_Data.fstar_refl_pattern embed_term
     FStar_Syntax_Syntax.t_term
-  
-let (unembed_branch :
+let unembed_branch:
   (FStar_Reflection_Data.pattern,FStar_Syntax_Syntax.term)
-    FStar_Pervasives_Native.tuple2 FStar_Syntax_Embeddings.unembedder)
-  = FStar_Syntax_Embeddings.unembed_pair unembed_pattern unembed_term 
-let (embed_aqualv :
+    FStar_Pervasives_Native.tuple2 FStar_Syntax_Embeddings.unembedder
+  = FStar_Syntax_Embeddings.unembed_pair unembed_pattern unembed_term
+let embed_aqualv:
   FStar_Range.range ->
-    FStar_Reflection_Data.aqualv -> FStar_Syntax_Syntax.term)
+    FStar_Reflection_Data.aqualv -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun q  ->
@@ -470,29 +434,27 @@ let (embed_aqualv :
         | FStar_Reflection_Data.Q_Explicit  ->
             FStar_Reflection_Data.ref_Q_Explicit
         | FStar_Reflection_Data.Q_Implicit  ->
-            FStar_Reflection_Data.ref_Q_Implicit
-         in
-      let uu___65_943 = r  in
+            FStar_Reflection_Data.ref_Q_Implicit in
+      let uu___65_943 = r in
       {
         FStar_Syntax_Syntax.n = (uu___65_943.FStar_Syntax_Syntax.n);
         FStar_Syntax_Syntax.pos = rng;
         FStar_Syntax_Syntax.vars = (uu___65_943.FStar_Syntax_Syntax.vars)
       }
-  
-let (unembed_aqualv :
+let unembed_aqualv:
   FStar_Syntax_Syntax.term ->
-    FStar_Reflection_Data.aqualv FStar_Pervasives_Native.option)
+    FStar_Reflection_Data.aqualv FStar_Pervasives_Native.option
   =
   fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____952 = FStar_Syntax_Util.head_and_args t1  in
+    let t1 = FStar_Syntax_Util.unascribe t in
+    let uu____952 = FStar_Syntax_Util.head_and_args t1 in
     match uu____952 with
     | (hd1,args) ->
         let uu____991 =
           let uu____1004 =
-            let uu____1005 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____1005.FStar_Syntax_Syntax.n  in
-          (uu____1004, args)  in
+            let uu____1005 = FStar_Syntax_Util.un_uinst hd1 in
+            uu____1005.FStar_Syntax_Syntax.n in
+          (uu____1004, args) in
         (match uu____991 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -505,27 +467,24 @@ let (unembed_aqualv :
          | uu____1048 ->
              ((let uu____1062 =
                  let uu____1067 =
-                   let uu____1068 = FStar_Syntax_Print.term_to_string t1  in
-                   FStar_Util.format1 "Not an embedded aqualv: %s" uu____1068
-                    in
-                 (FStar_Errors.Warning_NotEmbedded, uu____1067)  in
+                   let uu____1068 = FStar_Syntax_Print.term_to_string t1 in
+                   FStar_Util.format1 "Not an embedded aqualv: %s" uu____1068 in
+                 (FStar_Errors.Warning_NotEmbedded, uu____1067) in
                FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____1062);
               FStar_Pervasives_Native.None))
-  
-let (embed_argv :
+let embed_argv:
   (FStar_Syntax_Syntax.term,FStar_Reflection_Data.aqualv)
-    FStar_Pervasives_Native.tuple2 FStar_Syntax_Embeddings.embedder)
+    FStar_Pervasives_Native.tuple2 FStar_Syntax_Embeddings.embedder
   =
   FStar_Syntax_Embeddings.embed_pair embed_term FStar_Syntax_Syntax.t_term
     embed_aqualv FStar_Reflection_Data.fstar_refl_aqualv
-  
-let (unembed_argv :
+let unembed_argv:
   (FStar_Syntax_Syntax.term,FStar_Reflection_Data.aqualv)
-    FStar_Pervasives_Native.tuple2 FStar_Syntax_Embeddings.unembedder)
-  = FStar_Syntax_Embeddings.unembed_pair unembed_term unembed_aqualv 
-let (embed_term_view :
+    FStar_Pervasives_Native.tuple2 FStar_Syntax_Embeddings.unembedder
+  = FStar_Syntax_Embeddings.unembed_pair unembed_term unembed_aqualv
+let embed_term_view:
   FStar_Range.range ->
-    FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term)
+    FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun t  ->
@@ -534,198 +493,184 @@ let (embed_term_view :
           let uu____1093 =
             let uu____1094 =
               let uu____1095 =
-                let uu____1096 = embed_fvar rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____1096  in
-              [uu____1095]  in
+                let uu____1096 = embed_fvar rng fv in
+                FStar_Syntax_Syntax.as_arg uu____1096 in
+              [uu____1095] in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_FVar
-              uu____1094
-             in
+              uu____1094 in
           uu____1093 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Var bv ->
           let uu____1100 =
             let uu____1101 =
               let uu____1102 =
-                let uu____1103 = embed_binder rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1103  in
-              [uu____1102]  in
+                let uu____1103 = embed_binder rng bv in
+                FStar_Syntax_Syntax.as_arg uu____1103 in
+              [uu____1102] in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_Var
-              uu____1101
-             in
+              uu____1101 in
           uu____1100 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_App (hd1,a) ->
           let uu____1108 =
             let uu____1109 =
               let uu____1110 =
-                let uu____1111 = embed_term rng hd1  in
-                FStar_Syntax_Syntax.as_arg uu____1111  in
+                let uu____1111 = embed_term rng hd1 in
+                FStar_Syntax_Syntax.as_arg uu____1111 in
               let uu____1112 =
                 let uu____1115 =
-                  let uu____1116 = embed_argv rng a  in
-                  FStar_Syntax_Syntax.as_arg uu____1116  in
-                [uu____1115]  in
-              uu____1110 :: uu____1112  in
+                  let uu____1116 = embed_argv rng a in
+                  FStar_Syntax_Syntax.as_arg uu____1116 in
+                [uu____1115] in
+              uu____1110 :: uu____1112 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_App
-              uu____1109
-             in
+              uu____1109 in
           uu____1108 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Abs (b,t1) ->
           let uu____1121 =
             let uu____1122 =
               let uu____1123 =
-                let uu____1124 = embed_binder rng b  in
-                FStar_Syntax_Syntax.as_arg uu____1124  in
+                let uu____1124 = embed_binder rng b in
+                FStar_Syntax_Syntax.as_arg uu____1124 in
               let uu____1125 =
                 let uu____1128 =
-                  let uu____1129 = embed_term rng t1  in
-                  FStar_Syntax_Syntax.as_arg uu____1129  in
-                [uu____1128]  in
-              uu____1123 :: uu____1125  in
+                  let uu____1129 = embed_term rng t1 in
+                  FStar_Syntax_Syntax.as_arg uu____1129 in
+                [uu____1128] in
+              uu____1123 :: uu____1125 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_Abs
-              uu____1122
-             in
+              uu____1122 in
           uu____1121 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Arrow (b,c) ->
           let uu____1134 =
             let uu____1135 =
               let uu____1136 =
-                let uu____1137 = embed_binder rng b  in
-                FStar_Syntax_Syntax.as_arg uu____1137  in
+                let uu____1137 = embed_binder rng b in
+                FStar_Syntax_Syntax.as_arg uu____1137 in
               let uu____1138 =
                 let uu____1141 =
-                  let uu____1142 = embed_comp rng c  in
-                  FStar_Syntax_Syntax.as_arg uu____1142  in
-                [uu____1141]  in
-              uu____1136 :: uu____1138  in
+                  let uu____1142 = embed_comp rng c in
+                  FStar_Syntax_Syntax.as_arg uu____1142 in
+                [uu____1141] in
+              uu____1136 :: uu____1138 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_Arrow
-              uu____1135
-             in
+              uu____1135 in
           uu____1134 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Type u ->
           let uu____1146 =
             let uu____1147 =
               let uu____1148 =
-                let uu____1149 = FStar_Syntax_Embeddings.embed_unit rng ()
-                   in
-                FStar_Syntax_Syntax.as_arg uu____1149  in
-              [uu____1148]  in
+                let uu____1149 = FStar_Syntax_Embeddings.embed_unit rng () in
+                FStar_Syntax_Syntax.as_arg uu____1149 in
+              [uu____1148] in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_Type
-              uu____1147
-             in
+              uu____1147 in
           uu____1146 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Refine (bv,t1) ->
           let uu____1154 =
             let uu____1155 =
               let uu____1156 =
-                let uu____1157 = embed_binder rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1157  in
+                let uu____1157 = embed_binder rng bv in
+                FStar_Syntax_Syntax.as_arg uu____1157 in
               let uu____1158 =
                 let uu____1161 =
-                  let uu____1162 = embed_term rng t1  in
-                  FStar_Syntax_Syntax.as_arg uu____1162  in
-                [uu____1161]  in
-              uu____1156 :: uu____1158  in
+                  let uu____1162 = embed_term rng t1 in
+                  FStar_Syntax_Syntax.as_arg uu____1162 in
+                [uu____1161] in
+              uu____1156 :: uu____1158 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_Refine
-              uu____1155
-             in
+              uu____1155 in
           uu____1154 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Const c ->
           let uu____1166 =
             let uu____1167 =
               let uu____1168 =
-                let uu____1169 = embed_const rng c  in
-                FStar_Syntax_Syntax.as_arg uu____1169  in
-              [uu____1168]  in
+                let uu____1169 = embed_const rng c in
+                FStar_Syntax_Syntax.as_arg uu____1169 in
+              [uu____1168] in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_Const
-              uu____1167
-             in
+              uu____1167 in
           uu____1166 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Uvar (u,t1) ->
           let uu____1174 =
             let uu____1175 =
               let uu____1176 =
-                let uu____1177 = FStar_Syntax_Embeddings.embed_int rng u  in
-                FStar_Syntax_Syntax.as_arg uu____1177  in
+                let uu____1177 = FStar_Syntax_Embeddings.embed_int rng u in
+                FStar_Syntax_Syntax.as_arg uu____1177 in
               let uu____1178 =
                 let uu____1181 =
-                  let uu____1182 = embed_term rng t1  in
-                  FStar_Syntax_Syntax.as_arg uu____1182  in
-                [uu____1181]  in
-              uu____1176 :: uu____1178  in
+                  let uu____1182 = embed_term rng t1 in
+                  FStar_Syntax_Syntax.as_arg uu____1182 in
+                [uu____1181] in
+              uu____1176 :: uu____1178 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_Uvar
-              uu____1175
-             in
+              uu____1175 in
           uu____1174 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Let (b,t1,t2) ->
           let uu____1188 =
             let uu____1189 =
               let uu____1190 =
-                let uu____1191 = embed_binder rng b  in
-                FStar_Syntax_Syntax.as_arg uu____1191  in
+                let uu____1191 = embed_binder rng b in
+                FStar_Syntax_Syntax.as_arg uu____1191 in
               let uu____1192 =
                 let uu____1195 =
-                  let uu____1196 = embed_term rng t1  in
-                  FStar_Syntax_Syntax.as_arg uu____1196  in
+                  let uu____1196 = embed_term rng t1 in
+                  FStar_Syntax_Syntax.as_arg uu____1196 in
                 let uu____1197 =
                   let uu____1200 =
-                    let uu____1201 = embed_term rng t2  in
-                    FStar_Syntax_Syntax.as_arg uu____1201  in
-                  [uu____1200]  in
-                uu____1195 :: uu____1197  in
-              uu____1190 :: uu____1192  in
+                    let uu____1201 = embed_term rng t2 in
+                    FStar_Syntax_Syntax.as_arg uu____1201 in
+                  [uu____1200] in
+                uu____1195 :: uu____1197 in
+              uu____1190 :: uu____1192 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_Let
-              uu____1189
-             in
+              uu____1189 in
           uu____1188 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Match (t1,brs) ->
           let uu____1210 =
             let uu____1211 =
               let uu____1212 =
-                let uu____1213 = embed_term rng t1  in
-                FStar_Syntax_Syntax.as_arg uu____1213  in
+                let uu____1213 = embed_term rng t1 in
+                FStar_Syntax_Syntax.as_arg uu____1213 in
               let uu____1214 =
                 let uu____1217 =
                   let uu____1218 =
                     let uu____1219 =
                       FStar_Syntax_Embeddings.embed_list embed_branch
-                        FStar_Reflection_Data.fstar_refl_branch
-                       in
-                    uu____1219 rng brs  in
-                  FStar_Syntax_Syntax.as_arg uu____1218  in
-                [uu____1217]  in
-              uu____1212 :: uu____1214  in
+                        FStar_Reflection_Data.fstar_refl_branch in
+                    uu____1219 rng brs in
+                  FStar_Syntax_Syntax.as_arg uu____1218 in
+                [uu____1217] in
+              uu____1212 :: uu____1214 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Tv_Match
-              uu____1211
-             in
+              uu____1211 in
           uu____1210 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Tv_Unknown  ->
-          let uu___66_1237 = FStar_Reflection_Data.ref_Tv_Unknown  in
+          let uu___66_1237 = FStar_Reflection_Data.ref_Tv_Unknown in
           {
             FStar_Syntax_Syntax.n = (uu___66_1237.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = rng;
             FStar_Syntax_Syntax.vars =
               (uu___66_1237.FStar_Syntax_Syntax.vars)
           }
-  
-let (unembed_term_view :
+let unembed_term_view:
   FStar_Syntax_Syntax.term ->
-    FStar_Reflection_Data.term_view FStar_Pervasives_Native.option)
+    FStar_Reflection_Data.term_view FStar_Pervasives_Native.option
   =
   fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____1246 = FStar_Syntax_Util.head_and_args t1  in
+    let t1 = FStar_Syntax_Util.unascribe t in
+    let uu____1246 = FStar_Syntax_Util.head_and_args t1 in
     match uu____1246 with
     | (hd1,args) ->
         let uu____1285 =
           let uu____1298 =
-            let uu____1299 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____1299.FStar_Syntax_Syntax.n  in
-          (uu____1298, args)  in
+            let uu____1299 = FStar_Syntax_Util.un_uinst hd1 in
+            uu____1299.FStar_Syntax_Syntax.n in
+          (uu____1298, args) in
         (match uu____1285 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____1314)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_Var_lid
              ->
-             let uu____1339 = unembed_binder b  in
+             let uu____1339 = unembed_binder b in
              FStar_Util.bind_opt uu____1339
                (fun b1  ->
                   FStar_All.pipe_left
@@ -735,7 +680,7 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_FVar_lid
              ->
-             let uu____1373 = unembed_fvar f  in
+             let uu____1373 = unembed_fvar f in
              FStar_Util.bind_opt uu____1373
                (fun f1  ->
                   FStar_All.pipe_left
@@ -746,10 +691,10 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_App_lid
              ->
-             let uu____1419 = unembed_term l  in
+             let uu____1419 = unembed_term l in
              FStar_Util.bind_opt uu____1419
                (fun l1  ->
-                  let uu____1425 = unembed_argv r  in
+                  let uu____1425 = unembed_argv r in
                   FStar_Util.bind_opt uu____1425
                     (fun r1  ->
                        FStar_All.pipe_left
@@ -760,10 +705,10 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_Abs_lid
              ->
-             let uu____1487 = unembed_binder b  in
+             let uu____1487 = unembed_binder b in
              FStar_Util.bind_opt uu____1487
                (fun b1  ->
-                  let uu____1493 = unembed_term t2  in
+                  let uu____1493 = unembed_term t2 in
                   FStar_Util.bind_opt uu____1493
                     (fun t3  ->
                        FStar_All.pipe_left
@@ -774,10 +719,10 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_Arrow_lid
              ->
-             let uu____1539 = unembed_binder b  in
+             let uu____1539 = unembed_binder b in
              FStar_Util.bind_opt uu____1539
                (fun b1  ->
-                  let uu____1545 = unembed_comp t2  in
+                  let uu____1545 = unembed_comp t2 in
                   FStar_Util.bind_opt uu____1545
                     (fun c  ->
                        FStar_All.pipe_left
@@ -787,7 +732,7 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_Type_lid
              ->
-             let uu____1579 = FStar_Syntax_Embeddings.unembed_unit u  in
+             let uu____1579 = FStar_Syntax_Embeddings.unembed_unit u in
              FStar_Util.bind_opt uu____1579
                (fun u1  ->
                   FStar_All.pipe_left
@@ -798,10 +743,10 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_Refine_lid
              ->
-             let uu____1625 = unembed_binder b  in
+             let uu____1625 = unembed_binder b in
              FStar_Util.bind_opt uu____1625
                (fun b1  ->
-                  let uu____1631 = unembed_term t2  in
+                  let uu____1631 = unembed_term t2 in
                   FStar_Util.bind_opt uu____1631
                     (fun t3  ->
                        FStar_All.pipe_left
@@ -811,7 +756,7 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_Const_lid
              ->
-             let uu____1665 = unembed_const c  in
+             let uu____1665 = unembed_const c in
              FStar_Util.bind_opt uu____1665
                (fun c1  ->
                   FStar_All.pipe_left
@@ -822,10 +767,10 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_Uvar_lid
              ->
-             let uu____1711 = FStar_Syntax_Embeddings.unembed_int u  in
+             let uu____1711 = FStar_Syntax_Embeddings.unembed_int u in
              FStar_Util.bind_opt uu____1711
                (fun u1  ->
-                  let uu____1717 = unembed_term t2  in
+                  let uu____1717 = unembed_term t2 in
                   FStar_Util.bind_opt uu____1717
                     (fun t3  ->
                        FStar_All.pipe_left
@@ -836,13 +781,13 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_Let_lid
              ->
-             let uu____1775 = unembed_binder b  in
+             let uu____1775 = unembed_binder b in
              FStar_Util.bind_opt uu____1775
                (fun b1  ->
-                  let uu____1781 = unembed_term t11  in
+                  let uu____1781 = unembed_term t11 in
                   FStar_Util.bind_opt uu____1781
                     (fun t12  ->
-                       let uu____1787 = unembed_term t2  in
+                       let uu____1787 = unembed_term t2 in
                        FStar_Util.bind_opt uu____1787
                          (fun t21  ->
                             FStar_All.pipe_left
@@ -854,13 +799,13 @@ let (unembed_term_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Tv_Match_lid
              ->
-             let uu____1833 = unembed_term t2  in
+             let uu____1833 = unembed_term t2 in
              FStar_Util.bind_opt uu____1833
                (fun t3  ->
                   let uu____1839 =
                     let uu____1848 =
-                      FStar_Syntax_Embeddings.unembed_list unembed_branch  in
-                    uu____1848 brs  in
+                      FStar_Syntax_Embeddings.unembed_list unembed_branch in
+                    uu____1848 brs in
                   FStar_Util.bind_opt uu____1839
                     (fun brs1  ->
                        FStar_All.pipe_left
@@ -876,17 +821,15 @@ let (unembed_term_view :
          | uu____1902 ->
              ((let uu____1916 =
                  let uu____1921 =
-                   let uu____1922 = FStar_Syntax_Print.term_to_string t1  in
+                   let uu____1922 = FStar_Syntax_Print.term_to_string t1 in
                    FStar_Util.format1 "Not an embedded term_view: %s"
-                     uu____1922
-                    in
-                 (FStar_Errors.Warning_NotEmbedded, uu____1921)  in
+                     uu____1922 in
+                 (FStar_Errors.Warning_NotEmbedded, uu____1921) in
                FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____1916);
               FStar_Pervasives_Native.None))
-  
-let (embed_comp_view :
+let embed_comp_view:
   FStar_Range.range ->
-    FStar_Reflection_Data.comp_view -> FStar_Syntax_Syntax.term)
+    FStar_Reflection_Data.comp_view -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun cv  ->
@@ -895,59 +838,56 @@ let (embed_comp_view :
           let uu____1930 =
             let uu____1931 =
               let uu____1932 =
-                let uu____1933 = embed_term rng t  in
-                FStar_Syntax_Syntax.as_arg uu____1933  in
-              [uu____1932]  in
+                let uu____1933 = embed_term rng t in
+                FStar_Syntax_Syntax.as_arg uu____1933 in
+              [uu____1932] in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_C_Total
-              uu____1931
-             in
+              uu____1931 in
           uu____1930 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.C_Lemma (pre,post) ->
-          let post1 = FStar_Syntax_Util.unthunk_lemma_post post  in
+          let post1 = FStar_Syntax_Util.unthunk_lemma_post post in
           let uu____1941 =
             let uu____1942 =
               let uu____1943 =
-                let uu____1944 = embed_term rng pre  in
-                FStar_Syntax_Syntax.as_arg uu____1944  in
+                let uu____1944 = embed_term rng pre in
+                FStar_Syntax_Syntax.as_arg uu____1944 in
               let uu____1945 =
                 let uu____1948 =
-                  let uu____1949 = embed_term rng post1  in
-                  FStar_Syntax_Syntax.as_arg uu____1949  in
-                [uu____1948]  in
-              uu____1943 :: uu____1945  in
+                  let uu____1949 = embed_term rng post1 in
+                  FStar_Syntax_Syntax.as_arg uu____1949 in
+                [uu____1948] in
+              uu____1943 :: uu____1945 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_C_Lemma
-              uu____1942
-             in
+              uu____1942 in
           uu____1941 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.C_Unknown  ->
-          let uu___67_1952 = FStar_Reflection_Data.ref_C_Unknown  in
+          let uu___67_1952 = FStar_Reflection_Data.ref_C_Unknown in
           {
             FStar_Syntax_Syntax.n = (uu___67_1952.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = rng;
             FStar_Syntax_Syntax.vars =
               (uu___67_1952.FStar_Syntax_Syntax.vars)
           }
-  
-let (unembed_comp_view :
+let unembed_comp_view:
   FStar_Syntax_Syntax.term ->
-    FStar_Reflection_Data.comp_view FStar_Pervasives_Native.option)
+    FStar_Reflection_Data.comp_view FStar_Pervasives_Native.option
   =
   fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____1961 = FStar_Syntax_Util.head_and_args t1  in
+    let t1 = FStar_Syntax_Util.unascribe t in
+    let uu____1961 = FStar_Syntax_Util.head_and_args t1 in
     match uu____1961 with
     | (hd1,args) ->
         let uu____2000 =
           let uu____2013 =
-            let uu____2014 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____2014.FStar_Syntax_Syntax.n  in
-          (uu____2013, args)  in
+            let uu____2014 = FStar_Syntax_Util.un_uinst hd1 in
+            uu____2014.FStar_Syntax_Syntax.n in
+          (uu____2013, args) in
         (match uu____2000 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,(t2,uu____2029)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Total_lid
              ->
-             let uu____2054 = unembed_term t2  in
+             let uu____2054 = unembed_term t2 in
              FStar_Util.bind_opt uu____2054
                (fun t3  ->
                   FStar_All.pipe_left
@@ -958,10 +898,10 @@ let (unembed_comp_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Lemma_lid
              ->
-             let uu____2100 = unembed_term pre  in
+             let uu____2100 = unembed_term pre in
              FStar_Util.bind_opt uu____2100
                (fun pre1  ->
-                  let uu____2106 = unembed_term post  in
+                  let uu____2106 = unembed_term post in
                   FStar_Util.bind_opt uu____2106
                     (fun post1  ->
                        FStar_All.pipe_left
@@ -977,48 +917,42 @@ let (unembed_comp_view :
          | uu____2130 ->
              ((let uu____2144 =
                  let uu____2149 =
-                   let uu____2150 = FStar_Syntax_Print.term_to_string t1  in
+                   let uu____2150 = FStar_Syntax_Print.term_to_string t1 in
                    FStar_Util.format1 "Not an embedded comp_view: %s"
-                     uu____2150
-                    in
-                 (FStar_Errors.Warning_NotEmbedded, uu____2149)  in
+                     uu____2150 in
+                 (FStar_Errors.Warning_NotEmbedded, uu____2149) in
                FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____2144);
               FStar_Pervasives_Native.None))
-  
-let rec last : 'a . 'a Prims.list -> 'a =
+let rec last: 'a . 'a Prims.list -> 'a =
   fun l  ->
     match l with
     | [] -> failwith "last: empty list"
     | x::[] -> x
     | uu____2164::xs -> last xs
-  
-let rec init : 'a . 'a Prims.list -> 'a Prims.list =
+let rec init: 'a . 'a Prims.list -> 'a Prims.list =
   fun l  ->
     match l with
     | [] -> failwith "init: empty list"
     | x::[] -> []
-    | x::xs -> let uu____2189 = init xs  in x :: uu____2189
-  
-let (inspect_fv : FStar_Syntax_Syntax.fv -> Prims.string Prims.list) =
+    | x::xs -> let uu____2189 = init xs in x :: uu____2189
+let inspect_fv: FStar_Syntax_Syntax.fv -> Prims.string Prims.list =
   fun fv  ->
-    let uu____2199 = FStar_Syntax_Syntax.lid_of_fv fv  in
+    let uu____2199 = FStar_Syntax_Syntax.lid_of_fv fv in
     FStar_Ident.path_of_lid uu____2199
-  
-let (pack_fv : Prims.string Prims.list -> FStar_Syntax_Syntax.fv) =
+let pack_fv: Prims.string Prims.list -> FStar_Syntax_Syntax.fv =
   fun ns  ->
-    let uu____2207 = FStar_Parser_Const.p2l ns  in
+    let uu____2207 = FStar_Parser_Const.p2l ns in
     FStar_Syntax_Syntax.lid_as_fv uu____2207
       FStar_Syntax_Syntax.Delta_equational FStar_Pervasives_Native.None
-  
-let (inspect_bv : FStar_Syntax_Syntax.binder -> Prims.string) =
-  fun b  -> FStar_Syntax_Print.bv_to_string (FStar_Pervasives_Native.fst b) 
-let (inspect_const :
-  FStar_Syntax_Syntax.sconst -> FStar_Reflection_Data.vconst) =
+let inspect_bv: FStar_Syntax_Syntax.binder -> Prims.string =
+  fun b  -> FStar_Syntax_Print.bv_to_string (FStar_Pervasives_Native.fst b)
+let inspect_const: FStar_Syntax_Syntax.sconst -> FStar_Reflection_Data.vconst
+  =
   fun c  ->
     match c with
     | FStar_Const.Const_unit  -> FStar_Reflection_Data.C_Unit
     | FStar_Const.Const_int (s,uu____2215) ->
-        let uu____2228 = FStar_BigInt.big_int_of_string s  in
+        let uu____2228 = FStar_BigInt.big_int_of_string s in
         FStar_Reflection_Data.C_Int uu____2228
     | FStar_Const.Const_bool (true ) -> FStar_Reflection_Data.C_True
     | FStar_Const.Const_bool (false ) -> FStar_Reflection_Data.C_False
@@ -1026,25 +960,24 @@ let (inspect_const :
         FStar_Reflection_Data.C_String s
     | uu____2231 ->
         let uu____2232 =
-          let uu____2233 = FStar_Syntax_Print.const_to_string c  in
-          FStar_Util.format1 "unknown constant: %s" uu____2233  in
+          let uu____2233 = FStar_Syntax_Print.const_to_string c in
+          FStar_Util.format1 "unknown constant: %s" uu____2233 in
         failwith uu____2232
-  
-let rec (inspect :
-  FStar_Syntax_Syntax.term -> FStar_Reflection_Data.term_view) =
+let rec inspect: FStar_Syntax_Syntax.term -> FStar_Reflection_Data.term_view
+  =
   fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t  in
-    let t2 = FStar_Syntax_Util.un_uinst t1  in
+    let t1 = FStar_Syntax_Util.unascribe t in
+    let t2 = FStar_Syntax_Util.un_uinst t1 in
     match t2.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_meta (t3,uu____2240) -> inspect t3
     | FStar_Syntax_Syntax.Tm_name bv ->
-        let uu____2246 = FStar_Syntax_Syntax.mk_binder bv  in
+        let uu____2246 = FStar_Syntax_Syntax.mk_binder bv in
         FStar_Reflection_Data.Tv_Var uu____2246
     | FStar_Syntax_Syntax.Tm_fvar fv -> FStar_Reflection_Data.Tv_FVar fv
     | FStar_Syntax_Syntax.Tm_app (hd1,[]) ->
         failwith "inspect: empty arguments on Tm_app"
     | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-        let uu____2289 = last args  in
+        let uu____2289 = last args in
         (match uu____2289 with
          | (a,q) ->
              let q' =
@@ -1054,60 +987,58 @@ let rec (inspect :
                | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality )
                    -> FStar_Reflection_Data.Q_Explicit
                | FStar_Pervasives_Native.None  ->
-                   FStar_Reflection_Data.Q_Explicit
-                in
+                   FStar_Reflection_Data.Q_Explicit in
              let uu____2310 =
                let uu____2315 =
                  let uu____2318 =
-                   let uu____2319 = init args  in
-                   FStar_Syntax_Syntax.mk_Tm_app hd1 uu____2319  in
+                   let uu____2319 = init args in
+                   FStar_Syntax_Syntax.mk_Tm_app hd1 uu____2319 in
                  uu____2318 FStar_Pervasives_Native.None
-                   t2.FStar_Syntax_Syntax.pos
-                  in
-               (uu____2315, (a, q'))  in
+                   t2.FStar_Syntax_Syntax.pos in
+               (uu____2315, (a, q')) in
              FStar_Reflection_Data.Tv_App uu____2310)
     | FStar_Syntax_Syntax.Tm_abs ([],uu____2338,uu____2339) ->
         failwith "inspect: empty arguments on Tm_abs"
     | FStar_Syntax_Syntax.Tm_abs (bs,t3,k) ->
-        let uu____2381 = FStar_Syntax_Subst.open_term bs t3  in
+        let uu____2381 = FStar_Syntax_Subst.open_term bs t3 in
         (match uu____2381 with
          | (bs1,t4) ->
              (match bs1 with
               | [] -> failwith "impossible"
               | b::bs2 ->
                   let uu____2408 =
-                    let uu____2413 = FStar_Syntax_Util.abs bs2 t4 k  in
-                    (b, uu____2413)  in
+                    let uu____2413 = FStar_Syntax_Util.abs bs2 t4 k in
+                    (b, uu____2413) in
                   FStar_Reflection_Data.Tv_Abs uu____2408))
     | FStar_Syntax_Syntax.Tm_type uu____2418 ->
         FStar_Reflection_Data.Tv_Type ()
     | FStar_Syntax_Syntax.Tm_arrow ([],k) ->
         failwith "inspect: empty binders on arrow"
     | FStar_Syntax_Syntax.Tm_arrow uu____2434 ->
-        let uu____2447 = FStar_Syntax_Util.arrow_one t2  in
+        let uu____2447 = FStar_Syntax_Util.arrow_one t2 in
         (match uu____2447 with
          | FStar_Pervasives_Native.Some (b,c) ->
              FStar_Reflection_Data.Tv_Arrow (b, c)
          | FStar_Pervasives_Native.None  -> failwith "impossible")
     | FStar_Syntax_Syntax.Tm_refine (bv,t3) ->
-        let b = FStar_Syntax_Syntax.mk_binder bv  in
-        let uu____2471 = FStar_Syntax_Subst.open_term [b] t3  in
+        let b = FStar_Syntax_Syntax.mk_binder bv in
+        let uu____2471 = FStar_Syntax_Subst.open_term [b] t3 in
         (match uu____2471 with
          | (b',t4) ->
              let b1 =
                match b' with
                | b'1::[] -> b'1
-               | uu____2500 -> failwith "impossible"  in
+               | uu____2500 -> failwith "impossible" in
              FStar_Reflection_Data.Tv_Refine (b1, t4))
     | FStar_Syntax_Syntax.Tm_constant c ->
-        let uu____2510 = inspect_const c  in
+        let uu____2510 = inspect_const c in
         FStar_Reflection_Data.Tv_Const uu____2510
     | FStar_Syntax_Syntax.Tm_uvar (u,t3) ->
         let uu____2537 =
           let uu____2542 =
-            let uu____2543 = FStar_Syntax_Unionfind.uvar_id u  in
-            FStar_BigInt.of_int_fs uu____2543  in
-          (uu____2542, t3)  in
+            let uu____2543 = FStar_Syntax_Unionfind.uvar_id u in
+            FStar_BigInt.of_int_fs uu____2543 in
+          (uu____2542, t3) in
         FStar_Reflection_Data.Tv_Uvar uu____2537
     | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),t21) ->
         if lb.FStar_Syntax_Syntax.lbunivs <> []
@@ -1116,8 +1047,8 @@ let rec (inspect :
           (match lb.FStar_Syntax_Syntax.lbname with
            | FStar_Util.Inr uu____2563 -> FStar_Reflection_Data.Tv_Unknown
            | FStar_Util.Inl bv ->
-               let b = FStar_Syntax_Syntax.mk_binder bv  in
-               let uu____2566 = FStar_Syntax_Subst.open_term [b] t21  in
+               let b = FStar_Syntax_Syntax.mk_binder bv in
+               let uu____2566 = FStar_Syntax_Subst.open_term [b] t21 in
                (match uu____2566 with
                 | (bs,t22) ->
                     let b1 =
@@ -1125,15 +1056,14 @@ let rec (inspect :
                       | b1::[] -> b1
                       | uu____2595 ->
                           failwith
-                            "impossible: open_term returned different amount of binders"
-                       in
+                            "impossible: open_term returned different amount of binders" in
                     FStar_Reflection_Data.Tv_Let
                       (b1, (lb.FStar_Syntax_Syntax.lbdef), t22)))
     | FStar_Syntax_Syntax.Tm_match (t3,brs) ->
         let rec inspect_pat p =
           match p.FStar_Syntax_Syntax.v with
           | FStar_Syntax_Syntax.Pat_constant c ->
-              let uu____2653 = inspect_const c  in
+              let uu____2653 = inspect_const c in
               FStar_Reflection_Data.Pat_Constant uu____2653
           | FStar_Syntax_Syntax.Pat_cons (fv,ps) ->
               let uu____2672 =
@@ -1141,36 +1071,31 @@ let rec (inspect :
                   FStar_List.map
                     (fun uu____2691  ->
                        match uu____2691 with
-                       | (p1,uu____2699) -> inspect_pat p1) ps
-                   in
-                (fv, uu____2679)  in
+                       | (p1,uu____2699) -> inspect_pat p1) ps in
+                (fv, uu____2679) in
               FStar_Reflection_Data.Pat_Cons uu____2672
           | FStar_Syntax_Syntax.Pat_var bv ->
               FStar_Reflection_Data.Pat_Var bv
           | FStar_Syntax_Syntax.Pat_wild bv ->
               FStar_Reflection_Data.Pat_Wild bv
           | FStar_Syntax_Syntax.Pat_dot_term uu____2708 ->
-              failwith "NYI: Pat_dot_term"
-           in
-        let brs1 = FStar_List.map FStar_Syntax_Subst.open_branch brs  in
+              failwith "NYI: Pat_dot_term" in
+        let brs1 = FStar_List.map FStar_Syntax_Subst.open_branch brs in
         let brs2 =
           FStar_List.map
             (fun uu___53_2752  ->
                match uu___53_2752 with
                | (pat,uu____2774,t4) ->
-                   let uu____2792 = inspect_pat pat  in (uu____2792, t4))
-            brs1
-           in
+                   let uu____2792 = inspect_pat pat in (uu____2792, t4)) brs1 in
         FStar_Reflection_Data.Tv_Match (t3, brs2)
     | uu____2805 ->
-        ((let uu____2807 = FStar_Syntax_Print.tag_of_term t2  in
-          let uu____2808 = FStar_Syntax_Print.term_to_string t2  in
+        ((let uu____2807 = FStar_Syntax_Print.tag_of_term t2 in
+          let uu____2808 = FStar_Syntax_Print.term_to_string t2 in
           FStar_Util.print2 "inspect: outside of expected syntax (%s, %s)\n"
             uu____2807 uu____2808);
          FStar_Reflection_Data.Tv_Unknown)
-  
-let (inspect_comp :
-  FStar_Syntax_Syntax.comp -> FStar_Reflection_Data.comp_view) =
+let inspect_comp: FStar_Syntax_Syntax.comp -> FStar_Reflection_Data.comp_view
+  =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total (t,uu____2813) ->
@@ -1188,31 +1113,26 @@ let (inspect_comp :
         else FStar_Reflection_Data.C_Unknown
     | FStar_Syntax_Syntax.GTotal uu____2870 ->
         FStar_Reflection_Data.C_Unknown
-  
-let (pack_comp : FStar_Reflection_Data.comp_view -> FStar_Syntax_Syntax.comp)
-  =
+let pack_comp: FStar_Reflection_Data.comp_view -> FStar_Syntax_Syntax.comp =
   fun cv  ->
     match cv with
     | FStar_Reflection_Data.C_Total t -> FStar_Syntax_Syntax.mk_Total t
     | uu____2883 ->
         failwith "sorry, can embed comp_views other than C_Total for now"
-  
-let (pack_const : FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.sconst)
-  =
+let pack_const: FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.sconst =
   fun c  ->
     match c with
     | FStar_Reflection_Data.C_Unit  -> FStar_Const.Const_unit
     | FStar_Reflection_Data.C_Int i ->
         let uu____2888 =
-          let uu____2899 = FStar_BigInt.string_of_big_int i  in
-          (uu____2899, FStar_Pervasives_Native.None)  in
+          let uu____2899 = FStar_BigInt.string_of_big_int i in
+          (uu____2899, FStar_Pervasives_Native.None) in
         FStar_Const.Const_int uu____2888
     | FStar_Reflection_Data.C_True  -> FStar_Const.Const_bool true
     | FStar_Reflection_Data.C_False  -> FStar_Const.Const_bool false
     | FStar_Reflection_Data.C_String s ->
         FStar_Const.Const_string (s, FStar_Range.dummyRange)
-  
-let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
+let pack: FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term =
   fun tv  ->
     match tv with
     | FStar_Reflection_Data.Tv_Var (bv,uu____2915) ->
@@ -1222,13 +1142,11 @@ let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
         (match q with
          | FStar_Reflection_Data.Q_Explicit  ->
              let uu____2924 =
-               let uu____2933 = FStar_Syntax_Syntax.as_arg r  in [uu____2933]
-                in
+               let uu____2933 = FStar_Syntax_Syntax.as_arg r in [uu____2933] in
              FStar_Syntax_Util.mk_app l uu____2924
          | FStar_Reflection_Data.Q_Implicit  ->
              let uu____2934 =
-               let uu____2943 = FStar_Syntax_Syntax.iarg r  in [uu____2943]
-                in
+               let uu____2943 = FStar_Syntax_Syntax.iarg r in [uu____2943] in
              FStar_Syntax_Util.mk_app l uu____2934)
     | FStar_Reflection_Data.Tv_Abs (b,t) ->
         FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None
@@ -1239,40 +1157,39 @@ let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
     | FStar_Reflection_Data.Tv_Const c ->
         let uu____2956 =
           let uu____2959 =
-            let uu____2960 = pack_const c  in
-            FStar_Syntax_Syntax.Tm_constant uu____2960  in
-          FStar_Syntax_Syntax.mk uu____2959  in
+            let uu____2960 = pack_const c in
+            FStar_Syntax_Syntax.Tm_constant uu____2960 in
+          FStar_Syntax_Syntax.mk uu____2959 in
         uu____2956 FStar_Pervasives_Native.None FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Uvar (u,t) ->
-        let uu____2966 = FStar_BigInt.to_int_fs u  in
+        let uu____2966 = FStar_BigInt.to_int_fs u in
         FStar_Syntax_Util.uvar_from_id uu____2966 t
     | FStar_Reflection_Data.Tv_Let (b,t1,t2) ->
-        let bv = FStar_Pervasives_Native.fst b  in
+        let bv = FStar_Pervasives_Native.fst b in
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
-            []
-           in
+            [] in
         let uu____2974 =
           let uu____2977 =
             let uu____2978 =
-              let uu____2991 = FStar_Syntax_Subst.close [b] t2  in
-              ((false, [lb]), uu____2991)  in
-            FStar_Syntax_Syntax.Tm_let uu____2978  in
-          FStar_Syntax_Syntax.mk uu____2977  in
+              let uu____2991 = FStar_Syntax_Subst.close [b] t2 in
+              ((false, [lb]), uu____2991) in
+            FStar_Syntax_Syntax.Tm_let uu____2978 in
+          FStar_Syntax_Syntax.mk uu____2977 in
         uu____2974 FStar_Pervasives_Native.None FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Match (t,brs) ->
         let wrap v1 =
           {
             FStar_Syntax_Syntax.v = v1;
             FStar_Syntax_Syntax.p = FStar_Range.dummyRange
-          }  in
+          } in
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
               let uu____3020 =
-                let uu____3021 = pack_const c  in
-                FStar_Syntax_Syntax.Pat_constant uu____3021  in
+                let uu____3021 = pack_const c in
+                FStar_Syntax_Syntax.Pat_constant uu____3021 in
               FStar_All.pipe_left wrap uu____3020
           | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
               let uu____3030 =
@@ -1280,61 +1197,56 @@ let (pack : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
                   let uu____3044 =
                     FStar_List.map
                       (fun p1  ->
-                         let uu____3058 = pack_pat p1  in (uu____3058, false))
-                      ps
-                     in
-                  (fv, uu____3044)  in
-                FStar_Syntax_Syntax.Pat_cons uu____3031  in
+                         let uu____3058 = pack_pat p1 in (uu____3058, false))
+                      ps in
+                  (fv, uu____3044) in
+                FStar_Syntax_Syntax.Pat_cons uu____3031 in
               FStar_All.pipe_left wrap uu____3030
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
-              FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_wild bv)
-           in
+              FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_wild bv) in
         let brs1 =
           FStar_List.map
             (fun uu___54_3104  ->
                match uu___54_3104 with
                | (pat,t1) ->
-                   let uu____3121 = pack_pat pat  in
-                   (uu____3121, FStar_Pervasives_Native.None, t1)) brs
-           in
-        let brs2 = FStar_List.map FStar_Syntax_Subst.close_branch brs1  in
+                   let uu____3121 = pack_pat pat in
+                   (uu____3121, FStar_Pervasives_Native.None, t1)) brs in
+        let brs2 = FStar_List.map FStar_Syntax_Subst.close_branch brs1 in
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs2))
           FStar_Pervasives_Native.None FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Unknown  ->
         failwith "pack: unexpected term view"
-  
-let (embed_order :
-  FStar_Range.range -> FStar_Order.order -> FStar_Syntax_Syntax.term) =
+let embed_order:
+  FStar_Range.range -> FStar_Order.order -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun o  ->
       let r =
         match o with
         | FStar_Order.Lt  -> FStar_Reflection_Data.ord_Lt
         | FStar_Order.Eq  -> FStar_Reflection_Data.ord_Eq
-        | FStar_Order.Gt  -> FStar_Reflection_Data.ord_Gt  in
-      let uu___68_3140 = r  in
+        | FStar_Order.Gt  -> FStar_Reflection_Data.ord_Gt in
+      let uu___68_3140 = r in
       {
         FStar_Syntax_Syntax.n = (uu___68_3140.FStar_Syntax_Syntax.n);
         FStar_Syntax_Syntax.pos = rng;
         FStar_Syntax_Syntax.vars = (uu___68_3140.FStar_Syntax_Syntax.vars)
       }
-  
-let (unembed_order :
+let unembed_order:
   FStar_Syntax_Syntax.term ->
-    FStar_Order.order FStar_Pervasives_Native.option)
+    FStar_Order.order FStar_Pervasives_Native.option
   =
   fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____3149 = FStar_Syntax_Util.head_and_args t1  in
+    let t1 = FStar_Syntax_Util.unascribe t in
+    let uu____3149 = FStar_Syntax_Util.head_and_args t1 in
     match uu____3149 with
     | (hd1,args) ->
         let uu____3188 =
           let uu____3201 =
-            let uu____3202 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____3202.FStar_Syntax_Syntax.n  in
-          (uu____3201, args)  in
+            let uu____3202 = FStar_Syntax_Util.un_uinst hd1 in
+            uu____3202.FStar_Syntax_Syntax.n in
+          (uu____3201, args) in
         (match uu____3188 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1351,41 +1263,36 @@ let (unembed_order :
          | uu____3260 ->
              ((let uu____3274 =
                  let uu____3279 =
-                   let uu____3280 = FStar_Syntax_Print.term_to_string t1  in
-                   FStar_Util.format1 "Not an embedded order: %s" uu____3280
-                    in
-                 (FStar_Errors.Warning_NotEmbedded, uu____3279)  in
+                   let uu____3280 = FStar_Syntax_Print.term_to_string t1 in
+                   FStar_Util.format1 "Not an embedded order: %s" uu____3280 in
+                 (FStar_Errors.Warning_NotEmbedded, uu____3279) in
                FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____3274);
               FStar_Pervasives_Native.None))
-  
-let (compare_binder :
+let compare_binder:
   FStar_Syntax_Syntax.binder ->
-    FStar_Syntax_Syntax.binder -> FStar_Order.order)
+    FStar_Syntax_Syntax.binder -> FStar_Order.order
   =
   fun x  ->
     fun y  ->
       let n1 =
         FStar_Syntax_Syntax.order_bv (FStar_Pervasives_Native.fst x)
-          (FStar_Pervasives_Native.fst y)
-         in
+          (FStar_Pervasives_Native.fst y) in
       if n1 < (Prims.parse_int "0")
       then FStar_Order.Lt
       else
         if n1 = (Prims.parse_int "0") then FStar_Order.Eq else FStar_Order.Gt
-  
-let (is_free :
-  FStar_Syntax_Syntax.binder -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_free:
+  FStar_Syntax_Syntax.binder -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun x  ->
     fun t  -> FStar_Syntax_Util.is_free_in (FStar_Pervasives_Native.fst x) t
-  
-let (lookup_typ :
+let lookup_typ:
   FStar_TypeChecker_Env.env ->
-    Prims.string Prims.list -> FStar_Reflection_Data.sigelt_view)
+    Prims.string Prims.list -> FStar_Reflection_Data.sigelt_view
   =
   fun env  ->
     fun ns  ->
-      let lid = FStar_Parser_Const.p2l ns  in
-      let res = FStar_TypeChecker_Env.lookup_qname env lid  in
+      let lid = FStar_Parser_Const.p2l ns in
+      let res = FStar_TypeChecker_Env.lookup_qname env lid in
       match res with
       | FStar_Pervasives_Native.None  -> FStar_Reflection_Data.Unk
       | FStar_Pervasives_Native.Some (FStar_Util.Inl uu____3326,rng) ->
@@ -1394,10 +1301,10 @@ let (lookup_typ :
           (match se.FStar_Syntax_Syntax.sigel with
            | FStar_Syntax_Syntax.Sig_inductive_typ
                (lid1,us1,bs,t,uu____3427,dc_lids) ->
-               let nm = FStar_Ident.path_of_lid lid1  in
+               let nm = FStar_Ident.path_of_lid lid1 in
                let ctor1 dc_lid =
                  let uu____3444 =
-                   FStar_TypeChecker_Env.lookup_qname env dc_lid  in
+                   FStar_TypeChecker_Env.lookup_qname env dc_lid in
                  match uu____3444 with
                  | FStar_Pervasives_Native.Some
                      (FStar_Util.Inr (se1,us2),rng1) ->
@@ -1405,27 +1312,25 @@ let (lookup_typ :
                       | FStar_Syntax_Syntax.Sig_datacon
                           (lid2,us3,t1,uu____3497,n1,uu____3499) ->
                           let uu____3504 =
-                            let uu____3509 = FStar_Ident.path_of_lid lid2  in
-                            (uu____3509, t1)  in
+                            let uu____3509 = FStar_Ident.path_of_lid lid2 in
+                            (uu____3509, t1) in
                           FStar_Reflection_Data.Ctor uu____3504
                       | uu____3514 -> failwith "wat 1")
-                 | uu____3515 -> failwith "wat 2"  in
-               let ctors = FStar_List.map ctor1 dc_lids  in
+                 | uu____3515 -> failwith "wat 2" in
+               let ctors = FStar_List.map ctor1 dc_lids in
                FStar_Reflection_Data.Sg_Inductive (nm, bs, t, ctors)
            | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3524) ->
                let fv =
                  match lb.FStar_Syntax_Syntax.lbname with
                  | FStar_Util.Inr fv -> fv
                  | FStar_Util.Inl uu____3539 ->
-                     failwith "global Sig_let has bv"
-                  in
+                     failwith "global Sig_let has bv" in
                FStar_Reflection_Data.Sg_Let
                  (fv, (lb.FStar_Syntax_Syntax.lbtyp),
                    (lb.FStar_Syntax_Syntax.lbdef))
            | uu____3544 -> FStar_Reflection_Data.Unk)
-  
-let (embed_ctor :
-  FStar_Range.range -> FStar_Reflection_Data.ctor -> FStar_Syntax_Syntax.term)
+let embed_ctor:
+  FStar_Range.range -> FStar_Reflection_Data.ctor -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun c  ->
@@ -1435,44 +1340,41 @@ let (embed_ctor :
             let uu____3554 =
               let uu____3555 =
                 let uu____3556 =
-                  FStar_Syntax_Embeddings.embed_string_list rng nm  in
-                FStar_Syntax_Syntax.as_arg uu____3556  in
+                  FStar_Syntax_Embeddings.embed_string_list rng nm in
+                FStar_Syntax_Syntax.as_arg uu____3556 in
               let uu____3557 =
                 let uu____3560 =
-                  let uu____3561 = embed_term rng t  in
-                  FStar_Syntax_Syntax.as_arg uu____3561  in
-                [uu____3560]  in
-              uu____3555 :: uu____3557  in
+                  let uu____3561 = embed_term rng t in
+                  FStar_Syntax_Syntax.as_arg uu____3561 in
+                [uu____3560] in
+              uu____3555 :: uu____3557 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Ctor
-              uu____3554
-             in
+              uu____3554 in
           uu____3553 FStar_Pervasives_Native.None rng
-  
-let (unembed_ctor :
+let unembed_ctor:
   FStar_Syntax_Syntax.term ->
-    FStar_Reflection_Data.ctor FStar_Pervasives_Native.option)
+    FStar_Reflection_Data.ctor FStar_Pervasives_Native.option
   =
   fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____3572 = FStar_Syntax_Util.head_and_args t1  in
+    let t1 = FStar_Syntax_Util.unascribe t in
+    let uu____3572 = FStar_Syntax_Util.head_and_args t1 in
     match uu____3572 with
     | (hd1,args) ->
         let uu____3611 =
           let uu____3624 =
-            let uu____3625 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____3625.FStar_Syntax_Syntax.n  in
-          (uu____3624, args)  in
+            let uu____3625 = FStar_Syntax_Util.un_uinst hd1 in
+            uu____3625.FStar_Syntax_Syntax.n in
+          (uu____3624, args) in
         (match uu____3611 with
          | (FStar_Syntax_Syntax.Tm_fvar
             fv,(nm,uu____3640)::(t2,uu____3642)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Ctor_lid
              ->
-             let uu____3677 = FStar_Syntax_Embeddings.unembed_string_list nm
-                in
+             let uu____3677 = FStar_Syntax_Embeddings.unembed_string_list nm in
              FStar_Util.bind_opt uu____3677
                (fun nm1  ->
-                  let uu____3689 = unembed_term t2  in
+                  let uu____3689 = unembed_term t2 in
                   FStar_Util.bind_opt uu____3689
                     (fun t3  ->
                        FStar_All.pipe_left
@@ -1481,16 +1383,14 @@ let (unembed_ctor :
          | uu____3698 ->
              ((let uu____3712 =
                  let uu____3717 =
-                   let uu____3718 = FStar_Syntax_Print.term_to_string t1  in
-                   FStar_Util.format1 "Not an embedded ctor: %s" uu____3718
-                    in
-                 (FStar_Errors.Warning_NotEmbedded, uu____3717)  in
+                   let uu____3718 = FStar_Syntax_Print.term_to_string t1 in
+                   FStar_Util.format1 "Not an embedded ctor: %s" uu____3718 in
+                 (FStar_Errors.Warning_NotEmbedded, uu____3717) in
                FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____3712);
               FStar_Pervasives_Native.None))
-  
-let (embed_sigelt_view :
+let embed_sigelt_view:
   FStar_Range.range ->
-    FStar_Reflection_Data.sigelt_view -> FStar_Syntax_Syntax.term)
+    FStar_Reflection_Data.sigelt_view -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun sev  ->
@@ -1500,77 +1400,73 @@ let (embed_sigelt_view :
             let uu____3738 =
               let uu____3739 =
                 let uu____3740 =
-                  FStar_Syntax_Embeddings.embed_string_list rng nm  in
-                FStar_Syntax_Syntax.as_arg uu____3740  in
+                  FStar_Syntax_Embeddings.embed_string_list rng nm in
+                FStar_Syntax_Syntax.as_arg uu____3740 in
               let uu____3741 =
                 let uu____3744 =
-                  let uu____3745 = embed_binders rng bs  in
-                  FStar_Syntax_Syntax.as_arg uu____3745  in
+                  let uu____3745 = embed_binders rng bs in
+                  FStar_Syntax_Syntax.as_arg uu____3745 in
                 let uu____3746 =
                   let uu____3749 =
-                    let uu____3750 = embed_term rng t  in
-                    FStar_Syntax_Syntax.as_arg uu____3750  in
+                    let uu____3750 = embed_term rng t in
+                    FStar_Syntax_Syntax.as_arg uu____3750 in
                   let uu____3751 =
                     let uu____3754 =
                       let uu____3755 =
                         let uu____3756 =
                           FStar_Syntax_Embeddings.embed_list embed_ctor
-                            FStar_Reflection_Data.fstar_refl_ctor
-                           in
-                        uu____3756 rng dcs  in
-                      FStar_Syntax_Syntax.as_arg uu____3755  in
-                    [uu____3754]  in
-                  uu____3749 :: uu____3751  in
-                uu____3744 :: uu____3746  in
-              uu____3739 :: uu____3741  in
+                            FStar_Reflection_Data.fstar_refl_ctor in
+                        uu____3756 rng dcs in
+                      FStar_Syntax_Syntax.as_arg uu____3755 in
+                    [uu____3754] in
+                  uu____3749 :: uu____3751 in
+                uu____3744 :: uu____3746 in
+              uu____3739 :: uu____3741 in
             FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Sg_Inductive uu____3738
-             in
+              FStar_Reflection_Data.ref_Sg_Inductive uu____3738 in
           uu____3737 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Sg_Let (fv,ty,t) ->
           let uu____3769 =
             let uu____3770 =
               let uu____3771 =
-                let uu____3772 = embed_fvar rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____3772  in
+                let uu____3772 = embed_fvar rng fv in
+                FStar_Syntax_Syntax.as_arg uu____3772 in
               let uu____3773 =
                 let uu____3776 =
-                  let uu____3777 = embed_term rng ty  in
-                  FStar_Syntax_Syntax.as_arg uu____3777  in
+                  let uu____3777 = embed_term rng ty in
+                  FStar_Syntax_Syntax.as_arg uu____3777 in
                 let uu____3778 =
                   let uu____3781 =
-                    let uu____3782 = embed_term rng t  in
-                    FStar_Syntax_Syntax.as_arg uu____3782  in
-                  [uu____3781]  in
-                uu____3776 :: uu____3778  in
-              uu____3771 :: uu____3773  in
+                    let uu____3782 = embed_term rng t in
+                    FStar_Syntax_Syntax.as_arg uu____3782 in
+                  [uu____3781] in
+                uu____3776 :: uu____3778 in
+              uu____3771 :: uu____3773 in
             FStar_Syntax_Syntax.mk_Tm_app FStar_Reflection_Data.ref_Sg_Let
-              uu____3770
-             in
+              uu____3770 in
           uu____3769 FStar_Pervasives_Native.None rng
       | FStar_Reflection_Data.Unk  ->
-          let uu___69_3785 = FStar_Reflection_Data.ref_Unk  in
+          let uu___69_3785 = FStar_Reflection_Data.ref_Unk in
           {
             FStar_Syntax_Syntax.n = (uu___69_3785.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = rng;
             FStar_Syntax_Syntax.vars =
               (uu___69_3785.FStar_Syntax_Syntax.vars)
           }
-  
-let (unembed_sigelt_view :
+let unembed_sigelt_view:
   FStar_Syntax_Syntax.term ->
-    FStar_Reflection_Data.sigelt_view FStar_Pervasives_Native.option)
+    FStar_Reflection_Data.sigelt_view FStar_Pervasives_Native.option
   =
   fun t  ->
-    let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____3794 = FStar_Syntax_Util.head_and_args t1  in
+    let t1 = FStar_Syntax_Util.unascribe t in
+    let uu____3794 = FStar_Syntax_Util.head_and_args t1 in
     match uu____3794 with
     | (hd1,args) ->
         let uu____3833 =
           let uu____3846 =
-            let uu____3847 = FStar_Syntax_Util.un_uinst hd1  in
-            uu____3847.FStar_Syntax_Syntax.n  in
-          (uu____3846, args)  in
+            let uu____3847 = FStar_Syntax_Util.un_uinst hd1 in
+            uu____3847.FStar_Syntax_Syntax.n in
+          (uu____3846, args) in
         (match uu____3833 with
          | (FStar_Syntax_Syntax.Tm_fvar
             fv,(nm,uu____3862)::(bs,uu____3864)::(t2,uu____3866)::(dcs,uu____3868)::[])
@@ -1578,22 +1474,20 @@ let (unembed_sigelt_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Inductive_lid
              ->
-             let uu____3923 = FStar_Syntax_Embeddings.unembed_string_list nm
-                in
+             let uu____3923 = FStar_Syntax_Embeddings.unembed_string_list nm in
              FStar_Util.bind_opt uu____3923
                (fun nm1  ->
-                  let uu____3935 = unembed_binders bs  in
+                  let uu____3935 = unembed_binders bs in
                   FStar_Util.bind_opt uu____3935
                     (fun bs1  ->
-                       let uu____3947 = unembed_term t2  in
+                       let uu____3947 = unembed_term t2 in
                        FStar_Util.bind_opt uu____3947
                          (fun t3  ->
                             let uu____3953 =
                               let uu____3958 =
                                 FStar_Syntax_Embeddings.unembed_list
-                                  unembed_ctor
-                                 in
-                              uu____3958 dcs  in
+                                  unembed_ctor in
+                              uu____3958 dcs in
                             FStar_Util.bind_opt uu____3953
                               (fun dcs1  ->
                                  FStar_All.pipe_left
@@ -1606,13 +1500,13 @@ let (unembed_sigelt_view :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Let_lid
              ->
-             let uu____4030 = unembed_fvar fvar1  in
+             let uu____4030 = unembed_fvar fvar1 in
              FStar_Util.bind_opt uu____4030
                (fun fvar2  ->
-                  let uu____4036 = unembed_term ty  in
+                  let uu____4036 = unembed_term ty in
                   FStar_Util.bind_opt uu____4036
                     (fun ty1  ->
-                       let uu____4042 = unembed_term t2  in
+                       let uu____4042 = unembed_term t2 in
                        FStar_Util.bind_opt uu____4042
                          (fun t3  ->
                             FStar_All.pipe_left
@@ -1626,26 +1520,23 @@ let (unembed_sigelt_view :
          | uu____4064 ->
              ((let uu____4078 =
                  let uu____4083 =
-                   let uu____4084 = FStar_Syntax_Print.term_to_string t1  in
+                   let uu____4084 = FStar_Syntax_Print.term_to_string t1 in
                    FStar_Util.format1 "Not an embedded sigelt_view: %s"
-                     uu____4084
-                    in
-                 (FStar_Errors.Warning_NotEmbedded, uu____4083)  in
+                     uu____4084 in
+                 (FStar_Errors.Warning_NotEmbedded, uu____4083) in
                FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4078);
               FStar_Pervasives_Native.None))
-  
-let (binders_of_env :
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.binders) =
-  fun e  -> FStar_TypeChecker_Env.all_binders e 
-let type_of_binder :
+let binders_of_env: FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.binders
+  = fun e  -> FStar_TypeChecker_Env.all_binders e
+let type_of_binder:
   'Auu____4090 .
     (FStar_Syntax_Syntax.bv,'Auu____4090) FStar_Pervasives_Native.tuple2 ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
-  = fun b  -> match b with | (b1,uu____4106) -> b1.FStar_Syntax_Syntax.sort 
-let (term_eq :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
-  FStar_Syntax_Util.term_eq 
-let fresh_binder :
+  = fun b  -> match b with | (b1,uu____4106) -> b1.FStar_Syntax_Syntax.sort
+let term_eq:
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool =
+  FStar_Syntax_Util.term_eq
+let fresh_binder:
   'Auu____4113 .
     FStar_Syntax_Syntax.typ ->
       (FStar_Syntax_Syntax.bv,'Auu____4113 FStar_Pervasives_Native.option)
@@ -1653,8 +1544,7 @@ let fresh_binder :
   =
   fun t  ->
     let uu____4124 =
-      FStar_Syntax_Syntax.gen_bv "__refl" FStar_Pervasives_Native.None t  in
+      FStar_Syntax_Syntax.gen_bv "__refl" FStar_Pervasives_Native.None t in
     (uu____4124, FStar_Pervasives_Native.None)
-  
-let (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
-  FStar_Syntax_Print.term_to_string 
+let term_to_string: FStar_Syntax_Syntax.term -> Prims.string =
+  FStar_Syntax_Print.term_to_string

--- a/src/ocaml-output/FStar_Reflection_Data.ml
+++ b/src/ocaml-output/FStar_Reflection_Data.ml
@@ -3,424 +3,383 @@ type name = Prims.string Prims.list[@@deriving show]
 type typ = FStar_Syntax_Syntax.term[@@deriving show]
 type binders = FStar_Syntax_Syntax.binder Prims.list[@@deriving show]
 type vconst =
-  | C_Unit 
-  | C_Int of FStar_BigInt.t 
-  | C_True 
-  | C_False 
-  | C_String of Prims.string [@@deriving show]
-let (uu___is_C_Unit : vconst -> Prims.bool) =
+  | C_Unit
+  | C_Int of FStar_BigInt.t
+  | C_True
+  | C_False
+  | C_String of Prims.string[@@deriving show]
+let uu___is_C_Unit: vconst -> Prims.bool =
   fun projectee  ->
     match projectee with | C_Unit  -> true | uu____16 -> false
-  
-let (uu___is_C_Int : vconst -> Prims.bool) =
+let uu___is_C_Int: vconst -> Prims.bool =
   fun projectee  ->
     match projectee with | C_Int _0 -> true | uu____21 -> false
-  
-let (__proj__C_Int__item___0 : vconst -> FStar_BigInt.t) =
-  fun projectee  -> match projectee with | C_Int _0 -> _0 
-let (uu___is_C_True : vconst -> Prims.bool) =
+let __proj__C_Int__item___0: vconst -> FStar_BigInt.t =
+  fun projectee  -> match projectee with | C_Int _0 -> _0
+let uu___is_C_True: vconst -> Prims.bool =
   fun projectee  ->
     match projectee with | C_True  -> true | uu____32 -> false
-  
-let (uu___is_C_False : vconst -> Prims.bool) =
+let uu___is_C_False: vconst -> Prims.bool =
   fun projectee  ->
     match projectee with | C_False  -> true | uu____36 -> false
-  
-let (uu___is_C_String : vconst -> Prims.bool) =
+let uu___is_C_String: vconst -> Prims.bool =
   fun projectee  ->
     match projectee with | C_String _0 -> true | uu____41 -> false
-  
-let (__proj__C_String__item___0 : vconst -> Prims.string) =
-  fun projectee  -> match projectee with | C_String _0 -> _0 
+let __proj__C_String__item___0: vconst -> Prims.string =
+  fun projectee  -> match projectee with | C_String _0 -> _0
 type pattern =
-  | Pat_Constant of vconst 
+  | Pat_Constant of vconst
   | Pat_Cons of (FStar_Syntax_Syntax.fv,pattern Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | Pat_Var of FStar_Syntax_Syntax.bv 
-  | Pat_Wild of FStar_Syntax_Syntax.bv [@@deriving show]
-let (uu___is_Pat_Constant : pattern -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | Pat_Var of FStar_Syntax_Syntax.bv
+  | Pat_Wild of FStar_Syntax_Syntax.bv[@@deriving show]
+let uu___is_Pat_Constant: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | Pat_Constant _0 -> true | uu____75 -> false
-  
-let (__proj__Pat_Constant__item___0 : pattern -> vconst) =
-  fun projectee  -> match projectee with | Pat_Constant _0 -> _0 
-let (uu___is_Pat_Cons : pattern -> Prims.bool) =
+let __proj__Pat_Constant__item___0: pattern -> vconst =
+  fun projectee  -> match projectee with | Pat_Constant _0 -> _0
+let uu___is_Pat_Cons: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | Pat_Cons _0 -> true | uu____93 -> false
-  
-let (__proj__Pat_Cons__item___0 :
+let __proj__Pat_Cons__item___0:
   pattern ->
     (FStar_Syntax_Syntax.fv,pattern Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Pat_Cons _0 -> _0 
-let (uu___is_Pat_Var : pattern -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Pat_Cons _0 -> _0
+let uu___is_Pat_Var: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | Pat_Var _0 -> true | uu____123 -> false
-  
-let (__proj__Pat_Var__item___0 : pattern -> FStar_Syntax_Syntax.bv) =
-  fun projectee  -> match projectee with | Pat_Var _0 -> _0 
-let (uu___is_Pat_Wild : pattern -> Prims.bool) =
+let __proj__Pat_Var__item___0: pattern -> FStar_Syntax_Syntax.bv =
+  fun projectee  -> match projectee with | Pat_Var _0 -> _0
+let uu___is_Pat_Wild: pattern -> Prims.bool =
   fun projectee  ->
     match projectee with | Pat_Wild _0 -> true | uu____135 -> false
-  
-let (__proj__Pat_Wild__item___0 : pattern -> FStar_Syntax_Syntax.bv) =
-  fun projectee  -> match projectee with | Pat_Wild _0 -> _0 
+let __proj__Pat_Wild__item___0: pattern -> FStar_Syntax_Syntax.bv =
+  fun projectee  -> match projectee with | Pat_Wild _0 -> _0
 type branch =
   (pattern,FStar_Syntax_Syntax.term) FStar_Pervasives_Native.tuple2[@@deriving
                                                                     show]
 type aqualv =
-  | Q_Implicit 
-  | Q_Explicit [@@deriving show]
-let (uu___is_Q_Implicit : aqualv -> Prims.bool) =
+  | Q_Implicit
+  | Q_Explicit[@@deriving show]
+let uu___is_Q_Implicit: aqualv -> Prims.bool =
   fun projectee  ->
     match projectee with | Q_Implicit  -> true | uu____150 -> false
-  
-let (uu___is_Q_Explicit : aqualv -> Prims.bool) =
+let uu___is_Q_Explicit: aqualv -> Prims.bool =
   fun projectee  ->
     match projectee with | Q_Explicit  -> true | uu____154 -> false
-  
 type argv = (FStar_Syntax_Syntax.term,aqualv) FStar_Pervasives_Native.tuple2
 [@@deriving show]
 type term_view =
-  | Tv_Var of FStar_Syntax_Syntax.binder 
-  | Tv_FVar of FStar_Syntax_Syntax.fv 
+  | Tv_Var of FStar_Syntax_Syntax.binder
+  | Tv_FVar of FStar_Syntax_Syntax.fv
   | Tv_App of (FStar_Syntax_Syntax.term,argv) FStar_Pervasives_Native.tuple2
-  
   | Tv_Abs of (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.term)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Tv_Arrow of (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.comp)
-  FStar_Pervasives_Native.tuple2 
-  | Tv_Type of Prims.unit 
+  FStar_Pervasives_Native.tuple2
+  | Tv_Type of Prims.unit
   | Tv_Refine of (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.term)
-  FStar_Pervasives_Native.tuple2 
-  | Tv_Const of vconst 
-  | Tv_Uvar of (FStar_BigInt.t,typ) FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
+  | Tv_Const of vconst
+  | Tv_Uvar of (FStar_BigInt.t,typ) FStar_Pervasives_Native.tuple2
   | Tv_Let of
   (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | Tv_Match of (FStar_Syntax_Syntax.term,branch Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | Tv_Unknown [@@deriving show]
-let (uu___is_Tv_Var : term_view -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | Tv_Unknown[@@deriving show]
+let uu___is_Tv_Var: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Var _0 -> true | uu____239 -> false
-  
-let (__proj__Tv_Var__item___0 : term_view -> FStar_Syntax_Syntax.binder) =
-  fun projectee  -> match projectee with | Tv_Var _0 -> _0 
-let (uu___is_Tv_FVar : term_view -> Prims.bool) =
+let __proj__Tv_Var__item___0: term_view -> FStar_Syntax_Syntax.binder =
+  fun projectee  -> match projectee with | Tv_Var _0 -> _0
+let uu___is_Tv_FVar: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_FVar _0 -> true | uu____251 -> false
-  
-let (__proj__Tv_FVar__item___0 : term_view -> FStar_Syntax_Syntax.fv) =
-  fun projectee  -> match projectee with | Tv_FVar _0 -> _0 
-let (uu___is_Tv_App : term_view -> Prims.bool) =
+let __proj__Tv_FVar__item___0: term_view -> FStar_Syntax_Syntax.fv =
+  fun projectee  -> match projectee with | Tv_FVar _0 -> _0
+let uu___is_Tv_App: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_App _0 -> true | uu____267 -> false
-  
-let (__proj__Tv_App__item___0 :
-  term_view -> (FStar_Syntax_Syntax.term,argv) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tv_App _0 -> _0 
-let (uu___is_Tv_Abs : term_view -> Prims.bool) =
+let __proj__Tv_App__item___0:
+  term_view -> (FStar_Syntax_Syntax.term,argv) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tv_App _0 -> _0
+let uu___is_Tv_Abs: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Abs _0 -> true | uu____295 -> false
-  
-let (__proj__Tv_Abs__item___0 :
+let __proj__Tv_Abs__item___0:
   term_view ->
     (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tv_Abs _0 -> _0 
-let (uu___is_Tv_Arrow : term_view -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tv_Abs _0 -> _0
+let uu___is_Tv_Arrow: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Arrow _0 -> true | uu____323 -> false
-  
-let (__proj__Tv_Arrow__item___0 :
+let __proj__Tv_Arrow__item___0:
   term_view ->
     (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.comp)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tv_Arrow _0 -> _0 
-let (uu___is_Tv_Type : term_view -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tv_Arrow _0 -> _0
+let uu___is_Tv_Type: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Type _0 -> true | uu____347 -> false
-  
-let (__proj__Tv_Type__item___0 : term_view -> Prims.unit) =
-  fun projectee  -> () 
-let (uu___is_Tv_Refine : term_view -> Prims.bool) =
+let __proj__Tv_Type__item___0: term_view -> Prims.unit = fun projectee  -> ()
+let uu___is_Tv_Refine: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Refine _0 -> true | uu____363 -> false
-  
-let (__proj__Tv_Refine__item___0 :
+let __proj__Tv_Refine__item___0:
   term_view ->
     (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tv_Refine _0 -> _0 
-let (uu___is_Tv_Const : term_view -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tv_Refine _0 -> _0
+let uu___is_Tv_Const: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Const _0 -> true | uu____387 -> false
-  
-let (__proj__Tv_Const__item___0 : term_view -> vconst) =
-  fun projectee  -> match projectee with | Tv_Const _0 -> _0 
-let (uu___is_Tv_Uvar : term_view -> Prims.bool) =
+let __proj__Tv_Const__item___0: term_view -> vconst =
+  fun projectee  -> match projectee with | Tv_Const _0 -> _0
+let uu___is_Tv_Uvar: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Uvar _0 -> true | uu____403 -> false
-  
-let (__proj__Tv_Uvar__item___0 :
-  term_view -> (FStar_BigInt.t,typ) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Tv_Uvar _0 -> _0 
-let (uu___is_Tv_Let : term_view -> Prims.bool) =
+let __proj__Tv_Uvar__item___0:
+  term_view -> (FStar_BigInt.t,typ) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Tv_Uvar _0 -> _0
+let uu___is_Tv_Let: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Let _0 -> true | uu____433 -> false
-  
-let (__proj__Tv_Let__item___0 :
+let __proj__Tv_Let__item___0:
   term_view ->
     (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Tv_Let _0 -> _0 
-let (uu___is_Tv_Match : term_view -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Tv_Let _0 -> _0
+let uu___is_Tv_Match: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Match _0 -> true | uu____469 -> false
-  
-let (__proj__Tv_Match__item___0 :
+let __proj__Tv_Match__item___0:
   term_view ->
     (FStar_Syntax_Syntax.term,branch Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tv_Match _0 -> _0 
-let (uu___is_Tv_Unknown : term_view -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tv_Match _0 -> _0
+let uu___is_Tv_Unknown: term_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Tv_Unknown  -> true | uu____498 -> false
-  
 type comp_view =
-  | C_Total of typ 
+  | C_Total of typ
   | C_Lemma of (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-  FStar_Pervasives_Native.tuple2 
-  | C_Unknown [@@deriving show]
-let (uu___is_C_Total : comp_view -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | C_Unknown[@@deriving show]
+let uu___is_C_Total: comp_view -> Prims.bool =
   fun projectee  ->
     match projectee with | C_Total _0 -> true | uu____515 -> false
-  
-let (__proj__C_Total__item___0 : comp_view -> typ) =
-  fun projectee  -> match projectee with | C_Total _0 -> _0 
-let (uu___is_C_Lemma : comp_view -> Prims.bool) =
+let __proj__C_Total__item___0: comp_view -> typ =
+  fun projectee  -> match projectee with | C_Total _0 -> _0
+let uu___is_C_Lemma: comp_view -> Prims.bool =
   fun projectee  ->
     match projectee with | C_Lemma _0 -> true | uu____531 -> false
-  
-let (__proj__C_Lemma__item___0 :
+let __proj__C_Lemma__item___0:
   comp_view ->
     (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | C_Lemma _0 -> _0 
-let (uu___is_C_Unknown : comp_view -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | C_Lemma _0 -> _0
+let uu___is_C_Unknown: comp_view -> Prims.bool =
   fun projectee  ->
     match projectee with | C_Unknown  -> true | uu____554 -> false
-  
 type ctor =
-  | Ctor of (name,typ) FStar_Pervasives_Native.tuple2 [@@deriving show]
-let (uu___is_Ctor : ctor -> Prims.bool) = fun projectee  -> true 
-let (__proj__Ctor__item___0 :
-  ctor -> (name,typ) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Ctor _0 -> _0 
+  | Ctor of (name,typ) FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_Ctor: ctor -> Prims.bool = fun projectee  -> true
+let __proj__Ctor__item___0: ctor -> (name,typ) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Ctor _0 -> _0
 type sigelt_view =
   | Sg_Inductive of
   (name,FStar_Syntax_Syntax.binder Prims.list,typ,ctor Prims.list)
-  FStar_Pervasives_Native.tuple4 
+  FStar_Pervasives_Native.tuple4
   | Sg_Let of (FStar_Syntax_Syntax.fv,typ,FStar_Syntax_Syntax.term)
-  FStar_Pervasives_Native.tuple3 
-  | Unk [@@deriving show]
-let (uu___is_Sg_Inductive : sigelt_view -> Prims.bool) =
+  FStar_Pervasives_Native.tuple3
+  | Unk[@@deriving show]
+let uu___is_Sg_Inductive: sigelt_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Sg_Inductive _0 -> true | uu____624 -> false
-  
-let (__proj__Sg_Inductive__item___0 :
+let __proj__Sg_Inductive__item___0:
   sigelt_view ->
     (name,FStar_Syntax_Syntax.binder Prims.list,typ,ctor Prims.list)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | Sg_Inductive _0 -> _0 
-let (uu___is_Sg_Let : sigelt_view -> Prims.bool) =
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | Sg_Inductive _0 -> _0
+let uu___is_Sg_Let: sigelt_view -> Prims.bool =
   fun projectee  ->
     match projectee with | Sg_Let _0 -> true | uu____678 -> false
-  
-let (__proj__Sg_Let__item___0 :
+let __proj__Sg_Let__item___0:
   sigelt_view ->
     (FStar_Syntax_Syntax.fv,typ,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Sg_Let _0 -> _0 
-let (uu___is_Unk : sigelt_view -> Prims.bool) =
-  fun projectee  -> match projectee with | Unk  -> true | uu____707 -> false 
-let (fstar_refl_lid : Prims.string Prims.list -> FStar_Ident.lident) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Sg_Let _0 -> _0
+let uu___is_Unk: sigelt_view -> Prims.bool =
+  fun projectee  -> match projectee with | Unk  -> true | uu____707 -> false
+let fstar_refl_lid: Prims.string Prims.list -> FStar_Ident.lident =
   fun s  ->
     FStar_Ident.lid_of_path (FStar_List.append ["FStar"; "Reflection"] s)
       FStar_Range.dummyRange
-  
-let (fstar_refl_basic_lid : Prims.string -> FStar_Ident.lident) =
-  fun s  -> fstar_refl_lid ["Basic"; s] 
-let (fstar_refl_types_lid : Prims.string -> FStar_Ident.lident) =
-  fun s  -> fstar_refl_lid ["Types"; s] 
-let (fstar_refl_syntax_lid : Prims.string -> FStar_Ident.lident) =
-  fun s  -> fstar_refl_lid ["Syntax"; s] 
-let (fstar_refl_data_lid : Prims.string -> FStar_Ident.lident) =
-  fun s  -> fstar_refl_lid ["Data"; s] 
-let (mk_refl_types_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
+let fstar_refl_basic_lid: Prims.string -> FStar_Ident.lident =
+  fun s  -> fstar_refl_lid ["Basic"; s]
+let fstar_refl_types_lid: Prims.string -> FStar_Ident.lident =
+  fun s  -> fstar_refl_lid ["Types"; s]
+let fstar_refl_syntax_lid: Prims.string -> FStar_Ident.lident =
+  fun s  -> fstar_refl_lid ["Syntax"; s]
+let fstar_refl_data_lid: Prims.string -> FStar_Ident.lident =
+  fun s  -> fstar_refl_lid ["Data"; s]
+let mk_refl_types_lid_as_term: Prims.string -> FStar_Syntax_Syntax.term =
   fun s  ->
-    let uu____730 = fstar_refl_types_lid s  in
+    let uu____730 = fstar_refl_types_lid s in
     FStar_Syntax_Syntax.tconst uu____730
-  
-let (mk_refl_syntax_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
+let mk_refl_syntax_lid_as_term: Prims.string -> FStar_Syntax_Syntax.term =
   fun s  ->
-    let uu____734 = fstar_refl_syntax_lid s  in
+    let uu____734 = fstar_refl_syntax_lid s in
     FStar_Syntax_Syntax.tconst uu____734
-  
-let (mk_refl_data_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
+let mk_refl_data_lid_as_term: Prims.string -> FStar_Syntax_Syntax.term =
   fun s  ->
-    let uu____738 = fstar_refl_data_lid s  in
+    let uu____738 = fstar_refl_data_lid s in
     FStar_Syntax_Syntax.tconst uu____738
-  
-let (fstar_refl_tdataconstr :
-  Prims.string Prims.list -> FStar_Syntax_Syntax.term) =
+let fstar_refl_tdataconstr:
+  Prims.string Prims.list -> FStar_Syntax_Syntax.term =
   fun s  ->
-    let uu____746 = fstar_refl_lid s  in
+    let uu____746 = fstar_refl_lid s in
     FStar_Syntax_Syntax.tdataconstr uu____746
-  
-let (fstar_refl_aqualv : FStar_Syntax_Syntax.term) =
-  mk_refl_data_lid_as_term "aqualv" 
-let (fstar_refl_env : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "env" 
-let (fstar_refl_fvar : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "fv" 
-let (fstar_refl_comp : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "comp" 
-let (fstar_refl_comp_view : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "comp_view" 
-let (fstar_refl_binder : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "binder" 
-let (fstar_refl_binders : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "binders" 
-let (fstar_refl_term_view : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "term_view" 
-let (fstar_refl_sigelt : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "sigelt" 
-let (fstar_refl_ctor : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "ctor" 
-let (fstar_refl_pattern : FStar_Syntax_Syntax.term) =
-  mk_refl_syntax_lid_as_term "pattern" 
-let (fstar_refl_branch : FStar_Syntax_Syntax.term) =
-  mk_refl_types_lid_as_term "branch" 
-let (ref_Q_Explicit_lid : FStar_Ident.lident) =
-  fstar_refl_data_lid "Q_Explicit" 
-let (ref_Q_Implicit_lid : FStar_Ident.lident) =
-  fstar_refl_data_lid "Q_Implicit" 
-let (ref_Q_Explicit : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Q_Explicit_lid 
-let (ref_Q_Implicit : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Q_Implicit_lid 
-let (ref_C_Unit_lid : FStar_Ident.lident) = fstar_refl_data_lid "C_Unit" 
-let (ref_C_True_lid : FStar_Ident.lident) = fstar_refl_data_lid "C_True" 
-let (ref_C_False_lid : FStar_Ident.lident) = fstar_refl_data_lid "C_False" 
-let (ref_C_Int_lid : FStar_Ident.lident) = fstar_refl_data_lid "C_Int" 
-let (ref_C_String_lid : FStar_Ident.lident) = fstar_refl_data_lid "C_String" 
-let (ref_C_Unit : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_C_Unit_lid 
-let (ref_C_True : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_C_True_lid 
-let (ref_C_False : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_C_False_lid 
-let (ref_C_Int : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_C_Int_lid 
-let (ref_C_String : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_C_String_lid 
-let (ref_Pat_Constant_lid : FStar_Ident.lident) =
-  fstar_refl_data_lid "Pat_Constant" 
-let (ref_Pat_Cons_lid : FStar_Ident.lident) = fstar_refl_data_lid "Pat_Cons" 
-let (ref_Pat_Var_lid : FStar_Ident.lident) = fstar_refl_data_lid "Pat_Var" 
-let (ref_Pat_Wild_lid : FStar_Ident.lident) = fstar_refl_data_lid "Pat_Wild" 
-let (ref_Pat_Constant : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Pat_Constant_lid 
-let (ref_Pat_Cons : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Pat_Cons_lid 
-let (ref_Pat_Var : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Pat_Var_lid 
-let (ref_Pat_Wild : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Pat_Wild_lid 
-let (ref_Tv_Var_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_Var" 
-let (ref_Tv_FVar_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_FVar" 
-let (ref_Tv_App_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_App" 
-let (ref_Tv_Abs_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_Abs" 
-let (ref_Tv_Arrow_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_Arrow" 
-let (ref_Tv_Type_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_Type" 
-let (ref_Tv_Refine_lid : FStar_Ident.lident) =
-  fstar_refl_data_lid "Tv_Refine" 
-let (ref_Tv_Const_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_Const" 
-let (ref_Tv_Uvar_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_Uvar" 
-let (ref_Tv_Let_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_Let" 
-let (ref_Tv_Match_lid : FStar_Ident.lident) = fstar_refl_data_lid "Tv_Match" 
-let (ref_Tv_Unknown_lid : FStar_Ident.lident) =
-  fstar_refl_data_lid "Tv_Unknown" 
-let (ref_Tv_Var : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Var_lid 
-let (ref_Tv_FVar : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_FVar_lid 
-let (ref_Tv_App : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_App_lid 
-let (ref_Tv_Abs : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Abs_lid 
-let (ref_Tv_Arrow : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Arrow_lid 
-let (ref_Tv_Type : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Type_lid 
-let (ref_Tv_Refine : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Refine_lid 
-let (ref_Tv_Const : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Const_lid 
-let (ref_Tv_Uvar : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Uvar_lid 
-let (ref_Tv_Let : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Let_lid 
-let (ref_Tv_Match : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Match_lid 
-let (ref_Tv_Unknown : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Tv_Unknown_lid 
-let (ref_C_Total_lid : FStar_Ident.lident) = fstar_refl_data_lid "C_Total" 
-let (ref_C_Lemma_lid : FStar_Ident.lident) = fstar_refl_data_lid "C_Lemma" 
-let (ref_C_Unknown_lid : FStar_Ident.lident) =
-  fstar_refl_data_lid "C_Unknown" 
-let (ref_C_Total : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_C_Total_lid 
-let (ref_C_Lemma : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_C_Lemma_lid 
-let (ref_C_Unknown : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_C_Unknown_lid 
-let (ref_Sg_Inductive_lid : FStar_Ident.lident) =
-  fstar_refl_data_lid "Sg_Inductive" 
-let (ref_Sg_Let_lid : FStar_Ident.lident) = fstar_refl_data_lid "Sg_Let" 
-let (ref_Unk_lid : FStar_Ident.lident) = fstar_refl_data_lid "Unk" 
-let (ref_Ctor_lid : FStar_Ident.lident) = fstar_refl_data_lid "Ctor" 
-let (ref_Sg_Inductive : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Sg_Inductive_lid 
-let (ref_Sg_Let : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Sg_Let_lid 
-let (ref_Unk : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Unk_lid 
-let (ref_Ctor : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ref_Ctor_lid 
-let (t_binder : FStar_Syntax_Syntax.term) =
-  let uu____747 = fstar_refl_types_lid "binder"  in
-  FStar_All.pipe_left FStar_Syntax_Syntax.tabbrev uu____747 
-let (t_term : FStar_Syntax_Syntax.term) =
-  let uu____748 = fstar_refl_types_lid "term"  in
-  FStar_All.pipe_left FStar_Syntax_Syntax.tabbrev uu____748 
-let (t_fv : FStar_Syntax_Syntax.term) =
-  let uu____749 = fstar_refl_types_lid "fv"  in
-  FStar_All.pipe_left FStar_Syntax_Syntax.tabbrev uu____749 
-let (t_binders : FStar_Syntax_Syntax.term) =
-  let uu____750 = fstar_refl_types_lid "binders"  in
-  FStar_All.pipe_left FStar_Syntax_Syntax.tabbrev uu____750 
-let (ord_Lt_lid : FStar_Ident.lident) =
-  FStar_Ident.lid_of_path ["FStar"; "Order"; "Lt"] FStar_Range.dummyRange 
-let (ord_Eq_lid : FStar_Ident.lident) =
-  FStar_Ident.lid_of_path ["FStar"; "Order"; "Eq"] FStar_Range.dummyRange 
-let (ord_Gt_lid : FStar_Ident.lident) =
-  FStar_Ident.lid_of_path ["FStar"; "Order"; "Gt"] FStar_Range.dummyRange 
-let (ord_Lt : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ord_Lt_lid 
-let (ord_Eq : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ord_Eq_lid 
-let (ord_Gt : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr ord_Gt_lid 
+let fstar_refl_aqualv: FStar_Syntax_Syntax.term =
+  mk_refl_data_lid_as_term "aqualv"
+let fstar_refl_env: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "env"
+let fstar_refl_fvar: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "fv"
+let fstar_refl_comp: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "comp"
+let fstar_refl_comp_view: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "comp_view"
+let fstar_refl_binder: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "binder"
+let fstar_refl_binders: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "binders"
+let fstar_refl_term_view: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "term_view"
+let fstar_refl_sigelt: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "sigelt"
+let fstar_refl_ctor: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "ctor"
+let fstar_refl_pattern: FStar_Syntax_Syntax.term =
+  mk_refl_syntax_lid_as_term "pattern"
+let fstar_refl_branch: FStar_Syntax_Syntax.term =
+  mk_refl_types_lid_as_term "branch"
+let ref_Q_Explicit_lid: FStar_Ident.lident = fstar_refl_data_lid "Q_Explicit"
+let ref_Q_Implicit_lid: FStar_Ident.lident = fstar_refl_data_lid "Q_Implicit"
+let ref_Q_Explicit: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Q_Explicit_lid
+let ref_Q_Implicit: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Q_Implicit_lid
+let ref_C_Unit_lid: FStar_Ident.lident = fstar_refl_data_lid "C_Unit"
+let ref_C_True_lid: FStar_Ident.lident = fstar_refl_data_lid "C_True"
+let ref_C_False_lid: FStar_Ident.lident = fstar_refl_data_lid "C_False"
+let ref_C_Int_lid: FStar_Ident.lident = fstar_refl_data_lid "C_Int"
+let ref_C_String_lid: FStar_Ident.lident = fstar_refl_data_lid "C_String"
+let ref_C_Unit: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_C_Unit_lid
+let ref_C_True: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_C_True_lid
+let ref_C_False: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_C_False_lid
+let ref_C_Int: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_C_Int_lid
+let ref_C_String: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_C_String_lid
+let ref_Pat_Constant_lid: FStar_Ident.lident =
+  fstar_refl_data_lid "Pat_Constant"
+let ref_Pat_Cons_lid: FStar_Ident.lident = fstar_refl_data_lid "Pat_Cons"
+let ref_Pat_Var_lid: FStar_Ident.lident = fstar_refl_data_lid "Pat_Var"
+let ref_Pat_Wild_lid: FStar_Ident.lident = fstar_refl_data_lid "Pat_Wild"
+let ref_Pat_Constant: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Pat_Constant_lid
+let ref_Pat_Cons: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Pat_Cons_lid
+let ref_Pat_Var: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Pat_Var_lid
+let ref_Pat_Wild: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Pat_Wild_lid
+let ref_Tv_Var_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Var"
+let ref_Tv_FVar_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_FVar"
+let ref_Tv_App_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_App"
+let ref_Tv_Abs_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Abs"
+let ref_Tv_Arrow_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Arrow"
+let ref_Tv_Type_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Type"
+let ref_Tv_Refine_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Refine"
+let ref_Tv_Const_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Const"
+let ref_Tv_Uvar_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Uvar"
+let ref_Tv_Let_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Let"
+let ref_Tv_Match_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Match"
+let ref_Tv_Unknown_lid: FStar_Ident.lident = fstar_refl_data_lid "Tv_Unknown"
+let ref_Tv_Var: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Var_lid
+let ref_Tv_FVar: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_FVar_lid
+let ref_Tv_App: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_App_lid
+let ref_Tv_Abs: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Abs_lid
+let ref_Tv_Arrow: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Arrow_lid
+let ref_Tv_Type: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Type_lid
+let ref_Tv_Refine: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Refine_lid
+let ref_Tv_Const: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Const_lid
+let ref_Tv_Uvar: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Uvar_lid
+let ref_Tv_Let: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Let_lid
+let ref_Tv_Match: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Match_lid
+let ref_Tv_Unknown: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Tv_Unknown_lid
+let ref_C_Total_lid: FStar_Ident.lident = fstar_refl_data_lid "C_Total"
+let ref_C_Lemma_lid: FStar_Ident.lident = fstar_refl_data_lid "C_Lemma"
+let ref_C_Unknown_lid: FStar_Ident.lident = fstar_refl_data_lid "C_Unknown"
+let ref_C_Total: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_C_Total_lid
+let ref_C_Lemma: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_C_Lemma_lid
+let ref_C_Unknown: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_C_Unknown_lid
+let ref_Sg_Inductive_lid: FStar_Ident.lident =
+  fstar_refl_data_lid "Sg_Inductive"
+let ref_Sg_Let_lid: FStar_Ident.lident = fstar_refl_data_lid "Sg_Let"
+let ref_Unk_lid: FStar_Ident.lident = fstar_refl_data_lid "Unk"
+let ref_Ctor_lid: FStar_Ident.lident = fstar_refl_data_lid "Ctor"
+let ref_Sg_Inductive: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Sg_Inductive_lid
+let ref_Sg_Let: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Sg_Let_lid
+let ref_Unk: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Unk_lid
+let ref_Ctor: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ref_Ctor_lid
+let t_binder: FStar_Syntax_Syntax.term =
+  let uu____747 = fstar_refl_types_lid "binder" in
+  FStar_All.pipe_left FStar_Syntax_Syntax.tabbrev uu____747
+let t_term: FStar_Syntax_Syntax.term =
+  let uu____748 = fstar_refl_types_lid "term" in
+  FStar_All.pipe_left FStar_Syntax_Syntax.tabbrev uu____748
+let t_fv: FStar_Syntax_Syntax.term =
+  let uu____749 = fstar_refl_types_lid "fv" in
+  FStar_All.pipe_left FStar_Syntax_Syntax.tabbrev uu____749
+let t_binders: FStar_Syntax_Syntax.term =
+  let uu____750 = fstar_refl_types_lid "binders" in
+  FStar_All.pipe_left FStar_Syntax_Syntax.tabbrev uu____750
+let ord_Lt_lid: FStar_Ident.lident =
+  FStar_Ident.lid_of_path ["FStar"; "Order"; "Lt"] FStar_Range.dummyRange
+let ord_Eq_lid: FStar_Ident.lident =
+  FStar_Ident.lid_of_path ["FStar"; "Order"; "Eq"] FStar_Range.dummyRange
+let ord_Gt_lid: FStar_Ident.lident =
+  FStar_Ident.lid_of_path ["FStar"; "Order"; "Gt"] FStar_Range.dummyRange
+let ord_Lt: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ord_Lt_lid
+let ord_Eq: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ord_Eq_lid
+let ord_Gt: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr ord_Gt_lid

--- a/src/ocaml-output/FStar_Reflection_Interpreter.ml
+++ b/src/ocaml-output/FStar_Reflection_Interpreter.ml
@@ -1,5 +1,5 @@
 open Prims
-let int1 :
+let int1:
   'a 'b .
     FStar_Ident.lid ->
       ('a -> 'b) ->
@@ -17,15 +17,13 @@ let int1 :
             fun args  ->
               match args with
               | (a,uu____61)::[] ->
-                  let uu____78 = ua a  in
+                  let uu____78 = ua a in
                   FStar_Util.bind_opt uu____78
                     (fun a1  ->
-                       let uu____86 = let uu____87 = f a1  in em r uu____87
-                          in
+                       let uu____86 = let uu____87 = f a1 in em r uu____87 in
                        FStar_Pervasives_Native.Some uu____86)
               | uu____91 -> FStar_Pervasives_Native.None
-  
-let int2 :
+let int2:
   'a 'b 'c .
     FStar_Ident.lid ->
       ('a -> 'b -> 'c) ->
@@ -45,21 +43,19 @@ let int2 :
               fun args  ->
                 match args with
                 | (a,uu____172)::(b,uu____174)::[] ->
-                    let uu____201 = ua a  in
+                    let uu____201 = ua a in
                     FStar_Util.bind_opt uu____201
                       (fun a1  ->
-                         let uu____209 = ub b  in
+                         let uu____209 = ub b in
                          FStar_Util.bind_opt uu____209
                            (fun b1  ->
                               let uu____217 =
-                                let uu____218 = f a1 b1  in em r uu____218
-                                 in
+                                let uu____218 = f a1 b1 in em r uu____218 in
                               FStar_Pervasives_Native.Some uu____217))
                 | uu____222 -> FStar_Pervasives_Native.None
-  
-let (reflection_primops :
-  FStar_TypeChecker_Normalize.primitive_step Prims.list) =
-  let mklid nm = FStar_Reflection_Data.fstar_refl_basic_lid nm  in
+let reflection_primops: FStar_TypeChecker_Normalize.primitive_step Prims.list
+  =
+  let mklid nm = FStar_Reflection_Data.fstar_refl_basic_lid nm in
   let mk1 l arity fn =
     {
       FStar_TypeChecker_Normalize.name = l;
@@ -69,68 +65,60 @@ let (reflection_primops :
       FStar_TypeChecker_Normalize.interpretation =
         (fun ctxt  ->
            fun args  ->
-             let uu____258 = FStar_TypeChecker_Normalize.psc_range ctxt  in
+             let uu____258 = FStar_TypeChecker_Normalize.psc_range ctxt in
              fn uu____258 args)
-    }  in
+    } in
   let mk11 a b nm f u1 em =
-    let l = mklid nm  in mk1 l (Prims.parse_int "1") (int1 l f u1 em)  in
+    let l = mklid nm in mk1 l (Prims.parse_int "1") (int1 l f u1 em) in
   let mk2 a b c nm f u1 u2 em =
-    let l = mklid nm  in mk1 l (Prims.parse_int "2") (int2 l f u1 u2 em)  in
+    let l = mklid nm in mk1 l (Prims.parse_int "2") (int2 l f u1 u2 em) in
   let uu____388 =
     mk11 () () "__inspect"
       (fun a415  -> (Obj.magic FStar_Reflection_Basic.inspect) a415)
       (Obj.magic FStar_Reflection_Basic.unembed_term)
-      (Obj.magic FStar_Reflection_Basic.embed_term_view)
-     in
+      (Obj.magic FStar_Reflection_Basic.embed_term_view) in
   let uu____389 =
     let uu____392 =
       mk11 () () "__pack"
         (fun a416  -> (Obj.magic FStar_Reflection_Basic.pack) a416)
         (Obj.magic FStar_Reflection_Basic.unembed_term_view)
-        (Obj.magic FStar_Reflection_Basic.embed_term)
-       in
+        (Obj.magic FStar_Reflection_Basic.embed_term) in
     let uu____393 =
       let uu____396 =
         mk11 () () "__inspect_fv"
           (fun a417  -> (Obj.magic FStar_Reflection_Basic.inspect_fv) a417)
           (Obj.magic FStar_Reflection_Basic.unembed_fvar)
-          (Obj.magic FStar_Syntax_Embeddings.embed_string_list)
-         in
+          (Obj.magic FStar_Syntax_Embeddings.embed_string_list) in
       let uu____397 =
         let uu____400 =
           let uu____401 =
             FStar_Syntax_Embeddings.unembed_list
-              FStar_Syntax_Embeddings.unembed_string
-             in
+              FStar_Syntax_Embeddings.unembed_string in
           mk11 () () "__pack_fv"
             (fun a418  -> (Obj.magic FStar_Reflection_Basic.pack_fv) a418)
             (Obj.magic uu____401)
-            (Obj.magic FStar_Reflection_Basic.embed_fvar)
-           in
+            (Obj.magic FStar_Reflection_Basic.embed_fvar) in
         let uu____410 =
           let uu____413 =
             mk11 () () "__inspect_comp"
               (fun a419  ->
                  (Obj.magic FStar_Reflection_Basic.inspect_comp) a419)
               (Obj.magic FStar_Reflection_Basic.unembed_comp)
-              (Obj.magic FStar_Reflection_Basic.embed_comp_view)
-             in
+              (Obj.magic FStar_Reflection_Basic.embed_comp_view) in
           let uu____414 =
             let uu____417 =
               mk11 () () "__pack_comp"
                 (fun a420  ->
                    (Obj.magic FStar_Reflection_Basic.pack_comp) a420)
                 (Obj.magic FStar_Reflection_Basic.unembed_comp_view)
-                (Obj.magic FStar_Reflection_Basic.embed_comp)
-               in
+                (Obj.magic FStar_Reflection_Basic.embed_comp) in
             let uu____418 =
               let uu____421 =
                 mk11 () () "__inspect_bv"
                   (fun a421  ->
                      (Obj.magic FStar_Reflection_Basic.inspect_bv) a421)
                   (Obj.magic FStar_Reflection_Basic.unembed_binder)
-                  (Obj.magic FStar_Syntax_Embeddings.embed_string)
-                 in
+                  (Obj.magic FStar_Syntax_Embeddings.embed_string) in
               let uu____422 =
                 let uu____425 =
                   mk2 () () () "__compare_binder"
@@ -140,8 +128,7 @@ let (reflection_primops :
                            a422 a423)
                     (Obj.magic FStar_Reflection_Basic.unembed_binder)
                     (Obj.magic FStar_Reflection_Basic.unembed_binder)
-                    (Obj.magic FStar_Reflection_Basic.embed_order)
-                   in
+                    (Obj.magic FStar_Reflection_Basic.embed_order) in
                 let uu____426 =
                   let uu____429 =
                     mk11 () () "__type_of_binder"
@@ -149,8 +136,7 @@ let (reflection_primops :
                          (Obj.magic FStar_Reflection_Basic.type_of_binder)
                            a424)
                       (Obj.magic FStar_Reflection_Basic.unembed_binder)
-                      (Obj.magic FStar_Reflection_Basic.embed_term)
-                     in
+                      (Obj.magic FStar_Reflection_Basic.embed_term) in
                   let uu____430 =
                     let uu____433 =
                       mk2 () () () "__is_free"
@@ -160,8 +146,7 @@ let (reflection_primops :
                                a426)
                         (Obj.magic FStar_Reflection_Basic.unembed_binder)
                         (Obj.magic FStar_Reflection_Basic.unembed_term)
-                        (Obj.magic FStar_Syntax_Embeddings.embed_bool)
-                       in
+                        (Obj.magic FStar_Syntax_Embeddings.embed_bool) in
                     let uu____434 =
                       let uu____437 =
                         mk11 () () "__fresh_binder"
@@ -169,8 +154,7 @@ let (reflection_primops :
                              (Obj.magic FStar_Reflection_Basic.fresh_binder)
                                a427)
                           (Obj.magic FStar_Reflection_Basic.unembed_term)
-                          (Obj.magic FStar_Reflection_Basic.embed_binder)
-                         in
+                          (Obj.magic FStar_Reflection_Basic.embed_binder) in
                       let uu____438 =
                         let uu____441 =
                           mk2 () () () "__term_eq"
@@ -180,8 +164,7 @@ let (reflection_primops :
                                    a428 a429)
                             (Obj.magic FStar_Reflection_Basic.unembed_term)
                             (Obj.magic FStar_Reflection_Basic.unembed_term)
-                            (Obj.magic FStar_Syntax_Embeddings.embed_bool)
-                           in
+                            (Obj.magic FStar_Syntax_Embeddings.embed_bool) in
                         let uu____442 =
                           let uu____445 =
                             mk11 () () "__term_to_string"
@@ -190,8 +173,7 @@ let (reflection_primops :
                                     FStar_Reflection_Basic.term_to_string)
                                    a430)
                               (Obj.magic FStar_Reflection_Basic.unembed_term)
-                              (Obj.magic FStar_Syntax_Embeddings.embed_string)
-                             in
+                              (Obj.magic FStar_Syntax_Embeddings.embed_string) in
                           let uu____446 =
                             let uu____449 =
                               mk11 () () "__binders_of_env"
@@ -201,8 +183,7 @@ let (reflection_primops :
                                      a431)
                                 (Obj.magic FStar_Reflection_Basic.unembed_env)
                                 (Obj.magic
-                                   FStar_Reflection_Basic.embed_binders)
-                               in
+                                   FStar_Reflection_Basic.embed_binders) in
                             let uu____450 =
                               let uu____453 =
                                 mk2 () () () "__lookup_typ"
@@ -216,20 +197,19 @@ let (reflection_primops :
                                   (Obj.magic
                                      FStar_Syntax_Embeddings.unembed_string_list)
                                   (Obj.magic
-                                     FStar_Reflection_Basic.embed_sigelt_view)
-                                 in
-                              [uu____453]  in
-                            uu____449 :: uu____450  in
-                          uu____445 :: uu____446  in
-                        uu____441 :: uu____442  in
-                      uu____437 :: uu____438  in
-                    uu____433 :: uu____434  in
-                  uu____429 :: uu____430  in
-                uu____425 :: uu____426  in
-              uu____421 :: uu____422  in
-            uu____417 :: uu____418  in
-          uu____413 :: uu____414  in
-        uu____400 :: uu____410  in
-      uu____396 :: uu____397  in
-    uu____392 :: uu____393  in
-  uu____388 :: uu____389 
+                                     FStar_Reflection_Basic.embed_sigelt_view) in
+                              [uu____453] in
+                            uu____449 :: uu____450 in
+                          uu____445 :: uu____446 in
+                        uu____441 :: uu____442 in
+                      uu____437 :: uu____438 in
+                    uu____433 :: uu____434 in
+                  uu____429 :: uu____430 in
+                uu____425 :: uu____426 in
+              uu____421 :: uu____422 in
+            uu____417 :: uu____418 in
+          uu____413 :: uu____414 in
+        uu____400 :: uu____410 in
+      uu____396 :: uu____397 in
+    uu____392 :: uu____393 in
+  uu____388 :: uu____389

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -1,18 +1,17 @@
 open Prims
-let add_fuel :
+let add_fuel:
   'Auu____4 . 'Auu____4 -> 'Auu____4 Prims.list -> 'Auu____4 Prims.list =
   fun x  ->
     fun tl1  ->
-      let uu____19 = FStar_Options.unthrottle_inductives ()  in
+      let uu____19 = FStar_Options.unthrottle_inductives () in
       if uu____19 then tl1 else x :: tl1
-  
-let withenv :
+let withenv:
   'Auu____28 'Auu____29 'Auu____30 .
     'Auu____30 ->
       ('Auu____29,'Auu____28) FStar_Pervasives_Native.tuple2 ->
         ('Auu____29,'Auu____28,'Auu____30) FStar_Pervasives_Native.tuple3
-  = fun c  -> fun uu____48  -> match uu____48 with | (a,b) -> (a, b, c) 
-let vargs :
+  = fun c  -> fun uu____48  -> match uu____48 with | (a,b) -> (a, b, c)
+let vargs:
   'Auu____59 'Auu____60 'Auu____61 .
     (('Auu____61,'Auu____60) FStar_Util.either,'Auu____59)
       FStar_Pervasives_Native.tuple2 Prims.list ->
@@ -25,33 +24,29 @@ let vargs :
          match uu___79_107 with
          | (FStar_Util.Inl uu____116,uu____117) -> false
          | uu____122 -> true) args
-  
-let (escape : Prims.string -> Prims.string) =
-  fun s  -> FStar_Util.replace_char s 39 95 
-let (mk_term_projector_name :
-  FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> Prims.string) =
+let escape: Prims.string -> Prims.string =
+  fun s  -> FStar_Util.replace_char s 39 95
+let mk_term_projector_name:
+  FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> Prims.string =
   fun lid  ->
     fun a  ->
       let a1 =
-        let uu___102_143 = a  in
+        let uu___102_143 = a in
         let uu____144 =
-          FStar_Syntax_Util.unmangle_field_name a.FStar_Syntax_Syntax.ppname
-           in
+          FStar_Syntax_Util.unmangle_field_name a.FStar_Syntax_Syntax.ppname in
         {
           FStar_Syntax_Syntax.ppname = uu____144;
           FStar_Syntax_Syntax.index =
             (uu___102_143.FStar_Syntax_Syntax.index);
           FStar_Syntax_Syntax.sort = (uu___102_143.FStar_Syntax_Syntax.sort)
-        }  in
+        } in
       let uu____145 =
         FStar_Util.format2 "%s_%s" lid.FStar_Ident.str
-          (a1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-         in
+          (a1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText in
       FStar_All.pipe_left escape uu____145
-  
-let (primitive_projector_by_pos :
+let primitive_projector_by_pos:
   FStar_TypeChecker_Env.env ->
-    FStar_Ident.lident -> Prims.int -> Prims.string)
+    FStar_Ident.lident -> Prims.int -> Prims.string
   =
   fun env  ->
     fun lid  ->
@@ -60,18 +55,17 @@ let (primitive_projector_by_pos :
           let uu____159 =
             FStar_Util.format2
               "Projector %s on data constructor %s not found"
-              (Prims.string_of_int i) lid.FStar_Ident.str
-             in
-          failwith uu____159  in
-        let uu____160 = FStar_TypeChecker_Env.lookup_datacon env lid  in
+              (Prims.string_of_int i) lid.FStar_Ident.str in
+          failwith uu____159 in
+        let uu____160 = FStar_TypeChecker_Env.lookup_datacon env lid in
         match uu____160 with
         | (uu____165,t) ->
             let uu____167 =
-              let uu____168 = FStar_Syntax_Subst.compress t  in
-              uu____168.FStar_Syntax_Syntax.n  in
+              let uu____168 = FStar_Syntax_Subst.compress t in
+              uu____168.FStar_Syntax_Syntax.n in
             (match uu____167 with
              | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                 let uu____189 = FStar_Syntax_Subst.open_comp bs c  in
+                 let uu____189 = FStar_Syntax_Subst.open_comp bs c in
                  (match uu____189 with
                   | (binders,uu____195) ->
                       if
@@ -79,49 +73,42 @@ let (primitive_projector_by_pos :
                           (i >= (FStar_List.length binders))
                       then fail ()
                       else
-                        (let b = FStar_List.nth binders i  in
+                        (let b = FStar_List.nth binders i in
                          mk_term_projector_name lid
                            (FStar_Pervasives_Native.fst b)))
              | uu____210 -> fail ())
-  
-let (mk_term_projector_name_by_pos :
-  FStar_Ident.lident -> Prims.int -> Prims.string) =
+let mk_term_projector_name_by_pos:
+  FStar_Ident.lident -> Prims.int -> Prims.string =
   fun lid  ->
     fun i  ->
       let uu____217 =
         FStar_Util.format2 "%s_%s" lid.FStar_Ident.str
-          (Prims.string_of_int i)
-         in
+          (Prims.string_of_int i) in
       FStar_All.pipe_left escape uu____217
-  
-let (mk_term_projector :
-  FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term)
+let mk_term_projector:
+  FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term
   =
   fun lid  ->
     fun a  ->
       let uu____224 =
-        let uu____229 = mk_term_projector_name lid a  in
+        let uu____229 = mk_term_projector_name lid a in
         (uu____229,
           (FStar_SMTEncoding_Term.Arrow
              (FStar_SMTEncoding_Term.Term_sort,
-               FStar_SMTEncoding_Term.Term_sort)))
-         in
+               FStar_SMTEncoding_Term.Term_sort))) in
       FStar_SMTEncoding_Util.mkFreeV uu____224
-  
-let (mk_term_projector_by_pos :
-  FStar_Ident.lident -> Prims.int -> FStar_SMTEncoding_Term.term) =
+let mk_term_projector_by_pos:
+  FStar_Ident.lident -> Prims.int -> FStar_SMTEncoding_Term.term =
   fun lid  ->
     fun i  ->
       let uu____236 =
-        let uu____241 = mk_term_projector_name_by_pos lid i  in
+        let uu____241 = mk_term_projector_name_by_pos lid i in
         (uu____241,
           (FStar_SMTEncoding_Term.Arrow
              (FStar_SMTEncoding_Term.Term_sort,
-               FStar_SMTEncoding_Term.Term_sort)))
-         in
+               FStar_SMTEncoding_Term.Term_sort))) in
       FStar_SMTEncoding_Util.mkFreeV uu____236
-  
-let mk_data_tester :
+let mk_data_tester:
   'Auu____246 .
     'Auu____246 ->
       FStar_Ident.lident ->
@@ -130,169 +117,151 @@ let mk_data_tester :
   fun env  ->
     fun l  ->
       fun x  -> FStar_SMTEncoding_Term.mk_tester (escape l.FStar_Ident.str) x
-  
 type varops_t =
   {
-  push: Prims.unit -> Prims.unit ;
-  pop: Prims.unit -> Prims.unit ;
-  new_var: FStar_Ident.ident -> Prims.int -> Prims.string ;
-  new_fvar: FStar_Ident.lident -> Prims.string ;
-  fresh: Prims.string -> Prims.string ;
-  string_const: Prims.string -> FStar_SMTEncoding_Term.term ;
-  next_id: Prims.unit -> Prims.int ;
-  mk_unique: Prims.string -> Prims.string }[@@deriving show]
-let (__proj__Mkvarops_t__item__push : varops_t -> Prims.unit -> Prims.unit) =
+  push: Prims.unit -> Prims.unit;
+  pop: Prims.unit -> Prims.unit;
+  new_var: FStar_Ident.ident -> Prims.int -> Prims.string;
+  new_fvar: FStar_Ident.lident -> Prims.string;
+  fresh: Prims.string -> Prims.string;
+  string_const: Prims.string -> FStar_SMTEncoding_Term.term;
+  next_id: Prims.unit -> Prims.int;
+  mk_unique: Prims.string -> Prims.string;}[@@deriving show]
+let __proj__Mkvarops_t__item__push: varops_t -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
         new_fvar = __fname__new_fvar; fresh = __fname__fresh;
         string_const = __fname__string_const; next_id = __fname__next_id;
         mk_unique = __fname__mk_unique;_} -> __fname__push
-  
-let (__proj__Mkvarops_t__item__pop : varops_t -> Prims.unit -> Prims.unit) =
+let __proj__Mkvarops_t__item__pop: varops_t -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
         new_fvar = __fname__new_fvar; fresh = __fname__fresh;
         string_const = __fname__string_const; next_id = __fname__next_id;
         mk_unique = __fname__mk_unique;_} -> __fname__pop
-  
-let (__proj__Mkvarops_t__item__new_var :
-  varops_t -> FStar_Ident.ident -> Prims.int -> Prims.string) =
+let __proj__Mkvarops_t__item__new_var:
+  varops_t -> FStar_Ident.ident -> Prims.int -> Prims.string =
   fun projectee  ->
     match projectee with
     | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
         new_fvar = __fname__new_fvar; fresh = __fname__fresh;
         string_const = __fname__string_const; next_id = __fname__next_id;
         mk_unique = __fname__mk_unique;_} -> __fname__new_var
-  
-let (__proj__Mkvarops_t__item__new_fvar :
-  varops_t -> FStar_Ident.lident -> Prims.string) =
+let __proj__Mkvarops_t__item__new_fvar:
+  varops_t -> FStar_Ident.lident -> Prims.string =
   fun projectee  ->
     match projectee with
     | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
         new_fvar = __fname__new_fvar; fresh = __fname__fresh;
         string_const = __fname__string_const; next_id = __fname__next_id;
         mk_unique = __fname__mk_unique;_} -> __fname__new_fvar
-  
-let (__proj__Mkvarops_t__item__fresh :
-  varops_t -> Prims.string -> Prims.string) =
-  fun projectee  ->
-    match projectee with
-    | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
-        new_fvar = __fname__new_fvar; fresh = __fname__fresh;
-        string_const = __fname__string_const; next_id = __fname__next_id;
-        mk_unique = __fname__mk_unique;_} -> __fname__fresh
-  
-let (__proj__Mkvarops_t__item__string_const :
-  varops_t -> Prims.string -> FStar_SMTEncoding_Term.term) =
-  fun projectee  ->
-    match projectee with
-    | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
-        new_fvar = __fname__new_fvar; fresh = __fname__fresh;
-        string_const = __fname__string_const; next_id = __fname__next_id;
-        mk_unique = __fname__mk_unique;_} -> __fname__string_const
-  
-let (__proj__Mkvarops_t__item__next_id : varops_t -> Prims.unit -> Prims.int)
+let __proj__Mkvarops_t__item__fresh: varops_t -> Prims.string -> Prims.string
   =
   fun projectee  ->
     match projectee with
     | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
         new_fvar = __fname__new_fvar; fresh = __fname__fresh;
         string_const = __fname__string_const; next_id = __fname__next_id;
+        mk_unique = __fname__mk_unique;_} -> __fname__fresh
+let __proj__Mkvarops_t__item__string_const:
+  varops_t -> Prims.string -> FStar_SMTEncoding_Term.term =
+  fun projectee  ->
+    match projectee with
+    | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
+        new_fvar = __fname__new_fvar; fresh = __fname__fresh;
+        string_const = __fname__string_const; next_id = __fname__next_id;
+        mk_unique = __fname__mk_unique;_} -> __fname__string_const
+let __proj__Mkvarops_t__item__next_id: varops_t -> Prims.unit -> Prims.int =
+  fun projectee  ->
+    match projectee with
+    | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
+        new_fvar = __fname__new_fvar; fresh = __fname__fresh;
+        string_const = __fname__string_const; next_id = __fname__next_id;
         mk_unique = __fname__mk_unique;_} -> __fname__next_id
-  
-let (__proj__Mkvarops_t__item__mk_unique :
-  varops_t -> Prims.string -> Prims.string) =
+let __proj__Mkvarops_t__item__mk_unique:
+  varops_t -> Prims.string -> Prims.string =
   fun projectee  ->
     match projectee with
     | { push = __fname__push; pop = __fname__pop; new_var = __fname__new_var;
         new_fvar = __fname__new_fvar; fresh = __fname__fresh;
         string_const = __fname__string_const; next_id = __fname__next_id;
         mk_unique = __fname__mk_unique;_} -> __fname__mk_unique
-  
-let (varops : varops_t) =
-  let initial_ctr = (Prims.parse_int "100")  in
-  let ctr = FStar_Util.mk_ref initial_ctr  in
+let varops: varops_t =
+  let initial_ctr = Prims.parse_int "100" in
+  let ctr = FStar_Util.mk_ref initial_ctr in
   let new_scope uu____610 =
-    let uu____611 = FStar_Util.smap_create (Prims.parse_int "100")  in
-    let uu____614 = FStar_Util.smap_create (Prims.parse_int "100")  in
-    (uu____611, uu____614)  in
+    let uu____611 = FStar_Util.smap_create (Prims.parse_int "100") in
+    let uu____614 = FStar_Util.smap_create (Prims.parse_int "100") in
+    (uu____611, uu____614) in
   let scopes =
-    let uu____634 = let uu____645 = new_scope ()  in [uu____645]  in
-    FStar_Util.mk_ref uu____634  in
+    let uu____634 = let uu____645 = new_scope () in [uu____645] in
+    FStar_Util.mk_ref uu____634 in
   let mk_unique y =
-    let y1 = escape y  in
+    let y1 = escape y in
     let y2 =
       let uu____686 =
-        let uu____689 = FStar_ST.op_Bang scopes  in
+        let uu____689 = FStar_ST.op_Bang scopes in
         FStar_Util.find_map uu____689
           (fun uu____772  ->
              match uu____772 with
-             | (names1,uu____784) -> FStar_Util.smap_try_find names1 y1)
-         in
+             | (names1,uu____784) -> FStar_Util.smap_try_find names1 y1) in
       match uu____686 with
       | FStar_Pervasives_Native.None  -> y1
       | FStar_Pervasives_Native.Some uu____793 ->
           (FStar_Util.incr ctr;
            (let uu____828 =
               let uu____829 =
-                let uu____830 = FStar_ST.op_Bang ctr  in
-                Prims.string_of_int uu____830  in
-              Prims.strcat "__" uu____829  in
-            Prims.strcat y1 uu____828))
-       in
+                let uu____830 = FStar_ST.op_Bang ctr in
+                Prims.string_of_int uu____830 in
+              Prims.strcat "__" uu____829 in
+            Prims.strcat y1 uu____828)) in
     let top_scope =
       let uu____875 =
-        let uu____884 = FStar_ST.op_Bang scopes  in FStar_List.hd uu____884
-         in
-      FStar_All.pipe_left FStar_Pervasives_Native.fst uu____875  in
-    FStar_Util.smap_add top_scope y2 true; y2  in
+        let uu____884 = FStar_ST.op_Bang scopes in FStar_List.hd uu____884 in
+      FStar_All.pipe_left FStar_Pervasives_Native.fst uu____875 in
+    FStar_Util.smap_add top_scope y2 true; y2 in
   let new_var pp rn =
     FStar_All.pipe_left mk_unique
       (Prims.strcat pp.FStar_Ident.idText
-         (Prims.strcat "__" (Prims.string_of_int rn)))
-     in
-  let new_fvar lid = mk_unique lid.FStar_Ident.str  in
-  let next_id1 uu____993 = FStar_Util.incr ctr; FStar_ST.op_Bang ctr  in
+         (Prims.strcat "__" (Prims.string_of_int rn))) in
+  let new_fvar lid = mk_unique lid.FStar_Ident.str in
+  let next_id1 uu____993 = FStar_Util.incr ctr; FStar_ST.op_Bang ctr in
   let fresh1 pfx =
     let uu____1073 =
-      let uu____1074 = next_id1 ()  in
-      FStar_All.pipe_left Prims.string_of_int uu____1074  in
-    FStar_Util.format2 "%s_%s" pfx uu____1073  in
+      let uu____1074 = next_id1 () in
+      FStar_All.pipe_left Prims.string_of_int uu____1074 in
+    FStar_Util.format2 "%s_%s" pfx uu____1073 in
   let string_const s =
     let uu____1079 =
-      let uu____1082 = FStar_ST.op_Bang scopes  in
+      let uu____1082 = FStar_ST.op_Bang scopes in
       FStar_Util.find_map uu____1082
         (fun uu____1165  ->
            match uu____1165 with
-           | (uu____1176,strings) -> FStar_Util.smap_try_find strings s)
-       in
+           | (uu____1176,strings) -> FStar_Util.smap_try_find strings s) in
     match uu____1079 with
     | FStar_Pervasives_Native.Some f -> f
     | FStar_Pervasives_Native.None  ->
-        let id1 = next_id1 ()  in
+        let id1 = next_id1 () in
         let f =
-          let uu____1189 = FStar_SMTEncoding_Util.mk_String_const id1  in
-          FStar_All.pipe_left FStar_SMTEncoding_Term.boxString uu____1189  in
+          let uu____1189 = FStar_SMTEncoding_Util.mk_String_const id1 in
+          FStar_All.pipe_left FStar_SMTEncoding_Term.boxString uu____1189 in
         let top_scope =
           let uu____1193 =
-            let uu____1202 = FStar_ST.op_Bang scopes  in
-            FStar_List.hd uu____1202  in
-          FStar_All.pipe_left FStar_Pervasives_Native.snd uu____1193  in
-        (FStar_Util.smap_add top_scope s f; f)
-     in
+            let uu____1202 = FStar_ST.op_Bang scopes in
+            FStar_List.hd uu____1202 in
+          FStar_All.pipe_left FStar_Pervasives_Native.snd uu____1193 in
+        (FStar_Util.smap_add top_scope s f; f) in
   let push1 uu____1300 =
     let uu____1301 =
-      let uu____1312 = new_scope ()  in
-      let uu____1321 = FStar_ST.op_Bang scopes  in uu____1312 :: uu____1321
-       in
-    FStar_ST.op_Colon_Equals scopes uu____1301  in
+      let uu____1312 = new_scope () in
+      let uu____1321 = FStar_ST.op_Bang scopes in uu____1312 :: uu____1321 in
+    FStar_ST.op_Colon_Equals scopes uu____1301 in
   let pop1 uu____1465 =
     let uu____1466 =
-      let uu____1477 = FStar_ST.op_Bang scopes  in FStar_List.tl uu____1477
-       in
-    FStar_ST.op_Colon_Equals scopes uu____1466  in
+      let uu____1477 = FStar_ST.op_Bang scopes in FStar_List.tl uu____1477 in
+    FStar_ST.op_Colon_Equals scopes uu____1466 in
   {
     push = push1;
     pop = pop1;
@@ -302,60 +271,57 @@ let (varops : varops_t) =
     string_const;
     next_id = next_id1;
     mk_unique
-  } 
-let (unmangle : FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.bv) =
+  }
+let unmangle: FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.bv =
   fun x  ->
-    let uu___103_1621 = x  in
+    let uu___103_1621 = x in
     let uu____1622 =
-      FStar_Syntax_Util.unmangle_field_name x.FStar_Syntax_Syntax.ppname  in
+      FStar_Syntax_Util.unmangle_field_name x.FStar_Syntax_Syntax.ppname in
     {
       FStar_Syntax_Syntax.ppname = uu____1622;
       FStar_Syntax_Syntax.index = (uu___103_1621.FStar_Syntax_Syntax.index);
       FStar_Syntax_Syntax.sort = (uu___103_1621.FStar_Syntax_Syntax.sort)
     }
-  
 type binding =
   | Binding_var of (FStar_Syntax_Syntax.bv,FStar_SMTEncoding_Term.term)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Binding_fvar of
   (FStar_Ident.lident,Prims.string,FStar_SMTEncoding_Term.term
                                      FStar_Pervasives_Native.option,FStar_SMTEncoding_Term.term
                                                                     FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple4 [@@deriving show]
-let (uu___is_Binding_var : binding -> Prims.bool) =
+  FStar_Pervasives_Native.tuple4[@@deriving show]
+let uu___is_Binding_var: binding -> Prims.bool =
   fun projectee  ->
     match projectee with | Binding_var _0 -> true | uu____1655 -> false
-  
-let (__proj__Binding_var__item___0 :
+let __proj__Binding_var__item___0:
   binding ->
     (FStar_Syntax_Syntax.bv,FStar_SMTEncoding_Term.term)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Binding_var _0 -> _0 
-let (uu___is_Binding_fvar : binding -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Binding_var _0 -> _0
+let uu___is_Binding_fvar: binding -> Prims.bool =
   fun projectee  ->
     match projectee with | Binding_fvar _0 -> true | uu____1691 -> false
-  
-let (__proj__Binding_fvar__item___0 :
+let __proj__Binding_fvar__item___0:
   binding ->
     (FStar_Ident.lident,Prims.string,FStar_SMTEncoding_Term.term
                                        FStar_Pervasives_Native.option,
       FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | Binding_fvar _0 -> _0 
-let binder_of_eithervar :
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | Binding_fvar _0 -> _0
+let binder_of_eithervar:
   'Auu____1738 'Auu____1739 .
     'Auu____1739 ->
       ('Auu____1739,'Auu____1738 FStar_Pervasives_Native.option)
         FStar_Pervasives_Native.tuple2
-  = fun v1  -> (v1, FStar_Pervasives_Native.None) 
+  = fun v1  -> (v1, FStar_Pervasives_Native.None)
 type cache_entry =
   {
-  cache_symbol_name: Prims.string ;
-  cache_symbol_arg_sorts: FStar_SMTEncoding_Term.sort Prims.list ;
-  cache_symbol_decls: FStar_SMTEncoding_Term.decl Prims.list ;
-  cache_symbol_assumption_names: Prims.string Prims.list }[@@deriving show]
-let (__proj__Mkcache_entry__item__cache_symbol_name :
-  cache_entry -> Prims.string) =
+  cache_symbol_name: Prims.string;
+  cache_symbol_arg_sorts: FStar_SMTEncoding_Term.sort Prims.list;
+  cache_symbol_decls: FStar_SMTEncoding_Term.decl Prims.list;
+  cache_symbol_assumption_names: Prims.string Prims.list;}[@@deriving show]
+let __proj__Mkcache_entry__item__cache_symbol_name:
+  cache_entry -> Prims.string =
   fun projectee  ->
     match projectee with
     | { cache_symbol_name = __fname__cache_symbol_name;
@@ -364,9 +330,8 @@ let (__proj__Mkcache_entry__item__cache_symbol_name :
         cache_symbol_assumption_names =
           __fname__cache_symbol_assumption_names;_}
         -> __fname__cache_symbol_name
-  
-let (__proj__Mkcache_entry__item__cache_symbol_arg_sorts :
-  cache_entry -> FStar_SMTEncoding_Term.sort Prims.list) =
+let __proj__Mkcache_entry__item__cache_symbol_arg_sorts:
+  cache_entry -> FStar_SMTEncoding_Term.sort Prims.list =
   fun projectee  ->
     match projectee with
     | { cache_symbol_name = __fname__cache_symbol_name;
@@ -375,9 +340,8 @@ let (__proj__Mkcache_entry__item__cache_symbol_arg_sorts :
         cache_symbol_assumption_names =
           __fname__cache_symbol_assumption_names;_}
         -> __fname__cache_symbol_arg_sorts
-  
-let (__proj__Mkcache_entry__item__cache_symbol_decls :
-  cache_entry -> FStar_SMTEncoding_Term.decl Prims.list) =
+let __proj__Mkcache_entry__item__cache_symbol_decls:
+  cache_entry -> FStar_SMTEncoding_Term.decl Prims.list =
   fun projectee  ->
     match projectee with
     | { cache_symbol_name = __fname__cache_symbol_name;
@@ -386,9 +350,8 @@ let (__proj__Mkcache_entry__item__cache_symbol_decls :
         cache_symbol_assumption_names =
           __fname__cache_symbol_assumption_names;_}
         -> __fname__cache_symbol_decls
-  
-let (__proj__Mkcache_entry__item__cache_symbol_assumption_names :
-  cache_entry -> Prims.string Prims.list) =
+let __proj__Mkcache_entry__item__cache_symbol_assumption_names:
+  cache_entry -> Prims.string Prims.list =
   fun projectee  ->
     match projectee with
     | { cache_symbol_name = __fname__cache_symbol_name;
@@ -397,19 +360,18 @@ let (__proj__Mkcache_entry__item__cache_symbol_assumption_names :
         cache_symbol_assumption_names =
           __fname__cache_symbol_assumption_names;_}
         -> __fname__cache_symbol_assumption_names
-  
 type env_t =
   {
-  bindings: binding Prims.list ;
-  depth: Prims.int ;
-  tcenv: FStar_TypeChecker_Env.env ;
-  warn: Prims.bool ;
-  cache: cache_entry FStar_Util.smap ;
-  nolabels: Prims.bool ;
-  use_zfuel_name: Prims.bool ;
-  encode_non_total_function_typ: Prims.bool ;
-  current_module_name: Prims.string }[@@deriving show]
-let (__proj__Mkenv_t__item__bindings : env_t -> binding Prims.list) =
+  bindings: binding Prims.list;
+  depth: Prims.int;
+  tcenv: FStar_TypeChecker_Env.env;
+  warn: Prims.bool;
+  cache: cache_entry FStar_Util.smap;
+  nolabels: Prims.bool;
+  use_zfuel_name: Prims.bool;
+  encode_non_total_function_typ: Prims.bool;
+  current_module_name: Prims.string;}[@@deriving show]
+let __proj__Mkenv_t__item__bindings: env_t -> binding Prims.list =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; depth = __fname__depth;
@@ -420,8 +382,7 @@ let (__proj__Mkenv_t__item__bindings : env_t -> binding Prims.list) =
           __fname__encode_non_total_function_typ;
         current_module_name = __fname__current_module_name;_} ->
         __fname__bindings
-  
-let (__proj__Mkenv_t__item__depth : env_t -> Prims.int) =
+let __proj__Mkenv_t__item__depth: env_t -> Prims.int =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; depth = __fname__depth;
@@ -432,8 +393,7 @@ let (__proj__Mkenv_t__item__depth : env_t -> Prims.int) =
           __fname__encode_non_total_function_typ;
         current_module_name = __fname__current_module_name;_} ->
         __fname__depth
-  
-let (__proj__Mkenv_t__item__tcenv : env_t -> FStar_TypeChecker_Env.env) =
+let __proj__Mkenv_t__item__tcenv: env_t -> FStar_TypeChecker_Env.env =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; depth = __fname__depth;
@@ -444,8 +404,7 @@ let (__proj__Mkenv_t__item__tcenv : env_t -> FStar_TypeChecker_Env.env) =
           __fname__encode_non_total_function_typ;
         current_module_name = __fname__current_module_name;_} ->
         __fname__tcenv
-  
-let (__proj__Mkenv_t__item__warn : env_t -> Prims.bool) =
+let __proj__Mkenv_t__item__warn: env_t -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; depth = __fname__depth;
@@ -456,8 +415,7 @@ let (__proj__Mkenv_t__item__warn : env_t -> Prims.bool) =
           __fname__encode_non_total_function_typ;
         current_module_name = __fname__current_module_name;_} ->
         __fname__warn
-  
-let (__proj__Mkenv_t__item__cache : env_t -> cache_entry FStar_Util.smap) =
+let __proj__Mkenv_t__item__cache: env_t -> cache_entry FStar_Util.smap =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; depth = __fname__depth;
@@ -468,8 +426,7 @@ let (__proj__Mkenv_t__item__cache : env_t -> cache_entry FStar_Util.smap) =
           __fname__encode_non_total_function_typ;
         current_module_name = __fname__current_module_name;_} ->
         __fname__cache
-  
-let (__proj__Mkenv_t__item__nolabels : env_t -> Prims.bool) =
+let __proj__Mkenv_t__item__nolabels: env_t -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; depth = __fname__depth;
@@ -480,8 +437,7 @@ let (__proj__Mkenv_t__item__nolabels : env_t -> Prims.bool) =
           __fname__encode_non_total_function_typ;
         current_module_name = __fname__current_module_name;_} ->
         __fname__nolabels
-  
-let (__proj__Mkenv_t__item__use_zfuel_name : env_t -> Prims.bool) =
+let __proj__Mkenv_t__item__use_zfuel_name: env_t -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; depth = __fname__depth;
@@ -492,9 +448,8 @@ let (__proj__Mkenv_t__item__use_zfuel_name : env_t -> Prims.bool) =
           __fname__encode_non_total_function_typ;
         current_module_name = __fname__current_module_name;_} ->
         __fname__use_zfuel_name
-  
-let (__proj__Mkenv_t__item__encode_non_total_function_typ :
-  env_t -> Prims.bool) =
+let __proj__Mkenv_t__item__encode_non_total_function_typ: env_t -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; depth = __fname__depth;
@@ -505,8 +460,7 @@ let (__proj__Mkenv_t__item__encode_non_total_function_typ :
           __fname__encode_non_total_function_typ;
         current_module_name = __fname__current_module_name;_} ->
         __fname__encode_non_total_function_typ
-  
-let (__proj__Mkenv_t__item__current_module_name : env_t -> Prims.string) =
+let __proj__Mkenv_t__item__current_module_name: env_t -> Prims.string =
   fun projectee  ->
     match projectee with
     | { bindings = __fname__bindings; depth = __fname__depth;
@@ -517,8 +471,7 @@ let (__proj__Mkenv_t__item__current_module_name : env_t -> Prims.string) =
           __fname__encode_non_total_function_typ;
         current_module_name = __fname__current_module_name;_} ->
         __fname__current_module_name
-  
-let mk_cache_entry :
+let mk_cache_entry:
   'Auu____2035 .
     'Auu____2035 ->
       Prims.string ->
@@ -536,22 +489,18 @@ let mk_cache_entry :
                     match uu___80_2069 with
                     | FStar_SMTEncoding_Term.Assume a ->
                         [a.FStar_SMTEncoding_Term.assumption_name]
-                    | uu____2073 -> []))
-             in
+                    | uu____2073 -> [])) in
           {
             cache_symbol_name = tsym;
             cache_symbol_arg_sorts = cvar_sorts;
             cache_symbol_decls = t_decls;
             cache_symbol_assumption_names = names1
           }
-  
-let (use_cache_entry : cache_entry -> FStar_SMTEncoding_Term.decl Prims.list)
-  =
+let use_cache_entry: cache_entry -> FStar_SMTEncoding_Term.decl Prims.list =
   fun ce  ->
     [FStar_SMTEncoding_Term.RetainAssumptions
        (ce.cache_symbol_assumption_names)]
-  
-let (print_env : env_t -> Prims.string) =
+let print_env: env_t -> Prims.string =
   fun e  ->
     let uu____2082 =
       FStar_All.pipe_right e.bindings
@@ -561,57 +510,52 @@ let (print_env : env_t -> Prims.string) =
               | Binding_var (x,uu____2094) ->
                   FStar_Syntax_Print.bv_to_string x
               | Binding_fvar (l,uu____2096,uu____2097,uu____2098) ->
-                  FStar_Syntax_Print.lid_to_string l))
-       in
+                  FStar_Syntax_Print.lid_to_string l)) in
     FStar_All.pipe_right uu____2082 (FStar_String.concat ", ")
-  
-let lookup_binding :
+let lookup_binding:
   'Auu____2112 .
     env_t ->
       (binding -> 'Auu____2112 FStar_Pervasives_Native.option) ->
         'Auu____2112 FStar_Pervasives_Native.option
-  = fun env  -> fun f  -> FStar_Util.find_map env.bindings f 
-let (caption_t :
+  = fun env  -> fun f  -> FStar_Util.find_map env.bindings f
+let caption_t:
   env_t ->
-    FStar_Syntax_Syntax.term -> Prims.string FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term -> Prims.string FStar_Pervasives_Native.option
   =
   fun env  ->
     fun t  ->
       let uu____2140 =
-        FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low  in
+        FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low in
       if uu____2140
       then
-        let uu____2143 = FStar_Syntax_Print.term_to_string t  in
+        let uu____2143 = FStar_Syntax_Print.term_to_string t in
         FStar_Pervasives_Native.Some uu____2143
       else FStar_Pervasives_Native.None
-  
-let (fresh_fvar :
+let fresh_fvar:
   Prims.string ->
     FStar_SMTEncoding_Term.sort ->
       (Prims.string,FStar_SMTEncoding_Term.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun x  ->
     fun s  ->
-      let xsym = varops.fresh x  in
-      let uu____2156 = FStar_SMTEncoding_Util.mkFreeV (xsym, s)  in
+      let xsym = varops.fresh x in
+      let uu____2156 = FStar_SMTEncoding_Util.mkFreeV (xsym, s) in
       (xsym, uu____2156)
-  
-let (gen_term_var :
+let gen_term_var:
   env_t ->
     FStar_Syntax_Syntax.bv ->
       (Prims.string,FStar_SMTEncoding_Term.term,env_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun x  ->
-      let ysym = Prims.strcat "@x" (Prims.string_of_int env.depth)  in
+      let ysym = Prims.strcat "@x" (Prims.string_of_int env.depth) in
       let y =
         FStar_SMTEncoding_Util.mkFreeV
-          (ysym, FStar_SMTEncoding_Term.Term_sort)
-         in
+          (ysym, FStar_SMTEncoding_Term.Term_sort) in
       (ysym, y,
-        (let uu___104_2172 = env  in
+        (let uu___104_2172 = env in
          {
            bindings = ((Binding_var (x, y)) :: (env.bindings));
            depth = (env.depth + (Prims.parse_int "1"));
@@ -624,22 +568,20 @@ let (gen_term_var :
              (uu___104_2172.encode_non_total_function_typ);
            current_module_name = (uu___104_2172.current_module_name)
          }))
-  
-let (new_term_constant :
+let new_term_constant:
   env_t ->
     FStar_Syntax_Syntax.bv ->
       (Prims.string,FStar_SMTEncoding_Term.term,env_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun x  ->
       let ysym =
         varops.new_var x.FStar_Syntax_Syntax.ppname
-          x.FStar_Syntax_Syntax.index
-         in
-      let y = FStar_SMTEncoding_Util.mkApp (ysym, [])  in
+          x.FStar_Syntax_Syntax.index in
+      let y = FStar_SMTEncoding_Util.mkApp (ysym, []) in
       (ysym, y,
-        (let uu___105_2190 = env  in
+        (let uu___105_2190 = env in
          {
            bindings = ((Binding_var (x, y)) :: (env.bindings));
            depth = (uu___105_2190.depth);
@@ -652,21 +594,20 @@ let (new_term_constant :
              (uu___105_2190.encode_non_total_function_typ);
            current_module_name = (uu___105_2190.current_module_name)
          }))
-  
-let (new_term_constant_from_string :
+let new_term_constant_from_string:
   env_t ->
     FStar_Syntax_Syntax.bv ->
       Prims.string ->
         (Prims.string,FStar_SMTEncoding_Term.term,env_t)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun x  ->
       fun str  ->
-        let ysym = varops.mk_unique str  in
-        let y = FStar_SMTEncoding_Util.mkApp (ysym, [])  in
+        let ysym = varops.mk_unique str in
+        let y = FStar_SMTEncoding_Util.mkApp (ysym, []) in
         (ysym, y,
-          (let uu___106_2211 = env  in
+          (let uu___106_2211 = env in
            {
              bindings = ((Binding_var (x, y)) :: (env.bindings));
              depth = (uu___106_2211.depth);
@@ -679,13 +620,12 @@ let (new_term_constant_from_string :
                (uu___106_2211.encode_non_total_function_typ);
              current_module_name = (uu___106_2211.current_module_name)
            }))
-  
-let (push_term_var :
-  env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term -> env_t) =
+let push_term_var:
+  env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term -> env_t =
   fun env  ->
     fun x  ->
       fun t  ->
-        let uu___107_2221 = env  in
+        let uu___107_2221 = env in
         {
           bindings = ((Binding_var (x, t)) :: (env.bindings));
           depth = (uu___107_2221.depth);
@@ -698,9 +638,8 @@ let (push_term_var :
             (uu___107_2221.encode_non_total_function_typ);
           current_module_name = (uu___107_2221.current_module_name)
         }
-  
-let (lookup_term_var :
-  env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term) =
+let lookup_term_var:
+  env_t -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term =
   fun env  ->
     fun a  ->
       let aux a' =
@@ -709,49 +648,45 @@ let (lookup_term_var :
              match uu___82_2245 with
              | Binding_var (b,t) when FStar_Syntax_Syntax.bv_eq b a' ->
                  FStar_Pervasives_Native.Some (b, t)
-             | uu____2258 -> FStar_Pervasives_Native.None)
-         in
-      let uu____2263 = aux a  in
+             | uu____2258 -> FStar_Pervasives_Native.None) in
+      let uu____2263 = aux a in
       match uu____2263 with
       | FStar_Pervasives_Native.None  ->
-          let a2 = unmangle a  in
-          let uu____2275 = aux a2  in
+          let a2 = unmangle a in
+          let uu____2275 = aux a2 in
           (match uu____2275 with
            | FStar_Pervasives_Native.None  ->
                let uu____2286 =
-                 let uu____2287 = FStar_Syntax_Print.bv_to_string a2  in
-                 let uu____2288 = print_env env  in
+                 let uu____2287 = FStar_Syntax_Print.bv_to_string a2 in
+                 let uu____2288 = print_env env in
                  FStar_Util.format2
                    "Bound term variable not found (after unmangling): %s in environment: %s"
-                   uu____2287 uu____2288
-                  in
+                   uu____2287 uu____2288 in
                failwith uu____2286
            | FStar_Pervasives_Native.Some (b,t) -> t)
       | FStar_Pervasives_Native.Some (b,t) -> t
-  
-let (new_term_constant_and_tok_from_lid :
+let new_term_constant_and_tok_from_lid:
   env_t ->
     FStar_Ident.lident ->
-      (Prims.string,Prims.string,env_t) FStar_Pervasives_Native.tuple3)
+      (Prims.string,Prims.string,env_t) FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun x  ->
-      let fname = varops.new_fvar x  in
-      let ftok = Prims.strcat fname "@tok"  in
+      let fname = varops.new_fvar x in
+      let ftok = Prims.strcat fname "@tok" in
       let uu____2315 =
-        let uu___108_2316 = env  in
+        let uu___108_2316 = env in
         let uu____2317 =
           let uu____2320 =
             let uu____2321 =
               let uu____2334 =
-                let uu____2337 = FStar_SMTEncoding_Util.mkApp (ftok, [])  in
+                let uu____2337 = FStar_SMTEncoding_Util.mkApp (ftok, []) in
                 FStar_All.pipe_left
                   (fun _0_40  -> FStar_Pervasives_Native.Some _0_40)
-                  uu____2337
-                 in
-              (x, fname, uu____2334, FStar_Pervasives_Native.None)  in
-            Binding_fvar uu____2321  in
-          uu____2320 :: (env.bindings)  in
+                  uu____2337 in
+              (x, fname, uu____2334, FStar_Pervasives_Native.None) in
+            Binding_fvar uu____2321 in
+          uu____2320 :: (env.bindings) in
         {
           bindings = uu____2317;
           depth = (uu___108_2316.depth);
@@ -763,16 +698,15 @@ let (new_term_constant_and_tok_from_lid :
           encode_non_total_function_typ =
             (uu___108_2316.encode_non_total_function_typ);
           current_module_name = (uu___108_2316.current_module_name)
-        }  in
+        } in
       (fname, ftok, uu____2315)
-  
-let (try_lookup_lid :
+let try_lookup_lid:
   env_t ->
     FStar_Ident.lident ->
       (Prims.string,FStar_SMTEncoding_Term.term
                       FStar_Pervasives_Native.option,FStar_SMTEncoding_Term.term
                                                        FStar_Pervasives_Native.option)
-        FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun a  ->
@@ -782,8 +716,7 @@ let (try_lookup_lid :
            | Binding_fvar (b,t1,t2,t3) when FStar_Ident.lid_equals b a ->
                FStar_Pervasives_Native.Some (t1, t2, t3)
            | uu____2418 -> FStar_Pervasives_Native.None)
-  
-let (contains_name : env_t -> Prims.string -> Prims.bool) =
+let contains_name: env_t -> Prims.string -> Prims.bool =
   fun env  ->
     fun s  ->
       let uu____2435 =
@@ -792,40 +725,37 @@ let (contains_name : env_t -> Prims.string -> Prims.bool) =
              match uu___84_2443 with
              | Binding_fvar (b,t1,t2,t3) when b.FStar_Ident.str = s ->
                  FStar_Pervasives_Native.Some ()
-             | uu____2458 -> FStar_Pervasives_Native.None)
-         in
+             | uu____2458 -> FStar_Pervasives_Native.None) in
       FStar_All.pipe_right uu____2435 FStar_Option.isSome
-  
-let (lookup_lid :
+let lookup_lid:
   env_t ->
     FStar_Ident.lident ->
       (Prims.string,FStar_SMTEncoding_Term.term
                       FStar_Pervasives_Native.option,FStar_SMTEncoding_Term.term
                                                        FStar_Pervasives_Native.option)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun a  ->
-      let uu____2477 = try_lookup_lid env a  in
+      let uu____2477 = try_lookup_lid env a in
       match uu____2477 with
       | FStar_Pervasives_Native.None  ->
           let uu____2510 =
-            let uu____2511 = FStar_Syntax_Print.lid_to_string a  in
-            FStar_Util.format1 "Name not found: %s" uu____2511  in
+            let uu____2511 = FStar_Syntax_Print.lid_to_string a in
+            FStar_Util.format1 "Name not found: %s" uu____2511 in
           failwith uu____2510
       | FStar_Pervasives_Native.Some s -> s
-  
-let (push_free_var :
+let push_free_var:
   env_t ->
     FStar_Ident.lident ->
       Prims.string ->
-        FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option -> env_t)
+        FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option -> env_t
   =
   fun env  ->
     fun x  ->
       fun fname  ->
         fun ftok  ->
-          let uu___109_2559 = env  in
+          let uu___109_2559 = env in
           {
             bindings =
               ((Binding_fvar (x, fname, ftok, FStar_Pervasives_Native.None))
@@ -840,24 +770,21 @@ let (push_free_var :
               (uu___109_2559.encode_non_total_function_typ);
             current_module_name = (uu___109_2559.current_module_name)
           }
-  
-let (push_zfuel_name : env_t -> FStar_Ident.lident -> Prims.string -> env_t)
-  =
+let push_zfuel_name: env_t -> FStar_Ident.lident -> Prims.string -> env_t =
   fun env  ->
     fun x  ->
       fun f  ->
-        let uu____2573 = lookup_lid env x  in
+        let uu____2573 = lookup_lid env x in
         match uu____2573 with
         | (t1,t2,uu____2586) ->
             let t3 =
               let uu____2596 =
                 let uu____2603 =
-                  let uu____2606 = FStar_SMTEncoding_Util.mkApp ("ZFuel", [])
-                     in
-                  [uu____2606]  in
-                (f, uu____2603)  in
-              FStar_SMTEncoding_Util.mkApp uu____2596  in
-            let uu___110_2611 = env  in
+                  let uu____2606 = FStar_SMTEncoding_Util.mkApp ("ZFuel", []) in
+                  [uu____2606] in
+                (f, uu____2603) in
+              FStar_SMTEncoding_Util.mkApp uu____2596 in
+            let uu___110_2611 = env in
             {
               bindings =
                 ((Binding_fvar (x, t1, t2, (FStar_Pervasives_Native.Some t3)))
@@ -872,15 +799,14 @@ let (push_zfuel_name : env_t -> FStar_Ident.lident -> Prims.string -> env_t)
                 (uu___110_2611.encode_non_total_function_typ);
               current_module_name = (uu___110_2611.current_module_name)
             }
-  
-let (try_lookup_free_var :
+let try_lookup_free_var:
   env_t ->
     FStar_Ident.lident ->
-      FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option)
+      FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
-      let uu____2624 = try_lookup_lid env l  in
+      let uu____2624 = try_lookup_lid env l in
       match uu____2624 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (name,sym,zf_opt) ->
@@ -895,21 +821,18 @@ let (try_lookup_free_var :
                          let uu____2685 =
                            let uu____2686 =
                              let uu____2687 =
-                               FStar_SMTEncoding_Term.fv_of_term fuel  in
+                               FStar_SMTEncoding_Term.fv_of_term fuel in
                              FStar_All.pipe_right uu____2687
-                               FStar_Pervasives_Native.fst
-                              in
-                           FStar_Util.starts_with uu____2686 "fuel"  in
+                               FStar_Pervasives_Native.fst in
+                           FStar_Util.starts_with uu____2686 "fuel" in
                          if uu____2685
                          then
                            let uu____2690 =
                              let uu____2691 =
                                FStar_SMTEncoding_Util.mkFreeV
-                                 (name, FStar_SMTEncoding_Term.Term_sort)
-                                in
+                                 (name, FStar_SMTEncoding_Term.Term_sort) in
                              FStar_SMTEncoding_Term.mk_ApplyTF uu____2691
-                               fuel
-                              in
+                               fuel in
                            FStar_All.pipe_left
                              (fun _0_41  ->
                                 FStar_Pervasives_Native.Some _0_41)
@@ -917,41 +840,38 @@ let (try_lookup_free_var :
                          else FStar_Pervasives_Native.Some t
                      | uu____2695 -> FStar_Pervasives_Native.Some t)
                 | uu____2696 -> FStar_Pervasives_Native.None))
-  
-let (lookup_free_var :
+let lookup_free_var:
   env_t ->
     FStar_Ident.lident FStar_Syntax_Syntax.withinfo_t ->
-      FStar_SMTEncoding_Term.term)
+      FStar_SMTEncoding_Term.term
   =
   fun env  ->
     fun a  ->
-      let uu____2709 = try_lookup_free_var env a.FStar_Syntax_Syntax.v  in
+      let uu____2709 = try_lookup_free_var env a.FStar_Syntax_Syntax.v in
       match uu____2709 with
       | FStar_Pervasives_Native.Some t -> t
       | FStar_Pervasives_Native.None  ->
           let uu____2713 =
             let uu____2714 =
-              FStar_Syntax_Print.lid_to_string a.FStar_Syntax_Syntax.v  in
-            FStar_Util.format1 "Name not found: %s" uu____2714  in
+              FStar_Syntax_Print.lid_to_string a.FStar_Syntax_Syntax.v in
+            FStar_Util.format1 "Name not found: %s" uu____2714 in
           failwith uu____2713
-  
-let (lookup_free_var_name :
-  env_t -> FStar_Ident.lident FStar_Syntax_Syntax.withinfo_t -> Prims.string)
+let lookup_free_var_name:
+  env_t -> FStar_Ident.lident FStar_Syntax_Syntax.withinfo_t -> Prims.string
   =
   fun env  ->
     fun a  ->
-      let uu____2725 = lookup_lid env a.FStar_Syntax_Syntax.v  in
+      let uu____2725 = lookup_lid env a.FStar_Syntax_Syntax.v in
       match uu____2725 with | (x,uu____2737,uu____2738) -> x
-  
-let (lookup_free_var_sym :
+let lookup_free_var_sym:
   env_t ->
     FStar_Ident.lident FStar_Syntax_Syntax.withinfo_t ->
       (FStar_SMTEncoding_Term.op,FStar_SMTEncoding_Term.term Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun a  ->
-      let uu____2763 = lookup_lid env a.FStar_Syntax_Syntax.v  in
+      let uu____2763 = lookup_lid env a.FStar_Syntax_Syntax.v in
       match uu____2763 with
       | (name,sym,zf_opt) ->
           (match zf_opt with
@@ -970,11 +890,10 @@ let (lookup_free_var_sym :
                     (match sym1.FStar_SMTEncoding_Term.tm with
                      | FStar_SMTEncoding_Term.App (g,fuel::[]) -> (g, [fuel])
                      | uu____2839 -> ((FStar_SMTEncoding_Term.Var name), []))))
-  
-let (tok_of_name :
+let tok_of_name:
   env_t ->
     Prims.string ->
-      FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option)
+      FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option
   =
   fun env  ->
     fun nm  ->
@@ -984,8 +903,7 @@ let (tok_of_name :
            | Binding_fvar (uu____2858,nm',tok,uu____2861) when nm = nm' ->
                tok
            | uu____2870 -> FStar_Pervasives_Native.None)
-  
-let mkForall_fuel' :
+let mkForall_fuel':
   'Auu____2874 .
     'Auu____2874 ->
       (FStar_SMTEncoding_Term.pat Prims.list Prims.list,FStar_SMTEncoding_Term.fvs,
@@ -997,13 +915,12 @@ let mkForall_fuel' :
       match uu____2892 with
       | (pats,vars,body) ->
           let fallback uu____2917 =
-            FStar_SMTEncoding_Util.mkForall (pats, vars, body)  in
-          let uu____2922 = FStar_Options.unthrottle_inductives ()  in
+            FStar_SMTEncoding_Util.mkForall (pats, vars, body) in
+          let uu____2922 = FStar_Options.unthrottle_inductives () in
           if uu____2922
           then fallback ()
           else
-            (let uu____2924 = fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort
-                in
+            (let uu____2924 = fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort in
              match uu____2924 with
              | (fsym,fterm) ->
                  let add_fuel1 tms =
@@ -1015,9 +932,8 @@ let mkForall_fuel' :
                                (FStar_SMTEncoding_Term.Var "HasType",args) ->
                                FStar_SMTEncoding_Util.mkApp
                                  ("HasTypeFuel", (fterm :: args))
-                           | uu____2955 -> p))
-                    in
-                 let pats1 = FStar_List.map add_fuel1 pats  in
+                           | uu____2955 -> p)) in
+                 let pats1 = FStar_List.map add_fuel1 pats in
                  let body1 =
                    match body.FStar_SMTEncoding_Term.tm with
                    | FStar_SMTEncoding_Term.App
@@ -1026,27 +942,24 @@ let mkForall_fuel' :
                          match guard.FStar_SMTEncoding_Term.tm with
                          | FStar_SMTEncoding_Term.App
                              (FStar_SMTEncoding_Term.And ,guards) ->
-                             let uu____2976 = add_fuel1 guards  in
+                             let uu____2976 = add_fuel1 guards in
                              FStar_SMTEncoding_Util.mk_and_l uu____2976
                          | uu____2979 ->
-                             let uu____2980 = add_fuel1 [guard]  in
-                             FStar_All.pipe_right uu____2980 FStar_List.hd
-                          in
+                             let uu____2980 = add_fuel1 [guard] in
+                             FStar_All.pipe_right uu____2980 FStar_List.hd in
                        FStar_SMTEncoding_Util.mkImp (guard1, body')
-                   | uu____2985 -> body  in
-                 let vars1 = (fsym, FStar_SMTEncoding_Term.Fuel_sort) :: vars
-                    in
+                   | uu____2985 -> body in
+                 let vars1 = (fsym, FStar_SMTEncoding_Term.Fuel_sort) :: vars in
                  FStar_SMTEncoding_Util.mkForall (pats1, vars1, body1))
-  
-let (mkForall_fuel :
+let mkForall_fuel:
   (FStar_SMTEncoding_Term.pat Prims.list Prims.list,FStar_SMTEncoding_Term.fvs,
     FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple3 ->
-    FStar_SMTEncoding_Term.term)
-  = mkForall_fuel' (Prims.parse_int "1") 
-let (head_normal : env_t -> FStar_Syntax_Syntax.term -> Prims.bool) =
+    FStar_SMTEncoding_Term.term
+  = mkForall_fuel' (Prims.parse_int "1")
+let head_normal: env_t -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun env  ->
     fun t  ->
-      let t1 = FStar_Syntax_Util.unmeta t  in
+      let t1 = FStar_Syntax_Util.unmeta t in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_arrow uu____3026 -> true
       | FStar_Syntax_Syntax.Tm_refine uu____3039 -> true
@@ -1058,8 +971,7 @@ let (head_normal : env_t -> FStar_Syntax_Syntax.term -> Prims.bool) =
           let uu____3083 =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Eager_unfolding_only] env.tcenv
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           FStar_All.pipe_right uu____3083 FStar_Option.isNone
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
@@ -1069,17 +981,15 @@ let (head_normal : env_t -> FStar_Syntax_Syntax.term -> Prims.bool) =
           let uu____3124 =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Eager_unfolding_only] env.tcenv
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           FStar_All.pipe_right uu____3124 FStar_Option.isNone
       | uu____3141 -> false
-  
-let (head_redex : env_t -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let head_redex: env_t -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun env  ->
     fun t  ->
       let uu____3148 =
-        let uu____3149 = FStar_Syntax_Util.un_uinst t  in
-        uu____3149.FStar_Syntax_Syntax.n  in
+        let uu____3149 = FStar_Syntax_Util.un_uinst t in
+        uu____3149.FStar_Syntax_Syntax.n in
       match uu____3148 with
       | FStar_Syntax_Syntax.Tm_abs
           (uu____3152,uu____3153,FStar_Pervasives_Native.Some rc) ->
@@ -1099,15 +1009,13 @@ let (head_redex : env_t -> FStar_Syntax_Syntax.term -> Prims.bool) =
           let uu____3177 =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Eager_unfolding_only] env.tcenv
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           FStar_All.pipe_right uu____3177 FStar_Option.isSome
       | uu____3194 -> false
-  
-let (whnf : env_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let whnf: env_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun env  ->
     fun t  ->
-      let uu____3201 = head_normal env t  in
+      let uu____3201 = head_normal env t in
       if uu____3201
       then t
       else
@@ -1119,8 +1027,7 @@ let (whnf : env_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
             FStar_TypeChecker_Normalize.Zeta;
           FStar_TypeChecker_Normalize.Eager_unfolding;
           FStar_TypeChecker_Normalize.EraseUniverses] env.tcenv t
-  
-let (norm : env_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let norm: env_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun env  ->
     fun t  ->
       FStar_TypeChecker_Normalize.normalize
@@ -1128,21 +1035,18 @@ let (norm : env_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
         FStar_TypeChecker_Normalize.Exclude FStar_TypeChecker_Normalize.Zeta;
         FStar_TypeChecker_Normalize.Eager_unfolding;
         FStar_TypeChecker_Normalize.EraseUniverses] env.tcenv t
-  
-let (trivial_post : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let trivial_post: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun t  ->
     let uu____3212 =
-      let uu____3213 = FStar_Syntax_Syntax.null_binder t  in [uu____3213]  in
+      let uu____3213 = FStar_Syntax_Syntax.null_binder t in [uu____3213] in
     let uu____3214 =
       FStar_Syntax_Syntax.fvar FStar_Parser_Const.true_lid
-        FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None
-       in
+        FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None in
     FStar_Syntax_Util.abs uu____3212 uu____3214 FStar_Pervasives_Native.None
-  
-let (mk_Apply :
+let mk_Apply:
   FStar_SMTEncoding_Term.term ->
     (Prims.string,FStar_SMTEncoding_Term.sort) FStar_Pervasives_Native.tuple2
-      Prims.list -> FStar_SMTEncoding_Term.term)
+      Prims.list -> FStar_SMTEncoding_Term.term
   =
   fun e  ->
     fun vars  ->
@@ -1152,33 +1056,30 @@ let (mk_Apply :
               fun var  ->
                 match FStar_Pervasives_Native.snd var with
                 | FStar_SMTEncoding_Term.Fuel_sort  ->
-                    let uu____3252 = FStar_SMTEncoding_Util.mkFreeV var  in
+                    let uu____3252 = FStar_SMTEncoding_Util.mkFreeV var in
                     FStar_SMTEncoding_Term.mk_ApplyTF out uu____3252
                 | s ->
-                    let uu____3257 = FStar_SMTEncoding_Util.mkFreeV var  in
+                    let uu____3257 = FStar_SMTEncoding_Util.mkFreeV var in
                     FStar_SMTEncoding_Util.mk_ApplyTT out uu____3257) e)
-  
-let (mk_Apply_args :
+let mk_Apply_args:
   FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term)
+    FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term
   =
   fun e  ->
     fun args  ->
       FStar_All.pipe_right args
         (FStar_List.fold_left FStar_SMTEncoding_Util.mk_ApplyTT e)
-  
-let (is_app : FStar_SMTEncoding_Term.op -> Prims.bool) =
+let is_app: FStar_SMTEncoding_Term.op -> Prims.bool =
   fun uu___87_3272  ->
     match uu___87_3272 with
     | FStar_SMTEncoding_Term.Var "ApplyTT" -> true
     | FStar_SMTEncoding_Term.Var "ApplyTF" -> true
     | uu____3273 -> false
-  
-let (is_an_eta_expansion :
+let is_an_eta_expansion:
   env_t ->
     FStar_SMTEncoding_Term.fv Prims.list ->
       FStar_SMTEncoding_Term.term ->
-        FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option)
+        FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option
   =
   fun env  ->
     fun vars  ->
@@ -1203,29 +1104,25 @@ let (is_an_eta_expansion :
                           match a.FStar_SMTEncoding_Term.tm with
                           | FStar_SMTEncoding_Term.FreeV fv ->
                               FStar_SMTEncoding_Term.fv_eq fv v1
-                          | uu____3353 -> false) args (FStar_List.rev xs))
-                 in
+                          | uu____3353 -> false) args (FStar_List.rev xs)) in
               if uu____3342
               then tok_of_name env f
               else FStar_Pervasives_Native.None
           | (uu____3357,[]) ->
-              let fvs = FStar_SMTEncoding_Term.free_variables t  in
+              let fvs = FStar_SMTEncoding_Term.free_variables t in
               let uu____3361 =
                 FStar_All.pipe_right fvs
                   (FStar_List.for_all
                      (fun fv  ->
                         let uu____3365 =
                           FStar_Util.for_some
-                            (FStar_SMTEncoding_Term.fv_eq fv) vars
-                           in
-                        Prims.op_Negation uu____3365))
-                 in
+                            (FStar_SMTEncoding_Term.fv_eq fv) vars in
+                        Prims.op_Negation uu____3365)) in
               if uu____3361
               then FStar_Pervasives_Native.Some t
               else FStar_Pervasives_Native.None
-          | uu____3369 -> FStar_Pervasives_Native.None  in
+          | uu____3369 -> FStar_Pervasives_Native.None in
         check_partial_applications body (FStar_List.rev vars)
-  
 type label =
   (FStar_SMTEncoding_Term.fv,Prims.string,FStar_Range.range)
     FStar_Pervasives_Native.tuple3[@@deriving show]
@@ -1234,119 +1131,106 @@ type pattern =
   {
   pat_vars:
     (FStar_Syntax_Syntax.bv,FStar_SMTEncoding_Term.fv)
-      FStar_Pervasives_Native.tuple2 Prims.list
-    ;
+      FStar_Pervasives_Native.tuple2 Prims.list;
   pat_term:
     Prims.unit ->
       (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-        FStar_Pervasives_Native.tuple2
-    ;
-  guard: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term ;
+        FStar_Pervasives_Native.tuple2;
+  guard: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term;
   projections:
     FStar_SMTEncoding_Term.term ->
       (FStar_Syntax_Syntax.bv,FStar_SMTEncoding_Term.term)
-        FStar_Pervasives_Native.tuple2 Prims.list
-    }[@@deriving show]
-let (__proj__Mkpattern__item__pat_vars :
+        FStar_Pervasives_Native.tuple2 Prims.list;}[@@deriving show]
+let __proj__Mkpattern__item__pat_vars:
   pattern ->
     (FStar_Syntax_Syntax.bv,FStar_SMTEncoding_Term.fv)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
     | { pat_vars = __fname__pat_vars; pat_term = __fname__pat_term;
         guard = __fname__guard; projections = __fname__projections;_} ->
         __fname__pat_vars
-  
-let (__proj__Mkpattern__item__pat_term :
+let __proj__Mkpattern__item__pat_term:
   pattern ->
     Prims.unit ->
       (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun projectee  ->
     match projectee with
     | { pat_vars = __fname__pat_vars; pat_term = __fname__pat_term;
         guard = __fname__guard; projections = __fname__projections;_} ->
         __fname__pat_term
-  
-let (__proj__Mkpattern__item__guard :
-  pattern -> FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) =
+let __proj__Mkpattern__item__guard:
+  pattern -> FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
   fun projectee  ->
     match projectee with
     | { pat_vars = __fname__pat_vars; pat_term = __fname__pat_term;
         guard = __fname__guard; projections = __fname__projections;_} ->
         __fname__guard
-  
-let (__proj__Mkpattern__item__projections :
+let __proj__Mkpattern__item__projections:
   pattern ->
     FStar_SMTEncoding_Term.term ->
       (FStar_Syntax_Syntax.bv,FStar_SMTEncoding_Term.term)
-        FStar_Pervasives_Native.tuple2 Prims.list)
+        FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
     | { pat_vars = __fname__pat_vars; pat_term = __fname__pat_term;
         guard = __fname__guard; projections = __fname__projections;_} ->
         __fname__projections
-  
-exception Let_rec_unencodeable 
-let (uu___is_Let_rec_unencodeable : Prims.exn -> Prims.bool) =
+exception Let_rec_unencodeable
+let uu___is_Let_rec_unencodeable: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Let_rec_unencodeable  -> true
     | uu____3591 -> false
-  
-exception Inner_let_rec 
-let (uu___is_Inner_let_rec : Prims.exn -> Prims.bool) =
+exception Inner_let_rec
+let uu___is_Inner_let_rec: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | Inner_let_rec  -> true | uu____3595 -> false
-  
-let (as_function_typ :
+let as_function_typ:
   env_t ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t0  ->
       let rec aux norm1 t =
-        let t1 = FStar_Syntax_Subst.compress t  in
+        let t1 = FStar_Syntax_Subst.compress t in
         match t1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_arrow uu____3614 -> t1
         | FStar_Syntax_Syntax.Tm_refine uu____3627 ->
-            let uu____3634 = FStar_Syntax_Util.unrefine t1  in
+            let uu____3634 = FStar_Syntax_Util.unrefine t1 in
             aux true uu____3634
         | uu____3635 ->
             if norm1
-            then let uu____3636 = whnf env t1  in aux false uu____3636
+            then let uu____3636 = whnf env t1 in aux false uu____3636
             else
               (let uu____3638 =
                  let uu____3639 =
-                   FStar_Range.string_of_range t0.FStar_Syntax_Syntax.pos  in
-                 let uu____3640 = FStar_Syntax_Print.term_to_string t0  in
+                   FStar_Range.string_of_range t0.FStar_Syntax_Syntax.pos in
+                 let uu____3640 = FStar_Syntax_Print.term_to_string t0 in
                  FStar_Util.format2 "(%s) Expected a function typ; got %s"
-                   uu____3639 uu____3640
-                  in
-               failwith uu____3638)
-         in
+                   uu____3639 uu____3640 in
+               failwith uu____3638) in
       aux true t0
-  
-let rec (curried_arrow_formals_comp :
+let rec curried_arrow_formals_comp:
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.comp)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun k  ->
-    let k1 = FStar_Syntax_Subst.compress k  in
+    let k1 = FStar_Syntax_Subst.compress k in
     match k1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
         FStar_Syntax_Subst.open_comp bs c
     | FStar_Syntax_Syntax.Tm_refine (bv,uu____3672) ->
         curried_arrow_formals_comp bv.FStar_Syntax_Syntax.sort
     | uu____3677 ->
-        let uu____3678 = FStar_Syntax_Syntax.mk_Total k1  in ([], uu____3678)
-  
-let is_arithmetic_primitive :
+        let uu____3678 = FStar_Syntax_Syntax.mk_Total k1 in ([], uu____3678)
+let is_arithmetic_primitive:
   'Auu____3692 .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       'Auu____3692 Prims.list -> Prims.bool
@@ -1369,22 +1253,19 @@ let is_arithmetic_primitive :
       | (FStar_Syntax_Syntax.Tm_fvar fv,uu____3717::[]) ->
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.op_Minus
       | uu____3720 -> false
-  
-let (isInteger : FStar_Syntax_Syntax.term' -> Prims.bool) =
+let isInteger: FStar_Syntax_Syntax.term' -> Prims.bool =
   fun tm  ->
     match tm with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
         (n1,FStar_Pervasives_Native.None )) -> true
     | uu____3741 -> false
-  
-let (getInteger : FStar_Syntax_Syntax.term' -> Prims.int) =
+let getInteger: FStar_Syntax_Syntax.term' -> Prims.int =
   fun tm  ->
     match tm with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
         (n1,FStar_Pervasives_Native.None )) -> FStar_Util.int_of_string n1
     | uu____3756 -> failwith "Expected an Integer term"
-  
-let is_BitVector_primitive :
+let is_BitVector_primitive:
   'Auu____3760 .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,'Auu____3760)
@@ -1435,12 +1316,11 @@ let is_BitVector_primitive :
                 FStar_Parser_Const.bv_to_nat_lid))
             && (isInteger sz_arg.FStar_Syntax_Syntax.n)
       | uu____3890 -> false
-  
-let rec (encode_const :
+let rec encode_const:
   FStar_Const.sconst ->
     env_t ->
       (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decl Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun c  ->
     fun env  ->
@@ -1448,11 +1328,11 @@ let rec (encode_const :
       | FStar_Const.Const_unit  -> (FStar_SMTEncoding_Term.mk_Term_unit, [])
       | FStar_Const.Const_bool (true ) ->
           let uu____4109 =
-            FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkTrue  in
+            FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkTrue in
           (uu____4109, [])
       | FStar_Const.Const_bool (false ) ->
           let uu____4112 =
-            FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkFalse  in
+            FStar_SMTEncoding_Term.boxBool FStar_SMTEncoding_Util.mkFalse in
           (uu____4112, [])
       | FStar_Const.Const_char c1 ->
           let uu____4116 =
@@ -1461,54 +1341,51 @@ let rec (encode_const :
                 let uu____4127 =
                   let uu____4128 =
                     FStar_SMTEncoding_Util.mkInteger'
-                      (FStar_Util.int_of_char c1)
-                     in
-                  FStar_SMTEncoding_Term.boxInt uu____4128  in
-                [uu____4127]  in
-              ("FStar.Char.__char_of_int", uu____4124)  in
-            FStar_SMTEncoding_Util.mkApp uu____4117  in
+                      (FStar_Util.int_of_char c1) in
+                  FStar_SMTEncoding_Term.boxInt uu____4128 in
+                [uu____4127] in
+              ("FStar.Char.__char_of_int", uu____4124) in
+            FStar_SMTEncoding_Util.mkApp uu____4117 in
           (uu____4116, [])
       | FStar_Const.Const_int (i,FStar_Pervasives_Native.None ) ->
           let uu____4144 =
-            let uu____4145 = FStar_SMTEncoding_Util.mkInteger i  in
-            FStar_SMTEncoding_Term.boxInt uu____4145  in
+            let uu____4145 = FStar_SMTEncoding_Util.mkInteger i in
+            FStar_SMTEncoding_Term.boxInt uu____4145 in
           (uu____4144, [])
       | FStar_Const.Const_int (repr,FStar_Pervasives_Native.Some sw) ->
           let syntax_term =
             FStar_ToSyntax_ToSyntax.desugar_machine_integer
               (env.tcenv).FStar_TypeChecker_Env.dsenv repr sw
-              FStar_Range.dummyRange
-             in
+              FStar_Range.dummyRange in
           encode_term syntax_term env
       | FStar_Const.Const_string (s,uu____4166) ->
-          let uu____4167 = varops.string_const s  in (uu____4167, [])
+          let uu____4167 = varops.string_const s in (uu____4167, [])
       | FStar_Const.Const_range uu____4170 ->
-          let uu____4171 = FStar_SMTEncoding_Term.mk_Range_const ()  in
+          let uu____4171 = FStar_SMTEncoding_Term.mk_Range_const () in
           (uu____4171, [])
       | FStar_Const.Const_effect  ->
           (FStar_SMTEncoding_Term.mk_Term_type, [])
       | c1 ->
           let uu____4177 =
-            let uu____4178 = FStar_Syntax_Print.const_to_string c1  in
-            FStar_Util.format1 "Unhandled constant: %s" uu____4178  in
+            let uu____4178 = FStar_Syntax_Print.const_to_string c1 in
+            FStar_Util.format1 "Unhandled constant: %s" uu____4178 in
           failwith uu____4177
-
-and (encode_binders :
+and encode_binders:
   FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.binders ->
       env_t ->
         (FStar_SMTEncoding_Term.fv Prims.list,FStar_SMTEncoding_Term.term
                                                 Prims.list,env_t,FStar_SMTEncoding_Term.decls_t,
-          FStar_Syntax_Syntax.bv Prims.list) FStar_Pervasives_Native.tuple5)
+          FStar_Syntax_Syntax.bv Prims.list) FStar_Pervasives_Native.tuple5
   =
   fun fuel_opt  ->
     fun bs  ->
       fun env  ->
         (let uu____4207 =
-           FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low  in
+           FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low in
          if uu____4207
          then
-           let uu____4208 = FStar_Syntax_Print.binders_to_string ", " bs  in
+           let uu____4208 = FStar_Syntax_Print.binders_to_string ", " bs in
            FStar_Util.print1 "Encoding binders %s\n" uu____4208
          else ());
         (let uu____4210 =
@@ -1519,211 +1396,191 @@ and (encode_binders :
                      match uu____4294 with
                      | (vars,guards,env1,decls,names1) ->
                          let uu____4373 =
-                           let x = unmangle (FStar_Pervasives_Native.fst b)
-                              in
-                           let uu____4389 = gen_term_var env1 x  in
+                           let x = unmangle (FStar_Pervasives_Native.fst b) in
+                           let uu____4389 = gen_term_var env1 x in
                            match uu____4389 with
                            | (xxsym,xx,env') ->
                                let uu____4413 =
                                  let uu____4418 =
-                                   norm env1 x.FStar_Syntax_Syntax.sort  in
-                                 encode_term_pred fuel_opt uu____4418 env1 xx
-                                  in
+                                   norm env1 x.FStar_Syntax_Syntax.sort in
+                                 encode_term_pred fuel_opt uu____4418 env1 xx in
                                (match uu____4413 with
                                 | (guard_x_t,decls') ->
                                     ((xxsym,
                                        FStar_SMTEncoding_Term.Term_sort),
-                                      guard_x_t, env', decls', x))
-                            in
+                                      guard_x_t, env', decls', x)) in
                          (match uu____4373 with
                           | (v1,g,env2,decls',n1) ->
                               ((v1 :: vars), (g :: guards), env2,
                                 (FStar_List.append decls decls'), (n1 ::
-                                names1)))) ([], [], env, [], []))
-            in
+                                names1)))) ([], [], env, [], [])) in
          match uu____4210 with
          | (vars,guards,env1,decls,names1) ->
              ((FStar_List.rev vars), (FStar_List.rev guards), env1, decls,
                (FStar_List.rev names1)))
-
-and (encode_term_pred :
+and encode_term_pred:
   FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.typ ->
       env_t ->
         FStar_SMTEncoding_Term.term ->
           (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun fuel_opt  ->
     fun t  ->
       fun env  ->
         fun e  ->
-          let uu____4577 = encode_term t env  in
+          let uu____4577 = encode_term t env in
           match uu____4577 with
           | (t1,decls) ->
               let uu____4588 =
-                FStar_SMTEncoding_Term.mk_HasTypeWithFuel fuel_opt e t1  in
+                FStar_SMTEncoding_Term.mk_HasTypeWithFuel fuel_opt e t1 in
               (uu____4588, decls)
-
-and (encode_term_pred' :
+and encode_term_pred':
   FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.typ ->
       env_t ->
         FStar_SMTEncoding_Term.term ->
           (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun fuel_opt  ->
     fun t  ->
       fun env  ->
         fun e  ->
-          let uu____4599 = encode_term t env  in
+          let uu____4599 = encode_term t env in
           match uu____4599 with
           | (t1,decls) ->
               (match fuel_opt with
                | FStar_Pervasives_Native.None  ->
-                   let uu____4614 = FStar_SMTEncoding_Term.mk_HasTypeZ e t1
-                      in
+                   let uu____4614 = FStar_SMTEncoding_Term.mk_HasTypeZ e t1 in
                    (uu____4614, decls)
                | FStar_Pervasives_Native.Some f ->
                    let uu____4616 =
-                     FStar_SMTEncoding_Term.mk_HasTypeFuel f e t1  in
+                     FStar_SMTEncoding_Term.mk_HasTypeFuel f e t1 in
                    (uu____4616, decls))
-
-and (encode_arith_term :
+and encode_arith_term:
   env_t ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       FStar_Syntax_Syntax.args ->
         (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun head1  ->
       fun args_e  ->
-        let uu____4622 = encode_args args_e env  in
+        let uu____4622 = encode_args args_e env in
         match uu____4622 with
         | (arg_tms,decls) ->
             let head_fv =
               match head1.FStar_Syntax_Syntax.n with
               | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-              | uu____4641 -> failwith "Impossible"  in
+              | uu____4641 -> failwith "Impossible" in
             let unary arg_tms1 =
-              let uu____4650 = FStar_List.hd arg_tms1  in
-              FStar_SMTEncoding_Term.unboxInt uu____4650  in
+              let uu____4650 = FStar_List.hd arg_tms1 in
+              FStar_SMTEncoding_Term.unboxInt uu____4650 in
             let binary arg_tms1 =
               let uu____4663 =
-                let uu____4664 = FStar_List.hd arg_tms1  in
-                FStar_SMTEncoding_Term.unboxInt uu____4664  in
+                let uu____4664 = FStar_List.hd arg_tms1 in
+                FStar_SMTEncoding_Term.unboxInt uu____4664 in
               let uu____4665 =
                 let uu____4666 =
-                  let uu____4667 = FStar_List.tl arg_tms1  in
-                  FStar_List.hd uu____4667  in
-                FStar_SMTEncoding_Term.unboxInt uu____4666  in
-              (uu____4663, uu____4665)  in
+                  let uu____4667 = FStar_List.tl arg_tms1 in
+                  FStar_List.hd uu____4667 in
+                FStar_SMTEncoding_Term.unboxInt uu____4666 in
+              (uu____4663, uu____4665) in
             let mk_default uu____4673 =
               let uu____4674 =
-                lookup_free_var_sym env head_fv.FStar_Syntax_Syntax.fv_name
-                 in
+                lookup_free_var_sym env head_fv.FStar_Syntax_Syntax.fv_name in
               match uu____4674 with
               | (fname,fuel_args) ->
                   FStar_SMTEncoding_Util.mkApp'
-                    (fname, (FStar_List.append fuel_args arg_tms))
-               in
+                    (fname, (FStar_List.append fuel_args arg_tms)) in
             let mk_l a op mk_args ts =
-              let uu____4720 = FStar_Options.smtencoding_l_arith_native ()
-                 in
+              let uu____4720 = FStar_Options.smtencoding_l_arith_native () in
               if uu____4720
               then
-                let uu____4721 =
-                  let uu____4722 = mk_args ts  in op uu____4722  in
+                let uu____4721 = let uu____4722 = mk_args ts in op uu____4722 in
                 FStar_All.pipe_right uu____4721 FStar_SMTEncoding_Term.boxInt
-              else mk_default ()  in
+              else mk_default () in
             let mk_nl nm op ts =
-              let uu____4751 = FStar_Options.smtencoding_nl_arith_wrapped ()
-                 in
+              let uu____4751 = FStar_Options.smtencoding_nl_arith_wrapped () in
               if uu____4751
               then
-                let uu____4752 = binary ts  in
+                let uu____4752 = binary ts in
                 match uu____4752 with
                 | (t1,t2) ->
                     let uu____4759 =
-                      FStar_SMTEncoding_Util.mkApp (nm, [t1; t2])  in
+                      FStar_SMTEncoding_Util.mkApp (nm, [t1; t2]) in
                     FStar_All.pipe_right uu____4759
                       FStar_SMTEncoding_Term.boxInt
               else
                 (let uu____4763 =
-                   FStar_Options.smtencoding_nl_arith_native ()  in
+                   FStar_Options.smtencoding_nl_arith_native () in
                  if uu____4763
                  then
-                   let uu____4764 = op (binary ts)  in
+                   let uu____4764 = op (binary ts) in
                    FStar_All.pipe_right uu____4764
                      FStar_SMTEncoding_Term.boxInt
-                 else mk_default ())
-               in
+                 else mk_default ()) in
             let add1 =
               mk_l ()
                 (fun a415  -> (Obj.magic FStar_SMTEncoding_Util.mkAdd) a415)
-                (fun a416  -> (Obj.magic binary) a416)
-               in
+                (fun a416  -> (Obj.magic binary) a416) in
             let sub1 =
               mk_l ()
                 (fun a417  -> (Obj.magic FStar_SMTEncoding_Util.mkSub) a417)
-                (fun a418  -> (Obj.magic binary) a418)
-               in
+                (fun a418  -> (Obj.magic binary) a418) in
             let minus =
               mk_l ()
                 (fun a419  -> (Obj.magic FStar_SMTEncoding_Util.mkMinus) a419)
-                (fun a420  -> (Obj.magic unary) a420)
-               in
-            let mul1 = mk_nl "_mul" FStar_SMTEncoding_Util.mkMul  in
-            let div1 = mk_nl "_div" FStar_SMTEncoding_Util.mkDiv  in
-            let modulus = mk_nl "_mod" FStar_SMTEncoding_Util.mkMod  in
+                (fun a420  -> (Obj.magic unary) a420) in
+            let mul1 = mk_nl "_mul" FStar_SMTEncoding_Util.mkMul in
+            let div1 = mk_nl "_div" FStar_SMTEncoding_Util.mkDiv in
+            let modulus = mk_nl "_mod" FStar_SMTEncoding_Util.mkMod in
             let ops =
               [(FStar_Parser_Const.op_Addition, add1);
               (FStar_Parser_Const.op_Subtraction, sub1);
               (FStar_Parser_Const.op_Multiply, mul1);
               (FStar_Parser_Const.op_Division, div1);
               (FStar_Parser_Const.op_Modulus, modulus);
-              (FStar_Parser_Const.op_Minus, minus)]  in
+              (FStar_Parser_Const.op_Minus, minus)] in
             let uu____4887 =
               let uu____4896 =
                 FStar_List.tryFind
                   (fun uu____4918  ->
                      match uu____4918 with
                      | (l,uu____4928) ->
-                         FStar_Syntax_Syntax.fv_eq_lid head_fv l) ops
-                 in
-              FStar_All.pipe_right uu____4896 FStar_Util.must  in
+                         FStar_Syntax_Syntax.fv_eq_lid head_fv l) ops in
+              FStar_All.pipe_right uu____4896 FStar_Util.must in
             (match uu____4887 with
              | (uu____4967,op) ->
-                 let uu____4977 = op arg_tms  in (uu____4977, decls))
-
-and (encode_BitVector_term :
+                 let uu____4977 = op arg_tms in (uu____4977, decls))
+and encode_BitVector_term:
   env_t ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       FStar_Syntax_Syntax.arg Prims.list ->
         (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decl Prims.list)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun head1  ->
       fun args_e  ->
-        let uu____4985 = FStar_List.hd args_e  in
+        let uu____4985 = FStar_List.hd args_e in
         match uu____4985 with
         | (tm_sz,uu____4993) ->
-            let sz = getInteger tm_sz.FStar_Syntax_Syntax.n  in
+            let sz = getInteger tm_sz.FStar_Syntax_Syntax.n in
             let sz_key =
-              FStar_Util.format1 "BitVector_%s" (Prims.string_of_int sz)  in
+              FStar_Util.format1 "BitVector_%s" (Prims.string_of_int sz) in
             let sz_decls =
-              let uu____5003 = FStar_Util.smap_try_find env.cache sz_key  in
+              let uu____5003 = FStar_Util.smap_try_find env.cache sz_key in
               match uu____5003 with
               | FStar_Pervasives_Native.Some cache_entry -> []
               | FStar_Pervasives_Native.None  ->
-                  let t_decls = FStar_SMTEncoding_Term.mkBvConstructor sz  in
-                  ((let uu____5011 = mk_cache_entry env "" [] []  in
+                  let t_decls = FStar_SMTEncoding_Term.mkBvConstructor sz in
+                  ((let uu____5011 = mk_cache_entry env "" [] [] in
                     FStar_Util.smap_add env.cache sz_key uu____5011);
-                   t_decls)
-               in
+                   t_decls) in
             let uu____5012 =
               match ((head1.FStar_Syntax_Syntax.n), args_e) with
               | (FStar_Syntax_Syntax.Tm_fvar
@@ -1733,12 +1590,11 @@ and (encode_BitVector_term :
                     && (isInteger sz_arg.FStar_Syntax_Syntax.n)
                   ->
                   let uu____5084 =
-                    let uu____5087 = FStar_List.tail args_e  in
-                    FStar_List.tail uu____5087  in
+                    let uu____5087 = FStar_List.tail args_e in
+                    FStar_List.tail uu____5087 in
                   let uu____5090 =
-                    let uu____5093 = getInteger sz_arg.FStar_Syntax_Syntax.n
-                       in
-                    FStar_Pervasives_Native.Some uu____5093  in
+                    let uu____5093 = getInteger sz_arg.FStar_Syntax_Syntax.n in
+                    FStar_Pervasives_Native.Some uu____5093 in
                   (uu____5084, uu____5090)
               | (FStar_Syntax_Syntax.Tm_fvar
                  fv,uu____5099::(sz_arg,uu____5101)::uu____5102::[]) when
@@ -1746,178 +1602,156 @@ and (encode_BitVector_term :
                     FStar_Parser_Const.bv_uext_lid
                   ->
                   let uu____5151 =
-                    let uu____5152 = FStar_Syntax_Print.term_to_string sz_arg
-                       in
+                    let uu____5152 = FStar_Syntax_Print.term_to_string sz_arg in
                     FStar_Util.format1
-                      "Not a constant bitvector extend size: %s" uu____5152
-                     in
+                      "Not a constant bitvector extend size: %s" uu____5152 in
                   failwith uu____5151
               | uu____5161 ->
-                  let uu____5168 = FStar_List.tail args_e  in
-                  (uu____5168, FStar_Pervasives_Native.None)
-               in
+                  let uu____5168 = FStar_List.tail args_e in
+                  (uu____5168, FStar_Pervasives_Native.None) in
             (match uu____5012 with
              | (arg_tms,ext_sz) ->
-                 let uu____5191 = encode_args arg_tms env  in
+                 let uu____5191 = encode_args arg_tms env in
                  (match uu____5191 with
                   | (arg_tms1,decls) ->
                       let head_fv =
                         match head1.FStar_Syntax_Syntax.n with
                         | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-                        | uu____5212 -> failwith "Impossible"  in
+                        | uu____5212 -> failwith "Impossible" in
                       let unary arg_tms2 =
-                        let uu____5221 = FStar_List.hd arg_tms2  in
-                        FStar_SMTEncoding_Term.unboxBitVec sz uu____5221  in
+                        let uu____5221 = FStar_List.hd arg_tms2 in
+                        FStar_SMTEncoding_Term.unboxBitVec sz uu____5221 in
                       let unary_arith arg_tms2 =
-                        let uu____5230 = FStar_List.hd arg_tms2  in
-                        FStar_SMTEncoding_Term.unboxInt uu____5230  in
+                        let uu____5230 = FStar_List.hd arg_tms2 in
+                        FStar_SMTEncoding_Term.unboxInt uu____5230 in
                       let binary arg_tms2 =
                         let uu____5243 =
-                          let uu____5244 = FStar_List.hd arg_tms2  in
-                          FStar_SMTEncoding_Term.unboxBitVec sz uu____5244
-                           in
+                          let uu____5244 = FStar_List.hd arg_tms2 in
+                          FStar_SMTEncoding_Term.unboxBitVec sz uu____5244 in
                         let uu____5245 =
                           let uu____5246 =
-                            let uu____5247 = FStar_List.tl arg_tms2  in
-                            FStar_List.hd uu____5247  in
-                          FStar_SMTEncoding_Term.unboxBitVec sz uu____5246
-                           in
-                        (uu____5243, uu____5245)  in
+                            let uu____5247 = FStar_List.tl arg_tms2 in
+                            FStar_List.hd uu____5247 in
+                          FStar_SMTEncoding_Term.unboxBitVec sz uu____5246 in
+                        (uu____5243, uu____5245) in
                       let binary_arith arg_tms2 =
                         let uu____5262 =
-                          let uu____5263 = FStar_List.hd arg_tms2  in
-                          FStar_SMTEncoding_Term.unboxBitVec sz uu____5263
-                           in
+                          let uu____5263 = FStar_List.hd arg_tms2 in
+                          FStar_SMTEncoding_Term.unboxBitVec sz uu____5263 in
                         let uu____5264 =
                           let uu____5265 =
-                            let uu____5266 = FStar_List.tl arg_tms2  in
-                            FStar_List.hd uu____5266  in
-                          FStar_SMTEncoding_Term.unboxInt uu____5265  in
-                        (uu____5262, uu____5264)  in
+                            let uu____5266 = FStar_List.tl arg_tms2 in
+                            FStar_List.hd uu____5266 in
+                          FStar_SMTEncoding_Term.unboxInt uu____5265 in
+                        (uu____5262, uu____5264) in
                       let mk_bv a op mk_args resBox ts =
                         let uu____5308 =
-                          let uu____5309 = mk_args ts  in op uu____5309  in
-                        FStar_All.pipe_right uu____5308 resBox  in
+                          let uu____5309 = mk_args ts in op uu____5309 in
+                        FStar_All.pipe_right uu____5308 resBox in
                       let bv_and =
                         mk_bv ()
                           (fun a421  ->
                              (Obj.magic FStar_SMTEncoding_Util.mkBvAnd) a421)
                           (fun a422  -> (Obj.magic binary) a422)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_xor =
                         mk_bv ()
                           (fun a423  ->
                              (Obj.magic FStar_SMTEncoding_Util.mkBvXor) a423)
                           (fun a424  -> (Obj.magic binary) a424)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_or =
                         mk_bv ()
                           (fun a425  ->
                              (Obj.magic FStar_SMTEncoding_Util.mkBvOr) a425)
                           (fun a426  -> (Obj.magic binary) a426)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_add =
                         mk_bv ()
                           (fun a427  ->
                              (Obj.magic FStar_SMTEncoding_Util.mkBvAdd) a427)
                           (fun a428  -> (Obj.magic binary) a428)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_sub =
                         mk_bv ()
                           (fun a429  ->
                              (Obj.magic FStar_SMTEncoding_Util.mkBvSub) a429)
                           (fun a430  -> (Obj.magic binary) a430)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_shl =
                         mk_bv ()
                           (fun a431  ->
                              (Obj.magic (FStar_SMTEncoding_Util.mkBvShl sz))
                                a431)
                           (fun a432  -> (Obj.magic binary_arith) a432)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_shr =
                         mk_bv ()
                           (fun a433  ->
                              (Obj.magic (FStar_SMTEncoding_Util.mkBvShr sz))
                                a433)
                           (fun a434  -> (Obj.magic binary_arith) a434)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_udiv =
                         mk_bv ()
                           (fun a435  ->
                              (Obj.magic (FStar_SMTEncoding_Util.mkBvUdiv sz))
                                a435)
                           (fun a436  -> (Obj.magic binary_arith) a436)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_mod =
                         mk_bv ()
                           (fun a437  ->
                              (Obj.magic (FStar_SMTEncoding_Util.mkBvMod sz))
                                a437)
                           (fun a438  -> (Obj.magic binary_arith) a438)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_mul =
                         mk_bv ()
                           (fun a439  ->
                              (Obj.magic (FStar_SMTEncoding_Util.mkBvMul sz))
                                a439)
                           (fun a440  -> (Obj.magic binary_arith) a440)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let bv_ult =
                         mk_bv ()
                           (fun a441  ->
                              (Obj.magic FStar_SMTEncoding_Util.mkBvUlt) a441)
                           (fun a442  -> (Obj.magic binary) a442)
-                          FStar_SMTEncoding_Term.boxBool
-                         in
+                          FStar_SMTEncoding_Term.boxBool in
                       let bv_uext arg_tms2 =
                         let uu____5373 =
                           let uu____5376 =
                             match ext_sz with
                             | FStar_Pervasives_Native.Some x -> x
                             | FStar_Pervasives_Native.None  ->
-                                failwith "impossible"
-                             in
-                          FStar_SMTEncoding_Util.mkBvUext uu____5376  in
+                                failwith "impossible" in
+                          FStar_SMTEncoding_Util.mkBvUext uu____5376 in
                         let uu____5378 =
                           let uu____5381 =
                             let uu____5382 =
                               match ext_sz with
                               | FStar_Pervasives_Native.Some x -> x
                               | FStar_Pervasives_Native.None  ->
-                                  failwith "impossible"
-                               in
-                            sz + uu____5382  in
-                          FStar_SMTEncoding_Term.boxBitVec uu____5381  in
+                                  failwith "impossible" in
+                            sz + uu____5382 in
+                          FStar_SMTEncoding_Term.boxBitVec uu____5381 in
                         mk_bv () (fun a443  -> (Obj.magic uu____5373) a443)
                           (fun a444  -> (Obj.magic unary) a444) uu____5378
-                          arg_tms2
-                         in
+                          arg_tms2 in
                       let to_int1 =
                         mk_bv ()
                           (fun a445  ->
                              (Obj.magic FStar_SMTEncoding_Util.mkBvToNat)
                                a445) (fun a446  -> (Obj.magic unary) a446)
-                          FStar_SMTEncoding_Term.boxInt
-                         in
+                          FStar_SMTEncoding_Term.boxInt in
                       let bv_to =
                         mk_bv ()
                           (fun a447  ->
                              (Obj.magic (FStar_SMTEncoding_Util.mkNatToBv sz))
                                a447)
                           (fun a448  -> (Obj.magic unary_arith) a448)
-                          (FStar_SMTEncoding_Term.boxBitVec sz)
-                         in
+                          (FStar_SMTEncoding_Term.boxBitVec sz) in
                       let ops =
                         [(FStar_Parser_Const.bv_and_lid, bv_and);
                         (FStar_Parser_Const.bv_xor_lid, bv_xor);
@@ -1932,7 +1766,7 @@ and (encode_BitVector_term :
                         (FStar_Parser_Const.bv_ult_lid, bv_ult);
                         (FStar_Parser_Const.bv_uext_lid, bv_uext);
                         (FStar_Parser_Const.bv_to_nat_lid, to_int1);
-                        (FStar_Parser_Const.nat_to_bv_lid, bv_to)]  in
+                        (FStar_Parser_Const.nat_to_bv_lid, bv_to)] in
                       let uu____5581 =
                         let uu____5590 =
                           FStar_List.tryFind
@@ -1940,32 +1774,29 @@ and (encode_BitVector_term :
                                match uu____5612 with
                                | (l,uu____5622) ->
                                    FStar_Syntax_Syntax.fv_eq_lid head_fv l)
-                            ops
-                           in
-                        FStar_All.pipe_right uu____5590 FStar_Util.must  in
+                            ops in
+                        FStar_All.pipe_right uu____5590 FStar_Util.must in
                       (match uu____5581 with
                        | (uu____5663,op) ->
-                           let uu____5673 = op arg_tms1  in
+                           let uu____5673 = op arg_tms1 in
                            (uu____5673, (FStar_List.append sz_decls decls)))))
-
-and (encode_term :
+and encode_term:
   FStar_Syntax_Syntax.typ ->
     env_t ->
       (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     fun env  ->
-      let t0 = FStar_Syntax_Subst.compress t  in
+      let t0 = FStar_Syntax_Subst.compress t in
       (let uu____5684 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv)
-           (FStar_Options.Other "SMTEncoding")
-          in
+           (FStar_Options.Other "SMTEncoding") in
        if uu____5684
        then
-         let uu____5685 = FStar_Syntax_Print.tag_of_term t  in
-         let uu____5686 = FStar_Syntax_Print.tag_of_term t0  in
-         let uu____5687 = FStar_Syntax_Print.term_to_string t0  in
+         let uu____5685 = FStar_Syntax_Print.tag_of_term t in
+         let uu____5686 = FStar_Syntax_Print.tag_of_term t0 in
+         let uu____5687 = FStar_Syntax_Print.term_to_string t0 in
          FStar_Util.print3 "(%s) (%s)   %s\n" uu____5685 uu____5686
            uu____5687
        else ());
@@ -1974,40 +1805,35 @@ and (encode_term :
            let uu____5718 =
              let uu____5719 =
                FStar_All.pipe_left FStar_Range.string_of_range
-                 t.FStar_Syntax_Syntax.pos
-                in
-             let uu____5720 = FStar_Syntax_Print.tag_of_term t0  in
-             let uu____5721 = FStar_Syntax_Print.term_to_string t0  in
-             let uu____5722 = FStar_Syntax_Print.term_to_string t  in
+                 t.FStar_Syntax_Syntax.pos in
+             let uu____5720 = FStar_Syntax_Print.tag_of_term t0 in
+             let uu____5721 = FStar_Syntax_Print.term_to_string t0 in
+             let uu____5722 = FStar_Syntax_Print.term_to_string t in
              FStar_Util.format4 "(%s) Impossible: %s\n%s\n%s\n" uu____5719
-               uu____5720 uu____5721 uu____5722
-              in
+               uu____5720 uu____5721 uu____5722 in
            failwith uu____5718
        | FStar_Syntax_Syntax.Tm_unknown  ->
            let uu____5727 =
              let uu____5728 =
                FStar_All.pipe_left FStar_Range.string_of_range
-                 t.FStar_Syntax_Syntax.pos
-                in
-             let uu____5729 = FStar_Syntax_Print.tag_of_term t0  in
-             let uu____5730 = FStar_Syntax_Print.term_to_string t0  in
-             let uu____5731 = FStar_Syntax_Print.term_to_string t  in
+                 t.FStar_Syntax_Syntax.pos in
+             let uu____5729 = FStar_Syntax_Print.tag_of_term t0 in
+             let uu____5730 = FStar_Syntax_Print.term_to_string t0 in
+             let uu____5731 = FStar_Syntax_Print.term_to_string t in
              FStar_Util.format4 "(%s) Impossible: %s\n%s\n%s\n" uu____5728
-               uu____5729 uu____5730 uu____5731
-              in
+               uu____5729 uu____5730 uu____5731 in
            failwith uu____5727
        | FStar_Syntax_Syntax.Tm_bvar x ->
            let uu____5737 =
-             let uu____5738 = FStar_Syntax_Print.bv_to_string x  in
+             let uu____5738 = FStar_Syntax_Print.bv_to_string x in
              FStar_Util.format1 "Impossible: locally nameless; got %s"
-               uu____5738
-              in
+               uu____5738 in
            failwith uu____5737
        | FStar_Syntax_Syntax.Tm_ascribed (t1,(k,uu____5745),uu____5746) ->
            let uu____5795 =
              match k with
              | FStar_Util.Inl t2 -> FStar_Syntax_Util.is_unit t2
-             | uu____5803 -> false  in
+             | uu____5803 -> false in
            if uu____5795
            then (FStar_SMTEncoding_Term.mk_Term_unit, [])
            else encode_term t1 env
@@ -2018,56 +1844,52 @@ and (encode_term :
             (obj,desc,ty))
            ->
            let tsym =
-             let uu____5837 = varops.fresh "t"  in
-             (uu____5837, FStar_SMTEncoding_Term.Term_sort)  in
-           let t1 = FStar_SMTEncoding_Util.mkFreeV tsym  in
+             let uu____5837 = varops.fresh "t" in
+             (uu____5837, FStar_SMTEncoding_Term.Term_sort) in
+           let t1 = FStar_SMTEncoding_Util.mkFreeV tsym in
            let decl =
              let uu____5840 =
                let uu____5851 =
-                 let uu____5854 = FStar_Util.format1 "alien term (%s)" desc
-                    in
-                 FStar_Pervasives_Native.Some uu____5854  in
+                 let uu____5854 = FStar_Util.format1 "alien term (%s)" desc in
+                 FStar_Pervasives_Native.Some uu____5854 in
                ((FStar_Pervasives_Native.fst tsym), [],
-                 FStar_SMTEncoding_Term.Term_sort, uu____5851)
-                in
-             FStar_SMTEncoding_Term.DeclFun uu____5840  in
+                 FStar_SMTEncoding_Term.Term_sort, uu____5851) in
+             FStar_SMTEncoding_Term.DeclFun uu____5840 in
            (t1, [decl])
        | FStar_Syntax_Syntax.Tm_meta (t1,uu____5862) -> encode_term t1 env
        | FStar_Syntax_Syntax.Tm_name x ->
-           let t1 = lookup_term_var env x  in (t1, [])
+           let t1 = lookup_term_var env x in (t1, [])
        | FStar_Syntax_Syntax.Tm_fvar v1 ->
            let uu____5872 =
-             lookup_free_var env v1.FStar_Syntax_Syntax.fv_name  in
+             lookup_free_var env v1.FStar_Syntax_Syntax.fv_name in
            (uu____5872, [])
        | FStar_Syntax_Syntax.Tm_type uu____5875 ->
            (FStar_SMTEncoding_Term.mk_Term_type, [])
        | FStar_Syntax_Syntax.Tm_uinst (t1,uu____5879) -> encode_term t1 env
        | FStar_Syntax_Syntax.Tm_constant c -> encode_const c env
        | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
-           let module_name = env.current_module_name  in
-           let uu____5904 = FStar_Syntax_Subst.open_comp binders c  in
+           let module_name = env.current_module_name in
+           let uu____5904 = FStar_Syntax_Subst.open_comp binders c in
            (match uu____5904 with
             | (binders1,res) ->
                 let uu____5915 =
                   (env.encode_non_total_function_typ &&
                      (FStar_Syntax_Util.is_pure_or_ghost_comp res))
-                    || (FStar_Syntax_Util.is_tot_or_gtot_comp res)
-                   in
+                    || (FStar_Syntax_Util.is_tot_or_gtot_comp res) in
                 if uu____5915
                 then
                   let uu____5920 =
-                    encode_binders FStar_Pervasives_Native.None binders1 env
-                     in
+                    encode_binders FStar_Pervasives_Native.None binders1 env in
                   (match uu____5920 with
                    | (vars,guards,env',decls,uu____5945) ->
                        let fsym =
-                         let uu____5963 = varops.fresh "f"  in
-                         (uu____5963, FStar_SMTEncoding_Term.Term_sort)  in
-                       let f = FStar_SMTEncoding_Util.mkFreeV fsym  in
-                       let app = mk_Apply f vars  in
+                         let uu____5963 = varops.fresh "f" in
+                         (uu____5963, FStar_SMTEncoding_Term.Term_sort) in
+                       let f = FStar_SMTEncoding_Util.mkFreeV fsym in
+                       let app = mk_Apply f vars in
                        let uu____5966 =
                          FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
-                           (let uu___111_5975 = env.tcenv  in
+                           (let uu___111_5975 = env.tcenv in
                             {
                               FStar_TypeChecker_Env.solver =
                                 (uu___111_5975.FStar_TypeChecker_Env.solver);
@@ -2138,14 +1960,12 @@ and (encode_term :
                                 (uu___111_5975.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.dep_graph =
                                 (uu___111_5975.FStar_TypeChecker_Env.dep_graph)
-                            }) res
-                          in
+                            }) res in
                        (match uu____5966 with
                         | (pre_opt,res_t) ->
                             let uu____5986 =
                               encode_term_pred FStar_Pervasives_Native.None
-                                res_t env' app
-                               in
+                                res_t env' app in
                             (match uu____5986 with
                              | (res_pred,decls') ->
                                  let uu____5997 =
@@ -2153,37 +1973,31 @@ and (encode_term :
                                    | FStar_Pervasives_Native.None  ->
                                        let uu____6010 =
                                          FStar_SMTEncoding_Util.mk_and_l
-                                           guards
-                                          in
+                                           guards in
                                        (uu____6010, [])
                                    | FStar_Pervasives_Native.Some pre ->
                                        let uu____6014 =
-                                         encode_formula pre env'  in
+                                         encode_formula pre env' in
                                        (match uu____6014 with
                                         | (guard,decls0) ->
                                             let uu____6027 =
                                               FStar_SMTEncoding_Util.mk_and_l
-                                                (guard :: guards)
-                                               in
-                                            (uu____6027, decls0))
-                                    in
+                                                (guard :: guards) in
+                                            (uu____6027, decls0)) in
                                  (match uu____5997 with
                                   | (guards1,guard_decls) ->
                                       let t_interp =
                                         let uu____6039 =
                                           let uu____6050 =
                                             FStar_SMTEncoding_Util.mkImp
-                                              (guards1, res_pred)
-                                             in
-                                          ([[app]], vars, uu____6050)  in
+                                              (guards1, res_pred) in
+                                          ([[app]], vars, uu____6050) in
                                         FStar_SMTEncoding_Util.mkForall
-                                          uu____6039
-                                         in
+                                          uu____6039 in
                                       let cvars =
                                         let uu____6068 =
                                           FStar_SMTEncoding_Term.free_variables
-                                            t_interp
-                                           in
+                                            t_interp in
                                         FStar_All.pipe_right uu____6068
                                           (FStar_List.filter
                                              (fun uu____6082  ->
@@ -2191,20 +2005,16 @@ and (encode_term :
                                                 | (x,uu____6088) ->
                                                     x <>
                                                       (FStar_Pervasives_Native.fst
-                                                         fsym)))
-                                         in
+                                                         fsym))) in
                                       let tkey =
                                         FStar_SMTEncoding_Util.mkForall
-                                          ([], (fsym :: cvars), t_interp)
-                                         in
+                                          ([], (fsym :: cvars), t_interp) in
                                       let tkey_hash =
                                         FStar_SMTEncoding_Term.hash_of_term
-                                          tkey
-                                         in
+                                          tkey in
                                       let uu____6107 =
                                         FStar_Util.smap_try_find env.cache
-                                          tkey_hash
-                                         in
+                                          tkey_hash in
                                       (match uu____6107 with
                                        | FStar_Pervasives_Native.Some
                                            cache_entry ->
@@ -2213,14 +2023,11 @@ and (encode_term :
                                                let uu____6123 =
                                                  FStar_All.pipe_right cvars
                                                    (FStar_List.map
-                                                      FStar_SMTEncoding_Util.mkFreeV)
-                                                  in
+                                                      FStar_SMTEncoding_Util.mkFreeV) in
                                                ((cache_entry.cache_symbol_name),
-                                                 uu____6123)
-                                                in
+                                                 uu____6123) in
                                              FStar_SMTEncoding_Util.mkApp
-                                               uu____6116
-                                              in
+                                               uu____6116 in
                                            (uu____6115,
                                              (FStar_List.append decls
                                                 (FStar_List.append decls'
@@ -2233,84 +2040,67 @@ and (encode_term :
                                              let uu____6143 =
                                                let uu____6144 =
                                                  FStar_Util.digest_of_string
-                                                   tkey_hash
-                                                  in
+                                                   tkey_hash in
                                                Prims.strcat "Tm_arrow_"
-                                                 uu____6144
-                                                in
-                                             varops.mk_unique uu____6143  in
+                                                 uu____6144 in
+                                             varops.mk_unique uu____6143 in
                                            let cvar_sorts =
                                              FStar_List.map
                                                FStar_Pervasives_Native.snd
-                                               cvars
-                                              in
+                                               cvars in
                                            let caption =
                                              let uu____6155 =
-                                               FStar_Options.log_queries ()
-                                                in
+                                               FStar_Options.log_queries () in
                                              if uu____6155
                                              then
                                                let uu____6158 =
                                                  FStar_TypeChecker_Normalize.term_to_string
-                                                   env.tcenv t0
-                                                  in
+                                                   env.tcenv t0 in
                                                FStar_Pervasives_Native.Some
                                                  uu____6158
                                              else
-                                               FStar_Pervasives_Native.None
-                                              in
+                                               FStar_Pervasives_Native.None in
                                            let tdecl =
                                              FStar_SMTEncoding_Term.DeclFun
                                                (tsym, cvar_sorts,
                                                  FStar_SMTEncoding_Term.Term_sort,
-                                                 caption)
-                                              in
+                                                 caption) in
                                            let t1 =
                                              let uu____6166 =
                                                let uu____6173 =
                                                  FStar_List.map
                                                    FStar_SMTEncoding_Util.mkFreeV
-                                                   cvars
-                                                  in
-                                               (tsym, uu____6173)  in
+                                                   cvars in
+                                               (tsym, uu____6173) in
                                              FStar_SMTEncoding_Util.mkApp
-                                               uu____6166
-                                              in
+                                               uu____6166 in
                                            let t_has_kind =
                                              FStar_SMTEncoding_Term.mk_HasType
                                                t1
-                                               FStar_SMTEncoding_Term.mk_Term_type
-                                              in
+                                               FStar_SMTEncoding_Term.mk_Term_type in
                                            let k_assumption =
                                              let a_name =
-                                               Prims.strcat "kinding_" tsym
-                                                in
+                                               Prims.strcat "kinding_" tsym in
                                              let uu____6185 =
                                                let uu____6192 =
                                                  FStar_SMTEncoding_Util.mkForall
                                                    ([[t_has_kind]], cvars,
-                                                     t_has_kind)
-                                                  in
+                                                     t_has_kind) in
                                                (uu____6192,
                                                  (FStar_Pervasives_Native.Some
-                                                    a_name), a_name)
-                                                in
+                                                    a_name), a_name) in
                                              FStar_SMTEncoding_Util.mkAssume
-                                               uu____6185
-                                              in
+                                               uu____6185 in
                                            let f_has_t =
                                              FStar_SMTEncoding_Term.mk_HasType
-                                               f t1
-                                              in
+                                               f t1 in
                                            let f_has_t_z =
                                              FStar_SMTEncoding_Term.mk_HasTypeZ
-                                               f t1
-                                              in
+                                               f t1 in
                                            let pre_typing =
                                              let a_name =
                                                Prims.strcat "pre_typing_"
-                                                 tsym
-                                                in
+                                                 tsym in
                                              let uu____6213 =
                                                let uu____6220 =
                                                  let uu____6221 =
@@ -2319,57 +2109,44 @@ and (encode_term :
                                                        let uu____6238 =
                                                          let uu____6239 =
                                                            FStar_SMTEncoding_Term.mk_PreType
-                                                             f
-                                                            in
+                                                             f in
                                                          FStar_SMTEncoding_Term.mk_tester
                                                            "Tm_arrow"
-                                                           uu____6239
-                                                          in
-                                                       (f_has_t, uu____6238)
-                                                        in
+                                                           uu____6239 in
+                                                       (f_has_t, uu____6238) in
                                                      FStar_SMTEncoding_Util.mkImp
-                                                       uu____6233
-                                                      in
+                                                       uu____6233 in
                                                    ([[f_has_t]], (fsym ::
-                                                     cvars), uu____6232)
-                                                    in
-                                                 mkForall_fuel uu____6221  in
+                                                     cvars), uu____6232) in
+                                                 mkForall_fuel uu____6221 in
                                                (uu____6220,
                                                  (FStar_Pervasives_Native.Some
                                                     "pre-typing for functions"),
                                                  (Prims.strcat module_name
-                                                    (Prims.strcat "_" a_name)))
-                                                in
+                                                    (Prims.strcat "_" a_name))) in
                                              FStar_SMTEncoding_Util.mkAssume
-                                               uu____6213
-                                              in
+                                               uu____6213 in
                                            let t_interp1 =
                                              let a_name =
                                                Prims.strcat "interpretation_"
-                                                 tsym
-                                                in
+                                                 tsym in
                                              let uu____6262 =
                                                let uu____6269 =
                                                  let uu____6270 =
                                                    let uu____6281 =
                                                      FStar_SMTEncoding_Util.mkIff
-                                                       (f_has_t_z, t_interp)
-                                                      in
+                                                       (f_has_t_z, t_interp) in
                                                    ([[f_has_t_z]], (fsym ::
-                                                     cvars), uu____6281)
-                                                    in
+                                                     cvars), uu____6281) in
                                                  FStar_SMTEncoding_Util.mkForall
-                                                   uu____6270
-                                                  in
+                                                   uu____6270 in
                                                (uu____6269,
                                                  (FStar_Pervasives_Native.Some
                                                     a_name),
                                                  (Prims.strcat module_name
-                                                    (Prims.strcat "_" a_name)))
-                                                in
+                                                    (Prims.strcat "_" a_name))) in
                                              FStar_SMTEncoding_Util.mkAssume
-                                               uu____6262
-                                              in
+                                               uu____6262 in
                                            let t_decls =
                                              FStar_List.append (tdecl ::
                                                decls)
@@ -2378,42 +2155,37 @@ and (encode_term :
                                                      guard_decls
                                                      [k_assumption;
                                                      pre_typing;
-                                                     t_interp1]))
-                                              in
+                                                     t_interp1])) in
                                            ((let uu____6306 =
                                                mk_cache_entry env tsym
-                                                 cvar_sorts t_decls
-                                                in
+                                                 cvar_sorts t_decls in
                                              FStar_Util.smap_add env.cache
                                                tkey_hash uu____6306);
                                             (t1, t_decls)))))))
                 else
-                  (let tsym = varops.fresh "Non_total_Tm_arrow"  in
+                  (let tsym = varops.fresh "Non_total_Tm_arrow" in
                    let tdecl =
                      FStar_SMTEncoding_Term.DeclFun
                        (tsym, [], FStar_SMTEncoding_Term.Term_sort,
-                         FStar_Pervasives_Native.None)
-                      in
-                   let t1 = FStar_SMTEncoding_Util.mkApp (tsym, [])  in
+                         FStar_Pervasives_Native.None) in
+                   let t1 = FStar_SMTEncoding_Util.mkApp (tsym, []) in
                    let t_kinding =
                      let a_name =
-                       Prims.strcat "non_total_function_typing_" tsym  in
+                       Prims.strcat "non_total_function_typing_" tsym in
                      let uu____6321 =
                        let uu____6328 =
                          FStar_SMTEncoding_Term.mk_HasType t1
-                           FStar_SMTEncoding_Term.mk_Term_type
-                          in
+                           FStar_SMTEncoding_Term.mk_Term_type in
                        (uu____6328,
                          (FStar_Pervasives_Native.Some
                             "Typing for non-total arrows"),
-                         (Prims.strcat module_name (Prims.strcat "_" a_name)))
-                        in
-                     FStar_SMTEncoding_Util.mkAssume uu____6321  in
-                   let fsym = ("f", FStar_SMTEncoding_Term.Term_sort)  in
-                   let f = FStar_SMTEncoding_Util.mkFreeV fsym  in
-                   let f_has_t = FStar_SMTEncoding_Term.mk_HasType f t1  in
+                         (Prims.strcat module_name (Prims.strcat "_" a_name))) in
+                     FStar_SMTEncoding_Util.mkAssume uu____6321 in
+                   let fsym = ("f", FStar_SMTEncoding_Term.Term_sort) in
+                   let f = FStar_SMTEncoding_Util.mkFreeV fsym in
+                   let f_has_t = FStar_SMTEncoding_Term.mk_HasType f t1 in
                    let t_interp =
-                     let a_name = Prims.strcat "pre_typing_" tsym  in
+                     let a_name = Prims.strcat "pre_typing_" tsym in
                      let uu____6340 =
                        let uu____6347 =
                          let uu____6348 =
@@ -2421,18 +2193,16 @@ and (encode_term :
                              let uu____6360 =
                                let uu____6365 =
                                  let uu____6366 =
-                                   FStar_SMTEncoding_Term.mk_PreType f  in
+                                   FStar_SMTEncoding_Term.mk_PreType f in
                                  FStar_SMTEncoding_Term.mk_tester "Tm_arrow"
-                                   uu____6366
-                                  in
-                               (f_has_t, uu____6365)  in
-                             FStar_SMTEncoding_Util.mkImp uu____6360  in
-                           ([[f_has_t]], [fsym], uu____6359)  in
-                         mkForall_fuel uu____6348  in
+                                   uu____6366 in
+                               (f_has_t, uu____6365) in
+                             FStar_SMTEncoding_Util.mkImp uu____6360 in
+                           ([[f_has_t]], [fsym], uu____6359) in
+                         mkForall_fuel uu____6348 in
                        (uu____6347, (FStar_Pervasives_Native.Some a_name),
-                         (Prims.strcat module_name (Prims.strcat "_" a_name)))
-                        in
-                     FStar_SMTEncoding_Util.mkAssume uu____6340  in
+                         (Prims.strcat module_name (Prims.strcat "_" a_name))) in
+                     FStar_SMTEncoding_Util.mkAssume uu____6340 in
                    (t1, [tdecl; t_kinding; t_interp])))
        | FStar_Syntax_Syntax.Tm_refine uu____6393 ->
            let uu____6400 =
@@ -2440,95 +2210,79 @@ and (encode_term :
                FStar_TypeChecker_Normalize.normalize_refinement
                  [FStar_TypeChecker_Normalize.Weak;
                  FStar_TypeChecker_Normalize.HNF;
-                 FStar_TypeChecker_Normalize.EraseUniverses] env.tcenv t0
-                in
+                 FStar_TypeChecker_Normalize.EraseUniverses] env.tcenv t0 in
              match uu____6405 with
              | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine (x,f);
                  FStar_Syntax_Syntax.pos = uu____6412;
                  FStar_Syntax_Syntax.vars = uu____6413;_} ->
                  let uu____6420 =
                    FStar_Syntax_Subst.open_term
-                     [(x, FStar_Pervasives_Native.None)] f
-                    in
+                     [(x, FStar_Pervasives_Native.None)] f in
                  (match uu____6420 with
                   | (b,f1) ->
                       let uu____6445 =
-                        let uu____6446 = FStar_List.hd b  in
-                        FStar_Pervasives_Native.fst uu____6446  in
+                        let uu____6446 = FStar_List.hd b in
+                        FStar_Pervasives_Native.fst uu____6446 in
                       (uu____6445, f1))
-             | uu____6455 -> failwith "impossible"  in
+             | uu____6455 -> failwith "impossible" in
            (match uu____6400 with
             | (x,f) ->
-                let uu____6466 = encode_term x.FStar_Syntax_Syntax.sort env
-                   in
+                let uu____6466 = encode_term x.FStar_Syntax_Syntax.sort env in
                 (match uu____6466 with
                  | (base_t,decls) ->
-                     let uu____6477 = gen_term_var env x  in
+                     let uu____6477 = gen_term_var env x in
                      (match uu____6477 with
                       | (x1,xtm,env') ->
-                          let uu____6491 = encode_formula f env'  in
+                          let uu____6491 = encode_formula f env' in
                           (match uu____6491 with
                            | (refinement,decls') ->
                                let uu____6502 =
                                  fresh_fvar "f"
-                                   FStar_SMTEncoding_Term.Fuel_sort
-                                  in
+                                   FStar_SMTEncoding_Term.Fuel_sort in
                                (match uu____6502 with
                                 | (fsym,fterm) ->
                                     let tm_has_type_with_fuel =
                                       FStar_SMTEncoding_Term.mk_HasTypeWithFuel
                                         (FStar_Pervasives_Native.Some fterm)
-                                        xtm base_t
-                                       in
+                                        xtm base_t in
                                     let encoding =
                                       FStar_SMTEncoding_Util.mkAnd
-                                        (tm_has_type_with_fuel, refinement)
-                                       in
+                                        (tm_has_type_with_fuel, refinement) in
                                     let cvars =
                                       let uu____6518 =
                                         let uu____6521 =
                                           FStar_SMTEncoding_Term.free_variables
-                                            refinement
-                                           in
+                                            refinement in
                                         let uu____6528 =
                                           FStar_SMTEncoding_Term.free_variables
-                                            tm_has_type_with_fuel
-                                           in
+                                            tm_has_type_with_fuel in
                                         FStar_List.append uu____6521
-                                          uu____6528
-                                         in
+                                          uu____6528 in
                                       FStar_Util.remove_dups
                                         FStar_SMTEncoding_Term.fv_eq
-                                        uu____6518
-                                       in
+                                        uu____6518 in
                                     let cvars1 =
                                       FStar_All.pipe_right cvars
                                         (FStar_List.filter
                                            (fun uu____6561  ->
                                               match uu____6561 with
                                               | (y,uu____6567) ->
-                                                  (y <> x1) && (y <> fsym)))
-                                       in
+                                                  (y <> x1) && (y <> fsym))) in
                                     let xfv =
-                                      (x1, FStar_SMTEncoding_Term.Term_sort)
-                                       in
+                                      (x1, FStar_SMTEncoding_Term.Term_sort) in
                                     let ffv =
                                       (fsym,
-                                        FStar_SMTEncoding_Term.Fuel_sort)
-                                       in
+                                        FStar_SMTEncoding_Term.Fuel_sort) in
                                     let tkey =
                                       FStar_SMTEncoding_Util.mkForall
                                         ([], (ffv :: xfv :: cvars1),
-                                          encoding)
-                                       in
+                                          encoding) in
                                     let tkey_hash =
                                       FStar_SMTEncoding_Term.hash_of_term
-                                        tkey
-                                       in
+                                        tkey in
                                     let uu____6600 =
                                       FStar_Util.smap_try_find env.cache
-                                        tkey_hash
-                                       in
+                                        tkey_hash in
                                     (match uu____6600 with
                                      | FStar_Pervasives_Native.Some
                                          cache_entry ->
@@ -2537,78 +2291,63 @@ and (encode_term :
                                              let uu____6616 =
                                                FStar_All.pipe_right cvars1
                                                  (FStar_List.map
-                                                    FStar_SMTEncoding_Util.mkFreeV)
-                                                in
+                                                    FStar_SMTEncoding_Util.mkFreeV) in
                                              ((cache_entry.cache_symbol_name),
-                                               uu____6616)
-                                              in
+                                               uu____6616) in
                                            FStar_SMTEncoding_Util.mkApp
-                                             uu____6609
-                                            in
+                                             uu____6609 in
                                          (uu____6608,
                                            (FStar_List.append decls
                                               (FStar_List.append decls'
                                                  (use_cache_entry cache_entry))))
                                      | FStar_Pervasives_Native.None  ->
                                          let module_name =
-                                           env.current_module_name  in
+                                           env.current_module_name in
                                          let tsym =
                                            let uu____6637 =
                                              let uu____6638 =
                                                let uu____6639 =
                                                  FStar_Util.digest_of_string
-                                                   tkey_hash
-                                                  in
+                                                   tkey_hash in
                                                Prims.strcat "_Tm_refine_"
-                                                 uu____6639
-                                                in
+                                                 uu____6639 in
                                              Prims.strcat module_name
-                                               uu____6638
-                                              in
-                                           varops.mk_unique uu____6637  in
+                                               uu____6638 in
+                                           varops.mk_unique uu____6637 in
                                          let cvar_sorts =
                                            FStar_List.map
                                              FStar_Pervasives_Native.snd
-                                             cvars1
-                                            in
+                                             cvars1 in
                                          let tdecl =
                                            FStar_SMTEncoding_Term.DeclFun
                                              (tsym, cvar_sorts,
                                                FStar_SMTEncoding_Term.Term_sort,
-                                               FStar_Pervasives_Native.None)
-                                            in
+                                               FStar_Pervasives_Native.None) in
                                          let t1 =
                                            let uu____6653 =
                                              let uu____6660 =
                                                FStar_List.map
                                                  FStar_SMTEncoding_Util.mkFreeV
-                                                 cvars1
-                                                in
-                                             (tsym, uu____6660)  in
+                                                 cvars1 in
+                                             (tsym, uu____6660) in
                                            FStar_SMTEncoding_Util.mkApp
-                                             uu____6653
-                                            in
+                                             uu____6653 in
                                          let x_has_base_t =
                                            FStar_SMTEncoding_Term.mk_HasType
-                                             xtm base_t
-                                            in
+                                             xtm base_t in
                                          let x_has_t =
                                            FStar_SMTEncoding_Term.mk_HasTypeWithFuel
                                              (FStar_Pervasives_Native.Some
-                                                fterm) xtm t1
-                                            in
+                                                fterm) xtm t1 in
                                          let t_has_kind =
                                            FStar_SMTEncoding_Term.mk_HasType
                                              t1
-                                             FStar_SMTEncoding_Term.mk_Term_type
-                                            in
+                                             FStar_SMTEncoding_Term.mk_Term_type in
                                          let t_haseq_base =
                                            FStar_SMTEncoding_Term.mk_haseq
-                                             base_t
-                                            in
+                                             base_t in
                                          let t_haseq_ref =
-                                           FStar_SMTEncoding_Term.mk_haseq t1
-                                            in
+                                           FStar_SMTEncoding_Term.mk_haseq t1 in
                                          let t_haseq1 =
                                            let uu____6675 =
                                              let uu____6682 =
@@ -2616,90 +2355,73 @@ and (encode_term :
                                                  let uu____6694 =
                                                    FStar_SMTEncoding_Util.mkIff
                                                      (t_haseq_ref,
-                                                       t_haseq_base)
-                                                    in
+                                                       t_haseq_base) in
                                                  ([[t_haseq_ref]], cvars1,
-                                                   uu____6694)
-                                                  in
+                                                   uu____6694) in
                                                FStar_SMTEncoding_Util.mkForall
-                                                 uu____6683
-                                                in
+                                                 uu____6683 in
                                              (uu____6682,
                                                (FStar_Pervasives_Native.Some
                                                   (Prims.strcat "haseq for "
                                                      tsym)),
-                                               (Prims.strcat "haseq" tsym))
-                                              in
+                                               (Prims.strcat "haseq" tsym)) in
                                            FStar_SMTEncoding_Util.mkAssume
-                                             uu____6675
-                                            in
+                                             uu____6675 in
                                          let t_kinding =
                                            let uu____6712 =
                                              let uu____6719 =
                                                FStar_SMTEncoding_Util.mkForall
                                                  ([[t_has_kind]], cvars1,
-                                                   t_has_kind)
-                                                in
+                                                   t_has_kind) in
                                              (uu____6719,
                                                (FStar_Pervasives_Native.Some
                                                   "refinement kinding"),
                                                (Prims.strcat
-                                                  "refinement_kinding_" tsym))
-                                              in
+                                                  "refinement_kinding_" tsym)) in
                                            FStar_SMTEncoding_Util.mkAssume
-                                             uu____6712
-                                            in
+                                             uu____6712 in
                                          let t_interp =
                                            let uu____6737 =
                                              let uu____6744 =
                                                let uu____6745 =
                                                  let uu____6756 =
                                                    FStar_SMTEncoding_Util.mkIff
-                                                     (x_has_t, encoding)
-                                                    in
+                                                     (x_has_t, encoding) in
                                                  ([[x_has_t]], (ffv :: xfv ::
-                                                   cvars1), uu____6756)
-                                                  in
+                                                   cvars1), uu____6756) in
                                                FStar_SMTEncoding_Util.mkForall
-                                                 uu____6745
-                                                in
+                                                 uu____6745 in
                                              let uu____6779 =
                                                let uu____6782 =
                                                  FStar_Syntax_Print.term_to_string
-                                                   t0
-                                                  in
+                                                   t0 in
                                                FStar_Pervasives_Native.Some
-                                                 uu____6782
-                                                in
+                                                 uu____6782 in
                                              (uu____6744, uu____6779,
                                                (Prims.strcat
                                                   "refinement_interpretation_"
-                                                  tsym))
-                                              in
+                                                  tsym)) in
                                            FStar_SMTEncoding_Util.mkAssume
-                                             uu____6737
-                                            in
+                                             uu____6737 in
                                          let t_decls =
                                            FStar_List.append decls
                                              (FStar_List.append decls'
                                                 [tdecl;
                                                 t_kinding;
                                                 t_interp;
-                                                t_haseq1])
-                                            in
+                                                t_haseq1]) in
                                          ((let uu____6789 =
                                              mk_cache_entry env tsym
-                                               cvar_sorts t_decls
-                                              in
+                                               cvar_sorts t_decls in
                                            FStar_Util.smap_add env.cache
                                              tkey_hash uu____6789);
                                           (t1, t_decls))))))))
        | FStar_Syntax_Syntax.Tm_uvar (uv,k) ->
            let ttm =
-             let uu____6819 = FStar_Syntax_Unionfind.uvar_id uv  in
-             FStar_SMTEncoding_Util.mk_Term_uvar uu____6819  in
+             let uu____6819 = FStar_Syntax_Unionfind.uvar_id uv in
+             FStar_SMTEncoding_Util.mk_Term_uvar uu____6819 in
            let uu____6820 =
-             encode_term_pred FStar_Pervasives_Native.None k env ttm  in
+             encode_term_pred FStar_Pervasives_Native.None k env ttm in
            (match uu____6820 with
             | (t_has_k,decls) ->
                 let d =
@@ -2707,30 +2429,27 @@ and (encode_term :
                     let uu____6839 =
                       let uu____6840 =
                         let uu____6841 =
-                          let uu____6842 = FStar_Syntax_Unionfind.uvar_id uv
-                             in
+                          let uu____6842 = FStar_Syntax_Unionfind.uvar_id uv in
                           FStar_All.pipe_left FStar_Util.string_of_int
-                            uu____6842
-                           in
-                        FStar_Util.format1 "uvar_typing_%s" uu____6841  in
-                      varops.mk_unique uu____6840  in
+                            uu____6842 in
+                        FStar_Util.format1 "uvar_typing_%s" uu____6841 in
+                      varops.mk_unique uu____6840 in
                     (t_has_k, (FStar_Pervasives_Native.Some "Uvar typing"),
-                      uu____6839)
-                     in
-                  FStar_SMTEncoding_Util.mkAssume uu____6832  in
+                      uu____6839) in
+                  FStar_SMTEncoding_Util.mkAssume uu____6832 in
                 (ttm, (FStar_List.append decls [d])))
        | FStar_Syntax_Syntax.Tm_app uu____6847 ->
-           let uu____6862 = FStar_Syntax_Util.head_and_args t0  in
+           let uu____6862 = FStar_Syntax_Util.head_and_args t0 in
            (match uu____6862 with
             | (head1,args_e) ->
                 let uu____6903 =
                   let uu____6916 =
-                    let uu____6917 = FStar_Syntax_Subst.compress head1  in
-                    uu____6917.FStar_Syntax_Syntax.n  in
-                  (uu____6916, args_e)  in
+                    let uu____6917 = FStar_Syntax_Subst.compress head1 in
+                    uu____6917.FStar_Syntax_Syntax.n in
+                  (uu____6916, args_e) in
                 (match uu____6903 with
                  | uu____6932 when head_redex env head1 ->
-                     let uu____6945 = whnf env t  in
+                     let uu____6945 = whnf env t in
                      encode_term uu____6945 env
                  | uu____6946 when is_arithmetic_primitive head1 args_e ->
                      encode_arith_term env head1 args_e
@@ -2745,15 +2464,14 @@ and (encode_term :
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.lexcons_lid
                      ->
-                     let uu____7037 = encode_term v1 env  in
+                     let uu____7037 = encode_term v1 env in
                      (match uu____7037 with
                       | (v11,decls1) ->
-                          let uu____7048 = encode_term v2 env  in
+                          let uu____7048 = encode_term v2 env in
                           (match uu____7048 with
                            | (v21,decls2) ->
                                let uu____7059 =
-                                 FStar_SMTEncoding_Util.mk_LexCons v11 v21
-                                  in
+                                 FStar_SMTEncoding_Util.mk_LexCons v11 v21 in
                                (uu____7059,
                                  (FStar_List.append decls1 decls2))))
                  | (FStar_Syntax_Syntax.Tm_fvar
@@ -2761,15 +2479,14 @@ and (encode_term :
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.lexcons_lid
                      ->
-                     let uu____7114 = encode_term v1 env  in
+                     let uu____7114 = encode_term v1 env in
                      (match uu____7114 with
                       | (v11,decls1) ->
-                          let uu____7125 = encode_term v2 env  in
+                          let uu____7125 = encode_term v2 env in
                           (match uu____7125 with
                            | (v21,decls2) ->
                                let uu____7136 =
-                                 FStar_SMTEncoding_Util.mk_LexCons v11 v21
-                                  in
+                                 FStar_SMTEncoding_Util.mk_LexCons v11 v21 in
                                (uu____7136,
                                  (FStar_List.append decls1 decls2))))
                  | (FStar_Syntax_Syntax.Tm_constant
@@ -2784,46 +2501,42 @@ and (encode_term :
                  | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify
                     ),uu____7203) ->
                      let e0 =
-                       let uu____7221 = FStar_List.hd args_e  in
+                       let uu____7221 = FStar_List.hd args_e in
                        FStar_TypeChecker_Util.reify_body_with_arg env.tcenv
-                         head1 uu____7221
-                        in
+                         head1 uu____7221 in
                      ((let uu____7229 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env.tcenv)
-                           (FStar_Options.Other "SMTEncodingReify")
-                          in
+                           (FStar_Options.Other "SMTEncodingReify") in
                        if uu____7229
                        then
                          let uu____7230 =
-                           FStar_Syntax_Print.term_to_string e0  in
+                           FStar_Syntax_Print.term_to_string e0 in
                          FStar_Util.print1 "Result of normalization %s\n"
                            uu____7230
                        else ());
                       (let e =
                          let uu____7235 =
                            let uu____7236 =
-                             FStar_TypeChecker_Util.remove_reify e0  in
-                           let uu____7237 = FStar_List.tl args_e  in
+                             FStar_TypeChecker_Util.remove_reify e0 in
+                           let uu____7237 = FStar_List.tl args_e in
                            FStar_Syntax_Syntax.mk_Tm_app uu____7236
-                             uu____7237
-                            in
+                             uu____7237 in
                          uu____7235 FStar_Pervasives_Native.None
-                           t0.FStar_Syntax_Syntax.pos
-                          in
+                           t0.FStar_Syntax_Syntax.pos in
                        encode_term e env))
                  | (FStar_Syntax_Syntax.Tm_constant
                     (FStar_Const.Const_reflect
                     uu____7246),(arg,uu____7248)::[]) -> encode_term arg env
                  | uu____7273 ->
-                     let uu____7286 = encode_args args_e env  in
+                     let uu____7286 = encode_args args_e env in
                      (match uu____7286 with
                       | (args,decls) ->
                           let encode_partial_app ht_opt =
-                            let uu____7341 = encode_term head1 env  in
+                            let uu____7341 = encode_term head1 env in
                             match uu____7341 with
                             | (head2,decls') ->
-                                let app_tm = mk_Apply_args head2 args  in
+                                let app_tm = mk_Apply_args head2 args in
                                 (match ht_opt with
                                  | FStar_Pervasives_Native.None  ->
                                      (app_tm,
@@ -2832,8 +2545,7 @@ and (encode_term :
                                      ->
                                      let uu____7405 =
                                        FStar_Util.first_N
-                                         (FStar_List.length args_e) formals
-                                        in
+                                         (FStar_List.length args_e) formals in
                                      (match uu____7405 with
                                       | (formals1,rest) ->
                                           let subst1 =
@@ -2847,77 +2559,62 @@ and (encode_term :
                                                       (a,uu____7508)) ->
                                                        FStar_Syntax_Syntax.NT
                                                          (bv, a)) formals1
-                                              args_e
-                                             in
+                                              args_e in
                                           let ty =
                                             let uu____7526 =
-                                              FStar_Syntax_Util.arrow rest c
-                                               in
+                                              FStar_Syntax_Util.arrow rest c in
                                             FStar_All.pipe_right uu____7526
                                               (FStar_Syntax_Subst.subst
-                                                 subst1)
-                                             in
+                                                 subst1) in
                                           let uu____7531 =
                                             encode_term_pred
                                               FStar_Pervasives_Native.None ty
-                                              env app_tm
-                                             in
+                                              env app_tm in
                                           (match uu____7531 with
                                            | (has_type,decls'') ->
                                                let cvars =
                                                  FStar_SMTEncoding_Term.free_variables
-                                                   has_type
-                                                  in
+                                                   has_type in
                                                let e_typing =
                                                  let uu____7546 =
                                                    let uu____7553 =
                                                      FStar_SMTEncoding_Util.mkForall
                                                        ([[has_type]], cvars,
-                                                         has_type)
-                                                      in
+                                                         has_type) in
                                                    let uu____7562 =
                                                      let uu____7563 =
                                                        let uu____7564 =
                                                          let uu____7565 =
                                                            FStar_SMTEncoding_Term.hash_of_term
-                                                             app_tm
-                                                            in
+                                                             app_tm in
                                                          FStar_Util.digest_of_string
-                                                           uu____7565
-                                                          in
+                                                           uu____7565 in
                                                        Prims.strcat
                                                          "partial_app_typing_"
-                                                         uu____7564
-                                                        in
+                                                         uu____7564 in
                                                      varops.mk_unique
-                                                       uu____7563
-                                                      in
+                                                       uu____7563 in
                                                    (uu____7553,
                                                      (FStar_Pervasives_Native.Some
                                                         "Partial app typing"),
-                                                     uu____7562)
-                                                    in
+                                                     uu____7562) in
                                                  FStar_SMTEncoding_Util.mkAssume
-                                                   uu____7546
-                                                  in
+                                                   uu____7546 in
                                                (app_tm,
                                                  (FStar_List.append decls
                                                     (FStar_List.append decls'
                                                        (FStar_List.append
-                                                          decls'' [e_typing])))))))
-                             in
+                                                          decls'' [e_typing]))))))) in
                           let encode_full_app fv =
-                            let uu____7582 = lookup_free_var_sym env fv  in
+                            let uu____7582 = lookup_free_var_sym env fv in
                             match uu____7582 with
                             | (fname,fuel_args) ->
                                 let tm =
                                   FStar_SMTEncoding_Util.mkApp'
                                     (fname,
-                                      (FStar_List.append fuel_args args))
-                                   in
-                                (tm, decls)
-                             in
-                          let head2 = FStar_Syntax_Subst.compress head1  in
+                                      (FStar_List.append fuel_args args)) in
+                                (tm, decls) in
+                          let head2 = FStar_Syntax_Subst.compress head1 in
                           let head_type =
                             match head2.FStar_Syntax_Syntax.n with
                             | FStar_Syntax_Syntax.Tm_uinst
@@ -2944,14 +2641,11 @@ and (encode_term :
                                     let uu____7639 =
                                       FStar_TypeChecker_Env.lookup_lid
                                         env.tcenv
-                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                       in
+                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                                     FStar_All.pipe_right uu____7639
-                                      FStar_Pervasives_Native.fst
-                                     in
+                                      FStar_Pervasives_Native.fst in
                                   FStar_All.pipe_right uu____7634
-                                    FStar_Pervasives_Native.snd
-                                   in
+                                    FStar_Pervasives_Native.snd in
                                 FStar_Pervasives_Native.Some uu____7633
                             | FStar_Syntax_Syntax.Tm_fvar fv ->
                                 let uu____7669 =
@@ -2959,14 +2653,11 @@ and (encode_term :
                                     let uu____7675 =
                                       FStar_TypeChecker_Env.lookup_lid
                                         env.tcenv
-                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                       in
+                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                                     FStar_All.pipe_right uu____7675
-                                      FStar_Pervasives_Native.fst
-                                     in
+                                      FStar_Pervasives_Native.fst in
                                   FStar_All.pipe_right uu____7670
-                                    FStar_Pervasives_Native.snd
-                                   in
+                                    FStar_Pervasives_Native.snd in
                                 FStar_Pervasives_Native.Some uu____7669
                             | FStar_Syntax_Syntax.Tm_ascribed
                                 (uu____7704,(FStar_Util.Inl t1,uu____7706),uu____7707)
@@ -2976,7 +2667,7 @@ and (encode_term :
                                 ->
                                 FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.comp_result c)
-                            | uu____7808 -> FStar_Pervasives_Native.None  in
+                            | uu____7808 -> FStar_Pervasives_Native.None in
                           (match head_type with
                            | FStar_Pervasives_Native.None  ->
                                encode_partial_app
@@ -2988,13 +2679,11 @@ and (encode_term :
                                      [FStar_TypeChecker_Normalize.Weak;
                                      FStar_TypeChecker_Normalize.HNF;
                                      FStar_TypeChecker_Normalize.EraseUniverses]
-                                     env.tcenv head_type1
-                                    in
+                                     env.tcenv head_type1 in
                                  FStar_All.pipe_left
-                                   FStar_Syntax_Util.unrefine uu____7835
-                                  in
+                                   FStar_Syntax_Util.unrefine uu____7835 in
                                let uu____7836 =
-                                 curried_arrow_formals_comp head_type2  in
+                                 curried_arrow_formals_comp head_type2 in
                                (match uu____7836 with
                                 | (formals,c) ->
                                     (match head2.FStar_Syntax_Syntax.n with
@@ -3030,28 +2719,25 @@ and (encode_term :
                                            encode_partial_app
                                              FStar_Pervasives_Native.None))))))
        | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-           let uu____7917 = FStar_Syntax_Subst.open_term' bs body  in
+           let uu____7917 = FStar_Syntax_Subst.open_term' bs body in
            (match uu____7917 with
             | (bs1,body1,opening) ->
                 let fallback uu____7940 =
-                  let f = varops.fresh "Tm_abs"  in
+                  let f = varops.fresh "Tm_abs" in
                   let decl =
                     FStar_SMTEncoding_Term.DeclFun
                       (f, [], FStar_SMTEncoding_Term.Term_sort,
                         (FStar_Pervasives_Native.Some
-                           "Imprecise function encoding"))
-                     in
+                           "Imprecise function encoding")) in
                   let uu____7947 =
                     FStar_SMTEncoding_Util.mkFreeV
-                      (f, FStar_SMTEncoding_Term.Term_sort)
-                     in
-                  (uu____7947, [decl])  in
+                      (f, FStar_SMTEncoding_Term.Term_sort) in
+                  (uu____7947, [decl]) in
                 let is_impure rc =
                   let uu____7954 =
                     FStar_TypeChecker_Util.is_pure_or_ghost_effect env.tcenv
-                      rc.FStar_Syntax_Syntax.residual_effect
-                     in
-                  FStar_All.pipe_right uu____7954 Prims.op_Negation  in
+                      rc.FStar_Syntax_Syntax.residual_effect in
+                  FStar_All.pipe_right uu____7954 Prims.op_Negation in
                 let codomain_eff rc =
                   let res_typ =
                     match rc.FStar_Syntax_Syntax.residual_typ with
@@ -3059,17 +2745,16 @@ and (encode_term :
                         let uu____7964 =
                           FStar_TypeChecker_Rel.new_uvar
                             FStar_Range.dummyRange []
-                            FStar_Syntax_Util.ktype0
-                           in
+                            FStar_Syntax_Util.ktype0 in
                         FStar_All.pipe_right uu____7964
                           FStar_Pervasives_Native.fst
-                    | FStar_Pervasives_Native.Some t1 -> t1  in
+                    | FStar_Pervasives_Native.Some t1 -> t1 in
                   if
                     FStar_Ident.lid_equals
                       rc.FStar_Syntax_Syntax.residual_effect
                       FStar_Parser_Const.effect_Tot_lid
                   then
-                    let uu____7984 = FStar_Syntax_Syntax.mk_Total res_typ  in
+                    let uu____7984 = FStar_Syntax_Syntax.mk_Total res_typ in
                     FStar_Pervasives_Native.Some uu____7984
                   else
                     if
@@ -3077,24 +2762,20 @@ and (encode_term :
                         rc.FStar_Syntax_Syntax.residual_effect
                         FStar_Parser_Const.effect_GTot_lid
                     then
-                      (let uu____7988 = FStar_Syntax_Syntax.mk_GTotal res_typ
-                          in
+                      (let uu____7988 = FStar_Syntax_Syntax.mk_GTotal res_typ in
                        FStar_Pervasives_Native.Some uu____7988)
-                    else FStar_Pervasives_Native.None
-                   in
+                    else FStar_Pervasives_Native.None in
                 (match lopt with
                  | FStar_Pervasives_Native.None  ->
                      ((let uu____7995 =
                          let uu____8000 =
                            let uu____8001 =
-                             FStar_Syntax_Print.term_to_string t0  in
+                             FStar_Syntax_Print.term_to_string t0 in
                            FStar_Util.format1
                              "Losing precision when encoding a function literal: %s\n(Unnannotated abstraction in the compiler ?)"
-                             uu____8001
-                            in
+                             uu____8001 in
                          (FStar_Errors.Warning_FunctionLiteralPrecisionLoss,
-                           uu____8000)
-                          in
+                           uu____8000) in
                        FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
                          uu____7995);
                       fallback ())
@@ -3102,47 +2783,41 @@ and (encode_term :
                      let uu____8003 =
                        (is_impure rc) &&
                          (let uu____8005 =
-                            FStar_TypeChecker_Env.is_reifiable env.tcenv rc
-                             in
-                          Prims.op_Negation uu____8005)
-                        in
+                            FStar_TypeChecker_Env.is_reifiable env.tcenv rc in
+                          Prims.op_Negation uu____8005) in
                      if uu____8003
                      then fallback ()
                      else
-                       (let cache_size = FStar_Util.smap_size env.cache  in
+                       (let cache_size = FStar_Util.smap_size env.cache in
                         let uu____8012 =
-                          encode_binders FStar_Pervasives_Native.None bs1 env
-                           in
+                          encode_binders FStar_Pervasives_Native.None bs1 env in
                         match uu____8012 with
                         | (vars,guards,envbody,decls,uu____8037) ->
                             let body2 =
                               let uu____8051 =
                                 FStar_TypeChecker_Env.is_reifiable env.tcenv
-                                  rc
-                                 in
+                                  rc in
                               if uu____8051
                               then
                                 FStar_TypeChecker_Util.reify_body env.tcenv
                                   body1
-                              else body1  in
-                            let uu____8053 = encode_term body2 envbody  in
+                              else body1 in
+                            let uu____8053 = encode_term body2 envbody in
                             (match uu____8053 with
                              | (body3,decls') ->
                                  let uu____8064 =
-                                   let uu____8073 = codomain_eff rc  in
+                                   let uu____8073 = codomain_eff rc in
                                    match uu____8073 with
                                    | FStar_Pervasives_Native.None  ->
                                        (FStar_Pervasives_Native.None, [])
                                    | FStar_Pervasives_Native.Some c ->
                                        let tfun =
-                                         FStar_Syntax_Util.arrow bs1 c  in
-                                       let uu____8092 = encode_term tfun env
-                                          in
+                                         FStar_Syntax_Util.arrow bs1 c in
+                                       let uu____8092 = encode_term tfun env in
                                        (match uu____8092 with
                                         | (t1,decls1) ->
                                             ((FStar_Pervasives_Native.Some t1),
-                                              decls1))
-                                    in
+                                              decls1)) in
                                  (match uu____8064 with
                                   | (arrow_t_opt,decls'') ->
                                       let key_body =
@@ -3151,20 +2826,16 @@ and (encode_term :
                                             let uu____8136 =
                                               let uu____8141 =
                                                 FStar_SMTEncoding_Util.mk_and_l
-                                                  guards
-                                                 in
-                                              (uu____8141, body3)  in
+                                                  guards in
+                                              (uu____8141, body3) in
                                             FStar_SMTEncoding_Util.mkImp
-                                              uu____8136
-                                             in
-                                          ([], vars, uu____8135)  in
+                                              uu____8136 in
+                                          ([], vars, uu____8135) in
                                         FStar_SMTEncoding_Util.mkForall
-                                          uu____8124
-                                         in
+                                          uu____8124 in
                                       let cvars =
                                         FStar_SMTEncoding_Term.free_variables
-                                          key_body
-                                         in
+                                          key_body in
                                       let cvars1 =
                                         match arrow_t_opt with
                                         | FStar_Pervasives_Native.None  ->
@@ -3173,27 +2844,21 @@ and (encode_term :
                                             let uu____8153 =
                                               let uu____8156 =
                                                 FStar_SMTEncoding_Term.free_variables
-                                                  t1
-                                                 in
+                                                  t1 in
                                               FStar_List.append uu____8156
-                                                cvars
-                                               in
+                                                cvars in
                                             FStar_Util.remove_dups
                                               FStar_SMTEncoding_Term.fv_eq
-                                              uu____8153
-                                         in
+                                              uu____8153 in
                                       let tkey =
                                         FStar_SMTEncoding_Util.mkForall
-                                          ([], cvars1, key_body)
-                                         in
+                                          ([], cvars1, key_body) in
                                       let tkey_hash =
                                         FStar_SMTEncoding_Term.hash_of_term
-                                          tkey
-                                         in
+                                          tkey in
                                       let uu____8175 =
                                         FStar_Util.smap_try_find env.cache
-                                          tkey_hash
-                                         in
+                                          tkey_hash in
                                       (match uu____8175 with
                                        | FStar_Pervasives_Native.Some
                                            cache_entry ->
@@ -3202,14 +2867,11 @@ and (encode_term :
                                                let uu____8191 =
                                                  FStar_List.map
                                                    FStar_SMTEncoding_Util.mkFreeV
-                                                   cvars1
-                                                  in
+                                                   cvars1 in
                                                ((cache_entry.cache_symbol_name),
-                                                 uu____8191)
-                                                in
+                                                 uu____8191) in
                                              FStar_SMTEncoding_Util.mkApp
-                                               uu____8184
-                                              in
+                                               uu____8184 in
                                            (uu____8183,
                                              (FStar_List.append decls
                                                 (FStar_List.append decls'
@@ -3219,8 +2881,7 @@ and (encode_term :
                                        | FStar_Pervasives_Native.None  ->
                                            let uu____8202 =
                                              is_an_eta_expansion env vars
-                                               body3
-                                              in
+                                               body3 in
                                            (match uu____8202 with
                                             | FStar_Pervasives_Native.Some t1
                                                 ->
@@ -3228,62 +2889,50 @@ and (encode_term :
                                                   let uu____8213 =
                                                     let uu____8214 =
                                                       FStar_Util.smap_size
-                                                        env.cache
-                                                       in
-                                                    uu____8214 = cache_size
-                                                     in
+                                                        env.cache in
+                                                    uu____8214 = cache_size in
                                                   if uu____8213
                                                   then []
                                                   else
                                                     FStar_List.append decls
                                                       (FStar_List.append
-                                                         decls' decls'')
-                                                   in
+                                                         decls' decls'') in
                                                 (t1, decls1)
                                             | FStar_Pervasives_Native.None 
                                                 ->
                                                 let cvar_sorts =
                                                   FStar_List.map
                                                     FStar_Pervasives_Native.snd
-                                                    cvars1
-                                                   in
+                                                    cvars1 in
                                                 let fsym =
                                                   let module_name =
-                                                    env.current_module_name
-                                                     in
+                                                    env.current_module_name in
                                                   let fsym =
                                                     let uu____8230 =
                                                       let uu____8231 =
                                                         FStar_Util.digest_of_string
-                                                          tkey_hash
-                                                         in
+                                                          tkey_hash in
                                                       Prims.strcat "Tm_abs_"
-                                                        uu____8231
-                                                       in
+                                                        uu____8231 in
                                                     varops.mk_unique
-                                                      uu____8230
-                                                     in
+                                                      uu____8230 in
                                                   Prims.strcat module_name
-                                                    (Prims.strcat "_" fsym)
-                                                   in
+                                                    (Prims.strcat "_" fsym) in
                                                 let fdecl =
                                                   FStar_SMTEncoding_Term.DeclFun
                                                     (fsym, cvar_sorts,
                                                       FStar_SMTEncoding_Term.Term_sort,
-                                                      FStar_Pervasives_Native.None)
-                                                   in
+                                                      FStar_Pervasives_Native.None) in
                                                 let f =
                                                   let uu____8238 =
                                                     let uu____8245 =
                                                       FStar_List.map
                                                         FStar_SMTEncoding_Util.mkFreeV
-                                                        cvars1
-                                                       in
-                                                    (fsym, uu____8245)  in
+                                                        cvars1 in
+                                                    (fsym, uu____8245) in
                                                   FStar_SMTEncoding_Util.mkApp
-                                                    uu____8238
-                                                   in
-                                                let app = mk_Apply f vars  in
+                                                    uu____8238 in
+                                                let app = mk_Apply f vars in
                                                 let typing_f =
                                                   match arrow_t_opt with
                                                   | FStar_Pervasives_Native.None
@@ -3293,56 +2942,44 @@ and (encode_term :
                                                       let f_has_t =
                                                         FStar_SMTEncoding_Term.mk_HasTypeWithFuel
                                                           FStar_Pervasives_Native.None
-                                                          f t1
-                                                         in
+                                                          f t1 in
                                                       let a_name =
                                                         Prims.strcat
-                                                          "typing_" fsym
-                                                         in
+                                                          "typing_" fsym in
                                                       let uu____8263 =
                                                         let uu____8264 =
                                                           let uu____8271 =
                                                             FStar_SMTEncoding_Util.mkForall
                                                               ([[f]], cvars1,
-                                                                f_has_t)
-                                                             in
+                                                                f_has_t) in
                                                           (uu____8271,
                                                             (FStar_Pervasives_Native.Some
                                                                a_name),
-                                                            a_name)
-                                                           in
+                                                            a_name) in
                                                         FStar_SMTEncoding_Util.mkAssume
-                                                          uu____8264
-                                                         in
-                                                      [uu____8263]
-                                                   in
+                                                          uu____8264 in
+                                                      [uu____8263] in
                                                 let interp_f =
                                                   let a_name =
                                                     Prims.strcat
-                                                      "interpretation_" fsym
-                                                     in
+                                                      "interpretation_" fsym in
                                                   let uu____8284 =
                                                     let uu____8291 =
                                                       let uu____8292 =
                                                         let uu____8303 =
                                                           FStar_SMTEncoding_Util.mkEq
-                                                            (app, body3)
-                                                           in
+                                                            (app, body3) in
                                                         ([[app]],
                                                           (FStar_List.append
                                                              vars cvars1),
-                                                          uu____8303)
-                                                         in
+                                                          uu____8303) in
                                                       FStar_SMTEncoding_Util.mkForall
-                                                        uu____8292
-                                                       in
+                                                        uu____8292 in
                                                     (uu____8291,
                                                       (FStar_Pervasives_Native.Some
-                                                         a_name), a_name)
-                                                     in
+                                                         a_name), a_name) in
                                                   FStar_SMTEncoding_Util.mkAssume
-                                                    uu____8284
-                                                   in
+                                                    uu____8284 in
                                                 let f_decls =
                                                   FStar_List.append decls
                                                     (FStar_List.append decls'
@@ -3351,12 +2988,10 @@ and (encode_term :
                                                           (FStar_List.append
                                                              (fdecl ::
                                                              typing_f)
-                                                             [interp_f])))
-                                                   in
+                                                             [interp_f]))) in
                                                 ((let uu____8320 =
                                                     mk_cache_entry env fsym
-                                                      cvar_sorts f_decls
-                                                     in
+                                                      cvar_sorts f_decls in
                                                   FStar_Util.smap_add
                                                     env.cache tkey_hash
                                                     uu____8320);
@@ -3387,8 +3022,7 @@ and (encode_term :
        | FStar_Syntax_Syntax.Tm_match (e,pats) ->
            encode_match e pats FStar_SMTEncoding_Term.mk_Term_unit env
              encode_term)
-
-and (encode_let :
+and encode_let:
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.typ ->
       FStar_Syntax_Syntax.term ->
@@ -3400,7 +3034,7 @@ and (encode_let :
                    FStar_Pervasives_Native.tuple2)
               ->
               (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-                FStar_Pervasives_Native.tuple2)
+                FStar_Pervasives_Native.tuple2
   =
   fun x  ->
     fun t1  ->
@@ -3411,27 +3045,24 @@ and (encode_let :
               let uu____8459 =
                 let uu____8464 =
                   FStar_Syntax_Util.ascribe e1
-                    ((FStar_Util.Inl t1), FStar_Pervasives_Native.None)
-                   in
-                encode_term uu____8464 env  in
+                    ((FStar_Util.Inl t1), FStar_Pervasives_Native.None) in
+                encode_term uu____8464 env in
               match uu____8459 with
               | (ee1,decls1) ->
                   let uu____8485 =
                     FStar_Syntax_Subst.open_term
-                      [(x, FStar_Pervasives_Native.None)] e2
-                     in
+                      [(x, FStar_Pervasives_Native.None)] e2 in
                   (match uu____8485 with
                    | (xs,e21) ->
-                       let uu____8510 = FStar_List.hd xs  in
+                       let uu____8510 = FStar_List.hd xs in
                        (match uu____8510 with
                         | (x1,uu____8524) ->
-                            let env' = push_term_var env x1 ee1  in
-                            let uu____8526 = encode_body e21 env'  in
+                            let env' = push_term_var env x1 ee1 in
+                            let uu____8526 = encode_body e21 env' in
                             (match uu____8526 with
                              | (ee2,decls2) ->
                                  (ee2, (FStar_List.append decls1 decls2)))))
-
-and (encode_match :
+and encode_match:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.branch Prims.list ->
       FStar_SMTEncoding_Term.term ->
@@ -3442,7 +3073,7 @@ and (encode_match :
                  FStar_Pervasives_Native.tuple2)
             ->
             (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-              FStar_Pervasives_Native.tuple2)
+              FStar_Pervasives_Native.tuple2
   =
   fun e  ->
     fun pats  ->
@@ -3453,13 +3084,12 @@ and (encode_match :
               let uu____8565 =
                 let uu____8566 =
                   FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-                    FStar_Pervasives_Native.None FStar_Range.dummyRange
-                   in
-                FStar_Syntax_Syntax.null_bv uu____8566  in
-              gen_term_var env uu____8565  in
+                    FStar_Pervasives_Native.None FStar_Range.dummyRange in
+                FStar_Syntax_Syntax.null_bv uu____8566 in
+              gen_term_var env uu____8565 in
             match uu____8558 with
             | (scrsym,scr',env1) ->
-                let uu____8574 = encode_term e env1  in
+                let uu____8574 = encode_term e env1 in
                 (match uu____8574 with
                  | (scr,decls) ->
                      let uu____8585 =
@@ -3467,15 +3097,15 @@ and (encode_match :
                          match uu____8610 with
                          | (else_case,decls1) ->
                              let uu____8629 =
-                               FStar_Syntax_Subst.open_branch b  in
+                               FStar_Syntax_Subst.open_branch b in
                              (match uu____8629 with
                               | (p,w,br) ->
-                                  let uu____8655 = encode_pat env1 p  in
+                                  let uu____8655 = encode_pat env1 p in
                                   (match uu____8655 with
                                    | (env0,pattern) ->
-                                       let guard = pattern.guard scr'  in
+                                       let guard = pattern.guard scr' in
                                        let projections =
-                                         pattern.projections scr'  in
+                                         pattern.projections scr' in
                                        let env2 =
                                          FStar_All.pipe_right projections
                                            (FStar_List.fold_left
@@ -3484,15 +3114,14 @@ and (encode_match :
                                                    match uu____8692 with
                                                    | (x,t) ->
                                                        push_term_var env2 x t)
-                                              env1)
-                                          in
+                                              env1) in
                                        let uu____8699 =
                                          match w with
                                          | FStar_Pervasives_Native.None  ->
                                              (guard, [])
                                          | FStar_Pervasives_Native.Some w1 ->
                                              let uu____8721 =
-                                               encode_term w1 env2  in
+                                               encode_term w1 env2 in
                                              (match uu____8721 with
                                               | (w2,decls2) ->
                                                   let uu____8734 =
@@ -3501,61 +3130,50 @@ and (encode_match :
                                                         let uu____8741 =
                                                           let uu____8746 =
                                                             FStar_SMTEncoding_Term.boxBool
-                                                              FStar_SMTEncoding_Util.mkTrue
-                                                             in
-                                                          (w2, uu____8746)
-                                                           in
+                                                              FStar_SMTEncoding_Util.mkTrue in
+                                                          (w2, uu____8746) in
                                                         FStar_SMTEncoding_Util.mkEq
-                                                          uu____8741
-                                                         in
-                                                      (guard, uu____8740)  in
+                                                          uu____8741 in
+                                                      (guard, uu____8740) in
                                                     FStar_SMTEncoding_Util.mkAnd
-                                                      uu____8735
-                                                     in
-                                                  (uu____8734, decls2))
-                                          in
+                                                      uu____8735 in
+                                                  (uu____8734, decls2)) in
                                        (match uu____8699 with
                                         | (guard1,decls2) ->
                                             let uu____8759 =
-                                              encode_br br env2  in
+                                              encode_br br env2 in
                                             (match uu____8759 with
                                              | (br1,decls3) ->
                                                  let uu____8772 =
                                                    FStar_SMTEncoding_Util.mkITE
-                                                     (guard1, br1, else_case)
-                                                    in
+                                                     (guard1, br1, else_case) in
                                                  (uu____8772,
                                                    (FStar_List.append decls1
                                                       (FStar_List.append
-                                                         decls2 decls3)))))))
-                          in
+                                                         decls2 decls3))))))) in
                        FStar_List.fold_right encode_branch pats
-                         (default_case, decls)
-                        in
+                         (default_case, decls) in
                      (match uu____8585 with
                       | (match_tm,decls1) ->
                           let uu____8791 =
                             FStar_SMTEncoding_Term.mkLet'
                               ([((scrsym, FStar_SMTEncoding_Term.Term_sort),
-                                  scr)], match_tm) FStar_Range.dummyRange
-                             in
+                                  scr)], match_tm) FStar_Range.dummyRange in
                           (uu____8791, decls1)))
-
-and (encode_pat :
+and encode_pat:
   env_t ->
-    FStar_Syntax_Syntax.pat -> (env_t,pattern) FStar_Pervasives_Native.tuple2)
+    FStar_Syntax_Syntax.pat -> (env_t,pattern) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun pat  ->
       (let uu____8831 =
-         FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low  in
+         FStar_TypeChecker_Env.debug env.tcenv FStar_Options.Low in
        if uu____8831
        then
-         let uu____8832 = FStar_Syntax_Print.pat_to_string pat  in
+         let uu____8832 = FStar_Syntax_Print.pat_to_string pat in
          FStar_Util.print1 "Encoding pattern %s\n" uu____8832
        else ());
-      (let uu____8834 = FStar_TypeChecker_Util.decorated_pattern_as_term pat
-          in
+      (let uu____8834 = FStar_TypeChecker_Util.decorated_pattern_as_term pat in
        match uu____8834 with
        | (vars,pat_term) ->
            let uu____8851 =
@@ -3565,14 +3183,13 @@ and (encode_pat :
                      fun v1  ->
                        match uu____8904 with
                        | (env1,vars1) ->
-                           let uu____8956 = gen_term_var env1 v1  in
+                           let uu____8956 = gen_term_var env1 v1 in
                            (match uu____8956 with
                             | (xx,uu____8978,env2) ->
                                 (env2,
                                   ((v1,
                                      (xx, FStar_SMTEncoding_Term.Term_sort))
-                                  :: vars1)))) (env, []))
-              in
+                                  :: vars1)))) (env, [])) in
            (match uu____8851 with
             | (env1,vars1) ->
                 let rec mk_guard pat1 scrutinee =
@@ -3584,7 +3201,7 @@ and (encode_pat :
                   | FStar_Syntax_Syntax.Pat_dot_term uu____9059 ->
                       FStar_SMTEncoding_Util.mkTrue
                   | FStar_Syntax_Syntax.Pat_constant c ->
-                      let uu____9067 = encode_const c env1  in
+                      let uu____9067 = encode_const c env1 in
                       (match uu____9067 with
                        | (tm,decls) ->
                            ((match decls with
@@ -3597,20 +3214,17 @@ and (encode_pat :
                       let is_f =
                         let tc_name =
                           FStar_TypeChecker_Env.typ_of_datacon env1.tcenv
-                            (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                           in
+                            (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                         let uu____9108 =
                           FStar_TypeChecker_Env.datacons_of_typ env1.tcenv
-                            tc_name
-                           in
+                            tc_name in
                         match uu____9108 with
                         | (uu____9115,uu____9116::[]) ->
                             FStar_SMTEncoding_Util.mkTrue
                         | uu____9119 ->
                             mk_data_tester env1
                               (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                              scrutinee
-                         in
+                              scrutinee in
                       let sub_term_guards =
                         FStar_All.pipe_right args
                           (FStar_List.mapi
@@ -3621,17 +3235,13 @@ and (encode_pat :
                                       let proj =
                                         primitive_projector_by_pos env1.tcenv
                                           (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                          i
-                                         in
+                                          i in
                                       let uu____9166 =
                                         FStar_SMTEncoding_Util.mkApp
-                                          (proj, [scrutinee])
-                                         in
-                                      mk_guard arg uu____9166))
-                         in
+                                          (proj, [scrutinee]) in
+                                      mk_guard arg uu____9166)) in
                       FStar_SMTEncoding_Util.mk_and_l (is_f ::
-                        sub_term_guards)
-                   in
+                        sub_term_guards) in
                 let rec mk_projections pat1 scrutinee =
                   match pat1.FStar_Syntax_Syntax.v with
                   | FStar_Syntax_Syntax.Pat_dot_term (x,uu____9193) ->
@@ -3650,31 +3260,26 @@ and (encode_pat :
                                       let proj =
                                         primitive_projector_by_pos env1.tcenv
                                           (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                          i
-                                         in
+                                          i in
                                       let uu____9311 =
                                         FStar_SMTEncoding_Util.mkApp
-                                          (proj, [scrutinee])
-                                         in
-                                      mk_projections arg uu____9311))
-                         in
-                      FStar_All.pipe_right uu____9247 FStar_List.flatten
-                   in
-                let pat_term1 uu____9339 = encode_term pat_term env1  in
+                                          (proj, [scrutinee]) in
+                                      mk_projections arg uu____9311)) in
+                      FStar_All.pipe_right uu____9247 FStar_List.flatten in
+                let pat_term1 uu____9339 = encode_term pat_term env1 in
                 let pattern =
                   {
                     pat_vars = vars1;
                     pat_term = pat_term1;
                     guard = (mk_guard pat);
                     projections = (mk_projections pat)
-                  }  in
+                  } in
                 (env1, pattern)))
-
-and (encode_args :
+and encode_args:
   FStar_Syntax_Syntax.args ->
     env_t ->
       (FStar_SMTEncoding_Term.term Prims.list,FStar_SMTEncoding_Term.decls_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun l  ->
     fun env  ->
@@ -3685,100 +3290,93 @@ and (encode_args :
                 fun uu____9388  ->
                   match (uu____9387, uu____9388) with
                   | ((tms,decls),(t,uu____9424)) ->
-                      let uu____9445 = encode_term t env  in
+                      let uu____9445 = encode_term t env in
                       (match uu____9445 with
                        | (t1,decls') ->
                            ((t1 :: tms), (FStar_List.append decls decls'))))
-             ([], []))
-         in
+             ([], [])) in
       match uu____9349 with | (l1,decls) -> ((FStar_List.rev l1), decls)
-
-and (encode_function_type_as_formula :
+and encode_function_type_as_formula:
   FStar_Syntax_Syntax.typ ->
     env_t ->
       (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     fun env  ->
       let list_elements1 e =
-        let uu____9502 = FStar_Syntax_Util.list_elements e  in
+        let uu____9502 = FStar_Syntax_Util.list_elements e in
         match uu____9502 with
         | FStar_Pervasives_Native.Some l -> l
         | FStar_Pervasives_Native.None  ->
             (FStar_Errors.log_issue e.FStar_Syntax_Syntax.pos
                (FStar_Errors.Warning_NonListLiteralSMTPattern,
                  "SMT pattern is not a list literal; ignoring the pattern");
-             [])
-         in
+             []) in
       let one_pat p =
         let uu____9523 =
-          let uu____9538 = FStar_Syntax_Util.unmeta p  in
-          FStar_All.pipe_right uu____9538 FStar_Syntax_Util.head_and_args  in
+          let uu____9538 = FStar_Syntax_Util.unmeta p in
+          FStar_All.pipe_right uu____9538 FStar_Syntax_Util.head_and_args in
         match uu____9523 with
         | (head1,args) ->
             let uu____9577 =
               let uu____9590 =
-                let uu____9591 = FStar_Syntax_Util.un_uinst head1  in
-                uu____9591.FStar_Syntax_Syntax.n  in
-              (uu____9590, args)  in
+                let uu____9591 = FStar_Syntax_Util.un_uinst head1 in
+                uu____9591.FStar_Syntax_Syntax.n in
+              (uu____9590, args) in
             (match uu____9577 with
              | (FStar_Syntax_Syntax.Tm_fvar
                 fv,(uu____9605,uu____9606)::(e,uu____9608)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpat_lid
                  -> e
-             | uu____9643 -> failwith "Unexpected pattern term")
-         in
+             | uu____9643 -> failwith "Unexpected pattern term") in
       let lemma_pats p =
-        let elts = list_elements1 p  in
+        let elts = list_elements1 p in
         let smt_pat_or1 t1 =
           let uu____9679 =
-            let uu____9694 = FStar_Syntax_Util.unmeta t1  in
-            FStar_All.pipe_right uu____9694 FStar_Syntax_Util.head_and_args
-             in
+            let uu____9694 = FStar_Syntax_Util.unmeta t1 in
+            FStar_All.pipe_right uu____9694 FStar_Syntax_Util.head_and_args in
           match uu____9679 with
           | (head1,args) ->
               let uu____9735 =
                 let uu____9748 =
-                  let uu____9749 = FStar_Syntax_Util.un_uinst head1  in
-                  uu____9749.FStar_Syntax_Syntax.n  in
-                (uu____9748, args)  in
+                  let uu____9749 = FStar_Syntax_Util.un_uinst head1 in
+                  uu____9749.FStar_Syntax_Syntax.n in
+                (uu____9748, args) in
               (match uu____9735 with
                | (FStar_Syntax_Syntax.Tm_fvar fv,(e,uu____9766)::[]) when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.smtpatOr_lid
                    -> FStar_Pervasives_Native.Some e
-               | uu____9793 -> FStar_Pervasives_Native.None)
-           in
+               | uu____9793 -> FStar_Pervasives_Native.None) in
         match elts with
         | t1::[] ->
-            let uu____9815 = smt_pat_or1 t1  in
+            let uu____9815 = smt_pat_or1 t1 in
             (match uu____9815 with
              | FStar_Pervasives_Native.Some e ->
-                 let uu____9831 = list_elements1 e  in
+                 let uu____9831 = list_elements1 e in
                  FStar_All.pipe_right uu____9831
                    (FStar_List.map
                       (fun branch1  ->
-                         let uu____9849 = list_elements1 branch1  in
+                         let uu____9849 = list_elements1 branch1 in
                          FStar_All.pipe_right uu____9849
                            (FStar_List.map one_pat)))
              | uu____9860 ->
                  let uu____9865 =
-                   FStar_All.pipe_right elts (FStar_List.map one_pat)  in
+                   FStar_All.pipe_right elts (FStar_List.map one_pat) in
                  [uu____9865])
         | uu____9886 ->
             let uu____9889 =
-              FStar_All.pipe_right elts (FStar_List.map one_pat)  in
-            [uu____9889]
-         in
+              FStar_All.pipe_right elts (FStar_List.map one_pat) in
+            [uu____9889] in
       let uu____9910 =
         let uu____9929 =
-          let uu____9930 = FStar_Syntax_Subst.compress t  in
-          uu____9930.FStar_Syntax_Syntax.n  in
+          let uu____9930 = FStar_Syntax_Subst.compress t in
+          uu____9930.FStar_Syntax_Syntax.n in
         match uu____9929 with
         | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
-            let uu____9969 = FStar_Syntax_Subst.open_comp binders c  in
+            let uu____9969 = FStar_Syntax_Subst.open_comp binders c in
             (match uu____9969 with
              | (binders1,c1) ->
                  (match c1.FStar_Syntax_Syntax.n with
@@ -3790,14 +3388,14 @@ and (encode_function_type_as_formula :
                           (pre,uu____10016)::(post,uu____10018)::(pats,uu____10020)::[];
                         FStar_Syntax_Syntax.flags = uu____10021;_}
                       ->
-                      let uu____10062 = lemma_pats pats  in
+                      let uu____10062 = lemma_pats pats in
                       (binders1, pre, post, uu____10062)
                   | uu____10079 -> failwith "impos"))
-        | uu____10098 -> failwith "Impos"  in
+        | uu____10098 -> failwith "Impos" in
       match uu____9910 with
       | (binders,pre,post,patterns) ->
           let env1 =
-            let uu___112_10146 = env  in
+            let uu___112_10146 = env in
             {
               bindings = (uu___112_10146.bindings);
               depth = (uu___112_10146.depth);
@@ -3809,9 +3407,9 @@ and (encode_function_type_as_formula :
               encode_non_total_function_typ =
                 (uu___112_10146.encode_non_total_function_typ);
               current_module_name = (uu___112_10146.current_module_name)
-            }  in
+            } in
           let uu____10147 =
-            encode_binders FStar_Pervasives_Native.None binders env1  in
+            encode_binders FStar_Pervasives_Native.None binders env1 in
           (match uu____10147 with
            | (vars,guards,env2,decls,uu____10172) ->
                let uu____10185 =
@@ -3823,21 +3421,18 @@ and (encode_function_type_as_formula :
                              let uu____10265 =
                                FStar_All.pipe_right branch1
                                  (FStar_List.map
-                                    (fun t1  -> encode_smt_pattern t1 env2))
-                                in
+                                    (fun t1  -> encode_smt_pattern t1 env2)) in
                              FStar_All.pipe_right uu____10265
-                               FStar_List.unzip
-                              in
+                               FStar_List.unzip in
                            match uu____10254 with
-                           | (pats,decls1) -> (pats, decls1)))
-                    in
-                 FStar_All.pipe_right uu____10200 FStar_List.unzip  in
+                           | (pats,decls1) -> (pats, decls1))) in
+                 FStar_All.pipe_right uu____10200 FStar_List.unzip in
                (match uu____10185 with
                 | (pats,decls') ->
-                    let decls'1 = FStar_List.flatten decls'  in
-                    let post1 = FStar_Syntax_Util.unthunk_lemma_post post  in
+                    let decls'1 = FStar_List.flatten decls' in
+                    let post1 = FStar_Syntax_Util.unthunk_lemma_post post in
                     let env3 =
-                      let uu___113_10417 = env2  in
+                      let uu___113_10417 = env2 in
                       {
                         bindings = (uu___113_10417.bindings);
                         depth = (uu___113_10417.depth);
@@ -3850,120 +3445,110 @@ and (encode_function_type_as_formula :
                           (uu___113_10417.encode_non_total_function_typ);
                         current_module_name =
                           (uu___113_10417.current_module_name)
-                      }  in
+                      } in
                     let uu____10418 =
-                      let uu____10423 = FStar_Syntax_Util.unmeta pre  in
-                      encode_formula uu____10423 env3  in
+                      let uu____10423 = FStar_Syntax_Util.unmeta pre in
+                      encode_formula uu____10423 env3 in
                     (match uu____10418 with
                      | (pre1,decls'') ->
                          let uu____10430 =
-                           let uu____10435 = FStar_Syntax_Util.unmeta post1
-                              in
-                           encode_formula uu____10435 env3  in
+                           let uu____10435 = FStar_Syntax_Util.unmeta post1 in
+                           encode_formula uu____10435 env3 in
                          (match uu____10430 with
                           | (post2,decls''') ->
                               let decls1 =
                                 FStar_List.append decls
                                   (FStar_List.append
                                      (FStar_List.flatten decls'1)
-                                     (FStar_List.append decls'' decls'''))
-                                 in
+                                     (FStar_List.append decls'' decls''')) in
                               let uu____10445 =
                                 let uu____10446 =
                                   let uu____10457 =
                                     let uu____10458 =
                                       let uu____10463 =
                                         FStar_SMTEncoding_Util.mk_and_l (pre1
-                                          :: guards)
-                                         in
-                                      (uu____10463, post2)  in
-                                    FStar_SMTEncoding_Util.mkImp uu____10458
-                                     in
-                                  (pats, vars, uu____10457)  in
-                                FStar_SMTEncoding_Util.mkForall uu____10446
-                                 in
+                                          :: guards) in
+                                      (uu____10463, post2) in
+                                    FStar_SMTEncoding_Util.mkImp uu____10458 in
+                                  (pats, vars, uu____10457) in
+                                FStar_SMTEncoding_Util.mkForall uu____10446 in
                               (uu____10445, decls1)))))
-
-and (encode_smt_pattern :
+and encode_smt_pattern:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     env_t ->
       (FStar_SMTEncoding_Term.pat,FStar_SMTEncoding_Term.decl Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     fun env  ->
-      let uu____10476 = FStar_Syntax_Util.head_and_args t  in
+      let uu____10476 = FStar_Syntax_Util.head_and_args t in
       match uu____10476 with
       | (head1,args) ->
-          let head2 = FStar_Syntax_Util.un_uinst head1  in
+          let head2 = FStar_Syntax_Util.un_uinst head1 in
           (match ((head2.FStar_Syntax_Syntax.n), args) with
            | (FStar_Syntax_Syntax.Tm_fvar
               fv,uu____10535::(x,uu____10537)::(t1,uu____10539)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Parser_Const.has_type_lid
                ->
-               let uu____10586 = encode_term x env  in
+               let uu____10586 = encode_term x env in
                (match uu____10586 with
                 | (x1,decls) ->
-                    let uu____10599 = encode_term t1 env  in
+                    let uu____10599 = encode_term t1 env in
                     (match uu____10599 with
                      | (t2,decls') ->
                          let uu____10612 =
-                           FStar_SMTEncoding_Term.mk_HasType x1 t2  in
+                           FStar_SMTEncoding_Term.mk_HasType x1 t2 in
                          (uu____10612, (FStar_List.append decls decls'))))
            | uu____10615 -> encode_term t env)
-
-and (encode_formula :
+and encode_formula:
   FStar_Syntax_Syntax.typ ->
     env_t ->
       (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decls_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun phi  ->
     fun env  ->
       let debug1 phi1 =
         let uu____10638 =
           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env.tcenv)
-            (FStar_Options.Other "SMTEncoding")
-           in
+            (FStar_Options.Other "SMTEncoding") in
         if uu____10638
         then
-          let uu____10639 = FStar_Syntax_Print.tag_of_term phi1  in
-          let uu____10640 = FStar_Syntax_Print.term_to_string phi1  in
+          let uu____10639 = FStar_Syntax_Print.tag_of_term phi1 in
+          let uu____10640 = FStar_Syntax_Print.term_to_string phi1 in
           FStar_Util.print2 "Formula (%s)  %s\n" uu____10639 uu____10640
-        else ()  in
+        else () in
       let enc f r l =
         let uu____10673 =
           FStar_Util.fold_map
             (fun decls  ->
                fun x  ->
                  let uu____10701 =
-                   encode_term (FStar_Pervasives_Native.fst x) env  in
+                   encode_term (FStar_Pervasives_Native.fst x) env in
                  match uu____10701 with
-                 | (t,decls') -> ((FStar_List.append decls decls'), t)) [] l
-           in
+                 | (t,decls') -> ((FStar_List.append decls decls'), t)) [] l in
         match uu____10673 with
         | (decls,args) ->
             let uu____10730 =
-              let uu___114_10731 = f args  in
+              let uu___114_10731 = f args in
               {
                 FStar_SMTEncoding_Term.tm =
                   (uu___114_10731.FStar_SMTEncoding_Term.tm);
                 FStar_SMTEncoding_Term.freevars =
                   (uu___114_10731.FStar_SMTEncoding_Term.freevars);
                 FStar_SMTEncoding_Term.rng = r
-              }  in
-            (uu____10730, decls)
-         in
+              } in
+            (uu____10730, decls) in
       let const_op f r uu____10762 =
-        let uu____10775 = f r  in (uu____10775, [])  in
+        let uu____10775 = f r in (uu____10775, []) in
       let un_op f l =
-        let uu____10794 = FStar_List.hd l  in
-        FStar_All.pipe_left f uu____10794  in
+        let uu____10794 = FStar_List.hd l in
+        FStar_All.pipe_left f uu____10794 in
       let bin_op f uu___88_10810 =
         match uu___88_10810 with
         | t1::t2::[] -> f (t1, t2)
-        | uu____10821 -> failwith "Impossible"  in
+        | uu____10821 -> failwith "Impossible" in
       let enc_prop_c f r l =
         let uu____10855 =
           FStar_Util.fold_map
@@ -3971,24 +3556,22 @@ and (encode_formula :
                fun uu____10878  ->
                  match uu____10878 with
                  | (t,uu____10892) ->
-                     let uu____10893 = encode_formula t env  in
+                     let uu____10893 = encode_formula t env in
                      (match uu____10893 with
                       | (phi1,decls') ->
-                          ((FStar_List.append decls decls'), phi1))) [] l
-           in
+                          ((FStar_List.append decls decls'), phi1))) [] l in
         match uu____10855 with
         | (decls,phis) ->
             let uu____10922 =
-              let uu___115_10923 = f phis  in
+              let uu___115_10923 = f phis in
               {
                 FStar_SMTEncoding_Term.tm =
                   (uu___115_10923.FStar_SMTEncoding_Term.tm);
                 FStar_SMTEncoding_Term.freevars =
                   (uu___115_10923.FStar_SMTEncoding_Term.freevars);
                 FStar_SMTEncoding_Term.rng = r
-              }  in
-            (uu____10922, decls)
-         in
+              } in
+            (uu____10922, decls) in
       let eq_op r args =
         let rf =
           FStar_List.filter
@@ -3998,24 +3581,21 @@ and (encode_formula :
                    (match q with
                     | FStar_Pervasives_Native.Some
                         (FStar_Syntax_Syntax.Implicit uu____11003) -> false
-                    | uu____11004 -> true)) args
-           in
+                    | uu____11004 -> true)) args in
         if (FStar_List.length rf) <> (Prims.parse_int "2")
         then
           let uu____11019 =
             FStar_Util.format1
               "eq_op: got %s non-implicit arguments instead of 2?"
-              (Prims.string_of_int (FStar_List.length rf))
-             in
+              (Prims.string_of_int (FStar_List.length rf)) in
           failwith uu____11019
         else
-          (let uu____11033 = enc (bin_op FStar_SMTEncoding_Util.mkEq)  in
-           uu____11033 r rf)
-         in
+          (let uu____11033 = enc (bin_op FStar_SMTEncoding_Util.mkEq) in
+           uu____11033 r rf) in
       let mk_imp1 r uu___89_11058 =
         match uu___89_11058 with
         | (lhs,uu____11064)::(rhs,uu____11066)::[] ->
-            let uu____11093 = encode_formula rhs env  in
+            let uu____11093 = encode_formula rhs env in
             (match uu____11093 with
              | (l1,decls1) ->
                  (match l1.FStar_SMTEncoding_Term.tm with
@@ -4023,91 +3603,84 @@ and (encode_formula :
                       (FStar_SMTEncoding_Term.TrueOp ,uu____11108) ->
                       (l1, decls1)
                   | uu____11113 ->
-                      let uu____11114 = encode_formula lhs env  in
+                      let uu____11114 = encode_formula lhs env in
                       (match uu____11114 with
                        | (l2,decls2) ->
                            let uu____11125 =
-                             FStar_SMTEncoding_Term.mkImp (l2, l1) r  in
+                             FStar_SMTEncoding_Term.mkImp (l2, l1) r in
                            (uu____11125, (FStar_List.append decls1 decls2)))))
-        | uu____11128 -> failwith "impossible"  in
+        | uu____11128 -> failwith "impossible" in
       let mk_ite r uu___90_11149 =
         match uu___90_11149 with
         | (guard,uu____11155)::(_then,uu____11157)::(_else,uu____11159)::[]
             ->
-            let uu____11196 = encode_formula guard env  in
+            let uu____11196 = encode_formula guard env in
             (match uu____11196 with
              | (g,decls1) ->
-                 let uu____11207 = encode_formula _then env  in
+                 let uu____11207 = encode_formula _then env in
                  (match uu____11207 with
                   | (t,decls2) ->
-                      let uu____11218 = encode_formula _else env  in
+                      let uu____11218 = encode_formula _else env in
                       (match uu____11218 with
                        | (e,decls3) ->
-                           let res = FStar_SMTEncoding_Term.mkITE (g, t, e) r
-                              in
+                           let res = FStar_SMTEncoding_Term.mkITE (g, t, e) r in
                            (res,
                              (FStar_List.append decls1
                                 (FStar_List.append decls2 decls3))))))
-        | uu____11232 -> failwith "impossible"  in
+        | uu____11232 -> failwith "impossible" in
       let unboxInt_l f l =
-        let uu____11257 = FStar_List.map FStar_SMTEncoding_Term.unboxInt l
-           in
-        f uu____11257  in
+        let uu____11257 = FStar_List.map FStar_SMTEncoding_Term.unboxInt l in
+        f uu____11257 in
       let connectives =
         let uu____11275 =
-          let uu____11288 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkAnd)
-             in
-          (FStar_Parser_Const.and_lid, uu____11288)  in
+          let uu____11288 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkAnd) in
+          (FStar_Parser_Const.and_lid, uu____11288) in
         let uu____11305 =
           let uu____11320 =
-            let uu____11333 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkOr)
-               in
-            (FStar_Parser_Const.or_lid, uu____11333)  in
+            let uu____11333 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkOr) in
+            (FStar_Parser_Const.or_lid, uu____11333) in
           let uu____11350 =
             let uu____11365 =
               let uu____11380 =
                 let uu____11393 =
-                  enc_prop_c (bin_op FStar_SMTEncoding_Util.mkIff)  in
-                (FStar_Parser_Const.iff_lid, uu____11393)  in
+                  enc_prop_c (bin_op FStar_SMTEncoding_Util.mkIff) in
+                (FStar_Parser_Const.iff_lid, uu____11393) in
               let uu____11410 =
                 let uu____11425 =
                   let uu____11440 =
                     let uu____11453 =
-                      enc_prop_c (un_op FStar_SMTEncoding_Util.mkNot)  in
-                    (FStar_Parser_Const.not_lid, uu____11453)  in
+                      enc_prop_c (un_op FStar_SMTEncoding_Util.mkNot) in
+                    (FStar_Parser_Const.not_lid, uu____11453) in
                   [uu____11440;
                   (FStar_Parser_Const.eq2_lid, eq_op);
                   (FStar_Parser_Const.eq3_lid, eq_op);
                   (FStar_Parser_Const.true_lid,
                     (const_op FStar_SMTEncoding_Term.mkTrue));
                   (FStar_Parser_Const.false_lid,
-                    (const_op FStar_SMTEncoding_Term.mkFalse))]
-                   in
-                (FStar_Parser_Const.ite_lid, mk_ite) :: uu____11425  in
-              uu____11380 :: uu____11410  in
-            (FStar_Parser_Const.imp_lid, mk_imp1) :: uu____11365  in
-          uu____11320 :: uu____11350  in
-        uu____11275 :: uu____11305  in
+                    (const_op FStar_SMTEncoding_Term.mkFalse))] in
+                (FStar_Parser_Const.ite_lid, mk_ite) :: uu____11425 in
+              uu____11380 :: uu____11410 in
+            (FStar_Parser_Const.imp_lid, mk_imp1) :: uu____11365 in
+          uu____11320 :: uu____11350 in
+        uu____11275 :: uu____11305 in
       let rec fallback phi1 =
         match phi1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_meta
             (phi',FStar_Syntax_Syntax.Meta_labeled (msg,r,b)) ->
-            let uu____11774 = encode_formula phi' env  in
+            let uu____11774 = encode_formula phi' env in
             (match uu____11774 with
              | (phi2,decls) ->
                  let uu____11785 =
                    FStar_SMTEncoding_Term.mk
-                     (FStar_SMTEncoding_Term.Labeled (phi2, msg, r)) r
-                    in
+                     (FStar_SMTEncoding_Term.Labeled (phi2, msg, r)) r in
                  (uu____11785, decls))
         | FStar_Syntax_Syntax.Tm_meta uu____11786 ->
-            let uu____11793 = FStar_Syntax_Util.unmeta phi1  in
+            let uu____11793 = FStar_Syntax_Util.unmeta phi1 in
             encode_formula uu____11793 env
         | FStar_Syntax_Syntax.Tm_match (e,pats) ->
             let uu____11832 =
               encode_match e pats FStar_SMTEncoding_Util.mkFalse env
-                encode_formula
-               in
+                encode_formula in
             (match uu____11832 with | (t,decls) -> (t, decls))
         | FStar_Syntax_Syntax.Tm_let
             ((false
@@ -4118,24 +3691,24 @@ and (encode_formula :
                  FStar_Syntax_Syntax.lbdef = e1;
                  FStar_Syntax_Syntax.lbattrs = uu____11848;_}::[]),e2)
             ->
-            let uu____11872 = encode_let x t1 e1 e2 env encode_formula  in
+            let uu____11872 = encode_let x t1 e1 e2 env encode_formula in
             (match uu____11872 with | (t,decls) -> (t, decls))
         | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-            let head2 = FStar_Syntax_Util.un_uinst head1  in
+            let head2 = FStar_Syntax_Util.un_uinst head1 in
             (match ((head2.FStar_Syntax_Syntax.n), args) with
              | (FStar_Syntax_Syntax.Tm_fvar
                 fv,uu____11919::(x,uu____11921)::(t,uu____11923)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.has_type_lid
                  ->
-                 let uu____11970 = encode_term x env  in
+                 let uu____11970 = encode_term x env in
                  (match uu____11970 with
                   | (x1,decls) ->
-                      let uu____11981 = encode_term t env  in
+                      let uu____11981 = encode_term t env in
                       (match uu____11981 with
                        | (t1,decls') ->
                            let uu____11992 =
-                             FStar_SMTEncoding_Term.mk_HasType x1 t1  in
+                             FStar_SMTEncoding_Term.mk_HasType x1 t1 in
                            (uu____11992, (FStar_List.append decls decls'))))
              | (FStar_Syntax_Syntax.Tm_fvar
                 fv,(r,uu____11997)::(msg,uu____11999)::(phi2,uu____12001)::[])
@@ -4145,12 +3718,12 @@ and (encode_formula :
                  ->
                  let uu____12046 =
                    let uu____12051 =
-                     let uu____12052 = FStar_Syntax_Subst.compress r  in
-                     uu____12052.FStar_Syntax_Syntax.n  in
+                     let uu____12052 = FStar_Syntax_Subst.compress r in
+                     uu____12052.FStar_Syntax_Syntax.n in
                    let uu____12055 =
-                     let uu____12056 = FStar_Syntax_Subst.compress msg  in
-                     uu____12056.FStar_Syntax_Syntax.n  in
-                   (uu____12051, uu____12055)  in
+                     let uu____12056 = FStar_Syntax_Subst.compress msg in
+                     uu____12056.FStar_Syntax_Syntax.n in
+                   (uu____12051, uu____12055) in
                  (match uu____12046 with
                   | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
                      r1),FStar_Syntax_Syntax.Tm_constant
@@ -4161,8 +3734,7 @@ and (encode_formula :
                              (phi2,
                                (FStar_Syntax_Syntax.Meta_labeled
                                   (s, r1, false))))
-                          FStar_Pervasives_Native.None r1
-                         in
+                          FStar_Pervasives_Native.None r1 in
                       fallback phi3
                   | uu____12071 -> fallback phi2)
              | (FStar_Syntax_Syntax.Tm_fvar fv,(t,uu____12078)::[]) when
@@ -4173,15 +3745,15 @@ and (encode_formula :
                       FStar_Parser_Const.auto_squash_lid)
                  -> encode_formula t env
              | uu____12103 when head_redex env head2 ->
-                 let uu____12116 = whnf env phi1  in
+                 let uu____12116 = whnf env phi1 in
                  encode_formula uu____12116 env
              | uu____12117 ->
-                 let uu____12130 = encode_term phi1 env  in
+                 let uu____12130 = encode_term phi1 env in
                  (match uu____12130 with
                   | (tt,decls) ->
                       let uu____12141 =
                         FStar_SMTEncoding_Term.mk_Valid
-                          (let uu___116_12144 = tt  in
+                          (let uu___116_12144 = tt in
                            {
                              FStar_SMTEncoding_Term.tm =
                                (uu___116_12144.FStar_SMTEncoding_Term.tm);
@@ -4189,16 +3761,15 @@ and (encode_formula :
                                (uu___116_12144.FStar_SMTEncoding_Term.freevars);
                              FStar_SMTEncoding_Term.rng =
                                (phi1.FStar_Syntax_Syntax.pos)
-                           })
-                         in
+                           }) in
                       (uu____12141, decls)))
         | uu____12145 ->
-            let uu____12146 = encode_term phi1 env  in
+            let uu____12146 = encode_term phi1 env in
             (match uu____12146 with
              | (tt,decls) ->
                  let uu____12157 =
                    FStar_SMTEncoding_Term.mk_Valid
-                     (let uu___117_12160 = tt  in
+                     (let uu___117_12160 = tt in
                       {
                         FStar_SMTEncoding_Term.tm =
                           (uu___117_12160.FStar_SMTEncoding_Term.tm);
@@ -4206,13 +3777,10 @@ and (encode_formula :
                           (uu___117_12160.FStar_SMTEncoding_Term.freevars);
                         FStar_SMTEncoding_Term.rng =
                           (phi1.FStar_Syntax_Syntax.pos)
-                      })
-                    in
-                 (uu____12157, decls))
-         in
+                      }) in
+                 (uu____12157, decls)) in
       let encode_q_body env1 bs ps body =
-        let uu____12196 = encode_binders FStar_Pervasives_Native.None bs env1
-           in
+        let uu____12196 = encode_binders FStar_Pervasives_Native.None bs env1 in
         match uu____12196 with
         | (vars,guards,env2,decls,uu____12235) ->
             let uu____12248 =
@@ -4228,7 +3796,7 @@ and (encode_formula :
                                     match uu____12364 with
                                     | (t,uu____12378) ->
                                         encode_smt_pattern t
-                                          (let uu___118_12384 = env2  in
+                                          (let uu___118_12384 = env2 in
                                            {
                                              bindings =
                                                (uu___118_12384.bindings);
@@ -4243,17 +3811,14 @@ and (encode_formula :
                                                (uu___118_12384.encode_non_total_function_typ);
                                              current_module_name =
                                                (uu___118_12384.current_module_name)
-                                           })))
-                             in
-                          FStar_All.pipe_right uu____12324 FStar_List.unzip
-                           in
+                                           }))) in
+                          FStar_All.pipe_right uu____12324 FStar_List.unzip in
                         match uu____12313 with
-                        | (p1,decls1) -> (p1, (FStar_List.flatten decls1))))
-                 in
-              FStar_All.pipe_right uu____12261 FStar_List.unzip  in
+                        | (p1,decls1) -> (p1, (FStar_List.flatten decls1)))) in
+              FStar_All.pipe_right uu____12261 FStar_List.unzip in
             (match uu____12248 with
              | (pats,decls') ->
-                 let uu____12493 = encode_formula body env2  in
+                 let uu____12493 = encode_formula body env2 in
                  (match uu____12493 with
                   | (body1,decls'') ->
                       let guards1 =
@@ -4269,16 +3834,15 @@ and (encode_formula :
                                FStar_Parser_Const.guard_free)
                               = gf
                             -> []
-                        | uu____12541 -> guards  in
+                        | uu____12541 -> guards in
                       let uu____12546 =
-                        FStar_SMTEncoding_Util.mk_and_l guards1  in
+                        FStar_SMTEncoding_Util.mk_and_l guards1 in
                       (vars, pats, uu____12546, body1,
                         (FStar_List.append decls
                            (FStar_List.append (FStar_List.flatten decls')
-                              decls'')))))
-         in
+                              decls''))))) in
       debug1 phi;
-      (let phi1 = FStar_Syntax_Util.unascribe phi  in
+      (let phi1 = FStar_Syntax_Util.unascribe phi in
        let check_pattern_vars vars pats =
          let pats1 =
            FStar_All.pipe_right pats
@@ -4290,29 +3854,25 @@ and (encode_formula :
                          [FStar_TypeChecker_Normalize.Beta;
                          FStar_TypeChecker_Normalize.AllowUnboundUniverses;
                          FStar_TypeChecker_Normalize.EraseUniverses]
-                         env.tcenv x))
-            in
+                         env.tcenv x)) in
          match pats1 with
          | [] -> ()
          | hd1::tl1 ->
              let pat_vars =
-               let uu____12620 = FStar_Syntax_Free.names hd1  in
+               let uu____12620 = FStar_Syntax_Free.names hd1 in
                FStar_List.fold_left
                  (fun out  ->
                     fun x  ->
-                      let uu____12632 = FStar_Syntax_Free.names x  in
-                      FStar_Util.set_union out uu____12632) uu____12620 tl1
-                in
+                      let uu____12632 = FStar_Syntax_Free.names x in
+                      FStar_Util.set_union out uu____12632) uu____12620 tl1 in
              let uu____12635 =
                FStar_All.pipe_right vars
                  (FStar_Util.find_opt
                     (fun uu____12662  ->
                        match uu____12662 with
                        | (b,uu____12668) ->
-                           let uu____12669 = FStar_Util.set_mem b pat_vars
-                              in
-                           Prims.op_Negation uu____12669))
-                in
+                           let uu____12669 = FStar_Util.set_mem b pat_vars in
+                           Prims.op_Negation uu____12669)) in
              (match uu____12635 with
               | FStar_Pervasives_Native.None  -> ()
               | FStar_Pervasives_Native.Some (x,uu____12675) ->
@@ -4322,21 +3882,17 @@ and (encode_formula :
                          fun t  ->
                            FStar_Range.union_ranges out
                              t.FStar_Syntax_Syntax.pos)
-                      hd1.FStar_Syntax_Syntax.pos tl1
-                     in
+                      hd1.FStar_Syntax_Syntax.pos tl1 in
                   let uu____12689 =
                     let uu____12694 =
-                      let uu____12695 = FStar_Syntax_Print.bv_to_string x  in
+                      let uu____12695 = FStar_Syntax_Print.bv_to_string x in
                       FStar_Util.format1
                         "SMT pattern misses at least one bound variable: %s"
-                        uu____12695
-                       in
+                        uu____12695 in
                     (FStar_Errors.Warning_SMTPatternMissingBoundVar,
-                      uu____12694)
-                     in
-                  FStar_Errors.log_issue pos uu____12689)
-          in
-       let uu____12696 = FStar_Syntax_Util.destruct_typ_as_formula phi1  in
+                      uu____12694) in
+                  FStar_Errors.log_issue pos uu____12689) in
+       let uu____12696 = FStar_Syntax_Util.destruct_typ_as_formula phi1 in
        match uu____12696 with
        | FStar_Pervasives_Native.None  -> fallback phi1
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn (op,arms))
@@ -4346,8 +3902,7 @@ and (encode_formula :
                (FStar_List.tryFind
                   (fun uu____12763  ->
                      match uu____12763 with
-                     | (l,uu____12777) -> FStar_Ident.lid_equals op l))
-              in
+                     | (l,uu____12777) -> FStar_Ident.lid_equals op l)) in
            (match uu____12705 with
             | FStar_Pervasives_Native.None  -> fallback phi1
             | FStar_Pervasives_Native.Some (uu____12810,f) ->
@@ -4356,70 +3911,63 @@ and (encode_formula :
            (vars,pats,body)) ->
            (FStar_All.pipe_right pats
               (FStar_List.iter (check_pattern_vars vars));
-            (let uu____12850 = encode_q_body env vars pats body  in
+            (let uu____12850 = encode_q_body env vars pats body in
              match uu____12850 with
              | (vars1,pats1,guard,body1,decls) ->
                  let tm =
                    let uu____12895 =
                      let uu____12906 =
-                       FStar_SMTEncoding_Util.mkImp (guard, body1)  in
-                     (pats1, vars1, uu____12906)  in
+                       FStar_SMTEncoding_Util.mkImp (guard, body1) in
+                     (pats1, vars1, uu____12906) in
                    FStar_SMTEncoding_Term.mkForall uu____12895
-                     phi1.FStar_Syntax_Syntax.pos
-                    in
+                     phi1.FStar_Syntax_Syntax.pos in
                  (tm, decls)))
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QEx
            (vars,pats,body)) ->
            (FStar_All.pipe_right pats
               (FStar_List.iter (check_pattern_vars vars));
-            (let uu____12925 = encode_q_body env vars pats body  in
+            (let uu____12925 = encode_q_body env vars pats body in
              match uu____12925 with
              | (vars1,pats1,guard,body1,decls) ->
                  let uu____12969 =
                    let uu____12970 =
                      let uu____12981 =
-                       FStar_SMTEncoding_Util.mkAnd (guard, body1)  in
-                     (pats1, vars1, uu____12981)  in
+                       FStar_SMTEncoding_Util.mkAnd (guard, body1) in
+                     (pats1, vars1, uu____12981) in
                    FStar_SMTEncoding_Term.mkExists uu____12970
-                     phi1.FStar_Syntax_Syntax.pos
-                    in
+                     phi1.FStar_Syntax_Syntax.pos in
                  (uu____12969, decls))))
-
 type prims_t =
   {
   mk:
     FStar_Ident.lident ->
       Prims.string ->
         (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decl Prims.list)
-          FStar_Pervasives_Native.tuple2
-    ;
-  is: FStar_Ident.lident -> Prims.bool }[@@deriving show]
-let (__proj__Mkprims_t__item__mk :
+          FStar_Pervasives_Native.tuple2;
+  is: FStar_Ident.lident -> Prims.bool;}[@@deriving show]
+let __proj__Mkprims_t__item__mk:
   prims_t ->
     FStar_Ident.lident ->
       Prims.string ->
         (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.decl Prims.list)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun projectee  ->
     match projectee with
     | { mk = __fname__mk; is = __fname__is;_} -> __fname__mk
-  
-let (__proj__Mkprims_t__item__is :
-  prims_t -> FStar_Ident.lident -> Prims.bool) =
+let __proj__Mkprims_t__item__is: prims_t -> FStar_Ident.lident -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | { mk = __fname__mk; is = __fname__is;_} -> __fname__is
-  
-let (prims : prims_t) =
-  let uu____13074 = fresh_fvar "a" FStar_SMTEncoding_Term.Term_sort  in
+let prims: prims_t =
+  let uu____13074 = fresh_fvar "a" FStar_SMTEncoding_Term.Term_sort in
   match uu____13074 with
   | (asym,a) ->
-      let uu____13081 = fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort  in
+      let uu____13081 = fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort in
       (match uu____13081 with
        | (xsym,x) ->
-           let uu____13088 = fresh_fvar "y" FStar_SMTEncoding_Term.Term_sort
-              in
+           let uu____13088 = fresh_fvar "y" FStar_SMTEncoding_Term.Term_sort in
            (match uu____13088 with
             | (ysym,y) ->
                 let quant vars body x1 =
@@ -4427,27 +3975,23 @@ let (prims : prims_t) =
                     let uu____13132 =
                       let uu____13143 =
                         FStar_All.pipe_right vars
-                          (FStar_List.map FStar_Pervasives_Native.snd)
-                         in
+                          (FStar_List.map FStar_Pervasives_Native.snd) in
                       (x1, uu____13143, FStar_SMTEncoding_Term.Term_sort,
-                        FStar_Pervasives_Native.None)
-                       in
-                    FStar_SMTEncoding_Term.DeclFun uu____13132  in
-                  let xtok = Prims.strcat x1 "@tok"  in
+                        FStar_Pervasives_Native.None) in
+                    FStar_SMTEncoding_Term.DeclFun uu____13132 in
+                  let xtok = Prims.strcat x1 "@tok" in
                   let xtok_decl =
                     FStar_SMTEncoding_Term.DeclFun
                       (xtok, [], FStar_SMTEncoding_Term.Term_sort,
-                        FStar_Pervasives_Native.None)
-                     in
+                        FStar_Pervasives_Native.None) in
                   let xapp =
                     let uu____13169 =
                       let uu____13176 =
-                        FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars
-                         in
-                      (x1, uu____13176)  in
-                    FStar_SMTEncoding_Util.mkApp uu____13169  in
-                  let xtok1 = FStar_SMTEncoding_Util.mkApp (xtok, [])  in
-                  let xtok_app = mk_Apply xtok1 vars  in
+                        FStar_List.map FStar_SMTEncoding_Util.mkFreeV vars in
+                      (x1, uu____13176) in
+                    FStar_SMTEncoding_Util.mkApp uu____13169 in
+                  let xtok1 = FStar_SMTEncoding_Util.mkApp (xtok, []) in
+                  let xtok_app = mk_Apply xtok1 vars in
                   let uu____13189 =
                     let uu____13192 =
                       let uu____13195 =
@@ -4456,14 +4000,12 @@ let (prims : prims_t) =
                             let uu____13206 =
                               let uu____13207 =
                                 let uu____13218 =
-                                  FStar_SMTEncoding_Util.mkEq (xapp, body)
-                                   in
-                                ([[xapp]], vars, uu____13218)  in
-                              FStar_SMTEncoding_Util.mkForall uu____13207  in
+                                  FStar_SMTEncoding_Util.mkEq (xapp, body) in
+                                ([[xapp]], vars, uu____13218) in
+                              FStar_SMTEncoding_Util.mkForall uu____13207 in
                             (uu____13206, FStar_Pervasives_Native.None,
-                              (Prims.strcat "primitive_" x1))
-                             in
-                          FStar_SMTEncoding_Util.mkAssume uu____13199  in
+                              (Prims.strcat "primitive_" x1)) in
+                          FStar_SMTEncoding_Util.mkAssume uu____13199 in
                         let uu____13235 =
                           let uu____13238 =
                             let uu____13239 =
@@ -4471,54 +4013,48 @@ let (prims : prims_t) =
                                 let uu____13247 =
                                   let uu____13258 =
                                     FStar_SMTEncoding_Util.mkEq
-                                      (xtok_app, xapp)
-                                     in
-                                  ([[xtok_app]], vars, uu____13258)  in
-                                FStar_SMTEncoding_Util.mkForall uu____13247
-                                 in
+                                      (xtok_app, xapp) in
+                                  ([[xtok_app]], vars, uu____13258) in
+                                FStar_SMTEncoding_Util.mkForall uu____13247 in
                               (uu____13246,
                                 (FStar_Pervasives_Native.Some
                                    "Name-token correspondence"),
-                                (Prims.strcat "token_correspondence_" x1))
-                               in
-                            FStar_SMTEncoding_Util.mkAssume uu____13239  in
-                          [uu____13238]  in
-                        uu____13198 :: uu____13235  in
-                      xtok_decl :: uu____13195  in
-                    xname_decl :: uu____13192  in
-                  (xtok1, uu____13189)  in
+                                (Prims.strcat "token_correspondence_" x1)) in
+                            FStar_SMTEncoding_Util.mkAssume uu____13239 in
+                          [uu____13238] in
+                        uu____13198 :: uu____13235 in
+                      xtok_decl :: uu____13195 in
+                    xname_decl :: uu____13192 in
+                  (xtok1, uu____13189) in
                 let axy =
                   [(asym, FStar_SMTEncoding_Term.Term_sort);
                   (xsym, FStar_SMTEncoding_Term.Term_sort);
-                  (ysym, FStar_SMTEncoding_Term.Term_sort)]  in
+                  (ysym, FStar_SMTEncoding_Term.Term_sort)] in
                 let xy =
                   [(xsym, FStar_SMTEncoding_Term.Term_sort);
-                  (ysym, FStar_SMTEncoding_Term.Term_sort)]  in
-                let qx = [(xsym, FStar_SMTEncoding_Term.Term_sort)]  in
+                  (ysym, FStar_SMTEncoding_Term.Term_sort)] in
+                let qx = [(xsym, FStar_SMTEncoding_Term.Term_sort)] in
                 let prims1 =
                   let uu____13349 =
                     let uu____13362 =
                       let uu____13371 =
-                        let uu____13372 = FStar_SMTEncoding_Util.mkEq (x, y)
-                           in
+                        let uu____13372 = FStar_SMTEncoding_Util.mkEq (x, y) in
                         FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool
-                          uu____13372
-                         in
-                      quant axy uu____13371  in
-                    (FStar_Parser_Const.op_Eq, uu____13362)  in
+                          uu____13372 in
+                      quant axy uu____13371 in
+                    (FStar_Parser_Const.op_Eq, uu____13362) in
                   let uu____13381 =
                     let uu____13396 =
                       let uu____13409 =
                         let uu____13418 =
                           let uu____13419 =
                             let uu____13420 =
-                              FStar_SMTEncoding_Util.mkEq (x, y)  in
-                            FStar_SMTEncoding_Util.mkNot uu____13420  in
+                              FStar_SMTEncoding_Util.mkEq (x, y) in
+                            FStar_SMTEncoding_Util.mkNot uu____13420 in
                           FStar_All.pipe_left FStar_SMTEncoding_Term.boxBool
-                            uu____13419
-                           in
-                        quant axy uu____13418  in
-                      (FStar_Parser_Const.op_notEq, uu____13409)  in
+                            uu____13419 in
+                        quant axy uu____13418 in
+                      (FStar_Parser_Const.op_notEq, uu____13409) in
                     let uu____13429 =
                       let uu____13444 =
                         let uu____13457 =
@@ -4526,16 +4062,15 @@ let (prims : prims_t) =
                             let uu____13467 =
                               let uu____13468 =
                                 let uu____13473 =
-                                  FStar_SMTEncoding_Term.unboxInt x  in
+                                  FStar_SMTEncoding_Term.unboxInt x in
                                 let uu____13474 =
-                                  FStar_SMTEncoding_Term.unboxInt y  in
-                                (uu____13473, uu____13474)  in
-                              FStar_SMTEncoding_Util.mkLT uu____13468  in
+                                  FStar_SMTEncoding_Term.unboxInt y in
+                                (uu____13473, uu____13474) in
+                              FStar_SMTEncoding_Util.mkLT uu____13468 in
                             FStar_All.pipe_left
-                              FStar_SMTEncoding_Term.boxBool uu____13467
-                             in
-                          quant xy uu____13466  in
-                        (FStar_Parser_Const.op_LT, uu____13457)  in
+                              FStar_SMTEncoding_Term.boxBool uu____13467 in
+                          quant xy uu____13466 in
+                        (FStar_Parser_Const.op_LT, uu____13457) in
                       let uu____13483 =
                         let uu____13498 =
                           let uu____13511 =
@@ -4543,16 +4078,15 @@ let (prims : prims_t) =
                               let uu____13521 =
                                 let uu____13522 =
                                   let uu____13527 =
-                                    FStar_SMTEncoding_Term.unboxInt x  in
+                                    FStar_SMTEncoding_Term.unboxInt x in
                                   let uu____13528 =
-                                    FStar_SMTEncoding_Term.unboxInt y  in
-                                  (uu____13527, uu____13528)  in
-                                FStar_SMTEncoding_Util.mkLTE uu____13522  in
+                                    FStar_SMTEncoding_Term.unboxInt y in
+                                  (uu____13527, uu____13528) in
+                                FStar_SMTEncoding_Util.mkLTE uu____13522 in
                               FStar_All.pipe_left
-                                FStar_SMTEncoding_Term.boxBool uu____13521
-                               in
-                            quant xy uu____13520  in
-                          (FStar_Parser_Const.op_LTE, uu____13511)  in
+                                FStar_SMTEncoding_Term.boxBool uu____13521 in
+                            quant xy uu____13520 in
+                          (FStar_Parser_Const.op_LTE, uu____13511) in
                         let uu____13537 =
                           let uu____13552 =
                             let uu____13565 =
@@ -4560,16 +4094,15 @@ let (prims : prims_t) =
                                 let uu____13575 =
                                   let uu____13576 =
                                     let uu____13581 =
-                                      FStar_SMTEncoding_Term.unboxInt x  in
+                                      FStar_SMTEncoding_Term.unboxInt x in
                                     let uu____13582 =
-                                      FStar_SMTEncoding_Term.unboxInt y  in
-                                    (uu____13581, uu____13582)  in
-                                  FStar_SMTEncoding_Util.mkGT uu____13576  in
+                                      FStar_SMTEncoding_Term.unboxInt y in
+                                    (uu____13581, uu____13582) in
+                                  FStar_SMTEncoding_Util.mkGT uu____13576 in
                                 FStar_All.pipe_left
-                                  FStar_SMTEncoding_Term.boxBool uu____13575
-                                 in
-                              quant xy uu____13574  in
-                            (FStar_Parser_Const.op_GT, uu____13565)  in
+                                  FStar_SMTEncoding_Term.boxBool uu____13575 in
+                              quant xy uu____13574 in
+                            (FStar_Parser_Const.op_GT, uu____13565) in
                           let uu____13591 =
                             let uu____13606 =
                               let uu____13619 =
@@ -4577,18 +4110,16 @@ let (prims : prims_t) =
                                   let uu____13629 =
                                     let uu____13630 =
                                       let uu____13635 =
-                                        FStar_SMTEncoding_Term.unboxInt x  in
+                                        FStar_SMTEncoding_Term.unboxInt x in
                                       let uu____13636 =
-                                        FStar_SMTEncoding_Term.unboxInt y  in
-                                      (uu____13635, uu____13636)  in
-                                    FStar_SMTEncoding_Util.mkGTE uu____13630
-                                     in
+                                        FStar_SMTEncoding_Term.unboxInt y in
+                                      (uu____13635, uu____13636) in
+                                    FStar_SMTEncoding_Util.mkGTE uu____13630 in
                                   FStar_All.pipe_left
                                     FStar_SMTEncoding_Term.boxBool
-                                    uu____13629
-                                   in
-                                quant xy uu____13628  in
-                              (FStar_Parser_Const.op_GTE, uu____13619)  in
+                                    uu____13629 in
+                                quant xy uu____13628 in
+                              (FStar_Parser_Const.op_GTE, uu____13619) in
                             let uu____13645 =
                               let uu____13660 =
                                 let uu____13673 =
@@ -4596,41 +4127,32 @@ let (prims : prims_t) =
                                     let uu____13683 =
                                       let uu____13684 =
                                         let uu____13689 =
-                                          FStar_SMTEncoding_Term.unboxInt x
-                                           in
+                                          FStar_SMTEncoding_Term.unboxInt x in
                                         let uu____13690 =
-                                          FStar_SMTEncoding_Term.unboxInt y
-                                           in
-                                        (uu____13689, uu____13690)  in
+                                          FStar_SMTEncoding_Term.unboxInt y in
+                                        (uu____13689, uu____13690) in
                                       FStar_SMTEncoding_Util.mkSub
-                                        uu____13684
-                                       in
+                                        uu____13684 in
                                     FStar_All.pipe_left
                                       FStar_SMTEncoding_Term.boxInt
-                                      uu____13683
-                                     in
-                                  quant xy uu____13682  in
+                                      uu____13683 in
+                                  quant xy uu____13682 in
                                 (FStar_Parser_Const.op_Subtraction,
-                                  uu____13673)
-                                 in
+                                  uu____13673) in
                               let uu____13699 =
                                 let uu____13714 =
                                   let uu____13727 =
                                     let uu____13736 =
                                       let uu____13737 =
                                         let uu____13738 =
-                                          FStar_SMTEncoding_Term.unboxInt x
-                                           in
+                                          FStar_SMTEncoding_Term.unboxInt x in
                                         FStar_SMTEncoding_Util.mkMinus
-                                          uu____13738
-                                         in
+                                          uu____13738 in
                                       FStar_All.pipe_left
                                         FStar_SMTEncoding_Term.boxInt
-                                        uu____13737
-                                       in
-                                    quant qx uu____13736  in
-                                  (FStar_Parser_Const.op_Minus, uu____13727)
-                                   in
+                                        uu____13737 in
+                                    quant qx uu____13736 in
+                                  (FStar_Parser_Const.op_Minus, uu____13727) in
                                 let uu____13747 =
                                   let uu____13762 =
                                     let uu____13775 =
@@ -4639,24 +4161,19 @@ let (prims : prims_t) =
                                           let uu____13786 =
                                             let uu____13791 =
                                               FStar_SMTEncoding_Term.unboxInt
-                                                x
-                                               in
+                                                x in
                                             let uu____13792 =
                                               FStar_SMTEncoding_Term.unboxInt
-                                                y
-                                               in
-                                            (uu____13791, uu____13792)  in
+                                                y in
+                                            (uu____13791, uu____13792) in
                                           FStar_SMTEncoding_Util.mkAdd
-                                            uu____13786
-                                           in
+                                            uu____13786 in
                                         FStar_All.pipe_left
                                           FStar_SMTEncoding_Term.boxInt
-                                          uu____13785
-                                         in
-                                      quant xy uu____13784  in
+                                          uu____13785 in
+                                      quant xy uu____13784 in
                                     (FStar_Parser_Const.op_Addition,
-                                      uu____13775)
-                                     in
+                                      uu____13775) in
                                   let uu____13801 =
                                     let uu____13816 =
                                       let uu____13829 =
@@ -4665,24 +4182,19 @@ let (prims : prims_t) =
                                             let uu____13840 =
                                               let uu____13845 =
                                                 FStar_SMTEncoding_Term.unboxInt
-                                                  x
-                                                 in
+                                                  x in
                                               let uu____13846 =
                                                 FStar_SMTEncoding_Term.unboxInt
-                                                  y
-                                                 in
-                                              (uu____13845, uu____13846)  in
+                                                  y in
+                                              (uu____13845, uu____13846) in
                                             FStar_SMTEncoding_Util.mkMul
-                                              uu____13840
-                                             in
+                                              uu____13840 in
                                           FStar_All.pipe_left
                                             FStar_SMTEncoding_Term.boxInt
-                                            uu____13839
-                                           in
-                                        quant xy uu____13838  in
+                                            uu____13839 in
+                                        quant xy uu____13838 in
                                       (FStar_Parser_Const.op_Multiply,
-                                        uu____13829)
-                                       in
+                                        uu____13829) in
                                     let uu____13855 =
                                       let uu____13870 =
                                         let uu____13883 =
@@ -4691,25 +4203,19 @@ let (prims : prims_t) =
                                               let uu____13894 =
                                                 let uu____13899 =
                                                   FStar_SMTEncoding_Term.unboxInt
-                                                    x
-                                                   in
+                                                    x in
                                                 let uu____13900 =
                                                   FStar_SMTEncoding_Term.unboxInt
-                                                    y
-                                                   in
-                                                (uu____13899, uu____13900)
-                                                 in
+                                                    y in
+                                                (uu____13899, uu____13900) in
                                               FStar_SMTEncoding_Util.mkDiv
-                                                uu____13894
-                                               in
+                                                uu____13894 in
                                             FStar_All.pipe_left
                                               FStar_SMTEncoding_Term.boxInt
-                                              uu____13893
-                                             in
-                                          quant xy uu____13892  in
+                                              uu____13893 in
+                                          quant xy uu____13892 in
                                         (FStar_Parser_Const.op_Division,
-                                          uu____13883)
-                                         in
+                                          uu____13883) in
                                       let uu____13909 =
                                         let uu____13924 =
                                           let uu____13937 =
@@ -4718,25 +4224,19 @@ let (prims : prims_t) =
                                                 let uu____13948 =
                                                   let uu____13953 =
                                                     FStar_SMTEncoding_Term.unboxInt
-                                                      x
-                                                     in
+                                                      x in
                                                   let uu____13954 =
                                                     FStar_SMTEncoding_Term.unboxInt
-                                                      y
-                                                     in
-                                                  (uu____13953, uu____13954)
-                                                   in
+                                                      y in
+                                                  (uu____13953, uu____13954) in
                                                 FStar_SMTEncoding_Util.mkMod
-                                                  uu____13948
-                                                 in
+                                                  uu____13948 in
                                               FStar_All.pipe_left
                                                 FStar_SMTEncoding_Term.boxInt
-                                                uu____13947
-                                               in
-                                            quant xy uu____13946  in
+                                                uu____13947 in
+                                            quant xy uu____13946 in
                                           (FStar_Parser_Const.op_Modulus,
-                                            uu____13937)
-                                           in
+                                            uu____13937) in
                                         let uu____13963 =
                                           let uu____13978 =
                                             let uu____13991 =
@@ -4745,26 +4245,20 @@ let (prims : prims_t) =
                                                   let uu____14002 =
                                                     let uu____14007 =
                                                       FStar_SMTEncoding_Term.unboxBool
-                                                        x
-                                                       in
+                                                        x in
                                                     let uu____14008 =
                                                       FStar_SMTEncoding_Term.unboxBool
-                                                        y
-                                                       in
+                                                        y in
                                                     (uu____14007,
-                                                      uu____14008)
-                                                     in
+                                                      uu____14008) in
                                                   FStar_SMTEncoding_Util.mkAnd
-                                                    uu____14002
-                                                   in
+                                                    uu____14002 in
                                                 FStar_All.pipe_left
                                                   FStar_SMTEncoding_Term.boxBool
-                                                  uu____14001
-                                                 in
-                                              quant xy uu____14000  in
+                                                  uu____14001 in
+                                              quant xy uu____14000 in
                                             (FStar_Parser_Const.op_And,
-                                              uu____13991)
-                                             in
+                                              uu____13991) in
                                           let uu____14017 =
                                             let uu____14032 =
                                               let uu____14045 =
@@ -4773,26 +4267,20 @@ let (prims : prims_t) =
                                                     let uu____14056 =
                                                       let uu____14061 =
                                                         FStar_SMTEncoding_Term.unboxBool
-                                                          x
-                                                         in
+                                                          x in
                                                       let uu____14062 =
                                                         FStar_SMTEncoding_Term.unboxBool
-                                                          y
-                                                         in
+                                                          y in
                                                       (uu____14061,
-                                                        uu____14062)
-                                                       in
+                                                        uu____14062) in
                                                     FStar_SMTEncoding_Util.mkOr
-                                                      uu____14056
-                                                     in
+                                                      uu____14056 in
                                                   FStar_All.pipe_left
                                                     FStar_SMTEncoding_Term.boxBool
-                                                    uu____14055
-                                                   in
-                                                quant xy uu____14054  in
+                                                    uu____14055 in
+                                                quant xy uu____14054 in
                                               (FStar_Parser_Const.op_Or,
-                                                uu____14045)
-                                               in
+                                                uu____14045) in
                                             let uu____14071 =
                                               let uu____14086 =
                                                 let uu____14099 =
@@ -4800,34 +4288,30 @@ let (prims : prims_t) =
                                                     let uu____14109 =
                                                       let uu____14110 =
                                                         FStar_SMTEncoding_Term.unboxBool
-                                                          x
-                                                         in
+                                                          x in
                                                       FStar_SMTEncoding_Util.mkNot
-                                                        uu____14110
-                                                       in
+                                                        uu____14110 in
                                                     FStar_All.pipe_left
                                                       FStar_SMTEncoding_Term.boxBool
-                                                      uu____14109
-                                                     in
-                                                  quant qx uu____14108  in
+                                                      uu____14109 in
+                                                  quant qx uu____14108 in
                                                 (FStar_Parser_Const.op_Negation,
-                                                  uu____14099)
-                                                 in
-                                              [uu____14086]  in
-                                            uu____14032 :: uu____14071  in
-                                          uu____13978 :: uu____14017  in
-                                        uu____13924 :: uu____13963  in
-                                      uu____13870 :: uu____13909  in
-                                    uu____13816 :: uu____13855  in
-                                  uu____13762 :: uu____13801  in
-                                uu____13714 :: uu____13747  in
-                              uu____13660 :: uu____13699  in
-                            uu____13606 :: uu____13645  in
-                          uu____13552 :: uu____13591  in
-                        uu____13498 :: uu____13537  in
-                      uu____13444 :: uu____13483  in
-                    uu____13396 :: uu____13429  in
-                  uu____13349 :: uu____13381  in
+                                                  uu____14099) in
+                                              [uu____14086] in
+                                            uu____14032 :: uu____14071 in
+                                          uu____13978 :: uu____14017 in
+                                        uu____13924 :: uu____13963 in
+                                      uu____13870 :: uu____13909 in
+                                    uu____13816 :: uu____13855 in
+                                  uu____13762 :: uu____13801 in
+                                uu____13714 :: uu____13747 in
+                              uu____13660 :: uu____13699 in
+                            uu____13606 :: uu____13645 in
+                          uu____13552 :: uu____13591 in
+                        uu____13498 :: uu____13537 in
+                      uu____13444 :: uu____13483 in
+                    uu____13396 :: uu____13429 in
+                  uu____13349 :: uu____13381 in
                 let mk1 l v1 =
                   let uu____14324 =
                     let uu____14333 =
@@ -4836,44 +4320,39 @@ let (prims : prims_t) =
                            (fun uu____14391  ->
                               match uu____14391 with
                               | (l',uu____14405) ->
-                                  FStar_Ident.lid_equals l l'))
-                       in
+                                  FStar_Ident.lid_equals l l')) in
                     FStar_All.pipe_right uu____14333
                       (FStar_Option.map
                          (fun uu____14465  ->
-                            match uu____14465 with | (uu____14484,b) -> b v1))
-                     in
-                  FStar_All.pipe_right uu____14324 FStar_Option.get  in
+                            match uu____14465 with | (uu____14484,b) -> b v1)) in
+                  FStar_All.pipe_right uu____14324 FStar_Option.get in
                 let is l =
                   FStar_All.pipe_right prims1
                     (FStar_Util.for_some
                        (fun uu____14555  ->
                           match uu____14555 with
-                          | (l',uu____14569) -> FStar_Ident.lid_equals l l'))
-                   in
+                          | (l',uu____14569) -> FStar_Ident.lid_equals l l')) in
                 { mk = mk1; is }))
-  
-let (pretype_axiom :
+let pretype_axiom:
   env_t ->
     FStar_SMTEncoding_Term.term ->
       (Prims.string,FStar_SMTEncoding_Term.sort)
         FStar_Pervasives_Native.tuple2 Prims.list ->
-        FStar_SMTEncoding_Term.decl)
+        FStar_SMTEncoding_Term.decl
   =
   fun env  ->
     fun tapp  ->
       fun vars  ->
-        let uu____14607 = fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort  in
+        let uu____14607 = fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort in
         match uu____14607 with
         | (xxsym,xx) ->
-            let uu____14614 = fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort
-               in
+            let uu____14614 = fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort in
             (match uu____14614 with
              | (ffsym,ff) ->
                  let xx_has_type =
-                   FStar_SMTEncoding_Term.mk_HasTypeFuel ff xx tapp  in
-                 let tapp_hash = FStar_SMTEncoding_Term.hash_of_term tapp  in
-                 let module_name = env.current_module_name  in
+                   FStar_SMTEncoding_Term.mk_HasTypeFuel ff xx tapp in
+                 let tapp_hash = FStar_SMTEncoding_Term.hash_of_term tapp in
+                 let module_name = env.current_module_name in
                  let uu____14624 =
                    let uu____14631 =
                      let uu____14632 =
@@ -4883,53 +4362,47 @@ let (pretype_axiom :
                              let uu____14650 =
                                let uu____14655 =
                                  FStar_SMTEncoding_Util.mkApp
-                                   ("PreType", [xx])
-                                  in
-                               (tapp, uu____14655)  in
-                             FStar_SMTEncoding_Util.mkEq uu____14650  in
-                           (xx_has_type, uu____14649)  in
-                         FStar_SMTEncoding_Util.mkImp uu____14644  in
+                                   ("PreType", [xx]) in
+                               (tapp, uu____14655) in
+                             FStar_SMTEncoding_Util.mkEq uu____14650 in
+                           (xx_has_type, uu____14649) in
+                         FStar_SMTEncoding_Util.mkImp uu____14644 in
                        ([[xx_has_type]],
                          ((xxsym, FStar_SMTEncoding_Term.Term_sort) ::
                          (ffsym, FStar_SMTEncoding_Term.Fuel_sort) :: vars),
-                         uu____14643)
-                        in
-                     FStar_SMTEncoding_Util.mkForall uu____14632  in
+                         uu____14643) in
+                     FStar_SMTEncoding_Util.mkForall uu____14632 in
                    let uu____14680 =
                      let uu____14681 =
                        let uu____14682 =
                          let uu____14683 =
-                           FStar_Util.digest_of_string tapp_hash  in
-                         Prims.strcat "_pretyping_" uu____14683  in
-                       Prims.strcat module_name uu____14682  in
-                     varops.mk_unique uu____14681  in
+                           FStar_Util.digest_of_string tapp_hash in
+                         Prims.strcat "_pretyping_" uu____14683 in
+                       Prims.strcat module_name uu____14682 in
+                     varops.mk_unique uu____14681 in
                    (uu____14631, (FStar_Pervasives_Native.Some "pretyping"),
-                     uu____14680)
-                    in
+                     uu____14680) in
                  FStar_SMTEncoding_Util.mkAssume uu____14624)
-  
-let (primitive_type_axioms :
+let primitive_type_axioms:
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
       Prims.string ->
-        FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.decl Prims.list)
+        FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.decl Prims.list
   =
-  let xx = ("x", FStar_SMTEncoding_Term.Term_sort)  in
-  let x = FStar_SMTEncoding_Util.mkFreeV xx  in
-  let yy = ("y", FStar_SMTEncoding_Term.Term_sort)  in
-  let y = FStar_SMTEncoding_Util.mkFreeV yy  in
+  let xx = ("x", FStar_SMTEncoding_Term.Term_sort) in
+  let x = FStar_SMTEncoding_Util.mkFreeV xx in
+  let yy = ("y", FStar_SMTEncoding_Term.Term_sort) in
+  let y = FStar_SMTEncoding_Util.mkFreeV yy in
   let mk_unit env nm tt =
-    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt  in
+    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
     let uu____14719 =
       let uu____14720 =
         let uu____14727 =
           FStar_SMTEncoding_Term.mk_HasType
-            FStar_SMTEncoding_Term.mk_Term_unit tt
-           in
+            FStar_SMTEncoding_Term.mk_Term_unit tt in
         (uu____14727, (FStar_Pervasives_Native.Some "unit typing"),
-          "unit_typing")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____14720  in
+          "unit_typing") in
+      FStar_SMTEncoding_Util.mkAssume uu____14720 in
     let uu____14730 =
       let uu____14733 =
         let uu____14734 =
@@ -4939,40 +4412,37 @@ let (primitive_type_axioms :
                 let uu____14754 =
                   let uu____14759 =
                     FStar_SMTEncoding_Util.mkEq
-                      (x, FStar_SMTEncoding_Term.mk_Term_unit)
-                     in
-                  (typing_pred, uu____14759)  in
-                FStar_SMTEncoding_Util.mkImp uu____14754  in
-              ([[typing_pred]], [xx], uu____14753)  in
-            mkForall_fuel uu____14742  in
+                      (x, FStar_SMTEncoding_Term.mk_Term_unit) in
+                  (typing_pred, uu____14759) in
+                FStar_SMTEncoding_Util.mkImp uu____14754 in
+              ([[typing_pred]], [xx], uu____14753) in
+            mkForall_fuel uu____14742 in
           (uu____14741, (FStar_Pervasives_Native.Some "unit inversion"),
-            "unit_inversion")
-           in
-        FStar_SMTEncoding_Util.mkAssume uu____14734  in
-      [uu____14733]  in
-    uu____14719 :: uu____14730  in
+            "unit_inversion") in
+        FStar_SMTEncoding_Util.mkAssume uu____14734 in
+      [uu____14733] in
+    uu____14719 :: uu____14730 in
   let mk_bool env nm tt =
-    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt  in
-    let bb = ("b", FStar_SMTEncoding_Term.Bool_sort)  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
+    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
+    let bb = ("b", FStar_SMTEncoding_Term.Bool_sort) in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
     let uu____14801 =
       let uu____14802 =
         let uu____14809 =
           let uu____14810 =
             let uu____14821 =
               let uu____14826 =
-                let uu____14829 = FStar_SMTEncoding_Term.boxBool b  in
-                [uu____14829]  in
-              [uu____14826]  in
+                let uu____14829 = FStar_SMTEncoding_Term.boxBool b in
+                [uu____14829] in
+              [uu____14826] in
             let uu____14834 =
-              let uu____14835 = FStar_SMTEncoding_Term.boxBool b  in
-              FStar_SMTEncoding_Term.mk_HasType uu____14835 tt  in
-            (uu____14821, [bb], uu____14834)  in
-          FStar_SMTEncoding_Util.mkForall uu____14810  in
+              let uu____14835 = FStar_SMTEncoding_Term.boxBool b in
+              FStar_SMTEncoding_Term.mk_HasType uu____14835 tt in
+            (uu____14821, [bb], uu____14834) in
+          FStar_SMTEncoding_Util.mkForall uu____14810 in
         (uu____14809, (FStar_Pervasives_Native.Some "bool typing"),
-          "bool_typing")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____14802  in
+          "bool_typing") in
+      FStar_SMTEncoding_Util.mkAssume uu____14802 in
     let uu____14856 =
       let uu____14859 =
         let uu____14860 =
@@ -4983,62 +4453,59 @@ let (primitive_type_axioms :
                   let uu____14885 =
                     FStar_SMTEncoding_Term.mk_tester
                       (FStar_Pervasives_Native.fst
-                         FStar_SMTEncoding_Term.boxBoolFun) x
-                     in
-                  (typing_pred, uu____14885)  in
-                FStar_SMTEncoding_Util.mkImp uu____14880  in
-              ([[typing_pred]], [xx], uu____14879)  in
-            mkForall_fuel uu____14868  in
+                         FStar_SMTEncoding_Term.boxBoolFun) x in
+                  (typing_pred, uu____14885) in
+                FStar_SMTEncoding_Util.mkImp uu____14880 in
+              ([[typing_pred]], [xx], uu____14879) in
+            mkForall_fuel uu____14868 in
           (uu____14867, (FStar_Pervasives_Native.Some "bool inversion"),
-            "bool_inversion")
-           in
-        FStar_SMTEncoding_Util.mkAssume uu____14860  in
-      [uu____14859]  in
-    uu____14801 :: uu____14856  in
+            "bool_inversion") in
+        FStar_SMTEncoding_Util.mkAssume uu____14860 in
+      [uu____14859] in
+    uu____14801 :: uu____14856 in
   let mk_int env nm tt =
-    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt  in
-    let typing_pred_y = FStar_SMTEncoding_Term.mk_HasType y tt  in
-    let aa = ("a", FStar_SMTEncoding_Term.Int_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let bb = ("b", FStar_SMTEncoding_Term.Int_sort)  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
+    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
+    let typing_pred_y = FStar_SMTEncoding_Term.mk_HasType y tt in
+    let aa = ("a", FStar_SMTEncoding_Term.Int_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let bb = ("b", FStar_SMTEncoding_Term.Int_sort) in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
     let precedes =
       let uu____14935 =
         let uu____14936 =
           let uu____14943 =
             let uu____14946 =
               let uu____14949 =
-                let uu____14952 = FStar_SMTEncoding_Term.boxInt a  in
+                let uu____14952 = FStar_SMTEncoding_Term.boxInt a in
                 let uu____14953 =
-                  let uu____14956 = FStar_SMTEncoding_Term.boxInt b  in
-                  [uu____14956]  in
-                uu____14952 :: uu____14953  in
-              tt :: uu____14949  in
-            tt :: uu____14946  in
-          ("Prims.Precedes", uu____14943)  in
-        FStar_SMTEncoding_Util.mkApp uu____14936  in
-      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____14935  in
+                  let uu____14956 = FStar_SMTEncoding_Term.boxInt b in
+                  [uu____14956] in
+                uu____14952 :: uu____14953 in
+              tt :: uu____14949 in
+            tt :: uu____14946 in
+          ("Prims.Precedes", uu____14943) in
+        FStar_SMTEncoding_Util.mkApp uu____14936 in
+      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____14935 in
     let precedes_y_x =
-      let uu____14960 = FStar_SMTEncoding_Util.mkApp ("Precedes", [y; x])  in
-      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____14960  in
+      let uu____14960 = FStar_SMTEncoding_Util.mkApp ("Precedes", [y; x]) in
+      FStar_All.pipe_left FStar_SMTEncoding_Term.mk_Valid uu____14960 in
     let uu____14963 =
       let uu____14964 =
         let uu____14971 =
           let uu____14972 =
             let uu____14983 =
               let uu____14988 =
-                let uu____14991 = FStar_SMTEncoding_Term.boxInt b  in
-                [uu____14991]  in
-              [uu____14988]  in
+                let uu____14991 = FStar_SMTEncoding_Term.boxInt b in
+                [uu____14991] in
+              [uu____14988] in
             let uu____14996 =
-              let uu____14997 = FStar_SMTEncoding_Term.boxInt b  in
-              FStar_SMTEncoding_Term.mk_HasType uu____14997 tt  in
-            (uu____14983, [bb], uu____14996)  in
-          FStar_SMTEncoding_Util.mkForall uu____14972  in
+              let uu____14997 = FStar_SMTEncoding_Term.boxInt b in
+              FStar_SMTEncoding_Term.mk_HasType uu____14997 tt in
+            (uu____14983, [bb], uu____14996) in
+          FStar_SMTEncoding_Util.mkForall uu____14972 in
         (uu____14971, (FStar_Pervasives_Native.Some "int typing"),
-          "int_typing")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____14964  in
+          "int_typing") in
+      FStar_SMTEncoding_Util.mkAssume uu____14964 in
     let uu____15018 =
       let uu____15021 =
         let uu____15022 =
@@ -5049,16 +4516,14 @@ let (primitive_type_axioms :
                   let uu____15047 =
                     FStar_SMTEncoding_Term.mk_tester
                       (FStar_Pervasives_Native.fst
-                         FStar_SMTEncoding_Term.boxIntFun) x
-                     in
-                  (typing_pred, uu____15047)  in
-                FStar_SMTEncoding_Util.mkImp uu____15042  in
-              ([[typing_pred]], [xx], uu____15041)  in
-            mkForall_fuel uu____15030  in
+                         FStar_SMTEncoding_Term.boxIntFun) x in
+                  (typing_pred, uu____15047) in
+                FStar_SMTEncoding_Util.mkImp uu____15042 in
+              ([[typing_pred]], [xx], uu____15041) in
+            mkForall_fuel uu____15030 in
           (uu____15029, (FStar_Pervasives_Native.Some "int inversion"),
-            "int_inversion")
-           in
-        FStar_SMTEncoding_Util.mkAssume uu____15022  in
+            "int_inversion") in
+        FStar_SMTEncoding_Util.mkAssume uu____15022 in
       let uu____15072 =
         let uu____15075 =
           let uu____15076 =
@@ -5073,76 +4538,71 @@ let (primitive_type_axioms :
                             let uu____15111 =
                               let uu____15112 =
                                 let uu____15117 =
-                                  FStar_SMTEncoding_Term.unboxInt x  in
+                                  FStar_SMTEncoding_Term.unboxInt x in
                                 let uu____15118 =
                                   FStar_SMTEncoding_Util.mkInteger'
-                                    (Prims.parse_int "0")
-                                   in
-                                (uu____15117, uu____15118)  in
-                              FStar_SMTEncoding_Util.mkGT uu____15112  in
+                                    (Prims.parse_int "0") in
+                                (uu____15117, uu____15118) in
+                              FStar_SMTEncoding_Util.mkGT uu____15112 in
                             let uu____15119 =
                               let uu____15122 =
                                 let uu____15123 =
                                   let uu____15128 =
-                                    FStar_SMTEncoding_Term.unboxInt y  in
+                                    FStar_SMTEncoding_Term.unboxInt y in
                                   let uu____15129 =
                                     FStar_SMTEncoding_Util.mkInteger'
-                                      (Prims.parse_int "0")
-                                     in
-                                  (uu____15128, uu____15129)  in
-                                FStar_SMTEncoding_Util.mkGTE uu____15123  in
+                                      (Prims.parse_int "0") in
+                                  (uu____15128, uu____15129) in
+                                FStar_SMTEncoding_Util.mkGTE uu____15123 in
                               let uu____15130 =
                                 let uu____15133 =
                                   let uu____15134 =
                                     let uu____15139 =
-                                      FStar_SMTEncoding_Term.unboxInt y  in
+                                      FStar_SMTEncoding_Term.unboxInt y in
                                     let uu____15140 =
-                                      FStar_SMTEncoding_Term.unboxInt x  in
-                                    (uu____15139, uu____15140)  in
-                                  FStar_SMTEncoding_Util.mkLT uu____15134  in
-                                [uu____15133]  in
-                              uu____15122 :: uu____15130  in
-                            uu____15111 :: uu____15119  in
-                          typing_pred_y :: uu____15108  in
-                        typing_pred :: uu____15105  in
-                      FStar_SMTEncoding_Util.mk_and_l uu____15102  in
-                    (uu____15101, precedes_y_x)  in
-                  FStar_SMTEncoding_Util.mkImp uu____15096  in
+                                      FStar_SMTEncoding_Term.unboxInt x in
+                                    (uu____15139, uu____15140) in
+                                  FStar_SMTEncoding_Util.mkLT uu____15134 in
+                                [uu____15133] in
+                              uu____15122 :: uu____15130 in
+                            uu____15111 :: uu____15119 in
+                          typing_pred_y :: uu____15108 in
+                        typing_pred :: uu____15105 in
+                      FStar_SMTEncoding_Util.mk_and_l uu____15102 in
+                    (uu____15101, precedes_y_x) in
+                  FStar_SMTEncoding_Util.mkImp uu____15096 in
                 ([[typing_pred; typing_pred_y; precedes_y_x]], [xx; yy],
-                  uu____15095)
-                 in
-              mkForall_fuel uu____15084  in
+                  uu____15095) in
+              mkForall_fuel uu____15084 in
             (uu____15083,
               (FStar_Pervasives_Native.Some
                  "well-founded ordering on nat (alt)"),
-              "well-founded-ordering-on-nat")
-             in
-          FStar_SMTEncoding_Util.mkAssume uu____15076  in
-        [uu____15075]  in
-      uu____15021 :: uu____15072  in
-    uu____14963 :: uu____15018  in
+              "well-founded-ordering-on-nat") in
+          FStar_SMTEncoding_Util.mkAssume uu____15076 in
+        [uu____15075] in
+      uu____15021 :: uu____15072 in
+    uu____14963 :: uu____15018 in
   let mk_str env nm tt =
-    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt  in
-    let bb = ("b", FStar_SMTEncoding_Term.String_sort)  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
+    let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
+    let bb = ("b", FStar_SMTEncoding_Term.String_sort) in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
     let uu____15186 =
       let uu____15187 =
         let uu____15194 =
           let uu____15195 =
             let uu____15206 =
               let uu____15211 =
-                let uu____15214 = FStar_SMTEncoding_Term.boxString b  in
-                [uu____15214]  in
-              [uu____15211]  in
+                let uu____15214 = FStar_SMTEncoding_Term.boxString b in
+                [uu____15214] in
+              [uu____15211] in
             let uu____15219 =
-              let uu____15220 = FStar_SMTEncoding_Term.boxString b  in
-              FStar_SMTEncoding_Term.mk_HasType uu____15220 tt  in
-            (uu____15206, [bb], uu____15219)  in
-          FStar_SMTEncoding_Util.mkForall uu____15195  in
+              let uu____15220 = FStar_SMTEncoding_Term.boxString b in
+              FStar_SMTEncoding_Term.mk_HasType uu____15220 tt in
+            (uu____15206, [bb], uu____15219) in
+          FStar_SMTEncoding_Util.mkForall uu____15195 in
         (uu____15194, (FStar_Pervasives_Native.Some "string typing"),
-          "string_typing")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____15187  in
+          "string_typing") in
+      FStar_SMTEncoding_Util.mkAssume uu____15187 in
     let uu____15241 =
       let uu____15244 =
         let uu____15245 =
@@ -5153,46 +4613,41 @@ let (primitive_type_axioms :
                   let uu____15270 =
                     FStar_SMTEncoding_Term.mk_tester
                       (FStar_Pervasives_Native.fst
-                         FStar_SMTEncoding_Term.boxStringFun) x
-                     in
-                  (typing_pred, uu____15270)  in
-                FStar_SMTEncoding_Util.mkImp uu____15265  in
-              ([[typing_pred]], [xx], uu____15264)  in
-            mkForall_fuel uu____15253  in
+                         FStar_SMTEncoding_Term.boxStringFun) x in
+                  (typing_pred, uu____15270) in
+                FStar_SMTEncoding_Util.mkImp uu____15265 in
+              ([[typing_pred]], [xx], uu____15264) in
+            mkForall_fuel uu____15253 in
           (uu____15252, (FStar_Pervasives_Native.Some "string inversion"),
-            "string_inversion")
-           in
-        FStar_SMTEncoding_Util.mkAssume uu____15245  in
-      [uu____15244]  in
-    uu____15186 :: uu____15241  in
+            "string_inversion") in
+        FStar_SMTEncoding_Util.mkAssume uu____15245 in
+      [uu____15244] in
+    uu____15186 :: uu____15241 in
   let mk_true_interp env nm true_tm =
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [true_tm])  in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [true_tm]) in
     [FStar_SMTEncoding_Util.mkAssume
        (valid, (FStar_Pervasives_Native.Some "True interpretation"),
-         "true_interp")]
-     in
+         "true_interp")] in
   let mk_false_interp env nm false_tm =
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [false_tm])  in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [false_tm]) in
     let uu____15323 =
       let uu____15324 =
         let uu____15331 =
           FStar_SMTEncoding_Util.mkIff
-            (FStar_SMTEncoding_Util.mkFalse, valid)
-           in
+            (FStar_SMTEncoding_Util.mkFalse, valid) in
         (uu____15331, (FStar_Pervasives_Native.Some "False interpretation"),
-          "false_interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____15324  in
-    [uu____15323]  in
+          "false_interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____15324 in
+    [uu____15323] in
   let mk_and_interp env conj uu____15343 =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort)  in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
-    let l_and_a_b = FStar_SMTEncoding_Util.mkApp (conj, [a; b])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_and_a_b])  in
-    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a])  in
-    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b])  in
+    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
+    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
+    let l_and_a_b = FStar_SMTEncoding_Util.mkApp (conj, [a; b]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_and_a_b]) in
+    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
+    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
     let uu____15368 =
       let uu____15369 =
         let uu____15376 =
@@ -5200,25 +4655,24 @@ let (primitive_type_axioms :
             let uu____15388 =
               let uu____15389 =
                 let uu____15394 =
-                  FStar_SMTEncoding_Util.mkAnd (valid_a, valid_b)  in
-                (uu____15394, valid)  in
-              FStar_SMTEncoding_Util.mkIff uu____15389  in
-            ([[l_and_a_b]], [aa; bb], uu____15388)  in
-          FStar_SMTEncoding_Util.mkForall uu____15377  in
+                  FStar_SMTEncoding_Util.mkAnd (valid_a, valid_b) in
+                (uu____15394, valid) in
+              FStar_SMTEncoding_Util.mkIff uu____15389 in
+            ([[l_and_a_b]], [aa; bb], uu____15388) in
+          FStar_SMTEncoding_Util.mkForall uu____15377 in
         (uu____15376, (FStar_Pervasives_Native.Some "/\\ interpretation"),
-          "l_and-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____15369  in
-    [uu____15368]  in
+          "l_and-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____15369 in
+    [uu____15368] in
   let mk_or_interp env disj uu____15432 =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort)  in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
-    let l_or_a_b = FStar_SMTEncoding_Util.mkApp (disj, [a; b])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_or_a_b])  in
-    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a])  in
-    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b])  in
+    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
+    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
+    let l_or_a_b = FStar_SMTEncoding_Util.mkApp (disj, [a; b]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_or_a_b]) in
+    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
+    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
     let uu____15457 =
       let uu____15458 =
         let uu____15465 =
@@ -5226,77 +4680,74 @@ let (primitive_type_axioms :
             let uu____15477 =
               let uu____15478 =
                 let uu____15483 =
-                  FStar_SMTEncoding_Util.mkOr (valid_a, valid_b)  in
-                (uu____15483, valid)  in
-              FStar_SMTEncoding_Util.mkIff uu____15478  in
-            ([[l_or_a_b]], [aa; bb], uu____15477)  in
-          FStar_SMTEncoding_Util.mkForall uu____15466  in
+                  FStar_SMTEncoding_Util.mkOr (valid_a, valid_b) in
+                (uu____15483, valid) in
+              FStar_SMTEncoding_Util.mkIff uu____15478 in
+            ([[l_or_a_b]], [aa; bb], uu____15477) in
+          FStar_SMTEncoding_Util.mkForall uu____15466 in
         (uu____15465, (FStar_Pervasives_Native.Some "\\/ interpretation"),
-          "l_or-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____15458  in
-    [uu____15457]  in
+          "l_or-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____15458 in
+    [uu____15457] in
   let mk_eq2_interp env eq2 tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort)  in
-    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort)  in
-    let yy1 = ("y", FStar_SMTEncoding_Term.Term_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1  in
-    let y1 = FStar_SMTEncoding_Util.mkFreeV yy1  in
-    let eq2_x_y = FStar_SMTEncoding_Util.mkApp (eq2, [a; x1; y1])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [eq2_x_y])  in
+    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
+    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort) in
+    let yy1 = ("y", FStar_SMTEncoding_Term.Term_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1 in
+    let y1 = FStar_SMTEncoding_Util.mkFreeV yy1 in
+    let eq2_x_y = FStar_SMTEncoding_Util.mkApp (eq2, [a; x1; y1]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [eq2_x_y]) in
     let uu____15546 =
       let uu____15547 =
         let uu____15554 =
           let uu____15555 =
             let uu____15566 =
               let uu____15567 =
-                let uu____15572 = FStar_SMTEncoding_Util.mkEq (x1, y1)  in
-                (uu____15572, valid)  in
-              FStar_SMTEncoding_Util.mkIff uu____15567  in
-            ([[eq2_x_y]], [aa; xx1; yy1], uu____15566)  in
-          FStar_SMTEncoding_Util.mkForall uu____15555  in
+                let uu____15572 = FStar_SMTEncoding_Util.mkEq (x1, y1) in
+                (uu____15572, valid) in
+              FStar_SMTEncoding_Util.mkIff uu____15567 in
+            ([[eq2_x_y]], [aa; xx1; yy1], uu____15566) in
+          FStar_SMTEncoding_Util.mkForall uu____15555 in
         (uu____15554, (FStar_Pervasives_Native.Some "Eq2 interpretation"),
-          "eq2-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____15547  in
-    [uu____15546]  in
+          "eq2-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____15547 in
+    [uu____15546] in
   let mk_eq3_interp env eq3 tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort)  in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort)  in
-    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort)  in
-    let yy1 = ("y", FStar_SMTEncoding_Term.Term_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
-    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1  in
-    let y1 = FStar_SMTEncoding_Util.mkFreeV yy1  in
-    let eq3_x_y = FStar_SMTEncoding_Util.mkApp (eq3, [a; b; x1; y1])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [eq3_x_y])  in
+    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
+    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
+    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort) in
+    let yy1 = ("y", FStar_SMTEncoding_Term.Term_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
+    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1 in
+    let y1 = FStar_SMTEncoding_Util.mkFreeV yy1 in
+    let eq3_x_y = FStar_SMTEncoding_Util.mkApp (eq3, [a; b; x1; y1]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [eq3_x_y]) in
     let uu____15645 =
       let uu____15646 =
         let uu____15653 =
           let uu____15654 =
             let uu____15665 =
               let uu____15666 =
-                let uu____15671 = FStar_SMTEncoding_Util.mkEq (x1, y1)  in
-                (uu____15671, valid)  in
-              FStar_SMTEncoding_Util.mkIff uu____15666  in
-            ([[eq3_x_y]], [aa; bb; xx1; yy1], uu____15665)  in
-          FStar_SMTEncoding_Util.mkForall uu____15654  in
+                let uu____15671 = FStar_SMTEncoding_Util.mkEq (x1, y1) in
+                (uu____15671, valid) in
+              FStar_SMTEncoding_Util.mkIff uu____15666 in
+            ([[eq3_x_y]], [aa; bb; xx1; yy1], uu____15665) in
+          FStar_SMTEncoding_Util.mkForall uu____15654 in
         (uu____15653, (FStar_Pervasives_Native.Some "Eq3 interpretation"),
-          "eq3-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____15646  in
-    [uu____15645]  in
+          "eq3-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____15646 in
+    [uu____15645] in
   let mk_imp_interp env imp tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort)  in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
-    let l_imp_a_b = FStar_SMTEncoding_Util.mkApp (imp, [a; b])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_imp_a_b])  in
-    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a])  in
-    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b])  in
+    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
+    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
+    let l_imp_a_b = FStar_SMTEncoding_Util.mkApp (imp, [a; b]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_imp_a_b]) in
+    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
+    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
     let uu____15742 =
       let uu____15743 =
         let uu____15750 =
@@ -5304,25 +4755,24 @@ let (primitive_type_axioms :
             let uu____15762 =
               let uu____15763 =
                 let uu____15768 =
-                  FStar_SMTEncoding_Util.mkImp (valid_a, valid_b)  in
-                (uu____15768, valid)  in
-              FStar_SMTEncoding_Util.mkIff uu____15763  in
-            ([[l_imp_a_b]], [aa; bb], uu____15762)  in
-          FStar_SMTEncoding_Util.mkForall uu____15751  in
+                  FStar_SMTEncoding_Util.mkImp (valid_a, valid_b) in
+                (uu____15768, valid) in
+              FStar_SMTEncoding_Util.mkIff uu____15763 in
+            ([[l_imp_a_b]], [aa; bb], uu____15762) in
+          FStar_SMTEncoding_Util.mkForall uu____15751 in
         (uu____15750, (FStar_Pervasives_Native.Some "==> interpretation"),
-          "l_imp-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____15743  in
-    [uu____15742]  in
+          "l_imp-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____15743 in
+    [uu____15742] in
   let mk_iff_interp env iff tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort)  in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
-    let l_iff_a_b = FStar_SMTEncoding_Util.mkApp (iff, [a; b])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_iff_a_b])  in
-    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a])  in
-    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b])  in
+    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
+    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
+    let l_iff_a_b = FStar_SMTEncoding_Util.mkApp (iff, [a; b]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_iff_a_b]) in
+    let valid_a = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
+    let valid_b = FStar_SMTEncoding_Util.mkApp ("Valid", [b]) in
     let uu____15831 =
       let uu____15832 =
         let uu____15839 =
@@ -5330,53 +4780,51 @@ let (primitive_type_axioms :
             let uu____15851 =
               let uu____15852 =
                 let uu____15857 =
-                  FStar_SMTEncoding_Util.mkIff (valid_a, valid_b)  in
-                (uu____15857, valid)  in
-              FStar_SMTEncoding_Util.mkIff uu____15852  in
-            ([[l_iff_a_b]], [aa; bb], uu____15851)  in
-          FStar_SMTEncoding_Util.mkForall uu____15840  in
+                  FStar_SMTEncoding_Util.mkIff (valid_a, valid_b) in
+                (uu____15857, valid) in
+              FStar_SMTEncoding_Util.mkIff uu____15852 in
+            ([[l_iff_a_b]], [aa; bb], uu____15851) in
+          FStar_SMTEncoding_Util.mkForall uu____15840 in
         (uu____15839, (FStar_Pervasives_Native.Some "<==> interpretation"),
-          "l_iff-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____15832  in
-    [uu____15831]  in
+          "l_iff-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____15832 in
+    [uu____15831] in
   let mk_not_interp env l_not tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let l_not_a = FStar_SMTEncoding_Util.mkApp (l_not, [a])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_not_a])  in
+    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let l_not_a = FStar_SMTEncoding_Util.mkApp (l_not, [a]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_not_a]) in
     let not_valid_a =
-      let uu____15909 = FStar_SMTEncoding_Util.mkApp ("Valid", [a])  in
-      FStar_All.pipe_left FStar_SMTEncoding_Util.mkNot uu____15909  in
+      let uu____15909 = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
+      FStar_All.pipe_left FStar_SMTEncoding_Util.mkNot uu____15909 in
     let uu____15912 =
       let uu____15913 =
         let uu____15920 =
           let uu____15921 =
             let uu____15932 =
-              FStar_SMTEncoding_Util.mkIff (not_valid_a, valid)  in
-            ([[l_not_a]], [aa], uu____15932)  in
-          FStar_SMTEncoding_Util.mkForall uu____15921  in
+              FStar_SMTEncoding_Util.mkIff (not_valid_a, valid) in
+            ([[l_not_a]], [aa], uu____15932) in
+          FStar_SMTEncoding_Util.mkForall uu____15921 in
         (uu____15920, (FStar_Pervasives_Native.Some "not interpretation"),
-          "l_not-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____15913  in
-    [uu____15912]  in
+          "l_not-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____15913 in
+    [uu____15912] in
   let mk_forall_interp env for_all1 tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort)  in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort)  in
-    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
-    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1  in
-    let l_forall_a_b = FStar_SMTEncoding_Util.mkApp (for_all1, [a; b])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_forall_a_b])  in
+    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
+    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
+    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
+    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1 in
+    let l_forall_a_b = FStar_SMTEncoding_Util.mkApp (for_all1, [a; b]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_forall_a_b]) in
     let valid_b_x =
       let uu____15992 =
         let uu____15999 =
-          let uu____16002 = FStar_SMTEncoding_Util.mk_ApplyTT b x1  in
-          [uu____16002]  in
-        ("Valid", uu____15999)  in
-      FStar_SMTEncoding_Util.mkApp uu____15992  in
+          let uu____16002 = FStar_SMTEncoding_Util.mk_ApplyTT b x1 in
+          [uu____16002] in
+        ("Valid", uu____15999) in
+      FStar_SMTEncoding_Util.mkApp uu____15992 in
     let uu____16005 =
       let uu____16006 =
         let uu____16013 =
@@ -5388,42 +4836,41 @@ let (primitive_type_axioms :
                     let uu____16043 =
                       let uu____16048 =
                         let uu____16051 =
-                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a  in
-                        [uu____16051]  in
-                      [uu____16048]  in
+                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a in
+                        [uu____16051] in
+                      [uu____16048] in
                     let uu____16056 =
                       let uu____16057 =
                         let uu____16062 =
-                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a  in
-                        (uu____16062, valid_b_x)  in
-                      FStar_SMTEncoding_Util.mkImp uu____16057  in
-                    (uu____16043, [xx1], uu____16056)  in
-                  FStar_SMTEncoding_Util.mkForall uu____16032  in
-                (uu____16031, valid)  in
-              FStar_SMTEncoding_Util.mkIff uu____16026  in
-            ([[l_forall_a_b]], [aa; bb], uu____16025)  in
-          FStar_SMTEncoding_Util.mkForall uu____16014  in
+                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a in
+                        (uu____16062, valid_b_x) in
+                      FStar_SMTEncoding_Util.mkImp uu____16057 in
+                    (uu____16043, [xx1], uu____16056) in
+                  FStar_SMTEncoding_Util.mkForall uu____16032 in
+                (uu____16031, valid) in
+              FStar_SMTEncoding_Util.mkIff uu____16026 in
+            ([[l_forall_a_b]], [aa; bb], uu____16025) in
+          FStar_SMTEncoding_Util.mkForall uu____16014 in
         (uu____16013, (FStar_Pervasives_Native.Some "forall interpretation"),
-          "forall-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____16006  in
-    [uu____16005]  in
+          "forall-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____16006 in
+    [uu____16005] in
   let mk_exists_interp env for_some1 tt =
-    let aa = ("a", FStar_SMTEncoding_Term.Term_sort)  in
-    let bb = ("b", FStar_SMTEncoding_Term.Term_sort)  in
-    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort)  in
-    let a = FStar_SMTEncoding_Util.mkFreeV aa  in
-    let b = FStar_SMTEncoding_Util.mkFreeV bb  in
-    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1  in
-    let l_exists_a_b = FStar_SMTEncoding_Util.mkApp (for_some1, [a; b])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_exists_a_b])  in
+    let aa = ("a", FStar_SMTEncoding_Term.Term_sort) in
+    let bb = ("b", FStar_SMTEncoding_Term.Term_sort) in
+    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort) in
+    let a = FStar_SMTEncoding_Util.mkFreeV aa in
+    let b = FStar_SMTEncoding_Util.mkFreeV bb in
+    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1 in
+    let l_exists_a_b = FStar_SMTEncoding_Util.mkApp (for_some1, [a; b]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_exists_a_b]) in
     let valid_b_x =
       let uu____16144 =
         let uu____16151 =
-          let uu____16154 = FStar_SMTEncoding_Util.mk_ApplyTT b x1  in
-          [uu____16154]  in
-        ("Valid", uu____16151)  in
-      FStar_SMTEncoding_Util.mkApp uu____16144  in
+          let uu____16154 = FStar_SMTEncoding_Util.mk_ApplyTT b x1 in
+          [uu____16154] in
+        ("Valid", uu____16151) in
+      FStar_SMTEncoding_Util.mkApp uu____16144 in
     let uu____16157 =
       let uu____16158 =
         let uu____16165 =
@@ -5435,76 +4882,71 @@ let (primitive_type_axioms :
                     let uu____16195 =
                       let uu____16200 =
                         let uu____16203 =
-                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a  in
-                        [uu____16203]  in
-                      [uu____16200]  in
+                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a in
+                        [uu____16203] in
+                      [uu____16200] in
                     let uu____16208 =
                       let uu____16209 =
                         let uu____16214 =
-                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a  in
-                        (uu____16214, valid_b_x)  in
-                      FStar_SMTEncoding_Util.mkImp uu____16209  in
-                    (uu____16195, [xx1], uu____16208)  in
-                  FStar_SMTEncoding_Util.mkExists uu____16184  in
-                (uu____16183, valid)  in
-              FStar_SMTEncoding_Util.mkIff uu____16178  in
-            ([[l_exists_a_b]], [aa; bb], uu____16177)  in
-          FStar_SMTEncoding_Util.mkForall uu____16166  in
+                          FStar_SMTEncoding_Term.mk_HasTypeZ x1 a in
+                        (uu____16214, valid_b_x) in
+                      FStar_SMTEncoding_Util.mkImp uu____16209 in
+                    (uu____16195, [xx1], uu____16208) in
+                  FStar_SMTEncoding_Util.mkExists uu____16184 in
+                (uu____16183, valid) in
+              FStar_SMTEncoding_Util.mkIff uu____16178 in
+            ([[l_exists_a_b]], [aa; bb], uu____16177) in
+          FStar_SMTEncoding_Util.mkForall uu____16166 in
         (uu____16165, (FStar_Pervasives_Native.Some "exists interpretation"),
-          "exists-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____16158  in
-    [uu____16157]  in
+          "exists-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____16158 in
+    [uu____16157] in
   let mk_range_interp env range tt =
-    let range_ty = FStar_SMTEncoding_Util.mkApp (range, [])  in
+    let range_ty = FStar_SMTEncoding_Util.mkApp (range, []) in
     let uu____16274 =
       let uu____16275 =
         let uu____16282 =
-          let uu____16283 = FStar_SMTEncoding_Term.mk_Range_const ()  in
-          FStar_SMTEncoding_Term.mk_HasTypeZ uu____16283 range_ty  in
-        let uu____16284 = varops.mk_unique "typing_range_const"  in
+          let uu____16283 = FStar_SMTEncoding_Term.mk_Range_const () in
+          FStar_SMTEncoding_Term.mk_HasTypeZ uu____16283 range_ty in
+        let uu____16284 = varops.mk_unique "typing_range_const" in
         (uu____16282, (FStar_Pervasives_Native.Some "Range_const typing"),
-          uu____16284)
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____16275  in
-    [uu____16274]  in
+          uu____16284) in
+      FStar_SMTEncoding_Util.mkAssume uu____16275 in
+    [uu____16274] in
   let mk_inversion_axiom env inversion tt =
-    let tt1 = ("t", FStar_SMTEncoding_Term.Term_sort)  in
-    let t = FStar_SMTEncoding_Util.mkFreeV tt1  in
-    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort)  in
-    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1  in
-    let inversion_t = FStar_SMTEncoding_Util.mkApp (inversion, [t])  in
-    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [inversion_t])  in
+    let tt1 = ("t", FStar_SMTEncoding_Term.Term_sort) in
+    let t = FStar_SMTEncoding_Util.mkFreeV tt1 in
+    let xx1 = ("x", FStar_SMTEncoding_Term.Term_sort) in
+    let x1 = FStar_SMTEncoding_Util.mkFreeV xx1 in
+    let inversion_t = FStar_SMTEncoding_Util.mkApp (inversion, [t]) in
+    let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [inversion_t]) in
     let body =
-      let hastypeZ = FStar_SMTEncoding_Term.mk_HasTypeZ x1 t  in
+      let hastypeZ = FStar_SMTEncoding_Term.mk_HasTypeZ x1 t in
       let hastypeS =
-        let uu____16318 = FStar_SMTEncoding_Term.n_fuel (Prims.parse_int "1")
-           in
-        FStar_SMTEncoding_Term.mk_HasTypeFuel uu____16318 x1 t  in
+        let uu____16318 = FStar_SMTEncoding_Term.n_fuel (Prims.parse_int "1") in
+        FStar_SMTEncoding_Term.mk_HasTypeFuel uu____16318 x1 t in
       let uu____16319 =
-        let uu____16330 = FStar_SMTEncoding_Util.mkImp (hastypeZ, hastypeS)
-           in
-        ([[hastypeZ]], [xx1], uu____16330)  in
-      FStar_SMTEncoding_Util.mkForall uu____16319  in
+        let uu____16330 = FStar_SMTEncoding_Util.mkImp (hastypeZ, hastypeS) in
+        ([[hastypeZ]], [xx1], uu____16330) in
+      FStar_SMTEncoding_Util.mkForall uu____16319 in
     let uu____16353 =
       let uu____16354 =
         let uu____16361 =
           let uu____16362 =
-            let uu____16373 = FStar_SMTEncoding_Util.mkImp (valid, body)  in
-            ([[inversion_t]], [tt1], uu____16373)  in
-          FStar_SMTEncoding_Util.mkForall uu____16362  in
+            let uu____16373 = FStar_SMTEncoding_Util.mkImp (valid, body) in
+            ([[inversion_t]], [tt1], uu____16373) in
+          FStar_SMTEncoding_Util.mkForall uu____16362 in
         (uu____16361,
           (FStar_Pervasives_Native.Some "inversion interpretation"),
-          "inversion-interp")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____16354  in
-    [uu____16353]  in
+          "inversion-interp") in
+      FStar_SMTEncoding_Util.mkAssume uu____16354 in
+    [uu____16353] in
   let mk_with_type_axiom env with_type1 tt =
-    let tt1 = ("t", FStar_SMTEncoding_Term.Term_sort)  in
-    let t = FStar_SMTEncoding_Util.mkFreeV tt1  in
-    let ee = ("e", FStar_SMTEncoding_Term.Term_sort)  in
-    let e = FStar_SMTEncoding_Util.mkFreeV ee  in
-    let with_type_t_e = FStar_SMTEncoding_Util.mkApp (with_type1, [t; e])  in
+    let tt1 = ("t", FStar_SMTEncoding_Term.Term_sort) in
+    let t = FStar_SMTEncoding_Util.mkFreeV tt1 in
+    let ee = ("e", FStar_SMTEncoding_Term.Term_sort) in
+    let e = FStar_SMTEncoding_Util.mkFreeV ee in
+    let with_type_t_e = FStar_SMTEncoding_Util.mkApp (with_type1, [t; e]) in
     let uu____16423 =
       let uu____16424 =
         let uu____16431 =
@@ -5512,22 +4954,20 @@ let (primitive_type_axioms :
             let uu____16447 =
               let uu____16448 =
                 let uu____16453 =
-                  FStar_SMTEncoding_Util.mkEq (with_type_t_e, e)  in
+                  FStar_SMTEncoding_Util.mkEq (with_type_t_e, e) in
                 let uu____16454 =
-                  FStar_SMTEncoding_Term.mk_HasType with_type_t_e t  in
-                (uu____16453, uu____16454)  in
-              FStar_SMTEncoding_Util.mkAnd uu____16448  in
+                  FStar_SMTEncoding_Term.mk_HasType with_type_t_e t in
+                (uu____16453, uu____16454) in
+              FStar_SMTEncoding_Util.mkAnd uu____16448 in
             ([[with_type_t_e]],
               (FStar_Pervasives_Native.Some (Prims.parse_int "0")),
-              [tt1; ee], uu____16447)
-             in
-          FStar_SMTEncoding_Util.mkForall' uu____16432  in
+              [tt1; ee], uu____16447) in
+          FStar_SMTEncoding_Util.mkForall' uu____16432 in
         (uu____16431,
           (FStar_Pervasives_Native.Some "with_type primitive axiom"),
-          "@with_type_primitive_axiom")
-         in
-      FStar_SMTEncoding_Util.mkAssume uu____16424  in
-    [uu____16423]  in
+          "@with_type_primitive_axiom") in
+      FStar_SMTEncoding_Util.mkAssume uu____16424 in
+    [uu____16423] in
   let prims1 =
     [(FStar_Parser_Const.unit_lid, mk_unit);
     (FStar_Parser_Const.bool_lid, mk_bool);
@@ -5546,7 +4986,7 @@ let (primitive_type_axioms :
     (FStar_Parser_Const.exists_lid, mk_exists_interp);
     (FStar_Parser_Const.range_lid, mk_range_interp);
     (FStar_Parser_Const.inversion_lid, mk_inversion_axiom);
-    (FStar_Parser_Const.with_type_lid, mk_with_type_axiom)]  in
+    (FStar_Parser_Const.with_type_lid, mk_with_type_axiom)] in
   fun env  ->
     fun t  ->
       fun s  ->
@@ -5555,22 +4995,20 @@ let (primitive_type_axioms :
             FStar_Util.find_opt
               (fun uu____16826  ->
                  match uu____16826 with
-                 | (l,uu____16838) -> FStar_Ident.lid_equals l t) prims1
-             in
+                 | (l,uu____16838) -> FStar_Ident.lid_equals l t) prims1 in
           match uu____16800 with
           | FStar_Pervasives_Native.None  -> []
           | FStar_Pervasives_Native.Some (uu____16863,f) -> f env s tt
-  
-let (encode_smt_lemma :
+let encode_smt_lemma:
   env_t ->
     FStar_Syntax_Syntax.fv ->
-      FStar_Syntax_Syntax.typ -> FStar_SMTEncoding_Term.decl Prims.list)
+      FStar_Syntax_Syntax.typ -> FStar_SMTEncoding_Term.decl Prims.list
   =
   fun env  ->
     fun fv  ->
       fun t  ->
-        let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-        let uu____16899 = encode_function_type_as_formula t env  in
+        let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+        let uu____16899 = encode_function_type_as_formula t env in
         match uu____16899 with
         | (form,decls) ->
             FStar_List.append decls
@@ -5579,8 +5017,7 @@ let (encode_smt_lemma :
                    (FStar_Pervasives_Native.Some
                       (Prims.strcat "Lemma: " lid.FStar_Ident.str)),
                    (Prims.strcat "lemma_" lid.FStar_Ident.str))]
-  
-let (encode_free_var :
+let encode_free_var:
   Prims.bool ->
     env_t ->
       FStar_Syntax_Syntax.fv ->
@@ -5588,7 +5025,7 @@ let (encode_free_var :
           FStar_Syntax_Syntax.term ->
             FStar_Syntax_Syntax.qualifier Prims.list ->
               (FStar_SMTEncoding_Term.decl Prims.list,env_t)
-                FStar_Pervasives_Native.tuple2)
+                FStar_Pervasives_Native.tuple2
   =
   fun uninterpreted  ->
     fun env  ->
@@ -5597,78 +5034,70 @@ let (encode_free_var :
           fun t_norm  ->
             fun quals  ->
               let lid =
-                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
               let uu____16939 =
                 ((let uu____16942 =
                     (FStar_Syntax_Util.is_pure_or_ghost_function t_norm) ||
                       (FStar_TypeChecker_Env.is_reifiable_function env.tcenv
-                         t_norm)
-                     in
+                         t_norm) in
                   FStar_All.pipe_left Prims.op_Negation uu____16942) ||
                    (FStar_Syntax_Util.is_lemma t_norm))
-                  || uninterpreted
-                 in
+                  || uninterpreted in
               if uu____16939
               then
-                let uu____16949 = new_term_constant_and_tok_from_lid env lid
-                   in
+                let uu____16949 = new_term_constant_and_tok_from_lid env lid in
                 match uu____16949 with
                 | (vname,vtok,env1) ->
                     let arg_sorts =
                       let uu____16968 =
-                        let uu____16969 = FStar_Syntax_Subst.compress t_norm
-                           in
-                        uu____16969.FStar_Syntax_Syntax.n  in
+                        let uu____16969 = FStar_Syntax_Subst.compress t_norm in
+                        uu____16969.FStar_Syntax_Syntax.n in
                       match uu____16968 with
                       | FStar_Syntax_Syntax.Tm_arrow (binders,uu____16975) ->
                           FStar_All.pipe_right binders
                             (FStar_List.map
                                (fun uu____17005  ->
                                   FStar_SMTEncoding_Term.Term_sort))
-                      | uu____17010 -> []  in
+                      | uu____17010 -> [] in
                     let d =
                       FStar_SMTEncoding_Term.DeclFun
                         (vname, arg_sorts, FStar_SMTEncoding_Term.Term_sort,
                           (FStar_Pervasives_Native.Some
-                             "Uninterpreted function symbol for impure function"))
-                       in
+                             "Uninterpreted function symbol for impure function")) in
                     let dd =
                       FStar_SMTEncoding_Term.DeclFun
                         (vtok, [], FStar_SMTEncoding_Term.Term_sort,
                           (FStar_Pervasives_Native.Some
-                             "Uninterpreted name for impure function"))
-                       in
+                             "Uninterpreted name for impure function")) in
                     ([d; dd], env1)
               else
-                (let uu____17024 = prims.is lid  in
+                (let uu____17024 = prims.is lid in
                  if uu____17024
                  then
-                   let vname = varops.new_fvar lid  in
-                   let uu____17032 = prims.mk lid vname  in
+                   let vname = varops.new_fvar lid in
+                   let uu____17032 = prims.mk lid vname in
                    match uu____17032 with
                    | (tok,definition) ->
                        let env1 =
                          push_free_var env lid vname
-                           (FStar_Pervasives_Native.Some tok)
-                          in
+                           (FStar_Pervasives_Native.Some tok) in
                        (definition, env1)
                  else
                    (let encode_non_total_function_typ =
-                      lid.FStar_Ident.nsstr <> "Prims"  in
+                      lid.FStar_Ident.nsstr <> "Prims" in
                     let uu____17056 =
-                      let uu____17067 = curried_arrow_formals_comp t_norm  in
+                      let uu____17067 = curried_arrow_formals_comp t_norm in
                       match uu____17067 with
                       | (args,comp) ->
                           let comp1 =
                             let uu____17085 =
                               FStar_TypeChecker_Env.is_reifiable_comp
-                                env.tcenv comp
-                               in
+                                env.tcenv comp in
                             if uu____17085
                             then
                               let uu____17086 =
                                 FStar_TypeChecker_Env.reify_comp
-                                  (let uu___119_17089 = env.tcenv  in
+                                  (let uu___119_17089 = env.tcenv in
                                    {
                                      FStar_TypeChecker_Env.solver =
                                        (uu___119_17089.FStar_TypeChecker_Env.solver);
@@ -5739,26 +5168,23 @@ let (encode_free_var :
                                        (uu___119_17089.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.dep_graph =
                                        (uu___119_17089.FStar_TypeChecker_Env.dep_graph)
-                                   }) comp FStar_Syntax_Syntax.U_unknown
-                                 in
+                                   }) comp FStar_Syntax_Syntax.U_unknown in
                               FStar_Syntax_Syntax.mk_Total uu____17086
-                            else comp  in
+                            else comp in
                           if encode_non_total_function_typ
                           then
                             let uu____17101 =
                               FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
-                                env.tcenv comp1
-                               in
+                                env.tcenv comp1 in
                             (args, uu____17101)
                           else
                             (args,
                               (FStar_Pervasives_Native.None,
-                                (FStar_Syntax_Util.comp_result comp1)))
-                       in
+                                (FStar_Syntax_Util.comp_result comp1))) in
                     match uu____17056 with
                     | (formals,(pre_opt,res_t)) ->
                         let uu____17146 =
-                          new_term_constant_and_tok_from_lid env lid  in
+                          new_term_constant_and_tok_from_lid env lid in
                         (match uu____17146 with
                          | (vname,vtok,env1) ->
                              let vtok_tm =
@@ -5768,8 +5194,7 @@ let (encode_free_var :
                                      (vname,
                                        FStar_SMTEncoding_Term.Term_sort)
                                | uu____17167 ->
-                                   FStar_SMTEncoding_Util.mkApp (vtok, [])
-                                in
+                                   FStar_SMTEncoding_Util.mkApp (vtok, []) in
                              let mk_disc_proj_axioms guard encoded_res_t vapp
                                vars =
                                FStar_All.pipe_right quals
@@ -5779,15 +5204,14 @@ let (encode_free_var :
                                        | FStar_Syntax_Syntax.Discriminator d
                                            ->
                                            let uu____17213 =
-                                             FStar_Util.prefix vars  in
+                                             FStar_Util.prefix vars in
                                            (match uu____17213 with
                                             | (uu____17234,(xxsym,uu____17236))
                                                 ->
                                                 let xx =
                                                   FStar_SMTEncoding_Util.mkFreeV
                                                     (xxsym,
-                                                      FStar_SMTEncoding_Term.Term_sort)
-                                                   in
+                                                      FStar_SMTEncoding_Term.Term_sort) in
                                                 let uu____17254 =
                                                   let uu____17255 =
                                                     let uu____17262 =
@@ -5800,48 +5224,39 @@ let (encode_free_var :
                                                                 FStar_SMTEncoding_Term.mk_tester
                                                                   (escape
                                                                     d.FStar_Ident.str)
-                                                                  xx
-                                                                 in
+                                                                  xx in
                                                               FStar_All.pipe_left
                                                                 FStar_SMTEncoding_Term.boxBool
-                                                                uu____17281
-                                                               in
+                                                                uu____17281 in
                                                             (vapp,
-                                                              uu____17280)
-                                                             in
+                                                              uu____17280) in
                                                           FStar_SMTEncoding_Util.mkEq
-                                                            uu____17275
-                                                           in
+                                                            uu____17275 in
                                                         ([[vapp]], vars,
-                                                          uu____17274)
-                                                         in
+                                                          uu____17274) in
                                                       FStar_SMTEncoding_Util.mkForall
-                                                        uu____17263
-                                                       in
+                                                        uu____17263 in
                                                     (uu____17262,
                                                       (FStar_Pervasives_Native.Some
                                                          "Discriminator equation"),
                                                       (Prims.strcat
                                                          "disc_equation_"
                                                          (escape
-                                                            d.FStar_Ident.str)))
-                                                     in
+                                                            d.FStar_Ident.str))) in
                                                   FStar_SMTEncoding_Util.mkAssume
-                                                    uu____17255
-                                                   in
+                                                    uu____17255 in
                                                 [uu____17254])
                                        | FStar_Syntax_Syntax.Projector 
                                            (d,f) ->
                                            let uu____17300 =
-                                             FStar_Util.prefix vars  in
+                                             FStar_Util.prefix vars in
                                            (match uu____17300 with
                                             | (uu____17321,(xxsym,uu____17323))
                                                 ->
                                                 let xx =
                                                   FStar_SMTEncoding_Util.mkFreeV
                                                     (xxsym,
-                                                      FStar_SMTEncoding_Term.Term_sort)
-                                                   in
+                                                      FStar_SMTEncoding_Term.Term_sort) in
                                                 let f1 =
                                                   {
                                                     FStar_Syntax_Syntax.ppname
@@ -5851,45 +5266,36 @@ let (encode_free_var :
                                                     FStar_Syntax_Syntax.sort
                                                       =
                                                       FStar_Syntax_Syntax.tun
-                                                  }  in
+                                                  } in
                                                 let tp_name =
-                                                  mk_term_projector_name d f1
-                                                   in
+                                                  mk_term_projector_name d f1 in
                                                 let prim_app =
                                                   FStar_SMTEncoding_Util.mkApp
-                                                    (tp_name, [xx])
-                                                   in
+                                                    (tp_name, [xx]) in
                                                 let uu____17346 =
                                                   let uu____17347 =
                                                     let uu____17354 =
                                                       let uu____17355 =
                                                         let uu____17366 =
                                                           FStar_SMTEncoding_Util.mkEq
-                                                            (vapp, prim_app)
-                                                           in
+                                                            (vapp, prim_app) in
                                                         ([[vapp]], vars,
-                                                          uu____17366)
-                                                         in
+                                                          uu____17366) in
                                                       FStar_SMTEncoding_Util.mkForall
-                                                        uu____17355
-                                                       in
+                                                        uu____17355 in
                                                     (uu____17354,
                                                       (FStar_Pervasives_Native.Some
                                                          "Projector equation"),
                                                       (Prims.strcat
                                                          "proj_equation_"
-                                                         tp_name))
-                                                     in
+                                                         tp_name)) in
                                                   FStar_SMTEncoding_Util.mkAssume
-                                                    uu____17347
-                                                   in
+                                                    uu____17347 in
                                                 [uu____17346])
-                                       | uu____17383 -> []))
-                                in
+                                       | uu____17383 -> [])) in
                              let uu____17384 =
                                encode_binders FStar_Pervasives_Native.None
-                                 formals env1
-                                in
+                                 formals env1 in
                              (match uu____17384 with
                               | (vars,guards,env',decls1,uu____17411) ->
                                   let uu____17424 =
@@ -5897,36 +5303,30 @@ let (encode_free_var :
                                     | FStar_Pervasives_Native.None  ->
                                         let uu____17433 =
                                           FStar_SMTEncoding_Util.mk_and_l
-                                            guards
-                                           in
+                                            guards in
                                         (uu____17433, decls1)
                                     | FStar_Pervasives_Native.Some p ->
                                         let uu____17435 =
-                                          encode_formula p env'  in
+                                          encode_formula p env' in
                                         (match uu____17435 with
                                          | (g,ds) ->
                                              let uu____17446 =
                                                FStar_SMTEncoding_Util.mk_and_l
-                                                 (g :: guards)
-                                                in
+                                                 (g :: guards) in
                                              (uu____17446,
-                                               (FStar_List.append decls1 ds)))
-                                     in
+                                               (FStar_List.append decls1 ds))) in
                                   (match uu____17424 with
                                    | (guard,decls11) ->
-                                       let vtok_app = mk_Apply vtok_tm vars
-                                          in
+                                       let vtok_app = mk_Apply vtok_tm vars in
                                        let vapp =
                                          let uu____17459 =
                                            let uu____17466 =
                                              FStar_List.map
                                                FStar_SMTEncoding_Util.mkFreeV
-                                               vars
-                                              in
-                                           (vname, uu____17466)  in
+                                               vars in
+                                           (vname, uu____17466) in
                                          FStar_SMTEncoding_Util.mkApp
-                                           uu____17459
-                                          in
+                                           uu____17459 in
                                        let uu____17475 =
                                          let vname_decl =
                                            let uu____17483 =
@@ -5934,18 +5334,15 @@ let (encode_free_var :
                                                FStar_All.pipe_right formals
                                                  (FStar_List.map
                                                     (fun uu____17504  ->
-                                                       FStar_SMTEncoding_Term.Term_sort))
-                                                in
+                                                       FStar_SMTEncoding_Term.Term_sort)) in
                                              (vname, uu____17494,
                                                FStar_SMTEncoding_Term.Term_sort,
-                                               FStar_Pervasives_Native.None)
-                                              in
+                                               FStar_Pervasives_Native.None) in
                                            FStar_SMTEncoding_Term.DeclFun
-                                             uu____17483
-                                            in
+                                             uu____17483 in
                                          let uu____17513 =
                                            let env2 =
-                                             let uu___120_17519 = env1  in
+                                             let uu___120_17519 = env1 in
                                              {
                                                bindings =
                                                  (uu___120_17519.bindings);
@@ -5960,12 +5357,11 @@ let (encode_free_var :
                                                encode_non_total_function_typ;
                                                current_module_name =
                                                  (uu___120_17519.current_module_name)
-                                             }  in
+                                             } in
                                            let uu____17520 =
                                              let uu____17521 =
-                                               head_normal env2 tt  in
-                                             Prims.op_Negation uu____17521
-                                              in
+                                               head_normal env2 tt in
+                                             Prims.op_Negation uu____17521 in
                                            if uu____17520
                                            then
                                              encode_term_pred
@@ -5974,8 +5370,7 @@ let (encode_free_var :
                                            else
                                              encode_term_pred
                                                FStar_Pervasives_Native.None
-                                               t_norm env2 vtok_tm
-                                            in
+                                               t_norm env2 vtok_tm in
                                          match uu____17513 with
                                          | (tok_typing,decls2) ->
                                              let tok_typing1 =
@@ -5983,33 +5378,26 @@ let (encode_free_var :
                                                | uu____17536::uu____17537 ->
                                                    let ff =
                                                      ("ty",
-                                                       FStar_SMTEncoding_Term.Term_sort)
-                                                      in
+                                                       FStar_SMTEncoding_Term.Term_sort) in
                                                    let f =
                                                      FStar_SMTEncoding_Util.mkFreeV
-                                                       ff
-                                                      in
+                                                       ff in
                                                    let vtok_app_l =
-                                                     mk_Apply vtok_tm [ff]
-                                                      in
+                                                     mk_Apply vtok_tm [ff] in
                                                    let vtok_app_r =
                                                      mk_Apply f
                                                        [(vtok,
-                                                          FStar_SMTEncoding_Term.Term_sort)]
-                                                      in
+                                                          FStar_SMTEncoding_Term.Term_sort)] in
                                                    let guarded_tok_typing =
                                                      let uu____17577 =
                                                        let uu____17588 =
                                                          FStar_SMTEncoding_Term.mk_NoHoist
-                                                           f tok_typing
-                                                          in
+                                                           f tok_typing in
                                                        ([[vtok_app_l];
                                                         [vtok_app_r]], 
-                                                         [ff], uu____17588)
-                                                        in
+                                                         [ff], uu____17588) in
                                                      FStar_SMTEncoding_Util.mkForall
-                                                       uu____17577
-                                                      in
+                                                       uu____17577 in
                                                    FStar_SMTEncoding_Util.mkAssume
                                                      (guarded_tok_typing,
                                                        (FStar_Pervasives_Native.Some
@@ -6024,8 +5412,7 @@ let (encode_free_var :
                                                           "function token typing"),
                                                        (Prims.strcat
                                                           "function_token_typing_"
-                                                          vname))
-                                                in
+                                                          vname)) in
                                              let uu____17618 =
                                                match formals with
                                                | [] ->
@@ -6034,17 +5421,14 @@ let (encode_free_var :
                                                        let uu____17639 =
                                                          FStar_SMTEncoding_Util.mkFreeV
                                                            (vname,
-                                                             FStar_SMTEncoding_Term.Term_sort)
-                                                          in
+                                                             FStar_SMTEncoding_Term.Term_sort) in
                                                        FStar_All.pipe_left
                                                          (fun _0_42  ->
                                                             FStar_Pervasives_Native.Some
                                                               _0_42)
-                                                         uu____17639
-                                                        in
+                                                         uu____17639 in
                                                      push_free_var env1 lid
-                                                       vname uu____17636
-                                                      in
+                                                       vname uu____17636 in
                                                    ((FStar_List.append decls2
                                                        [tok_typing1]),
                                                      uu____17635)
@@ -6053,8 +5437,7 @@ let (encode_free_var :
                                                      FStar_SMTEncoding_Term.DeclFun
                                                        (vtok, [],
                                                          FStar_SMTEncoding_Term.Term_sort,
-                                                         FStar_Pervasives_Native.None)
-                                                      in
+                                                         FStar_Pervasives_Native.None) in
                                                    let name_tok_corr =
                                                      let uu____17651 =
                                                        let uu____17658 =
@@ -6062,53 +5445,43 @@ let (encode_free_var :
                                                            let uu____17670 =
                                                              FStar_SMTEncoding_Util.mkEq
                                                                (vtok_app,
-                                                                 vapp)
-                                                              in
+                                                                 vapp) in
                                                            ([[vtok_app];
                                                             [vapp]], vars,
-                                                             uu____17670)
-                                                            in
+                                                             uu____17670) in
                                                          FStar_SMTEncoding_Util.mkForall
-                                                           uu____17659
-                                                          in
+                                                           uu____17659 in
                                                        (uu____17658,
                                                          (FStar_Pervasives_Native.Some
                                                             "Name-token correspondence"),
                                                          (Prims.strcat
                                                             "token_correspondence_"
-                                                            vname))
-                                                        in
+                                                            vname)) in
                                                      FStar_SMTEncoding_Util.mkAssume
-                                                       uu____17651
-                                                      in
+                                                       uu____17651 in
                                                    ((FStar_List.append decls2
                                                        [vtok_decl;
                                                        name_tok_corr;
-                                                       tok_typing1]), env1)
-                                                in
+                                                       tok_typing1]), env1) in
                                              (match uu____17618 with
                                               | (tok_decl,env2) ->
                                                   ((vname_decl :: tok_decl),
-                                                    env2))
-                                          in
+                                                    env2)) in
                                        (match uu____17475 with
                                         | (decls2,env2) ->
                                             let uu____17713 =
                                               let res_t1 =
                                                 FStar_Syntax_Subst.compress
-                                                  res_t
-                                                 in
+                                                  res_t in
                                               let uu____17721 =
-                                                encode_term res_t1 env'  in
+                                                encode_term res_t1 env' in
                                               match uu____17721 with
                                               | (encoded_res_t,decls) ->
                                                   let uu____17734 =
                                                     FStar_SMTEncoding_Term.mk_HasType
-                                                      vapp encoded_res_t
-                                                     in
+                                                      vapp encoded_res_t in
                                                   (encoded_res_t,
-                                                    uu____17734, decls)
-                                               in
+                                                    uu____17734, decls) in
                                             (match uu____17713 with
                                              | (encoded_res_t,ty_pred,decls3)
                                                  ->
@@ -6118,30 +5491,24 @@ let (encode_free_var :
                                                        let uu____17753 =
                                                          let uu____17764 =
                                                            FStar_SMTEncoding_Util.mkImp
-                                                             (guard, ty_pred)
-                                                            in
+                                                             (guard, ty_pred) in
                                                          ([[vapp]], vars,
-                                                           uu____17764)
-                                                          in
+                                                           uu____17764) in
                                                        FStar_SMTEncoding_Util.mkForall
-                                                         uu____17753
-                                                        in
+                                                         uu____17753 in
                                                      (uu____17752,
                                                        (FStar_Pervasives_Native.Some
                                                           "free var typing"),
                                                        (Prims.strcat
-                                                          "typing_" vname))
-                                                      in
+                                                          "typing_" vname)) in
                                                    FStar_SMTEncoding_Util.mkAssume
-                                                     uu____17745
-                                                    in
+                                                     uu____17745 in
                                                  let freshness =
                                                    let uu____17780 =
                                                      FStar_All.pipe_right
                                                        quals
                                                        (FStar_List.contains
-                                                          FStar_Syntax_Syntax.New)
-                                                      in
+                                                          FStar_Syntax_Syntax.New) in
                                                    if uu____17780
                                                    then
                                                      let uu____17785 =
@@ -6150,27 +5517,22 @@ let (encode_free_var :
                                                            FStar_All.pipe_right
                                                              vars
                                                              (FStar_List.map
-                                                                FStar_Pervasives_Native.snd)
-                                                            in
+                                                                FStar_Pervasives_Native.snd) in
                                                          let uu____17808 =
-                                                           varops.next_id ()
-                                                            in
+                                                           varops.next_id () in
                                                          (vname, uu____17797,
                                                            FStar_SMTEncoding_Term.Term_sort,
-                                                           uu____17808)
-                                                          in
+                                                           uu____17808) in
                                                        FStar_SMTEncoding_Term.fresh_constructor
-                                                         uu____17786
-                                                        in
+                                                         uu____17786 in
                                                      let uu____17811 =
                                                        let uu____17814 =
                                                          pretype_axiom env2
-                                                           vapp vars
-                                                          in
-                                                       [uu____17814]  in
+                                                           vapp vars in
+                                                       [uu____17814] in
                                                      uu____17785 ::
                                                        uu____17811
-                                                   else []  in
+                                                   else [] in
                                                  let g =
                                                    let uu____17819 =
                                                      let uu____17822 =
@@ -6180,27 +5542,20 @@ let (encode_free_var :
                                                              mk_disc_proj_axioms
                                                                guard
                                                                encoded_res_t
-                                                               vapp vars
-                                                              in
+                                                               vapp vars in
                                                            typingAx ::
-                                                             uu____17831
-                                                            in
+                                                             uu____17831 in
                                                          FStar_List.append
                                                            freshness
-                                                           uu____17828
-                                                          in
+                                                           uu____17828 in
                                                        FStar_List.append
-                                                         decls3 uu____17825
-                                                        in
+                                                         decls3 uu____17825 in
                                                      FStar_List.append decls2
-                                                       uu____17822
-                                                      in
+                                                       uu____17822 in
                                                    FStar_List.append decls11
-                                                     uu____17819
-                                                    in
+                                                     uu____17819 in
                                                  (g, env2))))))))
-  
-let (declare_top_level_let :
+let declare_top_level_let:
   env_t ->
     FStar_Syntax_Syntax.fv ->
       FStar_Syntax_Syntax.term ->
@@ -6209,7 +5564,7 @@ let (declare_top_level_let :
                            FStar_Pervasives_Native.option)
              FStar_Pervasives_Native.tuple2,FStar_SMTEncoding_Term.decl
                                               Prims.list,env_t)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun x  ->
@@ -6217,56 +5572,52 @@ let (declare_top_level_let :
         fun t_norm  ->
           let uu____17862 =
             try_lookup_lid env
-              (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           match uu____17862 with
           | FStar_Pervasives_Native.None  ->
-              let uu____17899 = encode_free_var false env x t t_norm []  in
+              let uu____17899 = encode_free_var false env x t t_norm [] in
               (match uu____17899 with
                | (decls,env1) ->
                    let uu____17926 =
                      lookup_lid env1
-                       (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                      in
+                       (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                    (match uu____17926 with
                     | (n1,x',uu____17953) -> ((n1, x'), decls, env1)))
           | FStar_Pervasives_Native.Some (n1,x1,uu____17974) ->
               ((n1, x1), [], env)
-  
-let (encode_top_level_val :
+let encode_top_level_val:
   Prims.bool ->
     env_t ->
       FStar_Syntax_Syntax.fv ->
         FStar_Syntax_Syntax.term ->
           FStar_Syntax_Syntax.qualifier Prims.list ->
             (FStar_SMTEncoding_Term.decl Prims.list,env_t)
-              FStar_Pervasives_Native.tuple2)
+              FStar_Pervasives_Native.tuple2
   =
   fun uninterpreted  ->
     fun env  ->
       fun lid  ->
         fun t  ->
           fun quals  ->
-            let tt = norm env t  in
+            let tt = norm env t in
             let uu____18029 =
-              encode_free_var uninterpreted env lid t tt quals  in
+              encode_free_var uninterpreted env lid t tt quals in
             match uu____18029 with
             | (decls,env1) ->
-                let uu____18048 = FStar_Syntax_Util.is_smt_lemma t  in
+                let uu____18048 = FStar_Syntax_Util.is_smt_lemma t in
                 if uu____18048
                 then
                   let uu____18055 =
-                    let uu____18058 = encode_smt_lemma env1 lid tt  in
-                    FStar_List.append decls uu____18058  in
+                    let uu____18058 = encode_smt_lemma env1 lid tt in
+                    FStar_List.append decls uu____18058 in
                   (uu____18055, env1)
                 else (decls, env1)
-  
-let (encode_top_level_vals :
+let encode_top_level_vals:
   env_t ->
     FStar_Syntax_Syntax.letbinding Prims.list ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
         (FStar_SMTEncoding_Term.decl Prims.list,env_t)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun bindings  ->
@@ -6279,42 +5630,39 @@ let (encode_top_level_vals :
                   | (decls,env1) ->
                       let uu____18130 =
                         let uu____18137 =
-                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
+                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
                         encode_top_level_val false env1 uu____18137
-                          lb.FStar_Syntax_Syntax.lbtyp quals
-                         in
+                          lb.FStar_Syntax_Syntax.lbtyp quals in
                       (match uu____18130 with
                        | (decls',env2) ->
                            ((FStar_List.append decls decls'), env2)))
              ([], env))
-  
-let (is_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_tactic: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let fstar_tactics_tactic_lid =
-      FStar_Parser_Const.p2l ["FStar"; "Tactics"; "tactic"]  in
-    let uu____18158 = FStar_Syntax_Util.head_and_args t  in
+      FStar_Parser_Const.p2l ["FStar"; "Tactics"; "tactic"] in
+    let uu____18158 = FStar_Syntax_Util.head_and_args t in
     match uu____18158 with
     | (hd1,args) ->
         let uu____18195 =
-          let uu____18196 = FStar_Syntax_Util.un_uinst hd1  in
-          uu____18196.FStar_Syntax_Syntax.n  in
+          let uu____18196 = FStar_Syntax_Util.un_uinst hd1 in
+          uu____18196.FStar_Syntax_Syntax.n in
         (match uu____18195 with
          | FStar_Syntax_Syntax.Tm_fvar fv when
              FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_tactic_lid ->
              true
          | FStar_Syntax_Syntax.Tm_arrow (uu____18200,c) ->
-             let effect_name = FStar_Syntax_Util.comp_effect_name c  in
+             let effect_name = FStar_Syntax_Util.comp_effect_name c in
              FStar_Util.starts_with "FStar.Tactics"
                effect_name.FStar_Ident.str
          | uu____18219 -> false)
-  
-let (encode_top_level_let :
+let encode_top_level_let:
   env_t ->
     (Prims.bool,FStar_Syntax_Syntax.letbinding Prims.list)
       FStar_Pervasives_Native.tuple2 ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
         (FStar_SMTEncoding_Term.decl Prims.list,env_t)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun uu____18241  ->
@@ -6322,8 +5670,8 @@ let (encode_top_level_let :
         match uu____18241 with
         | (is_rec,bindings) ->
             let eta_expand1 binders formals body t =
-              let nbinders = FStar_List.length binders  in
-              let uu____18317 = FStar_Util.first_N nbinders formals  in
+              let nbinders = FStar_List.length binders in
+              let uu____18317 = FStar_Util.first_N nbinders formals in
               match uu____18317 with
               | (formals1,extra_formals) ->
                   let subst1 =
@@ -6334,11 +5682,10 @@ let (encode_top_level_let :
                            | ((formal,uu____18417),(binder,uu____18419)) ->
                                let uu____18428 =
                                  let uu____18435 =
-                                   FStar_Syntax_Syntax.bv_to_name binder  in
-                                 (formal, uu____18435)  in
+                                   FStar_Syntax_Syntax.bv_to_name binder in
+                                 (formal, uu____18435) in
                                FStar_Syntax_Syntax.NT uu____18428) formals1
-                      binders
-                     in
+                      binders in
                   let extra_formals1 =
                     let uu____18443 =
                       FStar_All.pipe_right extra_formals
@@ -6347,49 +5694,41 @@ let (encode_top_level_let :
                               match uu____18474 with
                               | (x,i) ->
                                   let uu____18485 =
-                                    let uu___121_18486 = x  in
+                                    let uu___121_18486 = x in
                                     let uu____18487 =
                                       FStar_Syntax_Subst.subst subst1
-                                        x.FStar_Syntax_Syntax.sort
-                                       in
+                                        x.FStar_Syntax_Syntax.sort in
                                     {
                                       FStar_Syntax_Syntax.ppname =
                                         (uu___121_18486.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
                                         (uu___121_18486.FStar_Syntax_Syntax.index);
                                       FStar_Syntax_Syntax.sort = uu____18487
-                                    }  in
-                                  (uu____18485, i)))
-                       in
+                                    } in
+                                  (uu____18485, i))) in
                     FStar_All.pipe_right uu____18443
-                      FStar_Syntax_Util.name_binders
-                     in
+                      FStar_Syntax_Util.name_binders in
                   let body1 =
                     let uu____18505 =
-                      let uu____18506 = FStar_Syntax_Subst.compress body  in
+                      let uu____18506 = FStar_Syntax_Subst.compress body in
                       let uu____18507 =
                         let uu____18508 =
-                          FStar_Syntax_Util.args_of_binders extra_formals1
-                           in
+                          FStar_Syntax_Util.args_of_binders extra_formals1 in
                         FStar_All.pipe_left FStar_Pervasives_Native.snd
-                          uu____18508
-                         in
+                          uu____18508 in
                       FStar_Syntax_Syntax.extend_app_n uu____18506
-                        uu____18507
-                       in
+                        uu____18507 in
                     uu____18505 FStar_Pervasives_Native.None
-                      body.FStar_Syntax_Syntax.pos
-                     in
-                  ((FStar_List.append binders extra_formals1), body1)
-               in
+                      body.FStar_Syntax_Syntax.pos in
+                  ((FStar_List.append binders extra_formals1), body1) in
             let destruct_bound_function flid t_norm e =
               let get_result_type c =
                 let uu____18569 =
-                  FStar_TypeChecker_Env.is_reifiable_comp env.tcenv c  in
+                  FStar_TypeChecker_Env.is_reifiable_comp env.tcenv c in
                 if uu____18569
                 then
                   FStar_TypeChecker_Env.reify_comp
-                    (let uu___122_18572 = env.tcenv  in
+                    (let uu___122_18572 = env.tcenv in
                      {
                        FStar_TypeChecker_Env.solver =
                          (uu___122_18572.FStar_TypeChecker_Env.solver);
@@ -6461,9 +5800,9 @@ let (encode_top_level_let :
                        FStar_TypeChecker_Env.dep_graph =
                          (uu___122_18572.FStar_TypeChecker_Env.dep_graph)
                      }) c FStar_Syntax_Syntax.U_unknown
-                else FStar_Syntax_Util.comp_result c  in
+                else FStar_Syntax_Util.comp_result c in
               let rec aux norm1 t_norm1 =
-                let uu____18605 = FStar_Syntax_Util.abs_formals e  in
+                let uu____18605 = FStar_Syntax_Util.abs_formals e in
                 match uu____18605 with
                 | (binders,body,lopt) ->
                     (match binders with
@@ -6471,31 +5810,26 @@ let (encode_top_level_let :
                          let uu____18685 =
                            let uu____18686 =
                              let uu____18689 =
-                               FStar_Syntax_Subst.compress t_norm1  in
+                               FStar_Syntax_Subst.compress t_norm1 in
                              FStar_All.pipe_left FStar_Syntax_Util.unascribe
-                               uu____18689
-                              in
-                           uu____18686.FStar_Syntax_Syntax.n  in
+                               uu____18689 in
+                           uu____18686.FStar_Syntax_Syntax.n in
                          (match uu____18685 with
                           | FStar_Syntax_Syntax.Tm_arrow (formals,c) ->
                               let uu____18732 =
-                                FStar_Syntax_Subst.open_comp formals c  in
+                                FStar_Syntax_Subst.open_comp formals c in
                               (match uu____18732 with
                                | (formals1,c1) ->
-                                   let nformals = FStar_List.length formals1
-                                      in
-                                   let nbinders = FStar_List.length binders
-                                      in
-                                   let tres = get_result_type c1  in
+                                   let nformals = FStar_List.length formals1 in
+                                   let nbinders = FStar_List.length binders in
+                                   let tres = get_result_type c1 in
                                    let uu____18774 =
                                      (nformals < nbinders) &&
-                                       (FStar_Syntax_Util.is_total_comp c1)
-                                      in
+                                       (FStar_Syntax_Util.is_total_comp c1) in
                                    if uu____18774
                                    then
                                      let uu____18809 =
-                                       FStar_Util.first_N nformals binders
-                                        in
+                                       FStar_Util.first_N nformals binders in
                                      (match uu____18809 with
                                       | (bs0,rest) ->
                                           let c2 =
@@ -6511,34 +5845,27 @@ let (encode_top_level_let :
                                                          let uu____18933 =
                                                            let uu____18940 =
                                                              FStar_Syntax_Syntax.bv_to_name
-                                                               b
-                                                              in
-                                                           (x, uu____18940)
-                                                            in
+                                                               b in
+                                                           (x, uu____18940) in
                                                          FStar_Syntax_Syntax.NT
                                                            uu____18933)
-                                                formals1 bs0
-                                               in
+                                                formals1 bs0 in
                                             FStar_Syntax_Subst.subst_comp
-                                              subst1 c1
-                                             in
+                                              subst1 c1 in
                                           let body1 =
                                             FStar_Syntax_Util.abs rest body
-                                              lopt
-                                             in
+                                              lopt in
                                           let uu____18942 =
                                             let uu____18963 =
-                                              get_result_type c2  in
-                                            (bs0, body1, bs0, uu____18963)
-                                             in
+                                              get_result_type c2 in
+                                            (bs0, body1, bs0, uu____18963) in
                                           (uu____18942, false))
                                    else
                                      if nformals > nbinders
                                      then
                                        (let uu____19031 =
                                           eta_expand1 binders formals1 body
-                                            tres
-                                           in
+                                            tres in
                                         match uu____19031 with
                                         | (binders1,body1) ->
                                             ((binders1, body1, formals1,
@@ -6549,8 +5876,8 @@ let (encode_top_level_let :
                           | FStar_Syntax_Syntax.Tm_refine (x,uu____19120) ->
                               let uu____19125 =
                                 let uu____19146 =
-                                  aux norm1 x.FStar_Syntax_Syntax.sort  in
-                                FStar_Pervasives_Native.fst uu____19146  in
+                                  aux norm1 x.FStar_Syntax_Syntax.sort in
+                                FStar_Pervasives_Native.fst uu____19146 in
                               (uu____19125, true)
                           | uu____19211 when Prims.op_Negation norm1 ->
                               let t_norm2 =
@@ -6564,47 +5891,43 @@ let (encode_top_level_let :
                                   FStar_TypeChecker_Normalize.UnfoldUntil
                                     FStar_Syntax_Syntax.Delta_constant;
                                   FStar_TypeChecker_Normalize.EraseUniverses]
-                                  env.tcenv t_norm1
-                                 in
+                                  env.tcenv t_norm1 in
                               aux true t_norm2
                           | uu____19213 ->
                               let uu____19214 =
                                 let uu____19215 =
-                                  FStar_Syntax_Print.term_to_string e  in
+                                  FStar_Syntax_Print.term_to_string e in
                                 let uu____19216 =
-                                  FStar_Syntax_Print.term_to_string t_norm1
-                                   in
+                                  FStar_Syntax_Print.term_to_string t_norm1 in
                                 FStar_Util.format3
                                   "Impossible! let-bound lambda %s = %s has a type that's not a function: %s\n"
                                   flid.FStar_Ident.str uu____19215
-                                  uu____19216
-                                 in
+                                  uu____19216 in
                               failwith uu____19214)
                      | uu____19241 ->
                          let rec aux' t_norm2 =
                            let uu____19266 =
                              let uu____19267 =
-                               FStar_Syntax_Subst.compress t_norm2  in
-                             uu____19267.FStar_Syntax_Syntax.n  in
+                               FStar_Syntax_Subst.compress t_norm2 in
+                             uu____19267.FStar_Syntax_Syntax.n in
                            match uu____19266 with
                            | FStar_Syntax_Syntax.Tm_arrow (formals,c) ->
                                let uu____19308 =
-                                 FStar_Syntax_Subst.open_comp formals c  in
+                                 FStar_Syntax_Subst.open_comp formals c in
                                (match uu____19308 with
                                 | (formals1,c1) ->
-                                    let tres = get_result_type c1  in
+                                    let tres = get_result_type c1 in
                                     let uu____19336 =
-                                      eta_expand1 [] formals1 e tres  in
+                                      eta_expand1 [] formals1 e tres in
                                     (match uu____19336 with
                                      | (binders1,body1) ->
                                          ((binders1, body1, formals1, tres),
                                            false)))
                            | FStar_Syntax_Syntax.Tm_refine (bv,uu____19416)
                                -> aux' bv.FStar_Syntax_Syntax.sort
-                           | uu____19421 -> (([], e, [], t_norm2), false)  in
-                         aux' t_norm1)
-                 in
-              aux false t_norm  in
+                           | uu____19421 -> (([], e, [], t_norm2), false) in
+                         aux' t_norm1) in
+              aux false t_norm in
             (try
                let uu____19477 =
                  FStar_All.pipe_right bindings
@@ -6612,8 +5935,7 @@ let (encode_top_level_let :
                       (fun lb  ->
                          (FStar_Syntax_Util.is_lemma
                             lb.FStar_Syntax_Syntax.lbtyp)
-                           || (is_tactic lb.FStar_Syntax_Syntax.lbtyp)))
-                  in
+                           || (is_tactic lb.FStar_Syntax_Syntax.lbtyp))) in
                if uu____19477
                then encode_top_level_vals env bindings quals
                else
@@ -6626,44 +5948,37 @@ let (encode_top_level_let :
                               | (toks,typs,decls,env1) ->
                                   ((let uu____19678 =
                                       FStar_Syntax_Util.is_lemma
-                                        lb.FStar_Syntax_Syntax.lbtyp
-                                       in
+                                        lb.FStar_Syntax_Syntax.lbtyp in
                                     if uu____19678
                                     then FStar_Exn.raise Let_rec_unencodeable
                                     else ());
                                    (let t_norm =
-                                      whnf env1 lb.FStar_Syntax_Syntax.lbtyp
-                                       in
+                                      whnf env1 lb.FStar_Syntax_Syntax.lbtyp in
                                     let uu____19681 =
                                       let uu____19696 =
                                         FStar_Util.right
-                                          lb.FStar_Syntax_Syntax.lbname
-                                         in
+                                          lb.FStar_Syntax_Syntax.lbname in
                                       declare_top_level_let env1 uu____19696
-                                        lb.FStar_Syntax_Syntax.lbtyp t_norm
-                                       in
+                                        lb.FStar_Syntax_Syntax.lbtyp t_norm in
                                     match uu____19681 with
                                     | (tok,decl,env2) ->
                                         let uu____19742 =
                                           let uu____19755 =
                                             let uu____19766 =
                                               FStar_Util.right
-                                                lb.FStar_Syntax_Syntax.lbname
-                                               in
-                                            (uu____19766, tok)  in
-                                          uu____19755 :: toks  in
+                                                lb.FStar_Syntax_Syntax.lbname in
+                                            (uu____19766, tok) in
+                                          uu____19755 :: toks in
                                         (uu____19742, (t_norm :: typs), (decl
                                           :: decls), env2))))
-                         ([], [], [], env))
-                     in
+                         ([], [], [], env)) in
                   match uu____19489 with
                   | (toks,typs,decls,env1) ->
-                      let toks1 = FStar_List.rev toks  in
+                      let toks1 = FStar_List.rev toks in
                       let decls1 =
                         FStar_All.pipe_right (FStar_List.rev decls)
-                          FStar_List.flatten
-                         in
-                      let typs1 = FStar_List.rev typs  in
+                          FStar_List.flatten in
+                      let typs1 = FStar_List.rev typs in
                       let mk_app1 curry f ftok vars =
                         match vars with
                         | [] ->
@@ -6678,18 +5993,15 @@ let (encode_top_level_let :
                                | FStar_Pervasives_Native.None  ->
                                    let uu____19957 =
                                      FStar_SMTEncoding_Util.mkFreeV
-                                       (f, FStar_SMTEncoding_Term.Term_sort)
-                                      in
+                                       (f, FStar_SMTEncoding_Term.Term_sort) in
                                    mk_Apply uu____19957 vars)
                             else
                               (let uu____19959 =
                                  let uu____19966 =
                                    FStar_List.map
-                                     FStar_SMTEncoding_Util.mkFreeV vars
-                                    in
-                                 (f, uu____19966)  in
-                               FStar_SMTEncoding_Util.mkApp uu____19959)
-                         in
+                                     FStar_SMTEncoding_Util.mkFreeV vars in
+                                 (f, uu____19966) in
+                               FStar_SMTEncoding_Util.mkApp uu____19959) in
                       let encode_non_rec_lbdef bindings1 typs2 toks2 env2 =
                         match (bindings1, typs2, toks2) with
                         | ({ FStar_Syntax_Syntax.lbname = uu____20048;
@@ -6700,23 +6012,20 @@ let (encode_top_level_let :
                              FStar_Syntax_Syntax.lbattrs = uu____20053;_}::[],t_norm::[],
                            (flid_fv,(f,ftok))::[]) ->
                             let flid =
-                              (flid_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                               in
+                              (flid_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                             let uu____20119 =
                               let uu____20126 =
                                 FStar_TypeChecker_Env.open_universes_in
-                                  env2.tcenv uvs [e; t_norm]
-                                 in
+                                  env2.tcenv uvs [e; t_norm] in
                               match uu____20126 with
                               | (tcenv',uu____20144,e_t) ->
                                   let uu____20150 =
                                     match e_t with
                                     | e1::t_norm1::[] -> (e1, t_norm1)
-                                    | uu____20161 -> failwith "Impossible"
-                                     in
+                                    | uu____20161 -> failwith "Impossible" in
                                   (match uu____20150 with
                                    | (e1,t_norm1) ->
-                                       ((let uu___125_20177 = env2  in
+                                       ((let uu___125_20177 = env2 in
                                          {
                                            bindings =
                                              (uu___125_20177.bindings);
@@ -6732,13 +6041,11 @@ let (encode_top_level_let :
                                              (uu___125_20177.encode_non_total_function_typ);
                                            current_module_name =
                                              (uu___125_20177.current_module_name)
-                                         }), e1, t_norm1))
-                               in
+                                         }), e1, t_norm1)) in
                             (match uu____20119 with
                              | (env',e1,t_norm1) ->
                                  let uu____20187 =
-                                   destruct_bound_function flid t_norm1 e1
-                                    in
+                                   destruct_bound_function flid t_norm1 e1 in
                                  (match uu____20187 with
                                   | ((binders,body,uu____20208,t_body),curry)
                                       ->
@@ -6747,18 +6054,15 @@ let (encode_top_level_let :
                                             (FStar_TypeChecker_Env.debug
                                                env2.tcenv)
                                             (FStar_Options.Other
-                                               "SMTEncoding")
-                                           in
+                                               "SMTEncoding") in
                                         if uu____20220
                                         then
                                           let uu____20221 =
                                             FStar_Syntax_Print.binders_to_string
-                                              ", " binders
-                                             in
+                                              ", " binders in
                                           let uu____20222 =
                                             FStar_Syntax_Print.term_to_string
-                                              body
-                                             in
+                                              body in
                                           FStar_Util.print2
                                             "Encoding let : binders=[%s], body=%s\n"
                                             uu____20221 uu____20222
@@ -6766,16 +6070,14 @@ let (encode_top_level_let :
                                        (let uu____20224 =
                                           encode_binders
                                             FStar_Pervasives_Native.None
-                                            binders env'
-                                           in
+                                            binders env' in
                                         match uu____20224 with
                                         | (vars,guards,env'1,binder_decls,uu____20251)
                                             ->
                                             let body1 =
                                               let uu____20265 =
                                                 FStar_TypeChecker_Env.is_reifiable_function
-                                                  env'1.tcenv t_norm1
-                                                 in
+                                                  env'1.tcenv t_norm1 in
                                               if uu____20265
                                               then
                                                 FStar_TypeChecker_Util.reify_body
@@ -6784,32 +6086,26 @@ let (encode_top_level_let :
                                                 FStar_Syntax_Util.ascribe
                                                   body
                                                   ((FStar_Util.Inl t_body),
-                                                    FStar_Pervasives_Native.None)
-                                               in
+                                                    FStar_Pervasives_Native.None) in
                                             let app =
-                                              mk_app1 curry f ftok vars  in
+                                              mk_app1 curry f ftok vars in
                                             let uu____20282 =
                                               let uu____20291 =
                                                 FStar_All.pipe_right quals
                                                   (FStar_List.contains
-                                                     FStar_Syntax_Syntax.Logic)
-                                                 in
+                                                     FStar_Syntax_Syntax.Logic) in
                                               if uu____20291
                                               then
                                                 let uu____20302 =
                                                   FStar_SMTEncoding_Term.mk_Valid
-                                                    app
-                                                   in
+                                                    app in
                                                 let uu____20303 =
-                                                  encode_formula body1 env'1
-                                                   in
+                                                  encode_formula body1 env'1 in
                                                 (uu____20302, uu____20303)
                                               else
                                                 (let uu____20313 =
-                                                   encode_term body1 env'1
-                                                    in
-                                                 (app, uu____20313))
-                                               in
+                                                   encode_term body1 env'1 in
+                                                 (app, uu____20313)) in
                                             (match uu____20282 with
                                              | (app1,(body2,decls2)) ->
                                                  let eqn =
@@ -6818,31 +6114,24 @@ let (encode_top_level_let :
                                                        let uu____20344 =
                                                          let uu____20355 =
                                                            FStar_SMTEncoding_Util.mkEq
-                                                             (app1, body2)
-                                                            in
+                                                             (app1, body2) in
                                                          ([[app1]], vars,
-                                                           uu____20355)
-                                                          in
+                                                           uu____20355) in
                                                        FStar_SMTEncoding_Util.mkForall
-                                                         uu____20344
-                                                        in
+                                                         uu____20344 in
                                                      let uu____20366 =
                                                        let uu____20369 =
                                                          FStar_Util.format1
                                                            "Equation for %s"
-                                                           flid.FStar_Ident.str
-                                                          in
+                                                           flid.FStar_Ident.str in
                                                        FStar_Pervasives_Native.Some
-                                                         uu____20369
-                                                        in
+                                                         uu____20369 in
                                                      (uu____20343,
                                                        uu____20366,
                                                        (Prims.strcat
-                                                          "equation_" f))
-                                                      in
+                                                          "equation_" f)) in
                                                    FStar_SMTEncoding_Util.mkAssume
-                                                     uu____20336
-                                                    in
+                                                     uu____20336 in
                                                  let uu____20372 =
                                                    let uu____20375 =
                                                      let uu____20378 =
@@ -6850,29 +6139,24 @@ let (encode_top_level_let :
                                                          let uu____20384 =
                                                            primitive_type_axioms
                                                              env2.tcenv flid
-                                                             f app1
-                                                            in
+                                                             f app1 in
                                                          FStar_List.append
-                                                           [eqn] uu____20384
-                                                          in
+                                                           [eqn] uu____20384 in
                                                        FStar_List.append
-                                                         decls2 uu____20381
-                                                        in
+                                                         decls2 uu____20381 in
                                                      FStar_List.append
                                                        binder_decls
-                                                       uu____20378
-                                                      in
+                                                       uu____20378 in
                                                    FStar_List.append decls1
-                                                     uu____20375
-                                                    in
+                                                     uu____20375 in
                                                  (uu____20372, env2))))))
-                        | uu____20389 -> failwith "Impossible"  in
+                        | uu____20389 -> failwith "Impossible" in
                       let encode_rec_lbdefs bindings1 typs2 toks2 env2 =
                         let fuel =
-                          let uu____20474 = varops.fresh "fuel"  in
-                          (uu____20474, FStar_SMTEncoding_Term.Fuel_sort)  in
-                        let fuel_tm = FStar_SMTEncoding_Util.mkFreeV fuel  in
-                        let env0 = env2  in
+                          let uu____20474 = varops.fresh "fuel" in
+                          (uu____20474, FStar_SMTEncoding_Term.Fuel_sort) in
+                        let fuel_tm = FStar_SMTEncoding_Util.mkFreeV fuel in
+                        let env0 = env2 in
                         let uu____20477 =
                           FStar_All.pipe_right toks2
                             (FStar_List.fold_left
@@ -6881,40 +6165,33 @@ let (encode_top_level_let :
                                     match (uu____20565, uu____20566) with
                                     | ((gtoks,env3),(flid_fv,(f,ftok))) ->
                                         let flid =
-                                          (flid_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                           in
+                                          (flid_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                                         let g =
                                           let uu____20714 =
                                             FStar_Ident.lid_add_suffix flid
-                                              "fuel_instrumented"
-                                             in
-                                          varops.new_fvar uu____20714  in
+                                              "fuel_instrumented" in
+                                          varops.new_fvar uu____20714 in
                                         let gtok =
                                           let uu____20716 =
                                             FStar_Ident.lid_add_suffix flid
-                                              "fuel_instrumented_token"
-                                             in
-                                          varops.new_fvar uu____20716  in
+                                              "fuel_instrumented_token" in
+                                          varops.new_fvar uu____20716 in
                                         let env4 =
                                           let uu____20718 =
                                             let uu____20721 =
                                               FStar_SMTEncoding_Util.mkApp
-                                                (g, [fuel_tm])
-                                               in
+                                                (g, [fuel_tm]) in
                                             FStar_All.pipe_left
                                               (fun _0_43  ->
                                                  FStar_Pervasives_Native.Some
-                                                   _0_43) uu____20721
-                                             in
+                                                   _0_43) uu____20721 in
                                           push_free_var env3 flid gtok
-                                            uu____20718
-                                           in
+                                            uu____20718 in
                                         (((flid, f, ftok, g, gtok) :: gtoks),
-                                          env4)) ([], env2))
-                           in
+                                          env4)) ([], env2)) in
                         match uu____20477 with
                         | (gtoks,env3) ->
-                            let gtoks1 = FStar_List.rev gtoks  in
+                            let gtoks1 = FStar_List.rev gtoks in
                             let encode_one_binding env01 uu____20877 t_norm
                               uu____20879 =
                               match (uu____20877, uu____20879) with
@@ -6935,19 +6212,17 @@ let (encode_top_level_let :
                                   let uu____20957 =
                                     let uu____20964 =
                                       FStar_TypeChecker_Env.open_universes_in
-                                        env3.tcenv uvs [e; t_norm]
-                                       in
+                                        env3.tcenv uvs [e; t_norm] in
                                     match uu____20964 with
                                     | (tcenv',uu____20986,e_t) ->
                                         let uu____20992 =
                                           match e_t with
                                           | e1::t_norm1::[] -> (e1, t_norm1)
                                           | uu____21003 ->
-                                              failwith "Impossible"
-                                           in
+                                              failwith "Impossible" in
                                         (match uu____20992 with
                                          | (e1,t_norm1) ->
-                                             ((let uu___126_21019 = env3  in
+                                             ((let uu___126_21019 = env3 in
                                                {
                                                  bindings =
                                                    (uu___126_21019.bindings);
@@ -6966,8 +6241,7 @@ let (encode_top_level_let :
                                                    (uu___126_21019.encode_non_total_function_typ);
                                                  current_module_name =
                                                    (uu___126_21019.current_module_name)
-                                               }), e1, t_norm1))
-                                     in
+                                               }), e1, t_norm1)) in
                                   (match uu____20957 with
                                    | (env',e1,t_norm1) ->
                                        ((let uu____21034 =
@@ -6975,22 +6249,18 @@ let (encode_top_level_let :
                                              (FStar_TypeChecker_Env.debug
                                                 env01.tcenv)
                                              (FStar_Options.Other
-                                                "SMTEncoding")
-                                            in
+                                                "SMTEncoding") in
                                          if uu____21034
                                          then
                                            let uu____21035 =
                                              FStar_Syntax_Print.lbname_to_string
-                                               lbn
-                                              in
+                                               lbn in
                                            let uu____21036 =
                                              FStar_Syntax_Print.term_to_string
-                                               t_norm1
-                                              in
+                                               t_norm1 in
                                            let uu____21037 =
                                              FStar_Syntax_Print.term_to_string
-                                               e1
-                                              in
+                                               e1 in
                                            FStar_Util.print3
                                              "Encoding let rec %s : %s = %s\n"
                                              uu____21035 uu____21036
@@ -6998,8 +6268,7 @@ let (encode_top_level_let :
                                          else ());
                                         (let uu____21039 =
                                            destruct_bound_function flid
-                                             t_norm1 e1
-                                            in
+                                             t_norm1 e1 in
                                          match uu____21039 with
                                          | ((binders,body,formals,tres),curry)
                                              ->
@@ -7008,26 +6277,21 @@ let (encode_top_level_let :
                                                    (FStar_TypeChecker_Env.debug
                                                       env01.tcenv)
                                                    (FStar_Options.Other
-                                                      "SMTEncoding")
-                                                  in
+                                                      "SMTEncoding") in
                                                if uu____21076
                                                then
                                                  let uu____21077 =
                                                    FStar_Syntax_Print.binders_to_string
-                                                     ", " binders
-                                                    in
+                                                     ", " binders in
                                                  let uu____21078 =
                                                    FStar_Syntax_Print.term_to_string
-                                                     body
-                                                    in
+                                                     body in
                                                  let uu____21079 =
                                                    FStar_Syntax_Print.binders_to_string
-                                                     ", " formals
-                                                    in
+                                                     ", " formals in
                                                  let uu____21080 =
                                                    FStar_Syntax_Print.term_to_string
-                                                     tres
-                                                    in
+                                                     tres in
                                                  FStar_Util.print4
                                                    "Encoding let rec: binders=[%s], body=%s, formals=[%s], tres=%s\n"
                                                    uu____21077 uu____21078
@@ -7041,8 +6305,7 @@ let (encode_top_level_let :
                                               (let uu____21084 =
                                                  encode_binders
                                                    FStar_Pervasives_Native.None
-                                                   binders env'
-                                                  in
+                                                   binders env' in
                                                match uu____21084 with
                                                | (vars,guards,env'1,binder_decls,uu____21115)
                                                    ->
@@ -7052,88 +6315,71 @@ let (encode_top_level_let :
                                                          let uu____21143 =
                                                            FStar_List.map
                                                              FStar_Pervasives_Native.snd
-                                                             vars
-                                                            in
+                                                             vars in
                                                          FStar_SMTEncoding_Term.Fuel_sort
-                                                           :: uu____21143
-                                                          in
+                                                           :: uu____21143 in
                                                        (g, uu____21140,
                                                          FStar_SMTEncoding_Term.Term_sort,
                                                          (FStar_Pervasives_Native.Some
-                                                            "Fuel-instrumented function name"))
-                                                        in
+                                                            "Fuel-instrumented function name")) in
                                                      FStar_SMTEncoding_Term.DeclFun
-                                                       uu____21129
-                                                      in
+                                                       uu____21129 in
                                                    let env02 =
                                                      push_zfuel_name env01
-                                                       flid g
-                                                      in
+                                                       flid g in
                                                    let decl_g_tok =
                                                      FStar_SMTEncoding_Term.DeclFun
                                                        (gtok, [],
                                                          FStar_SMTEncoding_Term.Term_sort,
                                                          (FStar_Pervasives_Native.Some
-                                                            "Token for fuel-instrumented partial applications"))
-                                                      in
+                                                            "Token for fuel-instrumented partial applications")) in
                                                    let vars_tm =
                                                      FStar_List.map
                                                        FStar_SMTEncoding_Util.mkFreeV
-                                                       vars
-                                                      in
+                                                       vars in
                                                    let app =
                                                      let uu____21168 =
                                                        let uu____21175 =
                                                          FStar_List.map
                                                            FStar_SMTEncoding_Util.mkFreeV
-                                                           vars
-                                                          in
-                                                       (f, uu____21175)  in
+                                                           vars in
+                                                       (f, uu____21175) in
                                                      FStar_SMTEncoding_Util.mkApp
-                                                       uu____21168
-                                                      in
+                                                       uu____21168 in
                                                    let gsapp =
                                                      let uu____21185 =
                                                        let uu____21192 =
                                                          let uu____21195 =
                                                            FStar_SMTEncoding_Util.mkApp
                                                              ("SFuel",
-                                                               [fuel_tm])
-                                                            in
+                                                               [fuel_tm]) in
                                                          uu____21195 ::
-                                                           vars_tm
-                                                          in
-                                                       (g, uu____21192)  in
+                                                           vars_tm in
+                                                       (g, uu____21192) in
                                                      FStar_SMTEncoding_Util.mkApp
-                                                       uu____21185
-                                                      in
+                                                       uu____21185 in
                                                    let gmax =
                                                      let uu____21201 =
                                                        let uu____21208 =
                                                          let uu____21211 =
                                                            FStar_SMTEncoding_Util.mkApp
-                                                             ("MaxFuel", [])
-                                                            in
+                                                             ("MaxFuel", []) in
                                                          uu____21211 ::
-                                                           vars_tm
-                                                          in
-                                                       (g, uu____21208)  in
+                                                           vars_tm in
+                                                       (g, uu____21208) in
                                                      FStar_SMTEncoding_Util.mkApp
-                                                       uu____21201
-                                                      in
+                                                       uu____21201 in
                                                    let body1 =
                                                      let uu____21217 =
                                                        FStar_TypeChecker_Env.is_reifiable_function
-                                                         env'1.tcenv t_norm1
-                                                        in
+                                                         env'1.tcenv t_norm1 in
                                                      if uu____21217
                                                      then
                                                        FStar_TypeChecker_Util.reify_body
                                                          env'1.tcenv body
-                                                     else body  in
+                                                     else body in
                                                    let uu____21219 =
-                                                     encode_term body1 env'1
-                                                      in
+                                                     encode_term body1 env'1 in
                                                    (match uu____21219 with
                                                     | (body_tm,decls2) ->
                                                         let eqn_g =
@@ -7145,37 +6391,31 @@ let (encode_top_level_let :
                                                                   =
                                                                   FStar_SMTEncoding_Util.mkEq
                                                                     (gsapp,
-                                                                    body_tm)
-                                                                   in
+                                                                    body_tm) in
                                                                 ([[gsapp]],
                                                                   (FStar_Pervasives_Native.Some
-                                                                    (Prims.parse_int "0")),
+                                                                    (Prims.parse_int
+                                                                    "0")),
                                                                   (fuel ::
                                                                   vars),
-                                                                  uu____21260)
-                                                                 in
+                                                                  uu____21260) in
                                                               FStar_SMTEncoding_Util.mkForall'
-                                                                uu____21245
-                                                               in
+                                                                uu____21245 in
                                                             let uu____21281 =
                                                               let uu____21284
                                                                 =
                                                                 FStar_Util.format1
                                                                   "Equation for fuel-instrumented recursive function: %s"
-                                                                  flid.FStar_Ident.str
-                                                                 in
+                                                                  flid.FStar_Ident.str in
                                                               FStar_Pervasives_Native.Some
-                                                                uu____21284
-                                                               in
+                                                                uu____21284 in
                                                             (uu____21244,
                                                               uu____21281,
                                                               (Prims.strcat
                                                                  "equation_with_fuel_"
-                                                                 g))
-                                                             in
+                                                                 g)) in
                                                           FStar_SMTEncoding_Util.mkAssume
-                                                            uu____21237
-                                                           in
+                                                            uu____21237 in
                                                         let eqn_f =
                                                           let uu____21288 =
                                                             let uu____21295 =
@@ -7185,25 +6425,20 @@ let (encode_top_level_let :
                                                                   =
                                                                   FStar_SMTEncoding_Util.mkEq
                                                                     (app,
-                                                                    gmax)
-                                                                   in
+                                                                    gmax) in
                                                                 ([[app]],
                                                                   vars,
-                                                                  uu____21307)
-                                                                 in
+                                                                  uu____21307) in
                                                               FStar_SMTEncoding_Util.mkForall
-                                                                uu____21296
-                                                               in
+                                                                uu____21296 in
                                                             (uu____21295,
                                                               (FStar_Pervasives_Native.Some
                                                                  "Correspondence of recursive function to instrumented version"),
                                                               (Prims.strcat
                                                                  "@fuel_correspondence_"
-                                                                 g))
-                                                             in
+                                                                 g)) in
                                                           FStar_SMTEncoding_Util.mkAssume
-                                                            uu____21288
-                                                           in
+                                                            uu____21288 in
                                                         let eqn_g' =
                                                           let uu____21321 =
                                                             let uu____21328 =
@@ -7222,48 +6457,38 @@ let (encode_top_level_let :
                                                                     let uu____21357
                                                                     =
                                                                     FStar_SMTEncoding_Term.n_fuel
-                                                                    (Prims.parse_int "0")
-                                                                     in
+                                                                    (Prims.parse_int
+                                                                    "0") in
                                                                     uu____21357
                                                                     ::
-                                                                    vars_tm
-                                                                     in
+                                                                    vars_tm in
                                                                     (g,
-                                                                    uu____21354)
-                                                                     in
+                                                                    uu____21354) in
                                                                     FStar_SMTEncoding_Util.mkApp
-                                                                    uu____21347
-                                                                     in
+                                                                    uu____21347 in
                                                                     (gsapp,
-                                                                    uu____21346)
-                                                                     in
+                                                                    uu____21346) in
                                                                   FStar_SMTEncoding_Util.mkEq
-                                                                    uu____21341
-                                                                   in
+                                                                    uu____21341 in
                                                                 ([[gsapp]],
                                                                   (fuel ::
                                                                   vars),
-                                                                  uu____21340)
-                                                                 in
+                                                                  uu____21340) in
                                                               FStar_SMTEncoding_Util.mkForall
-                                                                uu____21329
-                                                               in
+                                                                uu____21329 in
                                                             (uu____21328,
                                                               (FStar_Pervasives_Native.Some
                                                                  "Fuel irrelevance"),
                                                               (Prims.strcat
                                                                  "@fuel_irrelevance_"
-                                                                 g))
-                                                             in
+                                                                 g)) in
                                                           FStar_SMTEncoding_Util.mkAssume
-                                                            uu____21321
-                                                           in
+                                                            uu____21321 in
                                                         let uu____21380 =
                                                           let uu____21389 =
                                                             encode_binders
                                                               FStar_Pervasives_Native.None
-                                                              formals env02
-                                                             in
+                                                              formals env02 in
                                                           match uu____21389
                                                           with
                                                           | (vars1,v_guards,env4,binder_decls1,uu____21418)
@@ -7271,28 +6496,24 @@ let (encode_top_level_let :
                                                               let vars_tm1 =
                                                                 FStar_List.map
                                                                   FStar_SMTEncoding_Util.mkFreeV
-                                                                  vars1
-                                                                 in
+                                                                  vars1 in
                                                               let gapp =
                                                                 FStar_SMTEncoding_Util.mkApp
                                                                   (g,
                                                                     (fuel_tm
                                                                     ::
-                                                                    vars_tm1))
-                                                                 in
+                                                                    vars_tm1)) in
                                                               let tok_corr =
                                                                 let tok_app =
                                                                   let uu____21443
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     (gtok,
-                                                                    FStar_SMTEncoding_Term.Term_sort)
-                                                                     in
+                                                                    FStar_SMTEncoding_Term.Term_sort) in
                                                                   mk_Apply
                                                                     uu____21443
                                                                     (fuel ::
-                                                                    vars1)
-                                                                   in
+                                                                    vars1) in
                                                                 let uu____21448
                                                                   =
                                                                   let uu____21455
@@ -7303,16 +6524,14 @@ let (encode_top_level_let :
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (tok_app,
-                                                                    gapp)  in
+                                                                    gapp) in
                                                                     ([
                                                                     [tok_app]],
                                                                     (fuel ::
                                                                     vars1),
-                                                                    uu____21467)
-                                                                     in
+                                                                    uu____21467) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____21456
-                                                                     in
+                                                                    uu____21456 in
                                                                   (uu____21455,
                                                                     (
                                                                     FStar_Pervasives_Native.Some
@@ -7320,11 +6539,9 @@ let (encode_top_level_let :
                                                                     (
                                                                     Prims.strcat
                                                                     "fuel_token_correspondence_"
-                                                                    gtok))
-                                                                   in
+                                                                    gtok)) in
                                                                 FStar_SMTEncoding_Util.mkAssume
-                                                                  uu____21448
-                                                                 in
+                                                                  uu____21448 in
                                                               let uu____21488
                                                                 =
                                                                 let uu____21495
@@ -7332,8 +6549,7 @@ let (encode_top_level_let :
                                                                   encode_term_pred
                                                                     FStar_Pervasives_Native.None
                                                                     tres env4
-                                                                    gapp
-                                                                   in
+                                                                    gapp in
                                                                 match uu____21495
                                                                 with
                                                                 | (g_typing,d3)
@@ -7355,36 +6571,28 @@ let (encode_top_level_let :
                                                                     let uu____21537
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
-                                                                    v_guards
-                                                                     in
+                                                                    v_guards in
                                                                     (uu____21537,
-                                                                    g_typing)
-                                                                     in
+                                                                    g_typing) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____21532
-                                                                     in
+                                                                    uu____21532 in
                                                                     ([[gapp]],
                                                                     (fuel ::
                                                                     vars1),
-                                                                    uu____21531)
-                                                                     in
+                                                                    uu____21531) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____21520
-                                                                     in
+                                                                    uu____21520 in
                                                                     (uu____21519,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Typing correspondence of token to term"),
                                                                     (Prims.strcat
                                                                     "token_correspondence_"
-                                                                    g))  in
+                                                                    g)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____21512
-                                                                     in
-                                                                    [uu____21511]
-                                                                     in
+                                                                    uu____21512 in
+                                                                    [uu____21511] in
                                                                     (d3,
-                                                                    uu____21508)
-                                                                 in
+                                                                    uu____21508) in
                                                               (match uu____21488
                                                                with
                                                                | (aux_decls,typing_corr)
@@ -7394,8 +6602,7 @@ let (encode_top_level_let :
                                                                     aux_decls),
                                                                     (FStar_List.append
                                                                     typing_corr
-                                                                    [tok_corr])))
-                                                           in
+                                                                    [tok_corr]))) in
                                                         (match uu____21380
                                                          with
                                                          | (aux_decls,g_typing)
@@ -7414,11 +6621,10 @@ let (encode_top_level_let :
                                                                   eqn_g';
                                                                   eqn_f]
                                                                   g_typing),
-                                                               env02))))))))
-                               in
+                                                               env02)))))))) in
                             let uu____21602 =
                               let uu____21615 =
-                                FStar_List.zip3 gtoks1 typs2 bindings1  in
+                                FStar_List.zip3 gtoks1 typs2 bindings1 in
                               FStar_List.fold_left
                                 (fun uu____21694  ->
                                    fun uu____21695  ->
@@ -7426,15 +6632,13 @@ let (encode_top_level_let :
                                      | ((decls2,eqns,env01),(gtok,ty,lb)) ->
                                          let uu____21850 =
                                            encode_one_binding env01 gtok ty
-                                             lb
-                                            in
+                                             lb in
                                          (match uu____21850 with
                                           | (decls',eqns',env02) ->
                                               ((decls' :: decls2),
                                                 (FStar_List.append eqns' eqns),
                                                 env02))) ([decls1], [], env0)
-                                uu____21615
-                               in
+                                uu____21615 in
                             (match uu____21602 with
                              | (decls2,eqns,env01) ->
                                  let uu____21923 =
@@ -7442,21 +6646,18 @@ let (encode_top_level_let :
                                      match uu___92_21935 with
                                      | FStar_SMTEncoding_Term.DeclFun
                                          uu____21936 -> true
-                                     | uu____21947 -> false  in
+                                     | uu____21947 -> false in
                                    let uu____21948 =
                                      FStar_All.pipe_right decls2
-                                       FStar_List.flatten
-                                      in
+                                       FStar_List.flatten in
                                    FStar_All.pipe_right uu____21948
-                                     (FStar_List.partition isDeclFun)
-                                    in
+                                     (FStar_List.partition isDeclFun) in
                                  (match uu____21923 with
                                   | (prefix_decls,rest) ->
-                                      let eqns1 = FStar_List.rev eqns  in
+                                      let eqns1 = FStar_List.rev eqns in
                                       ((FStar_List.append prefix_decls
                                           (FStar_List.append rest eqns1)),
-                                        env01)))
-                         in
+                                        env01))) in
                       let uu____21988 =
                         (FStar_All.pipe_right quals
                            (FStar_Util.for_some
@@ -7474,11 +6675,9 @@ let (encode_top_level_let :
                                         t)
                                        ||
                                        (FStar_TypeChecker_Env.is_reifiable_function
-                                          env1.tcenv t)
-                                      in
+                                          env1.tcenv t) in
                                    FStar_All.pipe_left Prims.op_Negation
-                                     uu____21999)))
-                         in
+                                     uu____21999))) in
                       if uu____21988
                       then (decls1, env1)
                       else
@@ -7496,79 +6695,73 @@ let (encode_top_level_let :
                        (FStar_List.map
                           (fun lb  ->
                              FStar_Syntax_Print.lbname_to_string
-                               lb.FStar_Syntax_Syntax.lbname))
-                      in
+                               lb.FStar_Syntax_Syntax.lbname)) in
                    FStar_All.pipe_right uu____22051
-                     (FStar_String.concat " and ")
-                    in
+                     (FStar_String.concat " and ") in
                  let decl =
                    FStar_SMTEncoding_Term.Caption
-                     (Prims.strcat "let rec unencodeable: Skipping: " msg)
-                    in
+                     (Prims.strcat "let rec unencodeable: Skipping: " msg) in
                  ([decl], env))
-  
-let rec (encode_sigelt :
+let rec encode_sigelt:
   env_t ->
     FStar_Syntax_Syntax.sigelt ->
-      (FStar_SMTEncoding_Term.decls_t,env_t) FStar_Pervasives_Native.tuple2)
+      (FStar_SMTEncoding_Term.decls_t,env_t) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun se  ->
       let nm =
-        let uu____22100 = FStar_Syntax_Util.lid_of_sigelt se  in
+        let uu____22100 = FStar_Syntax_Util.lid_of_sigelt se in
         match uu____22100 with
         | FStar_Pervasives_Native.None  -> ""
-        | FStar_Pervasives_Native.Some l -> l.FStar_Ident.str  in
-      let uu____22104 = encode_sigelt' env se  in
+        | FStar_Pervasives_Native.Some l -> l.FStar_Ident.str in
+      let uu____22104 = encode_sigelt' env se in
       match uu____22104 with
       | (g,env1) ->
           let g1 =
             match g with
             | [] ->
                 let uu____22120 =
-                  let uu____22121 = FStar_Util.format1 "<Skipped %s/>" nm  in
-                  FStar_SMTEncoding_Term.Caption uu____22121  in
+                  let uu____22121 = FStar_Util.format1 "<Skipped %s/>" nm in
+                  FStar_SMTEncoding_Term.Caption uu____22121 in
                 [uu____22120]
             | uu____22122 ->
                 let uu____22123 =
                   let uu____22126 =
                     let uu____22127 =
-                      FStar_Util.format1 "<Start encoding %s>" nm  in
-                    FStar_SMTEncoding_Term.Caption uu____22127  in
-                  uu____22126 :: g  in
+                      FStar_Util.format1 "<Start encoding %s>" nm in
+                    FStar_SMTEncoding_Term.Caption uu____22127 in
+                  uu____22126 :: g in
                 let uu____22128 =
                   let uu____22131 =
                     let uu____22132 =
-                      FStar_Util.format1 "</end encoding %s>" nm  in
-                    FStar_SMTEncoding_Term.Caption uu____22132  in
-                  [uu____22131]  in
-                FStar_List.append uu____22123 uu____22128
-             in
+                      FStar_Util.format1 "</end encoding %s>" nm in
+                    FStar_SMTEncoding_Term.Caption uu____22132 in
+                  [uu____22131] in
+                FStar_List.append uu____22123 uu____22128 in
           (g1, env1)
-
-and (encode_sigelt' :
+and encode_sigelt':
   env_t ->
     FStar_Syntax_Syntax.sigelt ->
-      (FStar_SMTEncoding_Term.decls_t,env_t) FStar_Pervasives_Native.tuple2)
+      (FStar_SMTEncoding_Term.decls_t,env_t) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun se  ->
       let is_opaque_to_smt t =
         let uu____22145 =
-          let uu____22146 = FStar_Syntax_Subst.compress t  in
-          uu____22146.FStar_Syntax_Syntax.n  in
+          let uu____22146 = FStar_Syntax_Subst.compress t in
+          uu____22146.FStar_Syntax_Syntax.n in
         match uu____22145 with
         | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
             (s,uu____22150)) -> s = "opaque_to_smt"
-        | uu____22151 -> false  in
+        | uu____22151 -> false in
       let is_uninterpreted_by_smt t =
         let uu____22156 =
-          let uu____22157 = FStar_Syntax_Subst.compress t  in
-          uu____22157.FStar_Syntax_Syntax.n  in
+          let uu____22157 = FStar_Syntax_Subst.compress t in
+          uu____22157.FStar_Syntax_Syntax.n in
         match uu____22156 with
         | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
             (s,uu____22161)) -> s = "uninterpreted_by_smt"
-        | uu____22162 -> false  in
+        | uu____22162 -> false in
       match se.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____22167 ->
           failwith "impossible -- removed by tc.fs"
@@ -7580,9 +6773,8 @@ and (encode_sigelt' :
           let uu____22197 =
             let uu____22198 =
               FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
-                (FStar_List.contains FStar_Syntax_Syntax.Reifiable)
-               in
-            FStar_All.pipe_right uu____22198 Prims.op_Negation  in
+                (FStar_List.contains FStar_Syntax_Syntax.Reifiable) in
+            FStar_All.pipe_right uu____22198 Prims.op_Negation in
           if uu____22197
           then ([], env)
           else
@@ -7598,27 +6790,23 @@ and (encode_sigelt' :
                                 FStar_Parser_Const.effect_Tot_lid
                                 FStar_Pervasives_Native.None
                                 [FStar_Syntax_Syntax.TOTAL]))))
-                     FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos
-                in
+                     FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos in
              let encode_action env1 a =
                let uu____22244 =
                  new_term_constant_and_tok_from_lid env1
-                   a.FStar_Syntax_Syntax.action_name
-                  in
+                   a.FStar_Syntax_Syntax.action_name in
                match uu____22244 with
                | (aname,atok,env2) ->
                    let uu____22260 =
                      FStar_Syntax_Util.arrow_formals_comp
-                       a.FStar_Syntax_Syntax.action_typ
-                      in
+                       a.FStar_Syntax_Syntax.action_typ in
                    (match uu____22260 with
                     | (formals,uu____22278) ->
                         let uu____22291 =
                           let uu____22296 =
                             close_effect_params
-                              a.FStar_Syntax_Syntax.action_defn
-                             in
-                          encode_term uu____22296 env2  in
+                              a.FStar_Syntax_Syntax.action_defn in
+                          encode_term uu____22296 env2 in
                         (match uu____22291 with
                          | (tm,decls) ->
                              let a_decls =
@@ -7628,41 +6816,33 @@ and (encode_sigelt' :
                                      FStar_All.pipe_right formals
                                        (FStar_List.map
                                           (fun uu____22336  ->
-                                             FStar_SMTEncoding_Term.Term_sort))
-                                      in
+                                             FStar_SMTEncoding_Term.Term_sort)) in
                                    (aname, uu____22320,
                                      FStar_SMTEncoding_Term.Term_sort,
-                                     (FStar_Pervasives_Native.Some "Action"))
-                                    in
-                                 FStar_SMTEncoding_Term.DeclFun uu____22309
-                                  in
+                                     (FStar_Pervasives_Native.Some "Action")) in
+                                 FStar_SMTEncoding_Term.DeclFun uu____22309 in
                                [uu____22308;
                                FStar_SMTEncoding_Term.DeclFun
                                  (atok, [], FStar_SMTEncoding_Term.Term_sort,
                                    (FStar_Pervasives_Native.Some
-                                      "Action token"))]
-                                in
+                                      "Action token"))] in
                              let uu____22349 =
                                let aux uu____22401 uu____22402 =
                                  match (uu____22401, uu____22402) with
                                  | ((bv,uu____22454),(env3,acc_sorts,acc)) ->
-                                     let uu____22492 = gen_term_var env3 bv
-                                        in
+                                     let uu____22492 = gen_term_var env3 bv in
                                      (match uu____22492 with
                                       | (xxsym,xx,env4) ->
                                           (env4,
                                             ((xxsym,
                                                FStar_SMTEncoding_Term.Term_sort)
-                                            :: acc_sorts), (xx :: acc)))
-                                  in
+                                            :: acc_sorts), (xx :: acc))) in
                                FStar_List.fold_right aux formals
-                                 (env2, [], [])
-                                in
+                                 (env2, [], []) in
                              (match uu____22349 with
                               | (uu____22564,xs_sorts,xs) ->
                                   let app =
-                                    FStar_SMTEncoding_Util.mkApp (aname, xs)
-                                     in
+                                    FStar_SMTEncoding_Util.mkApp (aname, xs) in
                                   let a_eq =
                                     let uu____22587 =
                                       let uu____22594 =
@@ -7670,71 +6850,57 @@ and (encode_sigelt' :
                                           let uu____22606 =
                                             let uu____22607 =
                                               let uu____22612 =
-                                                mk_Apply tm xs_sorts  in
-                                              (app, uu____22612)  in
+                                                mk_Apply tm xs_sorts in
+                                              (app, uu____22612) in
                                             FStar_SMTEncoding_Util.mkEq
-                                              uu____22607
-                                             in
-                                          ([[app]], xs_sorts, uu____22606)
-                                           in
+                                              uu____22607 in
+                                          ([[app]], xs_sorts, uu____22606) in
                                         FStar_SMTEncoding_Util.mkForall
-                                          uu____22595
-                                         in
+                                          uu____22595 in
                                       (uu____22594,
                                         (FStar_Pervasives_Native.Some
                                            "Action equality"),
-                                        (Prims.strcat aname "_equality"))
-                                       in
+                                        (Prims.strcat aname "_equality")) in
                                     FStar_SMTEncoding_Util.mkAssume
-                                      uu____22587
-                                     in
+                                      uu____22587 in
                                   let tok_correspondence =
                                     let tok_term =
                                       FStar_SMTEncoding_Util.mkFreeV
                                         (atok,
-                                          FStar_SMTEncoding_Term.Term_sort)
-                                       in
-                                    let tok_app = mk_Apply tok_term xs_sorts
-                                       in
+                                          FStar_SMTEncoding_Term.Term_sort) in
+                                    let tok_app = mk_Apply tok_term xs_sorts in
                                     let uu____22632 =
                                       let uu____22639 =
                                         let uu____22640 =
                                           let uu____22651 =
                                             FStar_SMTEncoding_Util.mkEq
-                                              (tok_app, app)
-                                             in
+                                              (tok_app, app) in
                                           ([[tok_app]], xs_sorts,
-                                            uu____22651)
-                                           in
+                                            uu____22651) in
                                         FStar_SMTEncoding_Util.mkForall
-                                          uu____22640
-                                         in
+                                          uu____22640 in
                                       (uu____22639,
                                         (FStar_Pervasives_Native.Some
                                            "Action token correspondence"),
                                         (Prims.strcat aname
-                                           "_token_correspondence"))
-                                       in
+                                           "_token_correspondence")) in
                                     FStar_SMTEncoding_Util.mkAssume
-                                      uu____22632
-                                     in
+                                      uu____22632 in
                                   (env2,
                                     (FStar_List.append decls
                                        (FStar_List.append a_decls
-                                          [a_eq; tok_correspondence]))))))
-                in
+                                          [a_eq; tok_correspondence])))))) in
              let uu____22670 =
                FStar_Util.fold_map encode_action env
-                 ed.FStar_Syntax_Syntax.actions
-                in
+                 ed.FStar_Syntax_Syntax.actions in
              match uu____22670 with
              | (env1,decls2) -> ((FStar_List.flatten decls2), env1))
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____22698,uu____22699)
           when FStar_Ident.lid_equals lid FStar_Parser_Const.precedes_lid ->
-          let uu____22700 = new_term_constant_and_tok_from_lid env lid  in
+          let uu____22700 = new_term_constant_and_tok_from_lid env lid in
           (match uu____22700 with | (tname,ttok,env1) -> ([], env1))
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____22717,t) ->
-          let quals = se.FStar_Syntax_Syntax.sigquals  in
+          let quals = se.FStar_Syntax_Syntax.sigquals in
           let will_encode_definition =
             let uu____22723 =
               FStar_All.pipe_right quals
@@ -7745,40 +6911,36 @@ and (encode_sigelt' :
                       | FStar_Syntax_Syntax.Projector uu____22728 -> true
                       | FStar_Syntax_Syntax.Discriminator uu____22733 -> true
                       | FStar_Syntax_Syntax.Irreducible  -> true
-                      | uu____22734 -> false))
-               in
-            Prims.op_Negation uu____22723  in
+                      | uu____22734 -> false)) in
+            Prims.op_Negation uu____22723 in
           if will_encode_definition
           then ([], env)
           else
             (let fv =
                FStar_Syntax_Syntax.lid_as_fv lid
                  FStar_Syntax_Syntax.Delta_constant
-                 FStar_Pervasives_Native.None
-                in
+                 FStar_Pervasives_Native.None in
              let uu____22743 =
                let uu____22750 =
                  FStar_All.pipe_right se.FStar_Syntax_Syntax.sigattrs
-                   (FStar_Util.for_some is_uninterpreted_by_smt)
-                  in
-               encode_top_level_val uu____22750 env fv t quals  in
+                   (FStar_Util.for_some is_uninterpreted_by_smt) in
+               encode_top_level_val uu____22750 env fv t quals in
              match uu____22743 with
              | (decls,env1) ->
-                 let tname = lid.FStar_Ident.str  in
+                 let tname = lid.FStar_Ident.str in
                  let tsym =
                    FStar_SMTEncoding_Util.mkFreeV
-                     (tname, FStar_SMTEncoding_Term.Term_sort)
-                    in
+                     (tname, FStar_SMTEncoding_Term.Term_sort) in
                  let uu____22765 =
                    let uu____22768 =
-                     primitive_type_axioms env1.tcenv lid tname tsym  in
-                   FStar_List.append decls uu____22768  in
+                     primitive_type_axioms env1.tcenv lid tname tsym in
+                   FStar_List.append decls uu____22768 in
                  (uu____22765, env1))
       | FStar_Syntax_Syntax.Sig_assume (l,us,f) ->
-          let uu____22776 = FStar_Syntax_Subst.open_univ_vars us f  in
+          let uu____22776 = FStar_Syntax_Subst.open_univ_vars us f in
           (match uu____22776 with
            | (uu____22785,f1) ->
-               let uu____22787 = encode_formula f1 env  in
+               let uu____22787 = encode_formula f1 env in
                (match uu____22787 with
                 | (f2,decls) ->
                     let g =
@@ -7787,17 +6949,15 @@ and (encode_sigelt' :
                           let uu____22809 =
                             let uu____22812 =
                               let uu____22813 =
-                                FStar_Syntax_Print.lid_to_string l  in
-                              FStar_Util.format1 "Assumption: %s" uu____22813
-                               in
-                            FStar_Pervasives_Native.Some uu____22812  in
+                                FStar_Syntax_Print.lid_to_string l in
+                              FStar_Util.format1 "Assumption: %s" uu____22813 in
+                            FStar_Pervasives_Native.Some uu____22812 in
                           let uu____22814 =
                             varops.mk_unique
-                              (Prims.strcat "assumption_" l.FStar_Ident.str)
-                             in
-                          (f2, uu____22809, uu____22814)  in
-                        FStar_SMTEncoding_Util.mkAssume uu____22802  in
-                      [uu____22801]  in
+                              (Prims.strcat "assumption_" l.FStar_Ident.str) in
+                          (f2, uu____22809, uu____22814) in
+                        FStar_SMTEncoding_Util.mkAssume uu____22802 in
+                      [uu____22801] in
                     ((FStar_List.append decls g), env)))
       | FStar_Syntax_Syntax.Sig_let (lbs,uu____22820) when
           (FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
@@ -7806,7 +6966,7 @@ and (encode_sigelt' :
             (FStar_All.pipe_right se.FStar_Syntax_Syntax.sigattrs
                (FStar_Util.for_some is_opaque_to_smt))
           ->
-          let attrs = se.FStar_Syntax_Syntax.sigattrs  in
+          let attrs = se.FStar_Syntax_Syntax.sigattrs in
           let uu____22832 =
             FStar_Util.fold_map
               (fun env1  ->
@@ -7814,19 +6974,18 @@ and (encode_sigelt' :
                    let lid =
                      let uu____22850 =
                        let uu____22853 =
-                         FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                       uu____22853.FStar_Syntax_Syntax.fv_name  in
-                     uu____22850.FStar_Syntax_Syntax.v  in
+                         FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
+                       uu____22853.FStar_Syntax_Syntax.fv_name in
+                     uu____22850.FStar_Syntax_Syntax.v in
                    let uu____22854 =
                      let uu____22855 =
                        FStar_TypeChecker_Env.try_lookup_val_decl env1.tcenv
-                         lid
-                        in
-                     FStar_All.pipe_left FStar_Option.isNone uu____22855  in
+                         lid in
+                     FStar_All.pipe_left FStar_Option.isNone uu____22855 in
                    if uu____22854
                    then
                      let val_decl =
-                       let uu___129_22883 = se  in
+                       let uu___129_22883 = se in
                        {
                          FStar_Syntax_Syntax.sigel =
                            (FStar_Syntax_Syntax.Sig_declare_typ
@@ -7841,11 +7000,10 @@ and (encode_sigelt' :
                            (uu___129_22883.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
                            (uu___129_22883.FStar_Syntax_Syntax.sigattrs)
-                       }  in
-                     let uu____22888 = encode_sigelt' env1 val_decl  in
+                       } in
+                     let uu____22888 = encode_sigelt' env1 val_decl in
                      match uu____22888 with | (decls,env2) -> (env2, decls)
-                   else (env1, [])) env (FStar_Pervasives_Native.snd lbs)
-             in
+                   else (env1, [])) env (FStar_Pervasives_Native.snd lbs) in
           (match uu____22832 with
            | (env1,decls) -> ((FStar_List.flatten decls), env1))
       | FStar_Syntax_Syntax.Sig_let
@@ -7859,16 +7017,14 @@ and (encode_sigelt' :
           ->
           let uu____22946 =
             new_term_constant_and_tok_from_lid env
-              (b2t1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (b2t1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           (match uu____22946 with
            | (tname,ttok,env1) ->
-               let xx = ("x", FStar_SMTEncoding_Term.Term_sort)  in
-               let x = FStar_SMTEncoding_Util.mkFreeV xx  in
-               let b2t_x = FStar_SMTEncoding_Util.mkApp ("Prims.b2t", [x])
-                  in
+               let xx = ("x", FStar_SMTEncoding_Term.Term_sort) in
+               let x = FStar_SMTEncoding_Util.mkFreeV xx in
+               let b2t_x = FStar_SMTEncoding_Util.mkApp ("Prims.b2t", [x]) in
                let valid_b2t_x =
-                 FStar_SMTEncoding_Util.mkApp ("Valid", [b2t_x])  in
+                 FStar_SMTEncoding_Util.mkApp ("Valid", [b2t_x]) in
                let decls =
                  let uu____22975 =
                    let uu____22978 =
@@ -7881,23 +7037,20 @@ and (encode_sigelt' :
                                  FStar_SMTEncoding_Util.mkApp
                                    ((FStar_Pervasives_Native.snd
                                        FStar_SMTEncoding_Term.boxBoolFun),
-                                     [x])
-                                  in
-                               (valid_b2t_x, uu____23004)  in
-                             FStar_SMTEncoding_Util.mkEq uu____22999  in
-                           ([[b2t_x]], [xx], uu____22998)  in
-                         FStar_SMTEncoding_Util.mkForall uu____22987  in
+                                     [x]) in
+                               (valid_b2t_x, uu____23004) in
+                             FStar_SMTEncoding_Util.mkEq uu____22999 in
+                           ([[b2t_x]], [xx], uu____22998) in
+                         FStar_SMTEncoding_Util.mkForall uu____22987 in
                        (uu____22986,
-                         (FStar_Pervasives_Native.Some "b2t def"), "b2t_def")
-                        in
-                     FStar_SMTEncoding_Util.mkAssume uu____22979  in
-                   [uu____22978]  in
+                         (FStar_Pervasives_Native.Some "b2t def"), "b2t_def") in
+                     FStar_SMTEncoding_Util.mkAssume uu____22979 in
+                   [uu____22978] in
                  (FStar_SMTEncoding_Term.DeclFun
                     (tname, [FStar_SMTEncoding_Term.Term_sort],
                       FStar_SMTEncoding_Term.Term_sort,
                       FStar_Pervasives_Native.None))
-                   :: uu____22975
-                  in
+                   :: uu____22975 in
                (decls, env1))
       | FStar_Syntax_Syntax.Sig_let (uu____23037,uu____23038) when
           FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
@@ -7912,8 +7065,8 @@ and (encode_sigelt' :
              (FStar_Util.for_some
                 (fun l  ->
                    let uu____23063 =
-                     let uu____23064 = FStar_List.hd l.FStar_Ident.ns  in
-                     uu____23064.FStar_Ident.idText  in
+                     let uu____23064 = FStar_List.hd l.FStar_Ident.ns in
+                     uu____23064.FStar_Ident.idText in
                    uu____23063 = "Prims")))
             &&
             (FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
@@ -7932,14 +7085,14 @@ and (encode_sigelt' :
                   | FStar_Syntax_Syntax.Projector uu____23091 -> true
                   | uu____23096 -> false))
           ->
-          let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-          let l = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-          let uu____23099 = try_lookup_free_var env l  in
+          let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
+          let l = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+          let uu____23099 = try_lookup_free_var env l in
           (match uu____23099 with
            | FStar_Pervasives_Native.Some uu____23106 -> ([], env)
            | FStar_Pervasives_Native.None  ->
                let se1 =
-                 let uu___130_23110 = se  in
+                 let uu___130_23110 = se in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_declare_typ
@@ -7952,13 +7105,13 @@ and (encode_sigelt' :
                      (uu___130_23110.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
                      (uu___130_23110.FStar_Syntax_Syntax.sigattrs)
-                 }  in
+                 } in
                encode_sigelt env se1)
       | FStar_Syntax_Syntax.Sig_let ((is_rec,bindings),uu____23117) ->
           encode_top_level_let env (is_rec, bindings)
             se.FStar_Syntax_Syntax.sigquals
       | FStar_Syntax_Syntax.Sig_bundle (ses,uu____23135) ->
-          let uu____23144 = encode_sigelts env ses  in
+          let uu____23144 = encode_sigelts env ses in
           (match uu____23144 with
            | (g,env1) ->
                let uu____23161 =
@@ -7978,8 +7131,7 @@ and (encode_sigelt' :
                                FStar_SMTEncoding_Term.assumption_fact_ids =
                                  uu____23187;_}
                              -> false
-                         | uu____23190 -> true))
-                  in
+                         | uu____23190 -> true)) in
                (match uu____23161 with
                 | (g',inversions) ->
                     let uu____23205 =
@@ -7989,15 +7141,14 @@ and (encode_sigelt' :
                               match uu___99_23226 with
                               | FStar_SMTEncoding_Term.DeclFun uu____23227 ->
                                   true
-                              | uu____23238 -> false))
-                       in
+                              | uu____23238 -> false)) in
                     (match uu____23205 with
                      | (decls,rest) ->
                          ((FStar_List.append decls
                              (FStar_List.append rest inversions)), env1))))
       | FStar_Syntax_Syntax.Sig_inductive_typ
           (t,uu____23256,tps,k,uu____23259,datas) ->
-          let quals = se.FStar_Syntax_Syntax.sigquals  in
+          let quals = se.FStar_Syntax_Syntax.sigquals in
           let is_logical =
             FStar_All.pipe_right quals
               (FStar_Util.for_some
@@ -8005,12 +7156,11 @@ and (encode_sigelt' :
                     match uu___100_23276 with
                     | FStar_Syntax_Syntax.Logic  -> true
                     | FStar_Syntax_Syntax.Assumption  -> true
-                    | uu____23277 -> false))
-             in
+                    | uu____23277 -> false)) in
           let constructor_or_logic_type_decl c =
             if is_logical
             then
-              let uu____23286 = c  in
+              let uu____23286 = c in
               match uu____23286 with
               | (name,args,uu____23291,uu____23292,uu____23293) ->
                   let uu____23298 =
@@ -8020,28 +7170,25 @@ and (encode_sigelt' :
                           (FStar_List.map
                              (fun uu____23327  ->
                                 match uu____23327 with
-                                | (uu____23334,sort,uu____23336) -> sort))
-                         in
+                                | (uu____23334,sort,uu____23336) -> sort)) in
                       (name, uu____23310, FStar_SMTEncoding_Term.Term_sort,
-                        FStar_Pervasives_Native.None)
-                       in
-                    FStar_SMTEncoding_Term.DeclFun uu____23299  in
+                        FStar_Pervasives_Native.None) in
+                    FStar_SMTEncoding_Term.DeclFun uu____23299 in
                   [uu____23298]
-            else FStar_SMTEncoding_Term.constructor_to_decl c  in
+            else FStar_SMTEncoding_Term.constructor_to_decl c in
           let inversion_axioms tapp vars =
             let uu____23363 =
               FStar_All.pipe_right datas
                 (FStar_Util.for_some
                    (fun l  ->
                       let uu____23369 =
-                        FStar_TypeChecker_Env.try_lookup_lid env.tcenv l  in
-                      FStar_All.pipe_right uu____23369 FStar_Option.isNone))
-               in
+                        FStar_TypeChecker_Env.try_lookup_lid env.tcenv l in
+                      FStar_All.pipe_right uu____23369 FStar_Option.isNone)) in
             if uu____23363
             then []
             else
               (let uu____23401 =
-                 fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort  in
+                 fresh_fvar "x" FStar_SMTEncoding_Term.Term_sort in
                match uu____23401 with
                | (xxsym,xx) ->
                    let uu____23410 =
@@ -8053,29 +7200,25 @@ and (encode_sigelt' :
                                | (out,decls) ->
                                    let uu____23469 =
                                      FStar_TypeChecker_Env.lookup_datacon
-                                       env.tcenv l
-                                      in
+                                       env.tcenv l in
                                    (match uu____23469 with
                                     | (uu____23480,data_t) ->
                                         let uu____23482 =
                                           FStar_Syntax_Util.arrow_formals
-                                            data_t
-                                           in
+                                            data_t in
                                         (match uu____23482 with
                                          | (args,res) ->
                                              let indices =
                                                let uu____23528 =
                                                  let uu____23529 =
                                                    FStar_Syntax_Subst.compress
-                                                     res
-                                                    in
-                                                 uu____23529.FStar_Syntax_Syntax.n
-                                                  in
+                                                     res in
+                                                 uu____23529.FStar_Syntax_Syntax.n in
                                                match uu____23528 with
                                                | FStar_Syntax_Syntax.Tm_app
                                                    (uu____23540,indices) ->
                                                    indices
-                                               | uu____23562 -> []  in
+                                               | uu____23562 -> [] in
                                              let env1 =
                                                FStar_All.pipe_right args
                                                  (FStar_List.fold_left
@@ -8091,21 +7234,17 @@ and (encode_sigelt' :
                                                                  let uu____23601
                                                                    =
                                                                    mk_term_projector_name
-                                                                    l x
-                                                                    in
+                                                                    l x in
                                                                  (uu____23601,
-                                                                   [xx])
-                                                                  in
+                                                                   [xx]) in
                                                                FStar_SMTEncoding_Util.mkApp
-                                                                 uu____23594
-                                                                in
+                                                                 uu____23594 in
                                                              push_term_var
                                                                env1 x
                                                                uu____23593)
-                                                    env)
-                                                in
+                                                    env) in
                                              let uu____23604 =
-                                               encode_args indices env1  in
+                                               encode_args indices env1 in
                                              (match uu____23604 with
                                               | (indices1,decls') ->
                                                   (if
@@ -8126,47 +7265,37 @@ and (encode_sigelt' :
                                                                  let uu____23651
                                                                    =
                                                                    FStar_SMTEncoding_Util.mkFreeV
-                                                                    v1
-                                                                    in
+                                                                    v1 in
                                                                  (uu____23651,
-                                                                   a)
-                                                                  in
+                                                                   a) in
                                                                FStar_SMTEncoding_Util.mkEq
                                                                  uu____23646)
-                                                          vars indices1
-                                                         in
+                                                          vars indices1 in
                                                       FStar_All.pipe_right
                                                         uu____23630
-                                                        FStar_SMTEncoding_Util.mk_and_l
-                                                       in
+                                                        FStar_SMTEncoding_Util.mk_and_l in
                                                     let uu____23654 =
                                                       let uu____23655 =
                                                         let uu____23660 =
                                                           let uu____23661 =
                                                             let uu____23666 =
                                                               mk_data_tester
-                                                                env1 l xx
-                                                               in
+                                                                env1 l xx in
                                                             (uu____23666,
-                                                              eqs)
-                                                             in
+                                                              eqs) in
                                                           FStar_SMTEncoding_Util.mkAnd
-                                                            uu____23661
-                                                           in
-                                                        (out, uu____23660)
-                                                         in
+                                                            uu____23661 in
+                                                        (out, uu____23660) in
                                                       FStar_SMTEncoding_Util.mkOr
-                                                        uu____23655
-                                                       in
+                                                        uu____23655 in
                                                     (uu____23654,
                                                       (FStar_List.append
                                                          decls decls'))))))))
-                          (FStar_SMTEncoding_Util.mkFalse, []))
-                      in
+                          (FStar_SMTEncoding_Util.mkFalse, [])) in
                    (match uu____23410 with
                     | (data_ax,decls) ->
                         let uu____23679 =
-                          fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort  in
+                          fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort in
                         (match uu____23679 with
                          | (ffsym,ff) ->
                              let fuel_guarded_inversion =
@@ -8177,14 +7306,12 @@ and (encode_sigelt' :
                                  then
                                    let uu____23690 =
                                      FStar_SMTEncoding_Util.mkApp
-                                       ("SFuel", [ff])
-                                      in
+                                       ("SFuel", [ff]) in
                                    FStar_SMTEncoding_Term.mk_HasTypeFuel
                                      uu____23690 xx tapp
                                  else
                                    FStar_SMTEncoding_Term.mk_HasTypeFuel ff
-                                     xx tapp
-                                  in
+                                     xx tapp in
                                let uu____23694 =
                                  let uu____23701 =
                                    let uu____23702 =
@@ -8194,67 +7321,57 @@ and (encode_sigelt' :
                                            FStar_SMTEncoding_Term.Fuel_sort)
                                          ((xxsym,
                                             FStar_SMTEncoding_Term.Term_sort)
-                                         :: vars)
-                                        in
+                                         :: vars) in
                                      let uu____23728 =
                                        FStar_SMTEncoding_Util.mkImp
-                                         (xx_has_type_sfuel, data_ax)
-                                        in
+                                         (xx_has_type_sfuel, data_ax) in
                                      ([[xx_has_type_sfuel]], uu____23713,
-                                       uu____23728)
-                                      in
+                                       uu____23728) in
                                    FStar_SMTEncoding_Util.mkForall
-                                     uu____23702
-                                    in
+                                     uu____23702 in
                                  let uu____23743 =
                                    varops.mk_unique
                                      (Prims.strcat "fuel_guarded_inversion_"
-                                        t.FStar_Ident.str)
-                                    in
+                                        t.FStar_Ident.str) in
                                  (uu____23701,
                                    (FStar_Pervasives_Native.Some
-                                      "inversion axiom"), uu____23743)
-                                  in
-                               FStar_SMTEncoding_Util.mkAssume uu____23694
-                                in
-                             FStar_List.append decls [fuel_guarded_inversion])))
-             in
+                                      "inversion axiom"), uu____23743) in
+                               FStar_SMTEncoding_Util.mkAssume uu____23694 in
+                             FStar_List.append decls [fuel_guarded_inversion]))) in
           let uu____23746 =
             let uu____23759 =
-              let uu____23760 = FStar_Syntax_Subst.compress k  in
-              uu____23760.FStar_Syntax_Syntax.n  in
+              let uu____23760 = FStar_Syntax_Subst.compress k in
+              uu____23760.FStar_Syntax_Syntax.n in
             match uu____23759 with
             | FStar_Syntax_Syntax.Tm_arrow (formals,kres) ->
                 ((FStar_List.append tps formals),
                   (FStar_Syntax_Util.comp_result kres))
-            | uu____23805 -> (tps, k)  in
+            | uu____23805 -> (tps, k) in
           (match uu____23746 with
            | (formals,res) ->
-               let uu____23828 = FStar_Syntax_Subst.open_term formals res  in
+               let uu____23828 = FStar_Syntax_Subst.open_term formals res in
                (match uu____23828 with
                 | (formals1,res1) ->
                     let uu____23839 =
                       encode_binders FStar_Pervasives_Native.None formals1
-                        env
-                       in
+                        env in
                     (match uu____23839 with
                      | (vars,guards,env',binder_decls,uu____23864) ->
                          let uu____23877 =
-                           new_term_constant_and_tok_from_lid env t  in
+                           new_term_constant_and_tok_from_lid env t in
                          (match uu____23877 with
                           | (tname,ttok,env1) ->
                               let ttok_tm =
-                                FStar_SMTEncoding_Util.mkApp (ttok, [])  in
+                                FStar_SMTEncoding_Util.mkApp (ttok, []) in
                               let guard =
-                                FStar_SMTEncoding_Util.mk_and_l guards  in
+                                FStar_SMTEncoding_Util.mk_and_l guards in
                               let tapp =
                                 let uu____23896 =
                                   let uu____23903 =
                                     FStar_List.map
-                                      FStar_SMTEncoding_Util.mkFreeV vars
-                                     in
-                                  (tname, uu____23903)  in
-                                FStar_SMTEncoding_Util.mkApp uu____23896  in
+                                      FStar_SMTEncoding_Util.mkFreeV vars in
+                                  (tname, uu____23903) in
+                                FStar_SMTEncoding_Util.mkApp uu____23896 in
                               let uu____23912 =
                                 let tname_decl =
                                   let uu____23922 =
@@ -8265,15 +7382,12 @@ and (encode_sigelt' :
                                               match uu____23955 with
                                               | (n1,s) ->
                                                   ((Prims.strcat tname n1),
-                                                    s, false)))
-                                       in
-                                    let uu____23968 = varops.next_id ()  in
+                                                    s, false))) in
+                                    let uu____23968 = varops.next_id () in
                                     (tname, uu____23923,
                                       FStar_SMTEncoding_Term.Term_sort,
-                                      uu____23968, false)
-                                     in
-                                  constructor_or_logic_type_decl uu____23922
-                                   in
+                                      uu____23968, false) in
+                                  constructor_or_logic_type_decl uu____23922 in
                                 let uu____23977 =
                                   match vars with
                                   | [] ->
@@ -8281,16 +7395,13 @@ and (encode_sigelt' :
                                         let uu____23991 =
                                           let uu____23994 =
                                             FStar_SMTEncoding_Util.mkApp
-                                              (tname, [])
-                                             in
+                                              (tname, []) in
                                           FStar_All.pipe_left
                                             (fun _0_44  ->
                                                FStar_Pervasives_Native.Some
-                                                 _0_44) uu____23994
-                                           in
+                                                 _0_44) uu____23994 in
                                         push_free_var env1 t tname
-                                          uu____23991
-                                         in
+                                          uu____23991 in
                                       ([], uu____23990)
                                   | uu____24001 ->
                                       let ttok_decl =
@@ -8298,59 +7409,47 @@ and (encode_sigelt' :
                                           (ttok, [],
                                             FStar_SMTEncoding_Term.Term_sort,
                                             (FStar_Pervasives_Native.Some
-                                               "token"))
-                                         in
+                                               "token")) in
                                       let ttok_fresh =
-                                        let uu____24010 = varops.next_id ()
-                                           in
+                                        let uu____24010 = varops.next_id () in
                                         FStar_SMTEncoding_Term.fresh_token
                                           (ttok,
                                             FStar_SMTEncoding_Term.Term_sort)
-                                          uu____24010
-                                         in
-                                      let ttok_app = mk_Apply ttok_tm vars
-                                         in
-                                      let pats = [[ttok_app]; [tapp]]  in
+                                          uu____24010 in
+                                      let ttok_app = mk_Apply ttok_tm vars in
+                                      let pats = [[ttok_app]; [tapp]] in
                                       let name_tok_corr =
                                         let uu____24024 =
                                           let uu____24031 =
                                             let uu____24032 =
                                               let uu____24047 =
                                                 FStar_SMTEncoding_Util.mkEq
-                                                  (ttok_app, tapp)
-                                                 in
+                                                  (ttok_app, tapp) in
                                               (pats,
                                                 FStar_Pervasives_Native.None,
-                                                vars, uu____24047)
-                                               in
+                                                vars, uu____24047) in
                                             FStar_SMTEncoding_Util.mkForall'
-                                              uu____24032
-                                             in
+                                              uu____24032 in
                                           (uu____24031,
                                             (FStar_Pervasives_Native.Some
                                                "name-token correspondence"),
                                             (Prims.strcat
-                                               "token_correspondence_" ttok))
-                                           in
+                                               "token_correspondence_" ttok)) in
                                         FStar_SMTEncoding_Util.mkAssume
-                                          uu____24024
-                                         in
+                                          uu____24024 in
                                       ([ttok_decl; ttok_fresh; name_tok_corr],
-                                        env1)
-                                   in
+                                        env1) in
                                 match uu____23977 with
                                 | (tok_decls,env2) ->
                                     ((FStar_List.append tname_decl tok_decls),
-                                      env2)
-                                 in
+                                      env2) in
                               (match uu____23912 with
                                | (decls,env2) ->
                                    let kindingAx =
                                      let uu____24087 =
                                        encode_term_pred
                                          FStar_Pervasives_Native.None res1
-                                         env' tapp
-                                        in
+                                         env' tapp in
                                      match uu____24087 with
                                      | (k1,decls1) ->
                                          let karr =
@@ -8363,22 +7462,18 @@ and (encode_sigelt' :
                                                  let uu____24113 =
                                                    let uu____24114 =
                                                      FStar_SMTEncoding_Term.mk_PreType
-                                                       ttok_tm
-                                                      in
+                                                       ttok_tm in
                                                    FStar_SMTEncoding_Term.mk_tester
-                                                     "Tm_arrow" uu____24114
-                                                    in
+                                                     "Tm_arrow" uu____24114 in
                                                  (uu____24113,
                                                    (FStar_Pervasives_Native.Some
                                                       "kinding"),
                                                    (Prims.strcat
-                                                      "pre_kinding_" ttok))
-                                                  in
+                                                      "pre_kinding_" ttok)) in
                                                FStar_SMTEncoding_Util.mkAssume
-                                                 uu____24106
-                                                in
+                                                 uu____24106 in
                                              [uu____24105]
-                                           else []  in
+                                           else [] in
                                          let uu____24118 =
                                            let uu____24121 =
                                              let uu____24124 =
@@ -8387,44 +7482,34 @@ and (encode_sigelt' :
                                                    let uu____24133 =
                                                      let uu____24144 =
                                                        FStar_SMTEncoding_Util.mkImp
-                                                         (guard, k1)
-                                                        in
+                                                         (guard, k1) in
                                                      ([[tapp]], vars,
-                                                       uu____24144)
-                                                      in
+                                                       uu____24144) in
                                                    FStar_SMTEncoding_Util.mkForall
-                                                     uu____24133
-                                                    in
+                                                     uu____24133 in
                                                  (uu____24132,
                                                    FStar_Pervasives_Native.None,
                                                    (Prims.strcat "kinding_"
-                                                      ttok))
-                                                  in
+                                                      ttok)) in
                                                FStar_SMTEncoding_Util.mkAssume
-                                                 uu____24125
-                                                in
-                                             [uu____24124]  in
-                                           FStar_List.append karr uu____24121
-                                            in
-                                         FStar_List.append decls1 uu____24118
-                                      in
+                                                 uu____24125 in
+                                             [uu____24124] in
+                                           FStar_List.append karr uu____24121 in
+                                         FStar_List.append decls1 uu____24118 in
                                    let aux =
                                      let uu____24160 =
                                        let uu____24163 =
-                                         inversion_axioms tapp vars  in
+                                         inversion_axioms tapp vars in
                                        let uu____24166 =
                                          let uu____24169 =
-                                           pretype_axiom env2 tapp vars  in
-                                         [uu____24169]  in
+                                           pretype_axiom env2 tapp vars in
+                                         [uu____24169] in
                                        FStar_List.append uu____24163
-                                         uu____24166
-                                        in
-                                     FStar_List.append kindingAx uu____24160
-                                      in
+                                         uu____24166 in
+                                     FStar_List.append kindingAx uu____24160 in
                                    let g =
                                      FStar_List.append decls
-                                       (FStar_List.append binder_decls aux)
-                                      in
+                                       (FStar_List.append binder_decls aux) in
                                    (g, env2))))))
       | FStar_Syntax_Syntax.Sig_datacon
           (d,uu____24176,uu____24177,uu____24178,uu____24179,uu____24180)
@@ -8432,26 +7517,24 @@ and (encode_sigelt' :
           ([], env)
       | FStar_Syntax_Syntax.Sig_datacon
           (d,uu____24188,t,uu____24190,n_tps,uu____24192) ->
-          let quals = se.FStar_Syntax_Syntax.sigquals  in
-          let uu____24200 = new_term_constant_and_tok_from_lid env d  in
+          let quals = se.FStar_Syntax_Syntax.sigquals in
+          let uu____24200 = new_term_constant_and_tok_from_lid env d in
           (match uu____24200 with
            | (ddconstrsym,ddtok,env1) ->
-               let ddtok_tm = FStar_SMTEncoding_Util.mkApp (ddtok, [])  in
-               let uu____24217 = FStar_Syntax_Util.arrow_formals t  in
+               let ddtok_tm = FStar_SMTEncoding_Util.mkApp (ddtok, []) in
+               let uu____24217 = FStar_Syntax_Util.arrow_formals t in
                (match uu____24217 with
                 | (formals,t_res) ->
                     let uu____24252 =
-                      fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort  in
+                      fresh_fvar "f" FStar_SMTEncoding_Term.Fuel_sort in
                     (match uu____24252 with
                      | (fuel_var,fuel_tm) ->
                          let s_fuel_tm =
-                           FStar_SMTEncoding_Util.mkApp ("SFuel", [fuel_tm])
-                            in
+                           FStar_SMTEncoding_Util.mkApp ("SFuel", [fuel_tm]) in
                          let uu____24266 =
                            encode_binders
                              (FStar_Pervasives_Native.Some fuel_tm) formals
-                             env1
-                            in
+                             env1 in
                          (match uu____24266 with
                           | (vars,guards,env',binder_decls,names1) ->
                               let fields =
@@ -8459,38 +7542,32 @@ and (encode_sigelt' :
                                   (FStar_List.mapi
                                      (fun n1  ->
                                         fun x  ->
-                                          let projectible = true  in
+                                          let projectible = true in
                                           let uu____24336 =
-                                            mk_term_projector_name d x  in
+                                            mk_term_projector_name d x in
                                           (uu____24336,
                                             FStar_SMTEncoding_Term.Term_sort,
-                                            projectible)))
-                                 in
+                                            projectible))) in
                               let datacons =
                                 let uu____24338 =
-                                  let uu____24357 = varops.next_id ()  in
+                                  let uu____24357 = varops.next_id () in
                                   (ddconstrsym, fields,
                                     FStar_SMTEncoding_Term.Term_sort,
-                                    uu____24357, true)
-                                   in
+                                    uu____24357, true) in
                                 FStar_All.pipe_right uu____24338
-                                  FStar_SMTEncoding_Term.constructor_to_decl
-                                 in
-                              let app = mk_Apply ddtok_tm vars  in
+                                  FStar_SMTEncoding_Term.constructor_to_decl in
+                              let app = mk_Apply ddtok_tm vars in
                               let guard =
-                                FStar_SMTEncoding_Util.mk_and_l guards  in
+                                FStar_SMTEncoding_Util.mk_and_l guards in
                               let xvars =
                                 FStar_List.map FStar_SMTEncoding_Util.mkFreeV
-                                  vars
-                                 in
+                                  vars in
                               let dapp =
                                 FStar_SMTEncoding_Util.mkApp
-                                  (ddconstrsym, xvars)
-                                 in
+                                  (ddconstrsym, xvars) in
                               let uu____24396 =
                                 encode_term_pred FStar_Pervasives_Native.None
-                                  t env1 ddtok_tm
-                                 in
+                                  t env1 ddtok_tm in
                               (match uu____24396 with
                                | (tok_typing,decls3) ->
                                    let tok_typing1 =
@@ -8498,34 +7575,28 @@ and (encode_sigelt' :
                                      | uu____24408::uu____24409 ->
                                          let ff =
                                            ("ty",
-                                             FStar_SMTEncoding_Term.Term_sort)
-                                            in
+                                             FStar_SMTEncoding_Term.Term_sort) in
                                          let f =
-                                           FStar_SMTEncoding_Util.mkFreeV ff
-                                            in
+                                           FStar_SMTEncoding_Util.mkFreeV ff in
                                          let vtok_app_l =
-                                           mk_Apply ddtok_tm [ff]  in
+                                           mk_Apply ddtok_tm [ff] in
                                          let vtok_app_r =
                                            mk_Apply f
                                              [(ddtok,
-                                                FStar_SMTEncoding_Term.Term_sort)]
-                                            in
+                                                FStar_SMTEncoding_Term.Term_sort)] in
                                          let uu____24454 =
                                            let uu____24465 =
                                              FStar_SMTEncoding_Term.mk_NoHoist
-                                               f tok_typing
-                                              in
+                                               f tok_typing in
                                            ([[vtok_app_l]; [vtok_app_r]],
-                                             [ff], uu____24465)
-                                            in
+                                             [ff], uu____24465) in
                                          FStar_SMTEncoding_Util.mkForall
                                            uu____24454
-                                     | uu____24490 -> tok_typing  in
+                                     | uu____24490 -> tok_typing in
                                    let uu____24499 =
                                      encode_binders
                                        (FStar_Pervasives_Native.Some fuel_tm)
-                                       formals env1
-                                      in
+                                       formals env1 in
                                    (match uu____24499 with
                                     | (vars',guards',env'',decls_formals,uu____24524)
                                         ->
@@ -8533,50 +7604,41 @@ and (encode_sigelt' :
                                           let xvars1 =
                                             FStar_List.map
                                               FStar_SMTEncoding_Util.mkFreeV
-                                              vars'
-                                             in
+                                              vars' in
                                           let dapp1 =
                                             FStar_SMTEncoding_Util.mkApp
-                                              (ddconstrsym, xvars1)
-                                             in
+                                              (ddconstrsym, xvars1) in
                                           encode_term_pred
                                             (FStar_Pervasives_Native.Some
-                                               fuel_tm) t_res env'' dapp1
-                                           in
+                                               fuel_tm) t_res env'' dapp1 in
                                         (match uu____24537 with
                                          | (ty_pred',decls_pred) ->
                                              let guard' =
                                                FStar_SMTEncoding_Util.mk_and_l
-                                                 guards'
-                                                in
+                                                 guards' in
                                              let proxy_fresh =
                                                match formals with
                                                | [] -> []
                                                | uu____24568 ->
                                                    let uu____24575 =
                                                      let uu____24576 =
-                                                       varops.next_id ()  in
+                                                       varops.next_id () in
                                                      FStar_SMTEncoding_Term.fresh_token
                                                        (ddtok,
                                                          FStar_SMTEncoding_Term.Term_sort)
-                                                       uu____24576
-                                                      in
-                                                   [uu____24575]
-                                                in
+                                                       uu____24576 in
+                                                   [uu____24575] in
                                              let encode_elim uu____24586 =
                                                let uu____24587 =
                                                  FStar_Syntax_Util.head_and_args
-                                                   t_res
-                                                  in
+                                                   t_res in
                                                match uu____24587 with
                                                | (head1,args) ->
                                                    let uu____24630 =
                                                      let uu____24631 =
                                                        FStar_Syntax_Subst.compress
-                                                         head1
-                                                        in
-                                                     uu____24631.FStar_Syntax_Syntax.n
-                                                      in
+                                                         head1 in
+                                                     uu____24631.FStar_Syntax_Syntax.n in
                                                    (match uu____24630 with
                                                     | FStar_Syntax_Syntax.Tm_uinst
                                                         ({
@@ -8592,12 +7654,10 @@ and (encode_sigelt' :
                                                         let encoded_head =
                                                           lookup_free_var_name
                                                             env'
-                                                            fv.FStar_Syntax_Syntax.fv_name
-                                                           in
+                                                            fv.FStar_Syntax_Syntax.fv_name in
                                                         let uu____24649 =
                                                           encode_args args
-                                                            env'
-                                                           in
+                                                            env' in
                                                         (match uu____24649
                                                          with
                                                          | (encoded_args,arg_decls)
@@ -8621,19 +7681,15 @@ and (encode_sigelt' :
                                                                     let uu____24699
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
-                                                                    orig_arg
-                                                                     in
+                                                                    orig_arg in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu____24699
-                                                                     in
+                                                                    uu____24699 in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu____24698)
-                                                                     in
+                                                                    uu____24698) in
                                                                     FStar_Errors.raise_error
                                                                     uu____24693
-                                                                    orig_arg.FStar_Syntax_Syntax.pos
-                                                                  in
+                                                                    orig_arg.FStar_Syntax_Syntax.pos in
                                                                let guards1 =
                                                                  FStar_All.pipe_right
                                                                    guards
@@ -8645,33 +7701,28 @@ and (encode_sigelt' :
                                                                     let uu____24716
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
-                                                                    g  in
+                                                                    g in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu____24716
-                                                                     in
+                                                                    uu____24716 in
                                                                     if
                                                                     uu____24715
                                                                     then
                                                                     let uu____24729
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
-                                                                    g fv1 xv
-                                                                     in
+                                                                    g fv1 xv in
                                                                     [uu____24729]
-                                                                    else []))
-                                                                  in
+                                                                    else [])) in
                                                                FStar_SMTEncoding_Util.mk_and_l
-                                                                 guards1
-                                                                in
+                                                                 guards1 in
                                                              let uu____24731
                                                                =
                                                                let uu____24744
                                                                  =
                                                                  FStar_List.zip
                                                                    args
-                                                                   encoded_args
-                                                                  in
+                                                                   encoded_args in
                                                                FStar_List.fold_left
                                                                  (fun
                                                                     uu____24794
@@ -8693,12 +7744,10 @@ and (encode_sigelt' :
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
-                                                                    FStar_Syntax_Syntax.tun
-                                                                     in
+                                                                    FStar_Syntax_Syntax.tun in
                                                                     gen_term_var
                                                                     env2
-                                                                    uu____24897
-                                                                     in
+                                                                    uu____24897 in
                                                                     (match uu____24890
                                                                     with
                                                                     | 
@@ -8714,8 +7763,7 @@ and (encode_sigelt' :
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
-                                                                    arg xv
-                                                                     in
+                                                                    arg xv in
                                                                     uu____24918
                                                                     ::
                                                                     eqns_or_guards
@@ -8723,23 +7771,22 @@ and (encode_sigelt' :
                                                                     (let uu____24920
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
-                                                                    (arg, xv)
-                                                                     in
+                                                                    (arg, xv) in
                                                                     uu____24920
                                                                     ::
-                                                                    eqns_or_guards)
-                                                                     in
+                                                                    eqns_or_guards) in
                                                                     (env3,
                                                                     (xv ::
                                                                     arg_vars),
                                                                     eqns,
                                                                     (i +
-                                                                    (Prims.parse_int "1")))))
+                                                                    (Prims.parse_int
+                                                                    "1")))))
                                                                  (env', [],
                                                                    [],
-                                                                   (Prims.parse_int "0"))
-                                                                 uu____24744
-                                                                in
+                                                                   (Prims.parse_int
+                                                                    "0"))
+                                                                 uu____24744 in
                                                              (match uu____24731
                                                               with
                                                               | (uu____24935,arg_vars,elim_eqns_or_guards,uu____24938)
@@ -8747,36 +7794,31 @@ and (encode_sigelt' :
                                                                   let arg_vars1
                                                                     =
                                                                     FStar_List.rev
-                                                                    arg_vars
-                                                                     in
+                                                                    arg_vars in
                                                                   let ty =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     (encoded_head,
-                                                                    arg_vars1)
-                                                                     in
+                                                                    arg_vars1) in
                                                                   let xvars1
                                                                     =
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    vars  in
+                                                                    vars in
                                                                   let dapp1 =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     (ddconstrsym,
-                                                                    xvars1)
-                                                                     in
+                                                                    xvars1) in
                                                                   let ty_pred
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_HasTypeWithFuel
                                                                     (FStar_Pervasives_Native.Some
                                                                     s_fuel_tm)
-                                                                    dapp1 ty
-                                                                     in
+                                                                    dapp1 ty in
                                                                   let arg_binders
                                                                     =
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Term.fv_of_term
-                                                                    arg_vars1
-                                                                     in
+                                                                    arg_vars1 in
                                                                   let typing_inversion
                                                                     =
                                                                     let uu____24968
@@ -8792,8 +7834,7 @@ and (encode_sigelt' :
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                     (FStar_List.append
                                                                     vars
-                                                                    arg_binders)
-                                                                     in
+                                                                    arg_binders) in
                                                                     let uu____24998
                                                                     =
                                                                     let uu____24999
@@ -8803,32 +7844,25 @@ and (encode_sigelt' :
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
                                                                     elim_eqns_or_guards
-                                                                    guards)
-                                                                     in
+                                                                    guards) in
                                                                     (ty_pred,
-                                                                    uu____25004)
-                                                                     in
+                                                                    uu____25004) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____24999
-                                                                     in
+                                                                    uu____24999 in
                                                                     ([
                                                                     [ty_pred]],
                                                                     uu____24987,
-                                                                    uu____24998)
-                                                                     in
+                                                                    uu____24998) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____24976
-                                                                     in
+                                                                    uu____24976 in
                                                                     (uu____24975,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.strcat
                                                                     "data_elim_"
-                                                                    ddconstrsym))
-                                                                     in
+                                                                    ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____24968
-                                                                     in
+                                                                    uu____24968 in
                                                                   let subterm_ordering
                                                                     =
                                                                     if
@@ -8840,13 +7874,12 @@ and (encode_sigelt' :
                                                                     let uu____25027
                                                                     =
                                                                     varops.fresh
-                                                                    "x"  in
+                                                                    "x" in
                                                                     (uu____25027,
-                                                                    FStar_SMTEncoding_Term.Term_sort)
-                                                                     in
+                                                                    FStar_SMTEncoding_Term.Term_sort) in
                                                                     let xtm =
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    x  in
+                                                                    x in
                                                                     let uu____25029
                                                                     =
                                                                     let uu____25036
@@ -8860,12 +7893,9 @@ and (encode_sigelt' :
                                                                     let uu____25056
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_Precedes
-                                                                    xtm dapp1
-                                                                     in
-                                                                    [uu____25056]
-                                                                     in
-                                                                    [uu____25053]
-                                                                     in
+                                                                    xtm dapp1 in
+                                                                    [uu____25056] in
+                                                                    [uu____25053] in
                                                                     let uu____25061
                                                                     =
                                                                     let uu____25062
@@ -8874,35 +7904,28 @@ and (encode_sigelt' :
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_tester
                                                                     "LexCons"
-                                                                    xtm  in
+                                                                    xtm in
                                                                     let uu____25068
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_Precedes
-                                                                    xtm dapp1
-                                                                     in
+                                                                    xtm dapp1 in
                                                                     (uu____25067,
-                                                                    uu____25068)
-                                                                     in
+                                                                    uu____25068) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____25062
-                                                                     in
+                                                                    uu____25062 in
                                                                     (uu____25048,
                                                                     [x],
-                                                                    uu____25061)
-                                                                     in
+                                                                    uu____25061) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____25037
-                                                                     in
+                                                                    uu____25037 in
                                                                     let uu____25087
                                                                     =
                                                                     varops.mk_unique
-                                                                    "lextop"
-                                                                     in
+                                                                    "lextop" in
                                                                     (uu____25036,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "lextop is top"),
-                                                                    uu____25087)
-                                                                     in
+                                                                    uu____25087) in
                                                                     FStar_SMTEncoding_Util.mkAssume
                                                                     uu____25029
                                                                     else
@@ -8926,16 +7949,14 @@ and (encode_sigelt' :
                                                                     let uu____25123
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    v1  in
+                                                                    v1 in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     uu____25123
-                                                                    dapp1  in
-                                                                    [uu____25122])))
-                                                                     in
+                                                                    dapp1 in
+                                                                    [uu____25122]))) in
                                                                     FStar_All.pipe_right
                                                                     uu____25094
-                                                                    FStar_List.flatten
-                                                                     in
+                                                                    FStar_List.flatten in
                                                                     let uu____25130
                                                                     =
                                                                     let uu____25137
@@ -8949,8 +7970,7 @@ and (encode_sigelt' :
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                     (FStar_List.append
                                                                     vars
-                                                                    arg_binders)
-                                                                     in
+                                                                    arg_binders) in
                                                                     let uu____25160
                                                                     =
                                                                     let uu____25161
@@ -8958,31 +7978,25 @@ and (encode_sigelt' :
                                                                     let uu____25166
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
-                                                                    prec  in
+                                                                    prec in
                                                                     (ty_pred,
-                                                                    uu____25166)
-                                                                     in
+                                                                    uu____25166) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____25161
-                                                                     in
+                                                                    uu____25161 in
                                                                     ([
                                                                     [ty_pred]],
                                                                     uu____25149,
-                                                                    uu____25160)
-                                                                     in
+                                                                    uu____25160) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____25138
-                                                                     in
+                                                                    uu____25138 in
                                                                     (uu____25137,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.strcat
                                                                     "subterm_ordering_"
-                                                                    ddconstrsym))
-                                                                     in
+                                                                    ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____25130)
-                                                                     in
+                                                                    uu____25130) in
                                                                   (arg_decls,
                                                                     [typing_inversion;
                                                                     subterm_ordering])))
@@ -8991,12 +8005,10 @@ and (encode_sigelt' :
                                                         let encoded_head =
                                                           lookup_free_var_name
                                                             env'
-                                                            fv.FStar_Syntax_Syntax.fv_name
-                                                           in
+                                                            fv.FStar_Syntax_Syntax.fv_name in
                                                         let uu____25187 =
                                                           encode_args args
-                                                            env'
-                                                           in
+                                                            env' in
                                                         (match uu____25187
                                                          with
                                                          | (encoded_args,arg_decls)
@@ -9020,19 +8032,15 @@ and (encode_sigelt' :
                                                                     let uu____25237
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
-                                                                    orig_arg
-                                                                     in
+                                                                    orig_arg in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu____25237
-                                                                     in
+                                                                    uu____25237 in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu____25236)
-                                                                     in
+                                                                    uu____25236) in
                                                                     FStar_Errors.raise_error
                                                                     uu____25231
-                                                                    orig_arg.FStar_Syntax_Syntax.pos
-                                                                  in
+                                                                    orig_arg.FStar_Syntax_Syntax.pos in
                                                                let guards1 =
                                                                  FStar_All.pipe_right
                                                                    guards
@@ -9044,33 +8052,28 @@ and (encode_sigelt' :
                                                                     let uu____25254
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
-                                                                    g  in
+                                                                    g in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu____25254
-                                                                     in
+                                                                    uu____25254 in
                                                                     if
                                                                     uu____25253
                                                                     then
                                                                     let uu____25267
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
-                                                                    g fv1 xv
-                                                                     in
+                                                                    g fv1 xv in
                                                                     [uu____25267]
-                                                                    else []))
-                                                                  in
+                                                                    else [])) in
                                                                FStar_SMTEncoding_Util.mk_and_l
-                                                                 guards1
-                                                                in
+                                                                 guards1 in
                                                              let uu____25269
                                                                =
                                                                let uu____25282
                                                                  =
                                                                  FStar_List.zip
                                                                    args
-                                                                   encoded_args
-                                                                  in
+                                                                   encoded_args in
                                                                FStar_List.fold_left
                                                                  (fun
                                                                     uu____25332
@@ -9092,12 +8095,10 @@ and (encode_sigelt' :
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
-                                                                    FStar_Syntax_Syntax.tun
-                                                                     in
+                                                                    FStar_Syntax_Syntax.tun in
                                                                     gen_term_var
                                                                     env2
-                                                                    uu____25435
-                                                                     in
+                                                                    uu____25435 in
                                                                     (match uu____25428
                                                                     with
                                                                     | 
@@ -9113,8 +8114,7 @@ and (encode_sigelt' :
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
-                                                                    arg xv
-                                                                     in
+                                                                    arg xv in
                                                                     uu____25456
                                                                     ::
                                                                     eqns_or_guards
@@ -9122,23 +8122,22 @@ and (encode_sigelt' :
                                                                     (let uu____25458
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
-                                                                    (arg, xv)
-                                                                     in
+                                                                    (arg, xv) in
                                                                     uu____25458
                                                                     ::
-                                                                    eqns_or_guards)
-                                                                     in
+                                                                    eqns_or_guards) in
                                                                     (env3,
                                                                     (xv ::
                                                                     arg_vars),
                                                                     eqns,
                                                                     (i +
-                                                                    (Prims.parse_int "1")))))
+                                                                    (Prims.parse_int
+                                                                    "1")))))
                                                                  (env', [],
                                                                    [],
-                                                                   (Prims.parse_int "0"))
-                                                                 uu____25282
-                                                                in
+                                                                   (Prims.parse_int
+                                                                    "0"))
+                                                                 uu____25282 in
                                                              (match uu____25269
                                                               with
                                                               | (uu____25473,arg_vars,elim_eqns_or_guards,uu____25476)
@@ -9146,36 +8145,31 @@ and (encode_sigelt' :
                                                                   let arg_vars1
                                                                     =
                                                                     FStar_List.rev
-                                                                    arg_vars
-                                                                     in
+                                                                    arg_vars in
                                                                   let ty =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     (encoded_head,
-                                                                    arg_vars1)
-                                                                     in
+                                                                    arg_vars1) in
                                                                   let xvars1
                                                                     =
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    vars  in
+                                                                    vars in
                                                                   let dapp1 =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     (ddconstrsym,
-                                                                    xvars1)
-                                                                     in
+                                                                    xvars1) in
                                                                   let ty_pred
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_HasTypeWithFuel
                                                                     (FStar_Pervasives_Native.Some
                                                                     s_fuel_tm)
-                                                                    dapp1 ty
-                                                                     in
+                                                                    dapp1 ty in
                                                                   let arg_binders
                                                                     =
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Term.fv_of_term
-                                                                    arg_vars1
-                                                                     in
+                                                                    arg_vars1 in
                                                                   let typing_inversion
                                                                     =
                                                                     let uu____25506
@@ -9191,8 +8185,7 @@ and (encode_sigelt' :
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                     (FStar_List.append
                                                                     vars
-                                                                    arg_binders)
-                                                                     in
+                                                                    arg_binders) in
                                                                     let uu____25536
                                                                     =
                                                                     let uu____25537
@@ -9202,32 +8195,25 @@ and (encode_sigelt' :
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
                                                                     elim_eqns_or_guards
-                                                                    guards)
-                                                                     in
+                                                                    guards) in
                                                                     (ty_pred,
-                                                                    uu____25542)
-                                                                     in
+                                                                    uu____25542) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____25537
-                                                                     in
+                                                                    uu____25537 in
                                                                     ([
                                                                     [ty_pred]],
                                                                     uu____25525,
-                                                                    uu____25536)
-                                                                     in
+                                                                    uu____25536) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____25514
-                                                                     in
+                                                                    uu____25514 in
                                                                     (uu____25513,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.strcat
                                                                     "data_elim_"
-                                                                    ddconstrsym))
-                                                                     in
+                                                                    ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____25506
-                                                                     in
+                                                                    uu____25506 in
                                                                   let subterm_ordering
                                                                     =
                                                                     if
@@ -9239,13 +8225,12 @@ and (encode_sigelt' :
                                                                     let uu____25565
                                                                     =
                                                                     varops.fresh
-                                                                    "x"  in
+                                                                    "x" in
                                                                     (uu____25565,
-                                                                    FStar_SMTEncoding_Term.Term_sort)
-                                                                     in
+                                                                    FStar_SMTEncoding_Term.Term_sort) in
                                                                     let xtm =
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    x  in
+                                                                    x in
                                                                     let uu____25567
                                                                     =
                                                                     let uu____25574
@@ -9259,12 +8244,9 @@ and (encode_sigelt' :
                                                                     let uu____25594
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_Precedes
-                                                                    xtm dapp1
-                                                                     in
-                                                                    [uu____25594]
-                                                                     in
-                                                                    [uu____25591]
-                                                                     in
+                                                                    xtm dapp1 in
+                                                                    [uu____25594] in
+                                                                    [uu____25591] in
                                                                     let uu____25599
                                                                     =
                                                                     let uu____25600
@@ -9273,35 +8255,28 @@ and (encode_sigelt' :
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_tester
                                                                     "LexCons"
-                                                                    xtm  in
+                                                                    xtm in
                                                                     let uu____25606
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_Precedes
-                                                                    xtm dapp1
-                                                                     in
+                                                                    xtm dapp1 in
                                                                     (uu____25605,
-                                                                    uu____25606)
-                                                                     in
+                                                                    uu____25606) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____25600
-                                                                     in
+                                                                    uu____25600 in
                                                                     (uu____25586,
                                                                     [x],
-                                                                    uu____25599)
-                                                                     in
+                                                                    uu____25599) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____25575
-                                                                     in
+                                                                    uu____25575 in
                                                                     let uu____25625
                                                                     =
                                                                     varops.mk_unique
-                                                                    "lextop"
-                                                                     in
+                                                                    "lextop" in
                                                                     (uu____25574,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "lextop is top"),
-                                                                    uu____25625)
-                                                                     in
+                                                                    uu____25625) in
                                                                     FStar_SMTEncoding_Util.mkAssume
                                                                     uu____25567
                                                                     else
@@ -9325,16 +8300,14 @@ and (encode_sigelt' :
                                                                     let uu____25661
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    v1  in
+                                                                    v1 in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     uu____25661
-                                                                    dapp1  in
-                                                                    [uu____25660])))
-                                                                     in
+                                                                    dapp1 in
+                                                                    [uu____25660]))) in
                                                                     FStar_All.pipe_right
                                                                     uu____25632
-                                                                    FStar_List.flatten
-                                                                     in
+                                                                    FStar_List.flatten in
                                                                     let uu____25668
                                                                     =
                                                                     let uu____25675
@@ -9348,8 +8321,7 @@ and (encode_sigelt' :
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                     (FStar_List.append
                                                                     vars
-                                                                    arg_binders)
-                                                                     in
+                                                                    arg_binders) in
                                                                     let uu____25698
                                                                     =
                                                                     let uu____25699
@@ -9357,31 +8329,25 @@ and (encode_sigelt' :
                                                                     let uu____25704
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
-                                                                    prec  in
+                                                                    prec in
                                                                     (ty_pred,
-                                                                    uu____25704)
-                                                                     in
+                                                                    uu____25704) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____25699
-                                                                     in
+                                                                    uu____25699 in
                                                                     ([
                                                                     [ty_pred]],
                                                                     uu____25687,
-                                                                    uu____25698)
-                                                                     in
+                                                                    uu____25698) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____25676
-                                                                     in
+                                                                    uu____25676 in
                                                                     (uu____25675,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.strcat
                                                                     "subterm_ordering_"
-                                                                    ddconstrsym))
-                                                                     in
+                                                                    ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____25668)
-                                                                     in
+                                                                    uu____25668) in
                                                                   (arg_decls,
                                                                     [typing_inversion;
                                                                     subterm_ordering])))
@@ -9391,28 +8357,22 @@ and (encode_sigelt' :
                                                               let uu____25731
                                                                 =
                                                                 FStar_Syntax_Print.lid_to_string
-                                                                  d
-                                                                 in
+                                                                  d in
                                                               let uu____25732
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
-                                                                  head1
-                                                                 in
+                                                                  head1 in
                                                               FStar_Util.format2
                                                                 "Constructor %s builds an unexpected type %s\n"
                                                                 uu____25731
-                                                                uu____25732
-                                                               in
+                                                                uu____25732 in
                                                             (FStar_Errors.Warning_ConstructorBuildsUnexpectedType,
-                                                              uu____25730)
-                                                             in
+                                                              uu____25730) in
                                                           FStar_Errors.log_issue
                                                             se.FStar_Syntax_Syntax.sigrng
                                                             uu____25725);
-                                                         ([], [])))
-                                                in
-                                             let uu____25737 = encode_elim ()
-                                                in
+                                                         ([], []))) in
+                                             let uu____25737 = encode_elim () in
                                              (match uu____25737 with
                                               | (decls2,elim) ->
                                                   let g =
@@ -9430,22 +8390,18 @@ and (encode_sigelt' :
                                                                     let uu____25785
                                                                     =
                                                                     FStar_Syntax_Print.lid_to_string
-                                                                    d  in
+                                                                    d in
                                                                     FStar_Util.format1
                                                                     "data constructor proxy: %s"
-                                                                    uu____25785
-                                                                     in
+                                                                    uu____25785 in
                                                                   FStar_Pervasives_Native.Some
-                                                                    uu____25784
-                                                                   in
+                                                                    uu____25784 in
                                                                 (ddtok, [],
                                                                   FStar_SMTEncoding_Term.Term_sort,
-                                                                  uu____25781)
-                                                                 in
+                                                                  uu____25781) in
                                                               FStar_SMTEncoding_Term.DeclFun
-                                                                uu____25770
-                                                               in
-                                                            [uu____25769]  in
+                                                                uu____25770 in
+                                                            [uu____25769] in
                                                           let uu____25790 =
                                                             let uu____25793 =
                                                               let uu____25796
@@ -9468,24 +8424,20 @@ and (encode_sigelt' :
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app,
-                                                                    dapp)  in
+                                                                    dapp) in
                                                                     ([[app]],
                                                                     vars,
-                                                                    uu____25828)
-                                                                     in
+                                                                    uu____25828) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____25817
-                                                                     in
+                                                                    uu____25817 in
                                                                     (uu____25816,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "equality for proxy"),
                                                                     (Prims.strcat
                                                                     "equality_tok_"
-                                                                    ddtok))
-                                                                     in
+                                                                    ddtok)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____25809
-                                                                     in
+                                                                    uu____25809 in
                                                                     let uu____25841
                                                                     =
                                                                     let uu____25844
@@ -9501,37 +8453,30 @@ and (encode_sigelt' :
                                                                     add_fuel
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
-                                                                    vars'  in
+                                                                    vars' in
                                                                     let uu____25875
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkImp
                                                                     (guard',
-                                                                    ty_pred')
-                                                                     in
+                                                                    ty_pred') in
                                                                     ([
                                                                     [ty_pred']],
                                                                     uu____25864,
-                                                                    uu____25875)
-                                                                     in
+                                                                    uu____25875) in
                                                                     FStar_SMTEncoding_Util.mkForall
-                                                                    uu____25853
-                                                                     in
+                                                                    uu____25853 in
                                                                     (uu____25852,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing intro"),
                                                                     (Prims.strcat
                                                                     "data_typing_intro_"
-                                                                    ddtok))
-                                                                     in
+                                                                    ddtok)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____25845
-                                                                     in
-                                                                    [uu____25844]
-                                                                     in
+                                                                    uu____25845 in
+                                                                    [uu____25844] in
                                                                     uu____25808
                                                                     ::
-                                                                    uu____25841
-                                                                     in
+                                                                    uu____25841 in
                                                                     (FStar_SMTEncoding_Util.mkAssume
                                                                     (tok_typing1,
                                                                     (FStar_Pervasives_Native.Some
@@ -9540,46 +8485,36 @@ and (encode_sigelt' :
                                                                     "typing_tok_"
                                                                     ddtok)))
                                                                     ::
-                                                                    uu____25805
-                                                                     in
+                                                                    uu____25805 in
                                                                   FStar_List.append
                                                                     uu____25802
-                                                                    elim
-                                                                   in
+                                                                    elim in
                                                                 FStar_List.append
                                                                   decls_pred
-                                                                  uu____25799
-                                                                 in
+                                                                  uu____25799 in
                                                               FStar_List.append
                                                                 decls_formals
-                                                                uu____25796
-                                                               in
+                                                                uu____25796 in
                                                             FStar_List.append
                                                               proxy_fresh
-                                                              uu____25793
-                                                             in
+                                                              uu____25793 in
                                                           FStar_List.append
                                                             uu____25766
-                                                            uu____25790
-                                                           in
+                                                            uu____25790 in
                                                         FStar_List.append
-                                                          decls3 uu____25763
-                                                         in
+                                                          decls3 uu____25763 in
                                                       FStar_List.append
-                                                        decls2 uu____25760
-                                                       in
+                                                        decls2 uu____25760 in
                                                     FStar_List.append
                                                       binder_decls
-                                                      uu____25757
-                                                     in
+                                                      uu____25757 in
                                                   ((FStar_List.append
                                                       datacons g), env1)))))))))
-
-and (encode_sigelts :
+and encode_sigelts:
   env_t ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
       (FStar_SMTEncoding_Term.decl Prims.list,env_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun ses  ->
@@ -9589,15 +8524,14 @@ and (encode_sigelts :
               fun se  ->
                 match uu____25921 with
                 | (g,env1) ->
-                    let uu____25941 = encode_sigelt env1 se  in
+                    let uu____25941 = encode_sigelt env1 se in
                     (match uu____25941 with
                      | (g',env2) -> ((FStar_List.append g g'), env2)))
            ([], env))
-
-let (encode_env_bindings :
+let encode_env_bindings:
   env_t ->
     FStar_TypeChecker_Env.binding Prims.list ->
-      (FStar_SMTEncoding_Term.decls_t,env_t) FStar_Pervasives_Native.tuple2)
+      (FStar_SMTEncoding_Term.decls_t,env_t) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun bindings  ->
@@ -9615,114 +8549,98 @@ let (encode_env_bindings :
                      FStar_TypeChecker_Normalize.Simplify;
                      FStar_TypeChecker_Normalize.Primops;
                      FStar_TypeChecker_Normalize.EraseUniverses] env1.tcenv
-                     x.FStar_Syntax_Syntax.sort
-                    in
+                     x.FStar_Syntax_Syntax.sort in
                  ((let uu____26036 =
                      FStar_All.pipe_left
                        (FStar_TypeChecker_Env.debug env1.tcenv)
-                       (FStar_Options.Other "SMTEncoding")
-                      in
+                       (FStar_Options.Other "SMTEncoding") in
                    if uu____26036
                    then
-                     let uu____26037 = FStar_Syntax_Print.bv_to_string x  in
+                     let uu____26037 = FStar_Syntax_Print.bv_to_string x in
                      let uu____26038 =
                        FStar_Syntax_Print.term_to_string
-                         x.FStar_Syntax_Syntax.sort
-                        in
-                     let uu____26039 = FStar_Syntax_Print.term_to_string t1
-                        in
+                         x.FStar_Syntax_Syntax.sort in
+                     let uu____26039 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.print3 "Normalized %s : %s to %s\n"
                        uu____26037 uu____26038 uu____26039
                    else ());
-                  (let uu____26041 = encode_term t1 env1  in
+                  (let uu____26041 = encode_term t1 env1 in
                    match uu____26041 with
                    | (t,decls') ->
-                       let t_hash = FStar_SMTEncoding_Term.hash_of_term t  in
+                       let t_hash = FStar_SMTEncoding_Term.hash_of_term t in
                        let uu____26057 =
                          let uu____26064 =
                            let uu____26065 =
                              let uu____26066 =
-                               FStar_Util.digest_of_string t_hash  in
+                               FStar_Util.digest_of_string t_hash in
                              Prims.strcat uu____26066
-                               (Prims.strcat "_" (Prims.string_of_int i))
-                              in
-                           Prims.strcat "x_" uu____26065  in
-                         new_term_constant_from_string env1 x uu____26064  in
+                               (Prims.strcat "_" (Prims.string_of_int i)) in
+                           Prims.strcat "x_" uu____26065 in
+                         new_term_constant_from_string env1 x uu____26064 in
                        (match uu____26057 with
                         | (xxsym,xx,env') ->
                             let t2 =
                               FStar_SMTEncoding_Term.mk_HasTypeWithFuel
-                                FStar_Pervasives_Native.None xx t
-                               in
+                                FStar_Pervasives_Native.None xx t in
                             let caption =
-                              let uu____26082 = FStar_Options.log_queries ()
-                                 in
+                              let uu____26082 = FStar_Options.log_queries () in
                               if uu____26082
                               then
                                 let uu____26085 =
                                   let uu____26086 =
-                                    FStar_Syntax_Print.bv_to_string x  in
+                                    FStar_Syntax_Print.bv_to_string x in
                                   let uu____26087 =
                                     FStar_Syntax_Print.term_to_string
-                                      x.FStar_Syntax_Syntax.sort
-                                     in
+                                      x.FStar_Syntax_Syntax.sort in
                                   let uu____26088 =
-                                    FStar_Syntax_Print.term_to_string t1  in
+                                    FStar_Syntax_Print.term_to_string t1 in
                                   FStar_Util.format3 "%s : %s (%s)"
-                                    uu____26086 uu____26087 uu____26088
-                                   in
+                                    uu____26086 uu____26087 uu____26088 in
                                 FStar_Pervasives_Native.Some uu____26085
-                              else FStar_Pervasives_Native.None  in
+                              else FStar_Pervasives_Native.None in
                             let ax =
-                              let a_name = Prims.strcat "binder_" xxsym  in
+                              let a_name = Prims.strcat "binder_" xxsym in
                               FStar_SMTEncoding_Util.mkAssume
                                 (t2, (FStar_Pervasives_Native.Some a_name),
-                                  a_name)
-                               in
+                                  a_name) in
                             let g =
                               FStar_List.append
                                 [FStar_SMTEncoding_Term.DeclFun
                                    (xxsym, [],
                                      FStar_SMTEncoding_Term.Term_sort,
                                      caption)]
-                                (FStar_List.append decls' [ax])
-                               in
+                                (FStar_List.append decls' [ax]) in
                             ((i + (Prims.parse_int "1")),
                               (FStar_List.append decls g), env'))))
              | FStar_TypeChecker_Env.Binding_lid (x,(uu____26104,t)) ->
-                 let t_norm = whnf env1 t  in
+                 let t_norm = whnf env1 t in
                  let fv =
                    FStar_Syntax_Syntax.lid_as_fv x
                      FStar_Syntax_Syntax.Delta_constant
-                     FStar_Pervasives_Native.None
-                    in
-                 let uu____26118 = encode_free_var false env1 fv t t_norm []
-                    in
+                     FStar_Pervasives_Native.None in
+                 let uu____26118 = encode_free_var false env1 fv t t_norm [] in
                  (match uu____26118 with
                   | (g,env') ->
                       ((i + (Prims.parse_int "1")),
                         (FStar_List.append decls g), env'))
              | FStar_TypeChecker_Env.Binding_sig_inst
                  (uu____26141,se,uu____26143) ->
-                 let uu____26148 = encode_sigelt env1 se  in
+                 let uu____26148 = encode_sigelt env1 se in
                  (match uu____26148 with
                   | (g,env') ->
                       ((i + (Prims.parse_int "1")),
                         (FStar_List.append decls g), env'))
              | FStar_TypeChecker_Env.Binding_sig (uu____26165,se) ->
-                 let uu____26171 = encode_sigelt env1 se  in
+                 let uu____26171 = encode_sigelt env1 se in
                  (match uu____26171 with
                   | (g,env') ->
                       ((i + (Prims.parse_int "1")),
-                        (FStar_List.append decls g), env')))
-         in
+                        (FStar_List.append decls g), env'))) in
       let uu____26188 =
         FStar_List.fold_right encode_binding bindings
-          ((Prims.parse_int "0"), [], env)
-         in
+          ((Prims.parse_int "0"), [], env) in
       match uu____26188 with | (uu____26211,decls,env1) -> (decls, env1)
-  
-let encode_labels :
+let encode_labels:
   'Auu____26223 'Auu____26224 .
     ((Prims.string,FStar_SMTEncoding_Term.sort)
        FStar_Pervasives_Native.tuple2,'Auu____26224,'Auu____26223)
@@ -9741,8 +8659,7 @@ let encode_labels :
                   FStar_SMTEncoding_Term.DeclFun
                     ((FStar_Pervasives_Native.fst l), [],
                       FStar_SMTEncoding_Term.Bool_sort,
-                      FStar_Pervasives_Native.None)))
-       in
+                      FStar_Pervasives_Native.None))) in
     let suffix =
       FStar_All.pipe_right labs
         (FStar_List.collect
@@ -9752,26 +8669,23 @@ let encode_labels :
                   let uu____26375 =
                     FStar_All.pipe_left
                       (fun _0_45  -> FStar_SMTEncoding_Term.Echo _0_45)
-                      (FStar_Pervasives_Native.fst l)
-                     in
+                      (FStar_Pervasives_Native.fst l) in
                   let uu____26376 =
                     let uu____26379 =
-                      let uu____26380 = FStar_SMTEncoding_Util.mkFreeV l  in
-                      FStar_SMTEncoding_Term.Eval uu____26380  in
-                    [uu____26379]  in
-                  uu____26375 :: uu____26376))
-       in
+                      let uu____26380 = FStar_SMTEncoding_Util.mkFreeV l in
+                      FStar_SMTEncoding_Term.Eval uu____26380 in
+                    [uu____26379] in
+                  uu____26375 :: uu____26376)) in
     (prefix1, suffix)
-  
-let (last_env : env_t Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
-let (init_env : FStar_TypeChecker_Env.env -> Prims.unit) =
+let last_env: env_t Prims.list FStar_ST.ref = FStar_Util.mk_ref []
+let init_env: FStar_TypeChecker_Env.env -> Prims.unit =
   fun tcenv  ->
     let uu____26405 =
       let uu____26408 =
-        let uu____26409 = FStar_Util.smap_create (Prims.parse_int "100")  in
+        let uu____26409 = FStar_Util.smap_create (Prims.parse_int "100") in
         let uu____26412 =
-          let uu____26413 = FStar_TypeChecker_Env.current_module tcenv  in
-          FStar_All.pipe_right uu____26413 FStar_Ident.string_of_lid  in
+          let uu____26413 = FStar_TypeChecker_Env.current_module tcenv in
+          FStar_All.pipe_right uu____26413 FStar_Ident.string_of_lid in
         {
           bindings = [];
           depth = (Prims.parse_int "0");
@@ -9782,19 +8696,18 @@ let (init_env : FStar_TypeChecker_Env.env -> Prims.unit) =
           use_zfuel_name = false;
           encode_non_total_function_typ = true;
           current_module_name = uu____26412
-        }  in
-      [uu____26408]  in
+        } in
+      [uu____26408] in
     FStar_ST.op_Colon_Equals last_env uu____26405
-  
-let (get_env : FStar_Ident.lident -> FStar_TypeChecker_Env.env -> env_t) =
+let get_env: FStar_Ident.lident -> FStar_TypeChecker_Env.env -> env_t =
   fun cmn  ->
     fun tcenv  ->
-      let uu____26443 = FStar_ST.op_Bang last_env  in
+      let uu____26443 = FStar_ST.op_Bang last_env in
       match uu____26443 with
       | [] -> failwith "No env; call init first!"
       | e::uu____26470 ->
-          let uu___131_26473 = e  in
-          let uu____26474 = FStar_Ident.string_of_lid cmn  in
+          let uu___131_26473 = e in
+          let uu____26474 = FStar_Ident.string_of_lid cmn in
           {
             bindings = (uu___131_26473.bindings);
             depth = (uu___131_26473.depth);
@@ -9807,23 +8720,21 @@ let (get_env : FStar_Ident.lident -> FStar_TypeChecker_Env.env -> env_t) =
               (uu___131_26473.encode_non_total_function_typ);
             current_module_name = uu____26474
           }
-  
-let (set_env : env_t -> Prims.unit) =
+let set_env: env_t -> Prims.unit =
   fun env  ->
-    let uu____26478 = FStar_ST.op_Bang last_env  in
+    let uu____26478 = FStar_ST.op_Bang last_env in
     match uu____26478 with
     | [] -> failwith "Empty env stack"
     | uu____26504::tl1 -> FStar_ST.op_Colon_Equals last_env (env :: tl1)
-  
-let (push_env : Prims.unit -> Prims.unit) =
+let push_env: Prims.unit -> Prims.unit =
   fun uu____26533  ->
-    let uu____26534 = FStar_ST.op_Bang last_env  in
+    let uu____26534 = FStar_ST.op_Bang last_env in
     match uu____26534 with
     | [] -> failwith "Empty env stack"
     | hd1::tl1 ->
-        let refs = FStar_Util.smap_copy hd1.cache  in
+        let refs = FStar_Util.smap_copy hd1.cache in
         let top =
-          let uu___132_26568 = hd1  in
+          let uu___132_26568 = hd1 in
           {
             bindings = (uu___132_26568.bindings);
             depth = (uu___132_26568.depth);
@@ -9835,32 +8746,29 @@ let (push_env : Prims.unit -> Prims.unit) =
             encode_non_total_function_typ =
               (uu___132_26568.encode_non_total_function_typ);
             current_module_name = (uu___132_26568.current_module_name)
-          }  in
+          } in
         FStar_ST.op_Colon_Equals last_env (top :: hd1 :: tl1)
-  
-let (pop_env : Prims.unit -> Prims.unit) =
+let pop_env: Prims.unit -> Prims.unit =
   fun uu____26594  ->
-    let uu____26595 = FStar_ST.op_Bang last_env  in
+    let uu____26595 = FStar_ST.op_Bang last_env in
     match uu____26595 with
     | [] -> failwith "Popping an empty stack"
     | uu____26621::tl1 -> FStar_ST.op_Colon_Equals last_env tl1
-  
-let (init : FStar_TypeChecker_Env.env -> Prims.unit) =
+let init: FStar_TypeChecker_Env.env -> Prims.unit =
   fun tcenv  ->
     init_env tcenv;
     FStar_SMTEncoding_Z3.init ();
     FStar_SMTEncoding_Z3.giveZ3 [FStar_SMTEncoding_Term.DefPrelude]
-  
-let (push : Prims.string -> Prims.unit) =
-  fun msg  -> push_env (); varops.push (); FStar_SMTEncoding_Z3.push msg 
-let (pop : Prims.string -> Prims.unit) =
-  fun msg  -> pop_env (); varops.pop (); FStar_SMTEncoding_Z3.pop msg 
-let (open_fact_db_tags :
-  env_t -> FStar_SMTEncoding_Term.fact_db_id Prims.list) = fun env  -> [] 
-let (place_decl_in_fact_dbs :
+let push: Prims.string -> Prims.unit =
+  fun msg  -> push_env (); varops.push (); FStar_SMTEncoding_Z3.push msg
+let pop: Prims.string -> Prims.unit =
+  fun msg  -> pop_env (); varops.pop (); FStar_SMTEncoding_Z3.pop msg
+let open_fact_db_tags: env_t -> FStar_SMTEncoding_Term.fact_db_id Prims.list
+  = fun env  -> []
+let place_decl_in_fact_dbs:
   env_t ->
     FStar_SMTEncoding_Term.fact_db_id Prims.list ->
-      FStar_SMTEncoding_Term.decl -> FStar_SMTEncoding_Term.decl)
+      FStar_SMTEncoding_Term.decl -> FStar_SMTEncoding_Term.decl
   =
   fun env  ->
     fun fact_db_ids  ->
@@ -9868,7 +8776,7 @@ let (place_decl_in_fact_dbs :
         match (fact_db_ids, d) with
         | (uu____26685::uu____26686,FStar_SMTEncoding_Term.Assume a) ->
             FStar_SMTEncoding_Term.Assume
-              (let uu___133_26694 = a  in
+              (let uu___133_26694 = a in
                {
                  FStar_SMTEncoding_Term.assumption_term =
                    (uu___133_26694.FStar_SMTEncoding_Term.assumption_term);
@@ -9879,47 +8787,40 @@ let (place_decl_in_fact_dbs :
                  FStar_SMTEncoding_Term.assumption_fact_ids = fact_db_ids
                })
         | uu____26695 -> d
-  
-let (fact_dbs_for_lid :
-  env_t -> FStar_Ident.lid -> FStar_SMTEncoding_Term.fact_db_id Prims.list) =
+let fact_dbs_for_lid:
+  env_t -> FStar_Ident.lid -> FStar_SMTEncoding_Term.fact_db_id Prims.list =
   fun env  ->
     fun lid  ->
       let uu____26710 =
         let uu____26713 =
-          let uu____26714 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-          FStar_SMTEncoding_Term.Namespace uu____26714  in
-        let uu____26715 = open_fact_db_tags env  in uu____26713 ::
-          uu____26715
-         in
+          let uu____26714 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
+          FStar_SMTEncoding_Term.Namespace uu____26714 in
+        let uu____26715 = open_fact_db_tags env in uu____26713 :: uu____26715 in
       (FStar_SMTEncoding_Term.Name lid) :: uu____26710
-  
-let (encode_top_level_facts :
+let encode_top_level_facts:
   env_t ->
     FStar_Syntax_Syntax.sigelt ->
       (FStar_SMTEncoding_Term.decl Prims.list,env_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun se  ->
       let fact_db_ids =
         FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
-          (FStar_List.collect (fact_dbs_for_lid env))
-         in
-      let uu____26737 = encode_sigelt env se  in
+          (FStar_List.collect (fact_dbs_for_lid env)) in
+      let uu____26737 = encode_sigelt env se in
       match uu____26737 with
       | (g,env1) ->
           let g1 =
             FStar_All.pipe_right g
-              (FStar_List.map (place_decl_in_fact_dbs env1 fact_db_ids))
-             in
+              (FStar_List.map (place_decl_in_fact_dbs env1 fact_db_ids)) in
           (g1, env1)
-  
-let (encode_sig :
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> Prims.unit) =
+let encode_sig:
+  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> Prims.unit =
   fun tcenv  ->
     fun se  ->
       let caption decls =
-        let uu____26773 = FStar_Options.log_queries ()  in
+        let uu____26773 = FStar_Options.log_queries () in
         if uu____26773
         then
           let uu____26776 =
@@ -9927,55 +8828,48 @@ let (encode_sig :
               let uu____26778 =
                 let uu____26779 =
                   FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
-                    (FStar_List.map FStar_Syntax_Print.lid_to_string)
-                   in
-                FStar_All.pipe_right uu____26779 (FStar_String.concat ", ")
-                 in
-              Prims.strcat "encoding sigelt " uu____26778  in
-            FStar_SMTEncoding_Term.Caption uu____26777  in
+                    (FStar_List.map FStar_Syntax_Print.lid_to_string) in
+                FStar_All.pipe_right uu____26779 (FStar_String.concat ", ") in
+              Prims.strcat "encoding sigelt " uu____26778 in
+            FStar_SMTEncoding_Term.Caption uu____26777 in
           uu____26776 :: decls
-        else decls  in
-      (let uu____26790 = FStar_TypeChecker_Env.debug tcenv FStar_Options.Low
-          in
+        else decls in
+      (let uu____26790 = FStar_TypeChecker_Env.debug tcenv FStar_Options.Low in
        if uu____26790
        then
-         let uu____26791 = FStar_Syntax_Print.sigelt_to_string se  in
+         let uu____26791 = FStar_Syntax_Print.sigelt_to_string se in
          FStar_Util.print1 "+++++++++++Encoding sigelt %s\n" uu____26791
        else ());
       (let env =
-         let uu____26794 = FStar_TypeChecker_Env.current_module tcenv  in
-         get_env uu____26794 tcenv  in
-       let uu____26795 = encode_top_level_facts env se  in
+         let uu____26794 = FStar_TypeChecker_Env.current_module tcenv in
+         get_env uu____26794 tcenv in
+       let uu____26795 = encode_top_level_facts env se in
        match uu____26795 with
        | (decls,env1) ->
            (set_env env1;
-            (let uu____26809 = caption decls  in
+            (let uu____26809 = caption decls in
              FStar_SMTEncoding_Z3.giveZ3 uu____26809)))
-  
-let (encode_modul :
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.modul -> Prims.unit) =
+let encode_modul:
+  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.modul -> Prims.unit =
   fun tcenv  ->
     fun modul  ->
       let name =
         FStar_Util.format2 "%s %s"
           (if modul.FStar_Syntax_Syntax.is_interface
            then "interface"
-           else "module") (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
-         in
-      (let uu____26821 = FStar_TypeChecker_Env.debug tcenv FStar_Options.Low
-          in
+           else "module") (modul.FStar_Syntax_Syntax.name).FStar_Ident.str in
+      (let uu____26821 = FStar_TypeChecker_Env.debug tcenv FStar_Options.Low in
        if uu____26821
        then
          let uu____26822 =
            FStar_All.pipe_right
              (FStar_List.length modul.FStar_Syntax_Syntax.exports)
-             Prims.string_of_int
-            in
+             Prims.string_of_int in
          FStar_Util.print2
            "+++++++++++Encoding externals for %s ... %s exports\n" name
            uu____26822
        else ());
-      (let env = get_env modul.FStar_Syntax_Syntax.name tcenv  in
+      (let env = get_env modul.FStar_Syntax_Syntax.name tcenv in
        let encode_signature env1 ses =
          FStar_All.pipe_right ses
            (FStar_List.fold_left
@@ -9983,14 +8877,13 @@ let (encode_modul :
                  fun se  ->
                    match uu____26857 with
                    | (g,env2) ->
-                       let uu____26877 = encode_top_level_facts env2 se  in
+                       let uu____26877 = encode_top_level_facts env2 se in
                        (match uu____26877 with
                         | (g',env3) -> ((FStar_List.append g g'), env3)))
-              ([], env1))
-          in
+              ([], env1)) in
        let uu____26900 =
          encode_signature
-           (let uu___134_26909 = env  in
+           (let uu___134_26909 = env in
             {
               bindings = (uu___134_26909.bindings);
               depth = (uu___134_26909.depth);
@@ -10002,21 +8895,20 @@ let (encode_modul :
               encode_non_total_function_typ =
                 (uu___134_26909.encode_non_total_function_typ);
               current_module_name = (uu___134_26909.current_module_name)
-            }) modul.FStar_Syntax_Syntax.exports
-          in
+            }) modul.FStar_Syntax_Syntax.exports in
        match uu____26900 with
        | (decls,env1) ->
            let caption decls1 =
-             let uu____26926 = FStar_Options.log_queries ()  in
+             let uu____26926 = FStar_Options.log_queries () in
              if uu____26926
              then
-               let msg = Prims.strcat "Externals for " name  in
+               let msg = Prims.strcat "Externals for " name in
                FStar_List.append ((FStar_SMTEncoding_Term.Caption msg) ::
                  decls1)
                  [FStar_SMTEncoding_Term.Caption (Prims.strcat "End " msg)]
-             else decls1  in
+             else decls1 in
            (set_env
-              (let uu___135_26934 = env1  in
+              (let uu___135_26934 = env1 in
                {
                  bindings = (uu___135_26934.bindings);
                  depth = (uu___135_26934.depth);
@@ -10030,59 +8922,54 @@ let (encode_modul :
                  current_module_name = (uu___135_26934.current_module_name)
                });
             (let uu____26936 =
-               FStar_TypeChecker_Env.debug tcenv FStar_Options.Low  in
+               FStar_TypeChecker_Env.debug tcenv FStar_Options.Low in
              if uu____26936
              then FStar_Util.print1 "Done encoding externals for %s\n" name
              else ());
-            (let decls1 = caption decls  in
-             FStar_SMTEncoding_Z3.giveZ3 decls1)))
-  
-let (encode_query :
+            (let decls1 = caption decls in FStar_SMTEncoding_Z3.giveZ3 decls1)))
+let encode_query:
   (Prims.unit -> Prims.string) FStar_Pervasives_Native.option ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term ->
         (FStar_SMTEncoding_Term.decl Prims.list,FStar_SMTEncoding_ErrorReporting.label
                                                   Prims.list,FStar_SMTEncoding_Term.decl,
           FStar_SMTEncoding_Term.decl Prims.list)
-          FStar_Pervasives_Native.tuple4)
+          FStar_Pervasives_Native.tuple4
   =
   fun use_env_msg  ->
     fun tcenv  ->
       fun q  ->
         (let uu____26988 =
-           let uu____26989 = FStar_TypeChecker_Env.current_module tcenv  in
-           uu____26989.FStar_Ident.str  in
+           let uu____26989 = FStar_TypeChecker_Env.current_module tcenv in
+           uu____26989.FStar_Ident.str in
          FStar_SMTEncoding_Z3.query_logging.FStar_SMTEncoding_Z3.set_module_name
            uu____26988);
         (let env =
-           let uu____26991 = FStar_TypeChecker_Env.current_module tcenv  in
-           get_env uu____26991 tcenv  in
+           let uu____26991 = FStar_TypeChecker_Env.current_module tcenv in
+           get_env uu____26991 tcenv in
          let bindings =
            FStar_TypeChecker_Env.fold_env tcenv
-             (fun bs  -> fun b  -> b :: bs) []
-            in
+             (fun bs  -> fun b  -> b :: bs) [] in
          let uu____27003 =
            let rec aux bindings1 =
              match bindings1 with
              | (FStar_TypeChecker_Env.Binding_var x)::rest ->
-                 let uu____27038 = aux rest  in
+                 let uu____27038 = aux rest in
                  (match uu____27038 with
                   | (out,rest1) ->
                       let t =
                         let uu____27068 =
                           FStar_Syntax_Util.destruct_typ_as_formula
-                            x.FStar_Syntax_Syntax.sort
-                           in
+                            x.FStar_Syntax_Syntax.sort in
                         match uu____27068 with
                         | FStar_Pervasives_Native.Some uu____27073 ->
                             let uu____27074 =
                               FStar_Syntax_Syntax.new_bv
                                 FStar_Pervasives_Native.None
-                                FStar_Syntax_Syntax.t_unit
-                               in
+                                FStar_Syntax_Syntax.t_unit in
                             FStar_Syntax_Util.refine uu____27074
                               x.FStar_Syntax_Syntax.sort
-                        | uu____27075 -> x.FStar_Syntax_Syntax.sort  in
+                        | uu____27075 -> x.FStar_Syntax_Syntax.sort in
                       let t1 =
                         FStar_TypeChecker_Normalize.normalize
                           [FStar_TypeChecker_Normalize.Eager_unfolding;
@@ -10090,32 +8977,28 @@ let (encode_query :
                           FStar_TypeChecker_Normalize.Simplify;
                           FStar_TypeChecker_Normalize.Primops;
                           FStar_TypeChecker_Normalize.EraseUniverses]
-                          env.tcenv t
-                         in
+                          env.tcenv t in
                       let uu____27079 =
                         let uu____27082 =
                           FStar_Syntax_Syntax.mk_binder
-                            (let uu___136_27085 = x  in
+                            (let uu___136_27085 = x in
                              {
                                FStar_Syntax_Syntax.ppname =
                                  (uu___136_27085.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
                                  (uu___136_27085.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort = t1
-                             })
-                           in
-                        uu____27082 :: out  in
+                             }) in
+                        uu____27082 :: out in
                       (uu____27079, rest1))
-             | uu____27090 -> ([], bindings1)  in
-           let uu____27097 = aux bindings  in
+             | uu____27090 -> ([], bindings1) in
+           let uu____27097 = aux bindings in
            match uu____27097 with
            | (closing,bindings1) ->
                let uu____27122 =
                  FStar_Syntax_Util.close_forall_no_univs
-                   (FStar_List.rev closing) q
-                  in
-               (uu____27122, bindings1)
-            in
+                   (FStar_List.rev closing) q in
+               (uu____27122, bindings1) in
          match uu____27003 with
          | (q1,bindings1) ->
              let uu____27145 =
@@ -10125,9 +9008,8 @@ let (encode_query :
                       match uu___101_27155 with
                       | FStar_TypeChecker_Env.Binding_sig uu____27156 ->
                           false
-                      | uu____27163 -> true) bindings1
-                  in
-               encode_env_bindings env uu____27150  in
+                      | uu____27163 -> true) bindings1 in
+               encode_env_bindings env uu____27150 in
              (match uu____27145 with
               | (env_decls,env1) ->
                   ((let uu____27181 =
@@ -10139,53 +9021,45 @@ let (encode_query :
                         ||
                         (FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug tcenv)
-                           (FStar_Options.Other "SMTQuery"))
-                       in
+                           (FStar_Options.Other "SMTQuery")) in
                     if uu____27181
                     then
-                      let uu____27182 = FStar_Syntax_Print.term_to_string q1
-                         in
+                      let uu____27182 = FStar_Syntax_Print.term_to_string q1 in
                       FStar_Util.print1 "Encoding query formula: %s\n"
                         uu____27182
                     else ());
-                   (let uu____27184 = encode_formula q1 env1  in
+                   (let uu____27184 = encode_formula q1 env1 in
                     match uu____27184 with
                     | (phi,qdecls) ->
                         let uu____27205 =
                           let uu____27210 =
-                            FStar_TypeChecker_Env.get_range tcenv  in
+                            FStar_TypeChecker_Env.get_range tcenv in
                           FStar_SMTEncoding_ErrorReporting.label_goals
-                            use_env_msg uu____27210 phi
-                           in
+                            use_env_msg uu____27210 phi in
                         (match uu____27205 with
                          | (labels,phi1) ->
-                             let uu____27227 = encode_labels labels  in
+                             let uu____27227 = encode_labels labels in
                              (match uu____27227 with
                               | (label_prefix,label_suffix) ->
                                   let query_prelude =
                                     FStar_List.append env_decls
-                                      (FStar_List.append label_prefix qdecls)
-                                     in
+                                      (FStar_List.append label_prefix qdecls) in
                                   let qry =
                                     let uu____27264 =
                                       let uu____27271 =
-                                        FStar_SMTEncoding_Util.mkNot phi1  in
+                                        FStar_SMTEncoding_Util.mkNot phi1 in
                                       let uu____27272 =
-                                        varops.mk_unique "@query"  in
+                                        varops.mk_unique "@query" in
                                       (uu____27271,
                                         (FStar_Pervasives_Native.Some "query"),
-                                        uu____27272)
-                                       in
+                                        uu____27272) in
                                     FStar_SMTEncoding_Util.mkAssume
-                                      uu____27264
-                                     in
+                                      uu____27264 in
                                   let suffix =
                                     FStar_List.append
                                       [FStar_SMTEncoding_Term.Echo "<labels>"]
                                       (FStar_List.append label_suffix
                                          [FStar_SMTEncoding_Term.Echo
                                             "</labels>";
-                                         FStar_SMTEncoding_Term.Echo "Done!"])
-                                     in
+                                         FStar_SMTEncoding_Term.Echo "Done!"]) in
                                   (query_prelude, labels, qry, suffix)))))))
-  

--- a/src/ocaml-output/FStar_SMTEncoding_ErrorReporting.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_ErrorReporting.ml
@@ -1,23 +1,21 @@
 open Prims
-exception Not_a_wp_implication of Prims.string 
-let (uu___is_Not_a_wp_implication : Prims.exn -> Prims.bool) =
+exception Not_a_wp_implication of Prims.string
+let uu___is_Not_a_wp_implication: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Not_a_wp_implication uu____7 -> true
     | uu____8 -> false
-  
-let (__proj__Not_a_wp_implication__item__uu___ : Prims.exn -> Prims.string) =
+let __proj__Not_a_wp_implication__item__uu___: Prims.exn -> Prims.string =
   fun projectee  ->
     match projectee with | Not_a_wp_implication uu____15 -> uu____15
-  
 type label = FStar_SMTEncoding_Term.error_label[@@deriving show]
 type labels = FStar_SMTEncoding_Term.error_labels[@@deriving show]
-let (sort_labels :
+let sort_labels:
   (FStar_SMTEncoding_Term.error_label,Prims.bool)
     FStar_Pervasives_Native.tuple2 Prims.list ->
     ((FStar_SMTEncoding_Term.fv,Prims.string,FStar_Range.range)
        FStar_Pervasives_Native.tuple3,Prims.bool)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun l  ->
     FStar_List.sortWith
@@ -26,11 +24,10 @@ let (sort_labels :
            match (uu____63, uu____64) with
            | (((uu____105,uu____106,r1),uu____108),((uu____109,uu____110,r2),uu____112))
                -> FStar_Range.compare r1 r2) l
-  
-let (remove_dups :
+let remove_dups:
   labels ->
     (FStar_SMTEncoding_Term.fv,Prims.string,FStar_Range.range)
-      FStar_Pervasives_Native.tuple3 Prims.list)
+      FStar_Pervasives_Native.tuple3 Prims.list
   =
   fun l  ->
     FStar_Util.remove_dups
@@ -39,40 +36,37 @@ let (remove_dups :
            match (uu____170, uu____171) with
            | ((uu____196,m1,r1),(uu____199,m2,r2)) -> (r1 = r2) && (m1 = m2))
       l
-  
 type msg = (Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple2
 [@@deriving show]
 type ranges =
   (Prims.string FStar_Pervasives_Native.option,FStar_Range.range)
     FStar_Pervasives_Native.tuple2 Prims.list[@@deriving show]
-let (fresh_label :
+let fresh_label:
   Prims.string ->
     FStar_Range.range ->
       FStar_SMTEncoding_Term.term ->
-        (label,FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple2)
+        (label,FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple2
   =
-  let ctr = FStar_Util.mk_ref (Prims.parse_int "0")  in
+  let ctr = FStar_Util.mk_ref (Prims.parse_int "0") in
   fun message  ->
     fun range  ->
       fun t  ->
         let l =
           FStar_Util.incr ctr;
           (let uu____277 =
-             let uu____278 = FStar_ST.op_Bang ctr  in
-             FStar_Util.string_of_int uu____278  in
-           FStar_Util.format1 "label_%s" uu____277)
-           in
-        let lvar = (l, FStar_SMTEncoding_Term.Bool_sort)  in
-        let label = (lvar, message, range)  in
-        let lterm = FStar_SMTEncoding_Util.mkFreeV lvar  in
-        let lt1 = FStar_SMTEncoding_Term.mkOr (lterm, t) range  in
+             let uu____278 = FStar_ST.op_Bang ctr in
+             FStar_Util.string_of_int uu____278 in
+           FStar_Util.format1 "label_%s" uu____277) in
+        let lvar = (l, FStar_SMTEncoding_Term.Bool_sort) in
+        let label = (lvar, message, range) in
+        let lterm = FStar_SMTEncoding_Util.mkFreeV lvar in
+        let lt1 = FStar_SMTEncoding_Term.mkOr (lterm, t) range in
         (label, lt1)
-  
-let (label_goals :
+let label_goals:
   (Prims.unit -> Prims.string) FStar_Pervasives_Native.option ->
     FStar_Range.range ->
       FStar_SMTEncoding_Term.term ->
-        (labels,FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple2)
+        (labels,FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple2
   =
   fun use_env_msg  ->
     fun r  ->
@@ -88,11 +82,11 @@ let (label_goals :
           | (uu____407,FStar_SMTEncoding_Term.App
              (FStar_SMTEncoding_Term.Var "ApplyTT",tm1::uu____409)) ->
               is_a_post_condition post_name_opt tm1
-          | uu____418 -> false  in
+          | uu____418 -> false in
         let conjuncts t =
           match t.FStar_SMTEncoding_Term.tm with
           | FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.And ,cs) -> cs
-          | uu____438 -> [t]  in
+          | uu____438 -> [t] in
         let is_guard_free tm =
           match tm.FStar_SMTEncoding_Term.tm with
           | FStar_SMTEncoding_Term.Quant
@@ -108,32 +102,29 @@ let (label_goals :
                  FStar_SMTEncoding_Term.freevars = uu____450;
                  FStar_SMTEncoding_Term.rng = uu____451;_})
               -> true
-          | uu____488 -> false  in
+          | uu____488 -> false in
         let is_a_named_continuation lhs =
           FStar_All.pipe_right (conjuncts lhs)
-            (FStar_Util.for_some is_guard_free)
-           in
+            (FStar_Util.for_some is_guard_free) in
         let uu____495 =
           match use_env_msg with
           | FStar_Pervasives_Native.None  -> (false, "")
           | FStar_Pervasives_Native.Some f ->
-              let uu____511 = f ()  in (true, uu____511)
-           in
+              let uu____511 = f () in (true, uu____511) in
         match uu____495 with
         | (flag,msg_prefix) ->
             let fresh_label1 msg ropt rng t =
               let msg1 =
                 if flag
                 then Prims.strcat "Failed to verify implicit argument: " msg
-                else msg  in
+                else msg in
               let rng1 =
                 match ropt with
                 | FStar_Pervasives_Native.None  -> rng
                 | FStar_Pervasives_Native.Some r1 ->
-                    let uu____543 = FStar_Range.def_range rng  in
-                    FStar_Range.set_def_range r1 uu____543
-                 in
-              fresh_label msg1 rng1 t  in
+                    let uu____543 = FStar_Range.def_range rng in
+                    FStar_Range.set_def_range r1 uu____543 in
+              fresh_label msg1 rng1 t in
             let rec aux default_msg ropt post_name_opt labels q1 =
               match q1.FStar_SMTEncoding_Term.tm with
               | FStar_SMTEncoding_Term.BoundV uu____584 -> (labels, q1)
@@ -143,7 +134,7 @@ let (label_goals :
               | FStar_SMTEncoding_Term.Labeled
                   (arg,"could not prove post-condition",uu____602) ->
                   let fallback msg =
-                    aux default_msg ropt post_name_opt labels arg  in
+                    aux default_msg ropt post_name_opt labels arg in
                   (try
                      match arg.FStar_SMTEncoding_Term.tm with
                      | FStar_SMTEncoding_Term.Quant
@@ -161,12 +152,10 @@ let (label_goals :
                          ->
                          let post_name =
                            let uu____690 =
-                             let uu____691 = FStar_Syntax_Syntax.next_id ()
-                                in
+                             let uu____691 = FStar_Syntax_Syntax.next_id () in
                              FStar_All.pipe_left FStar_Util.string_of_int
-                               uu____691
-                              in
-                           Prims.strcat "^^post_condition_" uu____690  in
+                               uu____691 in
+                           Prims.strcat "^^post_condition_" uu____690 in
                          let names1 =
                            let uu____699 =
                              FStar_List.mapi
@@ -174,23 +163,19 @@ let (label_goals :
                                   fun s  ->
                                     let uu____715 =
                                       let uu____716 =
-                                        FStar_Util.string_of_int i  in
-                                      Prims.strcat "^^" uu____716  in
-                                    (uu____715, s)) sorts
-                              in
-                           (post_name, post) :: uu____699  in
+                                        FStar_Util.string_of_int i in
+                                      Prims.strcat "^^" uu____716 in
+                                    (uu____715, s)) sorts in
+                           (post_name, post) :: uu____699 in
                          let instantiation =
                            FStar_List.map FStar_SMTEncoding_Util.mkFreeV
-                             names1
-                            in
+                             names1 in
                          let uu____728 =
                            let uu____733 =
-                             FStar_SMTEncoding_Term.inst instantiation lhs
-                              in
+                             FStar_SMTEncoding_Term.inst instantiation lhs in
                            let uu____734 =
-                             FStar_SMTEncoding_Term.inst instantiation rhs
-                              in
-                           (uu____733, uu____734)  in
+                             FStar_SMTEncoding_Term.inst instantiation rhs in
+                           (uu____733, uu____734) in
                          (match uu____728 with
                           | (lhs1,rhs1) ->
                               let uu____743 =
@@ -199,7 +184,7 @@ let (label_goals :
                                     (FStar_SMTEncoding_Term.And ,clauses_lhs)
                                     ->
                                     let uu____761 =
-                                      FStar_Util.prefix clauses_lhs  in
+                                      FStar_Util.prefix clauses_lhs in
                                     (match uu____761 with
                                      | (req,ens) ->
                                          (match ens.FStar_SMTEncoding_Term.tm
@@ -227,8 +212,7 @@ let (label_goals :
                                                   FStar_Pervasives_Native.None
                                                   (FStar_Pervasives_Native.Some
                                                      post_name) labels
-                                                  ensures_conjuncts
-                                                 in
+                                                  ensures_conjuncts in
                                               (match uu____819 with
                                                | (labels1,ensures_conjuncts1)
                                                    ->
@@ -236,8 +220,7 @@ let (label_goals :
                                                      match pats_ens with
                                                      | [] -> [[post1]]
                                                      | []::[] -> [[post1]]
-                                                     | uu____861 -> pats_ens
-                                                      in
+                                                     | uu____861 -> pats_ens in
                                                    let ens1 =
                                                      let uu____867 =
                                                        let uu____868 =
@@ -247,33 +230,27 @@ let (label_goals :
                                                                 (FStar_SMTEncoding_Term.Imp,
                                                                   [ensures_conjuncts1;
                                                                   post1]))
-                                                             rng_ens
-                                                            in
+                                                             rng_ens in
                                                          (FStar_SMTEncoding_Term.Forall,
                                                            pats_ens1,
                                                            iopt_ens,
                                                            sorts_ens,
-                                                           uu____887)
-                                                          in
+                                                           uu____887) in
                                                        FStar_SMTEncoding_Term.Quant
-                                                         uu____868
-                                                        in
+                                                         uu____868 in
                                                      FStar_SMTEncoding_Term.mk
                                                        uu____867
-                                                       ens.FStar_SMTEncoding_Term.rng
-                                                      in
+                                                       ens.FStar_SMTEncoding_Term.rng in
                                                    let lhs2 =
                                                      FStar_SMTEncoding_Term.mk
                                                        (FStar_SMTEncoding_Term.App
                                                           (FStar_SMTEncoding_Term.And,
                                                             (FStar_List.append
                                                                req [ens1])))
-                                                       lhs1.FStar_SMTEncoding_Term.rng
-                                                      in
+                                                       lhs1.FStar_SMTEncoding_Term.rng in
                                                    let uu____901 =
                                                      FStar_SMTEncoding_Term.abstr
-                                                       names1 lhs2
-                                                      in
+                                                       names1 lhs2 in
                                                    (labels1, uu____901))
                                           | uu____904 ->
                                               let uu____905 =
@@ -282,35 +259,27 @@ let (label_goals :
                                                     let uu____908 =
                                                       let uu____909 =
                                                         FStar_SMTEncoding_Term.print_smt_term
-                                                          ens
-                                                         in
+                                                          ens in
                                                       Prims.strcat "  ... "
-                                                        uu____909
-                                                       in
+                                                        uu____909 in
                                                     Prims.strcat post_name
-                                                      uu____908
-                                                     in
+                                                      uu____908 in
                                                   Prims.strcat
                                                     "Ensures clause doesn't match post name:  "
-                                                    uu____907
-                                                   in
+                                                    uu____907 in
                                                 Not_a_wp_implication
-                                                  uu____906
-                                                 in
+                                                  uu____906 in
                                               FStar_Exn.raise uu____905))
                                 | uu____916 ->
                                     let uu____917 =
                                       let uu____918 =
                                         let uu____919 =
                                           FStar_SMTEncoding_Term.print_smt_term
-                                            lhs1
-                                           in
+                                            lhs1 in
                                         Prims.strcat "LHS not a conjunct: "
-                                          uu____919
-                                         in
-                                      Not_a_wp_implication uu____918  in
-                                    FStar_Exn.raise uu____917
-                                 in
+                                          uu____919 in
+                                      Not_a_wp_implication uu____918 in
+                                    FStar_Exn.raise uu____917 in
                               (match uu____743 with
                                | (labels1,lhs2) ->
                                    let uu____938 =
@@ -318,36 +287,31 @@ let (label_goals :
                                        aux default_msg
                                          FStar_Pervasives_Native.None
                                          (FStar_Pervasives_Native.Some
-                                            post_name) labels1 rhs1
-                                        in
+                                            post_name) labels1 rhs1 in
                                      match uu____945 with
                                      | (labels2,rhs2) ->
                                          let uu____964 =
                                            FStar_SMTEncoding_Term.abstr
-                                             names1 rhs2
-                                            in
-                                         (labels2, uu____964)
-                                      in
+                                             names1 rhs2 in
+                                         (labels2, uu____964) in
                                    (match uu____938 with
                                     | (labels2,rhs2) ->
                                         let body =
                                           FStar_SMTEncoding_Term.mkImp
-                                            (lhs2, rhs2) rng
-                                           in
+                                            (lhs2, rhs2) rng in
                                         let uu____980 =
                                           FStar_SMTEncoding_Term.mk
                                             (FStar_SMTEncoding_Term.Quant
                                                (FStar_SMTEncoding_Term.Forall,
                                                  pats, iopt, (post :: sorts),
                                                  body))
-                                            q1.FStar_SMTEncoding_Term.rng
-                                           in
+                                            q1.FStar_SMTEncoding_Term.rng in
                                         (labels2, uu____980))))
                      | uu____991 ->
                          let uu____992 =
                            let uu____993 =
-                             FStar_SMTEncoding_Term.print_smt_term arg  in
-                           Prims.strcat "arg not a quant: " uu____993  in
+                             FStar_SMTEncoding_Term.print_smt_term arg in
+                           Prims.strcat "arg not a quant: " uu____993 in
                          fallback uu____992
                    with | Not_a_wp_implication msg -> fallback msg)
               | FStar_SMTEncoding_Term.Labeled (arg,reason,r1) ->
@@ -365,21 +329,19 @@ let (label_goals :
                   when is_a_named_continuation lhs ->
                   let post_name =
                     let uu____1033 =
-                      let uu____1034 = FStar_Syntax_Syntax.next_id ()  in
-                      FStar_All.pipe_left FStar_Util.string_of_int uu____1034
-                       in
-                    Prims.strcat "^^post_condition_" uu____1033  in
-                  let names1 = (post_name, post)  in
+                      let uu____1034 = FStar_Syntax_Syntax.next_id () in
+                      FStar_All.pipe_left FStar_Util.string_of_int uu____1034 in
+                    Prims.strcat "^^post_condition_" uu____1033 in
+                  let names1 = (post_name, post) in
                   let instantiation =
-                    let uu____1043 = FStar_SMTEncoding_Util.mkFreeV names1
-                       in
-                    [uu____1043]  in
+                    let uu____1043 = FStar_SMTEncoding_Util.mkFreeV names1 in
+                    [uu____1043] in
                   let uu____1044 =
                     let uu____1049 =
-                      FStar_SMTEncoding_Term.inst instantiation lhs  in
+                      FStar_SMTEncoding_Term.inst instantiation lhs in
                     let uu____1050 =
-                      FStar_SMTEncoding_Term.inst instantiation rhs  in
-                    (uu____1049, uu____1050)  in
+                      FStar_SMTEncoding_Term.inst instantiation rhs in
+                    (uu____1049, uu____1050) in
                   (match uu____1044 with
                    | (lhs1,rhs1) ->
                        let uu____1059 =
@@ -411,8 +373,7 @@ let (label_goals :
                                     let uu____1140 =
                                       aux default_msg
                                         FStar_Pervasives_Native.None
-                                        post_name_opt labels1 r1
-                                       in
+                                        post_name_opt labels1 r1 in
                                     (match uu____1140 with
                                      | (labels2,r2) ->
                                          let uu____1159 =
@@ -423,32 +384,26 @@ let (label_goals :
                                                    FStar_SMTEncoding_Term.mk
                                                    (FStar_SMTEncoding_Term.App
                                                       (FStar_SMTEncoding_Term.Iff,
-                                                        [l; r2]))
-                                                  in
+                                                        [l; r2])) in
                                                (FStar_SMTEncoding_Term.Forall,
                                                  [[p]],
                                                  (FStar_Pervasives_Native.Some
                                                     (Prims.parse_int "0")),
-                                                 sorts, uu____1180)
-                                                in
+                                                 sorts, uu____1180) in
                                              FStar_SMTEncoding_Term.Quant
-                                               uu____1161
-                                              in
+                                               uu____1161 in
                                            FStar_SMTEncoding_Term.mk
                                              uu____1160
-                                             q1.FStar_SMTEncoding_Term.rng
-                                            in
+                                             q1.FStar_SMTEncoding_Term.rng in
                                          (labels2, uu____1159))
                                 | uu____1197 -> (labels1, tm)) labels
-                           (conjuncts lhs1)
-                          in
+                           (conjuncts lhs1) in
                        (match uu____1059 with
                         | (labels1,lhs_conjs) ->
                             let uu____1216 =
                               aux default_msg FStar_Pervasives_Native.None
                                 (FStar_Pervasives_Native.Some post_name)
-                                labels1 rhs1
-                               in
+                                labels1 rhs1 in
                             (match uu____1216 with
                              | (labels2,rhs2) ->
                                  let body =
@@ -457,60 +412,53 @@ let (label_goals :
                                        let uu____1242 =
                                          FStar_SMTEncoding_Term.mk_and_l
                                            lhs_conjs
-                                           lhs1.FStar_SMTEncoding_Term.rng
-                                          in
-                                       (uu____1242, rhs2)  in
+                                           lhs1.FStar_SMTEncoding_Term.rng in
+                                       (uu____1242, rhs2) in
                                      FStar_SMTEncoding_Term.mkImp uu____1237
-                                       rng
-                                      in
+                                       rng in
                                    FStar_All.pipe_right uu____1236
-                                     (FStar_SMTEncoding_Term.abstr [names1])
-                                    in
+                                     (FStar_SMTEncoding_Term.abstr [names1]) in
                                  let q2 =
                                    FStar_SMTEncoding_Term.mk
                                      (FStar_SMTEncoding_Term.Quant
                                         (FStar_SMTEncoding_Term.Forall, [],
                                           FStar_Pervasives_Native.None,
                                           [post], body))
-                                     q1.FStar_SMTEncoding_Term.rng
-                                    in
+                                     q1.FStar_SMTEncoding_Term.rng in
                                  (labels2, q2))))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Imp ,lhs::rhs::[]) ->
                   let uu____1268 =
-                    aux default_msg ropt post_name_opt labels rhs  in
+                    aux default_msg ropt post_name_opt labels rhs in
                   (match uu____1268 with
                    | (labels1,rhs1) ->
                        let uu____1287 =
-                         FStar_SMTEncoding_Util.mkImp (lhs, rhs1)  in
+                         FStar_SMTEncoding_Util.mkImp (lhs, rhs1) in
                        (labels1, uu____1287))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.And ,conjuncts1) ->
                   let uu____1295 =
                     FStar_Util.fold_map (aux default_msg ropt post_name_opt)
-                      labels conjuncts1
-                     in
+                      labels conjuncts1 in
                   (match uu____1295 with
                    | (labels1,conjuncts2) ->
                        let uu____1322 =
                          FStar_SMTEncoding_Term.mk_and_l conjuncts2
-                           q1.FStar_SMTEncoding_Term.rng
-                          in
+                           q1.FStar_SMTEncoding_Term.rng in
                        (labels1, uu____1322))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.ITE ,hd1::q11::q2::[]) ->
                   let uu____1330 =
-                    aux default_msg ropt post_name_opt labels q11  in
+                    aux default_msg ropt post_name_opt labels q11 in
                   (match uu____1330 with
                    | (labels1,q12) ->
                        let uu____1349 =
-                         aux default_msg ropt post_name_opt labels1 q2  in
+                         aux default_msg ropt post_name_opt labels1 q2 in
                        (match uu____1349 with
                         | (labels2,q21) ->
                             let uu____1368 =
                               FStar_SMTEncoding_Term.mkITE (hd1, q12, q21)
-                                q1.FStar_SMTEncoding_Term.rng
-                               in
+                                q1.FStar_SMTEncoding_Term.rng in
                             (labels2, uu____1368)))
               | FStar_SMTEncoding_Term.Quant
                   (FStar_SMTEncoding_Term.Exists
@@ -518,22 +466,19 @@ let (label_goals :
                   ->
                   let uu____1391 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1391 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Iff ,uu____1406) ->
                   let uu____1411 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1411 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Or ,uu____1426) ->
                   let uu____1431 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1431 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Var uu____1446,uu____1447) when
@@ -541,78 +486,67 @@ let (label_goals :
               | FStar_SMTEncoding_Term.FreeV uu____1454 ->
                   let uu____1459 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1459 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.TrueOp ,uu____1474) ->
                   let uu____1479 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1479 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.FalseOp ,uu____1494) ->
                   let uu____1499 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1499 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Not ,uu____1514) ->
                   let uu____1519 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1519 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Eq ,uu____1534) ->
                   let uu____1539 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1539 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.LT ,uu____1554) ->
                   let uu____1559 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1559 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.LTE ,uu____1574) ->
                   let uu____1579 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1579 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.GT ,uu____1594) ->
                   let uu____1599 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1599 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.GTE ,uu____1614) ->
                   let uu____1619 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1619 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvUlt ,uu____1634) ->
                   let uu____1639 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1639 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Var uu____1654,uu____1655) ->
                   let uu____1660 =
                     fresh_label1 default_msg ropt
-                      q1.FStar_SMTEncoding_Term.rng q1
-                     in
+                      q1.FStar_SMTEncoding_Term.rng q1 in
                   (match uu____1660 with | (lab,q2) -> ((lab :: labels), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Add ,uu____1675) ->
@@ -680,36 +614,32 @@ let (label_goals :
               | FStar_SMTEncoding_Term.Quant
                   (FStar_SMTEncoding_Term.Forall ,pats,iopt,sorts,body) ->
                   let uu____1928 =
-                    aux default_msg ropt post_name_opt labels body  in
+                    aux default_msg ropt post_name_opt labels body in
                   (match uu____1928 with
                    | (labels1,body1) ->
                        let uu____1947 =
                          FStar_SMTEncoding_Term.mk
                            (FStar_SMTEncoding_Term.Quant
                               (FStar_SMTEncoding_Term.Forall, pats, iopt,
-                                sorts, body1)) q1.FStar_SMTEncoding_Term.rng
-                          in
+                                sorts, body1)) q1.FStar_SMTEncoding_Term.rng in
                        (labels1, uu____1947))
               | FStar_SMTEncoding_Term.Let (es,body) ->
                   let uu____1964 =
-                    aux default_msg ropt post_name_opt labels body  in
+                    aux default_msg ropt post_name_opt labels body in
                   (match uu____1964 with
                    | (labels1,body1) ->
                        let uu____1983 =
                          FStar_SMTEncoding_Term.mkLet (es, body1)
-                           q1.FStar_SMTEncoding_Term.rng
-                          in
-                       (labels1, uu____1983))
-               in
+                           q1.FStar_SMTEncoding_Term.rng in
+                       (labels1, uu____1983)) in
             aux "assertion failed" FStar_Pervasives_Native.None
               FStar_Pervasives_Native.None [] q
-  
-let (detail_errors :
+let detail_errors:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
       labels ->
         (FStar_SMTEncoding_Term.decls_t -> FStar_SMTEncoding_Z3.z3result) ->
-          Prims.unit)
+          Prims.unit
   =
   fun hint_replay  ->
     fun env  ->
@@ -718,24 +648,22 @@ let (detail_errors :
           let print_banner uu____2008 =
             let msg =
               let uu____2010 =
-                let uu____2011 = FStar_TypeChecker_Env.get_range env  in
-                FStar_Range.string_of_range uu____2011  in
-              let uu____2012 = FStar_Util.string_of_int (Prims.parse_int "5")
-                 in
+                let uu____2011 = FStar_TypeChecker_Env.get_range env in
+                FStar_Range.string_of_range uu____2011 in
+              let uu____2012 = FStar_Util.string_of_int (Prims.parse_int "5") in
               let uu____2013 =
-                FStar_Util.string_of_int (FStar_List.length all_labels)  in
+                FStar_Util.string_of_int (FStar_List.length all_labels) in
               FStar_Util.format4
                 "Detailed %s report follows for %s\nTaking %s seconds per proof obligation (%s proofs in total)\n"
                 (if hint_replay then "hint replay" else "error") uu____2010
-                uu____2012 uu____2013
-               in
-            FStar_Util.print_error msg  in
+                uu____2012 uu____2013 in
+            FStar_Util.print_error msg in
           let print_result uu____2028 =
             match uu____2028 with
             | ((uu____2039,msg,r),success) ->
                 if success
                 then
-                  let uu____2049 = FStar_Range.string_of_range r  in
+                  let uu____2049 = FStar_Range.string_of_range r in
                   FStar_Util.print1 "OK: proof obligation at %s was proven\n"
                     uu____2049
                 else
@@ -748,15 +676,12 @@ let (detail_errors :
                   else
                     (let uu____2052 =
                        let uu____2057 =
-                         let uu____2058 = FStar_Range.string_of_range r  in
+                         let uu____2058 = FStar_Range.string_of_range r in
                          FStar_Util.format2
                            "XX: proof obligation at %s failed\n\t%s\n"
-                           uu____2058 msg
-                          in
-                       (FStar_Errors.Error_ProofObligationFailed, uu____2057)
-                        in
-                     FStar_Errors.log_issue r uu____2052)
-             in
+                           uu____2058 msg in
+                       (FStar_Errors.Error_ProofObligationFailed, uu____2057) in
+                     FStar_Errors.log_issue r uu____2052) in
           let elim labs =
             FStar_All.pipe_right labs
               (FStar_List.map
@@ -767,9 +692,9 @@ let (detail_errors :
                           let uu____2141 =
                             let uu____2142 =
                               let uu____2147 =
-                                FStar_SMTEncoding_Util.mkFreeV l  in
-                              (uu____2147, FStar_SMTEncoding_Util.mkTrue)  in
-                            FStar_SMTEncoding_Util.mkEq uu____2142  in
+                                FStar_SMTEncoding_Util.mkFreeV l in
+                              (uu____2147, FStar_SMTEncoding_Util.mkTrue) in
+                            FStar_SMTEncoding_Util.mkEq uu____2142 in
                           {
                             FStar_SMTEncoding_Term.assumption_term =
                               uu____2141;
@@ -779,40 +704,36 @@ let (detail_errors :
                               (Prims.strcat "@disable_label_"
                                  (FStar_Pervasives_Native.fst l));
                             FStar_SMTEncoding_Term.assumption_fact_ids = []
-                          }  in
-                        FStar_SMTEncoding_Term.Assume a))
-             in
+                          } in
+                        FStar_SMTEncoding_Term.Assume a)) in
           let rec linear_check eliminated errors active =
             FStar_SMTEncoding_Z3.refresh ();
             (match active with
              | [] ->
                  let results =
                    let uu____2202 =
-                     FStar_List.map (fun x  -> (x, true)) eliminated  in
+                     FStar_List.map (fun x  -> (x, true)) eliminated in
                    let uu____2215 =
-                     FStar_List.map (fun x  -> (x, false)) errors  in
-                   FStar_List.append uu____2202 uu____2215  in
+                     FStar_List.map (fun x  -> (x, false)) errors in
+                   FStar_List.append uu____2202 uu____2215 in
                  sort_labels results
              | hd1::tl1 ->
                  ((let uu____2237 =
-                     FStar_Util.string_of_int (FStar_List.length active)  in
+                     FStar_Util.string_of_int (FStar_List.length active) in
                    FStar_Util.print1 "%s, " uu____2237);
                   (let decls =
                      FStar_All.pipe_left elim
                        (FStar_List.append eliminated
-                          (FStar_List.append errors tl1))
-                      in
-                   let result = askZ3 decls  in
+                          (FStar_List.append errors tl1)) in
+                   let result = askZ3 decls in
                    match result.FStar_SMTEncoding_Z3.z3result_status with
                    | FStar_SMTEncoding_Z3.UNSAT uu____2268 ->
                        linear_check (hd1 :: eliminated) errors tl1
                    | uu____2269 ->
-                       linear_check eliminated (hd1 :: errors) tl1)))
-             in
+                       linear_check eliminated (hd1 :: errors) tl1))) in
           print_banner ();
           FStar_Options.set_option "z3rlimit"
             (FStar_Options.Int (Prims.parse_int "5"));
-          (let res = linear_check [] [] all_labels  in
+          (let res = linear_check [] [] all_labels in
            FStar_Util.print_string "\n";
            FStar_All.pipe_right res (FStar_List.iter print_result))
-  

--- a/src/ocaml-output/FStar_SMTEncoding_Solver.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Solver.ml
@@ -2,7 +2,7 @@ open Prims
 type z3_replay_result =
   (FStar_SMTEncoding_Z3.unsat_core,FStar_SMTEncoding_Term.error_labels)
     FStar_Util.either[@@deriving show]
-let z3_result_as_replay_result :
+let z3_result_as_replay_result:
   'Auu____9 'Auu____10 'Auu____11 .
     ('Auu____11,('Auu____10,'Auu____9) FStar_Pervasives_Native.tuple2)
       FStar_Util.either -> ('Auu____11,'Auu____10) FStar_Util.either
@@ -11,65 +11,62 @@ let z3_result_as_replay_result :
     match uu___58_27 with
     | FStar_Util.Inl l -> FStar_Util.Inl l
     | FStar_Util.Inr (r,uu____42) -> FStar_Util.Inr r
-  
-let (recorded_hints :
-  FStar_Util.hints FStar_Pervasives_Native.option FStar_ST.ref) =
-  FStar_Util.mk_ref FStar_Pervasives_Native.None 
-let (replaying_hints :
-  FStar_Util.hints FStar_Pervasives_Native.option FStar_ST.ref) =
-  FStar_Util.mk_ref FStar_Pervasives_Native.None 
-let (format_hints_file_name : Prims.string -> Prims.bool -> Prims.string) =
+let recorded_hints:
+  FStar_Util.hints FStar_Pervasives_Native.option FStar_ST.ref =
+  FStar_Util.mk_ref FStar_Pervasives_Native.None
+let replaying_hints:
+  FStar_Util.hints FStar_Pervasives_Native.option FStar_ST.ref =
+  FStar_Util.mk_ref FStar_Pervasives_Native.None
+let format_hints_file_name: Prims.string -> Prims.bool -> Prims.string =
   fun src_filename  ->
     fun checking_or_using_extracted_interface  ->
       let uu____87 =
         if checking_or_using_extracted_interface
         then FStar_Parser_Dep.interface_filename src_filename
-        else src_filename  in
+        else src_filename in
       FStar_Util.format1 "%s.hints" uu____87
-  
-let initialize_hints_db :
+let initialize_hints_db:
   'Auu____93 . Prims.string -> Prims.bool -> 'Auu____93 -> Prims.unit =
   fun src_filename  ->
     fun checking_or_using_extracted_interface  ->
       fun format_filename  ->
-        (let uu____107 = FStar_Options.record_hints ()  in
+        (let uu____107 = FStar_Options.record_hints () in
          if uu____107
          then
            FStar_ST.op_Colon_Equals recorded_hints
              (FStar_Pervasives_Native.Some [])
          else ());
-        (let uu____138 = FStar_Options.use_hints ()  in
+        (let uu____138 = FStar_Options.use_hints () in
          if uu____138
          then
            let norm_src_filename =
-             FStar_Util.normalize_file_path src_filename  in
+             FStar_Util.normalize_file_path src_filename in
            let src_filename_for_printing =
              if checking_or_using_extracted_interface
              then FStar_Parser_Dep.interface_filename norm_src_filename
-             else norm_src_filename  in
+             else norm_src_filename in
            let val_filename =
-             let uu____143 = FStar_Options.hint_file ()  in
+             let uu____143 = FStar_Options.hint_file () in
              match uu____143 with
              | FStar_Pervasives_Native.Some fn -> fn
              | FStar_Pervasives_Native.None  ->
                  format_hints_file_name norm_src_filename
-                   checking_or_using_extracted_interface
-              in
-           let uu____147 = FStar_Util.read_hints val_filename  in
+                   checking_or_using_extracted_interface in
+           let uu____147 = FStar_Util.read_hints val_filename in
            match uu____147 with
            | FStar_Pervasives_Native.Some hints ->
                let expected_digest =
-                 FStar_Util.digest_of_file norm_src_filename  in
-               ((let uu____153 = FStar_Options.hint_info ()  in
+                 FStar_Util.digest_of_file norm_src_filename in
+               ((let uu____153 = FStar_Options.hint_info () in
                  if uu____153
                  then
                    let uu____154 =
-                     let uu____155 = FStar_Options.hint_file ()  in
+                     let uu____155 = FStar_Options.hint_file () in
                      match uu____155 with
                      | FStar_Pervasives_Native.Some fn ->
                          Prims.strcat " from '"
                            (Prims.strcat val_filename "'")
-                     | uu____159 -> ""  in
+                     | uu____159 -> "" in
                    FStar_Util.print3 "(%s) digest is %s%s.\n"
                      src_filename_for_printing
                      (if hints.FStar_Util.module_digest = expected_digest
@@ -80,55 +77,49 @@ let initialize_hints_db :
                 FStar_ST.op_Colon_Equals replaying_hints
                   (FStar_Pervasives_Native.Some (hints.FStar_Util.hints)))
            | FStar_Pervasives_Native.None  ->
-               let uu____187 = FStar_Options.hint_info ()  in
+               let uu____187 = FStar_Options.hint_info () in
                (if uu____187
                 then
                   FStar_Util.print1 "(%s) Unable to read hint file.\n"
                     src_filename_for_printing
                 else ())
          else ())
-  
-let (finalize_hints_db : Prims.string -> Prims.bool -> Prims.unit) =
+let finalize_hints_db: Prims.string -> Prims.bool -> Prims.unit =
   fun src_filename  ->
     fun checking_or_using_extracted_interface  ->
-      (let uu____197 = FStar_Options.record_hints ()  in
+      (let uu____197 = FStar_Options.record_hints () in
        if uu____197
        then
          let hints =
-           let uu____199 = FStar_ST.op_Bang recorded_hints  in
-           FStar_Option.get uu____199  in
+           let uu____199 = FStar_ST.op_Bang recorded_hints in
+           FStar_Option.get uu____199 in
          let hints_db =
-           let uu____226 = FStar_Util.digest_of_file src_filename  in
-           { FStar_Util.module_digest = uu____226; FStar_Util.hints = hints }
-            in
-         let norm_src_filename = FStar_Util.normalize_file_path src_filename
-            in
+           let uu____226 = FStar_Util.digest_of_file src_filename in
+           { FStar_Util.module_digest = uu____226; FStar_Util.hints = hints } in
+         let norm_src_filename = FStar_Util.normalize_file_path src_filename in
          let val_filename =
-           let uu____229 = FStar_Options.hint_file ()  in
+           let uu____229 = FStar_Options.hint_file () in
            match uu____229 with
            | FStar_Pervasives_Native.Some fn -> fn
            | FStar_Pervasives_Native.None  ->
                format_hints_file_name norm_src_filename
-                 checking_or_using_extracted_interface
-            in
+                 checking_or_using_extracted_interface in
          FStar_Util.write_hints val_filename hints_db
        else ());
       FStar_ST.op_Colon_Equals recorded_hints FStar_Pervasives_Native.None;
       FStar_ST.op_Colon_Equals replaying_hints FStar_Pervasives_Native.None
-  
-let with_hints_db :
+let with_hints_db:
   'a . Prims.string -> Prims.bool -> (Prims.unit -> 'a) -> 'a =
   fun fname  ->
     fun checking_or_using_extracted_interface  ->
       fun f  ->
         initialize_hints_db fname checking_or_using_extracted_interface false;
-        (let result = f ()  in
+        (let result = f () in
          finalize_hints_db fname checking_or_using_extracted_interface;
          result)
-  
-let (filter_using_facts_from :
+let filter_using_facts_from:
   FStar_TypeChecker_Env.env ->
-    FStar_SMTEncoding_Term.decls_t -> FStar_SMTEncoding_Term.decl Prims.list)
+    FStar_SMTEncoding_Term.decls_t -> FStar_SMTEncoding_Term.decl Prims.list
   =
   fun e  ->
     fun theory  ->
@@ -136,7 +127,7 @@ let (filter_using_facts_from :
         match fid with
         | FStar_SMTEncoding_Term.Namespace lid ->
             FStar_TypeChecker_Env.should_enc_lid e lid
-        | uu____319 -> false  in
+        | uu____319 -> false in
       let matches_fact_ids include_assumption_names a =
         match a.FStar_SMTEncoding_Term.assumption_fact_ids with
         | [] -> true
@@ -147,21 +138,19 @@ let (filter_using_facts_from :
               ||
               (let uu____337 =
                  FStar_Util.smap_try_find include_assumption_names
-                   a.FStar_SMTEncoding_Term.assumption_name
-                  in
-               FStar_Option.isSome uu____337)
-         in
-      let theory_rev = FStar_List.rev theory  in
+                   a.FStar_SMTEncoding_Term.assumption_name in
+               FStar_Option.isSome uu____337) in
+      let theory_rev = FStar_List.rev theory in
       let pruned_theory =
         let include_assumption_names =
-          FStar_Util.smap_create (Prims.parse_int "10000")  in
+          FStar_Util.smap_create (Prims.parse_int "10000") in
         FStar_List.fold_left
           (fun out  ->
              fun d  ->
                match d with
                | FStar_SMTEncoding_Term.Assume a ->
                    let uu____362 =
-                     matches_fact_ids include_assumption_names a  in
+                     matches_fact_ids include_assumption_names a in
                    if uu____362 then d :: out else out
                | FStar_SMTEncoding_Term.RetainAssumptions names1 ->
                    (FStar_List.iter
@@ -171,23 +160,21 @@ let (filter_using_facts_from :
                     d
                     ::
                     out)
-               | uu____372 -> d :: out) [] theory_rev
-         in
+               | uu____372 -> d :: out) [] theory_rev in
       pruned_theory
-  
-let (filter_assertions :
+let filter_assertions:
   FStar_TypeChecker_Env.env ->
     FStar_SMTEncoding_Z3.unsat_core ->
       FStar_SMTEncoding_Term.decls_t ->
         (FStar_SMTEncoding_Term.decl Prims.list,Prims.bool)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun e  ->
     fun core  ->
       fun theory  ->
         match core with
         | FStar_Pervasives_Native.None  ->
-            let uu____396 = filter_using_facts_from e theory  in
+            let uu____396 = filter_using_facts_from e theory in
             (uu____396, false)
         | FStar_Pervasives_Native.Some core1 ->
             let uu____406 =
@@ -217,8 +204,7 @@ let (filter_assertions :
                                     (n_pruned + (Prims.parse_int "1")))
                           | uu____487 ->
                               ((d :: theory1), n_retained, n_pruned))) theory
-                ([], (Prims.parse_int "0"), (Prims.parse_int "0"))
-               in
+                ([], (Prims.parse_int "0"), (Prims.parse_int "0")) in
             (match uu____406 with
              | (theory',n_retained,n_pruned) ->
                  let uu____505 =
@@ -227,71 +213,63 @@ let (filter_assertions :
                        let uu____512 =
                          let uu____513 =
                            FStar_All.pipe_right core1
-                             (FStar_String.concat ", ")
-                            in
-                         Prims.strcat "UNSAT CORE: " uu____513  in
-                       FStar_SMTEncoding_Term.Caption uu____512  in
-                     [uu____511]  in
-                   FStar_List.append theory' uu____508  in
+                             (FStar_String.concat ", ") in
+                         Prims.strcat "UNSAT CORE: " uu____513 in
+                       FStar_SMTEncoding_Term.Caption uu____512 in
+                     [uu____511] in
+                   FStar_List.append theory' uu____508 in
                  (uu____505, true))
-  
-let (filter_facts_without_core :
+let filter_facts_without_core:
   FStar_TypeChecker_Env.env ->
     FStar_SMTEncoding_Term.decls_t ->
       (FStar_SMTEncoding_Term.decl Prims.list,Prims.bool)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun e  ->
     fun x  ->
-      let uu____530 = filter_using_facts_from e x  in (uu____530, false)
-  
+      let uu____530 = filter_using_facts_from e x in (uu____530, false)
 type errors =
   {
-  error_reason: Prims.string ;
-  error_fuel: Prims.int ;
-  error_ifuel: Prims.int ;
-  error_hint: Prims.string Prims.list FStar_Pervasives_Native.option ;
+  error_reason: Prims.string;
+  error_fuel: Prims.int;
+  error_ifuel: Prims.int;
+  error_hint: Prims.string Prims.list FStar_Pervasives_Native.option;
   error_messages:
     (FStar_Errors.raw_error,Prims.string,FStar_Range.range)
-      FStar_Pervasives_Native.tuple3 Prims.list
-    }[@@deriving show]
-let (__proj__Mkerrors__item__error_reason : errors -> Prims.string) =
+      FStar_Pervasives_Native.tuple3 Prims.list;}[@@deriving show]
+let __proj__Mkerrors__item__error_reason: errors -> Prims.string =
   fun projectee  ->
     match projectee with
     | { error_reason = __fname__error_reason;
         error_fuel = __fname__error_fuel; error_ifuel = __fname__error_ifuel;
         error_hint = __fname__error_hint;
         error_messages = __fname__error_messages;_} -> __fname__error_reason
-  
-let (__proj__Mkerrors__item__error_fuel : errors -> Prims.int) =
+let __proj__Mkerrors__item__error_fuel: errors -> Prims.int =
   fun projectee  ->
     match projectee with
     | { error_reason = __fname__error_reason;
         error_fuel = __fname__error_fuel; error_ifuel = __fname__error_ifuel;
         error_hint = __fname__error_hint;
         error_messages = __fname__error_messages;_} -> __fname__error_fuel
-  
-let (__proj__Mkerrors__item__error_ifuel : errors -> Prims.int) =
+let __proj__Mkerrors__item__error_ifuel: errors -> Prims.int =
   fun projectee  ->
     match projectee with
     | { error_reason = __fname__error_reason;
         error_fuel = __fname__error_fuel; error_ifuel = __fname__error_ifuel;
         error_hint = __fname__error_hint;
         error_messages = __fname__error_messages;_} -> __fname__error_ifuel
-  
-let (__proj__Mkerrors__item__error_hint :
-  errors -> Prims.string Prims.list FStar_Pervasives_Native.option) =
+let __proj__Mkerrors__item__error_hint:
+  errors -> Prims.string Prims.list FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { error_reason = __fname__error_reason;
         error_fuel = __fname__error_fuel; error_ifuel = __fname__error_ifuel;
         error_hint = __fname__error_hint;
         error_messages = __fname__error_messages;_} -> __fname__error_hint
-  
-let (__proj__Mkerrors__item__error_messages :
+let __proj__Mkerrors__item__error_messages:
   errors ->
     (FStar_Errors.raw_error,Prims.string,FStar_Range.range)
-      FStar_Pervasives_Native.tuple3 Prims.list)
+      FStar_Pervasives_Native.tuple3 Prims.list
   =
   fun projectee  ->
     match projectee with
@@ -300,32 +278,30 @@ let (__proj__Mkerrors__item__error_messages :
         error_hint = __fname__error_hint;
         error_messages = __fname__error_messages;_} ->
         __fname__error_messages
-  
-let (error_to_short_string : errors -> Prims.string) =
+let error_to_short_string: errors -> Prims.string =
   fun err  ->
-    let uu____694 = FStar_Util.string_of_int err.error_fuel  in
-    let uu____695 = FStar_Util.string_of_int err.error_ifuel  in
+    let uu____694 = FStar_Util.string_of_int err.error_fuel in
+    let uu____695 = FStar_Util.string_of_int err.error_ifuel in
     FStar_Util.format4 "%s (fuel=%s; ifuel=%s; %s)" err.error_reason
       uu____694 uu____695
       (if FStar_Option.isSome err.error_hint then "with hint" else "")
-  
 type query_settings =
   {
-  query_env: FStar_TypeChecker_Env.env ;
-  query_decl: FStar_SMTEncoding_Term.decl ;
-  query_name: Prims.string ;
-  query_index: Prims.int ;
-  query_range: FStar_Range.range ;
-  query_fuel: Prims.int ;
-  query_ifuel: Prims.int ;
-  query_rlimit: Prims.int ;
-  query_hint: FStar_SMTEncoding_Z3.unsat_core ;
-  query_errors: errors Prims.list ;
-  query_all_labels: FStar_SMTEncoding_Term.error_labels ;
-  query_suffix: FStar_SMTEncoding_Term.decl Prims.list ;
-  query_hash: Prims.string FStar_Pervasives_Native.option }[@@deriving show]
-let (__proj__Mkquery_settings__item__query_env :
-  query_settings -> FStar_TypeChecker_Env.env) =
+  query_env: FStar_TypeChecker_Env.env;
+  query_decl: FStar_SMTEncoding_Term.decl;
+  query_name: Prims.string;
+  query_index: Prims.int;
+  query_range: FStar_Range.range;
+  query_fuel: Prims.int;
+  query_ifuel: Prims.int;
+  query_rlimit: Prims.int;
+  query_hint: FStar_SMTEncoding_Z3.unsat_core;
+  query_errors: errors Prims.list;
+  query_all_labels: FStar_SMTEncoding_Term.error_labels;
+  query_suffix: FStar_SMTEncoding_Term.decl Prims.list;
+  query_hash: Prims.string FStar_Pervasives_Native.option;}[@@deriving show]
+let __proj__Mkquery_settings__item__query_env:
+  query_settings -> FStar_TypeChecker_Env.env =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -338,9 +314,8 @@ let (__proj__Mkquery_settings__item__query_env :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_env
-  
-let (__proj__Mkquery_settings__item__query_decl :
-  query_settings -> FStar_SMTEncoding_Term.decl) =
+let __proj__Mkquery_settings__item__query_decl:
+  query_settings -> FStar_SMTEncoding_Term.decl =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -353,9 +328,8 @@ let (__proj__Mkquery_settings__item__query_decl :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_decl
-  
-let (__proj__Mkquery_settings__item__query_name :
-  query_settings -> Prims.string) =
+let __proj__Mkquery_settings__item__query_name:
+  query_settings -> Prims.string =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -368,9 +342,8 @@ let (__proj__Mkquery_settings__item__query_name :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_name
-  
-let (__proj__Mkquery_settings__item__query_index :
-  query_settings -> Prims.int) =
+let __proj__Mkquery_settings__item__query_index: query_settings -> Prims.int
+  =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -383,9 +356,8 @@ let (__proj__Mkquery_settings__item__query_index :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_index
-  
-let (__proj__Mkquery_settings__item__query_range :
-  query_settings -> FStar_Range.range) =
+let __proj__Mkquery_settings__item__query_range:
+  query_settings -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -398,9 +370,7 @@ let (__proj__Mkquery_settings__item__query_range :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_range
-  
-let (__proj__Mkquery_settings__item__query_fuel :
-  query_settings -> Prims.int) =
+let __proj__Mkquery_settings__item__query_fuel: query_settings -> Prims.int =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -413,9 +383,8 @@ let (__proj__Mkquery_settings__item__query_fuel :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_fuel
-  
-let (__proj__Mkquery_settings__item__query_ifuel :
-  query_settings -> Prims.int) =
+let __proj__Mkquery_settings__item__query_ifuel: query_settings -> Prims.int
+  =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -428,9 +397,8 @@ let (__proj__Mkquery_settings__item__query_ifuel :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_ifuel
-  
-let (__proj__Mkquery_settings__item__query_rlimit :
-  query_settings -> Prims.int) =
+let __proj__Mkquery_settings__item__query_rlimit: query_settings -> Prims.int
+  =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -443,9 +411,8 @@ let (__proj__Mkquery_settings__item__query_rlimit :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_rlimit
-  
-let (__proj__Mkquery_settings__item__query_hint :
-  query_settings -> FStar_SMTEncoding_Z3.unsat_core) =
+let __proj__Mkquery_settings__item__query_hint:
+  query_settings -> FStar_SMTEncoding_Z3.unsat_core =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -458,9 +425,8 @@ let (__proj__Mkquery_settings__item__query_hint :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_hint
-  
-let (__proj__Mkquery_settings__item__query_errors :
-  query_settings -> errors Prims.list) =
+let __proj__Mkquery_settings__item__query_errors:
+  query_settings -> errors Prims.list =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -473,9 +439,8 @@ let (__proj__Mkquery_settings__item__query_errors :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_errors
-  
-let (__proj__Mkquery_settings__item__query_all_labels :
-  query_settings -> FStar_SMTEncoding_Term.error_labels) =
+let __proj__Mkquery_settings__item__query_all_labels:
+  query_settings -> FStar_SMTEncoding_Term.error_labels =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -488,9 +453,8 @@ let (__proj__Mkquery_settings__item__query_all_labels :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_all_labels
-  
-let (__proj__Mkquery_settings__item__query_suffix :
-  query_settings -> FStar_SMTEncoding_Term.decl Prims.list) =
+let __proj__Mkquery_settings__item__query_suffix:
+  query_settings -> FStar_SMTEncoding_Term.decl Prims.list =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -503,9 +467,8 @@ let (__proj__Mkquery_settings__item__query_suffix :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_suffix
-  
-let (__proj__Mkquery_settings__item__query_hash :
-  query_settings -> Prims.string FStar_Pervasives_Native.option) =
+let __proj__Mkquery_settings__item__query_hash:
+  query_settings -> Prims.string FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { query_env = __fname__query_env; query_decl = __fname__query_decl;
@@ -518,93 +481,88 @@ let (__proj__Mkquery_settings__item__query_hash :
         query_all_labels = __fname__query_all_labels;
         query_suffix = __fname__query_suffix;
         query_hash = __fname__query_hash;_} -> __fname__query_hash
-  
-let (with_fuel_and_diagnostics :
+let with_fuel_and_diagnostics:
   query_settings ->
     FStar_SMTEncoding_Term.decl Prims.list ->
-      FStar_SMTEncoding_Term.decl Prims.list)
+      FStar_SMTEncoding_Term.decl Prims.list
   =
   fun settings  ->
     fun label_assumptions  ->
-      let n1 = settings.query_fuel  in
-      let i = settings.query_ifuel  in
-      let rlimit = settings.query_rlimit  in
+      let n1 = settings.query_fuel in
+      let i = settings.query_ifuel in
+      let rlimit = settings.query_rlimit in
       let uu____1070 =
         let uu____1073 =
           let uu____1074 =
-            let uu____1075 = FStar_Util.string_of_int n1  in
-            let uu____1076 = FStar_Util.string_of_int i  in
-            FStar_Util.format2 "<fuel='%s' ifuel='%s'>" uu____1075 uu____1076
-             in
-          FStar_SMTEncoding_Term.Caption uu____1074  in
+            let uu____1075 = FStar_Util.string_of_int n1 in
+            let uu____1076 = FStar_Util.string_of_int i in
+            FStar_Util.format2 "<fuel='%s' ifuel='%s'>" uu____1075 uu____1076 in
+          FStar_SMTEncoding_Term.Caption uu____1074 in
         let uu____1077 =
           let uu____1080 =
             let uu____1081 =
               let uu____1088 =
                 let uu____1089 =
                   let uu____1094 =
-                    FStar_SMTEncoding_Util.mkApp ("MaxFuel", [])  in
-                  let uu____1097 = FStar_SMTEncoding_Term.n_fuel n1  in
-                  (uu____1094, uu____1097)  in
-                FStar_SMTEncoding_Util.mkEq uu____1089  in
+                    FStar_SMTEncoding_Util.mkApp ("MaxFuel", []) in
+                  let uu____1097 = FStar_SMTEncoding_Term.n_fuel n1 in
+                  (uu____1094, uu____1097) in
+                FStar_SMTEncoding_Util.mkEq uu____1089 in
               (uu____1088, FStar_Pervasives_Native.None,
-                "@MaxFuel_assumption")
-               in
-            FStar_SMTEncoding_Util.mkAssume uu____1081  in
+                "@MaxFuel_assumption") in
+            FStar_SMTEncoding_Util.mkAssume uu____1081 in
           let uu____1100 =
             let uu____1103 =
               let uu____1104 =
                 let uu____1111 =
                   let uu____1112 =
                     let uu____1117 =
-                      FStar_SMTEncoding_Util.mkApp ("MaxIFuel", [])  in
-                    let uu____1120 = FStar_SMTEncoding_Term.n_fuel i  in
-                    (uu____1117, uu____1120)  in
-                  FStar_SMTEncoding_Util.mkEq uu____1112  in
+                      FStar_SMTEncoding_Util.mkApp ("MaxIFuel", []) in
+                    let uu____1120 = FStar_SMTEncoding_Term.n_fuel i in
+                    (uu____1117, uu____1120) in
+                  FStar_SMTEncoding_Util.mkEq uu____1112 in
                 (uu____1111, FStar_Pervasives_Native.None,
-                  "@MaxIFuel_assumption")
-                 in
-              FStar_SMTEncoding_Util.mkAssume uu____1104  in
-            [uu____1103; settings.query_decl]  in
-          uu____1080 :: uu____1100  in
-        uu____1073 :: uu____1077  in
+                  "@MaxIFuel_assumption") in
+              FStar_SMTEncoding_Util.mkAssume uu____1104 in
+            [uu____1103; settings.query_decl] in
+          uu____1080 :: uu____1100 in
+        uu____1073 :: uu____1077 in
       let uu____1123 =
         let uu____1126 =
           let uu____1129 =
             let uu____1132 =
               let uu____1133 =
-                let uu____1138 = FStar_Util.string_of_int rlimit  in
-                ("rlimit", uu____1138)  in
-              FStar_SMTEncoding_Term.SetOption uu____1133  in
+                let uu____1138 = FStar_Util.string_of_int rlimit in
+                ("rlimit", uu____1138) in
+              FStar_SMTEncoding_Term.SetOption uu____1133 in
             [uu____1132;
             FStar_SMTEncoding_Term.CheckSat;
-            FStar_SMTEncoding_Term.GetReasonUnknown]  in
+            FStar_SMTEncoding_Term.GetReasonUnknown] in
           let uu____1139 =
             let uu____1142 =
-              let uu____1145 = FStar_Options.record_hints ()  in
+              let uu____1145 = FStar_Options.record_hints () in
               if uu____1145
               then [FStar_SMTEncoding_Term.GetUnsatCore]
-              else []  in
+              else [] in
             let uu____1149 =
               let uu____1152 =
-                let uu____1155 = FStar_Options.print_z3_statistics ()  in
+                let uu____1155 = FStar_Options.print_z3_statistics () in
                 if uu____1155
                 then [FStar_SMTEncoding_Term.GetStatistics]
-                else []  in
-              FStar_List.append uu____1152 settings.query_suffix  in
-            FStar_List.append uu____1142 uu____1149  in
-          FStar_List.append uu____1129 uu____1139  in
-        FStar_List.append label_assumptions uu____1126  in
+                else [] in
+              FStar_List.append uu____1152 settings.query_suffix in
+            FStar_List.append uu____1142 uu____1149 in
+          FStar_List.append uu____1129 uu____1139 in
+        FStar_List.append label_assumptions uu____1126 in
       FStar_List.append uu____1070 uu____1123
-  
-let (used_hint : query_settings -> Prims.bool) =
-  fun s  -> FStar_Option.isSome s.query_hint 
-let (get_hint_for :
-  Prims.string -> Prims.int -> FStar_Util.hint FStar_Pervasives_Native.option)
+let used_hint: query_settings -> Prims.bool =
+  fun s  -> FStar_Option.isSome s.query_hint
+let get_hint_for:
+  Prims.string -> Prims.int -> FStar_Util.hint FStar_Pervasives_Native.option
   =
   fun qname  ->
     fun qindex  ->
-      let uu____1172 = FStar_ST.op_Bang replaying_hints  in
+      let uu____1172 = FStar_ST.op_Bang replaying_hints in
       match uu____1172 with
       | FStar_Pervasives_Native.Some hints ->
           FStar_Util.find_map hints
@@ -616,10 +574,9 @@ let (get_hint_for :
                    -> FStar_Pervasives_Native.Some hint
                | uu____1211 -> FStar_Pervasives_Native.None)
       | uu____1214 -> FStar_Pervasives_Native.None
-  
-let (query_errors :
+let query_errors:
   query_settings ->
-    FStar_SMTEncoding_Z3.z3result -> errors FStar_Pervasives_Native.option)
+    FStar_SMTEncoding_Z3.z3result -> errors FStar_Pervasives_Native.option
   =
   fun settings  ->
     fun z3result  ->
@@ -628,8 +585,7 @@ let (query_errors :
       | uu____1228 ->
           let uu____1229 =
             FStar_SMTEncoding_Z3.status_string_and_errors
-              z3result.FStar_SMTEncoding_Z3.z3result_status
-             in
+              z3result.FStar_SMTEncoding_Z3.z3result_status in
           (match uu____1229 with
            | (msg,error_labels) ->
                let err =
@@ -639,32 +595,30 @@ let (query_errors :
                         match uu____1264 with
                         | (uu____1277,x,y) ->
                             (FStar_Errors.Error_Z3SolverError, x, y))
-                     error_labels
-                    in
+                     error_labels in
                  {
                    error_reason = msg;
                    error_fuel = (settings.query_fuel);
                    error_ifuel = (settings.query_ifuel);
                    error_hint = (settings.query_hint);
                    error_messages = uu____1239
-                 }  in
+                 } in
                FStar_Pervasives_Native.Some err)
-  
-let (detail_hint_replay :
-  query_settings -> FStar_SMTEncoding_Z3.z3result -> Prims.unit) =
+let detail_hint_replay:
+  query_settings -> FStar_SMTEncoding_Z3.z3result -> Prims.unit =
   fun settings  ->
     fun z3result  ->
       let uu____1286 =
-        (used_hint settings) && (FStar_Options.detail_hint_replay ())  in
+        (used_hint settings) && (FStar_Options.detail_hint_replay ()) in
       if uu____1286
       then
         match z3result.FStar_SMTEncoding_Z3.z3result_status with
         | FStar_SMTEncoding_Z3.UNSAT uu____1287 -> ()
         | _failed ->
             let ask_z3 label_assumptions =
-              let res = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+              let res = FStar_Util.mk_ref FStar_Pervasives_Native.None in
               (let uu____1305 =
-                 with_fuel_and_diagnostics settings label_assumptions  in
+                 with_fuel_and_diagnostics settings label_assumptions in
                FStar_SMTEncoding_Z3.ask
                  (filter_assertions settings.query_env settings.query_hint)
                  settings.query_hash settings.query_all_labels uu____1305
@@ -672,39 +626,34 @@ let (detail_hint_replay :
                  (fun r  ->
                     FStar_ST.op_Colon_Equals res
                       (FStar_Pervasives_Native.Some r)));
-              (let uu____1355 = FStar_ST.op_Bang res  in
-               FStar_Option.get uu____1355)
-               in
+              (let uu____1355 = FStar_ST.op_Bang res in
+               FStar_Option.get uu____1355) in
             FStar_SMTEncoding_ErrorReporting.detail_errors true
               settings.query_env settings.query_all_labels ask_z3
       else ()
-  
-let (find_localized_errors :
-  errors Prims.list -> errors FStar_Pervasives_Native.option) =
+let find_localized_errors:
+  errors Prims.list -> errors FStar_Pervasives_Native.option =
   fun errs  ->
     FStar_All.pipe_right errs
       (FStar_List.tryFind
          (fun err  ->
             match err.error_messages with | [] -> false | uu____1425 -> true))
-  
-let (has_localized_errors : errors Prims.list -> Prims.bool) =
+let has_localized_errors: errors Prims.list -> Prims.bool =
   fun errs  ->
-    let uu____1441 = find_localized_errors errs  in
+    let uu____1441 = find_localized_errors errs in
     FStar_Option.isSome uu____1441
-  
-let (report_errors : query_settings -> Prims.unit) =
+let report_errors: query_settings -> Prims.unit =
   fun settings  ->
     let uu____1447 =
       (FStar_Options.detail_errors ()) &&
-        (let uu____1449 = FStar_Options.n_cores ()  in
-         uu____1449 = (Prims.parse_int "1"))
-       in
+        (let uu____1449 = FStar_Options.n_cores () in
+         uu____1449 = (Prims.parse_int "1")) in
     if uu____1447
     then
       let initial_fuel1 =
-        let uu___60_1451 = settings  in
-        let uu____1452 = FStar_Options.initial_fuel ()  in
-        let uu____1453 = FStar_Options.initial_ifuel ()  in
+        let uu___60_1451 = settings in
+        let uu____1452 = FStar_Options.initial_fuel () in
+        let uu____1453 = FStar_Options.initial_ifuel () in
         {
           query_env = (uu___60_1451.query_env);
           query_decl = (uu___60_1451.query_decl);
@@ -719,31 +668,29 @@ let (report_errors : query_settings -> Prims.unit) =
           query_all_labels = (uu___60_1451.query_all_labels);
           query_suffix = (uu___60_1451.query_suffix);
           query_hash = (uu___60_1451.query_hash)
-        }  in
+        } in
       let ask_z3 label_assumptions =
-        let res = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+        let res = FStar_Util.mk_ref FStar_Pervasives_Native.None in
         (let uu____1472 =
-           with_fuel_and_diagnostics initial_fuel1 label_assumptions  in
+           with_fuel_and_diagnostics initial_fuel1 label_assumptions in
          FStar_SMTEncoding_Z3.ask
            (filter_facts_without_core settings.query_env) settings.query_hash
            settings.query_all_labels uu____1472 FStar_Pervasives_Native.None
            (fun r  ->
               FStar_ST.op_Colon_Equals res (FStar_Pervasives_Native.Some r)));
-        (let uu____1522 = FStar_ST.op_Bang res  in
-         FStar_Option.get uu____1522)
-         in
+        (let uu____1522 = FStar_ST.op_Bang res in FStar_Option.get uu____1522) in
       FStar_SMTEncoding_ErrorReporting.detail_errors false settings.query_env
         settings.query_all_labels ask_z3
     else
-      (let uu____1571 = find_localized_errors settings.query_errors  in
+      (let uu____1571 = find_localized_errors settings.query_errors in
        match uu____1571 with
        | FStar_Pervasives_Native.Some err ->
            (FStar_All.pipe_right settings.query_errors
               (FStar_List.iter
                  (fun e  ->
                     let uu____1581 =
-                      let uu____1582 = error_to_short_string e  in
-                      Prims.strcat "SMT solver says: " uu____1582  in
+                      let uu____1582 = error_to_short_string e in
+                      Prims.strcat "SMT solver says: " uu____1582 in
                     FStar_Errors.diag settings.query_range uu____1581));
             FStar_TypeChecker_Err.add_errors settings.query_env
               err.error_messages)
@@ -753,36 +700,30 @@ let (report_errors : query_settings -> Prims.unit) =
                FStar_All.pipe_right settings.query_errors
                  (FStar_List.map
                     (fun e  ->
-                       let uu____1594 = error_to_short_string e  in
-                       Prims.strcat "SMT solver says: " uu____1594))
-                in
-             FStar_All.pipe_right uu____1584 (FStar_String.concat "; ")  in
+                       let uu____1594 = error_to_short_string e in
+                       Prims.strcat "SMT solver says: " uu____1594)) in
+             FStar_All.pipe_right uu____1584 (FStar_String.concat "; ") in
            let uu____1597 =
              let uu____1606 =
                let uu____1613 =
                  FStar_Util.format1 "Unknown assertion failed (%s)"
-                   err_detail
-                  in
+                   err_detail in
                (FStar_Errors.Error_UnknownFatal_AssertionFailure, uu____1613,
-                 (settings.query_range))
-                in
-             [uu____1606]  in
+                 (settings.query_range)) in
+             [uu____1606] in
            FStar_TypeChecker_Err.add_errors settings.query_env uu____1597)
-  
-let (query_info :
-  query_settings -> FStar_SMTEncoding_Z3.z3result -> Prims.unit) =
+let query_info: query_settings -> FStar_SMTEncoding_Z3.z3result -> Prims.unit
+  =
   fun settings  ->
     fun z3result  ->
       let uu____1632 =
         (FStar_Options.hint_info ()) ||
-          (FStar_Options.print_z3_statistics ())
-         in
+          (FStar_Options.print_z3_statistics ()) in
       if uu____1632
       then
         let uu____1633 =
           FStar_SMTEncoding_Z3.status_string_and_errors
-            z3result.FStar_SMTEncoding_Z3.z3result_status
-           in
+            z3result.FStar_SMTEncoding_Z3.z3result_status in
         match uu____1633 with
         | (status_string,errs) ->
             let tag =
@@ -790,72 +731,64 @@ let (query_info :
               | FStar_SMTEncoding_Z3.UNSAT uu____1641 -> "succeeded"
               | uu____1642 ->
                   Prims.strcat "failed {reason-unknown="
-                    (Prims.strcat status_string "}")
-               in
+                    (Prims.strcat status_string "}") in
             let range =
               let uu____1644 =
                 let uu____1645 =
-                  FStar_Range.string_of_range settings.query_range  in
+                  FStar_Range.string_of_range settings.query_range in
                 let uu____1646 =
-                  let uu____1647 = FStar_SMTEncoding_Z3.at_log_file ()  in
-                  Prims.strcat uu____1647 ")"  in
-                Prims.strcat uu____1645 uu____1646  in
-              Prims.strcat "(" uu____1644  in
+                  let uu____1647 = FStar_SMTEncoding_Z3.at_log_file () in
+                  Prims.strcat uu____1647 ")" in
+                Prims.strcat uu____1645 uu____1646 in
+              Prims.strcat "(" uu____1644 in
             let used_hint_tag =
-              if used_hint settings then " (with hint)" else ""  in
+              if used_hint settings then " (with hint)" else "" in
             let stats =
-              let uu____1651 = FStar_Options.print_z3_statistics ()  in
+              let uu____1651 = FStar_Options.print_z3_statistics () in
               if uu____1651
               then
                 let f k v1 a =
                   Prims.strcat a
-                    (Prims.strcat k (Prims.strcat "=" (Prims.strcat v1 " ")))
-                   in
+                    (Prims.strcat k (Prims.strcat "=" (Prims.strcat v1 " "))) in
                 let str =
                   FStar_Util.smap_fold
                     z3result.FStar_SMTEncoding_Z3.z3result_statistics f
-                    "statistics={"
-                   in
+                    "statistics={" in
                 let uu____1663 =
                   FStar_Util.substring str (Prims.parse_int "0")
-                    ((FStar_String.length str) - (Prims.parse_int "1"))
-                   in
+                    ((FStar_String.length str) - (Prims.parse_int "1")) in
                 Prims.strcat uu____1663 "}"
-              else ""  in
+              else "" in
             ((let uu____1666 =
                 let uu____1669 =
                   let uu____1672 =
                     let uu____1675 =
-                      FStar_Util.string_of_int settings.query_index  in
+                      FStar_Util.string_of_int settings.query_index in
                     let uu____1676 =
                       let uu____1679 =
                         let uu____1682 =
                           let uu____1685 =
                             FStar_Util.string_of_int
-                              z3result.FStar_SMTEncoding_Z3.z3result_time
-                             in
+                              z3result.FStar_SMTEncoding_Z3.z3result_time in
                           let uu____1686 =
                             let uu____1689 =
-                              FStar_Util.string_of_int settings.query_fuel
-                               in
+                              FStar_Util.string_of_int settings.query_fuel in
                             let uu____1690 =
                               let uu____1693 =
-                                FStar_Util.string_of_int settings.query_ifuel
-                                 in
+                                FStar_Util.string_of_int settings.query_ifuel in
                               let uu____1694 =
                                 let uu____1697 =
                                   FStar_Util.string_of_int
-                                    settings.query_rlimit
-                                   in
-                                [uu____1697; stats]  in
-                              uu____1693 :: uu____1694  in
-                            uu____1689 :: uu____1690  in
-                          uu____1685 :: uu____1686  in
-                        used_hint_tag :: uu____1682  in
-                      tag :: uu____1679  in
-                    uu____1675 :: uu____1676  in
-                  (settings.query_name) :: uu____1672  in
-                range :: uu____1669  in
+                                    settings.query_rlimit in
+                                [uu____1697; stats] in
+                              uu____1693 :: uu____1694 in
+                            uu____1689 :: uu____1690 in
+                          uu____1685 :: uu____1686 in
+                        used_hint_tag :: uu____1682 in
+                      tag :: uu____1679 in
+                    uu____1675 :: uu____1676 in
+                  (settings.query_name) :: uu____1672 in
+                range :: uu____1669 in
               FStar_Util.print
                 "%s\tQuery-stats (%s, %s)\t%s%s in %s milliseconds with fuel %s and ifuel %s and rlimit %s %s\n"
                 uu____1666);
@@ -867,19 +800,18 @@ let (query_info :
                          let tag1 =
                            if used_hint settings
                            then "(Hint-replay failed): "
-                           else ""  in
+                           else "" in
                          FStar_Errors.log_issue range1
                            (FStar_Errors.Warning_HitReplayFailed,
                              (Prims.strcat tag1 msg)))))
       else ()
-  
-let (record_hint :
-  query_settings -> FStar_SMTEncoding_Z3.z3result -> Prims.unit) =
+let record_hint:
+  query_settings -> FStar_SMTEncoding_Z3.z3result -> Prims.unit =
   fun settings  ->
     fun z3result  ->
       let uu____1728 =
-        let uu____1729 = FStar_Options.record_hints ()  in
-        Prims.op_Negation uu____1729  in
+        let uu____1729 = FStar_Options.record_hints () in
+        Prims.op_Negation uu____1729 in
       if uu____1728
       then ()
       else
@@ -896,47 +828,44 @@ let (record_hint :
                 | FStar_SMTEncoding_Z3.UNSAT core1 ->
                     z3result.FStar_SMTEncoding_Z3.z3result_query_hash
                 | uu____1747 -> FStar_Pervasives_Native.None)
-           }  in
+           } in
          let store_hint hint =
-           let uu____1752 = FStar_ST.op_Bang recorded_hints  in
+           let uu____1752 = FStar_ST.op_Bang recorded_hints in
            match uu____1752 with
            | FStar_Pervasives_Native.Some l ->
                FStar_ST.op_Colon_Equals recorded_hints
                  (FStar_Pervasives_Native.Some
                     (FStar_List.append l [FStar_Pervasives_Native.Some hint]))
-           | uu____1812 -> ()  in
+           | uu____1812 -> () in
          match z3result.FStar_SMTEncoding_Z3.z3result_status with
          | FStar_SMTEncoding_Z3.UNSAT (FStar_Pervasives_Native.None ) ->
              let uu____1820 =
                let uu____1821 =
-                 get_hint_for settings.query_name settings.query_index  in
-               FStar_Option.get uu____1821  in
+                 get_hint_for settings.query_name settings.query_index in
+               FStar_Option.get uu____1821 in
              store_hint uu____1820
          | FStar_SMTEncoding_Z3.UNSAT unsat_core ->
              if used_hint settings
              then store_hint (mk_hint settings.query_hint)
              else store_hint (mk_hint unsat_core)
          | uu____1826 -> ())
-  
-let (process_result :
+let process_result:
   query_settings ->
-    FStar_SMTEncoding_Z3.z3result -> errors FStar_Pervasives_Native.option)
+    FStar_SMTEncoding_Z3.z3result -> errors FStar_Pervasives_Native.option
   =
   fun settings  ->
     fun result  ->
       (let uu____1838 =
          (used_hint settings) &&
-           (let uu____1840 = FStar_Options.z3_refresh ()  in
-            Prims.op_Negation uu____1840)
-          in
+           (let uu____1840 = FStar_Options.z3_refresh () in
+            Prims.op_Negation uu____1840) in
        if uu____1838 then FStar_SMTEncoding_Z3.refresh () else ());
-      (let errs = query_errors settings result  in
+      (let errs = query_errors settings result in
        query_info settings result;
        record_hint settings result;
        detail_hint_replay settings result;
        errs)
-  
-let (fold_queries :
+let fold_queries:
   query_settings Prims.list ->
     (query_settings ->
        (FStar_SMTEncoding_Z3.z3result -> Prims.unit) -> Prims.unit)
@@ -944,7 +873,7 @@ let (fold_queries :
       (query_settings ->
          FStar_SMTEncoding_Z3.z3result ->
            errors FStar_Pervasives_Native.option)
-        -> (errors Prims.list -> Prims.unit) -> Prims.unit)
+        -> (errors Prims.list -> Prims.unit) -> Prims.unit
   =
   fun qs  ->
     fun ask1  ->
@@ -956,20 +885,18 @@ let (fold_queries :
             | q::qs2 ->
                 ask1 q
                   (fun res  ->
-                     let uu____1926 = f q res  in
+                     let uu____1926 = f q res in
                      match uu____1926 with
                      | FStar_Pervasives_Native.None  -> ()
                      | FStar_Pervasives_Native.Some errs ->
-                         aux (errs :: acc) qs2)
-             in
+                         aux (errs :: acc) qs2) in
           aux [] qs
-  
-let (ask_and_report_errors :
+let ask_and_report_errors:
   FStar_TypeChecker_Env.env ->
     FStar_SMTEncoding_Term.error_labels ->
       FStar_SMTEncoding_Term.decl Prims.list ->
         FStar_SMTEncoding_Term.decl ->
-          FStar_SMTEncoding_Term.decl Prims.list -> Prims.unit)
+          FStar_SMTEncoding_Term.decl Prims.list -> Prims.unit
   =
   fun env  ->
     fun all_labels  ->
@@ -983,21 +910,20 @@ let (ask_and_report_errors :
                  | FStar_Pervasives_Native.None  ->
                      failwith "No query name set!"
                  | FStar_Pervasives_Native.Some (q,n1) ->
-                     ((FStar_Ident.text_of_lid q), n1)
-                  in
+                     ((FStar_Ident.text_of_lid q), n1) in
                match uu____1961 with
                | (qname,index1) ->
                    let rlimit =
-                     let uu____1993 = FStar_Options.z3_rlimit_factor ()  in
+                     let uu____1993 = FStar_Options.z3_rlimit_factor () in
                      let uu____1994 =
-                       let uu____1995 = FStar_Options.z3_rlimit ()  in
-                       uu____1995 * (Prims.parse_int "544656")  in
-                     uu____1993 * uu____1994  in
-                   let next_hint = get_hint_for qname index1  in
+                       let uu____1995 = FStar_Options.z3_rlimit () in
+                       uu____1995 * (Prims.parse_int "544656") in
+                     uu____1993 * uu____1994 in
+                   let next_hint = get_hint_for qname index1 in
                    let default_settings =
-                     let uu____2000 = FStar_TypeChecker_Env.get_range env  in
-                     let uu____2001 = FStar_Options.initial_fuel ()  in
-                     let uu____2002 = FStar_Options.initial_ifuel ()  in
+                     let uu____2000 = FStar_TypeChecker_Env.get_range env in
+                     let uu____2001 = FStar_Options.initial_fuel () in
+                     let uu____2002 = FStar_Options.initial_ifuel () in
                      {
                        query_env = env;
                        query_decl = query;
@@ -1024,9 +950,8 @@ let (ask_and_report_errors :
                                 FStar_Util.query_elapsed_time = uu____2012;
                                 FStar_Util.hash = h;_}
                               -> h)
-                     }  in
-                   (default_settings, next_hint)
-                in
+                     } in
+                   (default_settings, next_hint) in
              match uu____1954 with
              | (default_settings,next_hint) ->
                  let use_hints_setting =
@@ -1040,7 +965,7 @@ let (ask_and_report_errors :
                          FStar_Util.query_elapsed_time = uu____2038;
                          FStar_Util.hash = h;_}
                        ->
-                       [(let uu___61_2047 = default_settings  in
+                       [(let uu___61_2047 = default_settings in
                          {
                            query_env = (uu___61_2047.query_env);
                            query_decl = (uu___61_2047.query_decl);
@@ -1056,17 +981,17 @@ let (ask_and_report_errors :
                            query_suffix = (uu___61_2047.query_suffix);
                            query_hash = (uu___61_2047.query_hash)
                          })]
-                   | uu____2050 -> []  in
+                   | uu____2050 -> [] in
                  let initial_fuel_max_ifuel =
                    let uu____2056 =
-                     let uu____2057 = FStar_Options.max_ifuel ()  in
-                     let uu____2058 = FStar_Options.initial_ifuel ()  in
-                     uu____2057 > uu____2058  in
+                     let uu____2057 = FStar_Options.max_ifuel () in
+                     let uu____2058 = FStar_Options.initial_ifuel () in
+                     uu____2057 > uu____2058 in
                    if uu____2056
                    then
                      let uu____2061 =
-                       let uu___62_2062 = default_settings  in
-                       let uu____2063 = FStar_Options.max_ifuel ()  in
+                       let uu___62_2062 = default_settings in
+                       let uu____2063 = FStar_Options.max_ifuel () in
                        {
                          query_env = (uu___62_2062.query_env);
                          query_decl = (uu___62_2062.query_decl);
@@ -1081,24 +1006,24 @@ let (ask_and_report_errors :
                          query_all_labels = (uu___62_2062.query_all_labels);
                          query_suffix = (uu___62_2062.query_suffix);
                          query_hash = (uu___62_2062.query_hash)
-                       }  in
+                       } in
                      [uu____2061]
-                   else []  in
+                   else [] in
                  let half_max_fuel_max_ifuel =
                    let uu____2068 =
                      let uu____2069 =
-                       let uu____2070 = FStar_Options.max_fuel ()  in
-                       uu____2070 / (Prims.parse_int "2")  in
-                     let uu____2077 = FStar_Options.initial_fuel ()  in
-                     uu____2069 > uu____2077  in
+                       let uu____2070 = FStar_Options.max_fuel () in
+                       uu____2070 / (Prims.parse_int "2") in
+                     let uu____2077 = FStar_Options.initial_fuel () in
+                     uu____2069 > uu____2077 in
                    if uu____2068
                    then
                      let uu____2080 =
-                       let uu___63_2081 = default_settings  in
+                       let uu___63_2081 = default_settings in
                        let uu____2082 =
-                         let uu____2083 = FStar_Options.max_fuel ()  in
-                         uu____2083 / (Prims.parse_int "2")  in
-                       let uu____2090 = FStar_Options.max_ifuel ()  in
+                         let uu____2083 = FStar_Options.max_fuel () in
+                         uu____2083 / (Prims.parse_int "2") in
+                       let uu____2090 = FStar_Options.max_ifuel () in
                        {
                          query_env = (uu___63_2081.query_env);
                          query_decl = (uu___63_2081.query_decl);
@@ -1113,24 +1038,23 @@ let (ask_and_report_errors :
                          query_all_labels = (uu___63_2081.query_all_labels);
                          query_suffix = (uu___63_2081.query_suffix);
                          query_hash = (uu___63_2081.query_hash)
-                       }  in
+                       } in
                      [uu____2080]
-                   else []  in
+                   else [] in
                  let max_fuel_max_ifuel =
                    let uu____2095 =
-                     (let uu____2100 = FStar_Options.max_fuel ()  in
-                      let uu____2101 = FStar_Options.initial_fuel ()  in
+                     (let uu____2100 = FStar_Options.max_fuel () in
+                      let uu____2101 = FStar_Options.initial_fuel () in
                       uu____2100 > uu____2101) &&
-                       (let uu____2104 = FStar_Options.max_ifuel ()  in
-                        let uu____2105 = FStar_Options.initial_ifuel ()  in
-                        uu____2104 >= uu____2105)
-                      in
+                       (let uu____2104 = FStar_Options.max_ifuel () in
+                        let uu____2105 = FStar_Options.initial_ifuel () in
+                        uu____2104 >= uu____2105) in
                    if uu____2095
                    then
                      let uu____2108 =
-                       let uu___64_2109 = default_settings  in
-                       let uu____2110 = FStar_Options.max_fuel ()  in
-                       let uu____2111 = FStar_Options.max_ifuel ()  in
+                       let uu___64_2109 = default_settings in
+                       let uu____2110 = FStar_Options.max_fuel () in
+                       let uu____2111 = FStar_Options.max_ifuel () in
                        {
                          query_env = (uu___64_2109.query_env);
                          query_decl = (uu___64_2109.query_decl);
@@ -1145,19 +1069,19 @@ let (ask_and_report_errors :
                          query_all_labels = (uu___64_2109.query_all_labels);
                          query_suffix = (uu___64_2109.query_suffix);
                          query_hash = (uu___64_2109.query_hash)
-                       }  in
+                       } in
                      [uu____2108]
-                   else []  in
+                   else [] in
                  let min_fuel1 =
                    let uu____2116 =
-                     let uu____2117 = FStar_Options.min_fuel ()  in
-                     let uu____2118 = FStar_Options.initial_fuel ()  in
-                     uu____2117 < uu____2118  in
+                     let uu____2117 = FStar_Options.min_fuel () in
+                     let uu____2118 = FStar_Options.initial_fuel () in
+                     uu____2117 < uu____2118 in
                    if uu____2116
                    then
                      let uu____2121 =
-                       let uu___65_2122 = default_settings  in
-                       let uu____2123 = FStar_Options.min_fuel ()  in
+                       let uu___65_2122 = default_settings in
+                       let uu____2123 = FStar_Options.min_fuel () in
                        {
                          query_env = (uu___65_2122.query_env);
                          query_decl = (uu___65_2122.query_decl);
@@ -1172,36 +1096,33 @@ let (ask_and_report_errors :
                          query_all_labels = (uu___65_2122.query_all_labels);
                          query_suffix = (uu___65_2122.query_suffix);
                          query_hash = (uu___65_2122.query_hash)
-                       }  in
+                       } in
                      [uu____2121]
-                   else []  in
+                   else [] in
                  let all_configs =
                    FStar_List.append use_hints_setting
                      (FStar_List.append [default_settings]
                         (FStar_List.append initial_fuel_max_ifuel
                            (FStar_List.append half_max_fuel_max_ifuel
-                              max_fuel_max_ifuel)))
-                    in
+                              max_fuel_max_ifuel))) in
                  let check_one_config config k =
                    (let uu____2141 =
-                      (used_hint config) || (FStar_Options.z3_refresh ())  in
+                      (used_hint config) || (FStar_Options.z3_refresh ()) in
                     if uu____2141
                     then FStar_SMTEncoding_Z3.refresh ()
                     else ());
-                   (let uu____2143 = with_fuel_and_diagnostics config []  in
+                   (let uu____2143 = with_fuel_and_diagnostics config [] in
                     let uu____2146 =
-                      let uu____2149 = FStar_SMTEncoding_Z3.mk_fresh_scope ()
-                         in
-                      FStar_Pervasives_Native.Some uu____2149  in
+                      let uu____2149 = FStar_SMTEncoding_Z3.mk_fresh_scope () in
+                      FStar_Pervasives_Native.Some uu____2149 in
                     FStar_SMTEncoding_Z3.ask
                       (filter_assertions config.query_env config.query_hint)
                       config.query_hash config.query_all_labels uu____2143
-                      uu____2146 k)
-                    in
+                      uu____2146 k) in
                  let check_all_configs configs =
                    let report1 errs =
                      report_errors
-                       (let uu___66_2168 = default_settings  in
+                       (let uu___66_2168 = default_settings in
                         {
                           query_env = (uu___66_2168.query_env);
                           query_decl = (uu___66_2168.query_decl);
@@ -1216,15 +1137,13 @@ let (ask_and_report_errors :
                           query_all_labels = (uu___66_2168.query_all_labels);
                           query_suffix = (uu___66_2168.query_suffix);
                           query_hash = (uu___66_2168.query_hash)
-                        })
-                      in
+                        }) in
                    fold_queries configs check_one_config process_result
-                     report1
-                    in
+                     report1 in
                  let uu____2169 =
-                   let uu____2176 = FStar_Options.admit_smt_queries ()  in
-                   let uu____2177 = FStar_Options.admit_except ()  in
-                   (uu____2176, uu____2177)  in
+                   let uu____2176 = FStar_Options.admit_smt_queries () in
+                   let uu____2177 = FStar_Options.admit_except () in
+                   (uu____2176, uu____2177) in
                  (match uu____2169 with
                   | (true ,uu____2182) -> ()
                   | (false ,FStar_Pervasives_Native.None ) ->
@@ -1239,47 +1158,42 @@ let (ask_and_report_errors :
                                 let uu____2196 =
                                   let uu____2197 =
                                     FStar_Util.string_of_int
-                                      default_settings.query_index
-                                     in
-                                  Prims.strcat uu____2197 ")"  in
-                                Prims.strcat ", " uu____2196  in
+                                      default_settings.query_index in
+                                  Prims.strcat uu____2197 ")" in
+                                Prims.strcat ", " uu____2196 in
                               Prims.strcat default_settings.query_name
-                                uu____2195
-                               in
-                            Prims.strcat "(" uu____2194  in
+                                uu____2195 in
+                            Prims.strcat "(" uu____2194 in
                           full_query_id <> id1
-                        else default_settings.query_name <> id1  in
+                        else default_settings.query_name <> id1 in
                       if Prims.op_Negation skip
                       then check_all_configs all_configs
                       else ()))
-  
-let (solve :
+let solve:
   (Prims.unit -> Prims.string) FStar_Pervasives_Native.option ->
-    FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.unit)
+    FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.unit
   =
   fun use_env_msg  ->
     fun tcenv  ->
       fun q  ->
         (let uu____2219 =
            let uu____2220 =
-             let uu____2221 = FStar_TypeChecker_Env.get_range tcenv  in
-             FStar_All.pipe_left FStar_Range.string_of_range uu____2221  in
-           FStar_Util.format1 "Starting query at %s" uu____2220  in
+             let uu____2221 = FStar_TypeChecker_Env.get_range tcenv in
+             FStar_All.pipe_left FStar_Range.string_of_range uu____2221 in
+           FStar_Util.format1 "Starting query at %s" uu____2220 in
          FStar_SMTEncoding_Encode.push uu____2219);
-        (let tcenv1 = FStar_TypeChecker_Env.incr_query_index tcenv  in
+        (let tcenv1 = FStar_TypeChecker_Env.incr_query_index tcenv in
          let uu____2223 =
-           FStar_SMTEncoding_Encode.encode_query use_env_msg tcenv1 q  in
+           FStar_SMTEncoding_Encode.encode_query use_env_msg tcenv1 q in
          match uu____2223 with
          | (prefix1,labels,qry,suffix) ->
              let pop1 uu____2257 =
                let uu____2258 =
                  let uu____2259 =
-                   let uu____2260 = FStar_TypeChecker_Env.get_range tcenv1
-                      in
-                   FStar_All.pipe_left FStar_Range.string_of_range uu____2260
-                    in
-                 FStar_Util.format1 "Ending query at %s" uu____2259  in
-               FStar_SMTEncoding_Encode.pop uu____2258  in
+                   let uu____2260 = FStar_TypeChecker_Env.get_range tcenv1 in
+                   FStar_All.pipe_left FStar_Range.string_of_range uu____2260 in
+                 FStar_Util.format1 "Ending query at %s" uu____2259 in
+               FStar_SMTEncoding_Encode.pop uu____2258 in
              (match qry with
               | FStar_SMTEncoding_Term.Assume
                   {
@@ -1299,8 +1213,7 @@ let (solve :
                   (ask_and_report_errors tcenv1 labels prefix1 qry suffix;
                    pop1 ())
               | uu____2284 -> failwith "Impossible"))
-  
-let (solver : FStar_TypeChecker_Env.solver_t) =
+let solver: FStar_TypeChecker_Env.solver_t =
   {
     FStar_TypeChecker_Env.init = FStar_SMTEncoding_Encode.init;
     FStar_TypeChecker_Env.push = FStar_SMTEncoding_Encode.push;
@@ -1312,14 +1225,13 @@ let (solver : FStar_TypeChecker_Env.solver_t) =
       (fun e  ->
          fun g  ->
            let uu____2290 =
-             let uu____2297 = FStar_Options.peek ()  in (e, g, uu____2297)
-              in
+             let uu____2297 = FStar_Options.peek () in (e, g, uu____2297) in
            [uu____2290]);
     FStar_TypeChecker_Env.solve = solve;
     FStar_TypeChecker_Env.finish = FStar_SMTEncoding_Z3.finish;
     FStar_TypeChecker_Env.refresh = FStar_SMTEncoding_Z3.refresh
-  } 
-let (dummy : FStar_TypeChecker_Env.solver_t) =
+  }
+let dummy: FStar_TypeChecker_Env.solver_t =
   {
     FStar_TypeChecker_Env.init = (fun uu____2312  -> ());
     FStar_TypeChecker_Env.push = (fun uu____2314  -> ());
@@ -1332,11 +1244,10 @@ let (dummy : FStar_TypeChecker_Env.solver_t) =
       (fun e  ->
          fun g  ->
            let uu____2330 =
-             let uu____2337 = FStar_Options.peek ()  in (e, g, uu____2337)
-              in
+             let uu____2337 = FStar_Options.peek () in (e, g, uu____2337) in
            [uu____2330]);
     FStar_TypeChecker_Env.solve =
       (fun uu____2353  -> fun uu____2354  -> fun uu____2355  -> ());
     FStar_TypeChecker_Env.finish = (fun uu____2361  -> ());
     FStar_TypeChecker_Env.refresh = (fun uu____2363  -> ())
-  } 
+  }

--- a/src/ocaml-output/FStar_SMTEncoding_SplitQueryCases.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_SplitQueryCases.ml
@@ -1,11 +1,11 @@
 open Prims
-let rec (get_next_n_ite :
+let rec get_next_n_ite:
   Prims.int ->
     FStar_SMTEncoding_Term.term ->
       FStar_SMTEncoding_Term.term ->
         (FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) ->
           (Prims.bool,FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term,
-            FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple4)
+            FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple4
   =
   fun n1  ->
     fun t  ->
@@ -13,7 +13,7 @@ let rec (get_next_n_ite :
         fun f  ->
           if n1 <= (Prims.parse_int "0")
           then
-            let uu____34 = f FStar_SMTEncoding_Util.mkTrue  in
+            let uu____34 = f FStar_SMTEncoding_Util.mkTrue in
             (true, uu____34, negs, t)
           else
             (match t.FStar_SMTEncoding_Term.tm with
@@ -21,29 +21,27 @@ let rec (get_next_n_ite :
                  (FStar_SMTEncoding_Term.ITE ,g::t1::e::uu____47) ->
                  let uu____52 =
                    let uu____53 =
-                     let uu____58 = FStar_SMTEncoding_Util.mkNot g  in
-                     (negs, uu____58)  in
-                   FStar_SMTEncoding_Util.mkAnd uu____53  in
+                     let uu____58 = FStar_SMTEncoding_Util.mkNot g in
+                     (negs, uu____58) in
+                   FStar_SMTEncoding_Util.mkAnd uu____53 in
                  get_next_n_ite (n1 - (Prims.parse_int "1")) e uu____52
                    (fun x  ->
-                      let uu____62 = FStar_SMTEncoding_Util.mkITE (g, t1, x)
-                         in
+                      let uu____62 = FStar_SMTEncoding_Util.mkITE (g, t1, x) in
                       f uu____62)
              | FStar_SMTEncoding_Term.FreeV uu____63 ->
-                 let uu____68 = f FStar_SMTEncoding_Util.mkTrue  in
+                 let uu____68 = f FStar_SMTEncoding_Util.mkTrue in
                  (true, uu____68, negs, t)
              | uu____69 ->
                  (false, FStar_SMTEncoding_Util.mkFalse,
                    FStar_SMTEncoding_Util.mkFalse,
                    FStar_SMTEncoding_Util.mkFalse))
-  
-let rec (is_ite_all_the_way :
+let rec is_ite_all_the_way:
   Prims.int ->
     FStar_SMTEncoding_Term.term ->
       FStar_SMTEncoding_Term.term ->
         FStar_SMTEncoding_Term.term Prims.list ->
           (Prims.bool,FStar_SMTEncoding_Term.term Prims.list,FStar_SMTEncoding_Term.term)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun n1  ->
     fun t  ->
@@ -56,24 +54,23 @@ let rec (is_ite_all_the_way :
              | FStar_SMTEncoding_Term.FreeV uu____119 ->
                  let uu____124 =
                    let uu____125 =
-                     let uu____130 = FStar_SMTEncoding_Util.mkNot t  in
-                     (negs, uu____130)  in
-                   FStar_SMTEncoding_Util.mkAnd uu____125  in
+                     let uu____130 = FStar_SMTEncoding_Util.mkNot t in
+                     (negs, uu____130) in
+                   FStar_SMTEncoding_Util.mkAnd uu____125 in
                  (true, l, uu____124)
              | uu____133 ->
-                 let uu____134 = get_next_n_ite n1 t negs (fun x  -> x)  in
+                 let uu____134 = get_next_n_ite n1 t negs (fun x  -> x) in
                  (match uu____134 with
                   | (b,t1,negs',rest) ->
                       if b
                       then
                         let uu____165 =
                           let uu____168 =
-                            FStar_SMTEncoding_Util.mkImp (negs, t1)  in
-                          uu____168 :: l  in
+                            FStar_SMTEncoding_Util.mkImp (negs, t1) in
+                          uu____168 :: l in
                         is_ite_all_the_way n1 rest negs' uu____165
                       else (false, [], FStar_SMTEncoding_Util.mkFalse)))
-  
-let rec (parse_query_for_split_cases :
+let rec parse_query_for_split_cases:
   Prims.int ->
     FStar_SMTEncoding_Term.term ->
       (FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) ->
@@ -81,7 +78,7 @@ let rec (parse_query_for_split_cases :
                        FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term
                                                      Prims.list,FStar_SMTEncoding_Term.term)
                       FStar_Pervasives_Native.tuple3)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun n1  ->
     fun t  ->
@@ -92,7 +89,7 @@ let rec (parse_query_for_split_cases :
             parse_query_for_split_cases n1 t1
               (fun x  ->
                  let uu____237 =
-                   FStar_SMTEncoding_Util.mkForall'' (l, opt, l', x)  in
+                   FStar_SMTEncoding_Util.mkForall'' (l, opt, l', x) in
                  f uu____237)
         | FStar_SMTEncoding_Term.App
             (FStar_SMTEncoding_Term.Imp ,t1::t2::uu____248) ->
@@ -104,55 +101,48 @@ let rec (parse_query_for_split_cases :
                   ->
                   parse_query_for_split_cases n1 t2
                     (fun x  ->
-                       let uu____305 = FStar_SMTEncoding_Util.mkImp (t1, x)
-                          in
+                       let uu____305 = FStar_SMTEncoding_Util.mkImp (t1, x) in
                        f uu____305)
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.ITE ,uu____306) ->
                   let uu____311 =
-                    is_ite_all_the_way n1 t2 FStar_SMTEncoding_Util.mkTrue []
-                     in
+                    is_ite_all_the_way n1 t2 FStar_SMTEncoding_Util.mkTrue [] in
                   (match uu____311 with
                    | (b,l,negs) ->
                        (b,
                          (((fun x  ->
                               let uu____358 =
-                                FStar_SMTEncoding_Util.mkImp (t1, x)  in
+                                FStar_SMTEncoding_Util.mkImp (t1, x) in
                               f uu____358)), l, negs)))
               | uu____359 ->
                   (false,
                     (((fun uu____375  ->
                          FStar_Util.return_all FStar_SMTEncoding_Util.mkFalse)),
-                      [], FStar_SMTEncoding_Util.mkFalse))
-               in
+                      [], FStar_SMTEncoding_Util.mkFalse)) in
             r
         | FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.ITE ,uu____376)
             ->
             let uu____381 =
-              is_ite_all_the_way n1 t FStar_SMTEncoding_Util.mkTrue []  in
+              is_ite_all_the_way n1 t FStar_SMTEncoding_Util.mkTrue [] in
             (match uu____381 with | (b,l,negs) -> (b, (f, l, negs)))
         | uu____425 ->
             (false,
               (((fun uu____441  ->
                    FStar_Util.return_all FStar_SMTEncoding_Util.mkFalse)),
                 [], FStar_SMTEncoding_Util.mkFalse))
-  
-let (strip_not : FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term)
-  =
+let strip_not: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
   fun t  ->
     match t.FStar_SMTEncoding_Term.tm with
     | FStar_SMTEncoding_Term.App (FStar_SMTEncoding_Term.Not ,hd1::uu____446)
         -> hd1
     | uu____451 -> t
-  
-let (handle_query :
+let handle_query:
   (FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term
                                                                 Prims.list,
     FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple3 ->
-    (FStar_SMTEncoding_Term.decl -> Prims.unit) -> Prims.unit)
+    (FStar_SMTEncoding_Term.decl -> Prims.unit) -> Prims.unit
   =
   fun uu____470  ->
     fun check  ->
       match uu____470 with
       | (f,l,negs) -> failwith "SplitQueryCases is not currently supported"
-  

--- a/src/ocaml-output/FStar_SMTEncoding_Term.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Term.ml
@@ -1,61 +1,52 @@
 open Prims
 type sort =
-  | Bool_sort 
-  | Int_sort 
-  | String_sort 
-  | Term_sort 
-  | Fuel_sort 
-  | BitVec_sort of Prims.int 
-  | Array of (sort,sort) FStar_Pervasives_Native.tuple2 
-  | Arrow of (sort,sort) FStar_Pervasives_Native.tuple2 
-  | Sort of Prims.string [@@deriving show]
-let (uu___is_Bool_sort : sort -> Prims.bool) =
+  | Bool_sort
+  | Int_sort
+  | String_sort
+  | Term_sort
+  | Fuel_sort
+  | BitVec_sort of Prims.int
+  | Array of (sort,sort) FStar_Pervasives_Native.tuple2
+  | Arrow of (sort,sort) FStar_Pervasives_Native.tuple2
+  | Sort of Prims.string[@@deriving show]
+let uu___is_Bool_sort: sort -> Prims.bool =
   fun projectee  ->
     match projectee with | Bool_sort  -> true | uu____28 -> false
-  
-let (uu___is_Int_sort : sort -> Prims.bool) =
+let uu___is_Int_sort: sort -> Prims.bool =
   fun projectee  ->
     match projectee with | Int_sort  -> true | uu____32 -> false
-  
-let (uu___is_String_sort : sort -> Prims.bool) =
+let uu___is_String_sort: sort -> Prims.bool =
   fun projectee  ->
     match projectee with | String_sort  -> true | uu____36 -> false
-  
-let (uu___is_Term_sort : sort -> Prims.bool) =
+let uu___is_Term_sort: sort -> Prims.bool =
   fun projectee  ->
     match projectee with | Term_sort  -> true | uu____40 -> false
-  
-let (uu___is_Fuel_sort : sort -> Prims.bool) =
+let uu___is_Fuel_sort: sort -> Prims.bool =
   fun projectee  ->
     match projectee with | Fuel_sort  -> true | uu____44 -> false
-  
-let (uu___is_BitVec_sort : sort -> Prims.bool) =
+let uu___is_BitVec_sort: sort -> Prims.bool =
   fun projectee  ->
     match projectee with | BitVec_sort _0 -> true | uu____49 -> false
-  
-let (__proj__BitVec_sort__item___0 : sort -> Prims.int) =
-  fun projectee  -> match projectee with | BitVec_sort _0 -> _0 
-let (uu___is_Array : sort -> Prims.bool) =
+let __proj__BitVec_sort__item___0: sort -> Prims.int =
+  fun projectee  -> match projectee with | BitVec_sort _0 -> _0
+let uu___is_Array: sort -> Prims.bool =
   fun projectee  ->
     match projectee with | Array _0 -> true | uu____65 -> false
-  
-let (__proj__Array__item___0 :
-  sort -> (sort,sort) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Array _0 -> _0 
-let (uu___is_Arrow : sort -> Prims.bool) =
+let __proj__Array__item___0:
+  sort -> (sort,sort) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Array _0 -> _0
+let uu___is_Arrow: sort -> Prims.bool =
   fun projectee  ->
     match projectee with | Arrow _0 -> true | uu____93 -> false
-  
-let (__proj__Arrow__item___0 :
-  sort -> (sort,sort) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Arrow _0 -> _0 
-let (uu___is_Sort : sort -> Prims.bool) =
+let __proj__Arrow__item___0:
+  sort -> (sort,sort) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Arrow _0 -> _0
+let uu___is_Sort: sort -> Prims.bool =
   fun projectee  ->
     match projectee with | Sort _0 -> true | uu____117 -> false
-  
-let (__proj__Sort__item___0 : sort -> Prims.string) =
-  fun projectee  -> match projectee with | Sort _0 -> _0 
-let rec (strSort : sort -> Prims.string) =
+let __proj__Sort__item___0: sort -> Prims.string =
+  fun projectee  -> match projectee with | Sort _0 -> _0
+let rec strSort: sort -> Prims.string =
   fun x  ->
     match x with
     | Bool_sort  -> "Bool"
@@ -64,272 +55,240 @@ let rec (strSort : sort -> Prims.string) =
     | String_sort  -> "FString"
     | Fuel_sort  -> "Fuel"
     | BitVec_sort n1 ->
-        let uu____129 = FStar_Util.string_of_int n1  in
+        let uu____129 = FStar_Util.string_of_int n1 in
         FStar_Util.format1 "(_ BitVec %s)" uu____129
     | Array (s1,s2) ->
-        let uu____132 = strSort s1  in
-        let uu____133 = strSort s2  in
+        let uu____132 = strSort s1 in
+        let uu____133 = strSort s2 in
         FStar_Util.format2 "(Array %s %s)" uu____132 uu____133
     | Arrow (s1,s2) ->
-        let uu____136 = strSort s1  in
-        let uu____137 = strSort s2  in
+        let uu____136 = strSort s1 in
+        let uu____137 = strSort s2 in
         FStar_Util.format2 "(%s -> %s)" uu____136 uu____137
     | Sort s -> s
-  
 type op =
-  | TrueOp 
-  | FalseOp 
-  | Not 
-  | And 
-  | Or 
-  | Imp 
-  | Iff 
-  | Eq 
-  | LT 
-  | LTE 
-  | GT 
-  | GTE 
-  | Add 
-  | Sub 
-  | Div 
-  | Mul 
-  | Minus 
-  | Mod 
-  | BvAnd 
-  | BvXor 
-  | BvOr 
-  | BvAdd 
-  | BvSub 
-  | BvShl 
-  | BvShr 
-  | BvUdiv 
-  | BvMod 
-  | BvMul 
-  | BvUlt 
-  | BvUext of Prims.int 
-  | NatToBv of Prims.int 
-  | BvToNat 
-  | ITE 
-  | Var of Prims.string [@@deriving show]
-let (uu___is_TrueOp : op -> Prims.bool) =
+  | TrueOp
+  | FalseOp
+  | Not
+  | And
+  | Or
+  | Imp
+  | Iff
+  | Eq
+  | LT
+  | LTE
+  | GT
+  | GTE
+  | Add
+  | Sub
+  | Div
+  | Mul
+  | Minus
+  | Mod
+  | BvAnd
+  | BvXor
+  | BvOr
+  | BvAdd
+  | BvSub
+  | BvShl
+  | BvShr
+  | BvUdiv
+  | BvMod
+  | BvMul
+  | BvUlt
+  | BvUext of Prims.int
+  | NatToBv of Prims.int
+  | BvToNat
+  | ITE
+  | Var of Prims.string[@@deriving show]
+let uu___is_TrueOp: op -> Prims.bool =
   fun projectee  ->
     match projectee with | TrueOp  -> true | uu____154 -> false
-  
-let (uu___is_FalseOp : op -> Prims.bool) =
+let uu___is_FalseOp: op -> Prims.bool =
   fun projectee  ->
     match projectee with | FalseOp  -> true | uu____158 -> false
-  
-let (uu___is_Not : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Not  -> true | uu____162 -> false 
-let (uu___is_And : op -> Prims.bool) =
-  fun projectee  -> match projectee with | And  -> true | uu____166 -> false 
-let (uu___is_Or : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Or  -> true | uu____170 -> false 
-let (uu___is_Imp : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Imp  -> true | uu____174 -> false 
-let (uu___is_Iff : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Iff  -> true | uu____178 -> false 
-let (uu___is_Eq : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Eq  -> true | uu____182 -> false 
-let (uu___is_LT : op -> Prims.bool) =
-  fun projectee  -> match projectee with | LT  -> true | uu____186 -> false 
-let (uu___is_LTE : op -> Prims.bool) =
-  fun projectee  -> match projectee with | LTE  -> true | uu____190 -> false 
-let (uu___is_GT : op -> Prims.bool) =
-  fun projectee  -> match projectee with | GT  -> true | uu____194 -> false 
-let (uu___is_GTE : op -> Prims.bool) =
-  fun projectee  -> match projectee with | GTE  -> true | uu____198 -> false 
-let (uu___is_Add : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Add  -> true | uu____202 -> false 
-let (uu___is_Sub : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Sub  -> true | uu____206 -> false 
-let (uu___is_Div : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Div  -> true | uu____210 -> false 
-let (uu___is_Mul : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Mul  -> true | uu____214 -> false 
-let (uu___is_Minus : op -> Prims.bool) =
+let uu___is_Not: op -> Prims.bool =
+  fun projectee  -> match projectee with | Not  -> true | uu____162 -> false
+let uu___is_And: op -> Prims.bool =
+  fun projectee  -> match projectee with | And  -> true | uu____166 -> false
+let uu___is_Or: op -> Prims.bool =
+  fun projectee  -> match projectee with | Or  -> true | uu____170 -> false
+let uu___is_Imp: op -> Prims.bool =
+  fun projectee  -> match projectee with | Imp  -> true | uu____174 -> false
+let uu___is_Iff: op -> Prims.bool =
+  fun projectee  -> match projectee with | Iff  -> true | uu____178 -> false
+let uu___is_Eq: op -> Prims.bool =
+  fun projectee  -> match projectee with | Eq  -> true | uu____182 -> false
+let uu___is_LT: op -> Prims.bool =
+  fun projectee  -> match projectee with | LT  -> true | uu____186 -> false
+let uu___is_LTE: op -> Prims.bool =
+  fun projectee  -> match projectee with | LTE  -> true | uu____190 -> false
+let uu___is_GT: op -> Prims.bool =
+  fun projectee  -> match projectee with | GT  -> true | uu____194 -> false
+let uu___is_GTE: op -> Prims.bool =
+  fun projectee  -> match projectee with | GTE  -> true | uu____198 -> false
+let uu___is_Add: op -> Prims.bool =
+  fun projectee  -> match projectee with | Add  -> true | uu____202 -> false
+let uu___is_Sub: op -> Prims.bool =
+  fun projectee  -> match projectee with | Sub  -> true | uu____206 -> false
+let uu___is_Div: op -> Prims.bool =
+  fun projectee  -> match projectee with | Div  -> true | uu____210 -> false
+let uu___is_Mul: op -> Prims.bool =
+  fun projectee  -> match projectee with | Mul  -> true | uu____214 -> false
+let uu___is_Minus: op -> Prims.bool =
   fun projectee  ->
     match projectee with | Minus  -> true | uu____218 -> false
-  
-let (uu___is_Mod : op -> Prims.bool) =
-  fun projectee  -> match projectee with | Mod  -> true | uu____222 -> false 
-let (uu___is_BvAnd : op -> Prims.bool) =
+let uu___is_Mod: op -> Prims.bool =
+  fun projectee  -> match projectee with | Mod  -> true | uu____222 -> false
+let uu___is_BvAnd: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvAnd  -> true | uu____226 -> false
-  
-let (uu___is_BvXor : op -> Prims.bool) =
+let uu___is_BvXor: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvXor  -> true | uu____230 -> false
-  
-let (uu___is_BvOr : op -> Prims.bool) =
-  fun projectee  -> match projectee with | BvOr  -> true | uu____234 -> false 
-let (uu___is_BvAdd : op -> Prims.bool) =
+let uu___is_BvOr: op -> Prims.bool =
+  fun projectee  -> match projectee with | BvOr  -> true | uu____234 -> false
+let uu___is_BvAdd: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvAdd  -> true | uu____238 -> false
-  
-let (uu___is_BvSub : op -> Prims.bool) =
+let uu___is_BvSub: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvSub  -> true | uu____242 -> false
-  
-let (uu___is_BvShl : op -> Prims.bool) =
+let uu___is_BvShl: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvShl  -> true | uu____246 -> false
-  
-let (uu___is_BvShr : op -> Prims.bool) =
+let uu___is_BvShr: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvShr  -> true | uu____250 -> false
-  
-let (uu___is_BvUdiv : op -> Prims.bool) =
+let uu___is_BvUdiv: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvUdiv  -> true | uu____254 -> false
-  
-let (uu___is_BvMod : op -> Prims.bool) =
+let uu___is_BvMod: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvMod  -> true | uu____258 -> false
-  
-let (uu___is_BvMul : op -> Prims.bool) =
+let uu___is_BvMul: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvMul  -> true | uu____262 -> false
-  
-let (uu___is_BvUlt : op -> Prims.bool) =
+let uu___is_BvUlt: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvUlt  -> true | uu____266 -> false
-  
-let (uu___is_BvUext : op -> Prims.bool) =
+let uu___is_BvUext: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvUext _0 -> true | uu____271 -> false
-  
-let (__proj__BvUext__item___0 : op -> Prims.int) =
-  fun projectee  -> match projectee with | BvUext _0 -> _0 
-let (uu___is_NatToBv : op -> Prims.bool) =
+let __proj__BvUext__item___0: op -> Prims.int =
+  fun projectee  -> match projectee with | BvUext _0 -> _0
+let uu___is_NatToBv: op -> Prims.bool =
   fun projectee  ->
     match projectee with | NatToBv _0 -> true | uu____283 -> false
-  
-let (__proj__NatToBv__item___0 : op -> Prims.int) =
-  fun projectee  -> match projectee with | NatToBv _0 -> _0 
-let (uu___is_BvToNat : op -> Prims.bool) =
+let __proj__NatToBv__item___0: op -> Prims.int =
+  fun projectee  -> match projectee with | NatToBv _0 -> _0
+let uu___is_BvToNat: op -> Prims.bool =
   fun projectee  ->
     match projectee with | BvToNat  -> true | uu____294 -> false
-  
-let (uu___is_ITE : op -> Prims.bool) =
-  fun projectee  -> match projectee with | ITE  -> true | uu____298 -> false 
-let (uu___is_Var : op -> Prims.bool) =
+let uu___is_ITE: op -> Prims.bool =
+  fun projectee  -> match projectee with | ITE  -> true | uu____298 -> false
+let uu___is_Var: op -> Prims.bool =
   fun projectee  ->
     match projectee with | Var _0 -> true | uu____303 -> false
-  
-let (__proj__Var__item___0 : op -> Prims.string) =
-  fun projectee  -> match projectee with | Var _0 -> _0 
+let __proj__Var__item___0: op -> Prims.string =
+  fun projectee  -> match projectee with | Var _0 -> _0
 type qop =
-  | Forall 
-  | Exists [@@deriving show]
-let (uu___is_Forall : qop -> Prims.bool) =
+  | Forall
+  | Exists[@@deriving show]
+let uu___is_Forall: qop -> Prims.bool =
   fun projectee  ->
     match projectee with | Forall  -> true | uu____314 -> false
-  
-let (uu___is_Exists : qop -> Prims.bool) =
+let uu___is_Exists: qop -> Prims.bool =
   fun projectee  ->
     match projectee with | Exists  -> true | uu____318 -> false
-  
 type term' =
-  | Integer of Prims.string 
-  | BoundV of Prims.int 
-  | FreeV of (Prims.string,sort) FStar_Pervasives_Native.tuple2 
-  | App of (op,term Prims.list) FStar_Pervasives_Native.tuple2 
+  | Integer of Prims.string
+  | BoundV of Prims.int
+  | FreeV of (Prims.string,sort) FStar_Pervasives_Native.tuple2
+  | App of (op,term Prims.list) FStar_Pervasives_Native.tuple2
   | Quant of
   (qop,term Prims.list Prims.list,Prims.int FStar_Pervasives_Native.option,
-  sort Prims.list,term) FStar_Pervasives_Native.tuple5 
-  | Let of (term Prims.list,term) FStar_Pervasives_Native.tuple2 
+  sort Prims.list,term) FStar_Pervasives_Native.tuple5
+  | Let of (term Prims.list,term) FStar_Pervasives_Native.tuple2
   | Labeled of (term,Prims.string,FStar_Range.range)
-  FStar_Pervasives_Native.tuple3 
-  | LblPos of (term,Prims.string) FStar_Pervasives_Native.tuple2 [@@deriving
-                                                                   show]
+  FStar_Pervasives_Native.tuple3
+  | LblPos of (term,Prims.string) FStar_Pervasives_Native.tuple2[@@deriving
+                                                                  show]
 and term =
   {
-  tm: term' ;
+  tm: term';
   freevars:
     (Prims.string,sort) FStar_Pervasives_Native.tuple2 Prims.list
-      FStar_Syntax_Syntax.memo
-    ;
-  rng: FStar_Range.range }[@@deriving show]
-let (uu___is_Integer : term' -> Prims.bool) =
+      FStar_Syntax_Syntax.memo;
+  rng: FStar_Range.range;}[@@deriving show]
+let uu___is_Integer: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Integer _0 -> true | uu____440 -> false
-  
-let (__proj__Integer__item___0 : term' -> Prims.string) =
-  fun projectee  -> match projectee with | Integer _0 -> _0 
-let (uu___is_BoundV : term' -> Prims.bool) =
+let __proj__Integer__item___0: term' -> Prims.string =
+  fun projectee  -> match projectee with | Integer _0 -> _0
+let uu___is_BoundV: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | BoundV _0 -> true | uu____452 -> false
-  
-let (__proj__BoundV__item___0 : term' -> Prims.int) =
-  fun projectee  -> match projectee with | BoundV _0 -> _0 
-let (uu___is_FreeV : term' -> Prims.bool) =
+let __proj__BoundV__item___0: term' -> Prims.int =
+  fun projectee  -> match projectee with | BoundV _0 -> _0
+let uu___is_FreeV: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | FreeV _0 -> true | uu____468 -> false
-  
-let (__proj__FreeV__item___0 :
-  term' -> (Prims.string,sort) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | FreeV _0 -> _0 
-let (uu___is_App : term' -> Prims.bool) =
+let __proj__FreeV__item___0:
+  term' -> (Prims.string,sort) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | FreeV _0 -> _0
+let uu___is_App: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | App _0 -> true | uu____498 -> false
-  
-let (__proj__App__item___0 :
-  term' -> (op,term Prims.list) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | App _0 -> _0 
-let (uu___is_Quant : term' -> Prims.bool) =
+let __proj__App__item___0:
+  term' -> (op,term Prims.list) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | App _0 -> _0
+let uu___is_Quant: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Quant _0 -> true | uu____546 -> false
-  
-let (__proj__Quant__item___0 :
+let __proj__Quant__item___0:
   term' ->
     (qop,term Prims.list Prims.list,Prims.int FStar_Pervasives_Native.option,
-      sort Prims.list,term) FStar_Pervasives_Native.tuple5)
-  = fun projectee  -> match projectee with | Quant _0 -> _0 
-let (uu___is_Let : term' -> Prims.bool) =
+      sort Prims.list,term) FStar_Pervasives_Native.tuple5
+  = fun projectee  -> match projectee with | Quant _0 -> _0
+let uu___is_Let: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Let _0 -> true | uu____618 -> false
-  
-let (__proj__Let__item___0 :
-  term' -> (term Prims.list,term) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Let _0 -> _0 
-let (uu___is_Labeled : term' -> Prims.bool) =
+let __proj__Let__item___0:
+  term' -> (term Prims.list,term) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Let _0 -> _0
+let uu___is_Labeled: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Labeled _0 -> true | uu____654 -> false
-  
-let (__proj__Labeled__item___0 :
+let __proj__Labeled__item___0:
   term' ->
-    (term,Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Labeled _0 -> _0 
-let (uu___is_LblPos : term' -> Prims.bool) =
+    (term,Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Labeled _0 -> _0
+let uu___is_LblPos: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | LblPos _0 -> true | uu____688 -> false
-  
-let (__proj__LblPos__item___0 :
-  term' -> (term,Prims.string) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | LblPos _0 -> _0 
-let (__proj__Mkterm__item__tm : term -> term') =
+let __proj__LblPos__item___0:
+  term' -> (term,Prims.string) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | LblPos _0 -> _0
+let __proj__Mkterm__item__tm: term -> term' =
   fun projectee  ->
     match projectee with
     | { tm = __fname__tm; freevars = __fname__freevars; rng = __fname__rng;_}
         -> __fname__tm
-  
-let (__proj__Mkterm__item__freevars :
+let __proj__Mkterm__item__freevars:
   term ->
     (Prims.string,sort) FStar_Pervasives_Native.tuple2 Prims.list
-      FStar_Syntax_Syntax.memo)
+      FStar_Syntax_Syntax.memo
   =
   fun projectee  ->
     match projectee with
     | { tm = __fname__tm; freevars = __fname__freevars; rng = __fname__rng;_}
         -> __fname__freevars
-  
-let (__proj__Mkterm__item__rng : term -> FStar_Range.range) =
+let __proj__Mkterm__item__rng: term -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { tm = __fname__tm; freevars = __fname__freevars; rng = __fname__rng;_}
         -> __fname__rng
-  
 type pat = term[@@deriving show]
 type fv = (Prims.string,sort) FStar_Pervasives_Native.tuple2[@@deriving show]
 type fvs = (Prims.string,sort) FStar_Pervasives_Native.tuple2 Prims.list
@@ -345,34 +304,31 @@ type constructor_t =
     FStar_Pervasives_Native.tuple5[@@deriving show]
 type constructors = constructor_t Prims.list[@@deriving show]
 type fact_db_id =
-  | Name of FStar_Ident.lid 
-  | Namespace of FStar_Ident.lid 
-  | Tag of Prims.string [@@deriving show]
-let (uu___is_Name : fact_db_id -> Prims.bool) =
+  | Name of FStar_Ident.lid
+  | Namespace of FStar_Ident.lid
+  | Tag of Prims.string[@@deriving show]
+let uu___is_Name: fact_db_id -> Prims.bool =
   fun projectee  ->
     match projectee with | Name _0 -> true | uu____853 -> false
-  
-let (__proj__Name__item___0 : fact_db_id -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | Name _0 -> _0 
-let (uu___is_Namespace : fact_db_id -> Prims.bool) =
+let __proj__Name__item___0: fact_db_id -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | Name _0 -> _0
+let uu___is_Namespace: fact_db_id -> Prims.bool =
   fun projectee  ->
     match projectee with | Namespace _0 -> true | uu____865 -> false
-  
-let (__proj__Namespace__item___0 : fact_db_id -> FStar_Ident.lid) =
-  fun projectee  -> match projectee with | Namespace _0 -> _0 
-let (uu___is_Tag : fact_db_id -> Prims.bool) =
+let __proj__Namespace__item___0: fact_db_id -> FStar_Ident.lid =
+  fun projectee  -> match projectee with | Namespace _0 -> _0
+let uu___is_Tag: fact_db_id -> Prims.bool =
   fun projectee  ->
     match projectee with | Tag _0 -> true | uu____877 -> false
-  
-let (__proj__Tag__item___0 : fact_db_id -> Prims.string) =
-  fun projectee  -> match projectee with | Tag _0 -> _0 
+let __proj__Tag__item___0: fact_db_id -> Prims.string =
+  fun projectee  -> match projectee with | Tag _0 -> _0
 type assumption =
   {
-  assumption_term: term ;
-  assumption_caption: caption ;
-  assumption_name: Prims.string ;
-  assumption_fact_ids: fact_db_id Prims.list }[@@deriving show]
-let (__proj__Mkassumption__item__assumption_term : assumption -> term) =
+  assumption_term: term;
+  assumption_caption: caption;
+  assumption_name: Prims.string;
+  assumption_fact_ids: fact_db_id Prims.list;}[@@deriving show]
+let __proj__Mkassumption__item__assumption_term: assumption -> term =
   fun projectee  ->
     match projectee with
     | { assumption_term = __fname__assumption_term;
@@ -380,9 +336,7 @@ let (__proj__Mkassumption__item__assumption_term : assumption -> term) =
         assumption_name = __fname__assumption_name;
         assumption_fact_ids = __fname__assumption_fact_ids;_} ->
         __fname__assumption_term
-  
-let (__proj__Mkassumption__item__assumption_caption : assumption -> caption)
-  =
+let __proj__Mkassumption__item__assumption_caption: assumption -> caption =
   fun projectee  ->
     match projectee with
     | { assumption_term = __fname__assumption_term;
@@ -390,9 +344,7 @@ let (__proj__Mkassumption__item__assumption_caption : assumption -> caption)
         assumption_name = __fname__assumption_name;
         assumption_fact_ids = __fname__assumption_fact_ids;_} ->
         __fname__assumption_caption
-  
-let (__proj__Mkassumption__item__assumption_name :
-  assumption -> Prims.string) =
+let __proj__Mkassumption__item__assumption_name: assumption -> Prims.string =
   fun projectee  ->
     match projectee with
     | { assumption_term = __fname__assumption_term;
@@ -400,9 +352,8 @@ let (__proj__Mkassumption__item__assumption_name :
         assumption_name = __fname__assumption_name;
         assumption_fact_ids = __fname__assumption_fact_ids;_} ->
         __fname__assumption_name
-  
-let (__proj__Mkassumption__item__assumption_fact_ids :
-  assumption -> fact_db_id Prims.list) =
+let __proj__Mkassumption__item__assumption_fact_ids:
+  assumption -> fact_db_id Prims.list =
   fun projectee  ->
     match projectee with
     | { assumption_term = __fname__assumption_term;
@@ -410,142 +361,123 @@ let (__proj__Mkassumption__item__assumption_fact_ids :
         assumption_name = __fname__assumption_name;
         assumption_fact_ids = __fname__assumption_fact_ids;_} ->
         __fname__assumption_fact_ids
-  
 type decl =
-  | DefPrelude 
+  | DefPrelude
   | DeclFun of (Prims.string,sort Prims.list,sort,caption)
-  FStar_Pervasives_Native.tuple4 
+  FStar_Pervasives_Native.tuple4
   | DefineFun of (Prims.string,sort Prims.list,sort,term,caption)
-  FStar_Pervasives_Native.tuple5 
-  | Assume of assumption 
-  | Caption of Prims.string 
-  | Eval of term 
-  | Echo of Prims.string 
-  | RetainAssumptions of Prims.string Prims.list 
-  | Push 
-  | Pop 
-  | CheckSat 
-  | GetUnsatCore 
-  | SetOption of (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 
-  | GetStatistics 
-  | GetReasonUnknown [@@deriving show]
-let (uu___is_DefPrelude : decl -> Prims.bool) =
+  FStar_Pervasives_Native.tuple5
+  | Assume of assumption
+  | Caption of Prims.string
+  | Eval of term
+  | Echo of Prims.string
+  | RetainAssumptions of Prims.string Prims.list
+  | Push
+  | Pop
+  | CheckSat
+  | GetUnsatCore
+  | SetOption of (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2
+  | GetStatistics
+  | GetReasonUnknown[@@deriving show]
+let uu___is_DefPrelude: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DefPrelude  -> true | uu____1006 -> false
-  
-let (uu___is_DeclFun : decl -> Prims.bool) =
+let uu___is_DeclFun: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DeclFun _0 -> true | uu____1021 -> false
-  
-let (__proj__DeclFun__item___0 :
+let __proj__DeclFun__item___0:
   decl ->
     (Prims.string,sort Prims.list,sort,caption)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | DeclFun _0 -> _0 
-let (uu___is_DefineFun : decl -> Prims.bool) =
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | DeclFun _0 -> _0
+let uu___is_DefineFun: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | DefineFun _0 -> true | uu____1075 -> false
-  
-let (__proj__DefineFun__item___0 :
+let __proj__DefineFun__item___0:
   decl ->
     (Prims.string,sort Prims.list,sort,term,caption)
-      FStar_Pervasives_Native.tuple5)
-  = fun projectee  -> match projectee with | DefineFun _0 -> _0 
-let (uu___is_Assume : decl -> Prims.bool) =
+      FStar_Pervasives_Native.tuple5
+  = fun projectee  -> match projectee with | DefineFun _0 -> _0
+let uu___is_Assume: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | Assume _0 -> true | uu____1123 -> false
-  
-let (__proj__Assume__item___0 : decl -> assumption) =
-  fun projectee  -> match projectee with | Assume _0 -> _0 
-let (uu___is_Caption : decl -> Prims.bool) =
+let __proj__Assume__item___0: decl -> assumption =
+  fun projectee  -> match projectee with | Assume _0 -> _0
+let uu___is_Caption: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | Caption _0 -> true | uu____1135 -> false
-  
-let (__proj__Caption__item___0 : decl -> Prims.string) =
-  fun projectee  -> match projectee with | Caption _0 -> _0 
-let (uu___is_Eval : decl -> Prims.bool) =
+let __proj__Caption__item___0: decl -> Prims.string =
+  fun projectee  -> match projectee with | Caption _0 -> _0
+let uu___is_Eval: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | Eval _0 -> true | uu____1147 -> false
-  
-let (__proj__Eval__item___0 : decl -> term) =
-  fun projectee  -> match projectee with | Eval _0 -> _0 
-let (uu___is_Echo : decl -> Prims.bool) =
+let __proj__Eval__item___0: decl -> term =
+  fun projectee  -> match projectee with | Eval _0 -> _0
+let uu___is_Echo: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | Echo _0 -> true | uu____1159 -> false
-  
-let (__proj__Echo__item___0 : decl -> Prims.string) =
-  fun projectee  -> match projectee with | Echo _0 -> _0 
-let (uu___is_RetainAssumptions : decl -> Prims.bool) =
+let __proj__Echo__item___0: decl -> Prims.string =
+  fun projectee  -> match projectee with | Echo _0 -> _0
+let uu___is_RetainAssumptions: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | RetainAssumptions _0 -> true | uu____1173 -> false
-  
-let (__proj__RetainAssumptions__item___0 : decl -> Prims.string Prims.list) =
-  fun projectee  -> match projectee with | RetainAssumptions _0 -> _0 
-let (uu___is_Push : decl -> Prims.bool) =
+let __proj__RetainAssumptions__item___0: decl -> Prims.string Prims.list =
+  fun projectee  -> match projectee with | RetainAssumptions _0 -> _0
+let uu___is_Push: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | Push  -> true | uu____1190 -> false
-  
-let (uu___is_Pop : decl -> Prims.bool) =
-  fun projectee  -> match projectee with | Pop  -> true | uu____1194 -> false 
-let (uu___is_CheckSat : decl -> Prims.bool) =
+let uu___is_Pop: decl -> Prims.bool =
+  fun projectee  -> match projectee with | Pop  -> true | uu____1194 -> false
+let uu___is_CheckSat: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | CheckSat  -> true | uu____1198 -> false
-  
-let (uu___is_GetUnsatCore : decl -> Prims.bool) =
+let uu___is_GetUnsatCore: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | GetUnsatCore  -> true | uu____1202 -> false
-  
-let (uu___is_SetOption : decl -> Prims.bool) =
+let uu___is_SetOption: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | SetOption _0 -> true | uu____1211 -> false
-  
-let (__proj__SetOption__item___0 :
-  decl -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | SetOption _0 -> _0 
-let (uu___is_GetStatistics : decl -> Prims.bool) =
+let __proj__SetOption__item___0:
+  decl -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | SetOption _0 -> _0
+let uu___is_GetStatistics: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | GetStatistics  -> true | uu____1234 -> false
-  
-let (uu___is_GetReasonUnknown : decl -> Prims.bool) =
+let uu___is_GetReasonUnknown: decl -> Prims.bool =
   fun projectee  ->
     match projectee with | GetReasonUnknown  -> true | uu____1238 -> false
-  
 type decls_t = decl Prims.list[@@deriving show]
 type error_label =
   (fv,Prims.string,FStar_Range.range) FStar_Pervasives_Native.tuple3[@@deriving
                                                                     show]
 type error_labels = error_label Prims.list[@@deriving show]
-let (fv_eq : fv -> fv -> Prims.bool) =
+let fv_eq: fv -> fv -> Prims.bool =
   fun x  ->
     fun y  ->
       (FStar_Pervasives_Native.fst x) = (FStar_Pervasives_Native.fst y)
-  
-let fv_sort :
+let fv_sort:
   'Auu____1258 'Auu____1259 .
     ('Auu____1259,'Auu____1258) FStar_Pervasives_Native.tuple2 ->
       'Auu____1258
-  = fun x  -> FStar_Pervasives_Native.snd x 
-let (freevar_eq : term -> term -> Prims.bool) =
+  = fun x  -> FStar_Pervasives_Native.snd x
+let freevar_eq: term -> term -> Prims.bool =
   fun x  ->
     fun y  ->
       match ((x.tm), (y.tm)) with
       | (FreeV x1,FreeV y1) -> fv_eq x1 y1
       | uu____1288 -> false
-  
-let (freevar_sort : term -> sort) =
+let freevar_sort: term -> sort =
   fun uu___46_1295  ->
     match uu___46_1295 with
     | { tm = FreeV x; freevars = uu____1297; rng = uu____1298;_} -> fv_sort x
     | uu____1311 -> failwith "impossible"
-  
-let (fv_of_term : term -> fv) =
+let fv_of_term: term -> fv =
   fun uu___47_1314  ->
     match uu___47_1314 with
     | { tm = FreeV fv; freevars = uu____1316; rng = uu____1317;_} -> fv
     | uu____1330 -> failwith "impossible"
-  
-let rec (freevars :
-  term -> (Prims.string,sort) FStar_Pervasives_Native.tuple2 Prims.list) =
+let rec freevars:
+  term -> (Prims.string,sort) FStar_Pervasives_Native.tuple2 Prims.list =
   fun t  ->
     match t.tm with
     | Integer uu____1346 -> []
@@ -556,25 +488,22 @@ let rec (freevars :
     | Labeled (t1,uu____1401,uu____1402) -> freevars t1
     | LblPos (t1,uu____1404) -> freevars t1
     | Let (es,body) -> FStar_List.collect freevars (body :: es)
-  
-let (free_variables : term -> fvs) =
+let free_variables: term -> fvs =
   fun t  ->
-    let uu____1418 = FStar_ST.op_Bang t.freevars  in
+    let uu____1418 = FStar_ST.op_Bang t.freevars in
     match uu____1418 with
     | FStar_Pervasives_Native.Some b -> b
     | FStar_Pervasives_Native.None  ->
         let fvs =
-          let uu____1484 = freevars t  in
-          FStar_Util.remove_dups fv_eq uu____1484  in
+          let uu____1484 = freevars t in
+          FStar_Util.remove_dups fv_eq uu____1484 in
         (FStar_ST.op_Colon_Equals t.freevars
            (FStar_Pervasives_Native.Some fvs);
          fvs)
-  
-let (qop_to_string : qop -> Prims.string) =
+let qop_to_string: qop -> Prims.string =
   fun uu___48_1527  ->
     match uu___48_1527 with | Forall  -> "forall" | Exists  -> "exists"
-  
-let (op_to_string : op -> Prims.string) =
+let op_to_string: op -> Prims.string =
   fun uu___49_1530  ->
     match uu___49_1530 with
     | TrueOp  -> "true"
@@ -609,70 +538,66 @@ let (op_to_string : op -> Prims.string) =
     | BvUlt  -> "bvult"
     | BvToNat  -> "bv2int"
     | BvUext n1 ->
-        let uu____1532 = FStar_Util.string_of_int n1  in
+        let uu____1532 = FStar_Util.string_of_int n1 in
         FStar_Util.format1 "(_ zero_extend %s)" uu____1532
     | NatToBv n1 ->
-        let uu____1534 = FStar_Util.string_of_int n1  in
+        let uu____1534 = FStar_Util.string_of_int n1 in
         FStar_Util.format1 "(_ int2bv %s)" uu____1534
     | Var s -> s
-  
-let (weightToSmt : Prims.int FStar_Pervasives_Native.option -> Prims.string)
-  =
+let weightToSmt: Prims.int FStar_Pervasives_Native.option -> Prims.string =
   fun uu___50_1540  ->
     match uu___50_1540 with
     | FStar_Pervasives_Native.None  -> ""
     | FStar_Pervasives_Native.Some i ->
-        let uu____1544 = FStar_Util.string_of_int i  in
+        let uu____1544 = FStar_Util.string_of_int i in
         FStar_Util.format1 ":weight %s\n" uu____1544
-  
-let rec (hash_of_term' : term' -> Prims.string) =
+let rec hash_of_term': term' -> Prims.string =
   fun t  ->
     match t with
     | Integer i -> i
     | BoundV i ->
-        let uu____1552 = FStar_Util.string_of_int i  in
+        let uu____1552 = FStar_Util.string_of_int i in
         Prims.strcat "@" uu____1552
     | FreeV x ->
         let uu____1558 =
-          let uu____1559 = strSort (FStar_Pervasives_Native.snd x)  in
-          Prims.strcat ":" uu____1559  in
+          let uu____1559 = strSort (FStar_Pervasives_Native.snd x) in
+          Prims.strcat ":" uu____1559 in
         Prims.strcat (FStar_Pervasives_Native.fst x) uu____1558
     | App (op,tms) ->
         let uu____1566 =
-          let uu____1567 = op_to_string op  in
+          let uu____1567 = op_to_string op in
           let uu____1568 =
             let uu____1569 =
-              let uu____1570 = FStar_List.map hash_of_term tms  in
-              FStar_All.pipe_right uu____1570 (FStar_String.concat " ")  in
-            Prims.strcat uu____1569 ")"  in
-          Prims.strcat uu____1567 uu____1568  in
+              let uu____1570 = FStar_List.map hash_of_term tms in
+              FStar_All.pipe_right uu____1570 (FStar_String.concat " ") in
+            Prims.strcat uu____1569 ")" in
+          Prims.strcat uu____1567 uu____1568 in
         Prims.strcat "(" uu____1566
     | Labeled (t1,r1,r2) ->
-        let uu____1578 = hash_of_term t1  in
+        let uu____1578 = hash_of_term t1 in
         let uu____1579 =
-          let uu____1580 = FStar_Range.string_of_range r2  in
-          Prims.strcat r1 uu____1580  in
+          let uu____1580 = FStar_Range.string_of_range r2 in
+          Prims.strcat r1 uu____1580 in
         Prims.strcat uu____1578 uu____1579
     | LblPos (t1,r) ->
         let uu____1583 =
-          let uu____1584 = hash_of_term t1  in
+          let uu____1584 = hash_of_term t1 in
           Prims.strcat uu____1584
-            (Prims.strcat " :lblpos " (Prims.strcat r ")"))
-           in
+            (Prims.strcat " :lblpos " (Prims.strcat r ")")) in
         Prims.strcat "(! " uu____1583
     | Quant (qop,pats,wopt,sorts,body) ->
         let uu____1606 =
           let uu____1607 =
             let uu____1608 =
               let uu____1609 =
-                let uu____1610 = FStar_List.map strSort sorts  in
-                FStar_All.pipe_right uu____1610 (FStar_String.concat " ")  in
+                let uu____1610 = FStar_List.map strSort sorts in
+                FStar_All.pipe_right uu____1610 (FStar_String.concat " ") in
               let uu____1615 =
                 let uu____1616 =
-                  let uu____1617 = hash_of_term body  in
+                  let uu____1617 = hash_of_term body in
                   let uu____1618 =
                     let uu____1619 =
-                      let uu____1620 = weightToSmt wopt  in
+                      let uu____1620 = weightToSmt wopt in
                       let uu____1621 =
                         let uu____1622 =
                           let uu____1623 =
@@ -681,119 +606,104 @@ let rec (hash_of_term' : term' -> Prims.string) =
                                 (FStar_List.map
                                    (fun pats1  ->
                                       let uu____1640 =
-                                        FStar_List.map hash_of_term pats1  in
+                                        FStar_List.map hash_of_term pats1 in
                                       FStar_All.pipe_right uu____1640
-                                        (FStar_String.concat " ")))
-                               in
+                                        (FStar_String.concat " "))) in
                             FStar_All.pipe_right uu____1624
-                              (FStar_String.concat "; ")
-                             in
-                          Prims.strcat uu____1623 "))"  in
-                        Prims.strcat " " uu____1622  in
-                      Prims.strcat uu____1620 uu____1621  in
-                    Prims.strcat " " uu____1619  in
-                  Prims.strcat uu____1617 uu____1618  in
-                Prims.strcat ")(! " uu____1616  in
-              Prims.strcat uu____1609 uu____1615  in
-            Prims.strcat " (" uu____1608  in
-          Prims.strcat (qop_to_string qop) uu____1607  in
+                              (FStar_String.concat "; ") in
+                          Prims.strcat uu____1623 "))" in
+                        Prims.strcat " " uu____1622 in
+                      Prims.strcat uu____1620 uu____1621 in
+                    Prims.strcat " " uu____1619 in
+                  Prims.strcat uu____1617 uu____1618 in
+                Prims.strcat ")(! " uu____1616 in
+              Prims.strcat uu____1609 uu____1615 in
+            Prims.strcat " (" uu____1608 in
+          Prims.strcat (qop_to_string qop) uu____1607 in
         Prims.strcat "(" uu____1606
     | Let (es,body) ->
         let uu____1653 =
           let uu____1654 =
-            let uu____1655 = FStar_List.map hash_of_term es  in
-            FStar_All.pipe_right uu____1655 (FStar_String.concat " ")  in
+            let uu____1655 = FStar_List.map hash_of_term es in
+            FStar_All.pipe_right uu____1655 (FStar_String.concat " ") in
           let uu____1660 =
             let uu____1661 =
-              let uu____1662 = hash_of_term body  in
-              Prims.strcat uu____1662 ")"  in
-            Prims.strcat ") " uu____1661  in
-          Prims.strcat uu____1654 uu____1660  in
+              let uu____1662 = hash_of_term body in
+              Prims.strcat uu____1662 ")" in
+            Prims.strcat ") " uu____1661 in
+          Prims.strcat uu____1654 uu____1660 in
         Prims.strcat "(let (" uu____1653
-
-and (hash_of_term : term -> Prims.string) = fun tm  -> hash_of_term' tm.tm
-
-let (mkBoxFunctions :
-  Prims.string -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2)
-  = fun s  -> (s, (Prims.strcat s "_proj_0")) 
-let (boxIntFun : (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2)
-  = mkBoxFunctions "BoxInt" 
-let (boxBoolFun : (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2)
-  = mkBoxFunctions "BoxBool" 
-let (boxStringFun :
-  (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2) =
-  mkBoxFunctions "BoxString" 
-let (boxBitVecFun :
-  Prims.int -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2) =
+and hash_of_term: term -> Prims.string = fun tm  -> hash_of_term' tm.tm
+let mkBoxFunctions:
+  Prims.string -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2
+  = fun s  -> (s, (Prims.strcat s "_proj_0"))
+let boxIntFun: (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 =
+  mkBoxFunctions "BoxInt"
+let boxBoolFun: (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 =
+  mkBoxFunctions "BoxBool"
+let boxStringFun: (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2
+  = mkBoxFunctions "BoxString"
+let boxBitVecFun:
+  Prims.int -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2 =
   fun sz  ->
     let uu____1690 =
-      let uu____1691 = FStar_Util.string_of_int sz  in
-      Prims.strcat "BoxBitVec" uu____1691  in
+      let uu____1691 = FStar_Util.string_of_int sz in
+      Prims.strcat "BoxBitVec" uu____1691 in
     mkBoxFunctions uu____1690
-  
-let (isInjective : Prims.string -> Prims.bool) =
+let isInjective: Prims.string -> Prims.bool =
   fun s  ->
     if (FStar_String.length s) >= (Prims.parse_int "3")
     then
       (let uu____1697 =
-         FStar_String.substring s (Prims.parse_int "0") (Prims.parse_int "3")
-          in
+         FStar_String.substring s (Prims.parse_int "0") (Prims.parse_int "3") in
        uu____1697 = "Box") &&
         (let uu____1699 =
-           let uu____1700 = FStar_String.list_of_string s  in
-           FStar_List.existsML (fun c  -> c = 46) uu____1700  in
+           let uu____1700 = FStar_String.list_of_string s in
+           FStar_List.existsML (fun c  -> c = 46) uu____1700 in
          Prims.op_Negation uu____1699)
     else false
-  
-let (mk : term' -> FStar_Range.range -> term) =
+let mk: term' -> FStar_Range.range -> term =
   fun t  ->
     fun r  ->
-      let uu____1717 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+      let uu____1717 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
       { tm = t; freevars = uu____1717; rng = r }
-  
-let (mkTrue : FStar_Range.range -> term) = fun r  -> mk (App (TrueOp, [])) r 
-let (mkFalse : FStar_Range.range -> term) =
-  fun r  -> mk (App (FalseOp, [])) r 
-let (mkInteger : Prims.string -> FStar_Range.range -> term) =
+let mkTrue: FStar_Range.range -> term = fun r  -> mk (App (TrueOp, [])) r
+let mkFalse: FStar_Range.range -> term = fun r  -> mk (App (FalseOp, [])) r
+let mkInteger: Prims.string -> FStar_Range.range -> term =
   fun i  ->
     fun r  ->
       let uu____1778 =
-        let uu____1779 = FStar_Util.ensure_decimal i  in Integer uu____1779
-         in
+        let uu____1779 = FStar_Util.ensure_decimal i in Integer uu____1779 in
       mk uu____1778 r
-  
-let (mkInteger' : Prims.int -> FStar_Range.range -> term) =
+let mkInteger': Prims.int -> FStar_Range.range -> term =
   fun i  ->
     fun r  ->
-      let uu____1786 = FStar_Util.string_of_int i  in mkInteger uu____1786 r
-  
-let (mkBoundV : Prims.int -> FStar_Range.range -> term) =
-  fun i  -> fun r  -> mk (BoundV i) r 
-let (mkFreeV :
+      let uu____1786 = FStar_Util.string_of_int i in mkInteger uu____1786 r
+let mkBoundV: Prims.int -> FStar_Range.range -> term =
+  fun i  -> fun r  -> mk (BoundV i) r
+let mkFreeV:
   (Prims.string,sort) FStar_Pervasives_Native.tuple2 ->
-    FStar_Range.range -> term)
-  = fun x  -> fun r  -> mk (FreeV x) r 
-let (mkApp' :
+    FStar_Range.range -> term
+  = fun x  -> fun r  -> mk (FreeV x) r
+let mkApp':
   (op,term Prims.list) FStar_Pervasives_Native.tuple2 ->
-    FStar_Range.range -> term)
-  = fun f  -> fun r  -> mk (App f) r 
-let (mkApp :
+    FStar_Range.range -> term
+  = fun f  -> fun r  -> mk (App f) r
+let mkApp:
   (Prims.string,term Prims.list) FStar_Pervasives_Native.tuple2 ->
-    FStar_Range.range -> term)
+    FStar_Range.range -> term
   =
   fun uu____1835  ->
     fun r  -> match uu____1835 with | (s,args) -> mk (App ((Var s), args)) r
-  
-let (mkNot : term -> FStar_Range.range -> term) =
+let mkNot: term -> FStar_Range.range -> term =
   fun t  ->
     fun r  ->
       match t.tm with
       | App (TrueOp ,uu____1857) -> mkFalse r
       | App (FalseOp ,uu____1862) -> mkTrue r
       | uu____1867 -> mkApp' (Not, [t]) r
-  
-let (mkAnd :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
+let mkAnd:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
   fun uu____1878  ->
     fun r  ->
       match uu____1878 with
@@ -809,9 +719,8 @@ let (mkAnd :
            | (App (And ,ts1),uu____1931) ->
                mkApp' (And, (FStar_List.append ts1 [t2])) r
            | uu____1938 -> mkApp' (And, [t1; t2]) r)
-  
-let (mkOr :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
+let mkOr:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
   fun uu____1953  ->
     fun r  ->
       match uu____1953 with
@@ -827,9 +736,8 @@ let (mkOr :
            | (App (Or ,ts1),uu____2006) ->
                mkApp' (Or, (FStar_List.append ts1 [t2])) r
            | uu____2013 -> mkApp' (Or, [t1; t2]) r)
-  
-let (mkImp :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
+let mkImp:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
   fun uu____2028  ->
     fun r  ->
       match uu____2028 with
@@ -841,46 +749,43 @@ let (mkImp :
            | (uu____2054,App (Imp ,t1'::t2'::[])) ->
                let uu____2059 =
                  let uu____2066 =
-                   let uu____2069 = mkAnd (t1, t1') r  in [uu____2069; t2']
-                    in
-                 (Imp, uu____2066)  in
+                   let uu____2069 = mkAnd (t1, t1') r in [uu____2069; t2'] in
+                 (Imp, uu____2066) in
                mkApp' uu____2059 r
            | uu____2072 -> mkApp' (Imp, [t1; t2]) r)
-  
-let (mk_bin_op :
+let mk_bin_op:
   op ->
-    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term)
+    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term
   =
   fun op  ->
     fun uu____2090  ->
       fun r  -> match uu____2090 with | (t1,t2) -> mkApp' (op, [t1; t2]) r
-  
-let (mkMinus : term -> FStar_Range.range -> term) =
-  fun t  -> fun r  -> mkApp' (Minus, [t]) r 
-let (mkNatToBv : Prims.int -> term -> FStar_Range.range -> term) =
-  fun sz  -> fun t  -> fun r  -> mkApp' ((NatToBv sz), [t]) r 
-let (mkBvUext : Prims.int -> term -> FStar_Range.range -> term) =
-  fun sz  -> fun t  -> fun r  -> mkApp' ((BvUext sz), [t]) r 
-let (mkBvToNat : term -> FStar_Range.range -> term) =
-  fun t  -> fun r  -> mkApp' (BvToNat, [t]) r 
-let (mkBvAnd :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op BvAnd 
-let (mkBvXor :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op BvXor 
-let (mkBvOr :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op BvOr 
-let (mkBvAdd :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op BvAdd 
-let (mkBvSub :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op BvSub 
-let (mkBvShl :
+let mkMinus: term -> FStar_Range.range -> term =
+  fun t  -> fun r  -> mkApp' (Minus, [t]) r
+let mkNatToBv: Prims.int -> term -> FStar_Range.range -> term =
+  fun sz  -> fun t  -> fun r  -> mkApp' ((NatToBv sz), [t]) r
+let mkBvUext: Prims.int -> term -> FStar_Range.range -> term =
+  fun sz  -> fun t  -> fun r  -> mkApp' ((BvUext sz), [t]) r
+let mkBvToNat: term -> FStar_Range.range -> term =
+  fun t  -> fun r  -> mkApp' (BvToNat, [t]) r
+let mkBvAnd:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op BvAnd
+let mkBvXor:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op BvXor
+let mkBvOr:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op BvOr
+let mkBvAdd:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op BvAdd
+let mkBvSub:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op BvSub
+let mkBvShl:
   Prims.int ->
-    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term)
+    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term
   =
   fun sz  ->
     fun uu____2189  ->
@@ -890,14 +795,13 @@ let (mkBvShl :
             let uu____2197 =
               let uu____2204 =
                 let uu____2207 =
-                  let uu____2210 = mkNatToBv sz t2 r  in [uu____2210]  in
-                t1 :: uu____2207  in
-              (BvShl, uu____2204)  in
+                  let uu____2210 = mkNatToBv sz t2 r in [uu____2210] in
+                t1 :: uu____2207 in
+              (BvShl, uu____2204) in
             mkApp' uu____2197 r
-  
-let (mkBvShr :
+let mkBvShr:
   Prims.int ->
-    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term)
+    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term
   =
   fun sz  ->
     fun uu____2224  ->
@@ -907,14 +811,13 @@ let (mkBvShr :
             let uu____2232 =
               let uu____2239 =
                 let uu____2242 =
-                  let uu____2245 = mkNatToBv sz t2 r  in [uu____2245]  in
-                t1 :: uu____2242  in
-              (BvShr, uu____2239)  in
+                  let uu____2245 = mkNatToBv sz t2 r in [uu____2245] in
+                t1 :: uu____2242 in
+              (BvShr, uu____2239) in
             mkApp' uu____2232 r
-  
-let (mkBvUdiv :
+let mkBvUdiv:
   Prims.int ->
-    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term)
+    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term
   =
   fun sz  ->
     fun uu____2259  ->
@@ -924,14 +827,13 @@ let (mkBvUdiv :
             let uu____2267 =
               let uu____2274 =
                 let uu____2277 =
-                  let uu____2280 = mkNatToBv sz t2 r  in [uu____2280]  in
-                t1 :: uu____2277  in
-              (BvUdiv, uu____2274)  in
+                  let uu____2280 = mkNatToBv sz t2 r in [uu____2280] in
+                t1 :: uu____2277 in
+              (BvUdiv, uu____2274) in
             mkApp' uu____2267 r
-  
-let (mkBvMod :
+let mkBvMod:
   Prims.int ->
-    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term)
+    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term
   =
   fun sz  ->
     fun uu____2294  ->
@@ -941,14 +843,13 @@ let (mkBvMod :
             let uu____2302 =
               let uu____2309 =
                 let uu____2312 =
-                  let uu____2315 = mkNatToBv sz t2 r  in [uu____2315]  in
-                t1 :: uu____2312  in
-              (BvMod, uu____2309)  in
+                  let uu____2315 = mkNatToBv sz t2 r in [uu____2315] in
+                t1 :: uu____2312 in
+              (BvMod, uu____2309) in
             mkApp' uu____2302 r
-  
-let (mkBvMul :
+let mkBvMul:
   Prims.int ->
-    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term)
+    (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term
   =
   fun sz  ->
     fun uu____2329  ->
@@ -958,19 +859,18 @@ let (mkBvMul :
             let uu____2337 =
               let uu____2344 =
                 let uu____2347 =
-                  let uu____2350 = mkNatToBv sz t2 r  in [uu____2350]  in
-                t1 :: uu____2347  in
-              (BvMul, uu____2344)  in
+                  let uu____2350 = mkNatToBv sz t2 r in [uu____2350] in
+                t1 :: uu____2347 in
+              (BvMul, uu____2344) in
             mkApp' uu____2337 r
-  
-let (mkBvUlt :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op BvUlt 
-let (mkIff :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op Iff 
-let (mkEq :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
+let mkBvUlt:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op BvUlt
+let mkIff:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op Iff
+let mkEq:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
   fun uu____2377  ->
     fun r  ->
       match uu____2377 with
@@ -979,37 +879,36 @@ let (mkEq :
            | (App (Var f1,s1::[]),App (Var f2,s2::[])) when
                (f1 = f2) && (isInjective f1) -> mk_bin_op Eq (s1, s2) r
            | uu____2393 -> mk_bin_op Eq (t1, t2) r)
-  
-let (mkLT :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op LT 
-let (mkLTE :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op LTE 
-let (mkGT :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op GT 
-let (mkGTE :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op GTE 
-let (mkAdd :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op Add 
-let (mkSub :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op Sub 
-let (mkDiv :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op Div 
-let (mkMul :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op Mul 
-let (mkMod :
-  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term) =
-  mk_bin_op Mod 
-let (mkITE :
+let mkLT:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op LT
+let mkLTE:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op LTE
+let mkGT:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op GT
+let mkGTE:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op GTE
+let mkAdd:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op Add
+let mkSub:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op Sub
+let mkDiv:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op Div
+let mkMul:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op Mul
+let mkMod:
+  (term,term) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term =
+  mk_bin_op Mod
+let mkITE:
   (term,term,term) FStar_Pervasives_Native.tuple3 ->
-    FStar_Range.range -> term)
+    FStar_Range.range -> term
   =
   fun uu____2480  ->
     fun r  ->
@@ -1024,13 +923,11 @@ let (mkITE :
                     mkTrue r
                 | (App (TrueOp ,uu____2512),uu____2513) ->
                     let uu____2518 =
-                      let uu____2523 = mkNot t1 t1.rng  in (uu____2523, t3)
-                       in
+                      let uu____2523 = mkNot t1 t1.rng in (uu____2523, t3) in
                     mkImp uu____2518 r
                 | (uu____2524,App (TrueOp ,uu____2525)) -> mkImp (t1, t2) r
                 | (uu____2530,uu____2531) -> mkApp' (ITE, [t1; t2; t3]) r))
-  
-let (mkCases : term Prims.list -> FStar_Range.range -> term) =
+let mkCases: term Prims.list -> FStar_Range.range -> term =
   fun t  ->
     fun r  ->
       match t with
@@ -1038,11 +935,10 @@ let (mkCases : term Prims.list -> FStar_Range.range -> term) =
       | hd1::tl1 ->
           FStar_List.fold_left (fun out  -> fun t1  -> mkAnd (out, t1) r) hd1
             tl1
-  
-let (mkQuant :
+let mkQuant:
   (qop,term Prims.list Prims.list,Prims.int FStar_Pervasives_Native.option,
     sort Prims.list,term) FStar_Pervasives_Native.tuple5 ->
-    FStar_Range.range -> term)
+    FStar_Range.range -> term
   =
   fun uu____2574  ->
     fun r  ->
@@ -1054,10 +950,9 @@ let (mkQuant :
             (match body.tm with
              | App (TrueOp ,uu____2616) -> body
              | uu____2621 -> mk (Quant (qop, pats, wopt, vars, body)) r)
-  
-let (mkLet :
+let mkLet:
   (term Prims.list,term) FStar_Pervasives_Native.tuple2 ->
-    FStar_Range.range -> term)
+    FStar_Range.range -> term
   =
   fun uu____2640  ->
     fun r  ->
@@ -1066,21 +961,19 @@ let (mkLet :
           if (FStar_List.length es) = (Prims.parse_int "0")
           then body
           else mk (Let (es, body)) r
-  
-let (abstr : fv Prims.list -> term -> term) =
+let abstr: fv Prims.list -> term -> term =
   fun fvs  ->
     fun t  ->
-      let nvars = FStar_List.length fvs  in
+      let nvars = FStar_List.length fvs in
       let index_of fv =
-        let uu____2674 = FStar_Util.try_find_index (fv_eq fv) fvs  in
+        let uu____2674 = FStar_Util.try_find_index (fv_eq fv) fvs in
         match uu____2674 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some i ->
             FStar_Pervasives_Native.Some
-              (nvars - (i + (Prims.parse_int "1")))
-         in
+              (nvars - (i + (Prims.parse_int "1"))) in
       let rec aux ix t1 =
-        let uu____2693 = FStar_ST.op_Bang t1.freevars  in
+        let uu____2693 = FStar_ST.op_Bang t1.freevars in
         match uu____2693 with
         | FStar_Pervasives_Native.Some [] -> t1
         | uu____2747 ->
@@ -1088,37 +981,36 @@ let (abstr : fv Prims.list -> term -> term) =
              | Integer uu____2756 -> t1
              | BoundV uu____2757 -> t1
              | FreeV x ->
-                 let uu____2763 = index_of x  in
+                 let uu____2763 = index_of x in
                  (match uu____2763 with
                   | FStar_Pervasives_Native.None  -> t1
                   | FStar_Pervasives_Native.Some i ->
                       mkBoundV (i + ix) t1.rng)
              | App (op,tms) ->
                  let uu____2773 =
-                   let uu____2780 = FStar_List.map (aux ix) tms  in
-                   (op, uu____2780)  in
+                   let uu____2780 = FStar_List.map (aux ix) tms in
+                   (op, uu____2780) in
                  mkApp' uu____2773 t1.rng
              | Labeled (t2,r1,r2) ->
                  let uu____2788 =
                    let uu____2789 =
-                     let uu____2796 = aux ix t2  in (uu____2796, r1, r2)  in
-                   Labeled uu____2789  in
+                     let uu____2796 = aux ix t2 in (uu____2796, r1, r2) in
+                   Labeled uu____2789 in
                  mk uu____2788 t2.rng
              | LblPos (t2,r) ->
                  let uu____2799 =
                    let uu____2800 =
-                     let uu____2805 = aux ix t2  in (uu____2805, r)  in
-                   LblPos uu____2800  in
+                     let uu____2805 = aux ix t2 in (uu____2805, r) in
+                   LblPos uu____2800 in
                  mk uu____2799 t2.rng
              | Quant (qop,pats,wopt,vars,body) ->
-                 let n1 = FStar_List.length vars  in
+                 let n1 = FStar_List.length vars in
                  let uu____2828 =
                    let uu____2847 =
                      FStar_All.pipe_right pats
-                       (FStar_List.map (FStar_List.map (aux (ix + n1))))
-                      in
-                   let uu____2868 = aux (ix + n1) body  in
-                   (qop, uu____2847, wopt, vars, uu____2868)  in
+                       (FStar_List.map (FStar_List.map (aux (ix + n1)))) in
+                   let uu____2868 = aux (ix + n1) body in
+                   (qop, uu____2847, wopt, vars, uu____2868) in
                  mkQuant uu____2828 t1.rng
              | Let (es,body) ->
                  let uu____2887 =
@@ -1128,26 +1020,21 @@ let (abstr : fv Prims.list -> term -> term) =
                           match uu____2905 with
                           | (ix1,l) ->
                               let uu____2925 =
-                                let uu____2928 = aux ix1 e  in uu____2928 ::
-                                  l
-                                 in
+                                let uu____2928 = aux ix1 e in uu____2928 :: l in
                               ((ix1 + (Prims.parse_int "1")), uu____2925))
-                     (ix, []) es
-                    in
+                     (ix, []) es in
                  (match uu____2887 with
                   | (ix1,es_rev) ->
                       let uu____2939 =
-                        let uu____2946 = aux ix1 body  in
-                        ((FStar_List.rev es_rev), uu____2946)  in
-                      mkLet uu____2939 t1.rng))
-         in
+                        let uu____2946 = aux ix1 body in
+                        ((FStar_List.rev es_rev), uu____2946) in
+                      mkLet uu____2939 t1.rng)) in
       aux (Prims.parse_int "0") t
-  
-let (inst : term Prims.list -> term -> term) =
+let inst: term Prims.list -> term -> term =
   fun tms  ->
     fun t  ->
-      let tms1 = FStar_List.rev tms  in
-      let n1 = FStar_List.length tms1  in
+      let tms1 = FStar_List.rev tms in
+      let n1 = FStar_List.length tms1 in
       let rec aux shift t1 =
         match t1.tm with
         | Integer uu____2970 -> t1
@@ -1158,31 +1045,30 @@ let (inst : term Prims.list -> term -> term) =
             else t1
         | App (op,tms2) ->
             let uu____2988 =
-              let uu____2995 = FStar_List.map (aux shift) tms2  in
-              (op, uu____2995)  in
+              let uu____2995 = FStar_List.map (aux shift) tms2 in
+              (op, uu____2995) in
             mkApp' uu____2988 t1.rng
         | Labeled (t2,r1,r2) ->
             let uu____3003 =
               let uu____3004 =
-                let uu____3011 = aux shift t2  in (uu____3011, r1, r2)  in
-              Labeled uu____3004  in
+                let uu____3011 = aux shift t2 in (uu____3011, r1, r2) in
+              Labeled uu____3004 in
             mk uu____3003 t2.rng
         | LblPos (t2,r) ->
             let uu____3014 =
               let uu____3015 =
-                let uu____3020 = aux shift t2  in (uu____3020, r)  in
-              LblPos uu____3015  in
+                let uu____3020 = aux shift t2 in (uu____3020, r) in
+              LblPos uu____3015 in
             mk uu____3014 t2.rng
         | Quant (qop,pats,wopt,vars,body) ->
-            let m = FStar_List.length vars  in
-            let shift1 = shift + m  in
+            let m = FStar_List.length vars in
+            let shift1 = shift + m in
             let uu____3048 =
               let uu____3067 =
                 FStar_All.pipe_right pats
-                  (FStar_List.map (FStar_List.map (aux shift1)))
-                 in
-              let uu____3084 = aux shift1 body  in
-              (qop, uu____3067, wopt, vars, uu____3084)  in
+                  (FStar_List.map (FStar_List.map (aux shift1))) in
+              let uu____3084 = aux shift1 body in
+              (qop, uu____3067, wopt, vars, uu____3084) in
             mkQuant uu____3048 t1.rng
         | Let (es,body) ->
             let uu____3099 =
@@ -1192,29 +1078,23 @@ let (inst : term Prims.list -> term -> term) =
                      match uu____3117 with
                      | (ix,es1) ->
                          let uu____3137 =
-                           let uu____3140 = aux shift e  in uu____3140 :: es1
-                            in
+                           let uu____3140 = aux shift e in uu____3140 :: es1 in
                          ((shift + (Prims.parse_int "1")), uu____3137))
-                (shift, []) es
-               in
+                (shift, []) es in
             (match uu____3099 with
              | (shift1,es_rev) ->
                  let uu____3151 =
-                   let uu____3158 = aux shift1 body  in
-                   ((FStar_List.rev es_rev), uu____3158)  in
-                 mkLet uu____3151 t1.rng)
-         in
+                   let uu____3158 = aux shift1 body in
+                   ((FStar_List.rev es_rev), uu____3158) in
+                 mkLet uu____3151 t1.rng) in
       aux (Prims.parse_int "0") t
-  
-let (subst : term -> fv -> term -> term) =
+let subst: term -> fv -> term -> term =
   fun t  ->
-    fun fv  ->
-      fun s  -> let uu____3170 = abstr [fv] t  in inst [s] uu____3170
-  
-let (mkQuant' :
+    fun fv  -> fun s  -> let uu____3170 = abstr [fv] t in inst [s] uu____3170
+let mkQuant':
   (qop,term Prims.list Prims.list,Prims.int FStar_Pervasives_Native.option,
     fv Prims.list,term) FStar_Pervasives_Native.tuple5 ->
-    FStar_Range.range -> term)
+    FStar_Range.range -> term
   =
   fun uu____3193  ->
     match uu____3193 with
@@ -1222,132 +1102,120 @@ let (mkQuant' :
         let uu____3235 =
           let uu____3254 =
             FStar_All.pipe_right pats
-              (FStar_List.map (FStar_List.map (abstr vars)))
-             in
-          let uu____3271 = FStar_List.map fv_sort vars  in
-          let uu____3278 = abstr vars body  in
-          (qop, uu____3254, wopt, uu____3271, uu____3278)  in
+              (FStar_List.map (FStar_List.map (abstr vars))) in
+          let uu____3271 = FStar_List.map fv_sort vars in
+          let uu____3278 = abstr vars body in
+          (qop, uu____3254, wopt, uu____3271, uu____3278) in
         mkQuant uu____3235
-  
-let (mkForall'' :
+let mkForall'':
   (pat Prims.list Prims.list,Prims.int FStar_Pervasives_Native.option,
     sort Prims.list,term) FStar_Pervasives_Native.tuple4 ->
-    FStar_Range.range -> term)
+    FStar_Range.range -> term
   =
   fun uu____3307  ->
     fun r  ->
       match uu____3307 with
       | (pats,wopt,sorts,body) -> mkQuant (Forall, pats, wopt, sorts, body) r
-  
-let (mkForall' :
+let mkForall':
   (pat Prims.list Prims.list,Prims.int FStar_Pervasives_Native.option,
-    fvs,term) FStar_Pervasives_Native.tuple4 -> FStar_Range.range -> term)
+    fvs,term) FStar_Pervasives_Native.tuple4 -> FStar_Range.range -> term
   =
   fun uu____3371  ->
     fun r  ->
       match uu____3371 with
       | (pats,wopt,vars,body) ->
-          let uu____3403 = mkQuant' (Forall, pats, wopt, vars, body)  in
+          let uu____3403 = mkQuant' (Forall, pats, wopt, vars, body) in
           uu____3403 r
-  
-let (mkForall :
+let mkForall:
   (pat Prims.list Prims.list,fvs,term) FStar_Pervasives_Native.tuple3 ->
-    FStar_Range.range -> term)
+    FStar_Range.range -> term
   =
   fun uu____3426  ->
     fun r  ->
       match uu____3426 with
       | (pats,vars,body) ->
           let uu____3449 =
-            mkQuant' (Forall, pats, FStar_Pervasives_Native.None, vars, body)
-             in
+            mkQuant' (Forall, pats, FStar_Pervasives_Native.None, vars, body) in
           uu____3449 r
-  
-let (mkExists :
+let mkExists:
   (pat Prims.list Prims.list,fvs,term) FStar_Pervasives_Native.tuple3 ->
-    FStar_Range.range -> term)
+    FStar_Range.range -> term
   =
   fun uu____3472  ->
     fun r  ->
       match uu____3472 with
       | (pats,vars,body) ->
           let uu____3495 =
-            mkQuant' (Exists, pats, FStar_Pervasives_Native.None, vars, body)
-             in
+            mkQuant' (Exists, pats, FStar_Pervasives_Native.None, vars, body) in
           uu____3495 r
-  
-let (mkLet' :
+let mkLet':
   ((fv,term) FStar_Pervasives_Native.tuple2 Prims.list,term)
-    FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term)
+    FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term
   =
   fun uu____3518  ->
     fun r  ->
       match uu____3518 with
       | (bindings,body) ->
-          let uu____3544 = FStar_List.split bindings  in
+          let uu____3544 = FStar_List.split bindings in
           (match uu____3544 with
            | (vars,es) ->
                let uu____3563 =
-                 let uu____3570 = abstr vars body  in (es, uu____3570)  in
+                 let uu____3570 = abstr vars body in (es, uu____3570) in
                mkLet uu____3563 r)
-  
-let (norng : FStar_Range.range) = FStar_Range.dummyRange 
-let (mkDefineFun :
+let norng: FStar_Range.range = FStar_Range.dummyRange
+let mkDefineFun:
   (Prims.string,(Prims.string,sort) FStar_Pervasives_Native.tuple2 Prims.list,
-    sort,term,caption) FStar_Pervasives_Native.tuple5 -> decl)
+    sort,term,caption) FStar_Pervasives_Native.tuple5 -> decl
   =
   fun uu____3591  ->
     match uu____3591 with
     | (nm,vars,s,tm,c) ->
         let uu____3625 =
-          let uu____3638 = FStar_List.map fv_sort vars  in
-          let uu____3645 = abstr vars tm  in
-          (nm, uu____3638, s, uu____3645, c)  in
+          let uu____3638 = FStar_List.map fv_sort vars in
+          let uu____3645 = abstr vars tm in
+          (nm, uu____3638, s, uu____3645, c) in
         DefineFun uu____3625
-  
-let (constr_id_of_sort : sort -> Prims.string) =
+let constr_id_of_sort: sort -> Prims.string =
   fun sort  ->
-    let uu____3651 = strSort sort  in
+    let uu____3651 = strSort sort in
     FStar_Util.format1 "%s_constr_id" uu____3651
-  
-let (fresh_token :
-  (Prims.string,sort) FStar_Pervasives_Native.tuple2 -> Prims.int -> decl) =
+let fresh_token:
+  (Prims.string,sort) FStar_Pervasives_Native.tuple2 -> Prims.int -> decl =
   fun uu____3660  ->
     fun id1  ->
       match uu____3660 with
       | (tok_name,sort) ->
-          let a_name = Prims.strcat "fresh_token_" tok_name  in
+          let a_name = Prims.strcat "fresh_token_" tok_name in
           let a =
             let uu____3670 =
               let uu____3671 =
-                let uu____3676 = mkInteger' id1 norng  in
+                let uu____3676 = mkInteger' id1 norng in
                 let uu____3677 =
                   let uu____3678 =
-                    let uu____3685 = constr_id_of_sort sort  in
+                    let uu____3685 = constr_id_of_sort sort in
                     let uu____3686 =
-                      let uu____3689 = mkApp (tok_name, []) norng  in
-                      [uu____3689]  in
-                    (uu____3685, uu____3686)  in
-                  mkApp uu____3678 norng  in
-                (uu____3676, uu____3677)  in
-              mkEq uu____3671 norng  in
+                      let uu____3689 = mkApp (tok_name, []) norng in
+                      [uu____3689] in
+                    (uu____3685, uu____3686) in
+                  mkApp uu____3678 norng in
+                (uu____3676, uu____3677) in
+              mkEq uu____3671 norng in
             {
               assumption_term = uu____3670;
               assumption_caption =
                 (FStar_Pervasives_Native.Some "fresh token");
               assumption_name = a_name;
               assumption_fact_ids = []
-            }  in
+            } in
           Assume a
-  
-let (fresh_constructor :
+let fresh_constructor:
   (Prims.string,sort Prims.list,sort,Prims.int)
-    FStar_Pervasives_Native.tuple4 -> decl)
+    FStar_Pervasives_Native.tuple4 -> decl
   =
   fun uu____3706  ->
     match uu____3706 with
     | (name,arg_sorts,sort,id1) ->
-        let id2 = FStar_Util.string_of_int id1  in
+        let id2 = FStar_Util.string_of_int id1 in
         let bvars =
           FStar_All.pipe_right arg_sorts
             (FStar_List.mapi
@@ -1355,54 +1223,50 @@ let (fresh_constructor :
                   fun s  ->
                     let uu____3738 =
                       let uu____3743 =
-                        let uu____3744 = FStar_Util.string_of_int i  in
-                        Prims.strcat "x_" uu____3744  in
-                      (uu____3743, s)  in
-                    mkFreeV uu____3738 norng))
-           in
-        let bvar_names = FStar_List.map fv_of_term bvars  in
-        let capp = mkApp (name, bvars) norng  in
+                        let uu____3744 = FStar_Util.string_of_int i in
+                        Prims.strcat "x_" uu____3744 in
+                      (uu____3743, s) in
+                    mkFreeV uu____3738 norng)) in
+        let bvar_names = FStar_List.map fv_of_term bvars in
+        let capp = mkApp (name, bvars) norng in
         let cid_app =
           let uu____3752 =
-            let uu____3759 = constr_id_of_sort sort  in (uu____3759, [capp])
-             in
-          mkApp uu____3752 norng  in
-        let a_name = Prims.strcat "constructor_distinct_" name  in
+            let uu____3759 = constr_id_of_sort sort in (uu____3759, [capp]) in
+          mkApp uu____3752 norng in
+        let a_name = Prims.strcat "constructor_distinct_" name in
         let a =
           let uu____3764 =
             let uu____3765 =
               let uu____3776 =
                 let uu____3777 =
-                  let uu____3782 = mkInteger id2 norng  in
-                  (uu____3782, cid_app)  in
-                mkEq uu____3777 norng  in
-              ([[capp]], bvar_names, uu____3776)  in
-            mkForall uu____3765 norng  in
+                  let uu____3782 = mkInteger id2 norng in
+                  (uu____3782, cid_app) in
+                mkEq uu____3777 norng in
+              ([[capp]], bvar_names, uu____3776) in
+            mkForall uu____3765 norng in
           {
             assumption_term = uu____3764;
             assumption_caption =
               (FStar_Pervasives_Native.Some "Consrtructor distinct");
             assumption_name = a_name;
             assumption_fact_ids = []
-          }  in
+          } in
         Assume a
-  
-let (injective_constructor :
+let injective_constructor:
   (Prims.string,constructor_field Prims.list,sort)
-    FStar_Pervasives_Native.tuple3 -> decls_t)
+    FStar_Pervasives_Native.tuple3 -> decls_t
   =
   fun uu____3803  ->
     match uu____3803 with
     | (name,fields,sort) ->
-        let n_bvars = FStar_List.length fields  in
+        let n_bvars = FStar_List.length fields in
         let bvar_name i =
-          let uu____3824 = FStar_Util.string_of_int i  in
-          Prims.strcat "x_" uu____3824  in
-        let bvar_index i = n_bvars - (i + (Prims.parse_int "1"))  in
+          let uu____3824 = FStar_Util.string_of_int i in
+          Prims.strcat "x_" uu____3824 in
+        let bvar_index i = n_bvars - (i + (Prims.parse_int "1")) in
         let bvar i s =
-          let uu____3844 = let uu____3849 = bvar_name i  in (uu____3849, s)
-             in
-          mkFreeV uu____3844  in
+          let uu____3844 = let uu____3849 = bvar_name i in (uu____3849, s) in
+          mkFreeV uu____3844 in
         let bvars =
           FStar_All.pipe_right fields
             (FStar_List.mapi
@@ -1410,10 +1274,9 @@ let (injective_constructor :
                   fun uu____3870  ->
                     match uu____3870 with
                     | (uu____3877,s,uu____3879) ->
-                        let uu____3880 = bvar i s  in uu____3880 norng))
-           in
-        let bvar_names = FStar_List.map fv_of_term bvars  in
-        let capp = mkApp (name, bvars) norng  in
+                        let uu____3880 = bvar i s in uu____3880 norng)) in
+        let bvar_names = FStar_List.map fv_of_term bvars in
+        let capp = mkApp (name, bvars) norng in
         let uu____3889 =
           FStar_All.pipe_right fields
             (FStar_List.mapi
@@ -1421,12 +1284,11 @@ let (injective_constructor :
                   fun uu____3917  ->
                     match uu____3917 with
                     | (name1,s,projectible) ->
-                        let cproj_app = mkApp (name1, [capp]) norng  in
+                        let cproj_app = mkApp (name1, [capp]) norng in
                         let proj_name =
                           DeclFun
                             (name1, [sort], s,
-                              (FStar_Pervasives_Native.Some "Projector"))
-                           in
+                              (FStar_Pervasives_Native.Some "Projector")) in
                         if projectible
                         then
                           let a =
@@ -1435,12 +1297,12 @@ let (injective_constructor :
                                 let uu____3952 =
                                   let uu____3953 =
                                     let uu____3958 =
-                                      let uu____3959 = bvar i s  in
-                                      uu____3959 norng  in
-                                    (cproj_app, uu____3958)  in
-                                  mkEq uu____3953 norng  in
-                                ([[capp]], bvar_names, uu____3952)  in
-                              mkForall uu____3941 norng  in
+                                      let uu____3959 = bvar i s in
+                                      uu____3959 norng in
+                                    (cproj_app, uu____3958) in
+                                  mkEq uu____3953 norng in
+                                ([[capp]], bvar_names, uu____3952) in
+                              mkForall uu____3941 norng in
                             {
                               assumption_term = uu____3940;
                               assumption_caption =
@@ -1449,46 +1311,42 @@ let (injective_constructor :
                               assumption_name =
                                 (Prims.strcat "projection_inverse_" name1);
                               assumption_fact_ids = []
-                            }  in
+                            } in
                           [proj_name; Assume a]
-                        else [proj_name]))
-           in
+                        else [proj_name])) in
         FStar_All.pipe_right uu____3889 FStar_List.flatten
-  
-let (constructor_to_decl : constructor_t -> decls_t) =
+let constructor_to_decl: constructor_t -> decls_t =
   fun uu____3981  ->
     match uu____3981 with
     | (name,fields,sort,id1,injective) ->
-        let injective1 = injective || true  in
+        let injective1 = injective || true in
         let field_sorts =
           FStar_All.pipe_right fields
             (FStar_List.map
                (fun uu____4009  ->
                   match uu____4009 with
-                  | (uu____4016,sort1,uu____4018) -> sort1))
-           in
+                  | (uu____4016,sort1,uu____4018) -> sort1)) in
         let cdecl =
           DeclFun
             (name, field_sorts, sort,
-              (FStar_Pervasives_Native.Some "Constructor"))
-           in
-        let cid = fresh_constructor (name, field_sorts, sort, id1)  in
+              (FStar_Pervasives_Native.Some "Constructor")) in
+        let cid = fresh_constructor (name, field_sorts, sort, id1) in
         let disc =
-          let disc_name = Prims.strcat "is-" name  in
-          let xfv = ("x", sort)  in
-          let xx = mkFreeV xfv norng  in
+          let disc_name = Prims.strcat "is-" name in
+          let xfv = ("x", sort) in
+          let xx = mkFreeV xfv norng in
           let disc_eq =
             let uu____4036 =
               let uu____4041 =
                 let uu____4042 =
-                  let uu____4049 = constr_id_of_sort sort  in
-                  (uu____4049, [xx])  in
-                mkApp uu____4042 norng  in
+                  let uu____4049 = constr_id_of_sort sort in
+                  (uu____4049, [xx]) in
+                mkApp uu____4042 norng in
               let uu____4052 =
-                let uu____4053 = FStar_Util.string_of_int id1  in
-                mkInteger uu____4053 norng  in
-              (uu____4041, uu____4052)  in
-            mkEq uu____4036 norng  in
+                let uu____4053 = FStar_Util.string_of_int id1 in
+                mkInteger uu____4053 norng in
+              (uu____4041, uu____4052) in
+            mkEq uu____4036 norng in
           let uu____4054 =
             let uu____4069 =
               FStar_All.pipe_right fields
@@ -1499,67 +1357,61 @@ let (constructor_to_decl : constructor_t -> decls_t) =
                         | (proj,s,projectible) ->
                             if projectible
                             then
-                              let uu____4149 = mkApp (proj, [xx]) norng  in
+                              let uu____4149 = mkApp (proj, [xx]) norng in
                               (uu____4149, [])
                             else
                               (let fi =
                                  let uu____4168 =
                                    let uu____4169 =
-                                     FStar_Util.string_of_int i  in
-                                   Prims.strcat "f_" uu____4169  in
-                                 (uu____4168, s)  in
-                               let uu____4170 = mkFreeV fi norng  in
-                               (uu____4170, [fi]))))
-               in
-            FStar_All.pipe_right uu____4069 FStar_List.split  in
+                                     FStar_Util.string_of_int i in
+                                   Prims.strcat "f_" uu____4169 in
+                                 (uu____4168, s) in
+                               let uu____4170 = mkFreeV fi norng in
+                               (uu____4170, [fi])))) in
+            FStar_All.pipe_right uu____4069 FStar_List.split in
           match uu____4054 with
           | (proj_terms,ex_vars) ->
-              let ex_vars1 = FStar_List.flatten ex_vars  in
+              let ex_vars1 = FStar_List.flatten ex_vars in
               let disc_inv_body =
                 let uu____4251 =
-                  let uu____4256 = mkApp (name, proj_terms) norng  in
-                  (xx, uu____4256)  in
-                mkEq uu____4251 norng  in
+                  let uu____4256 = mkApp (name, proj_terms) norng in
+                  (xx, uu____4256) in
+                mkEq uu____4251 norng in
               let disc_inv_body1 =
                 match ex_vars1 with
                 | [] -> disc_inv_body
-                | uu____4264 -> mkExists ([], ex_vars1, disc_inv_body) norng
-                 in
-              let disc_ax = mkAnd (disc_eq, disc_inv_body1) norng  in
+                | uu____4264 -> mkExists ([], ex_vars1, disc_inv_body) norng in
+              let disc_ax = mkAnd (disc_eq, disc_inv_body1) norng in
               let def =
                 mkDefineFun
                   (disc_name, [xfv], Bool_sort, disc_ax,
-                    (FStar_Pervasives_Native.Some "Discriminator definition"))
-                 in
-              def
-           in
+                    (FStar_Pervasives_Native.Some "Discriminator definition")) in
+              def in
         let projs =
           if injective1
           then injective_constructor (name, fields, sort)
-          else []  in
+          else [] in
         let uu____4305 =
           let uu____4308 =
-            let uu____4309 = FStar_Util.format1 "<start constructor %s>" name
-               in
-            Caption uu____4309  in
-          uu____4308 :: cdecl :: cid :: projs  in
+            let uu____4309 = FStar_Util.format1 "<start constructor %s>" name in
+            Caption uu____4309 in
+          uu____4308 :: cdecl :: cid :: projs in
         let uu____4310 =
           let uu____4313 =
             let uu____4316 =
               let uu____4317 =
-                FStar_Util.format1 "</end constructor %s>" name  in
-              Caption uu____4317  in
-            [uu____4316]  in
-          FStar_List.append [disc] uu____4313  in
+                FStar_Util.format1 "</end constructor %s>" name in
+              Caption uu____4317 in
+            [uu____4316] in
+          FStar_List.append [disc] uu____4313 in
         FStar_List.append uu____4305 uu____4310
-  
-let (name_binders_inner :
+let name_binders_inner:
   Prims.string FStar_Pervasives_Native.option ->
     (Prims.string,sort) FStar_Pervasives_Native.tuple2 Prims.list ->
       Prims.int ->
         sort Prims.list ->
           ((Prims.string,sort) FStar_Pervasives_Native.tuple2 Prims.list,
-            Prims.string Prims.list,Prims.int) FStar_Pervasives_Native.tuple3)
+            Prims.string Prims.list,Prims.int) FStar_Pervasives_Native.tuple3
   =
   fun prefix_opt  ->
     fun outer_names  ->
@@ -1575,56 +1427,50 @@ let (name_binders_inner :
                           let prefix1 =
                             match s with
                             | Term_sort  -> "@x"
-                            | uu____4469 -> "@u"  in
+                            | uu____4469 -> "@u" in
                           let prefix2 =
                             match prefix_opt with
                             | FStar_Pervasives_Native.None  -> prefix1
                             | FStar_Pervasives_Native.Some p ->
-                                Prims.strcat p prefix1
-                             in
+                                Prims.strcat p prefix1 in
                           let nm =
-                            let uu____4473 = FStar_Util.string_of_int n1  in
-                            Prims.strcat prefix2 uu____4473  in
-                          let names2 = (nm, s) :: names1  in
+                            let uu____4473 = FStar_Util.string_of_int n1 in
+                            Prims.strcat prefix2 uu____4473 in
+                          let names2 = (nm, s) :: names1 in
                           let b =
-                            let uu____4486 = strSort s  in
-                            FStar_Util.format2 "(%s %s)" nm uu____4486  in
+                            let uu____4486 = strSort s in
+                            FStar_Util.format2 "(%s %s)" nm uu____4486 in
                           (names2, (b :: binders),
                             (n1 + (Prims.parse_int "1"))))
-                 (outer_names, [], start))
-             in
+                 (outer_names, [], start)) in
           match uu____4364 with
           | (names1,binders,n1) -> (names1, (FStar_List.rev binders), n1)
-  
-let (name_macro_binders :
+let name_macro_binders:
   sort Prims.list ->
     ((Prims.string,sort) FStar_Pervasives_Native.tuple2 Prims.list,Prims.string
                                                                     Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun sorts  ->
     let uu____4563 =
       name_binders_inner (FStar_Pervasives_Native.Some "__") []
-        (Prims.parse_int "0") sorts
-       in
+        (Prims.parse_int "0") sorts in
     match uu____4563 with
     | (names1,binders,n1) -> ((FStar_List.rev names1), binders)
-  
-let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
+let termToSmt: Prims.bool -> Prims.string -> term -> Prims.string =
   fun print_ranges  ->
     fun enclosing_name  ->
       fun t  ->
         let next_qid =
-          let ctr = FStar_Util.mk_ref (Prims.parse_int "0")  in
+          let ctr = FStar_Util.mk_ref (Prims.parse_int "0") in
           fun depth  ->
-            let n1 = FStar_ST.op_Bang ctr  in
+            let n1 = FStar_ST.op_Bang ctr in
             FStar_Util.incr ctr;
             if n1 = (Prims.parse_int "0")
             then enclosing_name
             else
-              (let uu____4718 = FStar_Util.string_of_int n1  in
-               FStar_Util.format2 "%s.%s" enclosing_name uu____4718)
-           in
+              (let uu____4718 = FStar_Util.string_of_int n1 in
+               FStar_Util.format2 "%s.%s" enclosing_name uu____4718) in
         let remove_guard_free pats =
           FStar_All.pipe_right pats
             (FStar_List.map
@@ -1640,40 +1486,36 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
                                                     rng = uu____4762;_}::[])
                               -> tm
                           | App (Var "Prims.guard_free",p::[]) -> p
-                          | uu____4776 -> tm))))
-           in
+                          | uu____4776 -> tm)))) in
         let rec aux' depth n1 names1 t1 =
-          let aux1 = aux (depth + (Prims.parse_int "1"))  in
+          let aux1 = aux (depth + (Prims.parse_int "1")) in
           match t1.tm with
           | Integer i -> i
           | BoundV i ->
-              let uu____4816 = FStar_List.nth names1 i  in
+              let uu____4816 = FStar_List.nth names1 i in
               FStar_All.pipe_right uu____4816 FStar_Pervasives_Native.fst
           | FreeV x -> FStar_Pervasives_Native.fst x
           | App (op,[]) -> op_to_string op
           | App (op,tms) ->
-              let uu____4831 = op_to_string op  in
+              let uu____4831 = op_to_string op in
               let uu____4832 =
-                let uu____4833 = FStar_List.map (aux1 n1 names1) tms  in
-                FStar_All.pipe_right uu____4833 (FStar_String.concat "\n")
-                 in
+                let uu____4833 = FStar_List.map (aux1 n1 names1) tms in
+                FStar_All.pipe_right uu____4833 (FStar_String.concat "\n") in
               FStar_Util.format2 "(%s %s)" uu____4831 uu____4832
           | Labeled (t2,uu____4839,uu____4840) -> aux1 n1 names1 t2
           | LblPos (t2,s) ->
-              let uu____4843 = aux1 n1 names1 t2  in
+              let uu____4843 = aux1 n1 names1 t2 in
               FStar_Util.format2 "(! %s :lblpos %s)" uu____4843 s
           | Quant (qop,pats,wopt,sorts,body) ->
-              let qid = next_qid ()  in
+              let qid = next_qid () in
               let uu____4866 =
                 name_binders_inner FStar_Pervasives_Native.None names1 n1
-                  sorts
-                 in
+                  sorts in
               (match uu____4866 with
                | (names2,binders,n2) ->
                    let binders1 =
-                     FStar_All.pipe_right binders (FStar_String.concat " ")
-                      in
-                   let pats1 = remove_guard_free pats  in
+                     FStar_All.pipe_right binders (FStar_String.concat " ") in
+                   let pats1 = remove_guard_free pats in
                    let pats_str =
                      match pats1 with
                      | []::[] -> ";;no pats"
@@ -1687,28 +1529,24 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
                                      let uu____4937 =
                                        FStar_List.map
                                          (fun p  ->
-                                            let uu____4943 = aux1 n2 names2 p
-                                               in
+                                            let uu____4943 = aux1 n2 names2 p in
                                             FStar_Util.format1 "%s"
-                                              uu____4943) pats2
-                                        in
-                                     FStar_String.concat " " uu____4937  in
+                                              uu____4943) pats2 in
+                                     FStar_String.concat " " uu____4937 in
                                    FStar_Util.format1 "\n:pattern (%s)"
-                                     uu____4936))
-                            in
+                                     uu____4936)) in
                          FStar_All.pipe_right uu____4920
-                           (FStar_String.concat "\n")
-                      in
+                           (FStar_String.concat "\n") in
                    let uu____4946 =
                      let uu____4949 =
                        let uu____4952 =
-                         let uu____4955 = aux1 n2 names2 body  in
+                         let uu____4955 = aux1 n2 names2 body in
                          let uu____4956 =
-                           let uu____4959 = weightToSmt wopt  in
-                           [uu____4959; pats_str; qid]  in
-                         uu____4955 :: uu____4956  in
-                       binders1 :: uu____4952  in
-                     (qop_to_string qop) :: uu____4949  in
+                           let uu____4959 = weightToSmt wopt in
+                           [uu____4959; pats_str; qid] in
+                         uu____4955 :: uu____4956 in
+                       binders1 :: uu____4952 in
+                     (qop_to_string qop) :: uu____4949 in
                    FStar_Util.format "(%s (%s)\n (! %s\n %s\n%s\n:qid %s))"
                      uu____4946)
           | Let (es,body) ->
@@ -1719,35 +1557,32 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
                        match uu____5003 with
                        | (names0,binders,n0) ->
                            let nm =
-                             let uu____5053 = FStar_Util.string_of_int n0  in
-                             Prims.strcat "@lb" uu____5053  in
-                           let names01 = (nm, Term_sort) :: names0  in
+                             let uu____5053 = FStar_Util.string_of_int n0 in
+                             Prims.strcat "@lb" uu____5053 in
+                           let names01 = (nm, Term_sort) :: names0 in
                            let b =
-                             let uu____5066 = aux1 n1 names1 e  in
-                             FStar_Util.format2 "(%s %s)" nm uu____5066  in
+                             let uu____5066 = aux1 n1 names1 e in
+                             FStar_Util.format2 "(%s %s)" nm uu____5066 in
                            (names01, (b :: binders),
                              (n0 + (Prims.parse_int "1")))) (names1, [], n1)
-                  es
-                 in
+                  es in
               (match uu____4966 with
                | (names2,binders,n2) ->
-                   let uu____5098 = aux1 n2 names2 body  in
+                   let uu____5098 = aux1 n2 names2 body in
                    FStar_Util.format2 "(let (%s)\n%s)"
                      (FStar_String.concat " " binders) uu____5098)
-        
         and aux depth n1 names1 t1 =
-          let s = aux' depth n1 names1 t1  in
+          let s = aux' depth n1 names1 t1 in
           if print_ranges && (t1.rng <> norng)
           then
-            let uu____5106 = FStar_Range.string_of_range t1.rng  in
-            let uu____5107 = FStar_Range.string_of_use_range t1.rng  in
+            let uu____5106 = FStar_Range.string_of_range t1.rng in
+            let uu____5107 = FStar_Range.string_of_use_range t1.rng in
             FStar_Util.format3 "\n;; def=%s; use=%s\n%s\n" uu____5106
               uu____5107 s
-          else s
-         in aux (Prims.parse_int "0") (Prims.parse_int "0") [] t
-  
-let (caption_to_string :
-  Prims.string FStar_Pervasives_Native.option -> Prims.string) =
+          else s in
+        aux (Prims.parse_int "0") (Prims.parse_int "0") [] t
+let caption_to_string:
+  Prims.string FStar_Pervasives_Native.option -> Prims.string =
   fun uu___51_5113  ->
     match uu___51_5113 with
     | FStar_Pervasives_Native.None  -> ""
@@ -1756,46 +1591,44 @@ let (caption_to_string :
           match FStar_Util.splitlines c with
           | [] -> failwith "Impossible"
           | hd1::[] -> (hd1, "")
-          | hd1::uu____5132 -> (hd1, "...")  in
+          | hd1::uu____5132 -> (hd1, "...") in
         (match uu____5117 with
          | (hd1,suffix) ->
              FStar_Util.format2 ";;;;;;;;;;;;;;;;%s%s\n" hd1 suffix)
-  
-let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
+let rec declToSmt': Prims.bool -> Prims.string -> decl -> Prims.string =
   fun print_ranges  ->
     fun z3options  ->
       fun decl  ->
-        let escape s = FStar_Util.replace_char s 39 95  in
+        let escape s = FStar_Util.replace_char s 39 95 in
         match decl with
         | DefPrelude  -> mkPrelude z3options
         | Caption c ->
-            let uu____5163 = FStar_Options.log_queries ()  in
+            let uu____5163 = FStar_Options.log_queries () in
             if uu____5163
             then
               let uu____5164 =
                 FStar_All.pipe_right (FStar_Util.splitlines c)
                   (fun uu___52_5168  ->
-                     match uu___52_5168 with | [] -> "" | h::t -> h)
-                 in
+                     match uu___52_5168 with | [] -> "" | h::t -> h) in
               FStar_Util.format1 "\n; %s" uu____5164
             else ""
         | DeclFun (f,argsorts,retsort,c) ->
-            let l = FStar_List.map strSort argsorts  in
-            let uu____5187 = caption_to_string c  in
-            let uu____5188 = strSort retsort  in
+            let l = FStar_List.map strSort argsorts in
+            let uu____5187 = caption_to_string c in
+            let uu____5188 = strSort retsort in
             FStar_Util.format4 "%s(declare-fun %s (%s) %s)" uu____5187 f
               (FStar_String.concat " " l) uu____5188
         | DefineFun (f,arg_sorts,retsort,body,c) ->
-            let uu____5198 = name_macro_binders arg_sorts  in
+            let uu____5198 = name_macro_binders arg_sorts in
             (match uu____5198 with
              | (names1,binders) ->
                  let body1 =
                    let uu____5230 =
-                     FStar_List.map (fun x  -> mkFreeV x norng) names1  in
-                   inst uu____5230 body  in
-                 let uu____5243 = caption_to_string c  in
-                 let uu____5244 = strSort retsort  in
-                 let uu____5245 = termToSmt print_ranges (escape f) body1  in
+                     FStar_List.map (fun x  -> mkFreeV x norng) names1 in
+                   inst uu____5230 body in
+                 let uu____5243 = caption_to_string c in
+                 let uu____5244 = strSort retsort in
+                 let uu____5245 = termToSmt print_ranges (escape f) body1 in
                  FStar_Util.format5 "%s(define-fun %s (%s) %s\n %s)"
                    uu____5243 f (FStar_String.concat " " binders) uu____5244
                    uu____5245)
@@ -1810,25 +1643,23 @@ let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
                       | Namespace ns ->
                           Prims.strcat "Namespace "
                             (FStar_Ident.text_of_lid ns)
-                      | Tag t -> Prims.strcat "Tag " t))
-               in
+                      | Tag t -> Prims.strcat "Tag " t)) in
             let fids =
-              let uu____5268 = FStar_Options.log_queries ()  in
+              let uu____5268 = FStar_Options.log_queries () in
               if uu____5268
               then
                 let uu____5269 =
-                  let uu____5270 = fact_ids_to_string a.assumption_fact_ids
-                     in
-                  FStar_String.concat "; " uu____5270  in
+                  let uu____5270 = fact_ids_to_string a.assumption_fact_ids in
+                  FStar_String.concat "; " uu____5270 in
                 FStar_Util.format1 ";;; Fact-ids: %s\n" uu____5269
-              else ""  in
-            let n1 = escape a.assumption_name  in
-            let uu____5275 = caption_to_string a.assumption_caption  in
-            let uu____5276 = termToSmt print_ranges n1 a.assumption_term  in
+              else "" in
+            let n1 = escape a.assumption_name in
+            let uu____5275 = caption_to_string a.assumption_caption in
+            let uu____5276 = termToSmt print_ranges n1 a.assumption_term in
             FStar_Util.format4 "%s%s(assert (! %s\n:named %s))" uu____5275
               fids uu____5276 n1
         | Eval t ->
-            let uu____5278 = termToSmt print_ranges "eval" t  in
+            let uu____5278 = termToSmt print_ranges "eval" t in
             FStar_Util.format1 "(eval %s)" uu____5278
         | Echo s -> FStar_Util.format1 "(echo \"%s\")" s
         | RetainAssumptions uu____5280 -> ""
@@ -1843,19 +1674,15 @@ let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
             "(echo \"<statistics>\")\n(get-info :all-statistics)\n(echo \"</statistics>\")"
         | GetReasonUnknown  ->
             "(echo \"<reason-unknown>\")\n(get-info :reason-unknown)\n(echo \"</reason-unknown>\")"
-
-and (declToSmt : Prims.string -> decl -> Prims.string) =
+and declToSmt: Prims.string -> decl -> Prims.string =
   fun z3options  -> fun decl  -> declToSmt' true z3options decl
-
-and (declToSmt_no_caps : Prims.string -> decl -> Prims.string) =
+and declToSmt_no_caps: Prims.string -> decl -> Prims.string =
   fun z3options  -> fun decl  -> declToSmt' false z3options decl
-
-and (mkPrelude : Prims.string -> Prims.string) =
+and mkPrelude: Prims.string -> Prims.string =
   fun z3options  ->
     let basic =
       Prims.strcat z3options
-        "(declare-sort FString)\n(declare-fun FString_constr_id (FString) Int)\n\n(declare-sort Term)\n(declare-fun Term_constr_id (Term) Int)\n(declare-datatypes () ((Fuel \n(ZFuel) \n(SFuel (prec Fuel)))))\n(declare-fun MaxIFuel () Fuel)\n(declare-fun MaxFuel () Fuel)\n(declare-fun PreType (Term) Term)\n(declare-fun Valid (Term) Bool)\n(declare-fun HasTypeFuel (Fuel Term Term) Bool)\n(define-fun HasTypeZ ((x Term) (t Term)) Bool\n(HasTypeFuel ZFuel x t))\n(define-fun HasType ((x Term) (t Term)) Bool\n(HasTypeFuel MaxIFuel x t))\n;;fuel irrelevance\n(assert (forall ((f Fuel) (x Term) (t Term))\n(! (= (HasTypeFuel (SFuel f) x t)\n(HasTypeZ x t))\n:pattern ((HasTypeFuel (SFuel f) x t)))))\n(declare-fun NoHoist (Term Bool) Bool)\n;;no-hoist\n(assert (forall ((dummy Term) (b Bool))\n(! (= (NoHoist dummy b)\nb)\n:pattern ((NoHoist dummy b)))))\n(define-fun  IsTyped ((x Term)) Bool\n(exists ((t Term)) (HasTypeZ x t)))\n(declare-fun ApplyTF (Term Fuel) Term)\n(declare-fun ApplyTT (Term Term) Term)\n(declare-fun Rank (Term) Int)\n(declare-fun Closure (Term) Term)\n(declare-fun ConsTerm (Term Term) Term)\n(declare-fun ConsFuel (Fuel Term) Term)\n(declare-fun Precedes (Term Term) Term)\n(declare-fun Tm_uvar (Int) Term)\n(define-fun Reify ((x Term)) Term x)\n(assert (forall ((t Term))\n(! (iff (exists ((e Term)) (HasType e t))\n(Valid t))\n:pattern ((Valid t)))))\n(assert (forall ((t1 Term) (t2 Term))\n(! (iff (Valid (Precedes t1 t2)) \n(< (Rank t1) (Rank t2)))\n:pattern ((Precedes t1 t2)))))\n(define-fun Prims.precedes ((a Term) (b Term) (t1 Term) (t2 Term)) Term\n(Precedes t1 t2))\n(declare-fun Range_const (Int) Term)\n(declare-fun _mul (Int Int) Int)\n(declare-fun _div (Int Int) Int)\n(declare-fun _mod (Int Int) Int)\n(assert (forall ((x Int) (y Int)) (! (= (_mul x y) (* x y)) :pattern ((_mul x y)))))\n(assert (forall ((x Int) (y Int)) (! (= (_div x y) (div x y)) :pattern ((_div x y)))))\n(assert (forall ((x Int) (y Int)) (! (= (_mod x y) (mod x y)) :pattern ((_mod x y)))))"
-       in
+        "(declare-sort FString)\n(declare-fun FString_constr_id (FString) Int)\n\n(declare-sort Term)\n(declare-fun Term_constr_id (Term) Int)\n(declare-datatypes () ((Fuel \n(ZFuel) \n(SFuel (prec Fuel)))))\n(declare-fun MaxIFuel () Fuel)\n(declare-fun MaxFuel () Fuel)\n(declare-fun PreType (Term) Term)\n(declare-fun Valid (Term) Bool)\n(declare-fun HasTypeFuel (Fuel Term Term) Bool)\n(define-fun HasTypeZ ((x Term) (t Term)) Bool\n(HasTypeFuel ZFuel x t))\n(define-fun HasType ((x Term) (t Term)) Bool\n(HasTypeFuel MaxIFuel x t))\n;;fuel irrelevance\n(assert (forall ((f Fuel) (x Term) (t Term))\n(! (= (HasTypeFuel (SFuel f) x t)\n(HasTypeZ x t))\n:pattern ((HasTypeFuel (SFuel f) x t)))))\n(declare-fun NoHoist (Term Bool) Bool)\n;;no-hoist\n(assert (forall ((dummy Term) (b Bool))\n(! (= (NoHoist dummy b)\nb)\n:pattern ((NoHoist dummy b)))))\n(define-fun  IsTyped ((x Term)) Bool\n(exists ((t Term)) (HasTypeZ x t)))\n(declare-fun ApplyTF (Term Fuel) Term)\n(declare-fun ApplyTT (Term Term) Term)\n(declare-fun Rank (Term) Int)\n(declare-fun Closure (Term) Term)\n(declare-fun ConsTerm (Term Term) Term)\n(declare-fun ConsFuel (Fuel Term) Term)\n(declare-fun Precedes (Term Term) Term)\n(declare-fun Tm_uvar (Int) Term)\n(define-fun Reify ((x Term)) Term x)\n(assert (forall ((t Term))\n(! (iff (exists ((e Term)) (HasType e t))\n(Valid t))\n:pattern ((Valid t)))))\n(assert (forall ((t1 Term) (t2 Term))\n(! (iff (Valid (Precedes t1 t2)) \n(< (Rank t1) (Rank t2)))\n:pattern ((Precedes t1 t2)))))\n(define-fun Prims.precedes ((a Term) (b Term) (t1 Term) (t2 Term)) Term\n(Precedes t1 t2))\n(declare-fun Range_const (Int) Term)\n(declare-fun _mul (Int Int) Int)\n(declare-fun _div (Int Int) Int)\n(declare-fun _mod (Int Int) Int)\n(assert (forall ((x Int) (y Int)) (! (= (_mul x y) (* x y)) :pattern ((_mul x y)))))\n(assert (forall ((x Int) (y Int)) (! (= (_div x y) (div x y)) :pattern ((_div x y)))))\n(assert (forall ((x Int) (y Int)) (! (= (_mod x y) (mod x y)) :pattern ((_mod x y)))))" in
     let constrs =
       [("FString_const", [("FString_const_proj_0", Int_sort, true)],
          String_sort, (Prims.parse_int "0"), true);
@@ -1874,70 +1701,59 @@ and (mkPrelude : Prims.string -> Prims.string) =
         Term_sort, (Prims.parse_int "9"), true);
       ("LexCons",
         [("LexCons_0", Term_sort, true); ("LexCons_1", Term_sort, true)],
-        Term_sort, (Prims.parse_int "11"), true)]
-       in
+        Term_sort, (Prims.parse_int "11"), true)] in
     let bcons =
       let uu____5609 =
         let uu____5612 =
           FStar_All.pipe_right constrs
-            (FStar_List.collect constructor_to_decl)
-           in
+            (FStar_List.collect constructor_to_decl) in
         FStar_All.pipe_right uu____5612
-          (FStar_List.map (declToSmt z3options))
-         in
-      FStar_All.pipe_right uu____5609 (FStar_String.concat "\n")  in
+          (FStar_List.map (declToSmt z3options)) in
+      FStar_All.pipe_right uu____5609 (FStar_String.concat "\n") in
     let lex_ordering =
-      "\n(define-fun is-Prims.LexCons ((t Term)) Bool \n(is-LexCons t))\n(assert (forall ((x1 Term) (x2 Term) (y1 Term) (y2 Term))\n(iff (Valid (Precedes (LexCons x1 x2) (LexCons y1 y2)))\n(or (Valid (Precedes x1 y1))\n(and (= x1 y1)\n(Valid (Precedes x2 y2)))))))\n"
-       in
+      "\n(define-fun is-Prims.LexCons ((t Term)) Bool \n(is-LexCons t))\n(assert (forall ((x1 Term) (x2 Term) (y1 Term) (y2 Term))\n(iff (Valid (Precedes (LexCons x1 x2) (LexCons y1 y2)))\n(or (Valid (Precedes x1 y1))\n(and (= x1 y1)\n(Valid (Precedes x2 y2)))))))\n" in
     Prims.strcat basic (Prims.strcat bcons lex_ordering)
-
-let (mkBvConstructor : Prims.int -> decls_t) =
+let mkBvConstructor: Prims.int -> decls_t =
   fun sz  ->
     let uu____5627 =
       let uu____5646 =
-        let uu____5647 = boxBitVecFun sz  in
-        FStar_Pervasives_Native.fst uu____5647  in
+        let uu____5647 = boxBitVecFun sz in
+        FStar_Pervasives_Native.fst uu____5647 in
       let uu____5652 =
         let uu____5661 =
           let uu____5668 =
-            let uu____5669 = boxBitVecFun sz  in
-            FStar_Pervasives_Native.snd uu____5669  in
-          (uu____5668, (BitVec_sort sz), true)  in
-        [uu____5661]  in
+            let uu____5669 = boxBitVecFun sz in
+            FStar_Pervasives_Native.snd uu____5669 in
+          (uu____5668, (BitVec_sort sz), true) in
+        [uu____5661] in
       (uu____5646, uu____5652, Term_sort, ((Prims.parse_int "12") + sz),
-        true)
-       in
+        true) in
     FStar_All.pipe_right uu____5627 constructor_to_decl
-  
-let (__range_c : Prims.int FStar_ST.ref) =
-  FStar_Util.mk_ref (Prims.parse_int "0") 
-let (mk_Range_const : Prims.unit -> term) =
+let __range_c: Prims.int FStar_ST.ref =
+  FStar_Util.mk_ref (Prims.parse_int "0")
+let mk_Range_const: Prims.unit -> term =
   fun uu____5727  ->
-    let i = FStar_ST.op_Bang __range_c  in
+    let i = FStar_ST.op_Bang __range_c in
     (let uu____5749 =
-       let uu____5750 = FStar_ST.op_Bang __range_c  in
-       uu____5750 + (Prims.parse_int "1")  in
+       let uu____5750 = FStar_ST.op_Bang __range_c in
+       uu____5750 + (Prims.parse_int "1") in
      FStar_ST.op_Colon_Equals __range_c uu____5749);
     (let uu____5789 =
-       let uu____5796 = let uu____5799 = mkInteger' i norng  in [uu____5799]
-          in
-       ("Range_const", uu____5796)  in
+       let uu____5796 = let uu____5799 = mkInteger' i norng in [uu____5799] in
+       ("Range_const", uu____5796) in
      mkApp uu____5789 norng)
-  
-let (mk_Term_type : term) = mkApp ("Tm_type", []) norng 
-let (mk_Term_app : term -> term -> FStar_Range.range -> term) =
-  fun t1  -> fun t2  -> fun r  -> mkApp ("Tm_app", [t1; t2]) r 
-let (mk_Term_uvar : Prims.int -> FStar_Range.range -> term) =
+let mk_Term_type: term = mkApp ("Tm_type", []) norng
+let mk_Term_app: term -> term -> FStar_Range.range -> term =
+  fun t1  -> fun t2  -> fun r  -> mkApp ("Tm_app", [t1; t2]) r
+let mk_Term_uvar: Prims.int -> FStar_Range.range -> term =
   fun i  ->
     fun r  ->
       let uu____5821 =
-        let uu____5828 = let uu____5831 = mkInteger' i norng  in [uu____5831]
-           in
-        ("Tm_uvar", uu____5828)  in
+        let uu____5828 = let uu____5831 = mkInteger' i norng in [uu____5831] in
+        ("Tm_uvar", uu____5828) in
       mkApp uu____5821 r
-  
-let (mk_Term_unit : term) = mkApp ("Tm_unit", []) norng 
-let (elim_box : Prims.bool -> Prims.string -> Prims.string -> term -> term) =
+let mk_Term_unit: term = mkApp ("Tm_unit", []) norng
+let elim_box: Prims.bool -> Prims.string -> Prims.string -> term -> term =
   fun cond  ->
     fun u  ->
       fun v1  ->
@@ -1945,67 +1761,57 @@ let (elim_box : Prims.bool -> Prims.string -> Prims.string -> term -> term) =
           match t.tm with
           | App (Var v',t1::[]) when (v1 = v') && cond -> t1
           | uu____5852 -> mkApp (u, [t]) t.rng
-  
-let (maybe_elim_box : Prims.string -> Prims.string -> term -> term) =
+let maybe_elim_box: Prims.string -> Prims.string -> term -> term =
   fun u  ->
     fun v1  ->
       fun t  ->
-        let uu____5864 = FStar_Options.smtencoding_elim_box ()  in
+        let uu____5864 = FStar_Options.smtencoding_elim_box () in
         elim_box uu____5864 u v1 t
-  
-let (boxInt : term -> term) =
+let boxInt: term -> term =
   fun t  ->
     maybe_elim_box (FStar_Pervasives_Native.fst boxIntFun)
       (FStar_Pervasives_Native.snd boxIntFun) t
-  
-let (unboxInt : term -> term) =
+let unboxInt: term -> term =
   fun t  ->
     maybe_elim_box (FStar_Pervasives_Native.snd boxIntFun)
       (FStar_Pervasives_Native.fst boxIntFun) t
-  
-let (boxBool : term -> term) =
+let boxBool: term -> term =
   fun t  ->
     maybe_elim_box (FStar_Pervasives_Native.fst boxBoolFun)
       (FStar_Pervasives_Native.snd boxBoolFun) t
-  
-let (unboxBool : term -> term) =
+let unboxBool: term -> term =
   fun t  ->
     maybe_elim_box (FStar_Pervasives_Native.snd boxBoolFun)
       (FStar_Pervasives_Native.fst boxBoolFun) t
-  
-let (boxString : term -> term) =
+let boxString: term -> term =
   fun t  ->
     maybe_elim_box (FStar_Pervasives_Native.fst boxStringFun)
       (FStar_Pervasives_Native.snd boxStringFun) t
-  
-let (unboxString : term -> term) =
+let unboxString: term -> term =
   fun t  ->
     maybe_elim_box (FStar_Pervasives_Native.snd boxStringFun)
       (FStar_Pervasives_Native.fst boxStringFun) t
-  
-let (boxBitVec : Prims.int -> term -> term) =
+let boxBitVec: Prims.int -> term -> term =
   fun sz  ->
     fun t  ->
       let uu____5889 =
-        let uu____5890 = boxBitVecFun sz  in
-        FStar_Pervasives_Native.fst uu____5890  in
+        let uu____5890 = boxBitVecFun sz in
+        FStar_Pervasives_Native.fst uu____5890 in
       let uu____5895 =
-        let uu____5896 = boxBitVecFun sz  in
-        FStar_Pervasives_Native.snd uu____5896  in
+        let uu____5896 = boxBitVecFun sz in
+        FStar_Pervasives_Native.snd uu____5896 in
       elim_box true uu____5889 uu____5895 t
-  
-let (unboxBitVec : Prims.int -> term -> term) =
+let unboxBitVec: Prims.int -> term -> term =
   fun sz  ->
     fun t  ->
       let uu____5907 =
-        let uu____5908 = boxBitVecFun sz  in
-        FStar_Pervasives_Native.snd uu____5908  in
+        let uu____5908 = boxBitVecFun sz in
+        FStar_Pervasives_Native.snd uu____5908 in
       let uu____5913 =
-        let uu____5914 = boxBitVecFun sz  in
-        FStar_Pervasives_Native.fst uu____5914  in
+        let uu____5914 = boxBitVecFun sz in
+        FStar_Pervasives_Native.fst uu____5914 in
       elim_box true uu____5907 uu____5913 t
-  
-let (boxTerm : sort -> term -> term) =
+let boxTerm: sort -> term -> term =
   fun sort  ->
     fun t  ->
       match sort with
@@ -2014,8 +1820,7 @@ let (boxTerm : sort -> term -> term) =
       | String_sort  -> boxString t
       | BitVec_sort sz -> boxBitVec sz t
       | uu____5926 -> FStar_Exn.raise FStar_Util.Impos
-  
-let (unboxTerm : sort -> term -> term) =
+let unboxTerm: sort -> term -> term =
   fun sort  ->
     fun t  ->
       match sort with
@@ -2024,66 +1829,61 @@ let (unboxTerm : sort -> term -> term) =
       | String_sort  -> unboxString t
       | BitVec_sort sz -> unboxBitVec sz t
       | uu____5934 -> FStar_Exn.raise FStar_Util.Impos
-  
-let rec (print_smt_term : term -> Prims.string) =
+let rec print_smt_term: term -> Prims.string =
   fun t  ->
     match t.tm with
     | Integer n1 -> FStar_Util.format1 "(Integer %s)" n1
     | BoundV n1 ->
-        let uu____5950 = FStar_Util.string_of_int n1  in
+        let uu____5950 = FStar_Util.string_of_int n1 in
         FStar_Util.format1 "(BoundV %s)" uu____5950
     | FreeV fv ->
         FStar_Util.format1 "(FreeV %s)" (FStar_Pervasives_Native.fst fv)
     | App (op,l) ->
-        let uu____5962 = op_to_string op  in
-        let uu____5963 = print_smt_term_list l  in
+        let uu____5962 = op_to_string op in
+        let uu____5963 = print_smt_term_list l in
         FStar_Util.format2 "(%s %s)" uu____5962 uu____5963
     | Labeled (t1,r1,r2) ->
-        let uu____5967 = print_smt_term t1  in
+        let uu____5967 = print_smt_term t1 in
         FStar_Util.format2 "(Labeled '%s' %s)" r1 uu____5967
     | LblPos (t1,s) ->
-        let uu____5970 = print_smt_term t1  in
+        let uu____5970 = print_smt_term t1 in
         FStar_Util.format2 "(LblPos %s %s)" s uu____5970
     | Quant (qop,l,uu____5973,uu____5974,t1) ->
-        let uu____5992 = print_smt_term_list_list l  in
-        let uu____5993 = print_smt_term t1  in
+        let uu____5992 = print_smt_term_list_list l in
+        let uu____5993 = print_smt_term t1 in
         FStar_Util.format3 "(%s %s %s)" (qop_to_string qop) uu____5992
           uu____5993
     | Let (es,body) ->
-        let uu____6000 = print_smt_term_list es  in
-        let uu____6001 = print_smt_term body  in
+        let uu____6000 = print_smt_term_list es in
+        let uu____6001 = print_smt_term body in
         FStar_Util.format2 "(let %s %s)" uu____6000 uu____6001
-
-and (print_smt_term_list : term Prims.list -> Prims.string) =
+and print_smt_term_list: term Prims.list -> Prims.string =
   fun l  ->
-    let uu____6005 = FStar_List.map print_smt_term l  in
+    let uu____6005 = FStar_List.map print_smt_term l in
     FStar_All.pipe_right uu____6005 (FStar_String.concat " ")
-
-and (print_smt_term_list_list : term Prims.list Prims.list -> Prims.string) =
+and print_smt_term_list_list: term Prims.list Prims.list -> Prims.string =
   fun l  ->
     FStar_List.fold_left
       (fun s  ->
          fun l1  ->
            let uu____6024 =
              let uu____6025 =
-               let uu____6026 = print_smt_term_list l1  in
-               Prims.strcat uu____6026 " ] "  in
-             Prims.strcat "; [ " uu____6025  in
+               let uu____6026 = print_smt_term_list l1 in
+               Prims.strcat uu____6026 " ] " in
+             Prims.strcat "; [ " uu____6025 in
            Prims.strcat s uu____6024) "" l
-
-let (getBoxedInteger : term -> Prims.int FStar_Pervasives_Native.option) =
+let getBoxedInteger: term -> Prims.int FStar_Pervasives_Native.option =
   fun t  ->
     match t.tm with
     | App (Var s,t2::[]) when s = (FStar_Pervasives_Native.fst boxIntFun) ->
         (match t2.tm with
          | Integer n1 ->
-             let uu____6041 = FStar_Util.int_of_string n1  in
+             let uu____6041 = FStar_Util.int_of_string n1 in
              FStar_Pervasives_Native.Some uu____6041
          | uu____6042 -> FStar_Pervasives_Native.None)
     | uu____6043 -> FStar_Pervasives_Native.None
-  
-let (mk_PreType : term -> term) = fun t  -> mkApp ("PreType", [t]) t.rng 
-let (mk_Valid : term -> term) =
+let mk_PreType: term -> term = fun t  -> mkApp ("PreType", [t]) t.rng
+let mk_Valid: term -> term =
   fun t  ->
     match t.tm with
     | App
@@ -2099,15 +1899,15 @@ let (mk_Valid : term -> term) =
                        tm = App
                          (Var "Prims.op_disEquality",uu____6069::t1::t2::[]);
                        freevars = uu____6072; rng = uu____6073;_}::[])
-        -> let uu____6086 = mkEq (t1, t2) norng  in mkNot uu____6086 t.rng
+        -> let uu____6086 = mkEq (t1, t2) norng in mkNot uu____6086 t.rng
     | App
         (Var
          "Prims.b2t",{ tm = App (Var "Prims.op_LessThanOrEqual",t1::t2::[]);
                        freevars = uu____6089; rng = uu____6090;_}::[])
         ->
         let uu____6103 =
-          let uu____6108 = unboxInt t1  in
-          let uu____6109 = unboxInt t2  in (uu____6108, uu____6109)  in
+          let uu____6108 = unboxInt t1 in
+          let uu____6109 = unboxInt t2 in (uu____6108, uu____6109) in
         mkLTE uu____6103 t.rng
     | App
         (Var
@@ -2115,8 +1915,8 @@ let (mk_Valid : term -> term) =
                        freevars = uu____6112; rng = uu____6113;_}::[])
         ->
         let uu____6126 =
-          let uu____6131 = unboxInt t1  in
-          let uu____6132 = unboxInt t2  in (uu____6131, uu____6132)  in
+          let uu____6131 = unboxInt t1 in
+          let uu____6132 = unboxInt t2 in (uu____6131, uu____6132) in
         mkLT uu____6126 t.rng
     | App
         (Var
@@ -2126,8 +1926,8 @@ let (mk_Valid : term -> term) =
                        freevars = uu____6135; rng = uu____6136;_}::[])
         ->
         let uu____6149 =
-          let uu____6154 = unboxInt t1  in
-          let uu____6155 = unboxInt t2  in (uu____6154, uu____6155)  in
+          let uu____6154 = unboxInt t1 in
+          let uu____6155 = unboxInt t2 in (uu____6154, uu____6155) in
         mkGTE uu____6149 t.rng
     | App
         (Var
@@ -2135,8 +1935,8 @@ let (mk_Valid : term -> term) =
                        freevars = uu____6158; rng = uu____6159;_}::[])
         ->
         let uu____6172 =
-          let uu____6177 = unboxInt t1  in
-          let uu____6178 = unboxInt t2  in (uu____6177, uu____6178)  in
+          let uu____6177 = unboxInt t1 in
+          let uu____6178 = unboxInt t2 in (uu____6177, uu____6178) in
         mkGT uu____6172 t.rng
     | App
         (Var
@@ -2144,8 +1944,8 @@ let (mk_Valid : term -> term) =
                        freevars = uu____6181; rng = uu____6182;_}::[])
         ->
         let uu____6195 =
-          let uu____6200 = unboxBool t1  in
-          let uu____6201 = unboxBool t2  in (uu____6200, uu____6201)  in
+          let uu____6200 = unboxBool t1 in
+          let uu____6201 = unboxBool t2 in (uu____6200, uu____6201) in
         mkAnd uu____6195 t.rng
     | App
         (Var
@@ -2153,29 +1953,29 @@ let (mk_Valid : term -> term) =
                        freevars = uu____6204; rng = uu____6205;_}::[])
         ->
         let uu____6218 =
-          let uu____6223 = unboxBool t1  in
-          let uu____6224 = unboxBool t2  in (uu____6223, uu____6224)  in
+          let uu____6223 = unboxBool t1 in
+          let uu____6224 = unboxBool t2 in (uu____6223, uu____6224) in
         mkOr uu____6218 t.rng
     | App
         (Var
          "Prims.b2t",{ tm = App (Var "Prims.op_Negation",t1::[]);
                        freevars = uu____6226; rng = uu____6227;_}::[])
-        -> let uu____6240 = unboxBool t1  in mkNot uu____6240 t1.rng
+        -> let uu____6240 = unboxBool t1 in mkNot uu____6240 t1.rng
     | App
         (Var
          "Prims.b2t",{ tm = App (Var "FStar.BV.bvult",t0::t1::t2::[]);
                        freevars = uu____6244; rng = uu____6245;_}::[])
         when
-        let uu____6258 = getBoxedInteger t0  in FStar_Util.is_some uu____6258
+        let uu____6258 = getBoxedInteger t0 in FStar_Util.is_some uu____6258
         ->
         let sz =
-          let uu____6262 = getBoxedInteger t0  in
+          let uu____6262 = getBoxedInteger t0 in
           match uu____6262 with
           | FStar_Pervasives_Native.Some sz -> sz
-          | uu____6266 -> failwith "impossible"  in
+          | uu____6266 -> failwith "impossible" in
         let uu____6269 =
-          let uu____6274 = unboxBitVec sz t1  in
-          let uu____6275 = unboxBitVec sz t2  in (uu____6274, uu____6275)  in
+          let uu____6274 = unboxBitVec sz t1 in
+          let uu____6275 = unboxBitVec sz t2 in (uu____6274, uu____6275) in
         mkBvUlt uu____6269 t.rng
     | App
         (Var
@@ -2185,97 +1985,90 @@ let (mk_Valid : term -> term) =
                                       freevars = uu____6280;
                                       rng = uu____6281;_}::uu____6282::[])
         when
-        let uu____6295 = getBoxedInteger t0  in FStar_Util.is_some uu____6295
+        let uu____6295 = getBoxedInteger t0 in FStar_Util.is_some uu____6295
         ->
         let sz =
-          let uu____6299 = getBoxedInteger t0  in
+          let uu____6299 = getBoxedInteger t0 in
           match uu____6299 with
           | FStar_Pervasives_Native.Some sz -> sz
-          | uu____6303 -> failwith "impossible"  in
+          | uu____6303 -> failwith "impossible" in
         let uu____6306 =
-          let uu____6311 = unboxBitVec sz t1  in
-          let uu____6312 = unboxBitVec sz t2  in (uu____6311, uu____6312)  in
+          let uu____6311 = unboxBitVec sz t1 in
+          let uu____6312 = unboxBitVec sz t2 in (uu____6311, uu____6312) in
         mkBvUlt uu____6306 t.rng
     | App (Var "Prims.b2t",t1::[]) ->
-        let uu___54_6316 = unboxBool t1  in
+        let uu___54_6316 = unboxBool t1 in
         {
           tm = (uu___54_6316.tm);
           freevars = (uu___54_6316.freevars);
           rng = (t.rng)
         }
     | uu____6317 -> mkApp ("Valid", [t]) t.rng
-  
-let (mk_HasType : term -> term -> term) =
-  fun v1  -> fun t  -> mkApp ("HasType", [v1; t]) t.rng 
-let (mk_HasTypeZ : term -> term -> term) =
-  fun v1  -> fun t  -> mkApp ("HasTypeZ", [v1; t]) t.rng 
-let (mk_IsTyped : term -> term) = fun v1  -> mkApp ("IsTyped", [v1]) norng 
-let (mk_HasTypeFuel : term -> term -> term -> term) =
+let mk_HasType: term -> term -> term =
+  fun v1  -> fun t  -> mkApp ("HasType", [v1; t]) t.rng
+let mk_HasTypeZ: term -> term -> term =
+  fun v1  -> fun t  -> mkApp ("HasTypeZ", [v1; t]) t.rng
+let mk_IsTyped: term -> term = fun v1  -> mkApp ("IsTyped", [v1]) norng
+let mk_HasTypeFuel: term -> term -> term -> term =
   fun f  ->
     fun v1  ->
       fun t  ->
-        let uu____6350 = FStar_Options.unthrottle_inductives ()  in
+        let uu____6350 = FStar_Options.unthrottle_inductives () in
         if uu____6350
         then mk_HasType v1 t
         else mkApp ("HasTypeFuel", [f; v1; t]) t.rng
-  
-let (mk_HasTypeWithFuel :
-  term FStar_Pervasives_Native.option -> term -> term -> term) =
+let mk_HasTypeWithFuel:
+  term FStar_Pervasives_Native.option -> term -> term -> term =
   fun f  ->
     fun v1  ->
       fun t  ->
         match f with
         | FStar_Pervasives_Native.None  -> mk_HasType v1 t
         | FStar_Pervasives_Native.Some f1 -> mk_HasTypeFuel f1 v1 t
-  
-let (mk_NoHoist : term -> term -> term) =
-  fun dummy  -> fun b  -> mkApp ("NoHoist", [dummy; b]) b.rng 
-let (mk_Destruct : term -> FStar_Range.range -> term) =
-  fun v1  -> mkApp ("Destruct", [v1]) 
-let (mk_Rank : term -> FStar_Range.range -> term) =
-  fun x  -> mkApp ("Rank", [x]) 
-let (mk_tester : Prims.string -> term -> term) =
-  fun n1  -> fun t  -> mkApp ((Prims.strcat "is-" n1), [t]) t.rng 
-let (mk_ApplyTF : term -> term -> term) =
-  fun t  -> fun t'  -> mkApp ("ApplyTF", [t; t']) t.rng 
-let (mk_ApplyTT : term -> term -> FStar_Range.range -> term) =
-  fun t  -> fun t'  -> fun r  -> mkApp ("ApplyTT", [t; t']) r 
-let (mk_String_const : Prims.int -> FStar_Range.range -> term) =
+let mk_NoHoist: term -> term -> term =
+  fun dummy  -> fun b  -> mkApp ("NoHoist", [dummy; b]) b.rng
+let mk_Destruct: term -> FStar_Range.range -> term =
+  fun v1  -> mkApp ("Destruct", [v1])
+let mk_Rank: term -> FStar_Range.range -> term =
+  fun x  -> mkApp ("Rank", [x])
+let mk_tester: Prims.string -> term -> term =
+  fun n1  -> fun t  -> mkApp ((Prims.strcat "is-" n1), [t]) t.rng
+let mk_ApplyTF: term -> term -> term =
+  fun t  -> fun t'  -> mkApp ("ApplyTF", [t; t']) t.rng
+let mk_ApplyTT: term -> term -> FStar_Range.range -> term =
+  fun t  -> fun t'  -> fun r  -> mkApp ("ApplyTT", [t; t']) r
+let mk_String_const: Prims.int -> FStar_Range.range -> term =
   fun i  ->
     fun r  ->
       let uu____6423 =
-        let uu____6430 = let uu____6433 = mkInteger' i norng  in [uu____6433]
-           in
-        ("FString_const", uu____6430)  in
+        let uu____6430 = let uu____6433 = mkInteger' i norng in [uu____6433] in
+        ("FString_const", uu____6430) in
       mkApp uu____6423 r
-  
-let (mk_Precedes : term -> term -> FStar_Range.range -> term) =
+let mk_Precedes: term -> term -> FStar_Range.range -> term =
   fun x1  ->
     fun x2  ->
       fun r  ->
-        let uu____6445 = mkApp ("Precedes", [x1; x2]) r  in
+        let uu____6445 = mkApp ("Precedes", [x1; x2]) r in
         FStar_All.pipe_right uu____6445 mk_Valid
-  
-let (mk_LexCons : term -> term -> FStar_Range.range -> term) =
-  fun x1  -> fun x2  -> fun r  -> mkApp ("LexCons", [x1; x2]) r 
-let rec (n_fuel : Prims.int -> term) =
+let mk_LexCons: term -> term -> FStar_Range.range -> term =
+  fun x1  -> fun x2  -> fun r  -> mkApp ("LexCons", [x1; x2]) r
+let rec n_fuel: Prims.int -> term =
   fun n1  ->
     if n1 = (Prims.parse_int "0")
     then mkApp ("ZFuel", []) norng
     else
       (let uu____6465 =
          let uu____6472 =
-           let uu____6475 = n_fuel (n1 - (Prims.parse_int "1"))  in
-           [uu____6475]  in
-         ("SFuel", uu____6472)  in
+           let uu____6475 = n_fuel (n1 - (Prims.parse_int "1")) in
+           [uu____6475] in
+         ("SFuel", uu____6472) in
        mkApp uu____6465 norng)
-  
-let (fuel_2 : term) = n_fuel (Prims.parse_int "2") 
-let (fuel_100 : term) = n_fuel (Prims.parse_int "100") 
-let (mk_and_opt :
+let fuel_2: term = n_fuel (Prims.parse_int "2")
+let fuel_100: term = n_fuel (Prims.parse_int "100")
+let mk_and_opt:
   term FStar_Pervasives_Native.option ->
     term FStar_Pervasives_Native.option ->
-      FStar_Range.range -> term FStar_Pervasives_Native.option)
+      FStar_Range.range -> term FStar_Pervasives_Native.option
   =
   fun p1  ->
     fun p2  ->
@@ -2283,7 +2076,7 @@ let (mk_and_opt :
         match (p1, p2) with
         | (FStar_Pervasives_Native.Some p11,FStar_Pervasives_Native.Some p21)
             ->
-            let uu____6509 = mkAnd (p11, p21) r  in
+            let uu____6509 = mkAnd (p11, p21) r in
             FStar_Pervasives_Native.Some uu____6509
         | (FStar_Pervasives_Native.Some p,FStar_Pervasives_Native.None ) ->
             FStar_Pervasives_Native.Some p
@@ -2291,31 +2084,26 @@ let (mk_and_opt :
             FStar_Pervasives_Native.Some p
         | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.None ) ->
             FStar_Pervasives_Native.None
-  
-let (mk_and_opt_l :
+let mk_and_opt_l:
   term FStar_Pervasives_Native.option Prims.list ->
-    FStar_Range.range -> term FStar_Pervasives_Native.option)
+    FStar_Range.range -> term FStar_Pervasives_Native.option
   =
   fun pl  ->
     fun r  ->
       FStar_List.fold_right (fun p  -> fun out  -> mk_and_opt p out r) pl
         FStar_Pervasives_Native.None
-  
-let (mk_and_l : term Prims.list -> FStar_Range.range -> term) =
+let mk_and_l: term Prims.list -> FStar_Range.range -> term =
   fun l  ->
     fun r  ->
-      let uu____6562 = mkTrue r  in
+      let uu____6562 = mkTrue r in
       FStar_List.fold_right (fun p1  -> fun p2  -> mkAnd (p1, p2) r) l
         uu____6562
-  
-let (mk_or_l : term Prims.list -> FStar_Range.range -> term) =
+let mk_or_l: term Prims.list -> FStar_Range.range -> term =
   fun l  ->
     fun r  ->
-      let uu____6577 = mkFalse r  in
+      let uu____6577 = mkFalse r in
       FStar_List.fold_right (fun p1  -> fun p2  -> mkOr (p1, p2) r) l
         uu____6577
-  
-let (mk_haseq : term -> term) =
+let mk_haseq: term -> term =
   fun t  ->
-    let uu____6585 = mkApp ("Prims.hasEq", [t]) t.rng  in mk_Valid uu____6585
-  
+    let uu____6585 = mkApp ("Prims.hasEq", [t]) t.rng in mk_Valid uu____6585

--- a/src/ocaml-output/FStar_SMTEncoding_Util.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Util.ml
@@ -1,7 +1,7 @@
 open Prims
-let (mkAssume :
+let mkAssume:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.caption,Prims.string)
-    FStar_Pervasives_Native.tuple3 -> FStar_SMTEncoding_Term.decl)
+    FStar_Pervasives_Native.tuple3 -> FStar_SMTEncoding_Term.decl
   =
   fun uu____9  ->
     match uu____9 with
@@ -13,208 +13,207 @@ let (mkAssume :
             FStar_SMTEncoding_Term.assumption_name = nm;
             FStar_SMTEncoding_Term.assumption_fact_ids = []
           }
-  
-let norng :
+let norng:
   'Auu____23 'Auu____24 .
     ('Auu____24 -> FStar_Range.range -> 'Auu____23) ->
       'Auu____24 -> 'Auu____23
-  = fun f  -> fun x  -> f x FStar_Range.dummyRange 
-let (mkTrue : FStar_SMTEncoding_Term.term) =
-  FStar_SMTEncoding_Term.mkTrue FStar_Range.dummyRange 
-let (mkFalse : FStar_SMTEncoding_Term.term) =
-  FStar_SMTEncoding_Term.mkFalse FStar_Range.dummyRange 
-let (mkInteger : Prims.string -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mkInteger 
-let (mkInteger' : Prims.int -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mkInteger' 
-let (mkBoundV : Prims.int -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mkBoundV 
-let (mkFreeV :
+  = fun f  -> fun x  -> f x FStar_Range.dummyRange
+let mkTrue: FStar_SMTEncoding_Term.term =
+  FStar_SMTEncoding_Term.mkTrue FStar_Range.dummyRange
+let mkFalse: FStar_SMTEncoding_Term.term =
+  FStar_SMTEncoding_Term.mkFalse FStar_Range.dummyRange
+let mkInteger: Prims.string -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mkInteger
+let mkInteger': Prims.int -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mkInteger'
+let mkBoundV: Prims.int -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mkBoundV
+let mkFreeV:
   (Prims.string,FStar_SMTEncoding_Term.sort) FStar_Pervasives_Native.tuple2
-    -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkFreeV 
-let (mkApp' :
+    -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkFreeV
+let mkApp':
   (FStar_SMTEncoding_Term.op,FStar_SMTEncoding_Term.term Prims.list)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkApp' 
-let (mkApp :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkApp'
+let mkApp:
   (Prims.string,FStar_SMTEncoding_Term.term Prims.list)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkApp 
-let (mkNot : FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mkNot 
-let (mkMinus : FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mkMinus 
-let (mkAnd :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkApp
+let mkNot: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mkNot
+let mkMinus: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mkMinus
+let mkAnd:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkAnd 
-let (mkOr :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkAnd
+let mkOr:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkOr 
-let (mkImp :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkOr
+let mkImp:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkImp 
-let (mkIff :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkImp
+let mkIff:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkIff 
-let (mkEq :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkIff
+let mkEq:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkEq 
-let (mkLT :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkEq
+let mkLT:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkLT 
-let (mkLTE :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkLT
+let mkLTE:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkLTE 
-let (mkGT :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkLTE
+let mkGT:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkGT 
-let (mkGTE :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkGT
+let mkGTE:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkGTE 
-let (mkAdd :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkGTE
+let mkAdd:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkAdd 
-let (mkSub :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkAdd
+let mkSub:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkSub 
-let (mkDiv :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkSub
+let mkDiv:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkDiv 
-let (mkMul :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkDiv
+let mkMul:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkMul 
-let (mkMod :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkMul
+let mkMod:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkMod 
-let (mkNatToBv :
-  Prims.int -> FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) =
-  fun sz  -> norng (FStar_SMTEncoding_Term.mkNatToBv sz) 
-let (mkBvAnd :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkMod
+let mkNatToBv:
+  Prims.int -> FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
+  fun sz  -> norng (FStar_SMTEncoding_Term.mkNatToBv sz)
+let mkBvAnd:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkBvAnd 
-let (mkBvXor :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkBvAnd
+let mkBvXor:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkBvXor 
-let (mkBvOr :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkBvXor
+let mkBvOr:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkBvOr 
-let (mkBvAdd :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkBvOr
+let mkBvAdd:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkBvAdd 
-let (mkBvSub :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkBvAdd
+let mkBvSub:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkBvSub 
-let (mkBvShl :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkBvSub
+let mkBvShl:
   Prims.int ->
     (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvShl sz) 
-let (mkBvShr :
+      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvShl sz)
+let mkBvShr:
   Prims.int ->
     (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvShr sz) 
-let (mkBvUdiv :
+      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvShr sz)
+let mkBvUdiv:
   Prims.int ->
     (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvUdiv sz) 
-let (mkBvMod :
+      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvUdiv sz)
+let mkBvMod:
   Prims.int ->
     (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvMod sz) 
-let (mkBvMul :
+      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvMod sz)
+let mkBvMul:
   Prims.int ->
     (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvMul sz) 
-let (mkBvUlt :
+      FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = fun sz  -> norng (FStar_SMTEncoding_Term.mkBvMul sz)
+let mkBvUlt:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkBvUlt 
-let (mkBvUext :
-  Prims.int -> FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term) =
-  fun sz  -> norng (FStar_SMTEncoding_Term.mkBvUext sz) 
-let (mkBvToNat : FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkBvToNat 
-let (mkITE :
+    FStar_Pervasives_Native.tuple2 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkBvUlt
+let mkBvUext:
+  Prims.int -> FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
+  fun sz  -> norng (FStar_SMTEncoding_Term.mkBvUext sz)
+let mkBvToNat: FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mkBvToNat
+let mkITE:
   (FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple3 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkITE 
-let (mkCases :
-  FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mkCases 
-let (mkForall :
+    FStar_Pervasives_Native.tuple3 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkITE
+let mkCases:
+  FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mkCases
+let mkForall:
   (FStar_SMTEncoding_Term.pat Prims.list Prims.list,FStar_SMTEncoding_Term.fvs,
     FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple3 ->
-    FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkForall 
-let (mkForall' :
+    FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkForall
+let mkForall':
   (FStar_SMTEncoding_Term.pat Prims.list Prims.list,Prims.int
                                                       FStar_Pervasives_Native.option,
     FStar_SMTEncoding_Term.fvs,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple4 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkForall' 
-let (mkForall'' :
+    FStar_Pervasives_Native.tuple4 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkForall'
+let mkForall'':
   (FStar_SMTEncoding_Term.pat Prims.list Prims.list,Prims.int
                                                       FStar_Pervasives_Native.option,
     FStar_SMTEncoding_Term.sort Prims.list,FStar_SMTEncoding_Term.term)
-    FStar_Pervasives_Native.tuple4 -> FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkForall'' 
-let (mkExists :
+    FStar_Pervasives_Native.tuple4 -> FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkForall''
+let mkExists:
   (FStar_SMTEncoding_Term.pat Prims.list Prims.list,FStar_SMTEncoding_Term.fvs,
     FStar_SMTEncoding_Term.term) FStar_Pervasives_Native.tuple3 ->
-    FStar_SMTEncoding_Term.term)
-  = norng FStar_SMTEncoding_Term.mkExists 
-let norng2 :
+    FStar_SMTEncoding_Term.term
+  = norng FStar_SMTEncoding_Term.mkExists
+let norng2:
   'Auu____502 'Auu____503 'Auu____504 .
     ('Auu____504 -> 'Auu____503 -> FStar_Range.range -> 'Auu____502) ->
       'Auu____504 -> 'Auu____503 -> 'Auu____502
-  = fun f  -> fun x  -> fun y  -> f x y FStar_Range.dummyRange 
-let (mk_Term_app :
+  = fun f  -> fun x  -> fun y  -> f x y FStar_Range.dummyRange
+let mk_Term_app:
   FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term)
-  = norng2 FStar_SMTEncoding_Term.mk_Term_app 
-let (mk_Term_uvar : Prims.int -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mk_Term_uvar 
-let (mk_and_l :
-  FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mk_and_l 
-let (mk_or_l :
-  FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mk_or_l 
-let (mk_ApplyTT :
+    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
+  = norng2 FStar_SMTEncoding_Term.mk_Term_app
+let mk_Term_uvar: Prims.int -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mk_Term_uvar
+let mk_and_l:
+  FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mk_and_l
+let mk_or_l:
+  FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mk_or_l
+let mk_ApplyTT:
   FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term)
-  = norng2 FStar_SMTEncoding_Term.mk_ApplyTT 
-let (mk_String_const : Prims.int -> FStar_SMTEncoding_Term.term) =
-  norng FStar_SMTEncoding_Term.mk_String_const 
-let (mk_Precedes :
+    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
+  = norng2 FStar_SMTEncoding_Term.mk_ApplyTT
+let mk_String_const: Prims.int -> FStar_SMTEncoding_Term.term =
+  norng FStar_SMTEncoding_Term.mk_String_const
+let mk_Precedes:
   FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term)
-  = norng2 FStar_SMTEncoding_Term.mk_Precedes 
-let (mk_LexCons :
+    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
+  = norng2 FStar_SMTEncoding_Term.mk_Precedes
+let mk_LexCons:
   FStar_SMTEncoding_Term.term ->
-    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term)
-  = norng2 FStar_SMTEncoding_Term.mk_LexCons 
+    FStar_SMTEncoding_Term.term -> FStar_SMTEncoding_Term.term
+  = norng2 FStar_SMTEncoding_Term.mk_LexCons

--- a/src/ocaml-output/FStar_SMTEncoding_Z3.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Z3.ml
@@ -1,34 +1,32 @@
 open Prims
-let (_z3hash_checked : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false 
-let (_z3hash_expected : Prims.string) = "1f29cebd4df6" 
-let (_z3url : Prims.string) =
-  "https://github.com/FStarLang/binaries/tree/master/z3-tested" 
-let (parse_z3_version_lines :
-  Prims.string -> Prims.string FStar_Pervasives_Native.option) =
+let _z3hash_checked: Prims.bool FStar_ST.ref = FStar_Util.mk_ref false
+let _z3hash_expected: Prims.string = "1f29cebd4df6"
+let _z3url: Prims.string =
+  "https://github.com/FStarLang/binaries/tree/master/z3-tested"
+let parse_z3_version_lines:
+  Prims.string -> Prims.string FStar_Pervasives_Native.option =
   fun out  ->
     match FStar_Util.splitlines out with
     | x::uu____22 ->
-        let trimmed = FStar_Util.trim_string x  in
-        let parts = FStar_Util.split trimmed " "  in
+        let trimmed = FStar_Util.trim_string x in
+        let parts = FStar_Util.split trimmed " " in
         let rec aux uu___36_36 =
           match uu___36_36 with
           | hash::[] ->
               let n1 =
                 Prims.min (FStar_String.strlen _z3hash_expected)
-                  (FStar_String.strlen hash)
-                 in
+                  (FStar_String.strlen hash) in
               let hash_prefix =
-                FStar_String.substring hash (Prims.parse_int "0") n1  in
+                FStar_String.substring hash (Prims.parse_int "0") n1 in
               if hash_prefix = _z3hash_expected
               then
-                ((let uu____47 = FStar_Options.debug_any ()  in
+                ((let uu____47 = FStar_Options.debug_any () in
                   if uu____47
                   then
                     let msg =
                       FStar_Util.format1
                         "Successfully found expected Z3 commit hash %s\n"
-                        hash
-                       in
+                        hash in
                     FStar_Util.print_string msg
                   else ());
                  FStar_Pervasives_Native.None)
@@ -36,62 +34,56 @@ let (parse_z3_version_lines :
                 (let msg =
                    FStar_Util.format2
                      "Expected Z3 commit hash \"%s\", got \"%s\""
-                     _z3hash_expected trimmed
-                    in
+                     _z3hash_expected trimmed in
                  FStar_Pervasives_Native.Some msg)
           | uu____52::q -> aux q
           | uu____56 ->
-              FStar_Pervasives_Native.Some "No Z3 commit hash found"
-           in
+              FStar_Pervasives_Native.Some "No Z3 commit hash found" in
         aux parts
     | uu____59 -> FStar_Pervasives_Native.Some "No Z3 version string found"
-  
-let (z3hash_warning_message :
+let z3hash_warning_message:
   Prims.unit ->
     (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun uu____70  ->
     let run_proc_result =
       try
         let uu____99 =
-          let uu____106 = FStar_Options.z3_exe ()  in
-          FStar_Util.run_proc uu____106 "-version" ""  in
+          let uu____106 = FStar_Options.z3_exe () in
+          FStar_Util.run_proc uu____106 "-version" "" in
         FStar_Pervasives_Native.Some uu____99
-      with | uu____124 -> FStar_Pervasives_Native.None  in
+      with | uu____124 -> FStar_Pervasives_Native.None in
     match run_proc_result with
     | FStar_Pervasives_Native.None  ->
         FStar_Pervasives_Native.Some
           (FStar_Errors.Error_Z3InvocationError, "Could not run Z3")
     | FStar_Pervasives_Native.Some (uu____147,out,uu____149) ->
-        let uu____156 = parse_z3_version_lines out  in
+        let uu____156 = parse_z3_version_lines out in
         (match uu____156 with
          | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
          | FStar_Pervasives_Native.Some msg ->
              FStar_Pervasives_Native.Some
                (FStar_Errors.Warning_Z3InvocationWarning, msg))
-  
-let (check_z3hash : Prims.unit -> Prims.unit) =
+let check_z3hash: Prims.unit -> Prims.unit =
   fun uu____176  ->
     let uu____177 =
-      let uu____178 = FStar_ST.op_Bang _z3hash_checked  in
-      Prims.op_Negation uu____178  in
+      let uu____178 = FStar_ST.op_Bang _z3hash_checked in
+      Prims.op_Negation uu____178 in
     if uu____177
     then
       (FStar_ST.op_Colon_Equals _z3hash_checked true;
-       (let uu____218 = z3hash_warning_message ()  in
+       (let uu____218 = z3hash_warning_message () in
         match uu____218 with
         | FStar_Pervasives_Native.None  -> ()
         | FStar_Pervasives_Native.Some (e,msg) ->
             let msg1 =
               FStar_Util.format4 "%s\n%s\n%s\n%s\n" msg
                 "Please download the version of Z3 corresponding to your platform from:"
-                _z3url "and add the bin/ subdirectory into your PATH"
-               in
+                _z3url "and add the bin/ subdirectory into your PATH" in
             FStar_Errors.log_issue FStar_Range.dummyRange (e, msg1)))
     else ()
-  
-let (ini_params : Prims.unit -> Prims.string) =
+let ini_params: Prims.unit -> Prims.string =
   fun uu____239  ->
     check_z3hash ();
     (let uu____241 =
@@ -99,77 +91,70 @@ let (ini_params : Prims.unit -> Prims.string) =
          let uu____247 =
            let uu____250 =
              let uu____251 =
-               let uu____252 = FStar_Options.z3_seed ()  in
-               FStar_Util.string_of_int uu____252  in
-             FStar_Util.format1 "smt.random_seed=%s" uu____251  in
-           [uu____250]  in
+               let uu____252 = FStar_Options.z3_seed () in
+               FStar_Util.string_of_int uu____252 in
+             FStar_Util.format1 "smt.random_seed=%s" uu____251 in
+           [uu____250] in
          "-smt2 -in auto_config=false model=true smt.relevancy=2 smt.case_split=3"
-           :: uu____247
-          in
-       let uu____253 = FStar_Options.z3_cliopt ()  in
-       FStar_List.append uu____244 uu____253  in
+           :: uu____247 in
+       let uu____253 = FStar_Options.z3_cliopt () in
+       FStar_List.append uu____244 uu____253 in
      FStar_String.concat " " uu____241)
-  
 type label = Prims.string[@@deriving show]
 type unsat_core = Prims.string Prims.list FStar_Pervasives_Native.option
 [@@deriving show]
 type z3status =
-  | UNSAT of unsat_core 
+  | UNSAT of unsat_core
   | SAT of
   (FStar_SMTEncoding_Term.error_labels,Prims.string
                                          FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | UNKNOWN of
   (FStar_SMTEncoding_Term.error_labels,Prims.string
                                          FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | TIMEOUT of
   (FStar_SMTEncoding_Term.error_labels,Prims.string
                                          FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
-  | KILLED [@@deriving show]
-let (uu___is_UNSAT : z3status -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | KILLED[@@deriving show]
+let uu___is_UNSAT: z3status -> Prims.bool =
   fun projectee  ->
     match projectee with | UNSAT _0 -> true | uu____298 -> false
-  
-let (__proj__UNSAT__item___0 : z3status -> unsat_core) =
-  fun projectee  -> match projectee with | UNSAT _0 -> _0 
-let (uu___is_SAT : z3status -> Prims.bool) =
+let __proj__UNSAT__item___0: z3status -> unsat_core =
+  fun projectee  -> match projectee with | UNSAT _0 -> _0
+let uu___is_SAT: z3status -> Prims.bool =
   fun projectee  ->
     match projectee with | SAT _0 -> true | uu____316 -> false
-  
-let (__proj__SAT__item___0 :
+let __proj__SAT__item___0:
   z3status ->
     (FStar_SMTEncoding_Term.error_labels,Prims.string
                                            FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | SAT _0 -> _0 
-let (uu___is_UNKNOWN : z3status -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | SAT _0 -> _0
+let uu___is_UNKNOWN: z3status -> Prims.bool =
   fun projectee  ->
     match projectee with | UNKNOWN _0 -> true | uu____352 -> false
-  
-let (__proj__UNKNOWN__item___0 :
+let __proj__UNKNOWN__item___0:
   z3status ->
     (FStar_SMTEncoding_Term.error_labels,Prims.string
                                            FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | UNKNOWN _0 -> _0 
-let (uu___is_TIMEOUT : z3status -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | UNKNOWN _0 -> _0
+let uu___is_TIMEOUT: z3status -> Prims.bool =
   fun projectee  ->
     match projectee with | TIMEOUT _0 -> true | uu____388 -> false
-  
-let (__proj__TIMEOUT__item___0 :
+let __proj__TIMEOUT__item___0:
   z3status ->
     (FStar_SMTEncoding_Term.error_labels,Prims.string
                                            FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | TIMEOUT _0 -> _0 
-let (uu___is_KILLED : z3status -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | TIMEOUT _0 -> _0
+let uu___is_KILLED: z3status -> Prims.bool =
   fun projectee  ->
     match projectee with | KILLED  -> true | uu____417 -> false
-  
 type z3statistics = Prims.string FStar_Util.smap[@@deriving show]
-let (status_tag : z3status -> Prims.string) =
+let status_tag: z3status -> Prims.string =
   fun uu___37_422  ->
     match uu___37_422 with
     | SAT uu____423 -> "sat"
@@ -177,11 +162,10 @@ let (status_tag : z3status -> Prims.string) =
     | UNKNOWN uu____431 -> "unknown"
     | TIMEOUT uu____438 -> "timeout"
     | KILLED  -> "killed"
-  
-let (status_string_and_errors :
+let status_string_and_errors:
   z3status ->
     (Prims.string,FStar_SMTEncoding_Term.error_labels)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun s  ->
     match s with
@@ -193,8 +177,7 @@ let (status_string_and_errors :
             (match msg with
              | FStar_Pervasives_Native.None  -> ""
              | FStar_Pervasives_Native.Some msg1 ->
-                 Prims.strcat " because " msg1)
-           in
+                 Prims.strcat " because " msg1) in
         (uu____467, errs)
     | UNKNOWN (errs,msg) ->
         let uu____475 =
@@ -202,8 +185,7 @@ let (status_string_and_errors :
             (match msg with
              | FStar_Pervasives_Native.None  -> ""
              | FStar_Pervasives_Native.Some msg1 ->
-                 Prims.strcat " because " msg1)
-           in
+                 Prims.strcat " because " msg1) in
         (uu____475, errs)
     | TIMEOUT (errs,msg) ->
         let uu____483 =
@@ -211,288 +193,262 @@ let (status_string_and_errors :
             (match msg with
              | FStar_Pervasives_Native.None  -> ""
              | FStar_Pervasives_Native.Some msg1 ->
-                 Prims.strcat " because " msg1)
-           in
+                 Prims.strcat " because " msg1) in
         (uu____483, errs)
-  
-let (tid : Prims.unit -> Prims.string) =
+let tid: Prims.unit -> Prims.string =
   fun uu____487  ->
-    let uu____488 = FStar_Util.current_tid ()  in
+    let uu____488 = FStar_Util.current_tid () in
     FStar_All.pipe_right uu____488 FStar_Util.string_of_int
-  
-let (new_z3proc : Prims.string -> FStar_Util.proc) =
+let new_z3proc: Prims.string -> FStar_Util.proc =
   fun id1  ->
-    let cond pid s = let x = (FStar_Util.trim_string s) = "Done!"  in x  in
-    let uu____500 = FStar_Options.z3_exe ()  in
-    let uu____501 = ini_params ()  in
+    let cond pid s = let x = (FStar_Util.trim_string s) = "Done!" in x in
+    let uu____500 = FStar_Options.z3_exe () in
+    let uu____501 = ini_params () in
     FStar_Util.start_process false id1 uu____500 uu____501 cond
-  
 type bgproc =
   {
-  grab: Prims.unit -> FStar_Util.proc ;
-  release: Prims.unit -> Prims.unit ;
-  refresh: Prims.unit -> Prims.unit ;
-  restart: Prims.unit -> Prims.unit }[@@deriving show]
-let (__proj__Mkbgproc__item__grab : bgproc -> Prims.unit -> FStar_Util.proc)
-  =
+  grab: Prims.unit -> FStar_Util.proc;
+  release: Prims.unit -> Prims.unit;
+  refresh: Prims.unit -> Prims.unit;
+  restart: Prims.unit -> Prims.unit;}[@@deriving show]
+let __proj__Mkbgproc__item__grab: bgproc -> Prims.unit -> FStar_Util.proc =
   fun projectee  ->
     match projectee with
     | { grab = __fname__grab; release = __fname__release;
         refresh = __fname__refresh; restart = __fname__restart;_} ->
         __fname__grab
-  
-let (__proj__Mkbgproc__item__release : bgproc -> Prims.unit -> Prims.unit) =
+let __proj__Mkbgproc__item__release: bgproc -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { grab = __fname__grab; release = __fname__release;
         refresh = __fname__refresh; restart = __fname__restart;_} ->
         __fname__release
-  
-let (__proj__Mkbgproc__item__refresh : bgproc -> Prims.unit -> Prims.unit) =
+let __proj__Mkbgproc__item__refresh: bgproc -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { grab = __fname__grab; release = __fname__release;
         refresh = __fname__refresh; restart = __fname__restart;_} ->
         __fname__refresh
-  
-let (__proj__Mkbgproc__item__restart : bgproc -> Prims.unit -> Prims.unit) =
+let __proj__Mkbgproc__item__restart: bgproc -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { grab = __fname__grab; release = __fname__release;
         refresh = __fname__refresh; restart = __fname__restart;_} ->
         __fname__restart
-  
 type query_log =
   {
-  get_module_name: Prims.unit -> Prims.string ;
-  set_module_name: Prims.string -> Prims.unit ;
-  write_to_log: Prims.string -> Prims.unit ;
-  close_log: Prims.unit -> Prims.unit ;
-  log_file_name: Prims.unit -> Prims.string }[@@deriving show]
-let (__proj__Mkquery_log__item__get_module_name :
-  query_log -> Prims.unit -> Prims.string) =
+  get_module_name: Prims.unit -> Prims.string;
+  set_module_name: Prims.string -> Prims.unit;
+  write_to_log: Prims.string -> Prims.unit;
+  close_log: Prims.unit -> Prims.unit;
+  log_file_name: Prims.unit -> Prims.string;}[@@deriving show]
+let __proj__Mkquery_log__item__get_module_name:
+  query_log -> Prims.unit -> Prims.string =
   fun projectee  ->
     match projectee with
     | { get_module_name = __fname__get_module_name;
         set_module_name = __fname__set_module_name;
         write_to_log = __fname__write_to_log; close_log = __fname__close_log;
         log_file_name = __fname__log_file_name;_} -> __fname__get_module_name
-  
-let (__proj__Mkquery_log__item__set_module_name :
-  query_log -> Prims.string -> Prims.unit) =
+let __proj__Mkquery_log__item__set_module_name:
+  query_log -> Prims.string -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { get_module_name = __fname__get_module_name;
         set_module_name = __fname__set_module_name;
         write_to_log = __fname__write_to_log; close_log = __fname__close_log;
         log_file_name = __fname__log_file_name;_} -> __fname__set_module_name
-  
-let (__proj__Mkquery_log__item__write_to_log :
-  query_log -> Prims.string -> Prims.unit) =
+let __proj__Mkquery_log__item__write_to_log:
+  query_log -> Prims.string -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { get_module_name = __fname__get_module_name;
         set_module_name = __fname__set_module_name;
         write_to_log = __fname__write_to_log; close_log = __fname__close_log;
         log_file_name = __fname__log_file_name;_} -> __fname__write_to_log
-  
-let (__proj__Mkquery_log__item__close_log :
-  query_log -> Prims.unit -> Prims.unit) =
+let __proj__Mkquery_log__item__close_log:
+  query_log -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { get_module_name = __fname__get_module_name;
         set_module_name = __fname__set_module_name;
         write_to_log = __fname__write_to_log; close_log = __fname__close_log;
         log_file_name = __fname__log_file_name;_} -> __fname__close_log
-  
-let (__proj__Mkquery_log__item__log_file_name :
-  query_log -> Prims.unit -> Prims.string) =
+let __proj__Mkquery_log__item__log_file_name:
+  query_log -> Prims.unit -> Prims.string =
   fun projectee  ->
     match projectee with
     | { get_module_name = __fname__get_module_name;
         set_module_name = __fname__set_module_name;
         write_to_log = __fname__write_to_log; close_log = __fname__close_log;
         log_file_name = __fname__log_file_name;_} -> __fname__log_file_name
-  
-let (query_logging : query_log) =
-  let query_number = FStar_Util.mk_ref (Prims.parse_int "0")  in
-  let log_file_opt = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-  let used_file_names = FStar_Util.mk_ref []  in
-  let current_module_name = FStar_Util.mk_ref FStar_Pervasives_Native.None
-     in
-  let current_file_name = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+let query_logging: query_log =
+  let query_number = FStar_Util.mk_ref (Prims.parse_int "0") in
+  let log_file_opt = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+  let used_file_names = FStar_Util.mk_ref [] in
+  let current_module_name = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+  let current_file_name = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   let set_module_name n1 =
     FStar_ST.op_Colon_Equals current_module_name
-      (FStar_Pervasives_Native.Some n1)
-     in
+      (FStar_Pervasives_Native.Some n1) in
   let get_module_name uu____855 =
-    let uu____856 = FStar_ST.op_Bang current_module_name  in
+    let uu____856 = FStar_ST.op_Bang current_module_name in
     match uu____856 with
     | FStar_Pervasives_Native.None  -> failwith "Module name not set"
-    | FStar_Pervasives_Native.Some n1 -> n1  in
+    | FStar_Pervasives_Native.Some n1 -> n1 in
   let new_log_file uu____908 =
-    let uu____909 = FStar_ST.op_Bang current_module_name  in
+    let uu____909 = FStar_ST.op_Bang current_module_name in
     match uu____909 with
     | FStar_Pervasives_Native.None  -> failwith "current module not set"
     | FStar_Pervasives_Native.Some n1 ->
         let file_name =
           let uu____959 =
-            let uu____966 = FStar_ST.op_Bang used_file_names  in
+            let uu____966 = FStar_ST.op_Bang used_file_names in
             FStar_List.tryFind
               (fun uu____1033  ->
-                 match uu____1033 with | (m,uu____1039) -> n1 = m) uu____966
-             in
+                 match uu____1033 with | (m,uu____1039) -> n1 = m) uu____966 in
           match uu____959 with
           | FStar_Pervasives_Native.None  ->
               ((let uu____1045 =
-                  let uu____1052 = FStar_ST.op_Bang used_file_names  in
-                  (n1, (Prims.parse_int "0")) :: uu____1052  in
+                  let uu____1052 = FStar_ST.op_Bang used_file_names in
+                  (n1, (Prims.parse_int "0")) :: uu____1052 in
                 FStar_ST.op_Colon_Equals used_file_names uu____1045);
                n1)
           | FStar_Pervasives_Native.Some (uu____1169,k) ->
               ((let uu____1176 =
-                  let uu____1183 = FStar_ST.op_Bang used_file_names  in
-                  (n1, (k + (Prims.parse_int "1"))) :: uu____1183  in
+                  let uu____1183 = FStar_ST.op_Bang used_file_names in
+                  (n1, (k + (Prims.parse_int "1"))) :: uu____1183 in
                 FStar_ST.op_Colon_Equals used_file_names uu____1176);
                (let uu____1300 =
-                  FStar_Util.string_of_int (k + (Prims.parse_int "1"))  in
-                FStar_Util.format2 "%s-%s" n1 uu____1300))
-           in
-        let file_name1 = FStar_Util.format1 "queries-%s.smt2" file_name  in
+                  FStar_Util.string_of_int (k + (Prims.parse_int "1")) in
+                FStar_Util.format2 "%s-%s" n1 uu____1300)) in
+        let file_name1 = FStar_Util.format1 "queries-%s.smt2" file_name in
         (FStar_ST.op_Colon_Equals current_file_name
            (FStar_Pervasives_Native.Some file_name1);
-         (let fh = FStar_Util.open_file_for_writing file_name1  in
+         (let fh = FStar_Util.open_file_for_writing file_name1 in
           FStar_ST.op_Colon_Equals log_file_opt
             (FStar_Pervasives_Native.Some fh);
-          fh))
-     in
+          fh)) in
   let get_log_file uu____1398 =
-    let uu____1399 = FStar_ST.op_Bang log_file_opt  in
+    let uu____1399 = FStar_ST.op_Bang log_file_opt in
     match uu____1399 with
     | FStar_Pervasives_Native.None  -> new_log_file ()
-    | FStar_Pervasives_Native.Some fh -> fh  in
+    | FStar_Pervasives_Native.Some fh -> fh in
   let append_to_log str =
-    let uu____1452 = get_log_file ()  in
-    FStar_Util.append_to_file uu____1452 str  in
+    let uu____1452 = get_log_file () in
+    FStar_Util.append_to_file uu____1452 str in
   let write_to_new_log str =
     let dir_name =
-      let uu____1458 = FStar_ST.op_Bang current_file_name  in
+      let uu____1458 = FStar_ST.op_Bang current_file_name in
       match uu____1458 with
       | FStar_Pervasives_Native.None  ->
           let dir_name =
-            let uu____1507 = FStar_ST.op_Bang current_module_name  in
+            let uu____1507 = FStar_ST.op_Bang current_module_name in
             match uu____1507 with
             | FStar_Pervasives_Native.None  ->
                 failwith "current module not set"
             | FStar_Pervasives_Native.Some n1 ->
-                FStar_Util.format1 "queries-%s" n1
-             in
+                FStar_Util.format1 "queries-%s" n1 in
           (FStar_Util.mkdir true dir_name;
            FStar_ST.op_Colon_Equals current_file_name
              (FStar_Pervasives_Native.Some dir_name);
            dir_name)
-      | FStar_Pervasives_Native.Some n1 -> n1  in
-    let qnum = FStar_ST.op_Bang query_number  in
+      | FStar_Pervasives_Native.Some n1 -> n1 in
+    let qnum = FStar_ST.op_Bang query_number in
     (let uu____1647 =
-       let uu____1648 = FStar_ST.op_Bang query_number  in
-       uu____1648 + (Prims.parse_int "1")  in
+       let uu____1648 = FStar_ST.op_Bang query_number in
+       uu____1648 + (Prims.parse_int "1") in
      FStar_ST.op_Colon_Equals query_number uu____1647);
     (let file_name =
-       let uu____1732 = FStar_Util.string_of_int qnum  in
-       FStar_Util.format1 "query-%s.smt2" uu____1732  in
-     let file_name1 = FStar_Util.concat_dir_filename dir_name file_name  in
-     FStar_Util.write_file file_name1 str)
-     in
+       let uu____1732 = FStar_Util.string_of_int qnum in
+       FStar_Util.format1 "query-%s.smt2" uu____1732 in
+     let file_name1 = FStar_Util.concat_dir_filename dir_name file_name in
+     FStar_Util.write_file file_name1 str) in
   let write_to_log str =
     let uu____1738 =
-      let uu____1739 = FStar_Options.n_cores ()  in
-      uu____1739 > (Prims.parse_int "1")  in
-    if uu____1738 then write_to_new_log str else append_to_log str  in
+      let uu____1739 = FStar_Options.n_cores () in
+      uu____1739 > (Prims.parse_int "1") in
+    if uu____1738 then write_to_new_log str else append_to_log str in
   let close_log uu____1744 =
-    let uu____1745 = FStar_ST.op_Bang log_file_opt  in
+    let uu____1745 = FStar_ST.op_Bang log_file_opt in
     match uu____1745 with
     | FStar_Pervasives_Native.None  -> ()
     | FStar_Pervasives_Native.Some fh ->
         (FStar_Util.close_file fh;
-         FStar_ST.op_Colon_Equals log_file_opt FStar_Pervasives_Native.None)
-     in
+         FStar_ST.op_Colon_Equals log_file_opt FStar_Pervasives_Native.None) in
   let log_file_name uu____1843 =
-    let uu____1844 = FStar_ST.op_Bang current_file_name  in
+    let uu____1844 = FStar_ST.op_Bang current_file_name in
     match uu____1844 with
     | FStar_Pervasives_Native.None  -> failwith "no log file"
-    | FStar_Pervasives_Native.Some n1 -> n1  in
+    | FStar_Pervasives_Native.Some n1 -> n1 in
   { get_module_name; set_module_name; write_to_log; close_log; log_file_name
-  } 
-let (bg_z3_proc : bgproc) =
-  let the_z3proc = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+  }
+let bg_z3_proc: bgproc =
+  let the_z3proc = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   let new_proc =
-    let ctr = FStar_Util.mk_ref (~- (Prims.parse_int "1"))  in
+    let ctr = FStar_Util.mk_ref (- (Prims.parse_int "1")) in
     fun uu____1906  ->
       let uu____1907 =
         let uu____1908 =
           FStar_Util.incr ctr;
-          (let uu____1943 = FStar_ST.op_Bang ctr  in
-           FStar_All.pipe_right uu____1943 FStar_Util.string_of_int)
-           in
-        FStar_Util.format1 "bg-%s" uu____1908  in
-      new_z3proc uu____1907
-     in
+          (let uu____1943 = FStar_ST.op_Bang ctr in
+           FStar_All.pipe_right uu____1943 FStar_Util.string_of_int) in
+        FStar_Util.format1 "bg-%s" uu____1908 in
+      new_z3proc uu____1907 in
   let z3proc uu____1988 =
     (let uu____1990 =
-       let uu____1991 = FStar_ST.op_Bang the_z3proc  in
-       uu____1991 = FStar_Pervasives_Native.None  in
+       let uu____1991 = FStar_ST.op_Bang the_z3proc in
+       uu____1991 = FStar_Pervasives_Native.None in
      if uu____1990
      then
        let uu____2041 =
-         let uu____2044 = new_proc ()  in
-         FStar_Pervasives_Native.Some uu____2044  in
+         let uu____2044 = new_proc () in
+         FStar_Pervasives_Native.Some uu____2044 in
        FStar_ST.op_Colon_Equals the_z3proc uu____2041
      else ());
-    (let uu____2091 = FStar_ST.op_Bang the_z3proc  in
-     FStar_Util.must uu____2091)
-     in
-  let x = []  in
-  let grab uu____2145 = FStar_Util.monitor_enter x; z3proc ()  in
-  let release uu____2152 = FStar_Util.monitor_exit x  in
+    (let uu____2091 = FStar_ST.op_Bang the_z3proc in
+     FStar_Util.must uu____2091) in
+  let x = [] in
+  let grab uu____2145 = FStar_Util.monitor_enter x; z3proc () in
+  let release uu____2152 = FStar_Util.monitor_exit x in
   let refresh uu____2158 =
-    let proc = grab ()  in
+    let proc = grab () in
     FStar_Util.kill_process proc;
     (let uu____2162 =
-       let uu____2165 = new_proc ()  in
-       FStar_Pervasives_Native.Some uu____2165  in
+       let uu____2165 = new_proc () in
+       FStar_Pervasives_Native.Some uu____2165 in
      FStar_ST.op_Colon_Equals the_z3proc uu____2162);
     query_logging.close_log ();
-    release ()  in
+    release () in
   let restart uu____2215 =
     FStar_Util.monitor_enter ();
     query_logging.close_log ();
     FStar_ST.op_Colon_Equals the_z3proc FStar_Pervasives_Native.None;
     (let uu____2265 =
-       let uu____2268 = new_proc ()  in
-       FStar_Pervasives_Native.Some uu____2268  in
+       let uu____2268 = new_proc () in
+       FStar_Pervasives_Native.Some uu____2268 in
      FStar_ST.op_Colon_Equals the_z3proc uu____2265);
-    FStar_Util.monitor_exit ()  in
-  { grab; release; refresh; restart } 
-let (at_log_file : Prims.unit -> Prims.string) =
+    FStar_Util.monitor_exit () in
+  { grab; release; refresh; restart }
+let at_log_file: Prims.unit -> Prims.string =
   fun uu____2316  ->
-    let uu____2317 = FStar_Options.log_queries ()  in
+    let uu____2317 = FStar_Options.log_queries () in
     if uu____2317
     then
-      let uu____2318 = query_logging.log_file_name ()  in
+      let uu____2318 = query_logging.log_file_name () in
       Prims.strcat "@" uu____2318
     else ""
-  
 type smt_output_section = Prims.string Prims.list[@@deriving show]
 type smt_output =
   {
-  smt_result: smt_output_section ;
-  smt_reason_unknown: smt_output_section FStar_Pervasives_Native.option ;
-  smt_unsat_core: smt_output_section FStar_Pervasives_Native.option ;
-  smt_statistics: smt_output_section FStar_Pervasives_Native.option ;
-  smt_labels: smt_output_section FStar_Pervasives_Native.option }[@@deriving
+  smt_result: smt_output_section;
+  smt_reason_unknown: smt_output_section FStar_Pervasives_Native.option;
+  smt_unsat_core: smt_output_section FStar_Pervasives_Native.option;
+  smt_statistics: smt_output_section FStar_Pervasives_Native.option;
+  smt_labels: smt_output_section FStar_Pervasives_Native.option;}[@@deriving
                                                                    show]
-let (__proj__Mksmt_output__item__smt_result :
-  smt_output -> smt_output_section) =
+let __proj__Mksmt_output__item__smt_result: smt_output -> smt_output_section
+  =
   fun projectee  ->
     match projectee with
     | { smt_result = __fname__smt_result;
@@ -500,9 +456,8 @@ let (__proj__Mksmt_output__item__smt_result :
         smt_unsat_core = __fname__smt_unsat_core;
         smt_statistics = __fname__smt_statistics;
         smt_labels = __fname__smt_labels;_} -> __fname__smt_result
-  
-let (__proj__Mksmt_output__item__smt_reason_unknown :
-  smt_output -> smt_output_section FStar_Pervasives_Native.option) =
+let __proj__Mksmt_output__item__smt_reason_unknown:
+  smt_output -> smt_output_section FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { smt_result = __fname__smt_result;
@@ -510,9 +465,8 @@ let (__proj__Mksmt_output__item__smt_reason_unknown :
         smt_unsat_core = __fname__smt_unsat_core;
         smt_statistics = __fname__smt_statistics;
         smt_labels = __fname__smt_labels;_} -> __fname__smt_reason_unknown
-  
-let (__proj__Mksmt_output__item__smt_unsat_core :
-  smt_output -> smt_output_section FStar_Pervasives_Native.option) =
+let __proj__Mksmt_output__item__smt_unsat_core:
+  smt_output -> smt_output_section FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { smt_result = __fname__smt_result;
@@ -520,9 +474,8 @@ let (__proj__Mksmt_output__item__smt_unsat_core :
         smt_unsat_core = __fname__smt_unsat_core;
         smt_statistics = __fname__smt_statistics;
         smt_labels = __fname__smt_labels;_} -> __fname__smt_unsat_core
-  
-let (__proj__Mksmt_output__item__smt_statistics :
-  smt_output -> smt_output_section FStar_Pervasives_Native.option) =
+let __proj__Mksmt_output__item__smt_statistics:
+  smt_output -> smt_output_section FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { smt_result = __fname__smt_result;
@@ -530,9 +483,8 @@ let (__proj__Mksmt_output__item__smt_statistics :
         smt_unsat_core = __fname__smt_unsat_core;
         smt_statistics = __fname__smt_statistics;
         smt_labels = __fname__smt_labels;_} -> __fname__smt_statistics
-  
-let (__proj__Mksmt_output__item__smt_labels :
-  smt_output -> smt_output_section FStar_Pervasives_Native.option) =
+let __proj__Mksmt_output__item__smt_labels:
+  smt_output -> smt_output_section FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { smt_result = __fname__smt_result;
@@ -540,8 +492,7 @@ let (__proj__Mksmt_output__item__smt_labels :
         smt_unsat_core = __fname__smt_unsat_core;
         smt_statistics = __fname__smt_statistics;
         smt_labels = __fname__smt_labels;_} -> __fname__smt_labels
-  
-let (smt_output_sections : Prims.string Prims.list -> smt_output) =
+let smt_output_sections: Prims.string Prims.list -> smt_output =
   fun lines  ->
     let rec until tag lines1 =
       match lines1 with
@@ -550,21 +501,20 @@ let (smt_output_sections : Prims.string Prims.list -> smt_output) =
           if tag = l
           then FStar_Pervasives_Native.Some ([], lines2)
           else
-            (let uu____2519 = until tag lines2  in
+            (let uu____2519 = until tag lines2 in
              FStar_Util.map_opt uu____2519
                (fun uu____2549  ->
                   match uu____2549 with
-                  | (until_tag,rest) -> ((l :: until_tag), rest)))
-       in
-    let start_tag tag = Prims.strcat "<" (Prims.strcat tag ">")  in
-    let end_tag tag = Prims.strcat "</" (Prims.strcat tag ">")  in
+                  | (until_tag,rest) -> ((l :: until_tag), rest))) in
+    let start_tag tag = Prims.strcat "<" (Prims.strcat tag ">") in
+    let end_tag tag = Prims.strcat "</" (Prims.strcat tag ">") in
     let find_section tag lines1 =
-      let uu____2619 = until (start_tag tag) lines1  in
+      let uu____2619 = until (start_tag tag) lines1 in
       match uu____2619 with
       | FStar_Pervasives_Native.None  ->
           (FStar_Pervasives_Native.None, lines1)
       | FStar_Pervasives_Native.Some (prefix1,suffix) ->
-          let uu____2674 = until (end_tag tag) suffix  in
+          let uu____2674 = until (end_tag tag) suffix in
           (match uu____2674 with
            | FStar_Pervasives_Native.None  ->
                failwith
@@ -572,49 +522,45 @@ let (smt_output_sections : Prims.string Prims.list -> smt_output) =
                     (Prims.strcat (end_tag tag) " not found"))
            | FStar_Pervasives_Native.Some (section,suffix1) ->
                ((FStar_Pervasives_Native.Some section),
-                 (FStar_List.append prefix1 suffix1)))
-       in
-    let uu____2739 = find_section "result" lines  in
+                 (FStar_List.append prefix1 suffix1))) in
+    let uu____2739 = find_section "result" lines in
     match uu____2739 with
     | (result_opt,lines1) ->
-        let result = FStar_Util.must result_opt  in
-        let uu____2769 = find_section "reason-unknown" lines1  in
+        let result = FStar_Util.must result_opt in
+        let uu____2769 = find_section "reason-unknown" lines1 in
         (match uu____2769 with
          | (reason_unknown,lines2) ->
-             let uu____2794 = find_section "unsat-core" lines2  in
+             let uu____2794 = find_section "unsat-core" lines2 in
              (match uu____2794 with
               | (unsat_core,lines3) ->
-                  let uu____2819 = find_section "statistics" lines3  in
+                  let uu____2819 = find_section "statistics" lines3 in
                   (match uu____2819 with
                    | (statistics,lines4) ->
-                       let uu____2844 = find_section "labels" lines4  in
+                       let uu____2844 = find_section "labels" lines4 in
                        (match uu____2844 with
                         | (labels,lines5) ->
                             let remaining =
-                              let uu____2872 = until "Done!" lines5  in
+                              let uu____2872 = until "Done!" lines5 in
                               match uu____2872 with
                               | FStar_Pervasives_Native.None  -> lines5
                               | FStar_Pervasives_Native.Some (prefix1,suffix)
-                                  -> FStar_List.append prefix1 suffix
-                               in
+                                  -> FStar_List.append prefix1 suffix in
                             ((match remaining with
                               | [] -> ()
                               | uu____2912 ->
                                   let uu____2915 =
                                     let uu____2920 =
                                       let uu____2921 =
-                                        query_logging.get_module_name ()  in
+                                        query_logging.get_module_name () in
                                       FStar_Util.format2
                                         "%s: Unexpected output from Z3: %s\n"
                                         uu____2921
-                                        (FStar_String.concat "\n" remaining)
-                                       in
+                                        (FStar_String.concat "\n" remaining) in
                                     (FStar_Errors.Warning_UnexpectedZ3Output,
-                                      uu____2920)
-                                     in
+                                      uu____2920) in
                                   FStar_Errors.log_issue
                                     FStar_Range.dummyRange uu____2915);
-                             (let uu____2922 = FStar_Util.must result_opt  in
+                             (let uu____2922 = FStar_Util.must result_opt in
                               {
                                 smt_result = uu____2922;
                                 smt_reason_unknown = reason_unknown;
@@ -622,12 +568,11 @@ let (smt_output_sections : Prims.string Prims.list -> smt_output) =
                                 smt_statistics = statistics;
                                 smt_labels = labels
                               }))))))
-  
-let (doZ3Exe :
+let doZ3Exe:
   Prims.bool ->
     Prims.string ->
       FStar_SMTEncoding_Term.error_labels ->
-        (z3status,z3statistics) FStar_Pervasives_Native.tuple2)
+        (z3status,z3statistics) FStar_Pervasives_Native.tuple2
   =
   fun fresh  ->
     fun input  ->
@@ -635,28 +580,23 @@ let (doZ3Exe :
         let parse z3out =
           let lines =
             FStar_All.pipe_right (FStar_String.split [10] z3out)
-              (FStar_List.map FStar_Util.trim_string)
-             in
-          let smt_output = smt_output_sections lines  in
+              (FStar_List.map FStar_Util.trim_string) in
+          let smt_output = smt_output_sections lines in
           let unsat_core =
             match smt_output.smt_unsat_core with
             | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
             | FStar_Pervasives_Native.Some s ->
-                let s1 = FStar_Util.trim_string (FStar_String.concat " " s)
-                   in
+                let s1 = FStar_Util.trim_string (FStar_String.concat " " s) in
                 let s2 =
                   FStar_Util.substring s1 (Prims.parse_int "1")
-                    ((FStar_String.length s1) - (Prims.parse_int "2"))
-                   in
+                    ((FStar_String.length s1) - (Prims.parse_int "2")) in
                 if FStar_Util.starts_with s2 "error"
                 then FStar_Pervasives_Native.None
                 else
                   (let uu____2982 =
                      FStar_All.pipe_right (FStar_Util.split s2 " ")
-                       (FStar_Util.sort_with FStar_String.compare)
-                      in
-                   FStar_Pervasives_Native.Some uu____2982)
-             in
+                       (FStar_Util.sort_with FStar_String.compare) in
+                   FStar_Pervasives_Native.Some uu____2982) in
           let labels =
             match smt_output.smt_labels with
             | FStar_Pervasives_Native.None  -> []
@@ -665,11 +605,11 @@ let (doZ3Exe :
                   match lines2 with
                   | lname::"false"::rest when
                       FStar_Util.starts_with lname "label_" ->
-                      let uu____3043 = lblnegs rest  in lname :: uu____3043
+                      let uu____3043 = lblnegs rest in lname :: uu____3043
                   | lname::uu____3047::rest when
                       FStar_Util.starts_with lname "label_" -> lblnegs rest
-                  | uu____3051 -> []  in
-                let lblnegs1 = lblnegs lines1  in
+                  | uu____3051 -> [] in
+                let lblnegs1 = lblnegs lines1 in
                 FStar_All.pipe_right lblnegs1
                   (FStar_List.collect
                      (fun l  ->
@@ -679,80 +619,71 @@ let (doZ3Exe :
                                (fun uu____3123  ->
                                   match uu____3123 with
                                   | (m,uu____3135,uu____3136) ->
-                                      (FStar_Pervasives_Native.fst m) = l))
-                           in
+                                      (FStar_Pervasives_Native.fst m) = l)) in
                         match uu____3084 with
                         | FStar_Pervasives_Native.None  -> []
                         | FStar_Pervasives_Native.Some (lbl,msg,r) ->
-                            [(lbl, msg, r)]))
-             in
+                            [(lbl, msg, r)])) in
           let statistics =
-            let statistics = FStar_Util.smap_create (Prims.parse_int "0")  in
+            let statistics = FStar_Util.smap_create (Prims.parse_int "0") in
             match smt_output.smt_statistics with
             | FStar_Pervasives_Native.None  -> statistics
             | FStar_Pervasives_Native.Some lines1 ->
                 let parse_line line =
                   let pline =
-                    FStar_Util.split (FStar_Util.trim_string line) ":"  in
+                    FStar_Util.split (FStar_Util.trim_string line) ":" in
                   match pline with
                   | "("::entry::[] ->
-                      let tokens = FStar_Util.split entry " "  in
-                      let key = FStar_List.hd tokens  in
+                      let tokens = FStar_Util.split entry " " in
+                      let key = FStar_List.hd tokens in
                       let ltok =
                         FStar_List.nth tokens
-                          ((FStar_List.length tokens) - (Prims.parse_int "1"))
-                         in
+                          ((FStar_List.length tokens) - (Prims.parse_int "1")) in
                       let value =
                         if FStar_Util.ends_with ltok ")"
                         then
                           FStar_Util.substring ltok (Prims.parse_int "0")
                             ((FStar_String.length ltok) -
                                (Prims.parse_int "1"))
-                        else ltok  in
+                        else ltok in
                       FStar_Util.smap_add statistics key value
                   | ""::entry::[] ->
-                      let tokens = FStar_Util.split entry " "  in
-                      let key = FStar_List.hd tokens  in
+                      let tokens = FStar_Util.split entry " " in
+                      let key = FStar_List.hd tokens in
                       let ltok =
                         FStar_List.nth tokens
-                          ((FStar_List.length tokens) - (Prims.parse_int "1"))
-                         in
+                          ((FStar_List.length tokens) - (Prims.parse_int "1")) in
                       let value =
                         if FStar_Util.ends_with ltok ")"
                         then
                           FStar_Util.substring ltok (Prims.parse_int "0")
                             ((FStar_String.length ltok) -
                                (Prims.parse_int "1"))
-                        else ltok  in
+                        else ltok in
                       FStar_Util.smap_add statistics key value
-                  | uu____3248 -> ()  in
-                (FStar_List.iter parse_line lines1; statistics)
-             in
+                  | uu____3248 -> () in
+                (FStar_List.iter parse_line lines1; statistics) in
           let reason_unknown =
             FStar_Util.map_opt smt_output.smt_reason_unknown
               (fun x  ->
-                 let ru = FStar_String.concat " " x  in
+                 let ru = FStar_String.concat " " x in
                  if FStar_Util.starts_with ru "(:reason-unknown \""
                  then
                    let reason =
                      FStar_Util.substring_from ru
-                       (FStar_String.length "(:reason-unknown \"")
-                      in
+                       (FStar_String.length "(:reason-unknown \"") in
                    let res =
                      FStar_String.substring reason (Prims.parse_int "0")
-                       ((FStar_String.length reason) - (Prims.parse_int "2"))
-                      in
+                       ((FStar_String.length reason) - (Prims.parse_int "2")) in
                    res
-                 else ru)
-             in
+                 else ru) in
           let status =
-            (let uu____3266 = FStar_Options.debug_any ()  in
+            (let uu____3266 = FStar_Options.debug_any () in
              if uu____3266
              then
                let uu____3267 =
                  FStar_Util.format1 "Z3 says: %s\n"
-                   (FStar_String.concat "\n" smt_output.smt_result)
-                  in
+                   (FStar_String.concat "\n" smt_output.smt_result) in
                FStar_All.pipe_left FStar_Util.print_string uu____3267
              else ());
             (match smt_output.smt_result with
@@ -765,54 +696,46 @@ let (doZ3Exe :
                  let uu____3313 =
                    FStar_Util.format1
                      "Unexpected output from Z3: got output result: %s\n"
-                     (FStar_String.concat "\n" smt_output.smt_result)
-                    in
-                 failwith uu____3313)
-             in
-          (status, statistics)  in
-        let cond pid s = let x = (FStar_Util.trim_string s) = "Done!"  in x
-           in
+                     (FStar_String.concat "\n" smt_output.smt_result) in
+                 failwith uu____3313) in
+          (status, statistics) in
+        let cond pid s = let x = (FStar_Util.trim_string s) = "Done!" in x in
         let stdout1 =
           if fresh
           then
-            let uu____3323 = tid ()  in
-            let uu____3324 = FStar_Options.z3_exe ()  in
-            let uu____3325 = ini_params ()  in
+            let uu____3323 = tid () in
+            let uu____3324 = FStar_Options.z3_exe () in
+            let uu____3325 = ini_params () in
             FStar_Util.launch_process false uu____3323 uu____3324 uu____3325
               input cond
           else
-            (let proc = bg_z3_proc.grab ()  in
-             let stdout1 = FStar_Util.ask_process proc input  in
-             bg_z3_proc.release (); stdout1)
-           in
+            (let proc = bg_z3_proc.grab () in
+             let stdout1 = FStar_Util.ask_process proc input in
+             bg_z3_proc.release (); stdout1) in
         parse (FStar_Util.trim_string stdout1)
-  
-let (z3_options : Prims.unit -> Prims.string) =
+let z3_options: Prims.unit -> Prims.string =
   fun uu____3332  ->
     "(set-option :global-decls false)\n(set-option :smt.mbqi false)\n(set-option :auto_config false)\n(set-option :produce-unsat-cores true)\n"
-  
 type 'a job = {
-  job: Prims.unit -> 'a ;
-  callback: 'a -> Prims.unit }[@@deriving show]
-let __proj__Mkjob__item__job : 'a . 'a job -> Prims.unit -> 'a =
+  job: Prims.unit -> 'a;
+  callback: 'a -> Prims.unit;}[@@deriving show]
+let __proj__Mkjob__item__job: 'a . 'a job -> Prims.unit -> 'a =
   fun projectee  ->
     match projectee with
     | { job = __fname__job; callback = __fname__callback;_} -> __fname__job
-  
-let __proj__Mkjob__item__callback : 'a . 'a job -> 'a -> Prims.unit =
+let __proj__Mkjob__item__callback: 'a . 'a job -> 'a -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { job = __fname__job; callback = __fname__callback;_} ->
         __fname__callback
-  
 type z3result =
   {
-  z3result_status: z3status ;
-  z3result_time: Prims.int ;
-  z3result_statistics: z3statistics ;
-  z3result_query_hash: Prims.string FStar_Pervasives_Native.option }[@@deriving
+  z3result_status: z3status;
+  z3result_time: Prims.int;
+  z3result_statistics: z3statistics;
+  z3result_query_hash: Prims.string FStar_Pervasives_Native.option;}[@@deriving
                                                                     show]
-let (__proj__Mkz3result__item__z3result_status : z3result -> z3status) =
+let __proj__Mkz3result__item__z3result_status: z3result -> z3status =
   fun projectee  ->
     match projectee with
     | { z3result_status = __fname__z3result_status;
@@ -820,8 +743,7 @@ let (__proj__Mkz3result__item__z3result_status : z3result -> z3status) =
         z3result_statistics = __fname__z3result_statistics;
         z3result_query_hash = __fname__z3result_query_hash;_} ->
         __fname__z3result_status
-  
-let (__proj__Mkz3result__item__z3result_time : z3result -> Prims.int) =
+let __proj__Mkz3result__item__z3result_time: z3result -> Prims.int =
   fun projectee  ->
     match projectee with
     | { z3result_status = __fname__z3result_status;
@@ -829,9 +751,7 @@ let (__proj__Mkz3result__item__z3result_time : z3result -> Prims.int) =
         z3result_statistics = __fname__z3result_statistics;
         z3result_query_hash = __fname__z3result_query_hash;_} ->
         __fname__z3result_time
-  
-let (__proj__Mkz3result__item__z3result_statistics :
-  z3result -> z3statistics) =
+let __proj__Mkz3result__item__z3result_statistics: z3result -> z3statistics =
   fun projectee  ->
     match projectee with
     | { z3result_status = __fname__z3result_status;
@@ -839,9 +759,8 @@ let (__proj__Mkz3result__item__z3result_statistics :
         z3result_statistics = __fname__z3result_statistics;
         z3result_query_hash = __fname__z3result_query_hash;_} ->
         __fname__z3result_statistics
-  
-let (__proj__Mkz3result__item__z3result_query_hash :
-  z3result -> Prims.string FStar_Pervasives_Native.option) =
+let __proj__Mkz3result__item__z3result_query_hash:
+  z3result -> Prims.string FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { z3result_status = __fname__z3result_status;
@@ -849,51 +768,48 @@ let (__proj__Mkz3result__item__z3result_query_hash :
         z3result_statistics = __fname__z3result_statistics;
         z3result_query_hash = __fname__z3result_query_hash;_} ->
         __fname__z3result_query_hash
-  
 type z3job = z3result job[@@deriving show]
-let (job_queue : z3job Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
-let (pending_jobs : Prims.int FStar_ST.ref) =
-  FStar_Util.mk_ref (Prims.parse_int "0") 
-let with_monitor :
+let job_queue: z3job Prims.list FStar_ST.ref = FStar_Util.mk_ref []
+let pending_jobs: Prims.int FStar_ST.ref =
+  FStar_Util.mk_ref (Prims.parse_int "0")
+let with_monitor:
   'Auu____3485 'Auu____3486 .
     'Auu____3486 -> (Prims.unit -> 'Auu____3485) -> 'Auu____3485
   =
   fun m  ->
     fun f  ->
       FStar_Util.monitor_enter m;
-      (let res = f ()  in FStar_Util.monitor_exit m; res)
-  
-let (z3_job :
+      (let res = f () in FStar_Util.monitor_exit m; res)
+let z3_job:
   Prims.bool ->
     FStar_SMTEncoding_Term.error_labels ->
       Prims.string ->
-        Prims.string FStar_Pervasives_Native.option -> Prims.unit -> z3result)
+        Prims.string FStar_Pervasives_Native.option -> Prims.unit -> z3result
   =
   fun fresh  ->
     fun label_messages  ->
       fun input  ->
         fun qhash  ->
           fun uu____3519  ->
-            let start = FStar_Util.now ()  in
+            let start = FStar_Util.now () in
             let uu____3523 =
               try doZ3Exe fresh input label_messages
               with
               | uu____3547 when
-                  let uu____3548 = FStar_Options.trace_error ()  in
+                  let uu____3548 = FStar_Options.trace_error () in
                   Prims.op_Negation uu____3548 ->
                   (bg_z3_proc.refresh ();
                    (let uu____3550 =
-                      FStar_Util.smap_create (Prims.parse_int "0")  in
+                      FStar_Util.smap_create (Prims.parse_int "0") in
                     ((UNKNOWN
                         ([],
                           (FStar_Pervasives_Native.Some
-                             "Z3 raised an exception"))), uu____3550)))
-               in
+                             "Z3 raised an exception"))), uu____3550))) in
             match uu____3523 with
             | (status,statistics) ->
                 let uu____3561 =
-                  let uu____3566 = FStar_Util.now ()  in
-                  FStar_Util.time_diff start uu____3566  in
+                  let uu____3566 = FStar_Util.now () in
+                  FStar_Util.time_diff start uu____3566 in
                 (match uu____3561 with
                  | (uu____3567,elapsed_time) ->
                      {
@@ -902,125 +818,109 @@ let (z3_job :
                        z3result_statistics = statistics;
                        z3result_query_hash = qhash
                      })
-  
-let (running : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false 
-let rec (dequeue' : Prims.unit -> Prims.unit) =
+let running: Prims.bool FStar_ST.ref = FStar_Util.mk_ref false
+let rec dequeue': Prims.unit -> Prims.unit =
   fun uu____3588  ->
     let j =
-      let uu____3590 = FStar_ST.op_Bang job_queue  in
+      let uu____3590 = FStar_ST.op_Bang job_queue in
       match uu____3590 with
       | [] -> failwith "Impossible"
-      | hd1::tl1 -> (FStar_ST.op_Colon_Equals job_queue tl1; hd1)  in
+      | hd1::tl1 -> (FStar_ST.op_Colon_Equals job_queue tl1; hd1) in
     FStar_Util.incr pending_jobs;
     FStar_Util.monitor_exit job_queue;
     run_job j;
     with_monitor job_queue (fun uu____3657  -> FStar_Util.decr pending_jobs);
     dequeue ()
-
-and (dequeue : Prims.unit -> Prims.unit) =
+and dequeue: Prims.unit -> Prims.unit =
   fun uu____3659  ->
-    let uu____3660 = FStar_ST.op_Bang running  in
+    let uu____3660 = FStar_ST.op_Bang running in
     if uu____3660
     then
       let rec aux uu____3683 =
         FStar_Util.monitor_enter job_queue;
-        (let uu____3689 = FStar_ST.op_Bang job_queue  in
+        (let uu____3689 = FStar_ST.op_Bang job_queue in
          match uu____3689 with
          | [] ->
              (FStar_Util.monitor_exit job_queue;
               FStar_Util.sleep (Prims.parse_int "50");
               aux ())
-         | uu____3721 -> dequeue' ())
-         in
+         | uu____3721 -> dequeue' ()) in
       aux ()
     else ()
-
-and (run_job : z3job -> Prims.unit) =
+and run_job: z3job -> Prims.unit =
   fun j  ->
-    let uu____3725 = j.job ()  in FStar_All.pipe_left j.callback uu____3725
-
-let (init : Prims.unit -> Prims.unit) =
+    let uu____3725 = j.job () in FStar_All.pipe_left j.callback uu____3725
+let init: Prims.unit -> Prims.unit =
   fun uu____3728  ->
     FStar_ST.op_Colon_Equals running true;
-    (let n_cores1 = FStar_Options.n_cores ()  in
+    (let n_cores1 = FStar_Options.n_cores () in
      if n_cores1 > (Prims.parse_int "1")
      then
        let rec aux n1 =
          if n1 = (Prims.parse_int "0")
          then ()
-         else (FStar_Util.spawn dequeue; aux (n1 - (Prims.parse_int "1")))
-          in
+         else (FStar_Util.spawn dequeue; aux (n1 - (Prims.parse_int "1"))) in
        aux n_cores1
      else ())
-  
-let (enqueue : z3job -> Prims.unit) =
+let enqueue: z3job -> Prims.unit =
   fun j  ->
     FStar_Util.monitor_enter job_queue;
     (let uu____3766 =
-       let uu____3769 = FStar_ST.op_Bang job_queue  in
-       FStar_List.append uu____3769 [j]  in
+       let uu____3769 = FStar_ST.op_Bang job_queue in
+       FStar_List.append uu____3769 [j] in
      FStar_ST.op_Colon_Equals job_queue uu____3766);
     FStar_Util.monitor_pulse job_queue;
     FStar_Util.monitor_exit job_queue
-  
-let (finish : Prims.unit -> Prims.unit) =
+let finish: Prims.unit -> Prims.unit =
   fun uu____3829  ->
     let rec aux uu____3833 =
       let uu____3834 =
         with_monitor job_queue
           (fun uu____3850  ->
-             let uu____3851 = FStar_ST.op_Bang pending_jobs  in
+             let uu____3851 = FStar_ST.op_Bang pending_jobs in
              let uu____3871 =
-               let uu____3872 = FStar_ST.op_Bang job_queue  in
-               FStar_List.length uu____3872  in
-             (uu____3851, uu____3871))
-         in
+               let uu____3872 = FStar_ST.op_Bang job_queue in
+               FStar_List.length uu____3872 in
+             (uu____3851, uu____3871)) in
       match uu____3834 with
       | (n1,m) ->
           if (n1 + m) = (Prims.parse_int "0")
           then FStar_ST.op_Colon_Equals running false
-          else (FStar_Util.sleep (Prims.parse_int "500"); aux ())
-       in
+          else (FStar_Util.sleep (Prims.parse_int "500"); aux ()) in
     aux ()
-  
 type scope_t = FStar_SMTEncoding_Term.decl Prims.list Prims.list[@@deriving
                                                                   show]
-let (fresh_scope :
-  FStar_SMTEncoding_Term.decl Prims.list Prims.list FStar_ST.ref) =
-  FStar_Util.mk_ref [[]] 
-let (mk_fresh_scope : Prims.unit -> scope_t) =
-  fun uu____3960  -> FStar_ST.op_Bang fresh_scope 
-let (bg_scope : FStar_SMTEncoding_Term.decl Prims.list FStar_ST.ref) =
-  FStar_Util.mk_ref [] 
-let (push : Prims.string -> Prims.unit) =
+let fresh_scope:
+  FStar_SMTEncoding_Term.decl Prims.list Prims.list FStar_ST.ref =
+  FStar_Util.mk_ref [[]]
+let mk_fresh_scope: Prims.unit -> scope_t =
+  fun uu____3960  -> FStar_ST.op_Bang fresh_scope
+let bg_scope: FStar_SMTEncoding_Term.decl Prims.list FStar_ST.ref =
+  FStar_Util.mk_ref []
+let push: Prims.string -> Prims.unit =
   fun msg  ->
     (let uu____4009 =
-       let uu____4014 = FStar_ST.op_Bang fresh_scope  in
+       let uu____4014 = FStar_ST.op_Bang fresh_scope in
        [FStar_SMTEncoding_Term.Caption msg; FStar_SMTEncoding_Term.Push] ::
-         uu____4014
-        in
+         uu____4014 in
      FStar_ST.op_Colon_Equals fresh_scope uu____4009);
     (let uu____4075 =
-       let uu____4078 = FStar_ST.op_Bang bg_scope  in
+       let uu____4078 = FStar_ST.op_Bang bg_scope in
        FStar_List.append uu____4078
-         [FStar_SMTEncoding_Term.Push; FStar_SMTEncoding_Term.Caption msg]
-        in
+         [FStar_SMTEncoding_Term.Push; FStar_SMTEncoding_Term.Caption msg] in
      FStar_ST.op_Colon_Equals bg_scope uu____4075)
-  
-let (pop : Prims.string -> Prims.unit) =
+let pop: Prims.string -> Prims.unit =
   fun msg  ->
     (let uu____4131 =
-       let uu____4136 = FStar_ST.op_Bang fresh_scope  in
-       FStar_List.tl uu____4136  in
+       let uu____4136 = FStar_ST.op_Bang fresh_scope in
+       FStar_List.tl uu____4136 in
      FStar_ST.op_Colon_Equals fresh_scope uu____4131);
     (let uu____4197 =
-       let uu____4200 = FStar_ST.op_Bang bg_scope  in
+       let uu____4200 = FStar_ST.op_Bang bg_scope in
        FStar_List.append uu____4200
-         [FStar_SMTEncoding_Term.Caption msg; FStar_SMTEncoding_Term.Pop]
-        in
+         [FStar_SMTEncoding_Term.Caption msg; FStar_SMTEncoding_Term.Pop] in
      FStar_ST.op_Colon_Equals bg_scope uu____4197)
-  
-let (giveZ3 : FStar_SMTEncoding_Term.decl Prims.list -> Prims.unit) =
+let giveZ3: FStar_SMTEncoding_Term.decl Prims.list -> Prims.unit =
   fun decls  ->
     FStar_All.pipe_right decls
       (FStar_List.iter
@@ -1029,42 +929,39 @@ let (giveZ3 : FStar_SMTEncoding_Term.decl Prims.list -> Prims.unit) =
             | FStar_SMTEncoding_Term.Push  -> failwith "Unexpected push/pop"
             | FStar_SMTEncoding_Term.Pop  -> failwith "Unexpected push/pop"
             | uu____4261 -> ()));
-    (let uu____4263 = FStar_ST.op_Bang fresh_scope  in
+    (let uu____4263 = FStar_ST.op_Bang fresh_scope in
      match uu____4263 with
      | hd1::tl1 ->
          FStar_ST.op_Colon_Equals fresh_scope ((FStar_List.append hd1 decls)
            :: tl1)
      | uu____4334 -> failwith "Impossible");
     (let uu____4339 =
-       let uu____4342 = FStar_ST.op_Bang bg_scope  in
-       FStar_List.append uu____4342 decls  in
+       let uu____4342 = FStar_ST.op_Bang bg_scope in
+       FStar_List.append uu____4342 decls in
      FStar_ST.op_Colon_Equals bg_scope uu____4339)
-  
-let (refresh : Prims.unit -> Prims.unit) =
+let refresh: Prims.unit -> Prims.unit =
   fun uu____4393  ->
     (let uu____4395 =
-       let uu____4396 = FStar_Options.n_cores ()  in
-       uu____4396 < (Prims.parse_int "2")  in
+       let uu____4396 = FStar_Options.n_cores () in
+       uu____4396 < (Prims.parse_int "2") in
      if uu____4395 then bg_z3_proc.refresh () else ());
     (let uu____4398 =
        let uu____4401 =
-         let uu____4406 = FStar_ST.op_Bang fresh_scope  in
-         FStar_List.rev uu____4406  in
-       FStar_List.flatten uu____4401  in
+         let uu____4406 = FStar_ST.op_Bang fresh_scope in
+         FStar_List.rev uu____4406 in
+       FStar_List.flatten uu____4401 in
      FStar_ST.op_Colon_Equals bg_scope uu____4398)
-  
-let (mk_input :
+let mk_input:
   FStar_SMTEncoding_Term.decl Prims.list ->
     (Prims.string,Prims.string FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun theory  ->
-    let options = z3_options ()  in
+    let options = z3_options () in
     let uu____4477 =
       let uu____4484 =
         (FStar_Options.record_hints ()) ||
-          ((FStar_Options.use_hints ()) && (FStar_Options.use_hint_hashes ()))
-         in
+          ((FStar_Options.use_hints ()) && (FStar_Options.use_hint_hashes ())) in
       if uu____4484
       then
         let uu____4491 =
@@ -1074,29 +971,27 @@ let (mk_input :
                  (fun uu___39_4530  ->
                     match uu___39_4530 with
                     | FStar_SMTEncoding_Term.CheckSat  -> true
-                    | uu____4531 -> false))
-             in
-          FStar_All.pipe_right uu____4502 FStar_Option.get  in
+                    | uu____4531 -> false)) in
+          FStar_All.pipe_right uu____4502 FStar_Option.get in
         match uu____4491 with
         | (prefix1,check_sat,suffix) ->
             let pp =
-              FStar_List.map (FStar_SMTEncoding_Term.declToSmt options)  in
+              FStar_List.map (FStar_SMTEncoding_Term.declToSmt options) in
             let pp_no_cap =
               FStar_List.map
-                (FStar_SMTEncoding_Term.declToSmt_no_caps options)
-               in
-            let suffix1 = check_sat :: suffix  in
-            let ps_lines = pp prefix1  in
-            let ss_lines = pp suffix1  in
-            let ps = FStar_String.concat "\n" ps_lines  in
-            let ss = FStar_String.concat "\n" ss_lines  in
+                (FStar_SMTEncoding_Term.declToSmt_no_caps options) in
+            let suffix1 = check_sat :: suffix in
+            let ps_lines = pp prefix1 in
+            let ss_lines = pp suffix1 in
+            let ps = FStar_String.concat "\n" ps_lines in
+            let ss = FStar_String.concat "\n" ss_lines in
             let uncaption uu___40_4609 =
               match uu___40_4609 with
               | FStar_SMTEncoding_Term.Caption uu____4610 ->
                   FStar_SMTEncoding_Term.Caption ""
               | FStar_SMTEncoding_Term.Assume a ->
                   FStar_SMTEncoding_Term.Assume
-                    (let uu___45_4614 = a  in
+                    (let uu___45_4614 = a in
                      {
                        FStar_SMTEncoding_Term.assumption_term =
                          (uu___45_4614.FStar_SMTEncoding_Term.assumption_term);
@@ -1113,52 +1008,46 @@ let (mk_input :
               | FStar_SMTEncoding_Term.DefineFun (n1,a,s,b,uu____4631) ->
                   FStar_SMTEncoding_Term.DefineFun
                     (n1, a, s, b, FStar_Pervasives_Native.None)
-              | d -> d  in
+              | d -> d in
             let hs =
               let uu____4642 =
                 let uu____4645 =
                   let uu____4648 =
-                    FStar_All.pipe_right prefix1 (FStar_List.map uncaption)
-                     in
-                  FStar_All.pipe_right uu____4648 pp_no_cap  in
+                    FStar_All.pipe_right prefix1 (FStar_List.map uncaption) in
+                  FStar_All.pipe_right uu____4648 pp_no_cap in
                 FStar_All.pipe_right uu____4645
-                  (FStar_List.filter (fun s  -> s <> ""))
-                 in
-              FStar_All.pipe_right uu____4642 (FStar_String.concat "\n")  in
+                  (FStar_List.filter (fun s  -> s <> "")) in
+              FStar_All.pipe_right uu____4642 (FStar_String.concat "\n") in
             let uu____4667 =
-              let uu____4670 = FStar_Util.digest_of_string hs  in
-              FStar_Pervasives_Native.Some uu____4670  in
+              let uu____4670 = FStar_Util.digest_of_string hs in
+              FStar_Pervasives_Native.Some uu____4670 in
             ((Prims.strcat ps (Prims.strcat "\n" ss)), uu____4667)
       else
         (let uu____4674 =
            let uu____4675 =
-             FStar_List.map (FStar_SMTEncoding_Term.declToSmt options) theory
-              in
-           FStar_All.pipe_right uu____4675 (FStar_String.concat "\n")  in
-         (uu____4674, FStar_Pervasives_Native.None))
-       in
+             FStar_List.map (FStar_SMTEncoding_Term.declToSmt options) theory in
+           FStar_All.pipe_right uu____4675 (FStar_String.concat "\n") in
+         (uu____4674, FStar_Pervasives_Native.None)) in
     match uu____4477 with
     | (r,hash) ->
-        ((let uu____4695 = FStar_Options.log_queries ()  in
+        ((let uu____4695 = FStar_Options.log_queries () in
           if uu____4695 then query_logging.write_to_log r else ());
          (r, hash))
-  
 type cb = z3result -> Prims.unit[@@deriving show]
-let (cache_hit :
+let cache_hit:
   Prims.string FStar_Pervasives_Native.option ->
-    Prims.string FStar_Pervasives_Native.option -> cb -> Prims.bool)
+    Prims.string FStar_Pervasives_Native.option -> cb -> Prims.bool
   =
   fun cache  ->
     fun qhash  ->
       fun cb  ->
         let uu____4720 =
-          (FStar_Options.use_hints ()) && (FStar_Options.use_hint_hashes ())
-           in
+          (FStar_Options.use_hints ()) && (FStar_Options.use_hint_hashes ()) in
         if uu____4720
         then
           match qhash with
           | FStar_Pervasives_Native.Some x when qhash = cache ->
-              let stats = FStar_Util.smap_create (Prims.parse_int "0")  in
+              let stats = FStar_Util.smap_create (Prims.parse_int "0") in
               (FStar_Util.smap_add stats "fstar_cache_hit" "1";
                (let result =
                   {
@@ -1166,19 +1055,18 @@ let (cache_hit :
                     z3result_time = (Prims.parse_int "0");
                     z3result_statistics = stats;
                     z3result_query_hash = qhash
-                  }  in
+                  } in
                 cb result; true))
           | uu____4731 -> false
         else false
-  
-let (ask_1_core :
+let ask_1_core:
   (FStar_SMTEncoding_Term.decls_t ->
      (FStar_SMTEncoding_Term.decls_t,Prims.bool)
        FStar_Pervasives_Native.tuple2)
     ->
     Prims.string FStar_Pervasives_Native.option ->
       FStar_SMTEncoding_Term.error_labels ->
-        FStar_SMTEncoding_Term.decls_t -> cb -> Prims.unit)
+        FStar_SMTEncoding_Term.decls_t -> cb -> Prims.unit
   =
   fun filter_theory  ->
     fun cache  ->
@@ -1186,21 +1074,20 @@ let (ask_1_core :
         fun qry  ->
           fun cb  ->
             let theory =
-              let uu____4772 = FStar_ST.op_Bang bg_scope  in
+              let uu____4772 = FStar_ST.op_Bang bg_scope in
               FStar_List.append uu____4772
                 (FStar_List.append [FStar_SMTEncoding_Term.Push]
-                   (FStar_List.append qry [FStar_SMTEncoding_Term.Pop]))
-               in
-            let uu____4798 = filter_theory theory  in
+                   (FStar_List.append qry [FStar_SMTEncoding_Term.Pop])) in
+            let uu____4798 = filter_theory theory in
             match uu____4798 with
             | (theory1,used_unsat_core) ->
-                let uu____4805 = mk_input theory1  in
+                let uu____4805 = mk_input theory1 in
                 (match uu____4805 with
                  | (input,qhash) ->
                      (FStar_ST.op_Colon_Equals bg_scope [];
                       (let uu____4842 =
-                         let uu____4843 = cache_hit cache qhash cb  in
-                         Prims.op_Negation uu____4843  in
+                         let uu____4843 = cache_hit cache qhash cb in
+                         Prims.op_Negation uu____4843 in
                        if uu____4842
                        then
                          run_job
@@ -1209,8 +1096,7 @@ let (ask_1_core :
                              callback = cb
                            }
                        else ())))
-  
-let (ask_n_cores :
+let ask_n_cores:
   (FStar_SMTEncoding_Term.decls_t ->
      (FStar_SMTEncoding_Term.decls_t,Prims.bool)
        FStar_Pervasives_Native.tuple2)
@@ -1218,7 +1104,7 @@ let (ask_n_cores :
     Prims.string FStar_Pervasives_Native.option ->
       FStar_SMTEncoding_Term.error_labels ->
         FStar_SMTEncoding_Term.decls_t ->
-          scope_t FStar_Pervasives_Native.option -> cb -> Prims.unit)
+          scope_t FStar_Pervasives_Native.option -> cb -> Prims.unit
   =
   fun filter_theory  ->
     fun cache  ->
@@ -1232,24 +1118,22 @@ let (ask_n_cores :
                   | FStar_Pervasives_Native.Some s -> FStar_List.rev s
                   | FStar_Pervasives_Native.None  ->
                       (FStar_ST.op_Colon_Equals bg_scope [];
-                       (let uu____4929 = FStar_ST.op_Bang fresh_scope  in
-                        FStar_List.rev uu____4929))
-                   in
-                FStar_List.flatten uu____4893  in
+                       (let uu____4929 = FStar_ST.op_Bang fresh_scope in
+                        FStar_List.rev uu____4929)) in
+                FStar_List.flatten uu____4893 in
               let theory1 =
                 FStar_List.append theory
                   (FStar_List.append [FStar_SMTEncoding_Term.Push]
-                     (FStar_List.append qry [FStar_SMTEncoding_Term.Pop]))
-                 in
-              let uu____4966 = filter_theory theory1  in
+                     (FStar_List.append qry [FStar_SMTEncoding_Term.Pop])) in
+              let uu____4966 = filter_theory theory1 in
               match uu____4966 with
               | (theory2,used_unsat_core) ->
-                  let uu____4973 = mk_input theory2  in
+                  let uu____4973 = mk_input theory2 in
                   (match uu____4973 with
                    | (input,qhash) ->
                        let uu____4986 =
-                         let uu____4987 = cache_hit cache qhash cb  in
-                         Prims.op_Negation uu____4987  in
+                         let uu____4987 = cache_hit cache qhash cb in
+                         Prims.op_Negation uu____4987 in
                        if uu____4986
                        then
                          enqueue
@@ -1258,8 +1142,7 @@ let (ask_n_cores :
                              callback = cb
                            }
                        else ())
-  
-let (ask :
+let ask:
   (FStar_SMTEncoding_Term.decls_t ->
      (FStar_SMTEncoding_Term.decls_t,Prims.bool)
        FStar_Pervasives_Native.tuple2)
@@ -1267,7 +1150,7 @@ let (ask :
     Prims.string FStar_Pervasives_Native.option ->
       FStar_SMTEncoding_Term.error_labels ->
         FStar_SMTEncoding_Term.decl Prims.list ->
-          scope_t FStar_Pervasives_Native.option -> cb -> Prims.unit)
+          scope_t FStar_Pervasives_Native.option -> cb -> Prims.unit
   =
   fun filter1  ->
     fun cache  ->
@@ -1276,9 +1159,8 @@ let (ask :
           fun scope  ->
             fun cb  ->
               let uu____5036 =
-                let uu____5037 = FStar_Options.n_cores ()  in
-                uu____5037 = (Prims.parse_int "1")  in
+                let uu____5037 = FStar_Options.n_cores () in
+                uu____5037 = (Prims.parse_int "1") in
               if uu____5036
               then ask_1_core filter1 cache label_messages qry cb
               else ask_n_cores filter1 cache label_messages qry scope cb
-  

--- a/src/ocaml-output/FStar_Syntax_Embeddings.ml
+++ b/src/ocaml-output/FStar_Syntax_Embeddings.ml
@@ -4,24 +4,22 @@ type 'a embedder = FStar_Range.range -> 'a -> FStar_Syntax_Syntax.term
 type 'a unembedder =
   FStar_Syntax_Syntax.term -> 'a FStar_Pervasives_Native.option[@@deriving
                                                                  show]
-let (embed_unit :
-  FStar_Range.range -> Prims.unit -> FStar_Syntax_Syntax.term) =
+let embed_unit: FStar_Range.range -> Prims.unit -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun u  ->
-      let uu___38_26 = FStar_Syntax_Util.exp_unit  in
+      let uu___38_26 = FStar_Syntax_Util.exp_unit in
       {
         FStar_Syntax_Syntax.n = (uu___38_26.FStar_Syntax_Syntax.n);
         FStar_Syntax_Syntax.pos = rng;
         FStar_Syntax_Syntax.vars = (uu___38_26.FStar_Syntax_Syntax.vars)
       }
-  
-let (__unembed_unit :
+let __unembed_unit:
   Prims.bool ->
-    FStar_Syntax_Syntax.term -> Prims.unit FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term -> Prims.unit FStar_Pervasives_Native.option
   =
   fun w  ->
     fun t0  ->
-      let t = FStar_Syntax_Util.unascribe t0  in
+      let t = FStar_Syntax_Util.unascribe t0 in
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_unit ) ->
           FStar_Pervasives_Native.Some ()
@@ -30,41 +28,38 @@ let (__unembed_unit :
            then
              (let uu____44 =
                 let uu____49 =
-                  let uu____50 = FStar_Syntax_Print.term_to_string t  in
-                  FStar_Util.format1 "Not an embedded unit: %s" uu____50  in
-                (FStar_Errors.Warning_NotEmbedded, uu____49)  in
+                  let uu____50 = FStar_Syntax_Print.term_to_string t in
+                  FStar_Util.format1 "Not an embedded unit: %s" uu____50 in
+                (FStar_Errors.Warning_NotEmbedded, uu____49) in
               FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____44)
            else ();
            FStar_Pervasives_Native.None)
-  
-let (unembed_unit :
-  FStar_Syntax_Syntax.term -> Prims.unit FStar_Pervasives_Native.option) =
-  fun t  -> __unembed_unit true t 
-let (unembed_unit_safe :
-  FStar_Syntax_Syntax.term -> Prims.unit FStar_Pervasives_Native.option) =
-  fun t  -> __unembed_unit false t 
-let (embed_bool :
-  FStar_Range.range -> Prims.bool -> FStar_Syntax_Syntax.term) =
+let unembed_unit:
+  FStar_Syntax_Syntax.term -> Prims.unit FStar_Pervasives_Native.option =
+  fun t  -> __unembed_unit true t
+let unembed_unit_safe:
+  FStar_Syntax_Syntax.term -> Prims.unit FStar_Pervasives_Native.option =
+  fun t  -> __unembed_unit false t
+let embed_bool: FStar_Range.range -> Prims.bool -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun b  ->
       let t =
         if b
         then FStar_Syntax_Util.exp_true_bool
-        else FStar_Syntax_Util.exp_false_bool  in
-      let uu___39_81 = t  in
+        else FStar_Syntax_Util.exp_false_bool in
+      let uu___39_81 = t in
       {
         FStar_Syntax_Syntax.n = (uu___39_81.FStar_Syntax_Syntax.n);
         FStar_Syntax_Syntax.pos = rng;
         FStar_Syntax_Syntax.vars = (uu___39_81.FStar_Syntax_Syntax.vars)
       }
-  
-let (__unembed_bool :
+let __unembed_bool:
   Prims.bool ->
-    FStar_Syntax_Syntax.term -> Prims.bool FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term -> Prims.bool FStar_Pervasives_Native.option
   =
   fun w  ->
     fun t0  ->
-      let t = FStar_Syntax_Util.unmeta_safe t0  in
+      let t = FStar_Syntax_Util.unmeta_safe t0 in
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool b) ->
           FStar_Pervasives_Native.Some b
@@ -73,39 +68,37 @@ let (__unembed_bool :
            then
              (let uu____100 =
                 let uu____105 =
-                  let uu____106 = FStar_Syntax_Print.term_to_string t0  in
-                  FStar_Util.format1 "Not an embedded bool: %s" uu____106  in
-                (FStar_Errors.Warning_NotEmbedded, uu____105)  in
+                  let uu____106 = FStar_Syntax_Print.term_to_string t0 in
+                  FStar_Util.format1 "Not an embedded bool: %s" uu____106 in
+                (FStar_Errors.Warning_NotEmbedded, uu____105) in
               FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____100)
            else ();
            FStar_Pervasives_Native.None)
-  
-let (unembed_bool :
-  FStar_Syntax_Syntax.term -> Prims.bool FStar_Pervasives_Native.option) =
-  fun t  -> __unembed_bool true t 
-let (unembed_bool_safe :
-  FStar_Syntax_Syntax.term -> Prims.bool FStar_Pervasives_Native.option) =
-  fun t  -> __unembed_bool false t 
-let (embed_char :
-  FStar_Range.range -> FStar_Char.char -> FStar_Syntax_Syntax.term) =
+let unembed_bool:
+  FStar_Syntax_Syntax.term -> Prims.bool FStar_Pervasives_Native.option =
+  fun t  -> __unembed_bool true t
+let unembed_bool_safe:
+  FStar_Syntax_Syntax.term -> Prims.bool FStar_Pervasives_Native.option =
+  fun t  -> __unembed_bool false t
+let embed_char:
+  FStar_Range.range -> FStar_Char.char -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun c  ->
-      let t = FStar_Syntax_Util.exp_char c  in
-      let uu___40_134 = t  in
+      let t = FStar_Syntax_Util.exp_char c in
+      let uu___40_134 = t in
       {
         FStar_Syntax_Syntax.n = (uu___40_134.FStar_Syntax_Syntax.n);
         FStar_Syntax_Syntax.pos = rng;
         FStar_Syntax_Syntax.vars = (uu___40_134.FStar_Syntax_Syntax.vars)
       }
-  
-let (__unembed_char :
+let __unembed_char:
   Prims.bool ->
     FStar_Syntax_Syntax.term ->
-      FStar_Char.char FStar_Pervasives_Native.option)
+      FStar_Char.char FStar_Pervasives_Native.option
   =
   fun w  ->
     fun t0  ->
-      let t = FStar_Syntax_Util.unmeta_safe t0  in
+      let t = FStar_Syntax_Util.unmeta_safe t0 in
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c) ->
           FStar_Pervasives_Native.Some c
@@ -114,78 +107,74 @@ let (__unembed_char :
            then
              (let uu____154 =
                 let uu____159 =
-                  let uu____160 = FStar_Syntax_Print.term_to_string t0  in
-                  FStar_Util.format1 "Not an embedded char: %s" uu____160  in
-                (FStar_Errors.Warning_NotEmbedded, uu____159)  in
+                  let uu____160 = FStar_Syntax_Print.term_to_string t0 in
+                  FStar_Util.format1 "Not an embedded char: %s" uu____160 in
+                (FStar_Errors.Warning_NotEmbedded, uu____159) in
               FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____154)
            else ();
            FStar_Pervasives_Native.None)
-  
-let (unembed_char :
-  FStar_Syntax_Syntax.term -> FStar_Char.char FStar_Pervasives_Native.option)
-  = fun t  -> __unembed_char true t 
-let (unembed_char_safe :
-  FStar_Syntax_Syntax.term -> FStar_Char.char FStar_Pervasives_Native.option)
-  = fun t  -> __unembed_char false t 
-let (embed_int :
-  FStar_Range.range -> FStar_BigInt.t -> FStar_Syntax_Syntax.term) =
+let unembed_char:
+  FStar_Syntax_Syntax.term -> FStar_Char.char FStar_Pervasives_Native.option
+  = fun t  -> __unembed_char true t
+let unembed_char_safe:
+  FStar_Syntax_Syntax.term -> FStar_Char.char FStar_Pervasives_Native.option
+  = fun t  -> __unembed_char false t
+let embed_int:
+  FStar_Range.range -> FStar_BigInt.t -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun i  ->
       let t =
-        let uu____189 = FStar_BigInt.string_of_big_int i  in
-        FStar_Syntax_Util.exp_int uu____189  in
-      let uu___41_190 = t  in
+        let uu____189 = FStar_BigInt.string_of_big_int i in
+        FStar_Syntax_Util.exp_int uu____189 in
+      let uu___41_190 = t in
       {
         FStar_Syntax_Syntax.n = (uu___41_190.FStar_Syntax_Syntax.n);
         FStar_Syntax_Syntax.pos = rng;
         FStar_Syntax_Syntax.vars = (uu___41_190.FStar_Syntax_Syntax.vars)
       }
-  
-let (__unembed_int :
+let __unembed_int:
   Prims.bool ->
-    FStar_Syntax_Syntax.term -> FStar_BigInt.t FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term -> FStar_BigInt.t FStar_Pervasives_Native.option
   =
   fun w  ->
     fun t0  ->
-      let t = FStar_Syntax_Util.unmeta_safe t0  in
+      let t = FStar_Syntax_Util.unmeta_safe t0 in
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int (s,uu____205))
           ->
-          let uu____218 = FStar_BigInt.big_int_of_string s  in
+          let uu____218 = FStar_BigInt.big_int_of_string s in
           FStar_Pervasives_Native.Some uu____218
       | uu____219 ->
           (if w
            then
              (let uu____221 =
                 let uu____226 =
-                  let uu____227 = FStar_Syntax_Print.term_to_string t0  in
-                  FStar_Util.format1 "Not an embedded int: %s" uu____227  in
-                (FStar_Errors.Warning_NotEmbedded, uu____226)  in
+                  let uu____227 = FStar_Syntax_Print.term_to_string t0 in
+                  FStar_Util.format1 "Not an embedded int: %s" uu____227 in
+                (FStar_Errors.Warning_NotEmbedded, uu____226) in
               FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____221)
            else ();
            FStar_Pervasives_Native.None)
-  
-let (unembed_int :
-  FStar_Syntax_Syntax.term -> FStar_BigInt.t FStar_Pervasives_Native.option)
-  = fun t  -> __unembed_int true t 
-let (unembed_int_safe :
-  FStar_Syntax_Syntax.term -> FStar_BigInt.t FStar_Pervasives_Native.option)
-  = fun t  -> __unembed_int false t 
-let (embed_string :
-  FStar_Range.range -> Prims.string -> FStar_Syntax_Syntax.term) =
+let unembed_int:
+  FStar_Syntax_Syntax.term -> FStar_BigInt.t FStar_Pervasives_Native.option =
+  fun t  -> __unembed_int true t
+let unembed_int_safe:
+  FStar_Syntax_Syntax.term -> FStar_BigInt.t FStar_Pervasives_Native.option =
+  fun t  -> __unembed_int false t
+let embed_string:
+  FStar_Range.range -> Prims.string -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun s  ->
       FStar_Syntax_Syntax.mk
         (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string (s, rng)))
         FStar_Pervasives_Native.None rng
-  
-let (__unembed_string :
+let __unembed_string:
   Prims.bool ->
-    FStar_Syntax_Syntax.term -> Prims.string FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term -> Prims.string FStar_Pervasives_Native.option
   =
   fun w  ->
     fun t0  ->
-      let t = FStar_Syntax_Util.unmeta_safe t0  in
+      let t = FStar_Syntax_Util.unmeta_safe t0 in
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
           (s,uu____266)) -> FStar_Pervasives_Native.Some s
@@ -194,21 +183,19 @@ let (__unembed_string :
            then
              (let uu____269 =
                 let uu____274 =
-                  let uu____275 = FStar_Syntax_Print.term_to_string t0  in
-                  FStar_Util.format1 "Not an embedded string: %s" uu____275
-                   in
-                (FStar_Errors.Warning_NotEmbedded, uu____274)  in
+                  let uu____275 = FStar_Syntax_Print.term_to_string t0 in
+                  FStar_Util.format1 "Not an embedded string: %s" uu____275 in
+                (FStar_Errors.Warning_NotEmbedded, uu____274) in
               FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____269)
            else ();
            FStar_Pervasives_Native.None)
-  
-let (unembed_string :
-  FStar_Syntax_Syntax.term -> Prims.string FStar_Pervasives_Native.option) =
-  fun t  -> __unembed_string true t 
-let (unembed_string_safe :
-  FStar_Syntax_Syntax.term -> Prims.string FStar_Pervasives_Native.option) =
-  fun t  -> __unembed_string false t 
-let embed_pair :
+let unembed_string:
+  FStar_Syntax_Syntax.term -> Prims.string FStar_Pervasives_Native.option =
+  fun t  -> __unembed_string true t
+let unembed_string_safe:
+  FStar_Syntax_Syntax.term -> Prims.string FStar_Pervasives_Native.option =
+  fun t  -> __unembed_string false t
+let embed_pair:
   'a 'b .
     'a embedder ->
       FStar_Syntax_Syntax.typ ->
@@ -226,33 +213,30 @@ let embed_pair :
                 let uu____359 =
                   let uu____360 =
                     FStar_Syntax_Syntax.tdataconstr
-                      FStar_Parser_Const.lid_Mktuple2
-                     in
+                      FStar_Parser_Const.lid_Mktuple2 in
                   FStar_Syntax_Syntax.mk_Tm_uinst uu____360
-                    [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-                   in
+                    [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] in
                 let uu____361 =
-                  let uu____362 = FStar_Syntax_Syntax.iarg t_a  in
+                  let uu____362 = FStar_Syntax_Syntax.iarg t_a in
                   let uu____363 =
-                    let uu____366 = FStar_Syntax_Syntax.iarg t_b  in
+                    let uu____366 = FStar_Syntax_Syntax.iarg t_b in
                     let uu____367 =
                       let uu____370 =
                         let uu____371 =
-                          embed_a rng (FStar_Pervasives_Native.fst x)  in
-                        FStar_Syntax_Syntax.as_arg uu____371  in
+                          embed_a rng (FStar_Pervasives_Native.fst x) in
+                        FStar_Syntax_Syntax.as_arg uu____371 in
                       let uu____375 =
                         let uu____378 =
                           let uu____379 =
-                            embed_b rng (FStar_Pervasives_Native.snd x)  in
-                          FStar_Syntax_Syntax.as_arg uu____379  in
-                        [uu____378]  in
-                      uu____370 :: uu____375  in
-                    uu____366 :: uu____367  in
-                  uu____362 :: uu____363  in
-                FStar_Syntax_Syntax.mk_Tm_app uu____359 uu____361  in
+                            embed_b rng (FStar_Pervasives_Native.snd x) in
+                          FStar_Syntax_Syntax.as_arg uu____379 in
+                        [uu____378] in
+                      uu____370 :: uu____375 in
+                    uu____366 :: uu____367 in
+                  uu____362 :: uu____363 in
+                FStar_Syntax_Syntax.mk_Tm_app uu____359 uu____361 in
               uu____358 FStar_Pervasives_Native.None rng
-  
-let __unembed_pair :
+let __unembed_pair:
   'a 'b .
     Prims.bool ->
       'a unembedder ->
@@ -265,15 +249,15 @@ let __unembed_pair :
     fun unembed_a  ->
       fun unembed_b  ->
         fun t0  ->
-          let t = FStar_Syntax_Util.unmeta_safe t0  in
-          let uu____432 = FStar_Syntax_Util.head_and_args t  in
+          let t = FStar_Syntax_Util.unmeta_safe t0 in
+          let uu____432 = FStar_Syntax_Util.head_and_args t in
           match uu____432 with
           | (hd1,args) ->
               let uu____475 =
                 let uu____488 =
-                  let uu____489 = FStar_Syntax_Util.un_uinst hd1  in
-                  uu____489.FStar_Syntax_Syntax.n  in
-                (uu____488, args)  in
+                  let uu____489 = FStar_Syntax_Util.un_uinst hd1 in
+                  uu____489.FStar_Syntax_Syntax.n in
+                (uu____488, args) in
               (match uu____475 with
                | (FStar_Syntax_Syntax.Tm_fvar
                   fv,uu____507::uu____508::(a,uu____510)::(b,uu____512)::[])
@@ -281,10 +265,10 @@ let __unembed_pair :
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.lid_Mktuple2
                    ->
-                   let uu____571 = unembed_a a  in
+                   let uu____571 = unembed_a a in
                    FStar_Util.bind_opt uu____571
                      (fun a1  ->
-                        let uu____583 = unembed_b b  in
+                        let uu____583 = unembed_b b in
                         FStar_Util.bind_opt uu____583
                           (fun b1  -> FStar_Pervasives_Native.Some (a1, b1)))
                | uu____598 ->
@@ -293,27 +277,25 @@ let __unembed_pair :
                       (let uu____612 =
                          let uu____617 =
                            let uu____618 =
-                             FStar_Syntax_Print.term_to_string t0  in
+                             FStar_Syntax_Print.term_to_string t0 in
                            FStar_Util.format1 "Not an embedded pair: %s"
-                             uu____618
-                            in
-                         (FStar_Errors.Warning_NotEmbedded, uu____617)  in
+                             uu____618 in
+                         (FStar_Errors.Warning_NotEmbedded, uu____617) in
                        FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
                          uu____612)
                     else ();
                     FStar_Pervasives_Native.None))
-  
-let unembed_pair :
+let unembed_pair:
   'a 'b .
     'a unembedder ->
       'b unembedder -> ('a,'b) FStar_Pervasives_Native.tuple2 unembedder
-  = fun ul  -> fun ur  -> fun t  -> __unembed_pair true ul ur t 
-let unembed_pair_safe :
+  = fun ul  -> fun ur  -> fun t  -> __unembed_pair true ul ur t
+let unembed_pair_safe:
   'a 'b .
     'a unembedder ->
       'b unembedder -> ('a,'b) FStar_Pervasives_Native.tuple2 unembedder
-  = fun ul  -> fun ur  -> fun t  -> __unembed_pair false ul ur t 
-let embed_option :
+  = fun ul  -> fun ur  -> fun t  -> __unembed_pair false ul ur t
+let embed_option:
   'a .
     'a embedder ->
       FStar_Syntax_Syntax.typ -> 'a FStar_Pervasives_Native.option embedder
@@ -328,38 +310,32 @@ let embed_option :
                 let uu____770 =
                   let uu____771 =
                     FStar_Syntax_Syntax.tdataconstr
-                      FStar_Parser_Const.none_lid
-                     in
+                      FStar_Parser_Const.none_lid in
                   FStar_Syntax_Syntax.mk_Tm_uinst uu____771
-                    [FStar_Syntax_Syntax.U_zero]
-                   in
+                    [FStar_Syntax_Syntax.U_zero] in
                 let uu____772 =
-                  let uu____773 = FStar_Syntax_Syntax.iarg typ  in
-                  [uu____773]  in
-                FStar_Syntax_Syntax.mk_Tm_app uu____770 uu____772  in
+                  let uu____773 = FStar_Syntax_Syntax.iarg typ in [uu____773] in
+                FStar_Syntax_Syntax.mk_Tm_app uu____770 uu____772 in
               uu____769 FStar_Pervasives_Native.None rng
           | FStar_Pervasives_Native.Some a ->
               let uu____777 =
                 let uu____778 =
                   let uu____779 =
                     FStar_Syntax_Syntax.tdataconstr
-                      FStar_Parser_Const.some_lid
-                     in
+                      FStar_Parser_Const.some_lid in
                   FStar_Syntax_Syntax.mk_Tm_uinst uu____779
-                    [FStar_Syntax_Syntax.U_zero]
-                   in
+                    [FStar_Syntax_Syntax.U_zero] in
                 let uu____780 =
-                  let uu____781 = FStar_Syntax_Syntax.iarg typ  in
+                  let uu____781 = FStar_Syntax_Syntax.iarg typ in
                   let uu____782 =
                     let uu____785 =
-                      let uu____786 = embed_a rng a  in
-                      FStar_Syntax_Syntax.as_arg uu____786  in
-                    [uu____785]  in
-                  uu____781 :: uu____782  in
-                FStar_Syntax_Syntax.mk_Tm_app uu____778 uu____780  in
+                      let uu____786 = embed_a rng a in
+                      FStar_Syntax_Syntax.as_arg uu____786 in
+                    [uu____785] in
+                  uu____781 :: uu____782 in
+                FStar_Syntax_Syntax.mk_Tm_app uu____778 uu____780 in
               uu____777 FStar_Pervasives_Native.None rng
-  
-let __unembed_option :
+let __unembed_option:
   'a .
     Prims.bool ->
       'a unembedder ->
@@ -369,15 +345,15 @@ let __unembed_option :
   fun w  ->
     fun unembed_a  ->
       fun t0  ->
-        let t = FStar_Syntax_Util.unmeta_safe t0  in
-        let uu____822 = FStar_Syntax_Util.head_and_args t  in
+        let t = FStar_Syntax_Util.unmeta_safe t0 in
+        let uu____822 = FStar_Syntax_Util.head_and_args t in
         match uu____822 with
         | (hd1,args) ->
             let uu____863 =
               let uu____876 =
-                let uu____877 = FStar_Syntax_Util.un_uinst hd1  in
-                uu____877.FStar_Syntax_Syntax.n  in
-              (uu____876, args)  in
+                let uu____877 = FStar_Syntax_Util.un_uinst hd1 in
+                uu____877.FStar_Syntax_Syntax.n in
+              (uu____876, args) in
             (match uu____863 with
              | (FStar_Syntax_Syntax.Tm_fvar fv,uu____893) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.none_lid
@@ -386,7 +362,7 @@ let __unembed_option :
                  when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.some_lid
                  ->
-                 let uu____952 = unembed_a a  in
+                 let uu____952 = unembed_a a in
                  FStar_Util.bind_opt uu____952
                    (fun a1  ->
                       FStar_Pervasives_Native.Some
@@ -396,24 +372,21 @@ let __unembed_option :
                   then
                     (let uu____977 =
                        let uu____982 =
-                         let uu____983 = FStar_Syntax_Print.term_to_string t0
-                            in
+                         let uu____983 = FStar_Syntax_Print.term_to_string t0 in
                          FStar_Util.format1 "Not an embedded option: %s"
-                           uu____983
-                          in
-                       (FStar_Errors.Warning_NotEmbedded, uu____982)  in
+                           uu____983 in
+                       (FStar_Errors.Warning_NotEmbedded, uu____982) in
                      FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
                        uu____977)
                   else ();
                   FStar_Pervasives_Native.None))
-  
-let unembed_option :
+let unembed_option:
   'a . 'a unembedder -> 'a FStar_Pervasives_Native.option unembedder =
-  fun ua  -> fun t  -> __unembed_option true ua t 
-let unembed_option_safe :
+  fun ua  -> fun t  -> __unembed_option true ua t
+let unembed_option_safe:
   'a . 'a unembedder -> 'a FStar_Pervasives_Native.option unembedder =
-  fun ua  -> fun t  -> __unembed_option false ua t 
-let rec embed_list :
+  fun ua  -> fun t  -> __unembed_option false ua t
+let rec embed_list:
   'a . 'a embedder -> FStar_Syntax_Syntax.typ -> 'a Prims.list embedder =
   fun embed_a  ->
     fun typ  ->
@@ -425,45 +398,40 @@ let rec embed_list :
                 let uu____1089 =
                   let uu____1090 =
                     FStar_Syntax_Syntax.tdataconstr
-                      FStar_Parser_Const.nil_lid
-                     in
+                      FStar_Parser_Const.nil_lid in
                   FStar_Syntax_Syntax.mk_Tm_uinst uu____1090
-                    [FStar_Syntax_Syntax.U_zero]
-                   in
+                    [FStar_Syntax_Syntax.U_zero] in
                 let uu____1091 =
-                  let uu____1092 = FStar_Syntax_Syntax.iarg typ  in
-                  [uu____1092]  in
-                FStar_Syntax_Syntax.mk_Tm_app uu____1089 uu____1091  in
+                  let uu____1092 = FStar_Syntax_Syntax.iarg typ in
+                  [uu____1092] in
+                FStar_Syntax_Syntax.mk_Tm_app uu____1089 uu____1091 in
               uu____1088 FStar_Pervasives_Native.None rng
           | hd1::tl1 ->
               let uu____1099 =
                 let uu____1100 =
                   let uu____1101 =
                     FStar_Syntax_Syntax.tdataconstr
-                      FStar_Parser_Const.cons_lid
-                     in
+                      FStar_Parser_Const.cons_lid in
                   FStar_Syntax_Syntax.mk_Tm_uinst uu____1101
-                    [FStar_Syntax_Syntax.U_zero]
-                   in
+                    [FStar_Syntax_Syntax.U_zero] in
                 let uu____1102 =
-                  let uu____1103 = FStar_Syntax_Syntax.iarg typ  in
+                  let uu____1103 = FStar_Syntax_Syntax.iarg typ in
                   let uu____1104 =
                     let uu____1107 =
-                      let uu____1108 = embed_a rng hd1  in
-                      FStar_Syntax_Syntax.as_arg uu____1108  in
+                      let uu____1108 = embed_a rng hd1 in
+                      FStar_Syntax_Syntax.as_arg uu____1108 in
                     let uu____1112 =
                       let uu____1115 =
                         let uu____1116 =
-                          let uu____1117 = embed_list embed_a typ  in
-                          uu____1117 rng tl1  in
-                        FStar_Syntax_Syntax.as_arg uu____1116  in
-                      [uu____1115]  in
-                    uu____1107 :: uu____1112  in
-                  uu____1103 :: uu____1104  in
-                FStar_Syntax_Syntax.mk_Tm_app uu____1100 uu____1102  in
+                          let uu____1117 = embed_list embed_a typ in
+                          uu____1117 rng tl1 in
+                        FStar_Syntax_Syntax.as_arg uu____1116 in
+                      [uu____1115] in
+                    uu____1107 :: uu____1112 in
+                  uu____1103 :: uu____1104 in
+                FStar_Syntax_Syntax.mk_Tm_app uu____1100 uu____1102 in
               uu____1099 FStar_Pervasives_Native.None rng
-  
-let rec __unembed_list :
+let rec __unembed_list:
   'a .
     Prims.bool ->
       'a unembedder ->
@@ -473,15 +441,15 @@ let rec __unembed_list :
   fun w  ->
     fun unembed_a  ->
       fun t0  ->
-        let t = FStar_Syntax_Util.unmeta_safe t0  in
-        let uu____1164 = FStar_Syntax_Util.head_and_args t  in
+        let t = FStar_Syntax_Util.unmeta_safe t0 in
+        let uu____1164 = FStar_Syntax_Util.head_and_args t in
         match uu____1164 with
         | (hd1,args) ->
             let uu____1205 =
               let uu____1218 =
-                let uu____1219 = FStar_Syntax_Util.un_uinst hd1  in
-                uu____1219.FStar_Syntax_Syntax.n  in
-              (uu____1218, args)  in
+                let uu____1219 = FStar_Syntax_Util.un_uinst hd1 in
+                uu____1219.FStar_Syntax_Syntax.n in
+              (uu____1218, args) in
             (match uu____1205 with
              | (FStar_Syntax_Syntax.Tm_fvar fv,uu____1235) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid
@@ -490,10 +458,10 @@ let rec __unembed_list :
                 fv,_t::(hd2,uu____1257)::(tl1,uu____1259)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid
                  ->
-                 let uu____1306 = unembed_a hd2  in
+                 let uu____1306 = unembed_a hd2 in
                  FStar_Util.bind_opt uu____1306
                    (fun hd3  ->
-                      let uu____1316 = __unembed_list w unembed_a tl1  in
+                      let uu____1316 = __unembed_list w unembed_a tl1 in
                       FStar_Util.bind_opt uu____1316
                         (fun tl2  ->
                            FStar_Pervasives_Native.Some (hd3 :: tl2)))
@@ -503,108 +471,94 @@ let rec __unembed_list :
                     (let uu____1349 =
                        let uu____1354 =
                          let uu____1355 =
-                           FStar_Syntax_Print.term_to_string t0  in
+                           FStar_Syntax_Print.term_to_string t0 in
                          FStar_Util.format1 "Not an embedded list: %s"
-                           uu____1355
-                          in
-                       (FStar_Errors.Warning_NotEmbedded, uu____1354)  in
+                           uu____1355 in
+                       (FStar_Errors.Warning_NotEmbedded, uu____1354) in
                      FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
                        uu____1349)
                   else ();
                   FStar_Pervasives_Native.None))
-  
-let unembed_list : 'a . 'a unembedder -> 'a Prims.list unembedder =
-  fun ua  -> fun t  -> __unembed_list true ua t 
-let unembed_list_safe : 'a . 'a unembedder -> 'a Prims.list unembedder =
-  fun ua  -> fun t  -> __unembed_list false ua t 
-let (embed_string_list :
-  FStar_Range.range -> Prims.string Prims.list -> FStar_Syntax_Syntax.term) =
+let unembed_list: 'a . 'a unembedder -> 'a Prims.list unembedder =
+  fun ua  -> fun t  -> __unembed_list true ua t
+let unembed_list_safe: 'a . 'a unembedder -> 'a Prims.list unembedder =
+  fun ua  -> fun t  -> __unembed_list false ua t
+let embed_string_list:
+  FStar_Range.range -> Prims.string Prims.list -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun ss  ->
-      let uu____1434 = embed_list embed_string FStar_Syntax_Syntax.t_string
-         in
+      let uu____1434 = embed_list embed_string FStar_Syntax_Syntax.t_string in
       uu____1434 rng ss
-  
-let (unembed_string_list :
+let unembed_string_list:
   FStar_Syntax_Syntax.term ->
-    Prims.string Prims.list FStar_Pervasives_Native.option)
-  = fun t  -> let uu____1451 = unembed_list unembed_string  in uu____1451 t 
-let (unembed_string_list_safe :
+    Prims.string Prims.list FStar_Pervasives_Native.option
+  = fun t  -> let uu____1451 = unembed_list unembed_string in uu____1451 t
+let unembed_string_list_safe:
   FStar_Syntax_Syntax.term ->
-    Prims.string Prims.list FStar_Pervasives_Native.option)
+    Prims.string Prims.list FStar_Pervasives_Native.option
   =
   fun t  ->
-    let uu____1467 = unembed_list_safe unembed_string_safe  in uu____1467 t
-  
+    let uu____1467 = unembed_list_safe unembed_string_safe in uu____1467 t
 type norm_step =
-  | Simpl 
-  | Weak 
-  | HNF 
-  | Primops 
-  | Delta 
-  | Zeta 
-  | Iota 
-  | UnfoldOnly of Prims.string Prims.list 
-  | UnfoldAttr of FStar_Syntax_Syntax.attribute [@@deriving show]
-let (uu___is_Simpl : norm_step -> Prims.bool) =
+  | Simpl
+  | Weak
+  | HNF
+  | Primops
+  | Delta
+  | Zeta
+  | Iota
+  | UnfoldOnly of Prims.string Prims.list
+  | UnfoldAttr of FStar_Syntax_Syntax.attribute[@@deriving show]
+let uu___is_Simpl: norm_step -> Prims.bool =
   fun projectee  ->
     match projectee with | Simpl  -> true | uu____1487 -> false
-  
-let (uu___is_Weak : norm_step -> Prims.bool) =
+let uu___is_Weak: norm_step -> Prims.bool =
   fun projectee  ->
     match projectee with | Weak  -> true | uu____1491 -> false
-  
-let (uu___is_HNF : norm_step -> Prims.bool) =
-  fun projectee  -> match projectee with | HNF  -> true | uu____1495 -> false 
-let (uu___is_Primops : norm_step -> Prims.bool) =
+let uu___is_HNF: norm_step -> Prims.bool =
+  fun projectee  -> match projectee with | HNF  -> true | uu____1495 -> false
+let uu___is_Primops: norm_step -> Prims.bool =
   fun projectee  ->
     match projectee with | Primops  -> true | uu____1499 -> false
-  
-let (uu___is_Delta : norm_step -> Prims.bool) =
+let uu___is_Delta: norm_step -> Prims.bool =
   fun projectee  ->
     match projectee with | Delta  -> true | uu____1503 -> false
-  
-let (uu___is_Zeta : norm_step -> Prims.bool) =
+let uu___is_Zeta: norm_step -> Prims.bool =
   fun projectee  ->
     match projectee with | Zeta  -> true | uu____1507 -> false
-  
-let (uu___is_Iota : norm_step -> Prims.bool) =
+let uu___is_Iota: norm_step -> Prims.bool =
   fun projectee  ->
     match projectee with | Iota  -> true | uu____1511 -> false
-  
-let (uu___is_UnfoldOnly : norm_step -> Prims.bool) =
+let uu___is_UnfoldOnly: norm_step -> Prims.bool =
   fun projectee  ->
     match projectee with | UnfoldOnly _0 -> true | uu____1518 -> false
-  
-let (__proj__UnfoldOnly__item___0 : norm_step -> Prims.string Prims.list) =
-  fun projectee  -> match projectee with | UnfoldOnly _0 -> _0 
-let (uu___is_UnfoldAttr : norm_step -> Prims.bool) =
+let __proj__UnfoldOnly__item___0: norm_step -> Prims.string Prims.list =
+  fun projectee  -> match projectee with | UnfoldOnly _0 -> _0
+let uu___is_UnfoldAttr: norm_step -> Prims.bool =
   fun projectee  ->
     match projectee with | UnfoldAttr _0 -> true | uu____1536 -> false
-  
-let (__proj__UnfoldAttr__item___0 :
-  norm_step -> FStar_Syntax_Syntax.attribute) =
-  fun projectee  -> match projectee with | UnfoldAttr _0 -> _0 
-let (steps_Simpl : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_simpl 
-let (steps_Weak : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_weak 
-let (steps_HNF : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_hnf 
-let (steps_Primops : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_primops 
-let (steps_Delta : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_delta 
-let (steps_Zeta : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_zeta 
-let (steps_Iota : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_iota 
-let (steps_UnfoldOnly : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_unfoldonly 
-let (steps_UnfoldAttr : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_unfoldattr 
-let (embed_norm_step :
-  FStar_Range.range -> norm_step -> FStar_Syntax_Syntax.term) =
+let __proj__UnfoldAttr__item___0: norm_step -> FStar_Syntax_Syntax.attribute
+  = fun projectee  -> match projectee with | UnfoldAttr _0 -> _0
+let steps_Simpl: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_simpl
+let steps_Weak: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_weak
+let steps_HNF: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_hnf
+let steps_Primops: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_primops
+let steps_Delta: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_delta
+let steps_Zeta: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_zeta
+let steps_Iota: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_iota
+let steps_UnfoldOnly: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_unfoldonly
+let steps_UnfoldAttr: FStar_Syntax_Syntax.term =
+  FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.steps_unfoldattr
+let embed_norm_step:
+  FStar_Range.range -> norm_step -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun n1  ->
       match n1 with
@@ -621,35 +575,33 @@ let (embed_norm_step :
               let uu____1558 =
                 let uu____1559 =
                   let uu____1560 =
-                    embed_list embed_string FStar_Syntax_Syntax.t_string  in
-                  uu____1560 rng l  in
-                FStar_Syntax_Syntax.as_arg uu____1559  in
-              [uu____1558]  in
-            FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldOnly uu____1557  in
+                    embed_list embed_string FStar_Syntax_Syntax.t_string in
+                  uu____1560 rng l in
+                FStar_Syntax_Syntax.as_arg uu____1559 in
+              [uu____1558] in
+            FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldOnly uu____1557 in
           uu____1556 FStar_Pervasives_Native.None rng
       | UnfoldAttr a ->
           let uu____1571 =
             let uu____1572 =
-              let uu____1573 = FStar_Syntax_Syntax.as_arg a  in [uu____1573]
-               in
-            FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldAttr uu____1572  in
+              let uu____1573 = FStar_Syntax_Syntax.as_arg a in [uu____1573] in
+            FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldAttr uu____1572 in
           uu____1571 FStar_Pervasives_Native.None rng
-  
-let (__unembed_norm_step :
+let __unembed_norm_step:
   Prims.bool ->
-    FStar_Syntax_Syntax.term -> norm_step FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term -> norm_step FStar_Pervasives_Native.option
   =
   fun w  ->
     fun t0  ->
-      let t = FStar_Syntax_Util.unmeta_safe t0  in
-      let uu____1587 = FStar_Syntax_Util.head_and_args t  in
+      let t = FStar_Syntax_Util.unmeta_safe t0 in
+      let uu____1587 = FStar_Syntax_Util.head_and_args t in
       match uu____1587 with
       | (hd1,args) ->
           let uu____1626 =
             let uu____1639 =
-              let uu____1640 = FStar_Syntax_Util.un_uinst hd1  in
-              uu____1640.FStar_Syntax_Syntax.n  in
-            (uu____1639, args)  in
+              let uu____1640 = FStar_Syntax_Util.un_uinst hd1 in
+              uu____1640.FStar_Syntax_Syntax.n in
+            (uu____1639, args) in
           (match uu____1626 with
            | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
@@ -680,8 +632,7 @@ let (__unembed_norm_step :
                  FStar_Parser_Const.steps_unfoldonly
                ->
                let uu____1785 =
-                 let uu____1790 = unembed_list unembed_string  in
-                 uu____1790 l  in
+                 let uu____1790 = unembed_list unembed_string in uu____1790 l in
                FStar_Util.bind_opt uu____1785
                  (fun ss  ->
                     FStar_All.pipe_left
@@ -697,39 +648,35 @@ let (__unembed_norm_step :
                 then
                   (let uu____1859 =
                      let uu____1864 =
-                       let uu____1865 = FStar_Syntax_Print.term_to_string t0
-                          in
+                       let uu____1865 = FStar_Syntax_Print.term_to_string t0 in
                        FStar_Util.format1 "Not an embedded norm_step: %s"
-                         uu____1865
-                        in
-                     (FStar_Errors.Warning_NotEmbedded, uu____1864)  in
+                         uu____1865 in
+                     (FStar_Errors.Warning_NotEmbedded, uu____1864) in
                    FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
                      uu____1859)
                 else ();
                 FStar_Pervasives_Native.None))
-  
-let (unembed_norm_step :
-  FStar_Syntax_Syntax.term -> norm_step FStar_Pervasives_Native.option) =
-  fun t  -> __unembed_norm_step true t 
-let (unembed_norm_step_safe :
-  FStar_Syntax_Syntax.term -> norm_step FStar_Pervasives_Native.option) =
-  fun t  -> __unembed_norm_step false t 
-let (embed_range :
-  FStar_Range.range -> FStar_Range.range -> FStar_Syntax_Syntax.term) =
+let unembed_norm_step:
+  FStar_Syntax_Syntax.term -> norm_step FStar_Pervasives_Native.option =
+  fun t  -> __unembed_norm_step true t
+let unembed_norm_step_safe:
+  FStar_Syntax_Syntax.term -> norm_step FStar_Pervasives_Native.option =
+  fun t  -> __unembed_norm_step false t
+let embed_range:
+  FStar_Range.range -> FStar_Range.range -> FStar_Syntax_Syntax.term =
   fun rng  ->
     fun r  ->
       FStar_Syntax_Syntax.mk
         (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range r))
         FStar_Pervasives_Native.None rng
-  
-let (__unembed_range :
+let __unembed_range:
   Prims.bool ->
     FStar_Syntax_Syntax.term ->
-      FStar_Range.range FStar_Pervasives_Native.option)
+      FStar_Range.range FStar_Pervasives_Native.option
   =
   fun w  ->
     fun t0  ->
-      let t = FStar_Syntax_Util.unmeta_safe t0  in
+      let t = FStar_Syntax_Util.unmeta_safe t0 in
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range r) ->
           FStar_Pervasives_Native.Some r
@@ -738,19 +685,17 @@ let (__unembed_range :
            then
              (let uu____1906 =
                 let uu____1911 =
-                  let uu____1912 = FStar_Syntax_Print.term_to_string t0  in
-                  FStar_Util.format1 "Not an embedded range: %s" uu____1912
-                   in
-                (FStar_Errors.Warning_NotEmbedded, uu____1911)  in
+                  let uu____1912 = FStar_Syntax_Print.term_to_string t0 in
+                  FStar_Util.format1 "Not an embedded range: %s" uu____1912 in
+                (FStar_Errors.Warning_NotEmbedded, uu____1911) in
               FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1906)
            else ();
            FStar_Pervasives_Native.None)
-  
-let (unembed_range :
+let unembed_range:
   FStar_Syntax_Syntax.term ->
-    FStar_Range.range FStar_Pervasives_Native.option)
-  = fun t  -> __unembed_range true t 
-let (unembed_range_safe :
+    FStar_Range.range FStar_Pervasives_Native.option
+  = fun t  -> __unembed_range true t
+let unembed_range_safe:
   FStar_Syntax_Syntax.term ->
-    FStar_Range.range FStar_Pervasives_Native.option)
-  = fun t  -> __unembed_range false t 
+    FStar_Range.range FStar_Pervasives_Native.option
+  = fun t  -> __unembed_range false t

--- a/src/ocaml-output/FStar_Syntax_Free.ml
+++ b/src/ocaml-output/FStar_Syntax_Free.ml
@@ -2,38 +2,35 @@ open Prims
 type free_vars_and_fvars =
   (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
     FStar_Pervasives_Native.tuple2[@@deriving show]
-let (no_free_vars :
+let no_free_vars:
   (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-    FStar_Pervasives_Native.tuple2)
+    FStar_Pervasives_Native.tuple2
   =
-  let uu____13 = FStar_Syntax_Syntax.new_fv_set ()  in
+  let uu____13 = FStar_Syntax_Syntax.new_fv_set () in
   ({
      FStar_Syntax_Syntax.free_names = [];
      FStar_Syntax_Syntax.free_uvars = [];
      FStar_Syntax_Syntax.free_univs = [];
      FStar_Syntax_Syntax.free_univ_names = []
    }, uu____13)
-  
-let (singleton_fvar :
+let singleton_fvar:
   FStar_Syntax_Syntax.fv ->
     (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun fv  ->
     let uu____43 =
-      let uu____46 = FStar_Syntax_Syntax.new_fv_set ()  in
+      let uu____46 = FStar_Syntax_Syntax.new_fv_set () in
       FStar_Util.set_add
-        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v uu____46
-       in
+        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v uu____46 in
     ((FStar_Pervasives_Native.fst no_free_vars), uu____43)
-  
-let (singleton_bv :
+let singleton_bv:
   FStar_Syntax_Syntax.bv ->
     (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun x  ->
-    ((let uu___23_65 = FStar_Pervasives_Native.fst no_free_vars  in
+    ((let uu___23_65 = FStar_Pervasives_Native.fst no_free_vars in
       {
         FStar_Syntax_Syntax.free_names = [x];
         FStar_Syntax_Syntax.free_uvars =
@@ -43,18 +40,17 @@ let (singleton_bv :
         FStar_Syntax_Syntax.free_univ_names =
           (uu___23_65.FStar_Syntax_Syntax.free_univ_names)
       }), (FStar_Pervasives_Native.snd no_free_vars))
-  
-let (singleton_uv :
+let singleton_uv:
   ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
       FStar_Pervasives_Native.option FStar_Unionfind.p_uvar,FStar_Syntax_Syntax.version)
      FStar_Pervasives_Native.tuple2,FStar_Syntax_Syntax.term'
                                       FStar_Syntax_Syntax.syntax)
     FStar_Pervasives_Native.tuple2 ->
     (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun x  ->
-    ((let uu___24_114 = FStar_Pervasives_Native.fst no_free_vars  in
+    ((let uu___24_114 = FStar_Pervasives_Native.fst no_free_vars in
       {
         FStar_Syntax_Syntax.free_names =
           (uu___24_114.FStar_Syntax_Syntax.free_names);
@@ -64,14 +60,13 @@ let (singleton_uv :
         FStar_Syntax_Syntax.free_univ_names =
           (uu___24_114.FStar_Syntax_Syntax.free_univ_names)
       }), (FStar_Pervasives_Native.snd no_free_vars))
-  
-let (singleton_univ :
+let singleton_univ:
   FStar_Syntax_Syntax.universe_uvar ->
     (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun x  ->
-    ((let uu___25_163 = FStar_Pervasives_Native.fst no_free_vars  in
+    ((let uu___25_163 = FStar_Pervasives_Native.fst no_free_vars in
       {
         FStar_Syntax_Syntax.free_names =
           (uu___25_163.FStar_Syntax_Syntax.free_names);
@@ -81,14 +76,13 @@ let (singleton_univ :
         FStar_Syntax_Syntax.free_univ_names =
           (uu___25_163.FStar_Syntax_Syntax.free_univ_names)
       }), (FStar_Pervasives_Native.snd no_free_vars))
-  
-let (singleton_univ_name :
+let singleton_univ_name:
   FStar_Syntax_Syntax.univ_name ->
     (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun x  ->
-    ((let uu___26_180 = FStar_Pervasives_Native.fst no_free_vars  in
+    ((let uu___26_180 = FStar_Pervasives_Native.fst no_free_vars in
       {
         FStar_Syntax_Syntax.free_names =
           (uu___26_180.FStar_Syntax_Syntax.free_names);
@@ -98,8 +92,7 @@ let (singleton_univ_name :
           (uu___26_180.FStar_Syntax_Syntax.free_univs);
         FStar_Syntax_Syntax.free_univ_names = [x]
       }), (FStar_Pervasives_Native.snd no_free_vars))
-  
-let union :
+let union:
   'Auu____188 .
     (FStar_Syntax_Syntax.free_vars,'Auu____188 FStar_Util.set)
       FStar_Pervasives_Native.tuple2 ->
@@ -112,8 +105,7 @@ let union :
     fun f2  ->
       let uu____227 =
         FStar_Util.set_union (FStar_Pervasives_Native.snd f1)
-          (FStar_Pervasives_Native.snd f2)
-         in
+          (FStar_Pervasives_Native.snd f2) in
       ({
          FStar_Syntax_Syntax.free_names =
            (FStar_List.append
@@ -132,14 +124,13 @@ let union :
               (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_univ_names
               (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_univ_names)
        }, uu____227)
-  
-let rec (free_univs :
+let rec free_univs:
   FStar_Syntax_Syntax.universe ->
     (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun u  ->
-    let uu____277 = FStar_Syntax_Subst.compress_univ u  in
+    let uu____277 = FStar_Syntax_Subst.compress_univ u in
     match uu____277 with
     | FStar_Syntax_Syntax.U_zero  -> no_free_vars
     | FStar_Syntax_Syntax.U_bvar uu____284 -> no_free_vars
@@ -149,12 +140,11 @@ let rec (free_univs :
     | FStar_Syntax_Syntax.U_max us ->
         FStar_List.fold_left
           (fun out  ->
-             fun x  -> let uu____307 = free_univs x  in union out uu____307)
+             fun x  -> let uu____307 = free_univs x in union out uu____307)
           no_free_vars us
     | FStar_Syntax_Syntax.U_unif u1 -> singleton_univ u1
-  
-let rec (free_names_and_uvs' :
-  FStar_Syntax_Syntax.term -> Prims.bool -> free_vars_and_fvars) =
+let rec free_names_and_uvs':
+  FStar_Syntax_Syntax.term -> Prims.bool -> free_vars_and_fvars =
   fun tm  ->
     fun use_cache  ->
       let aux_binders bs from_body =
@@ -167,12 +157,10 @@ let rec (free_names_and_uvs' :
                     | (x,uu____485) ->
                         let uu____486 =
                           free_names_and_uvars x.FStar_Syntax_Syntax.sort
-                            use_cache
-                           in
-                        union n1 uu____486) no_free_vars)
-           in
-        union from_binders from_body  in
-      let t = FStar_Syntax_Subst.compress tm  in
+                            use_cache in
+                        union n1 uu____486) no_free_vars) in
+        union from_binders from_body in
+      let t = FStar_Syntax_Subst.compress tm in
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_delayed uu____494 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x -> singleton_bv x
@@ -183,26 +171,26 @@ let rec (free_names_and_uvs' :
       | FStar_Syntax_Syntax.Tm_constant uu____561 -> no_free_vars
       | FStar_Syntax_Syntax.Tm_unknown  -> no_free_vars
       | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
-          let f = free_names_and_uvars t1 use_cache  in
+          let f = free_names_and_uvars t1 use_cache in
           FStar_List.fold_left
             (fun out  ->
-               fun u  -> let uu____592 = free_univs u  in union out uu____592)
+               fun u  -> let uu____592 = free_univs u in union out uu____592)
             f us
       | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____601) ->
-          let uu____622 = free_names_and_uvars t1 use_cache  in
+          let uu____622 = free_names_and_uvars t1 use_cache in
           aux_binders bs uu____622
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____647 = free_names_and_uvars_comp c use_cache  in
+          let uu____647 = free_names_and_uvars_comp c use_cache in
           aux_binders bs uu____647
       | FStar_Syntax_Syntax.Tm_refine (bv,t1) ->
-          let uu____660 = free_names_and_uvars t1 use_cache  in
+          let uu____660 = free_names_and_uvars t1 use_cache in
           aux_binders [(bv, FStar_Pervasives_Native.None)] uu____660
       | FStar_Syntax_Syntax.Tm_app (t1,args) ->
-          let uu____703 = free_names_and_uvars t1 use_cache  in
+          let uu____703 = free_names_and_uvars t1 use_cache in
           free_names_and_uvars_args args uu____703 use_cache
       | FStar_Syntax_Syntax.Tm_match (t1,pats) ->
           let uu____748 =
-            let uu____773 = free_names_and_uvars t1 use_cache  in
+            let uu____773 = free_names_and_uvars t1 use_cache in
             FStar_List.fold_left
               (fun n1  ->
                  fun uu____808  ->
@@ -212,99 +200,90 @@ let rec (free_names_and_uvs' :
                          match wopt with
                          | FStar_Pervasives_Native.None  -> no_free_vars
                          | FStar_Pervasives_Native.Some w ->
-                             free_names_and_uvars w use_cache
-                          in
-                       let n2 = free_names_and_uvars t2 use_cache  in
+                             free_names_and_uvars w use_cache in
+                       let n2 = free_names_and_uvars t2 use_cache in
                        let n3 =
-                         let uu____882 = FStar_Syntax_Syntax.pat_bvs p  in
+                         let uu____882 = FStar_Syntax_Syntax.pat_bvs p in
                          FStar_All.pipe_right uu____882
                            (FStar_List.fold_left
                               (fun n3  ->
                                  fun x  ->
                                    let uu____910 =
                                      free_names_and_uvars
-                                       x.FStar_Syntax_Syntax.sort use_cache
-                                      in
-                                   union n3 uu____910) n1)
-                          in
-                       let uu____917 = union n11 n2  in union n3 uu____917)
-              uu____773
-             in
+                                       x.FStar_Syntax_Syntax.sort use_cache in
+                                   union n3 uu____910) n1) in
+                       let uu____917 = union n11 n2 in union n3 uu____917)
+              uu____773 in
           FStar_All.pipe_right pats uu____748
       | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____948) ->
-          let u1 = free_names_and_uvars t1 use_cache  in
+          let u1 = free_names_and_uvars t1 use_cache in
           let u2 =
             match FStar_Pervasives_Native.fst asc with
             | FStar_Util.Inl t2 -> free_names_and_uvars t2 use_cache
-            | FStar_Util.Inr c2 -> free_names_and_uvars_comp c2 use_cache  in
+            | FStar_Util.Inr c2 -> free_names_and_uvars_comp c2 use_cache in
           (match FStar_Pervasives_Native.snd asc with
            | FStar_Pervasives_Native.None  -> union u1 u2
            | FStar_Pervasives_Native.Some tac ->
-               let uu____1054 = union u1 u2  in
-               let uu____1061 = free_names_and_uvars tac use_cache  in
+               let uu____1054 = union u1 u2 in
+               let uu____1061 = free_names_and_uvars tac use_cache in
                union uu____1054 uu____1061)
       | FStar_Syntax_Syntax.Tm_let (lbs,t1) ->
           let uu____1086 =
-            let uu____1097 = free_names_and_uvars t1 use_cache  in
+            let uu____1097 = free_names_and_uvars t1 use_cache in
             FStar_List.fold_left
               (fun n1  ->
                  fun lb  ->
                    let uu____1121 =
                      let uu____1128 =
                        free_names_and_uvars lb.FStar_Syntax_Syntax.lbtyp
-                         use_cache
-                        in
+                         use_cache in
                      let uu____1135 =
                        free_names_and_uvars lb.FStar_Syntax_Syntax.lbdef
-                         use_cache
-                        in
-                     union uu____1128 uu____1135  in
-                   union n1 uu____1121) uu____1097
-             in
+                         use_cache in
+                     union uu____1128 uu____1135 in
+                   union n1 uu____1121) uu____1097 in
           FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs) uu____1086
       | FStar_Syntax_Syntax.Tm_meta
           (t1,FStar_Syntax_Syntax.Meta_pattern args) ->
-          let uu____1168 = free_names_and_uvars t1 use_cache  in
+          let uu____1168 = free_names_and_uvars t1 use_cache in
           FStar_List.fold_right
             (fun a  -> fun acc  -> free_names_and_uvars_args a acc use_cache)
             args uu____1168
       | FStar_Syntax_Syntax.Tm_meta
           (t1,FStar_Syntax_Syntax.Meta_monadic (uu____1208,t')) ->
-          let uu____1218 = free_names_and_uvars t1 use_cache  in
-          let uu____1225 = free_names_and_uvars t' use_cache  in
+          let uu____1218 = free_names_and_uvars t1 use_cache in
+          let uu____1225 = free_names_and_uvars t' use_cache in
           union uu____1218 uu____1225
       | FStar_Syntax_Syntax.Tm_meta (t1,uu____1233) ->
           free_names_and_uvars t1 use_cache
-
-and (free_names_and_uvars :
+and free_names_and_uvars:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     Prims.bool ->
       (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     fun use_cache  ->
-      let t1 = FStar_Syntax_Subst.compress t  in
-      let uu____1243 = FStar_ST.op_Bang t1.FStar_Syntax_Syntax.vars  in
+      let t1 = FStar_Syntax_Subst.compress t in
+      let uu____1243 = FStar_ST.op_Bang t1.FStar_Syntax_Syntax.vars in
       match uu____1243 with
       | FStar_Pervasives_Native.Some n1 when
-          let uu____1276 = should_invalidate_cache n1 use_cache  in
+          let uu____1276 = should_invalidate_cache n1 use_cache in
           Prims.op_Negation uu____1276 ->
-          let uu____1277 = FStar_Syntax_Syntax.new_fv_set ()  in
+          let uu____1277 = FStar_Syntax_Syntax.new_fv_set () in
           (n1, uu____1277)
       | uu____1282 ->
           (FStar_ST.op_Colon_Equals t1.FStar_Syntax_Syntax.vars
              FStar_Pervasives_Native.None;
-           (let n1 = free_names_and_uvs' t1 use_cache  in
+           (let n1 = free_names_and_uvs' t1 use_cache in
             FStar_ST.op_Colon_Equals t1.FStar_Syntax_Syntax.vars
               (FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst n1));
             n1))
-
-and (free_names_and_uvars_args :
+and free_names_and_uvars_args:
   (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
     FStar_Pervasives_Native.tuple2 Prims.list ->
     (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-      FStar_Pervasives_Native.tuple2 -> Prims.bool -> free_vars_and_fvars)
+      FStar_Pervasives_Native.tuple2 -> Prims.bool -> free_vars_and_fvars
   =
   fun args  ->
     fun acc  ->
@@ -315,16 +294,15 @@ and (free_names_and_uvars_args :
                 fun uu____1385  ->
                   match uu____1385 with
                   | (x,uu____1405) ->
-                      let uu____1410 = free_names_and_uvars x use_cache  in
+                      let uu____1410 = free_names_and_uvars x use_cache in
                       union n1 uu____1410) acc)
-
-and (free_names_and_uvars_binders :
+and free_names_and_uvars_binders:
   FStar_Syntax_Syntax.binders ->
     (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
       FStar_Pervasives_Native.tuple2 ->
       Prims.bool ->
         (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun bs  ->
     fun acc  ->
@@ -337,29 +315,27 @@ and (free_names_and_uvars_binders :
                   | (x,uu____1466) ->
                       let uu____1467 =
                         free_names_and_uvars x.FStar_Syntax_Syntax.sort
-                          use_cache
-                         in
+                          use_cache in
                       union n1 uu____1467) acc)
-
-and (free_names_and_uvars_comp :
+and free_names_and_uvars_comp:
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     Prims.bool ->
       (FStar_Syntax_Syntax.free_vars,FStar_Ident.lident FStar_Util.set)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun c  ->
     fun use_cache  ->
-      let uu____1478 = FStar_ST.op_Bang c.FStar_Syntax_Syntax.vars  in
+      let uu____1478 = FStar_ST.op_Bang c.FStar_Syntax_Syntax.vars in
       match uu____1478 with
       | FStar_Pervasives_Native.Some n1 ->
-          let uu____1511 = should_invalidate_cache n1 use_cache  in
+          let uu____1511 = should_invalidate_cache n1 use_cache in
           if uu____1511
           then
             (FStar_ST.op_Colon_Equals c.FStar_Syntax_Syntax.vars
                FStar_Pervasives_Native.None;
              free_names_and_uvars_comp c use_cache)
           else
-            (let uu____1543 = FStar_Syntax_Syntax.new_fv_set ()  in
+            (let uu____1543 = FStar_Syntax_Syntax.new_fv_set () in
              (n1, uu____1543))
       | uu____1548 ->
           let n1 =
@@ -370,34 +346,30 @@ and (free_names_and_uvars_comp :
                 free_names_and_uvars t use_cache
             | FStar_Syntax_Syntax.GTotal (t,FStar_Pervasives_Native.Some u)
                 ->
-                let uu____1586 = free_univs u  in
-                let uu____1593 = free_names_and_uvars t use_cache  in
+                let uu____1586 = free_univs u in
+                let uu____1593 = free_names_and_uvars t use_cache in
                 union uu____1586 uu____1593
             | FStar_Syntax_Syntax.Total (t,FStar_Pervasives_Native.Some u) ->
-                let uu____1608 = free_univs u  in
-                let uu____1615 = free_names_and_uvars t use_cache  in
+                let uu____1608 = free_univs u in
+                let uu____1615 = free_names_and_uvars t use_cache in
                 union uu____1608 uu____1615
             | FStar_Syntax_Syntax.Comp ct ->
                 let us =
                   let uu____1624 =
                     free_names_and_uvars ct.FStar_Syntax_Syntax.result_typ
-                      use_cache
-                     in
+                      use_cache in
                   free_names_and_uvars_args
-                    ct.FStar_Syntax_Syntax.effect_args uu____1624 use_cache
-                   in
+                    ct.FStar_Syntax_Syntax.effect_args uu____1624 use_cache in
                 FStar_List.fold_left
                   (fun us1  ->
                      fun u  ->
-                       let uu____1648 = free_univs u  in union us1 uu____1648)
-                  us ct.FStar_Syntax_Syntax.comp_univs
-             in
+                       let uu____1648 = free_univs u in union us1 uu____1648)
+                  us ct.FStar_Syntax_Syntax.comp_univs in
           (FStar_ST.op_Colon_Equals c.FStar_Syntax_Syntax.vars
              (FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst n1));
            n1)
-
-and (should_invalidate_cache :
-  FStar_Syntax_Syntax.free_vars -> Prims.bool -> Prims.bool) =
+and should_invalidate_cache:
+  FStar_Syntax_Syntax.free_vars -> Prims.bool -> Prims.bool =
   fun n1  ->
     fun use_cache  ->
       (Prims.op_Negation use_cache) ||
@@ -406,7 +378,7 @@ and (should_invalidate_cache :
                (fun uu____1712  ->
                   match uu____1712 with
                   | (u,uu____1720) ->
-                      let uu____1725 = FStar_Syntax_Unionfind.find u  in
+                      let uu____1725 = FStar_Syntax_Unionfind.find u in
                       (match uu____1725 with
                        | FStar_Pervasives_Native.Some uu____1728 -> true
                        | uu____1729 -> false))))
@@ -414,12 +386,11 @@ and (should_invalidate_cache :
            (FStar_All.pipe_right n1.FStar_Syntax_Syntax.free_univs
               (FStar_Util.for_some
                  (fun u  ->
-                    let uu____1738 = FStar_Syntax_Unionfind.univ_find u  in
+                    let uu____1738 = FStar_Syntax_Unionfind.univ_find u in
                     match uu____1738 with
                     | FStar_Pervasives_Native.Some uu____1741 -> true
                     | FStar_Pervasives_Native.None  -> false))))
-
-let compare_uv :
+let compare_uv:
   'Auu____1746 'Auu____1747 .
     (FStar_Syntax_Syntax.uvar,'Auu____1747) FStar_Pervasives_Native.tuple2 ->
       (FStar_Syntax_Syntax.uvar,'Auu____1746) FStar_Pervasives_Native.tuple2
@@ -428,86 +399,77 @@ let compare_uv :
   fun uv1  ->
     fun uv2  ->
       let uu____1772 =
-        FStar_Syntax_Unionfind.uvar_id (FStar_Pervasives_Native.fst uv1)  in
+        FStar_Syntax_Unionfind.uvar_id (FStar_Pervasives_Native.fst uv1) in
       let uu____1773 =
-        FStar_Syntax_Unionfind.uvar_id (FStar_Pervasives_Native.fst uv2)  in
+        FStar_Syntax_Unionfind.uvar_id (FStar_Pervasives_Native.fst uv2) in
       uu____1772 - uu____1773
-  
-let (new_uv_set : Prims.unit -> FStar_Syntax_Syntax.uvars) =
-  fun uu____1776  -> FStar_Util.new_set compare_uv 
-let (compare_universe_uvar :
+let new_uv_set: Prims.unit -> FStar_Syntax_Syntax.uvars =
+  fun uu____1776  -> FStar_Util.new_set compare_uv
+let compare_universe_uvar:
   FStar_Syntax_Syntax.universe_uvar ->
-    FStar_Syntax_Syntax.universe_uvar -> Prims.int)
+    FStar_Syntax_Syntax.universe_uvar -> Prims.int
   =
   fun x  ->
     fun y  ->
-      let uu____1793 = FStar_Syntax_Unionfind.univ_uvar_id x  in
-      let uu____1794 = FStar_Syntax_Unionfind.univ_uvar_id y  in
+      let uu____1793 = FStar_Syntax_Unionfind.univ_uvar_id x in
+      let uu____1794 = FStar_Syntax_Unionfind.univ_uvar_id y in
       uu____1793 - uu____1794
-  
-let (new_universe_uvar_set :
-  Prims.unit -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
-  fun uu____1799  -> FStar_Util.new_set compare_universe_uvar 
-let (names :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set) =
+let new_universe_uvar_set:
+  Prims.unit -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set =
+  fun uu____1799  -> FStar_Util.new_set compare_universe_uvar
+let names: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set
+  =
   fun t  ->
     let uu____1807 =
       let uu____1810 =
-        let uu____1811 = free_names_and_uvars t true  in
-        FStar_Pervasives_Native.fst uu____1811  in
-      uu____1810.FStar_Syntax_Syntax.free_names  in
+        let uu____1811 = free_names_and_uvars t true in
+        FStar_Pervasives_Native.fst uu____1811 in
+      uu____1810.FStar_Syntax_Syntax.free_names in
     FStar_Util.as_set uu____1807 FStar_Syntax_Syntax.order_bv
-  
-let (uvars :
+let uvars:
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.uvar,FStar_Syntax_Syntax.typ)
-      FStar_Pervasives_Native.tuple2 FStar_Util.set)
+      FStar_Pervasives_Native.tuple2 FStar_Util.set
   =
   fun t  ->
     let uu____1829 =
       let uu____1848 =
-        let uu____1849 = free_names_and_uvars t true  in
-        FStar_Pervasives_Native.fst uu____1849  in
-      uu____1848.FStar_Syntax_Syntax.free_uvars  in
+        let uu____1849 = free_names_and_uvars t true in
+        FStar_Pervasives_Native.fst uu____1849 in
+      uu____1848.FStar_Syntax_Syntax.free_uvars in
     FStar_Util.as_set uu____1829 compare_uv
-  
-let (univs :
+let univs:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.universe_uvar FStar_Util.set)
+    FStar_Syntax_Syntax.universe_uvar FStar_Util.set
   =
   fun t  ->
     let uu____1883 =
       let uu____1886 =
-        let uu____1887 = free_names_and_uvars t true  in
-        FStar_Pervasives_Native.fst uu____1887  in
-      uu____1886.FStar_Syntax_Syntax.free_univs  in
+        let uu____1887 = free_names_and_uvars t true in
+        FStar_Pervasives_Native.fst uu____1887 in
+      uu____1886.FStar_Syntax_Syntax.free_univs in
     FStar_Util.as_set uu____1883 compare_universe_uvar
-  
-let (univnames :
+let univnames:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.univ_name FStar_Util.fifo_set)
+    FStar_Syntax_Syntax.univ_name FStar_Util.fifo_set
   =
   fun t  ->
     let uu____1901 =
       let uu____1904 =
-        let uu____1905 = free_names_and_uvars t true  in
-        FStar_Pervasives_Native.fst uu____1905  in
-      uu____1904.FStar_Syntax_Syntax.free_univ_names  in
+        let uu____1905 = free_names_and_uvars t true in
+        FStar_Pervasives_Native.fst uu____1905 in
+      uu____1904.FStar_Syntax_Syntax.free_univ_names in
     FStar_Util.as_fifo_set uu____1901 FStar_Syntax_Syntax.order_univ_name
-  
-let (fvars : FStar_Syntax_Syntax.term -> FStar_Ident.lident FStar_Util.set) =
+let fvars: FStar_Syntax_Syntax.term -> FStar_Ident.lident FStar_Util.set =
   fun t  ->
-    let uu____1919 = free_names_and_uvars t false  in
+    let uu____1919 = free_names_and_uvars t false in
     FStar_Pervasives_Native.snd uu____1919
-  
-let (names_of_binders :
-  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.bv FStar_Util.set) =
+let names_of_binders:
+  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.bv FStar_Util.set =
   fun bs  ->
     let uu____1933 =
       let uu____1936 =
-        let uu____1937 = free_names_and_uvars_binders bs no_free_vars true
-           in
-        FStar_Pervasives_Native.fst uu____1937  in
-      uu____1936.FStar_Syntax_Syntax.free_names  in
+        let uu____1937 = free_names_and_uvars_binders bs no_free_vars true in
+        FStar_Pervasives_Native.fst uu____1937 in
+      uu____1936.FStar_Syntax_Syntax.free_names in
     FStar_Util.as_set uu____1933 FStar_Syntax_Syntax.order_bv
-  

--- a/src/ocaml-output/FStar_Syntax_InstFV.ml
+++ b/src/ocaml-output/FStar_Syntax_InstFV.ml
@@ -2,7 +2,7 @@ open Prims
 type inst_t =
   (FStar_Ident.lident,FStar_Syntax_Syntax.universes)
     FStar_Pervasives_Native.tuple2 Prims.list[@@deriving show]
-let mk :
+let mk:
   'Auu____11 'Auu____12 .
     'Auu____12 FStar_Syntax_Syntax.syntax ->
       'Auu____11 -> 'Auu____11 FStar_Syntax_Syntax.syntax
@@ -11,16 +11,15 @@ let mk :
     fun s  ->
       FStar_Syntax_Syntax.mk s FStar_Pervasives_Native.None
         t.FStar_Syntax_Syntax.pos
-  
-let rec (inst :
+let rec inst:
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
-    -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun s  ->
     fun t  ->
-      let t1 = FStar_Syntax_Subst.compress t  in
-      let mk1 = mk t1  in
+      let t1 = FStar_Syntax_Subst.compress t in
+      let mk1 = mk t1 in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_delayed uu____113 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name uu____138 -> t1
@@ -33,37 +32,36 @@ let rec (inst :
       | FStar_Syntax_Syntax.Tm_uinst uu____176 -> t1
       | FStar_Syntax_Syntax.Tm_fvar fv -> s t1 fv
       | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-          let bs1 = inst_binders s bs  in
-          let body1 = inst s body  in
+          let bs1 = inst_binders s bs in
+          let body1 = inst s body in
           let uu____209 =
             let uu____210 =
-              let uu____227 = inst_lcomp_opt s lopt  in
-              (bs1, body1, uu____227)  in
-            FStar_Syntax_Syntax.Tm_abs uu____210  in
+              let uu____227 = inst_lcomp_opt s lopt in
+              (bs1, body1, uu____227) in
+            FStar_Syntax_Syntax.Tm_abs uu____210 in
           mk1 uu____209
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let bs1 = inst_binders s bs  in
-          let c1 = inst_comp s c  in
+          let bs1 = inst_binders s bs in
+          let c1 = inst_comp s c in
           mk1 (FStar_Syntax_Syntax.Tm_arrow (bs1, c1))
       | FStar_Syntax_Syntax.Tm_refine (bv,t2) ->
           let bv1 =
-            let uu___25_263 = bv  in
-            let uu____264 = inst s bv.FStar_Syntax_Syntax.sort  in
+            let uu___25_263 = bv in
+            let uu____264 = inst s bv.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___25_263.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___25_263.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____264
-            }  in
-          let t3 = inst s t2  in
-          mk1 (FStar_Syntax_Syntax.Tm_refine (bv1, t3))
+            } in
+          let t3 = inst s t2 in mk1 (FStar_Syntax_Syntax.Tm_refine (bv1, t3))
       | FStar_Syntax_Syntax.Tm_app (t2,args) ->
           let uu____290 =
             let uu____291 =
-              let uu____306 = inst s t2  in
-              let uu____307 = inst_args s args  in (uu____306, uu____307)  in
-            FStar_Syntax_Syntax.Tm_app uu____291  in
+              let uu____306 = inst s t2 in
+              let uu____307 = inst_args s args in (uu____306, uu____307) in
+            FStar_Syntax_Syntax.Tm_app uu____291 in
           mk1 uu____290
       | FStar_Syntax_Syntax.Tm_match (t2,pats) ->
           let pats1 =
@@ -77,36 +75,31 @@ let rec (inst :
                           | FStar_Pervasives_Native.None  ->
                               FStar_Pervasives_Native.None
                           | FStar_Pervasives_Native.Some w ->
-                              let uu____467 = inst s w  in
-                              FStar_Pervasives_Native.Some uu____467
-                           in
-                        let t4 = inst s t3  in (p, wopt1, t4)))
-             in
+                              let uu____467 = inst s w in
+                              FStar_Pervasives_Native.Some uu____467 in
+                        let t4 = inst s t3 in (p, wopt1, t4))) in
           let uu____473 =
-            let uu____474 = let uu____497 = inst s t2  in (uu____497, pats1)
-               in
-            FStar_Syntax_Syntax.Tm_match uu____474  in
+            let uu____474 = let uu____497 = inst s t2 in (uu____497, pats1) in
+            FStar_Syntax_Syntax.Tm_match uu____474 in
           mk1 uu____473
       | FStar_Syntax_Syntax.Tm_ascribed (t11,asc,f) ->
           let inst_asc uu____580 =
             match uu____580 with
             | (annot,topt) ->
-                let topt1 = FStar_Util.map_opt topt (inst s)  in
+                let topt1 = FStar_Util.map_opt topt (inst s) in
                 let annot1 =
                   match annot with
                   | FStar_Util.Inl t2 ->
-                      let uu____642 = inst s t2  in FStar_Util.Inl uu____642
+                      let uu____642 = inst s t2 in FStar_Util.Inl uu____642
                   | FStar_Util.Inr c ->
-                      let uu____650 = inst_comp s c  in
-                      FStar_Util.Inr uu____650
-                   in
-                (annot1, topt1)
-             in
+                      let uu____650 = inst_comp s c in
+                      FStar_Util.Inr uu____650 in
+                (annot1, topt1) in
           let uu____663 =
             let uu____664 =
-              let uu____691 = inst s t11  in
-              let uu____692 = inst_asc asc  in (uu____691, uu____692, f)  in
-            FStar_Syntax_Syntax.Tm_ascribed uu____664  in
+              let uu____691 = inst s t11 in
+              let uu____692 = inst_asc asc in (uu____691, uu____692, f) in
+            FStar_Syntax_Syntax.Tm_ascribed uu____664 in
           mk1 uu____663
       | FStar_Syntax_Syntax.Tm_let (lbs,t2) ->
           let lbs1 =
@@ -114,9 +107,9 @@ let rec (inst :
               FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                 (FStar_List.map
                    (fun lb  ->
-                      let uu___26_758 = lb  in
-                      let uu____759 = inst s lb.FStar_Syntax_Syntax.lbtyp  in
-                      let uu____762 = inst s lb.FStar_Syntax_Syntax.lbdef  in
+                      let uu___26_758 = lb in
+                      let uu____759 = inst s lb.FStar_Syntax_Syntax.lbtyp in
+                      let uu____762 = inst s lb.FStar_Syntax_Syntax.lbdef in
                       {
                         FStar_Syntax_Syntax.lbname =
                           (uu___26_758.FStar_Syntax_Syntax.lbname);
@@ -128,50 +121,44 @@ let rec (inst :
                         FStar_Syntax_Syntax.lbdef = uu____762;
                         FStar_Syntax_Syntax.lbattrs =
                           (uu___26_758.FStar_Syntax_Syntax.lbattrs)
-                      }))
-               in
-            ((FStar_Pervasives_Native.fst lbs), uu____744)  in
+                      })) in
+            ((FStar_Pervasives_Native.fst lbs), uu____744) in
           let uu____769 =
-            let uu____770 = let uu____783 = inst s t2  in (lbs1, uu____783)
-               in
-            FStar_Syntax_Syntax.Tm_let uu____770  in
+            let uu____770 = let uu____783 = inst s t2 in (lbs1, uu____783) in
+            FStar_Syntax_Syntax.Tm_let uu____770 in
           mk1 uu____769
       | FStar_Syntax_Syntax.Tm_meta
           (t2,FStar_Syntax_Syntax.Meta_pattern args) ->
           let uu____806 =
             let uu____807 =
-              let uu____814 = inst s t2  in
+              let uu____814 = inst s t2 in
               let uu____815 =
                 let uu____816 =
-                  FStar_All.pipe_right args (FStar_List.map (inst_args s))
-                   in
-                FStar_Syntax_Syntax.Meta_pattern uu____816  in
-              (uu____814, uu____815)  in
-            FStar_Syntax_Syntax.Tm_meta uu____807  in
+                  FStar_All.pipe_right args (FStar_List.map (inst_args s)) in
+                FStar_Syntax_Syntax.Meta_pattern uu____816 in
+              (uu____814, uu____815) in
+            FStar_Syntax_Syntax.Tm_meta uu____807 in
           mk1 uu____806
       | FStar_Syntax_Syntax.Tm_meta
           (t2,FStar_Syntax_Syntax.Meta_monadic (m,t')) ->
           let uu____874 =
             let uu____875 =
-              let uu____882 = inst s t2  in
+              let uu____882 = inst s t2 in
               let uu____883 =
-                let uu____884 = let uu____891 = inst s t'  in (m, uu____891)
-                   in
-                FStar_Syntax_Syntax.Meta_monadic uu____884  in
-              (uu____882, uu____883)  in
-            FStar_Syntax_Syntax.Tm_meta uu____875  in
+                let uu____884 = let uu____891 = inst s t' in (m, uu____891) in
+                FStar_Syntax_Syntax.Meta_monadic uu____884 in
+              (uu____882, uu____883) in
+            FStar_Syntax_Syntax.Tm_meta uu____875 in
           mk1 uu____874
       | FStar_Syntax_Syntax.Tm_meta (t2,tag) ->
           let uu____898 =
-            let uu____899 = let uu____906 = inst s t2  in (uu____906, tag)
-               in
-            FStar_Syntax_Syntax.Tm_meta uu____899  in
+            let uu____899 = let uu____906 = inst s t2 in (uu____906, tag) in
+            FStar_Syntax_Syntax.Tm_meta uu____899 in
           mk1 uu____898
-
-and (inst_binders :
+and inst_binders:
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
-    -> FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders)
+    -> FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders
   =
   fun s  ->
     fun bs  ->
@@ -181,25 +168,24 @@ and (inst_binders :
               match uu____931 with
               | (x,imp) ->
                   let uu____942 =
-                    let uu___27_943 = x  in
-                    let uu____944 = inst s x.FStar_Syntax_Syntax.sort  in
+                    let uu___27_943 = x in
+                    let uu____944 = inst s x.FStar_Syntax_Syntax.sort in
                     {
                       FStar_Syntax_Syntax.ppname =
                         (uu___27_943.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
                         (uu___27_943.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort = uu____944
-                    }  in
+                    } in
                   (uu____942, imp)))
-
-and (inst_args :
+and inst_args:
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
     ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
       FStar_Pervasives_Native.tuple2 Prims.list ->
       (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
-        FStar_Pervasives_Native.tuple2 Prims.list)
+        FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun s  ->
     fun args  ->
@@ -207,40 +193,37 @@ and (inst_args :
         (FStar_List.map
            (fun uu____987  ->
               match uu____987 with
-              | (a,imp) -> let uu____998 = inst s a  in (uu____998, imp)))
-
-and (inst_comp :
+              | (a,imp) -> let uu____998 = inst s a in (uu____998, imp)))
+and inst_comp:
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
     ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax
   =
   fun s  ->
     fun c  ->
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Total (t,uopt) ->
-          let uu____1019 = inst s t  in
+          let uu____1019 = inst s t in
           FStar_Syntax_Syntax.mk_Total' uu____1019 uopt
       | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-          let uu____1030 = inst s t  in
+          let uu____1030 = inst s t in
           FStar_Syntax_Syntax.mk_GTotal' uu____1030 uopt
       | FStar_Syntax_Syntax.Comp ct ->
           let ct1 =
-            let uu___28_1033 = ct  in
-            let uu____1034 = inst s ct.FStar_Syntax_Syntax.result_typ  in
-            let uu____1037 = inst_args s ct.FStar_Syntax_Syntax.effect_args
-               in
+            let uu___28_1033 = ct in
+            let uu____1034 = inst s ct.FStar_Syntax_Syntax.result_typ in
+            let uu____1037 = inst_args s ct.FStar_Syntax_Syntax.effect_args in
             let uu____1046 =
               FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                 (FStar_List.map
                    (fun uu___24_1056  ->
                       match uu___24_1056 with
                       | FStar_Syntax_Syntax.DECREASES t ->
-                          let uu____1060 = inst s t  in
+                          let uu____1060 = inst s t in
                           FStar_Syntax_Syntax.DECREASES uu____1060
-                      | f -> f))
-               in
+                      | f -> f)) in
             {
               FStar_Syntax_Syntax.comp_univs =
                 (uu___28_1033.FStar_Syntax_Syntax.comp_univs);
@@ -249,15 +232,14 @@ and (inst_comp :
               FStar_Syntax_Syntax.result_typ = uu____1034;
               FStar_Syntax_Syntax.effect_args = uu____1037;
               FStar_Syntax_Syntax.flags = uu____1046
-            }  in
+            } in
           FStar_Syntax_Syntax.mk_Comp ct1
-
-and (inst_lcomp_opt :
+and inst_lcomp_opt:
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
     ->
     FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
-      FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option
   =
   fun s  ->
     fun l  ->
@@ -265,21 +247,19 @@ and (inst_lcomp_opt :
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some rc ->
           let uu____1075 =
-            let uu___29_1076 = rc  in
+            let uu___29_1076 = rc in
             let uu____1077 =
-              FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ (inst s)
-               in
+              FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ (inst s) in
             {
               FStar_Syntax_Syntax.residual_effect =
                 (uu___29_1076.FStar_Syntax_Syntax.residual_effect);
               FStar_Syntax_Syntax.residual_typ = uu____1077;
               FStar_Syntax_Syntax.residual_flags =
                 (uu___29_1076.FStar_Syntax_Syntax.residual_flags)
-            }  in
+            } in
           FStar_Pervasives_Native.Some uu____1075
-
-let (instantiate :
-  inst_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let instantiate:
+  inst_t -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun i  ->
     fun t  ->
       match i with
@@ -293,12 +273,9 @@ let (instantiate :
                    | (x,uu____1122) ->
                        FStar_Ident.lid_equals x
                          (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                i
-               in
+                i in
             match uu____1102 with
             | FStar_Pervasives_Native.None  -> t1
             | FStar_Pervasives_Native.Some (uu____1127,us) ->
-                mk t1 (FStar_Syntax_Syntax.Tm_uinst (t1, us))
-             in
+                mk t1 (FStar_Syntax_Syntax.Tm_uinst (t1, us)) in
           inst inst_fv t
-  

--- a/src/ocaml-output/FStar_Syntax_MutRecTy.ml
+++ b/src/ocaml-output/FStar_Syntax_MutRecTy.ml
@@ -1,11 +1,11 @@
 open Prims
-let (disentangle_abbrevs_from_bundle :
+let disentangle_abbrevs_from_bundle:
   FStar_Syntax_Syntax.sigelt Prims.list ->
     FStar_Syntax_Syntax.qualifier Prims.list ->
       FStar_Ident.lident Prims.list ->
         FStar_Range.range ->
           (FStar_Syntax_Syntax.sigelt,FStar_Syntax_Syntax.sigelt Prims.list)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun sigelts  ->
     fun quals  ->
@@ -13,8 +13,7 @@ let (disentangle_abbrevs_from_bundle :
         fun rng  ->
           let sigattrs =
             FStar_List.collect (fun s  -> s.FStar_Syntax_Syntax.sigattrs)
-              sigelts
-             in
+              sigelts in
           let type_abbrev_sigelts =
             FStar_All.pipe_right sigelts
               (FStar_List.collect
@@ -34,8 +33,7 @@ let (disentangle_abbrevs_from_bundle :
                     | FStar_Syntax_Syntax.Sig_let (uu____89,uu____90) ->
                         failwith
                           "mutrecty: disentangle_abbrevs_from_bundle: type_abbrev_sigelts: impossible"
-                    | uu____97 -> []))
-             in
+                    | uu____97 -> [])) in
           match type_abbrev_sigelts with
           | [] ->
               ({
@@ -71,16 +69,14 @@ let (disentangle_abbrevs_from_bundle :
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                         | uu____160 ->
                             failwith
-                              "mutrecty: disentangle_abbrevs_from_bundle: type_abbrevs: impossible"))
-                 in
+                              "mutrecty: disentangle_abbrevs_from_bundle: type_abbrevs: impossible")) in
               let unfolded_type_abbrevs =
-                let rev_unfolded_type_abbrevs = FStar_Util.mk_ref []  in
-                let in_progress = FStar_Util.mk_ref []  in
-                let not_unfolded_yet = FStar_Util.mk_ref type_abbrev_sigelts
-                   in
+                let rev_unfolded_type_abbrevs = FStar_Util.mk_ref [] in
+                let in_progress = FStar_Util.mk_ref [] in
+                let not_unfolded_yet = FStar_Util.mk_ref type_abbrev_sigelts in
                 let remove_not_unfolded lid =
                   let uu____189 =
-                    let uu____192 = FStar_ST.op_Bang not_unfolded_yet  in
+                    let uu____192 = FStar_ST.op_Bang not_unfolded_yet in
                     FStar_All.pipe_right uu____192
                       (FStar_List.filter
                          (fun x  ->
@@ -103,9 +99,8 @@ let (disentangle_abbrevs_from_bundle :
                                 Prims.op_Negation
                                   (FStar_Ident.lid_equals lid
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                            | uu____284 -> true))
-                     in
-                  FStar_ST.op_Colon_Equals not_unfolded_yet uu____189  in
+                            | uu____284 -> true)) in
+                  FStar_ST.op_Colon_Equals not_unfolded_yet uu____189 in
                 let rec unfold_abbrev_fv t fv =
                   let replacee x =
                     match x.FStar_Syntax_Syntax.sigel with
@@ -123,7 +118,7 @@ let (disentangle_abbrevs_from_bundle :
                           (fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                         -> FStar_Pervasives_Native.Some x
-                    | uu____378 -> FStar_Pervasives_Native.None  in
+                    | uu____378 -> FStar_Pervasives_Native.None in
                   let replacee_term x =
                     match replacee x with
                     | FStar_Pervasives_Native.Some
@@ -147,33 +142,31 @@ let (disentangle_abbrevs_from_bundle :
                           FStar_Syntax_Syntax.sigmeta = uu____401;
                           FStar_Syntax_Syntax.sigattrs = uu____402;_}
                         -> FStar_Pervasives_Native.Some tm
-                    | uu____435 -> FStar_Pervasives_Native.None  in
+                    | uu____435 -> FStar_Pervasives_Native.None in
                   let uu____440 =
                     let uu____445 =
-                      FStar_ST.op_Bang rev_unfolded_type_abbrevs  in
-                    FStar_Util.find_map uu____445 replacee_term  in
+                      FStar_ST.op_Bang rev_unfolded_type_abbrevs in
+                    FStar_Util.find_map uu____445 replacee_term in
                   match uu____440 with
                   | FStar_Pervasives_Native.Some x -> x
                   | FStar_Pervasives_Native.None  ->
                       let uu____502 =
-                        FStar_Util.find_map type_abbrev_sigelts replacee  in
+                        FStar_Util.find_map type_abbrev_sigelts replacee in
                       (match uu____502 with
                        | FStar_Pervasives_Native.Some se ->
                            let uu____506 =
-                             let uu____507 = FStar_ST.op_Bang in_progress  in
+                             let uu____507 = FStar_ST.op_Bang in_progress in
                              FStar_List.existsb
                                (fun x  ->
                                   FStar_Ident.lid_equals x
                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                               uu____507
-                              in
+                               uu____507 in
                            if uu____506
                            then
                              let msg =
                                FStar_Util.format1
                                  "Cycle on %s in mutually recursive type abbreviations"
-                                 ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                                in
+                                 ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_CycleInRecTypeAbbreviation,
                                  msg)
@@ -181,7 +174,6 @@ let (disentangle_abbrevs_from_bundle :
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                            else unfold_abbrev se
                        | uu____559 -> t)
-                
                 and unfold_abbrev x =
                   match x.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____564)
@@ -192,19 +184,17 @@ let (disentangle_abbrevs_from_bundle :
                              (fun uu___27_585  ->
                                 match uu___27_585 with
                                 | FStar_Syntax_Syntax.Noeq  -> false
-                                | uu____586 -> true))
-                         in
+                                | uu____586 -> true)) in
                       let lid =
                         match lb.FStar_Syntax_Syntax.lbname with
                         | FStar_Util.Inr fv ->
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                         | uu____589 ->
                             failwith
-                              "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: lid: impossible"
-                         in
+                              "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: lid: impossible" in
                       ((let uu____595 =
-                          let uu____598 = FStar_ST.op_Bang in_progress  in
-                          lid :: uu____598  in
+                          let uu____598 = FStar_ST.op_Bang in_progress in lid
+                            :: uu____598 in
                         FStar_ST.op_Colon_Equals in_progress uu____595);
                        (match () with
                         | () ->
@@ -213,14 +203,12 @@ let (disentangle_abbrevs_from_bundle :
                               | () ->
                                   let ty' =
                                     FStar_Syntax_InstFV.inst unfold_abbrev_fv
-                                      lb.FStar_Syntax_Syntax.lbtyp
-                                     in
+                                      lb.FStar_Syntax_Syntax.lbtyp in
                                   let tm' =
                                     FStar_Syntax_InstFV.inst unfold_abbrev_fv
-                                      lb.FStar_Syntax_Syntax.lbdef
-                                     in
+                                      lb.FStar_Syntax_Syntax.lbdef in
                                   let lb' =
-                                    let uu___28_695 = lb  in
+                                    let uu___28_695 = lb in
                                     {
                                       FStar_Syntax_Syntax.lbname =
                                         (uu___28_695.FStar_Syntax_Syntax.lbname);
@@ -232,17 +220,15 @@ let (disentangle_abbrevs_from_bundle :
                                       FStar_Syntax_Syntax.lbdef = tm';
                                       FStar_Syntax_Syntax.lbattrs =
                                         (uu___28_695.FStar_Syntax_Syntax.lbattrs)
-                                    }  in
+                                    } in
                                   let sigelt' =
                                     FStar_Syntax_Syntax.Sig_let
-                                      ((false, [lb']), [lid])
-                                     in
+                                      ((false, [lb']), [lid]) in
                                   ((let uu____708 =
                                       let uu____711 =
                                         FStar_ST.op_Bang
-                                          rev_unfolded_type_abbrevs
-                                         in
-                                      (let uu___29_760 = x  in
+                                          rev_unfolded_type_abbrevs in
+                                      (let uu___29_760 = x in
                                        {
                                          FStar_Syntax_Syntax.sigel = sigelt';
                                          FStar_Syntax_Syntax.sigrng =
@@ -253,42 +239,37 @@ let (disentangle_abbrevs_from_bundle :
                                            (uu___29_760.FStar_Syntax_Syntax.sigmeta);
                                          FStar_Syntax_Syntax.sigattrs =
                                            (uu___29_760.FStar_Syntax_Syntax.sigattrs)
-                                       }) :: uu____711
-                                       in
+                                       }) :: uu____711 in
                                     FStar_ST.op_Colon_Equals
                                       rev_unfolded_type_abbrevs uu____708);
                                    (match () with
                                     | () ->
                                         ((let uu____807 =
                                             let uu____810 =
-                                              FStar_ST.op_Bang in_progress
-                                               in
-                                            FStar_List.tl uu____810  in
+                                              FStar_ST.op_Bang in_progress in
+                                            FStar_List.tl uu____810 in
                                           FStar_ST.op_Colon_Equals
                                             in_progress uu____807);
                                          (match () with | () -> tm'))))))))
                   | uu____903 ->
                       failwith
-                        "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: impossible"
-                 in
+                        "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: impossible" in
                 let rec aux uu____909 =
-                  let uu____910 = FStar_ST.op_Bang not_unfolded_yet  in
+                  let uu____910 = FStar_ST.op_Bang not_unfolded_yet in
                   match uu____910 with
-                  | x::uu____961 -> let _unused = unfold_abbrev x  in aux ()
+                  | x::uu____961 -> let _unused = unfold_abbrev x in aux ()
                   | uu____965 ->
                       let uu____968 =
-                        FStar_ST.op_Bang rev_unfolded_type_abbrevs  in
-                      FStar_List.rev uu____968
-                   in
-                aux ()  in
+                        FStar_ST.op_Bang rev_unfolded_type_abbrevs in
+                      FStar_List.rev uu____968 in
+                aux () in
               let filter_out_type_abbrevs l =
                 FStar_List.filter
                   (fun lid  ->
                      FStar_List.for_all
                        (fun lid'  ->
                           Prims.op_Negation (FStar_Ident.lid_equals lid lid'))
-                       type_abbrevs) l
-                 in
+                       type_abbrevs) l in
               let inductives_with_abbrevs_unfolded =
                 let find_in_unfolded fv =
                   FStar_Util.find_map unfolded_type_abbrevs
@@ -312,22 +293,21 @@ let (disentangle_abbrevs_from_bundle :
                              (fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                            -> FStar_Pervasives_Native.Some tm
-                       | uu____1089 -> FStar_Pervasives_Native.None)
-                   in
+                       | uu____1089 -> FStar_Pervasives_Native.None) in
                 let unfold_fv t fv =
-                  let uu____1099 = find_in_unfolded fv  in
+                  let uu____1099 = find_in_unfolded fv in
                   match uu____1099 with
                   | FStar_Pervasives_Native.Some t' -> t'
-                  | uu____1109 -> t  in
+                  | uu____1109 -> t in
                 let unfold_in_sig x =
                   match x.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_inductive_typ
                       (lid,univs,bnd,ty,mut,dc) ->
                       let bnd' =
-                        FStar_Syntax_InstFV.inst_binders unfold_fv bnd  in
-                      let ty' = FStar_Syntax_InstFV.inst unfold_fv ty  in
-                      let mut' = filter_out_type_abbrevs mut  in
-                      [(let uu___30_1142 = x  in
+                        FStar_Syntax_InstFV.inst_binders unfold_fv bnd in
+                      let ty' = FStar_Syntax_InstFV.inst unfold_fv ty in
+                      let mut' = filter_out_type_abbrevs mut in
+                      [(let uu___30_1142 = x in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_inductive_typ
@@ -343,9 +323,9 @@ let (disentangle_abbrevs_from_bundle :
                         })]
                   | FStar_Syntax_Syntax.Sig_datacon
                       (lid,univs,ty,res,npars,mut) ->
-                      let ty' = FStar_Syntax_InstFV.inst unfold_fv ty  in
-                      let mut' = filter_out_type_abbrevs mut  in
-                      [(let uu___31_1162 = x  in
+                      let ty' = FStar_Syntax_InstFV.inst unfold_fv ty in
+                      let mut' = filter_out_type_abbrevs mut in
+                      [(let uu___31_1162 = x in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_datacon
@@ -362,10 +342,9 @@ let (disentangle_abbrevs_from_bundle :
                   | FStar_Syntax_Syntax.Sig_let (uu____1165,uu____1166) -> []
                   | uu____1171 ->
                       failwith
-                        "mutrecty: inductives_with_abbrevs_unfolded: unfold_in_sig: impossible"
-                   in
-                FStar_List.collect unfold_in_sig sigelts  in
-              let new_members = filter_out_type_abbrevs members  in
+                        "mutrecty: inductives_with_abbrevs_unfolded: unfold_in_sig: impossible" in
+                FStar_List.collect unfold_in_sig sigelts in
+              let new_members = filter_out_type_abbrevs members in
               let new_bundle =
                 {
                   FStar_Syntax_Syntax.sigel =
@@ -376,6 +355,5 @@ let (disentangle_abbrevs_from_bundle :
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = sigattrs
-                }  in
+                } in
               (new_bundle, unfolded_type_abbrevs)
-  

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -1,56 +1,47 @@
 open Prims
-let rec (delta_depth_to_string :
-  FStar_Syntax_Syntax.delta_depth -> Prims.string) =
+let rec delta_depth_to_string:
+  FStar_Syntax_Syntax.delta_depth -> Prims.string =
   fun uu___66_3  ->
     match uu___66_3 with
     | FStar_Syntax_Syntax.Delta_constant  -> "Delta_constant"
     | FStar_Syntax_Syntax.Delta_defined_at_level i ->
-        let uu____5 = FStar_Util.string_of_int i  in
+        let uu____5 = FStar_Util.string_of_int i in
         Prims.strcat "Delta_defined_at_level " uu____5
     | FStar_Syntax_Syntax.Delta_equational  -> "Delta_equational"
     | FStar_Syntax_Syntax.Delta_abstract d ->
         let uu____7 =
-          let uu____8 = delta_depth_to_string d  in Prims.strcat uu____8 ")"
-           in
+          let uu____8 = delta_depth_to_string d in Prims.strcat uu____8 ")" in
         Prims.strcat "Delta_abstract (" uu____7
-  
-let (sli : FStar_Ident.lident -> Prims.string) =
+let sli: FStar_Ident.lident -> Prims.string =
   fun l  ->
-    let uu____12 = FStar_Options.print_real_names ()  in
+    let uu____12 = FStar_Options.print_real_names () in
     if uu____12
     then l.FStar_Ident.str
     else (l.FStar_Ident.ident).FStar_Ident.idText
-  
-let (lid_to_string : FStar_Ident.lid -> Prims.string) = fun l  -> sli l 
-let (fv_to_string : FStar_Syntax_Syntax.fv -> Prims.string) =
+let lid_to_string: FStar_Ident.lid -> Prims.string = fun l  -> sli l
+let fv_to_string: FStar_Syntax_Syntax.fv -> Prims.string =
   fun fv  ->
     lid_to_string (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-  
-let (bv_to_string : FStar_Syntax_Syntax.bv -> Prims.string) =
+let bv_to_string: FStar_Syntax_Syntax.bv -> Prims.string =
   fun bv  ->
     let uu____23 =
-      let uu____24 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index
-         in
-      Prims.strcat "#" uu____24  in
+      let uu____24 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index in
+      Prims.strcat "#" uu____24 in
     Prims.strcat (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText uu____23
-  
-let (nm_to_string : FStar_Syntax_Syntax.bv -> Prims.string) =
+let nm_to_string: FStar_Syntax_Syntax.bv -> Prims.string =
   fun bv  ->
-    let uu____28 = FStar_Options.print_real_names ()  in
+    let uu____28 = FStar_Options.print_real_names () in
     if uu____28
     then bv_to_string bv
     else (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-  
-let (db_to_string : FStar_Syntax_Syntax.bv -> Prims.string) =
+let db_to_string: FStar_Syntax_Syntax.bv -> Prims.string =
   fun bv  ->
     let uu____33 =
-      let uu____34 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index
-         in
-      Prims.strcat "@" uu____34  in
+      let uu____34 = FStar_Util.string_of_int bv.FStar_Syntax_Syntax.index in
+      Prims.strcat "@" uu____34 in
     Prims.strcat (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText uu____33
-  
-let (infix_prim_ops :
-  (FStar_Ident.lident,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list)
+let infix_prim_ops:
+  (FStar_Ident.lident,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list
   =
   [(FStar_Parser_Const.op_Addition, "+");
   (FStar_Parser_Const.op_Subtraction, "-");
@@ -72,16 +63,16 @@ let (infix_prim_ops :
   (FStar_Parser_Const.iff_lid, "<==>");
   (FStar_Parser_Const.precedes_lid, "<<");
   (FStar_Parser_Const.eq2_lid, "==");
-  (FStar_Parser_Const.eq3_lid, "===")] 
-let (unary_prim_ops :
-  (FStar_Ident.lident,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list)
+  (FStar_Parser_Const.eq3_lid, "===")]
+let unary_prim_ops:
+  (FStar_Ident.lident,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list
   =
   [(FStar_Parser_Const.op_Negation, "not");
   (FStar_Parser_Const.op_Minus, "-");
-  (FStar_Parser_Const.not_lid, "~")] 
-let (is_prim_op :
+  (FStar_Parser_Const.not_lid, "~")]
+let is_prim_op:
   FStar_Ident.lident Prims.list ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool
   =
   fun ps  ->
     fun f  ->
@@ -90,45 +81,40 @@ let (is_prim_op :
           FStar_All.pipe_right ps
             (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv))
       | uu____168 -> false
-  
-let (get_lid :
-  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> FStar_Ident.lident)
+let get_lid:
+  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> FStar_Ident.lident
   =
   fun f  ->
     match f.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
     | uu____177 -> failwith "get_lid"
-  
-let (is_infix_prim_op : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_infix_prim_op: FStar_Syntax_Syntax.term -> Prims.bool =
   fun e  ->
     is_prim_op
       (FStar_Pervasives_Native.fst (FStar_List.split infix_prim_ops)) e
-  
-let (is_unary_prim_op : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_unary_prim_op: FStar_Syntax_Syntax.term -> Prims.bool =
   fun e  ->
     is_prim_op
       (FStar_Pervasives_Native.fst (FStar_List.split unary_prim_ops)) e
-  
-let (quants :
-  (FStar_Ident.lident,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list)
+let quants:
+  (FStar_Ident.lident,Prims.string) FStar_Pervasives_Native.tuple2 Prims.list
   =
   [(FStar_Parser_Const.forall_lid, "forall");
-  (FStar_Parser_Const.exists_lid, "exists")] 
+  (FStar_Parser_Const.exists_lid, "exists")]
 type exp = FStar_Syntax_Syntax.term[@@deriving show]
-let (is_b2t : FStar_Syntax_Syntax.typ -> Prims.bool) =
-  fun t  -> is_prim_op [FStar_Parser_Const.b2t_lid] t 
-let (is_quant : FStar_Syntax_Syntax.typ -> Prims.bool) =
+let is_b2t: FStar_Syntax_Syntax.typ -> Prims.bool =
+  fun t  -> is_prim_op [FStar_Parser_Const.b2t_lid] t
+let is_quant: FStar_Syntax_Syntax.typ -> Prims.bool =
   fun t  ->
     is_prim_op (FStar_Pervasives_Native.fst (FStar_List.split quants)) t
-  
-let (is_ite : FStar_Syntax_Syntax.typ -> Prims.bool) =
-  fun t  -> is_prim_op [FStar_Parser_Const.ite_lid] t 
-let (is_lex_cons : exp -> Prims.bool) =
-  fun f  -> is_prim_op [FStar_Parser_Const.lexcons_lid] f 
-let (is_lex_top : exp -> Prims.bool) =
-  fun f  -> is_prim_op [FStar_Parser_Const.lextop_lid] f 
-let is_inr :
+let is_ite: FStar_Syntax_Syntax.typ -> Prims.bool =
+  fun t  -> is_prim_op [FStar_Parser_Const.ite_lid] t
+let is_lex_cons: exp -> Prims.bool =
+  fun f  -> is_prim_op [FStar_Parser_Const.lexcons_lid] f
+let is_lex_top: exp -> Prims.bool =
+  fun f  -> is_prim_op [FStar_Parser_Const.lextop_lid] f
+let is_inr:
   'Auu____232 'Auu____233 .
     ('Auu____233,'Auu____232) FStar_Util.either -> Prims.bool
   =
@@ -136,8 +122,7 @@ let is_inr :
     match uu___67_241 with
     | FStar_Util.Inl uu____246 -> false
     | FStar_Util.Inr uu____247 -> true
-  
-let filter_imp :
+let filter_imp:
   'Auu____250 .
     ('Auu____250,FStar_Syntax_Syntax.arg_qualifier
                    FStar_Pervasives_Native.option)
@@ -154,183 +139,164 @@ let filter_imp :
             | (uu____311,FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Implicit uu____312)) -> false
             | uu____315 -> true))
-  
-let rec (reconstruct_lex :
+let rec reconstruct_lex:
   exp ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun e  ->
     let uu____331 =
-      let uu____332 = FStar_Syntax_Subst.compress e  in
-      uu____332.FStar_Syntax_Syntax.n  in
+      let uu____332 = FStar_Syntax_Subst.compress e in
+      uu____332.FStar_Syntax_Syntax.n in
     match uu____331 with
     | FStar_Syntax_Syntax.Tm_app (f,args) ->
-        let args1 = filter_imp args  in
-        let exps = FStar_List.map FStar_Pervasives_Native.fst args1  in
+        let args1 = filter_imp args in
+        let exps = FStar_List.map FStar_Pervasives_Native.fst args1 in
         let uu____395 =
           (is_lex_cons f) &&
-            ((FStar_List.length exps) = (Prims.parse_int "2"))
-           in
+            ((FStar_List.length exps) = (Prims.parse_int "2")) in
         if uu____395
         then
           let uu____404 =
-            let uu____411 = FStar_List.nth exps (Prims.parse_int "1")  in
-            reconstruct_lex uu____411  in
+            let uu____411 = FStar_List.nth exps (Prims.parse_int "1") in
+            reconstruct_lex uu____411 in
           (match uu____404 with
            | FStar_Pervasives_Native.Some xs ->
                let uu____429 =
-                 let uu____434 = FStar_List.nth exps (Prims.parse_int "0")
-                    in
-                 uu____434 :: xs  in
+                 let uu____434 = FStar_List.nth exps (Prims.parse_int "0") in
+                 uu____434 :: xs in
                FStar_Pervasives_Native.Some uu____429
            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None)
         else FStar_Pervasives_Native.None
     | uu____458 ->
-        let uu____459 = is_lex_top e  in
+        let uu____459 = is_lex_top e in
         if uu____459
         then FStar_Pervasives_Native.Some []
         else FStar_Pervasives_Native.None
-  
-let rec find : 'a . ('a -> Prims.bool) -> 'a Prims.list -> 'a =
+let rec find: 'a . ('a -> Prims.bool) -> 'a Prims.list -> 'a =
   fun f  ->
     fun l  ->
       match l with
       | [] -> failwith "blah"
       | hd1::tl1 ->
-          let uu____503 = f hd1  in if uu____503 then hd1 else find f tl1
-  
-let (find_lid :
+          let uu____503 = f hd1 in if uu____503 then hd1 else find f tl1
+let find_lid:
   FStar_Ident.lident ->
     (FStar_Ident.lident,Prims.string) FStar_Pervasives_Native.tuple2
-      Prims.list -> Prims.string)
+      Prims.list -> Prims.string
   =
   fun x  ->
     fun xs  ->
       let uu____523 =
         find
           (fun p  -> FStar_Ident.lid_equals x (FStar_Pervasives_Native.fst p))
-          xs
-         in
+          xs in
       FStar_Pervasives_Native.snd uu____523
-  
-let (infix_prim_op_to_string :
-  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
-  fun e  -> let uu____545 = get_lid e  in find_lid uu____545 infix_prim_ops 
-let (unary_prim_op_to_string :
-  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
-  fun e  -> let uu____553 = get_lid e  in find_lid uu____553 unary_prim_ops 
-let (quant_to_string :
-  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
-  fun t  -> let uu____561 = get_lid t  in find_lid uu____561 quants 
-let (const_to_string : FStar_Const.sconst -> Prims.string) =
-  fun x  -> FStar_Parser_Const.const_to_string x 
-let (lbname_to_string : FStar_Syntax_Syntax.lbname -> Prims.string) =
+let infix_prim_op_to_string:
+  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string =
+  fun e  -> let uu____545 = get_lid e in find_lid uu____545 infix_prim_ops
+let unary_prim_op_to_string:
+  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string =
+  fun e  -> let uu____553 = get_lid e in find_lid uu____553 unary_prim_ops
+let quant_to_string:
+  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string =
+  fun t  -> let uu____561 = get_lid t in find_lid uu____561 quants
+let const_to_string: FStar_Const.sconst -> Prims.string =
+  fun x  -> FStar_Parser_Const.const_to_string x
+let lbname_to_string: FStar_Syntax_Syntax.lbname -> Prims.string =
   fun uu___69_567  ->
     match uu___69_567 with
     | FStar_Util.Inl l -> bv_to_string l
     | FStar_Util.Inr l ->
         lid_to_string (l.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-  
-let (uvar_to_string : FStar_Syntax_Syntax.uvar -> Prims.string) =
+let uvar_to_string: FStar_Syntax_Syntax.uvar -> Prims.string =
   fun u  ->
-    let uu____573 = FStar_Options.hide_uvar_nums ()  in
+    let uu____573 = FStar_Options.hide_uvar_nums () in
     if uu____573
     then "?"
     else
       (let uu____575 =
-         let uu____576 = FStar_Syntax_Unionfind.uvar_id u  in
-         FStar_All.pipe_right uu____576 FStar_Util.string_of_int  in
+         let uu____576 = FStar_Syntax_Unionfind.uvar_id u in
+         FStar_All.pipe_right uu____576 FStar_Util.string_of_int in
        Prims.strcat "?" uu____575)
-  
-let (version_to_string : FStar_Syntax_Syntax.version -> Prims.string) =
+let version_to_string: FStar_Syntax_Syntax.version -> Prims.string =
   fun v1  ->
-    let uu____580 = FStar_Util.string_of_int v1.FStar_Syntax_Syntax.major  in
-    let uu____581 = FStar_Util.string_of_int v1.FStar_Syntax_Syntax.minor  in
+    let uu____580 = FStar_Util.string_of_int v1.FStar_Syntax_Syntax.major in
+    let uu____581 = FStar_Util.string_of_int v1.FStar_Syntax_Syntax.minor in
     FStar_Util.format2 "%s.%s" uu____580 uu____581
-  
-let (univ_uvar_to_string : FStar_Syntax_Syntax.universe_uvar -> Prims.string)
-  =
+let univ_uvar_to_string: FStar_Syntax_Syntax.universe_uvar -> Prims.string =
   fun u  ->
-    let uu____585 = FStar_Options.hide_uvar_nums ()  in
+    let uu____585 = FStar_Options.hide_uvar_nums () in
     if uu____585
     then "?"
     else
       (let uu____587 =
          let uu____588 =
-           let uu____589 = FStar_Syntax_Unionfind.univ_uvar_id u  in
-           FStar_All.pipe_right uu____589 FStar_Util.string_of_int  in
+           let uu____589 = FStar_Syntax_Unionfind.univ_uvar_id u in
+           FStar_All.pipe_right uu____589 FStar_Util.string_of_int in
          let uu____590 =
-           let uu____591 = version_to_string (FStar_Pervasives_Native.snd u)
-              in
-           Prims.strcat ":" uu____591  in
-         Prims.strcat uu____588 uu____590  in
+           let uu____591 = version_to_string (FStar_Pervasives_Native.snd u) in
+           Prims.strcat ":" uu____591 in
+         Prims.strcat uu____588 uu____590 in
        Prims.strcat "?" uu____587)
-  
-let rec (int_of_univ :
+let rec int_of_univ:
   Prims.int ->
     FStar_Syntax_Syntax.universe ->
       (Prims.int,FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun n1  ->
     fun u  ->
-      let uu____608 = FStar_Syntax_Subst.compress_univ u  in
+      let uu____608 = FStar_Syntax_Subst.compress_univ u in
       match uu____608 with
       | FStar_Syntax_Syntax.U_zero  -> (n1, FStar_Pervasives_Native.None)
       | FStar_Syntax_Syntax.U_succ u1 ->
           int_of_univ (n1 + (Prims.parse_int "1")) u1
       | uu____618 -> (n1, (FStar_Pervasives_Native.Some u))
-  
-let rec (univ_to_string : FStar_Syntax_Syntax.universe -> Prims.string) =
+let rec univ_to_string: FStar_Syntax_Syntax.universe -> Prims.string =
   fun u  ->
     let uu____624 =
-      let uu____625 = FStar_Options.ugly ()  in Prims.op_Negation uu____625
-       in
+      let uu____625 = FStar_Options.ugly () in Prims.op_Negation uu____625 in
     if uu____624
     then
-      let e = FStar_Syntax_Resugar.resugar_universe u FStar_Range.dummyRange
-         in
-      let d = FStar_Parser_ToDocument.term_to_document e  in
+      let e = FStar_Syntax_Resugar.resugar_universe u FStar_Range.dummyRange in
+      let d = FStar_Parser_ToDocument.term_to_document e in
       FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
         (Prims.parse_int "100") d
     else
-      (let uu____629 = FStar_Syntax_Subst.compress_univ u  in
+      (let uu____629 = FStar_Syntax_Subst.compress_univ u in
        match uu____629 with
        | FStar_Syntax_Syntax.U_unif u1 -> univ_uvar_to_string u1
        | FStar_Syntax_Syntax.U_name x -> x.FStar_Ident.idText
        | FStar_Syntax_Syntax.U_bvar x ->
-           let uu____641 = FStar_Util.string_of_int x  in
+           let uu____641 = FStar_Util.string_of_int x in
            Prims.strcat "@" uu____641
        | FStar_Syntax_Syntax.U_zero  -> "0"
        | FStar_Syntax_Syntax.U_succ u1 ->
-           let uu____643 = int_of_univ (Prims.parse_int "1") u1  in
+           let uu____643 = int_of_univ (Prims.parse_int "1") u1 in
            (match uu____643 with
             | (n1,FStar_Pervasives_Native.None ) ->
                 FStar_Util.string_of_int n1
             | (n1,FStar_Pervasives_Native.Some u2) ->
-                let uu____657 = univ_to_string u2  in
-                let uu____658 = FStar_Util.string_of_int n1  in
+                let uu____657 = univ_to_string u2 in
+                let uu____658 = FStar_Util.string_of_int n1 in
                 FStar_Util.format2 "(%s + %s)" uu____657 uu____658)
        | FStar_Syntax_Syntax.U_max us ->
            let uu____662 =
-             let uu____663 = FStar_List.map univ_to_string us  in
-             FStar_All.pipe_right uu____663 (FStar_String.concat ", ")  in
+             let uu____663 = FStar_List.map univ_to_string us in
+             FStar_All.pipe_right uu____663 (FStar_String.concat ", ") in
            FStar_Util.format1 "(max %s)" uu____662
        | FStar_Syntax_Syntax.U_unknown  -> "unknown")
-  
-let (univs_to_string :
-  FStar_Syntax_Syntax.universe Prims.list -> Prims.string) =
+let univs_to_string: FStar_Syntax_Syntax.universe Prims.list -> Prims.string
+  =
   fun us  ->
-    let uu____675 = FStar_List.map univ_to_string us  in
+    let uu____675 = FStar_List.map univ_to_string us in
     FStar_All.pipe_right uu____675 (FStar_String.concat ", ")
-  
-let (univ_names_to_string : FStar_Ident.ident Prims.list -> Prims.string) =
+let univ_names_to_string: FStar_Ident.ident Prims.list -> Prims.string =
   fun us  ->
-    let uu____687 = FStar_List.map (fun x  -> x.FStar_Ident.idText) us  in
+    let uu____687 = FStar_List.map (fun x  -> x.FStar_Ident.idText) us in
     FStar_All.pipe_right uu____687 (FStar_String.concat ", ")
-  
-let (qual_to_string : FStar_Syntax_Syntax.qualifier -> Prims.string) =
+let qual_to_string: FStar_Syntax_Syntax.qualifier -> Prims.string =
   fun uu___70_696  ->
     match uu___70_696 with
     | FStar_Syntax_Syntax.Assumption  -> "assume"
@@ -347,33 +313,31 @@ let (qual_to_string : FStar_Syntax_Syntax.qualifier -> Prims.string) =
     | FStar_Syntax_Syntax.Logic  -> "logic"
     | FStar_Syntax_Syntax.TotalEffect  -> "total"
     | FStar_Syntax_Syntax.Discriminator l ->
-        let uu____698 = lid_to_string l  in
+        let uu____698 = lid_to_string l in
         FStar_Util.format1 "(Discriminator %s)" uu____698
     | FStar_Syntax_Syntax.Projector (l,x) ->
-        let uu____701 = lid_to_string l  in
+        let uu____701 = lid_to_string l in
         FStar_Util.format2 "(Projector %s %s)" uu____701 x.FStar_Ident.idText
     | FStar_Syntax_Syntax.RecordType (ns,fns) ->
         let uu____712 =
-          let uu____713 = FStar_Ident.path_of_ns ns  in
-          FStar_Ident.text_of_path uu____713  in
+          let uu____713 = FStar_Ident.path_of_ns ns in
+          FStar_Ident.text_of_path uu____713 in
         let uu____716 =
           let uu____717 =
-            FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id)
-             in
-          FStar_All.pipe_right uu____717 (FStar_String.concat ", ")  in
+            FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id) in
+          FStar_All.pipe_right uu____717 (FStar_String.concat ", ") in
         FStar_Util.format2 "(RecordType %s %s)" uu____712 uu____716
     | FStar_Syntax_Syntax.RecordConstructor (ns,fns) ->
         let uu____736 =
-          let uu____737 = FStar_Ident.path_of_ns ns  in
-          FStar_Ident.text_of_path uu____737  in
+          let uu____737 = FStar_Ident.path_of_ns ns in
+          FStar_Ident.text_of_path uu____737 in
         let uu____740 =
           let uu____741 =
-            FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id)
-             in
-          FStar_All.pipe_right uu____741 (FStar_String.concat ", ")  in
+            FStar_All.pipe_right fns (FStar_List.map FStar_Ident.text_of_id) in
+          FStar_All.pipe_right uu____741 (FStar_String.concat ", ") in
         FStar_Util.format2 "(RecordConstructor %s %s)" uu____736 uu____740
     | FStar_Syntax_Syntax.Action eff_lid ->
-        let uu____751 = lid_to_string eff_lid  in
+        let uu____751 = lid_to_string eff_lid in
         FStar_Util.format1 "(Action %s)" uu____751
     | FStar_Syntax_Syntax.ExceptionConstructor  -> "ExceptionConstructor"
     | FStar_Syntax_Syntax.HasMaskedEffect  -> "HasMaskedEffect"
@@ -382,38 +346,34 @@ let (qual_to_string : FStar_Syntax_Syntax.qualifier -> Prims.string) =
     | FStar_Syntax_Syntax.Reflectable l ->
         FStar_Util.format1 "(reflect %s)" l.FStar_Ident.str
     | FStar_Syntax_Syntax.OnlyName  -> "OnlyName"
-  
-let (quals_to_string :
-  FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string) =
+let quals_to_string: FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string
+  =
   fun quals  ->
     match quals with
     | [] -> ""
     | uu____760 ->
         let uu____763 =
-          FStar_All.pipe_right quals (FStar_List.map qual_to_string)  in
+          FStar_All.pipe_right quals (FStar_List.map qual_to_string) in
         FStar_All.pipe_right uu____763 (FStar_String.concat " ")
-  
-let (quals_to_string' :
-  FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string) =
+let quals_to_string':
+  FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string =
   fun quals  ->
     match quals with
     | [] -> ""
     | uu____779 ->
-        let uu____782 = quals_to_string quals  in Prims.strcat uu____782 " "
-  
-let (paren : Prims.string -> Prims.string) =
-  fun s  -> Prims.strcat "(" (Prims.strcat s ")") 
-let rec (tag_of_term : FStar_Syntax_Syntax.term -> Prims.string) =
+        let uu____782 = quals_to_string quals in Prims.strcat uu____782 " "
+let paren: Prims.string -> Prims.string =
+  fun s  -> Prims.strcat "(" (Prims.strcat s ")")
+let rec tag_of_term: FStar_Syntax_Syntax.term -> Prims.string =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_bvar x ->
-        let uu____848 = db_to_string x  in Prims.strcat "Tm_bvar: " uu____848
+        let uu____848 = db_to_string x in Prims.strcat "Tm_bvar: " uu____848
     | FStar_Syntax_Syntax.Tm_name x ->
-        let uu____850 = nm_to_string x  in Prims.strcat "Tm_name: " uu____850
+        let uu____850 = nm_to_string x in Prims.strcat "Tm_name: " uu____850
     | FStar_Syntax_Syntax.Tm_fvar x ->
         let uu____852 =
-          lid_to_string (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-           in
+          lid_to_string (x.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
         Prims.strcat "Tm_fvar: " uu____852
     | FStar_Syntax_Syntax.Tm_uinst uu____853 -> "Tm_uinst"
     | FStar_Syntax_Syntax.Tm_constant uu____860 -> "Tm_constant"
@@ -427,31 +387,29 @@ let rec (tag_of_term : FStar_Syntax_Syntax.term -> Prims.string) =
     | FStar_Syntax_Syntax.Tm_let uu____964 -> "Tm_let"
     | FStar_Syntax_Syntax.Tm_uvar uu____977 -> "Tm_uvar"
     | FStar_Syntax_Syntax.Tm_delayed (uu____994,m) ->
-        let uu____1036 = FStar_ST.op_Bang m  in
+        let uu____1036 = FStar_ST.op_Bang m in
         (match uu____1036 with
          | FStar_Pervasives_Native.None  -> "Tm_delayed"
          | FStar_Pervasives_Native.Some uu____1092 -> "Tm_delayed-resolved")
     | FStar_Syntax_Syntax.Tm_meta (uu____1097,m) ->
-        let uu____1103 = metadata_to_string m  in
+        let uu____1103 = metadata_to_string m in
         Prims.strcat "Tm_meta:" uu____1103
     | FStar_Syntax_Syntax.Tm_unknown  -> "Tm_unknown"
-
-and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
+and term_to_string: FStar_Syntax_Syntax.term -> Prims.string =
   fun x  ->
     let uu____1105 =
-      let uu____1106 = FStar_Options.ugly ()  in Prims.op_Negation uu____1106
-       in
+      let uu____1106 = FStar_Options.ugly () in Prims.op_Negation uu____1106 in
     if uu____1105
     then
-      let e = FStar_Syntax_Resugar.resugar_term x  in
-      let d = FStar_Parser_ToDocument.term_to_document e  in
+      let e = FStar_Syntax_Resugar.resugar_term x in
+      let d = FStar_Parser_ToDocument.term_to_document e in
       FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
         (Prims.parse_int "100") d
     else
-      (let x1 = FStar_Syntax_Subst.compress x  in
+      (let x1 = FStar_Syntax_Subst.compress x in
        let x2 =
-         let uu____1112 = FStar_Options.print_implicits ()  in
-         if uu____1112 then x1 else FStar_Syntax_Util.unmeta x1  in
+         let uu____1112 = FStar_Options.print_implicits () in
+         if uu____1112 then x1 else FStar_Syntax_Util.unmeta x1 in
        match x2.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Tm_delayed uu____1114 -> failwith "impossible"
        | FStar_Syntax_Syntax.Tm_app (uu____1139,[]) -> failwith "Empty args!"
@@ -467,29 +425,27 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                            (FStar_List.map
                               (fun uu____1223  ->
                                  match uu____1223 with
-                                 | (t1,uu____1229) -> term_to_string t1))
-                          in
+                                 | (t1,uu____1229) -> term_to_string t1)) in
                        FStar_All.pipe_right uu____1205
-                         (FStar_String.concat "; ")))
-                in
-             FStar_All.pipe_right uu____1175 (FStar_String.concat "\\/")  in
-           let uu____1234 = term_to_string t  in
+                         (FStar_String.concat "; "))) in
+             FStar_All.pipe_right uu____1175 (FStar_String.concat "\\/") in
+           let uu____1234 = term_to_string t in
            FStar_Util.format2 "{:pattern %s} %s" pats uu____1234
        | FStar_Syntax_Syntax.Tm_meta
            (t,FStar_Syntax_Syntax.Meta_monadic (m,t')) ->
-           let uu____1246 = tag_of_term t  in
-           let uu____1247 = sli m  in
-           let uu____1248 = term_to_string t'  in
-           let uu____1249 = term_to_string t  in
+           let uu____1246 = tag_of_term t in
+           let uu____1247 = sli m in
+           let uu____1248 = term_to_string t' in
+           let uu____1249 = term_to_string t in
            FStar_Util.format4 "(Monadic-%s{%s %s} %s)" uu____1246 uu____1247
              uu____1248 uu____1249
        | FStar_Syntax_Syntax.Tm_meta
            (t,FStar_Syntax_Syntax.Meta_monadic_lift (m0,m1,t')) ->
-           let uu____1262 = tag_of_term t  in
-           let uu____1263 = term_to_string t'  in
-           let uu____1264 = sli m0  in
-           let uu____1265 = sli m1  in
-           let uu____1266 = term_to_string t  in
+           let uu____1262 = tag_of_term t in
+           let uu____1263 = term_to_string t' in
+           let uu____1264 = sli m0 in
+           let uu____1265 = sli m1 in
+           let uu____1266 = term_to_string t in
            FStar_Util.format5 "(MonadicLift-%s{%s : %s -> %s} %s)" uu____1262
              uu____1263 uu____1264 uu____1265 uu____1266
        | FStar_Syntax_Syntax.Tm_meta
@@ -497,81 +453,78 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
            FStar_Util.format1 "(Meta_alien \"%s\")" s
        | FStar_Syntax_Syntax.Tm_meta
            (t,FStar_Syntax_Syntax.Meta_labeled (l,r,b)) ->
-           let uu____1287 = FStar_Range.string_of_range r  in
-           let uu____1288 = term_to_string t  in
+           let uu____1287 = FStar_Range.string_of_range r in
+           let uu____1288 = term_to_string t in
            FStar_Util.format3 "Meta_labeled(%s, %s){%s}" l uu____1287
              uu____1288
        | FStar_Syntax_Syntax.Tm_meta (t,FStar_Syntax_Syntax.Meta_named l) ->
-           let uu____1295 = lid_to_string l  in
+           let uu____1295 = lid_to_string l in
            let uu____1296 =
-             FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos  in
-           let uu____1297 = term_to_string t  in
+             FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos in
+           let uu____1297 = term_to_string t in
            FStar_Util.format3 "Meta_named(%s, %s){%s}" uu____1295 uu____1296
              uu____1297
        | FStar_Syntax_Syntax.Tm_meta
            (t,FStar_Syntax_Syntax.Meta_desugared uu____1299) ->
-           let uu____1304 = term_to_string t  in
+           let uu____1304 = term_to_string t in
            FStar_Util.format1 "Meta_desugared{%s}" uu____1304
        | FStar_Syntax_Syntax.Tm_bvar x3 ->
-           let uu____1306 = db_to_string x3  in
+           let uu____1306 = db_to_string x3 in
            let uu____1307 =
              let uu____1308 =
-               let uu____1309 = tag_of_term x3.FStar_Syntax_Syntax.sort  in
-               Prims.strcat uu____1309 ")"  in
-             Prims.strcat ":(" uu____1308  in
+               let uu____1309 = tag_of_term x3.FStar_Syntax_Syntax.sort in
+               Prims.strcat uu____1309 ")" in
+             Prims.strcat ":(" uu____1308 in
            Prims.strcat uu____1306 uu____1307
        | FStar_Syntax_Syntax.Tm_name x3 -> nm_to_string x3
        | FStar_Syntax_Syntax.Tm_fvar f -> fv_to_string f
        | FStar_Syntax_Syntax.Tm_uvar (u,uu____1313) -> uvar_to_string u
        | FStar_Syntax_Syntax.Tm_constant c -> const_to_string c
        | FStar_Syntax_Syntax.Tm_type u ->
-           let uu____1340 = FStar_Options.print_universes ()  in
+           let uu____1340 = FStar_Options.print_universes () in
            if uu____1340
            then
-             let uu____1341 = univ_to_string u  in
+             let uu____1341 = univ_to_string u in
              FStar_Util.format1 "Type u#(%s)" uu____1341
            else "Type"
        | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-           let uu____1361 = binders_to_string " -> " bs  in
-           let uu____1362 = comp_to_string c  in
+           let uu____1361 = binders_to_string " -> " bs in
+           let uu____1362 = comp_to_string c in
            FStar_Util.format2 "(%s -> %s)" uu____1361 uu____1362
        | FStar_Syntax_Syntax.Tm_abs (bs,t2,lc) ->
            (match lc with
             | FStar_Pervasives_Native.Some rc when
                 FStar_Options.print_implicits () ->
-                let uu____1387 = binders_to_string " " bs  in
-                let uu____1388 = term_to_string t2  in
+                let uu____1387 = binders_to_string " " bs in
+                let uu____1388 = term_to_string t2 in
                 let uu____1389 =
                   if FStar_Option.isNone rc.FStar_Syntax_Syntax.residual_typ
                   then "None"
                   else
                     (let uu____1393 =
-                       FStar_Option.get rc.FStar_Syntax_Syntax.residual_typ
-                        in
-                     term_to_string uu____1393)
-                   in
+                       FStar_Option.get rc.FStar_Syntax_Syntax.residual_typ in
+                     term_to_string uu____1393) in
                 FStar_Util.format4 "(fun %s -> (%s $$ (residual) %s %s))"
                   uu____1387 uu____1388
                   (rc.FStar_Syntax_Syntax.residual_effect).FStar_Ident.str
                   uu____1389
             | uu____1396 ->
-                let uu____1399 = binders_to_string " " bs  in
-                let uu____1400 = term_to_string t2  in
+                let uu____1399 = binders_to_string " " bs in
+                let uu____1400 = term_to_string t2 in
                 FStar_Util.format2 "(fun %s -> %s)" uu____1399 uu____1400)
        | FStar_Syntax_Syntax.Tm_refine (xt,f) ->
-           let uu____1407 = bv_to_string xt  in
+           let uu____1407 = bv_to_string xt in
            let uu____1408 =
-             FStar_All.pipe_right xt.FStar_Syntax_Syntax.sort term_to_string
-              in
-           let uu____1411 = FStar_All.pipe_right f formula_to_string  in
+             FStar_All.pipe_right xt.FStar_Syntax_Syntax.sort term_to_string in
+           let uu____1411 = FStar_All.pipe_right f formula_to_string in
            FStar_Util.format3 "(%s:%s{%s})" uu____1407 uu____1408 uu____1411
        | FStar_Syntax_Syntax.Tm_app (t,args) ->
-           let uu____1436 = term_to_string t  in
-           let uu____1437 = args_to_string args  in
+           let uu____1436 = term_to_string t in
+           let uu____1437 = args_to_string args in
            FStar_Util.format2 "(%s %s)" uu____1436 uu____1437
        | FStar_Syntax_Syntax.Tm_let (lbs,e) ->
-           let uu____1456 = lbs_to_string [] lbs  in
-           let uu____1457 = term_to_string e  in
+           let uu____1456 = lbs_to_string [] lbs in
+           let uu____1457 = term_to_string e in
            FStar_Util.format2 "%s\nin\n%s" uu____1456 uu____1457
        | FStar_Syntax_Syntax.Tm_ascribed (e,(annot,topt),eff_name) ->
            let annot1 =
@@ -579,24 +532,22 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
              | FStar_Util.Inl t ->
                  let uu____1518 =
                    let uu____1519 =
-                     FStar_Util.map_opt eff_name FStar_Ident.text_of_lid  in
+                     FStar_Util.map_opt eff_name FStar_Ident.text_of_lid in
                    FStar_All.pipe_right uu____1519
-                     (FStar_Util.dflt "default")
-                    in
-                 let uu____1524 = term_to_string t  in
+                     (FStar_Util.dflt "default") in
+                 let uu____1524 = term_to_string t in
                  FStar_Util.format2 "[%s] %s" uu____1518 uu____1524
-             | FStar_Util.Inr c -> comp_to_string c  in
+             | FStar_Util.Inr c -> comp_to_string c in
            let topt1 =
              match topt with
              | FStar_Pervasives_Native.None  -> ""
              | FStar_Pervasives_Native.Some t ->
-                 let uu____1540 = term_to_string t  in
-                 FStar_Util.format1 "by %s" uu____1540
-              in
-           let uu____1541 = term_to_string e  in
+                 let uu____1540 = term_to_string t in
+                 FStar_Util.format1 "by %s" uu____1540 in
+           let uu____1541 = term_to_string e in
            FStar_Util.format3 "(%s <ascribed: %s %s)" uu____1541 annot1 topt1
        | FStar_Syntax_Syntax.Tm_match (head1,branches) ->
-           let uu____1580 = term_to_string head1  in
+           let uu____1580 = term_to_string head1 in
            let uu____1581 =
              let uu____1582 =
                FStar_All.pipe_right branches
@@ -605,128 +556,118 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                        match uu____1618 with
                        | (p,wopt,e) ->
                            let uu____1634 =
-                             FStar_All.pipe_right p pat_to_string  in
+                             FStar_All.pipe_right p pat_to_string in
                            let uu____1635 =
                              match wopt with
                              | FStar_Pervasives_Native.None  -> ""
                              | FStar_Pervasives_Native.Some w ->
                                  let uu____1637 =
-                                   FStar_All.pipe_right w term_to_string  in
-                                 FStar_Util.format1 "when %s" uu____1637
-                              in
+                                   FStar_All.pipe_right w term_to_string in
+                                 FStar_Util.format1 "when %s" uu____1637 in
                            let uu____1638 =
-                             FStar_All.pipe_right e term_to_string  in
+                             FStar_All.pipe_right e term_to_string in
                            FStar_Util.format3 "%s %s -> %s" uu____1634
-                             uu____1635 uu____1638))
-                in
-             FStar_Util.concat_l "\n\t|" uu____1582  in
+                             uu____1635 uu____1638)) in
+             FStar_Util.concat_l "\n\t|" uu____1582 in
            FStar_Util.format2 "(match %s with\n\t| %s)" uu____1580 uu____1581
        | FStar_Syntax_Syntax.Tm_uinst (t,us) ->
-           let uu____1645 = FStar_Options.print_universes ()  in
+           let uu____1645 = FStar_Options.print_universes () in
            if uu____1645
            then
-             let uu____1646 = term_to_string t  in
-             let uu____1647 = univs_to_string us  in
+             let uu____1646 = term_to_string t in
+             let uu____1647 = univs_to_string us in
              FStar_Util.format2 "%s<%s>" uu____1646 uu____1647
            else term_to_string t
        | uu____1649 -> tag_of_term x2)
-
-and (pat_to_string : FStar_Syntax_Syntax.pat -> Prims.string) =
+and pat_to_string: FStar_Syntax_Syntax.pat -> Prims.string =
   fun x  ->
     let uu____1651 =
-      let uu____1652 = FStar_Options.ugly ()  in Prims.op_Negation uu____1652
-       in
+      let uu____1652 = FStar_Options.ugly () in Prims.op_Negation uu____1652 in
     if uu____1651
     then
-      let e = FStar_Syntax_Resugar.resugar_pat x  in
-      let d = FStar_Parser_ToDocument.pat_to_document e  in
+      let e = FStar_Syntax_Resugar.resugar_pat x in
+      let d = FStar_Parser_ToDocument.pat_to_document e in
       FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
         (Prims.parse_int "100") d
     else
       (match x.FStar_Syntax_Syntax.v with
        | FStar_Syntax_Syntax.Pat_cons (l,pats) ->
-           let uu____1674 = fv_to_string l  in
+           let uu____1674 = fv_to_string l in
            let uu____1675 =
              let uu____1676 =
                FStar_List.map
                  (fun uu____1687  ->
                     match uu____1687 with
                     | (x1,b) ->
-                        let p = pat_to_string x1  in
-                        if b then Prims.strcat "#" p else p) pats
-                in
-             FStar_All.pipe_right uu____1676 (FStar_String.concat " ")  in
+                        let p = pat_to_string x1 in
+                        if b then Prims.strcat "#" p else p) pats in
+             FStar_All.pipe_right uu____1676 (FStar_String.concat " ") in
            FStar_Util.format2 "(%s %s)" uu____1674 uu____1675
        | FStar_Syntax_Syntax.Pat_dot_term (x1,uu____1699) ->
-           let uu____1704 = FStar_Options.print_bound_var_types ()  in
+           let uu____1704 = FStar_Options.print_bound_var_types () in
            if uu____1704
            then
-             let uu____1705 = bv_to_string x1  in
-             let uu____1706 = term_to_string x1.FStar_Syntax_Syntax.sort  in
+             let uu____1705 = bv_to_string x1 in
+             let uu____1706 = term_to_string x1.FStar_Syntax_Syntax.sort in
              FStar_Util.format2 ".%s:%s" uu____1705 uu____1706
            else
-             (let uu____1708 = bv_to_string x1  in
+             (let uu____1708 = bv_to_string x1 in
               FStar_Util.format1 ".%s" uu____1708)
        | FStar_Syntax_Syntax.Pat_var x1 ->
-           let uu____1710 = FStar_Options.print_bound_var_types ()  in
+           let uu____1710 = FStar_Options.print_bound_var_types () in
            if uu____1710
            then
-             let uu____1711 = bv_to_string x1  in
-             let uu____1712 = term_to_string x1.FStar_Syntax_Syntax.sort  in
+             let uu____1711 = bv_to_string x1 in
+             let uu____1712 = term_to_string x1.FStar_Syntax_Syntax.sort in
              FStar_Util.format2 "%s:%s" uu____1711 uu____1712
            else bv_to_string x1
        | FStar_Syntax_Syntax.Pat_constant c -> const_to_string c
        | FStar_Syntax_Syntax.Pat_wild x1 ->
-           let uu____1716 = FStar_Options.print_real_names ()  in
+           let uu____1716 = FStar_Options.print_real_names () in
            if uu____1716
            then
-             let uu____1717 = bv_to_string x1  in
+             let uu____1717 = bv_to_string x1 in
              Prims.strcat "Pat_wild " uu____1717
            else "_")
-
-and (lbs_to_string :
+and lbs_to_string:
   FStar_Syntax_Syntax.qualifier Prims.list ->
     (Prims.bool,FStar_Syntax_Syntax.letbinding Prims.list)
-      FStar_Pervasives_Native.tuple2 -> Prims.string)
+      FStar_Pervasives_Native.tuple2 -> Prims.string
   =
   fun quals  ->
     fun lbs  ->
-      let uu____1729 = quals_to_string' quals  in
+      let uu____1729 = quals_to_string' quals in
       let uu____1730 =
         let uu____1731 =
           FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
             (FStar_List.map
                (fun lb  ->
                   let uu____1747 =
-                    attrs_to_string lb.FStar_Syntax_Syntax.lbattrs  in
+                    attrs_to_string lb.FStar_Syntax_Syntax.lbattrs in
                   let uu____1748 =
-                    lbname_to_string lb.FStar_Syntax_Syntax.lbname  in
+                    lbname_to_string lb.FStar_Syntax_Syntax.lbname in
                   let uu____1749 =
-                    let uu____1750 = FStar_Options.print_universes ()  in
+                    let uu____1750 = FStar_Options.print_universes () in
                     if uu____1750
                     then
                       let uu____1751 =
                         let uu____1752 =
-                          univ_names_to_string lb.FStar_Syntax_Syntax.lbunivs
-                           in
-                        Prims.strcat uu____1752 ">"  in
+                          univ_names_to_string lb.FStar_Syntax_Syntax.lbunivs in
+                        Prims.strcat uu____1752 ">" in
                       Prims.strcat "<" uu____1751
-                    else ""  in
+                    else "" in
                   let uu____1754 =
-                    term_to_string lb.FStar_Syntax_Syntax.lbtyp  in
+                    term_to_string lb.FStar_Syntax_Syntax.lbtyp in
                   let uu____1755 =
                     FStar_All.pipe_right lb.FStar_Syntax_Syntax.lbdef
-                      term_to_string
-                     in
+                      term_to_string in
                   FStar_Util.format5 "%s%s %s : %s = %s" uu____1747
-                    uu____1748 uu____1749 uu____1754 uu____1755))
-           in
-        FStar_Util.concat_l "\n and " uu____1731  in
+                    uu____1748 uu____1749 uu____1754 uu____1755)) in
+        FStar_Util.concat_l "\n and " uu____1731 in
       FStar_Util.format3 "%slet %s %s" uu____1729
         (if FStar_Pervasives_Native.fst lbs then "rec" else "") uu____1730
-
-and (attrs_to_string :
-  FStar_Syntax_Syntax.attribute Prims.list -> Prims.string) =
+and attrs_to_string: FStar_Syntax_Syntax.attribute Prims.list -> Prims.string
+  =
   fun uu___71_1761  ->
     match uu___71_1761 with
     | [] -> ""
@@ -735,24 +676,21 @@ and (attrs_to_string :
           let uu____1768 =
             FStar_List.map
               (fun t  ->
-                 let uu____1774 = term_to_string t  in paren uu____1774) tms
-             in
-          FStar_All.pipe_right uu____1768 (FStar_String.concat "; ")  in
+                 let uu____1774 = term_to_string t in paren uu____1774) tms in
+          FStar_All.pipe_right uu____1768 (FStar_String.concat "; ") in
         FStar_Util.format1 "[@ %s]" uu____1767
-
-and (lcomp_to_string : FStar_Syntax_Syntax.lcomp -> Prims.string) =
+and lcomp_to_string: FStar_Syntax_Syntax.lcomp -> Prims.string =
   fun lc  ->
-    let uu____1778 = FStar_Options.print_effect_args ()  in
+    let uu____1778 = FStar_Options.print_effect_args () in
     if uu____1778
     then
-      let uu____1779 = FStar_Syntax_Syntax.lcomp_comp lc  in
+      let uu____1779 = FStar_Syntax_Syntax.lcomp_comp lc in
       comp_to_string uu____1779
     else
-      (let uu____1781 = sli lc.FStar_Syntax_Syntax.eff_name  in
-       let uu____1782 = term_to_string lc.FStar_Syntax_Syntax.res_typ  in
+      (let uu____1781 = sli lc.FStar_Syntax_Syntax.eff_name in
+       let uu____1782 = term_to_string lc.FStar_Syntax_Syntax.res_typ in
        FStar_Util.format2 "%s %s" uu____1781 uu____1782)
-
-and (aqual_to_string : FStar_Syntax_Syntax.aqual -> Prims.string) =
+and aqual_to_string: FStar_Syntax_Syntax.aqual -> Prims.string =
   fun uu___72_1783  ->
     match uu___72_1783 with
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit (false )) ->
@@ -761,186 +699,166 @@ and (aqual_to_string : FStar_Syntax_Syntax.aqual -> Prims.string) =
         "#."
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality ) -> "$"
     | uu____1784 -> ""
-
-and (imp_to_string :
-  Prims.string -> FStar_Syntax_Syntax.aqual -> Prims.string) =
+and imp_to_string: Prims.string -> FStar_Syntax_Syntax.aqual -> Prims.string
+  =
   fun s  ->
     fun aq  ->
-      let uu____1787 = aqual_to_string aq  in Prims.strcat uu____1787 s
-
-and (binder_to_string' :
-  Prims.bool -> FStar_Syntax_Syntax.binder -> Prims.string) =
+      let uu____1787 = aqual_to_string aq in Prims.strcat uu____1787 s
+and binder_to_string':
+  Prims.bool -> FStar_Syntax_Syntax.binder -> Prims.string =
   fun is_arrow  ->
     fun b  ->
       let uu____1790 =
-        let uu____1791 = FStar_Options.ugly ()  in
-        Prims.op_Negation uu____1791  in
+        let uu____1791 = FStar_Options.ugly () in
+        Prims.op_Negation uu____1791 in
       if uu____1790
       then
         let uu____1792 =
-          FStar_Syntax_Resugar.resugar_binder b FStar_Range.dummyRange  in
+          FStar_Syntax_Resugar.resugar_binder b FStar_Range.dummyRange in
         match uu____1792 with
         | FStar_Pervasives_Native.None  -> ""
         | FStar_Pervasives_Native.Some e ->
-            let d = FStar_Parser_ToDocument.binder_to_document e  in
+            let d = FStar_Parser_ToDocument.binder_to_document e in
             FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
               (Prims.parse_int "100") d
       else
-        (let uu____1798 = b  in
+        (let uu____1798 = b in
          match uu____1798 with
          | (a,imp) ->
-             let uu____1801 = FStar_Syntax_Syntax.is_null_binder b  in
+             let uu____1801 = FStar_Syntax_Syntax.is_null_binder b in
              if uu____1801
              then
-               let uu____1802 = term_to_string a.FStar_Syntax_Syntax.sort  in
+               let uu____1802 = term_to_string a.FStar_Syntax_Syntax.sort in
                Prims.strcat "_:" uu____1802
              else
                (let uu____1804 =
                   (Prims.op_Negation is_arrow) &&
-                    (let uu____1806 = FStar_Options.print_bound_var_types ()
-                        in
-                     Prims.op_Negation uu____1806)
-                   in
+                    (let uu____1806 = FStar_Options.print_bound_var_types () in
+                     Prims.op_Negation uu____1806) in
                 if uu____1804
                 then
-                  let uu____1807 = nm_to_string a  in
+                  let uu____1807 = nm_to_string a in
                   imp_to_string uu____1807 imp
                 else
                   (let uu____1809 =
-                     let uu____1810 = nm_to_string a  in
+                     let uu____1810 = nm_to_string a in
                      let uu____1811 =
                        let uu____1812 =
-                         term_to_string a.FStar_Syntax_Syntax.sort  in
-                       Prims.strcat ":" uu____1812  in
-                     Prims.strcat uu____1810 uu____1811  in
+                         term_to_string a.FStar_Syntax_Syntax.sort in
+                       Prims.strcat ":" uu____1812 in
+                     Prims.strcat uu____1810 uu____1811 in
                    imp_to_string uu____1809 imp)))
-
-and (binder_to_string : FStar_Syntax_Syntax.binder -> Prims.string) =
+and binder_to_string: FStar_Syntax_Syntax.binder -> Prims.string =
   fun b  -> binder_to_string' false b
-
-and (arrow_binder_to_string : FStar_Syntax_Syntax.binder -> Prims.string) =
+and arrow_binder_to_string: FStar_Syntax_Syntax.binder -> Prims.string =
   fun b  -> binder_to_string' true b
-
-and (binders_to_string :
-  Prims.string -> FStar_Syntax_Syntax.binders -> Prims.string) =
+and binders_to_string:
+  Prims.string -> FStar_Syntax_Syntax.binders -> Prims.string =
   fun sep  ->
     fun bs  ->
       let bs1 =
-        let uu____1818 = FStar_Options.print_implicits ()  in
-        if uu____1818 then bs else filter_imp bs  in
+        let uu____1818 = FStar_Options.print_implicits () in
+        if uu____1818 then bs else filter_imp bs in
       if sep = " -> "
       then
         let uu____1820 =
-          FStar_All.pipe_right bs1 (FStar_List.map arrow_binder_to_string)
-           in
+          FStar_All.pipe_right bs1 (FStar_List.map arrow_binder_to_string) in
         FStar_All.pipe_right uu____1820 (FStar_String.concat sep)
       else
         (let uu____1828 =
-           FStar_All.pipe_right bs1 (FStar_List.map binder_to_string)  in
+           FStar_All.pipe_right bs1 (FStar_List.map binder_to_string) in
          FStar_All.pipe_right uu____1828 (FStar_String.concat sep))
-
-and (arg_to_string :
+and arg_to_string:
   (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.aqual)
-    FStar_Pervasives_Native.tuple2 -> Prims.string)
+    FStar_Pervasives_Native.tuple2 -> Prims.string
   =
   fun uu___73_1835  ->
     match uu___73_1835 with
     | (a,imp) ->
-        let uu____1842 = term_to_string a  in imp_to_string uu____1842 imp
-
-and (args_to_string : FStar_Syntax_Syntax.args -> Prims.string) =
+        let uu____1842 = term_to_string a in imp_to_string uu____1842 imp
+and args_to_string: FStar_Syntax_Syntax.args -> Prims.string =
   fun args  ->
     let args1 =
-      let uu____1845 = FStar_Options.print_implicits ()  in
-      if uu____1845 then args else filter_imp args  in
+      let uu____1845 = FStar_Options.print_implicits () in
+      if uu____1845 then args else filter_imp args in
     let uu____1849 =
-      FStar_All.pipe_right args1 (FStar_List.map arg_to_string)  in
+      FStar_All.pipe_right args1 (FStar_List.map arg_to_string) in
     FStar_All.pipe_right uu____1849 (FStar_String.concat " ")
-
-and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
+and comp_to_string: FStar_Syntax_Syntax.comp -> Prims.string =
   fun c  ->
     let uu____1861 =
-      let uu____1862 = FStar_Options.ugly ()  in Prims.op_Negation uu____1862
-       in
+      let uu____1862 = FStar_Options.ugly () in Prims.op_Negation uu____1862 in
     if uu____1861
     then
-      let e = FStar_Syntax_Resugar.resugar_comp c  in
-      let d = FStar_Parser_ToDocument.term_to_document e  in
+      let e = FStar_Syntax_Resugar.resugar_comp c in
+      let d = FStar_Parser_ToDocument.term_to_document e in
       FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
         (Prims.parse_int "100") d
     else
       (match c.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Total (t,uopt) ->
            let uu____1876 =
-             let uu____1877 = FStar_Syntax_Subst.compress t  in
-             uu____1877.FStar_Syntax_Syntax.n  in
+             let uu____1877 = FStar_Syntax_Subst.compress t in
+             uu____1877.FStar_Syntax_Syntax.n in
            (match uu____1876 with
             | FStar_Syntax_Syntax.Tm_type uu____1880 when
                 let uu____1881 =
                   (FStar_Options.print_implicits ()) ||
-                    (FStar_Options.print_universes ())
-                   in
+                    (FStar_Options.print_universes ()) in
                 Prims.op_Negation uu____1881 -> term_to_string t
             | uu____1882 ->
                 (match uopt with
                  | FStar_Pervasives_Native.Some u when
                      FStar_Options.print_universes () ->
-                     let uu____1884 = univ_to_string u  in
-                     let uu____1885 = term_to_string t  in
+                     let uu____1884 = univ_to_string u in
+                     let uu____1885 = term_to_string t in
                      FStar_Util.format2 "Tot<%s> %s" uu____1884 uu____1885
                  | uu____1886 ->
-                     let uu____1889 = term_to_string t  in
+                     let uu____1889 = term_to_string t in
                      FStar_Util.format1 "Tot %s" uu____1889))
        | FStar_Syntax_Syntax.GTotal (t,uopt) ->
            let uu____1900 =
-             let uu____1901 = FStar_Syntax_Subst.compress t  in
-             uu____1901.FStar_Syntax_Syntax.n  in
+             let uu____1901 = FStar_Syntax_Subst.compress t in
+             uu____1901.FStar_Syntax_Syntax.n in
            (match uu____1900 with
             | FStar_Syntax_Syntax.Tm_type uu____1904 when
                 let uu____1905 =
                   (FStar_Options.print_implicits ()) ||
-                    (FStar_Options.print_universes ())
-                   in
+                    (FStar_Options.print_universes ()) in
                 Prims.op_Negation uu____1905 -> term_to_string t
             | uu____1906 ->
                 (match uopt with
                  | FStar_Pervasives_Native.Some u when
                      FStar_Options.print_universes () ->
-                     let uu____1908 = univ_to_string u  in
-                     let uu____1909 = term_to_string t  in
+                     let uu____1908 = univ_to_string u in
+                     let uu____1909 = term_to_string t in
                      FStar_Util.format2 "GTot<%s> %s" uu____1908 uu____1909
                  | uu____1910 ->
-                     let uu____1913 = term_to_string t  in
+                     let uu____1913 = term_to_string t in
                      FStar_Util.format1 "GTot %s" uu____1913))
        | FStar_Syntax_Syntax.Comp c1 ->
            let basic =
-             let uu____1916 = FStar_Options.print_effect_args ()  in
+             let uu____1916 = FStar_Options.print_effect_args () in
              if uu____1916
              then
-               let uu____1917 = sli c1.FStar_Syntax_Syntax.effect_name  in
+               let uu____1917 = sli c1.FStar_Syntax_Syntax.effect_name in
                let uu____1918 =
                  let uu____1919 =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.comp_univs
-                     (FStar_List.map univ_to_string)
-                    in
-                 FStar_All.pipe_right uu____1919 (FStar_String.concat ", ")
-                  in
+                     (FStar_List.map univ_to_string) in
+                 FStar_All.pipe_right uu____1919 (FStar_String.concat ", ") in
                let uu____1926 =
-                 term_to_string c1.FStar_Syntax_Syntax.result_typ  in
+                 term_to_string c1.FStar_Syntax_Syntax.result_typ in
                let uu____1927 =
                  let uu____1928 =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.effect_args
-                     (FStar_List.map arg_to_string)
-                    in
-                 FStar_All.pipe_right uu____1928 (FStar_String.concat ", ")
-                  in
+                     (FStar_List.map arg_to_string) in
+                 FStar_All.pipe_right uu____1928 (FStar_String.concat ", ") in
                let uu____1947 =
                  let uu____1948 =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
-                     (FStar_List.map cflags_to_string)
-                    in
-                 FStar_All.pipe_right uu____1948 (FStar_String.concat " ")
-                  in
+                     (FStar_List.map cflags_to_string) in
+                 FStar_All.pipe_right uu____1948 (FStar_String.concat " ") in
                FStar_Util.format5 "%s<%s> (%s) %s (attributes %s)" uu____1917
                  uu____1918 uu____1926 uu____1927 uu____1947
              else
@@ -952,55 +870,46 @@ and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
                            | FStar_Syntax_Syntax.TOTAL  -> true
                            | uu____1963 -> false)))
                     &&
-                    (let uu____1965 = FStar_Options.print_effect_args ()  in
-                     Prims.op_Negation uu____1965)
-                   in
+                    (let uu____1965 = FStar_Options.print_effect_args () in
+                     Prims.op_Negation uu____1965) in
                 if uu____1958
                 then
                   let uu____1966 =
-                    term_to_string c1.FStar_Syntax_Syntax.result_typ  in
+                    term_to_string c1.FStar_Syntax_Syntax.result_typ in
                   FStar_Util.format1 "Tot %s" uu____1966
                 else
                   (let uu____1968 =
-                     ((let uu____1971 = FStar_Options.print_effect_args ()
-                          in
+                     ((let uu____1971 = FStar_Options.print_effect_args () in
                        Prims.op_Negation uu____1971) &&
-                        (let uu____1973 = FStar_Options.print_implicits ()
-                            in
+                        (let uu____1973 = FStar_Options.print_implicits () in
                          Prims.op_Negation uu____1973))
                        &&
                        (FStar_Ident.lid_equals
                           c1.FStar_Syntax_Syntax.effect_name
-                          FStar_Parser_Const.effect_ML_lid)
-                      in
+                          FStar_Parser_Const.effect_ML_lid) in
                    if uu____1968
                    then term_to_string c1.FStar_Syntax_Syntax.result_typ
                    else
                      (let uu____1975 =
-                        (let uu____1978 = FStar_Options.print_effect_args ()
-                            in
+                        (let uu____1978 = FStar_Options.print_effect_args () in
                          Prims.op_Negation uu____1978) &&
                           (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                              (FStar_Util.for_some
                                 (fun uu___75_1982  ->
                                    match uu___75_1982 with
                                    | FStar_Syntax_Syntax.MLEFFECT  -> true
-                                   | uu____1983 -> false)))
-                         in
+                                   | uu____1983 -> false))) in
                       if uu____1975
                       then
                         let uu____1984 =
-                          term_to_string c1.FStar_Syntax_Syntax.result_typ
-                           in
+                          term_to_string c1.FStar_Syntax_Syntax.result_typ in
                         FStar_Util.format1 "ALL %s" uu____1984
                       else
                         (let uu____1986 =
-                           sli c1.FStar_Syntax_Syntax.effect_name  in
+                           sli c1.FStar_Syntax_Syntax.effect_name in
                          let uu____1987 =
-                           term_to_string c1.FStar_Syntax_Syntax.result_typ
-                            in
-                         FStar_Util.format2 "%s (%s)" uu____1986 uu____1987))))
-              in
+                           term_to_string c1.FStar_Syntax_Syntax.result_typ in
+                         FStar_Util.format2 "%s (%s)" uu____1986 uu____1987)))) in
            let dec =
              let uu____1989 =
                FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
@@ -1009,16 +918,13 @@ and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
                        match uu___76_1999 with
                        | FStar_Syntax_Syntax.DECREASES e ->
                            let uu____2005 =
-                             let uu____2006 = term_to_string e  in
-                             FStar_Util.format1 " (decreases %s)" uu____2006
-                              in
+                             let uu____2006 = term_to_string e in
+                             FStar_Util.format1 " (decreases %s)" uu____2006 in
                            [uu____2005]
-                       | uu____2007 -> []))
-                in
-             FStar_All.pipe_right uu____1989 (FStar_String.concat " ")  in
+                       | uu____2007 -> [])) in
+             FStar_All.pipe_right uu____1989 (FStar_String.concat " ") in
            FStar_Util.format2 "%s%s" basic dec)
-
-and (cflags_to_string : FStar_Syntax_Syntax.cflags -> Prims.string) =
+and cflags_to_string: FStar_Syntax_Syntax.cflags -> Prims.string =
   fun c  ->
     match c with
     | FStar_Syntax_Syntax.TOTAL  -> "total"
@@ -1031,12 +937,10 @@ and (cflags_to_string : FStar_Syntax_Syntax.cflags -> Prims.string) =
     | FStar_Syntax_Syntax.LEMMA  -> "lemma"
     | FStar_Syntax_Syntax.CPS  -> "cps"
     | FStar_Syntax_Syntax.DECREASES uu____2011 -> ""
-
-and (formula_to_string :
-  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string) =
+and formula_to_string:
+  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.string =
   fun phi  -> term_to_string phi
-
-and (metadata_to_string : FStar_Syntax_Syntax.metadata -> Prims.string) =
+and metadata_to_string: FStar_Syntax_Syntax.metadata -> Prims.string =
   fun uu___77_2017  ->
     match uu___77_2017 with
     | FStar_Syntax_Syntax.Meta_pattern ps ->
@@ -1050,249 +954,218 @@ and (metadata_to_string : FStar_Syntax_Syntax.metadata -> Prims.string) =
                         (FStar_List.map
                            (fun uu____2078  ->
                               match uu____2078 with
-                              | (t,uu____2084) -> term_to_string t))
-                       in
+                              | (t,uu____2084) -> term_to_string t)) in
                     FStar_All.pipe_right uu____2060
-                      (FStar_String.concat "; ")))
-             in
-          FStar_All.pipe_right uu____2030 (FStar_String.concat "\\/")  in
+                      (FStar_String.concat "; "))) in
+          FStar_All.pipe_right uu____2030 (FStar_String.concat "\\/") in
         FStar_Util.format1 "{Meta_pattern %s}" pats
     | FStar_Syntax_Syntax.Meta_named lid ->
-        let uu____2090 = sli lid  in
+        let uu____2090 = sli lid in
         FStar_Util.format1 "{Meta_named %s}" uu____2090
     | FStar_Syntax_Syntax.Meta_labeled (l,r,uu____2093) ->
-        let uu____2094 = FStar_Range.string_of_range r  in
+        let uu____2094 = FStar_Range.string_of_range r in
         FStar_Util.format2 "{Meta_labeled (%s, %s)}" l uu____2094
     | FStar_Syntax_Syntax.Meta_desugared msi -> "{Meta_desugared}"
     | FStar_Syntax_Syntax.Meta_monadic (m,t) ->
-        let uu____2102 = sli m  in
-        let uu____2103 = term_to_string t  in
+        let uu____2102 = sli m in
+        let uu____2103 = term_to_string t in
         FStar_Util.format2 "{Meta_monadic(%s @ %s)}" uu____2102 uu____2103
     | FStar_Syntax_Syntax.Meta_monadic_lift (m,m',t) ->
-        let uu____2111 = sli m  in
-        let uu____2112 = sli m'  in
-        let uu____2113 = term_to_string t  in
+        let uu____2111 = sli m in
+        let uu____2112 = sli m' in
+        let uu____2113 = term_to_string t in
         FStar_Util.format3 "{Meta_monadic_lift(%s -> %s @ %s)}" uu____2111
           uu____2112 uu____2113
     | FStar_Syntax_Syntax.Meta_alien (uu____2114,s,t) ->
-        let uu____2121 = term_to_string t  in
+        let uu____2121 = term_to_string t in
         FStar_Util.format2 "{Meta_alien (%s, %s)}" s uu____2121
-
-let (binder_to_json : FStar_Syntax_Syntax.binder -> FStar_Util.json) =
+let binder_to_json: FStar_Syntax_Syntax.binder -> FStar_Util.json =
   fun b  ->
-    let uu____2125 = b  in
+    let uu____2125 = b in
     match uu____2125 with
     | (a,imp) ->
         let n1 =
-          let uu____2129 = FStar_Syntax_Syntax.is_null_binder b  in
+          let uu____2129 = FStar_Syntax_Syntax.is_null_binder b in
           if uu____2129
           then FStar_Util.JsonNull
           else
             (let uu____2131 =
-               let uu____2132 = nm_to_string a  in
-               imp_to_string uu____2132 imp  in
-             FStar_Util.JsonStr uu____2131)
-           in
+               let uu____2132 = nm_to_string a in
+               imp_to_string uu____2132 imp in
+             FStar_Util.JsonStr uu____2131) in
         let t =
-          let uu____2134 = term_to_string a.FStar_Syntax_Syntax.sort  in
-          FStar_Util.JsonStr uu____2134  in
+          let uu____2134 = term_to_string a.FStar_Syntax_Syntax.sort in
+          FStar_Util.JsonStr uu____2134 in
         FStar_Util.JsonAssoc [("name", n1); ("type", t)]
-  
-let (binders_to_json : FStar_Syntax_Syntax.binders -> FStar_Util.json) =
+let binders_to_json: FStar_Syntax_Syntax.binders -> FStar_Util.json =
   fun bs  ->
-    let uu____2150 = FStar_List.map binder_to_json bs  in
+    let uu____2150 = FStar_List.map binder_to_json bs in
     FStar_Util.JsonList uu____2150
-  
-let (enclose_universes : Prims.string -> Prims.string) =
+let enclose_universes: Prims.string -> Prims.string =
   fun s  ->
-    let uu____2156 = FStar_Options.print_universes ()  in
+    let uu____2156 = FStar_Options.print_universes () in
     if uu____2156 then Prims.strcat "<" (Prims.strcat s ">") else ""
-  
-let (tscheme_to_string : FStar_Syntax_Syntax.tscheme -> Prims.string) =
+let tscheme_to_string: FStar_Syntax_Syntax.tscheme -> Prims.string =
   fun s  ->
     let uu____2161 =
-      let uu____2162 = FStar_Options.ugly ()  in Prims.op_Negation uu____2162
-       in
+      let uu____2162 = FStar_Options.ugly () in Prims.op_Negation uu____2162 in
     if uu____2161
     then
-      let d = FStar_Syntax_Resugar.resugar_tscheme s  in
-      let d1 = FStar_Parser_ToDocument.decl_to_document d  in
+      let d = FStar_Syntax_Resugar.resugar_tscheme s in
+      let d1 = FStar_Parser_ToDocument.decl_to_document d in
       FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
         (Prims.parse_int "100") d1
     else
-      (let uu____2166 = s  in
+      (let uu____2166 = s in
        match uu____2166 with
        | (us,t) ->
            let uu____2173 =
-             let uu____2174 = univ_names_to_string us  in
-             FStar_All.pipe_left enclose_universes uu____2174  in
-           let uu____2175 = term_to_string t  in
+             let uu____2174 = univ_names_to_string us in
+             FStar_All.pipe_left enclose_universes uu____2174 in
+           let uu____2175 = term_to_string t in
            FStar_Util.format2 "%s%s" uu____2173 uu____2175)
-  
-let (action_to_string : FStar_Syntax_Syntax.action -> Prims.string) =
+let action_to_string: FStar_Syntax_Syntax.action -> Prims.string =
   fun a  ->
-    let uu____2179 = sli a.FStar_Syntax_Syntax.action_name  in
+    let uu____2179 = sli a.FStar_Syntax_Syntax.action_name in
     let uu____2180 =
-      binders_to_string " " a.FStar_Syntax_Syntax.action_params  in
+      binders_to_string " " a.FStar_Syntax_Syntax.action_params in
     let uu____2181 =
       let uu____2182 =
-        univ_names_to_string a.FStar_Syntax_Syntax.action_univs  in
-      FStar_All.pipe_left enclose_universes uu____2182  in
-    let uu____2183 = term_to_string a.FStar_Syntax_Syntax.action_typ  in
-    let uu____2184 = term_to_string a.FStar_Syntax_Syntax.action_defn  in
+        univ_names_to_string a.FStar_Syntax_Syntax.action_univs in
+      FStar_All.pipe_left enclose_universes uu____2182 in
+    let uu____2183 = term_to_string a.FStar_Syntax_Syntax.action_typ in
+    let uu____2184 = term_to_string a.FStar_Syntax_Syntax.action_defn in
     FStar_Util.format5 "%s%s %s : %s = %s" uu____2179 uu____2180 uu____2181
       uu____2183 uu____2184
-  
-let (eff_decl_to_string' :
+let eff_decl_to_string':
   Prims.bool ->
     FStar_Range.range ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
-        FStar_Syntax_Syntax.eff_decl -> Prims.string)
+        FStar_Syntax_Syntax.eff_decl -> Prims.string
   =
   fun for_free  ->
     fun r  ->
       fun q  ->
         fun ed  ->
           let uu____2201 =
-            let uu____2202 = FStar_Options.ugly ()  in
-            Prims.op_Negation uu____2202  in
+            let uu____2202 = FStar_Options.ugly () in
+            Prims.op_Negation uu____2202 in
           if uu____2201
           then
-            let d = FStar_Syntax_Resugar.resugar_eff_decl for_free r q ed  in
-            let d1 = FStar_Parser_ToDocument.decl_to_document d  in
+            let d = FStar_Syntax_Resugar.resugar_eff_decl for_free r q ed in
+            let d1 = FStar_Parser_ToDocument.decl_to_document d in
             FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
               (Prims.parse_int "100") d1
           else
             (let actions_to_string actions =
                let uu____2214 =
                  FStar_All.pipe_right actions
-                   (FStar_List.map action_to_string)
-                  in
-               FStar_All.pipe_right uu____2214 (FStar_String.concat ",\n\t")
-                in
+                   (FStar_List.map action_to_string) in
+               FStar_All.pipe_right uu____2214 (FStar_String.concat ",\n\t") in
              let uu____2223 =
                let uu____2226 =
-                 let uu____2229 = lid_to_string ed.FStar_Syntax_Syntax.mname
-                    in
+                 let uu____2229 = lid_to_string ed.FStar_Syntax_Syntax.mname in
                  let uu____2230 =
                    let uu____2233 =
                      let uu____2234 =
-                       univ_names_to_string ed.FStar_Syntax_Syntax.univs  in
-                     FStar_All.pipe_left enclose_universes uu____2234  in
+                       univ_names_to_string ed.FStar_Syntax_Syntax.univs in
+                     FStar_All.pipe_left enclose_universes uu____2234 in
                    let uu____2235 =
                      let uu____2238 =
-                       binders_to_string " " ed.FStar_Syntax_Syntax.binders
-                        in
+                       binders_to_string " " ed.FStar_Syntax_Syntax.binders in
                      let uu____2239 =
                        let uu____2242 =
-                         term_to_string ed.FStar_Syntax_Syntax.signature  in
+                         term_to_string ed.FStar_Syntax_Syntax.signature in
                        let uu____2243 =
                          let uu____2246 =
-                           tscheme_to_string ed.FStar_Syntax_Syntax.ret_wp
-                            in
+                           tscheme_to_string ed.FStar_Syntax_Syntax.ret_wp in
                          let uu____2247 =
                            let uu____2250 =
-                             tscheme_to_string ed.FStar_Syntax_Syntax.bind_wp
-                              in
+                             tscheme_to_string ed.FStar_Syntax_Syntax.bind_wp in
                            let uu____2251 =
                              let uu____2254 =
                                tscheme_to_string
-                                 ed.FStar_Syntax_Syntax.if_then_else
-                                in
+                                 ed.FStar_Syntax_Syntax.if_then_else in
                              let uu____2255 =
                                let uu____2258 =
                                  tscheme_to_string
-                                   ed.FStar_Syntax_Syntax.ite_wp
-                                  in
+                                   ed.FStar_Syntax_Syntax.ite_wp in
                                let uu____2259 =
                                  let uu____2262 =
                                    tscheme_to_string
-                                     ed.FStar_Syntax_Syntax.stronger
-                                    in
+                                     ed.FStar_Syntax_Syntax.stronger in
                                  let uu____2263 =
                                    let uu____2266 =
                                      tscheme_to_string
-                                       ed.FStar_Syntax_Syntax.close_wp
-                                      in
+                                       ed.FStar_Syntax_Syntax.close_wp in
                                    let uu____2267 =
                                      let uu____2270 =
                                        tscheme_to_string
-                                         ed.FStar_Syntax_Syntax.assert_p
-                                        in
+                                         ed.FStar_Syntax_Syntax.assert_p in
                                      let uu____2271 =
                                        let uu____2274 =
                                          tscheme_to_string
-                                           ed.FStar_Syntax_Syntax.assume_p
-                                          in
+                                           ed.FStar_Syntax_Syntax.assume_p in
                                        let uu____2275 =
                                          let uu____2278 =
                                            tscheme_to_string
-                                             ed.FStar_Syntax_Syntax.null_wp
-                                            in
+                                             ed.FStar_Syntax_Syntax.null_wp in
                                          let uu____2279 =
                                            let uu____2282 =
                                              tscheme_to_string
-                                               ed.FStar_Syntax_Syntax.trivial
-                                              in
+                                               ed.FStar_Syntax_Syntax.trivial in
                                            let uu____2283 =
                                              let uu____2286 =
                                                term_to_string
-                                                 ed.FStar_Syntax_Syntax.repr
-                                                in
+                                                 ed.FStar_Syntax_Syntax.repr in
                                              let uu____2287 =
                                                let uu____2290 =
                                                  tscheme_to_string
-                                                   ed.FStar_Syntax_Syntax.bind_repr
-                                                  in
+                                                   ed.FStar_Syntax_Syntax.bind_repr in
                                                let uu____2291 =
                                                  let uu____2294 =
                                                    tscheme_to_string
-                                                     ed.FStar_Syntax_Syntax.return_repr
-                                                    in
+                                                     ed.FStar_Syntax_Syntax.return_repr in
                                                  let uu____2295 =
                                                    let uu____2298 =
                                                      actions_to_string
-                                                       ed.FStar_Syntax_Syntax.actions
-                                                      in
-                                                   [uu____2298]  in
-                                                 uu____2294 :: uu____2295  in
-                                               uu____2290 :: uu____2291  in
-                                             uu____2286 :: uu____2287  in
-                                           uu____2282 :: uu____2283  in
-                                         uu____2278 :: uu____2279  in
-                                       uu____2274 :: uu____2275  in
-                                     uu____2270 :: uu____2271  in
-                                   uu____2266 :: uu____2267  in
-                                 uu____2262 :: uu____2263  in
-                               uu____2258 :: uu____2259  in
-                             uu____2254 :: uu____2255  in
-                           uu____2250 :: uu____2251  in
-                         uu____2246 :: uu____2247  in
-                       uu____2242 :: uu____2243  in
-                     uu____2238 :: uu____2239  in
-                   uu____2233 :: uu____2235  in
-                 uu____2229 :: uu____2230  in
-               (if for_free then "_for_free " else "") :: uu____2226  in
+                                                       ed.FStar_Syntax_Syntax.actions in
+                                                   [uu____2298] in
+                                                 uu____2294 :: uu____2295 in
+                                               uu____2290 :: uu____2291 in
+                                             uu____2286 :: uu____2287 in
+                                           uu____2282 :: uu____2283 in
+                                         uu____2278 :: uu____2279 in
+                                       uu____2274 :: uu____2275 in
+                                     uu____2270 :: uu____2271 in
+                                   uu____2266 :: uu____2267 in
+                                 uu____2262 :: uu____2263 in
+                               uu____2258 :: uu____2259 in
+                             uu____2254 :: uu____2255 in
+                           uu____2250 :: uu____2251 in
+                         uu____2246 :: uu____2247 in
+                       uu____2242 :: uu____2243 in
+                     uu____2238 :: uu____2239 in
+                   uu____2233 :: uu____2235 in
+                 uu____2229 :: uu____2230 in
+               (if for_free then "_for_free " else "") :: uu____2226 in
              FStar_Util.format
                "new_effect%s { %s%s %s : %s \n  return_wp   = %s\n; bind_wp     = %s\n; if_then_else= %s\n; ite_wp      = %s\n; stronger    = %s\n; close_wp    = %s\n; assert_p    = %s\n; assume_p    = %s\n; null_wp     = %s\n; trivial     = %s\n; repr        = %s\n; bind_repr   = %s\n; return_repr = %s\nand effect_actions\n\t%s\n}\n"
                uu____2223)
-  
-let (eff_decl_to_string :
-  Prims.bool -> FStar_Syntax_Syntax.eff_decl -> Prims.string) =
+let eff_decl_to_string:
+  Prims.bool -> FStar_Syntax_Syntax.eff_decl -> Prims.string =
   fun for_free  ->
     fun ed  -> eff_decl_to_string' for_free FStar_Range.dummyRange [] ed
-  
-let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
+let rec sigelt_to_string: FStar_Syntax_Syntax.sigelt -> Prims.string =
   fun x  ->
     let uu____2309 =
-      let uu____2310 = FStar_Options.ugly ()  in Prims.op_Negation uu____2310
-       in
+      let uu____2310 = FStar_Options.ugly () in Prims.op_Negation uu____2310 in
     if uu____2309
     then
-      let e = FStar_Syntax_Resugar.resugar_sigelt x  in
+      let e = FStar_Syntax_Resugar.resugar_sigelt x in
       match e with
       | FStar_Pervasives_Native.Some d ->
-          let d1 = FStar_Parser_ToDocument.decl_to_document d  in
+          let d1 = FStar_Parser_ToDocument.decl_to_document d in
           FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
             (Prims.parse_int "100") d1
       | uu____2316 -> ""
@@ -1310,51 +1183,50 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
              -> FStar_Util.format1 "#set-options \"%s\"" s
          | FStar_Syntax_Syntax.Sig_inductive_typ
              (lid,univs1,tps,k,uu____2327,uu____2328) ->
-             let uu____2337 = quals_to_string' x.FStar_Syntax_Syntax.sigquals
-                in
-             let uu____2338 = binders_to_string " " tps  in
-             let uu____2339 = term_to_string k  in
+             let uu____2337 = quals_to_string' x.FStar_Syntax_Syntax.sigquals in
+             let uu____2338 = binders_to_string " " tps in
+             let uu____2339 = term_to_string k in
              FStar_Util.format4 "%stype %s %s : %s" uu____2337
                lid.FStar_Ident.str uu____2338 uu____2339
          | FStar_Syntax_Syntax.Sig_datacon
              (lid,univs1,t,uu____2343,uu____2344,uu____2345) ->
-             let uu____2350 = FStar_Options.print_universes ()  in
+             let uu____2350 = FStar_Options.print_universes () in
              if uu____2350
              then
-               let uu____2351 = univ_names_to_string univs1  in
-               let uu____2352 = term_to_string t  in
+               let uu____2351 = univ_names_to_string univs1 in
+               let uu____2352 = term_to_string t in
                FStar_Util.format3 "datacon<%s> %s : %s" uu____2351
                  lid.FStar_Ident.str uu____2352
              else
-               (let uu____2354 = term_to_string t  in
+               (let uu____2354 = term_to_string t in
                 FStar_Util.format2 "datacon %s : %s" lid.FStar_Ident.str
                   uu____2354)
          | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs1,t) ->
-             let uu____2358 = FStar_Syntax_Subst.open_univ_vars univs1 t  in
+             let uu____2358 = FStar_Syntax_Subst.open_univ_vars univs1 t in
              (match uu____2358 with
               | (univs2,t1) ->
                   let uu____2365 =
-                    quals_to_string' x.FStar_Syntax_Syntax.sigquals  in
+                    quals_to_string' x.FStar_Syntax_Syntax.sigquals in
                   let uu____2366 =
-                    let uu____2367 = FStar_Options.print_universes ()  in
+                    let uu____2367 = FStar_Options.print_universes () in
                     if uu____2367
                     then
-                      let uu____2368 = univ_names_to_string univs2  in
+                      let uu____2368 = univ_names_to_string univs2 in
                       FStar_Util.format1 "<%s>" uu____2368
-                    else ""  in
-                  let uu____2370 = term_to_string t1  in
+                    else "" in
+                  let uu____2370 = term_to_string t1 in
                   FStar_Util.format4 "%sval %s %s : %s" uu____2365
                     lid.FStar_Ident.str uu____2366 uu____2370)
          | FStar_Syntax_Syntax.Sig_assume (lid,uu____2372,f) ->
-             let uu____2374 = term_to_string f  in
+             let uu____2374 = term_to_string f in
              FStar_Util.format2 "val %s : %s" lid.FStar_Ident.str uu____2374
          | FStar_Syntax_Syntax.Sig_let (lbs,uu____2376) ->
              lbs_to_string x.FStar_Syntax_Syntax.sigquals lbs
          | FStar_Syntax_Syntax.Sig_main e ->
-             let uu____2382 = term_to_string e  in
+             let uu____2382 = term_to_string e in
              FStar_Util.format1 "let _ = %s" uu____2382
          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____2384) ->
-             let uu____2393 = FStar_List.map sigelt_to_string ses  in
+             let uu____2393 = FStar_List.map sigelt_to_string ses in
              FStar_All.pipe_right uu____2393 (FStar_String.concat "\n")
          | FStar_Syntax_Syntax.Sig_new_effect ed ->
              eff_decl_to_string' false x.FStar_Syntax_Syntax.sigrng
@@ -1370,72 +1242,65 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
                | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.None
                   ) -> failwith "impossible"
                | (FStar_Pervasives_Native.Some lift_wp,uu____2411) -> lift_wp
-               | (uu____2418,FStar_Pervasives_Native.Some lift) -> lift  in
+               | (uu____2418,FStar_Pervasives_Native.Some lift) -> lift in
              let uu____2426 =
                FStar_Syntax_Subst.open_univ_vars
                  (FStar_Pervasives_Native.fst lift_wp)
-                 (FStar_Pervasives_Native.snd lift_wp)
-                in
+                 (FStar_Pervasives_Native.snd lift_wp) in
              (match uu____2426 with
               | (us,t) ->
                   let uu____2437 =
-                    lid_to_string se.FStar_Syntax_Syntax.source  in
+                    lid_to_string se.FStar_Syntax_Syntax.source in
                   let uu____2438 =
-                    lid_to_string se.FStar_Syntax_Syntax.target  in
-                  let uu____2439 = univ_names_to_string us  in
-                  let uu____2440 = term_to_string t  in
+                    lid_to_string se.FStar_Syntax_Syntax.target in
+                  let uu____2439 = univ_names_to_string us in
+                  let uu____2440 = term_to_string t in
                   FStar_Util.format4 "sub_effect %s ~> %s : <%s> %s"
                     uu____2437 uu____2438 uu____2439 uu____2440)
          | FStar_Syntax_Syntax.Sig_effect_abbrev (l,univs1,tps,c,flags1) ->
-             let uu____2450 = FStar_Options.print_universes ()  in
+             let uu____2450 = FStar_Options.print_universes () in
              if uu____2450
              then
                let uu____2451 =
                  let uu____2456 =
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_arrow (tps, c))
-                     FStar_Pervasives_Native.None FStar_Range.dummyRange
-                    in
-                 FStar_Syntax_Subst.open_univ_vars univs1 uu____2456  in
+                     FStar_Pervasives_Native.None FStar_Range.dummyRange in
+                 FStar_Syntax_Subst.open_univ_vars univs1 uu____2456 in
                (match uu____2451 with
                 | (univs2,t) ->
                     let uu____2459 =
                       let uu____2472 =
-                        let uu____2473 = FStar_Syntax_Subst.compress t  in
-                        uu____2473.FStar_Syntax_Syntax.n  in
+                        let uu____2473 = FStar_Syntax_Subst.compress t in
+                        uu____2473.FStar_Syntax_Syntax.n in
                       match uu____2472 with
                       | FStar_Syntax_Syntax.Tm_arrow (bs,c1) -> (bs, c1)
-                      | uu____2514 -> failwith "impossible"  in
+                      | uu____2514 -> failwith "impossible" in
                     (match uu____2459 with
                      | (tps1,c1) ->
-                         let uu____2545 = sli l  in
-                         let uu____2546 = univ_names_to_string univs2  in
-                         let uu____2547 = binders_to_string " " tps1  in
-                         let uu____2548 = comp_to_string c1  in
+                         let uu____2545 = sli l in
+                         let uu____2546 = univ_names_to_string univs2 in
+                         let uu____2547 = binders_to_string " " tps1 in
+                         let uu____2548 = comp_to_string c1 in
                          FStar_Util.format4 "effect %s<%s> %s = %s"
                            uu____2545 uu____2546 uu____2547 uu____2548))
              else
-               (let uu____2550 = sli l  in
-                let uu____2551 = binders_to_string " " tps  in
-                let uu____2552 = comp_to_string c  in
+               (let uu____2550 = sli l in
+                let uu____2551 = binders_to_string " " tps in
+                let uu____2552 = comp_to_string c in
                 FStar_Util.format3 "effect %s %s = %s" uu____2550 uu____2551
-                  uu____2552)
-          in
+                  uu____2552) in
        match x.FStar_Syntax_Syntax.sigattrs with
        | [] -> basic
        | uu____2553 ->
-           let uu____2556 = attrs_to_string x.FStar_Syntax_Syntax.sigattrs
-              in
+           let uu____2556 = attrs_to_string x.FStar_Syntax_Syntax.sigattrs in
            Prims.strcat uu____2556 (Prims.strcat "\n" basic))
-  
-let (format_error : FStar_Range.range -> Prims.string -> Prims.string) =
+let format_error: FStar_Range.range -> Prims.string -> Prims.string =
   fun r  ->
     fun msg  ->
-      let uu____2563 = FStar_Range.string_of_range r  in
+      let uu____2563 = FStar_Range.string_of_range r in
       FStar_Util.format2 "%s: %s\n" uu____2563 msg
-  
-let rec (sigelt_to_string_short : FStar_Syntax_Syntax.sigelt -> Prims.string)
-  =
+let rec sigelt_to_string_short: FStar_Syntax_Syntax.sigelt -> Prims.string =
   fun x  ->
     match x.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_let
@@ -1446,66 +1311,60 @@ let rec (sigelt_to_string_short : FStar_Syntax_Syntax.sigelt -> Prims.string)
                        FStar_Syntax_Syntax.lbdef = uu____2572;
                        FStar_Syntax_Syntax.lbattrs = uu____2573;_}::[]),uu____2574)
         ->
-        let uu____2601 = lbname_to_string lb  in
-        let uu____2602 = term_to_string t  in
+        let uu____2601 = lbname_to_string lb in
+        let uu____2602 = term_to_string t in
         FStar_Util.format2 "let %s : %s" uu____2601 uu____2602
     | uu____2603 ->
         let uu____2604 =
           FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt x)
-            (FStar_List.map (fun l  -> l.FStar_Ident.str))
-           in
+            (FStar_List.map (fun l  -> l.FStar_Ident.str)) in
         FStar_All.pipe_right uu____2604 (FStar_String.concat ", ")
-  
-let rec (modul_to_string : FStar_Syntax_Syntax.modul -> Prims.string) =
+let rec modul_to_string: FStar_Syntax_Syntax.modul -> Prims.string =
   fun m  ->
-    let uu____2618 = sli m.FStar_Syntax_Syntax.name  in
+    let uu____2618 = sli m.FStar_Syntax_Syntax.name in
     let uu____2619 =
       let uu____2620 =
-        FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.declarations
-         in
-      FStar_All.pipe_right uu____2620 (FStar_String.concat "\n")  in
+        FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.declarations in
+      FStar_All.pipe_right uu____2620 (FStar_String.concat "\n") in
     let uu____2625 =
       let uu____2626 =
-        FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.exports  in
-      FStar_All.pipe_right uu____2626 (FStar_String.concat "\n")  in
+        FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.exports in
+      FStar_All.pipe_right uu____2626 (FStar_String.concat "\n") in
     FStar_Util.format3 "module %s\nDeclarations:\n%s\nExports:\n%s\n"
       uu____2618 uu____2619 uu____2625
-  
-let (subst_elt_to_string : FStar_Syntax_Syntax.subst_elt -> Prims.string) =
+let subst_elt_to_string: FStar_Syntax_Syntax.subst_elt -> Prims.string =
   fun uu___78_2633  ->
     match uu___78_2633 with
     | FStar_Syntax_Syntax.DB (i,x) ->
-        let uu____2636 = FStar_Util.string_of_int i  in
-        let uu____2637 = bv_to_string x  in
+        let uu____2636 = FStar_Util.string_of_int i in
+        let uu____2637 = bv_to_string x in
         FStar_Util.format2 "DB (%s, %s)" uu____2636 uu____2637
     | FStar_Syntax_Syntax.NM (x,i) ->
-        let uu____2640 = bv_to_string x  in
-        let uu____2641 = FStar_Util.string_of_int i  in
+        let uu____2640 = bv_to_string x in
+        let uu____2641 = FStar_Util.string_of_int i in
         FStar_Util.format2 "NM (%s, %s)" uu____2640 uu____2641
     | FStar_Syntax_Syntax.NT (x,t) ->
-        let uu____2648 = bv_to_string x  in
-        let uu____2649 = term_to_string t  in
+        let uu____2648 = bv_to_string x in
+        let uu____2649 = term_to_string t in
         FStar_Util.format2 "DB (%s, %s)" uu____2648 uu____2649
     | FStar_Syntax_Syntax.UN (i,u) ->
-        let uu____2652 = FStar_Util.string_of_int i  in
-        let uu____2653 = univ_to_string u  in
+        let uu____2652 = FStar_Util.string_of_int i in
+        let uu____2653 = univ_to_string u in
         FStar_Util.format2 "UN (%s, %s)" uu____2652 uu____2653
     | FStar_Syntax_Syntax.UD (u,i) ->
-        let uu____2656 = FStar_Util.string_of_int i  in
+        let uu____2656 = FStar_Util.string_of_int i in
         FStar_Util.format2 "UD (%s, %s)" u.FStar_Ident.idText uu____2656
-  
-let (subst_to_string : FStar_Syntax_Syntax.subst_t -> Prims.string) =
+let subst_to_string: FStar_Syntax_Syntax.subst_t -> Prims.string =
   fun s  ->
     let uu____2660 =
-      FStar_All.pipe_right s (FStar_List.map subst_elt_to_string)  in
+      FStar_All.pipe_right s (FStar_List.map subst_elt_to_string) in
     FStar_All.pipe_right uu____2660 (FStar_String.concat "; ")
-  
-let (abs_ascription_to_string :
+let abs_ascription_to_string:
   (FStar_Syntax_Syntax.lcomp,FStar_Ident.lident) FStar_Util.either
-    FStar_Pervasives_Native.option -> Prims.string)
+    FStar_Pervasives_Native.option -> Prims.string
   =
   fun ascription  ->
-    let strb = FStar_Util.new_string_builder ()  in
+    let strb = FStar_Util.new_string_builder () in
     (match ascription with
      | FStar_Pervasives_Native.None  ->
          FStar_Util.string_builder_append strb "None"
@@ -1517,43 +1376,40 @@ let (abs_ascription_to_string :
          (FStar_Util.string_builder_append strb "Some Inr ";
           FStar_Util.string_builder_append strb (FStar_Ident.text_of_lid lid)));
     FStar_Util.string_of_string_builder strb
-  
-let list_to_string :
+let list_to_string:
   'a . ('a -> Prims.string) -> 'a Prims.list -> Prims.string =
   fun f  ->
     fun elts  ->
       match elts with
       | [] -> "[]"
       | x::xs ->
-          let strb = FStar_Util.new_string_builder ()  in
+          let strb = FStar_Util.new_string_builder () in
           (FStar_Util.string_builder_append strb "[";
-           (let uu____2728 = f x  in
+           (let uu____2728 = f x in
             FStar_Util.string_builder_append strb uu____2728);
            FStar_List.iter
              (fun x1  ->
                 FStar_Util.string_builder_append strb "; ";
-                (let uu____2735 = f x1  in
+                (let uu____2735 = f x1 in
                  FStar_Util.string_builder_append strb uu____2735)) xs;
            FStar_Util.string_builder_append strb "]";
            FStar_Util.string_of_string_builder strb)
-  
-let set_to_string :
+let set_to_string:
   'a . ('a -> Prims.string) -> 'a FStar_Util.set -> Prims.string =
   fun f  ->
     fun s  ->
-      let elts = FStar_Util.set_elements s  in
+      let elts = FStar_Util.set_elements s in
       match elts with
       | [] -> "{}"
       | x::xs ->
-          let strb = FStar_Util.new_string_builder ()  in
+          let strb = FStar_Util.new_string_builder () in
           (FStar_Util.string_builder_append strb "{";
-           (let uu____2768 = f x  in
+           (let uu____2768 = f x in
             FStar_Util.string_builder_append strb uu____2768);
            FStar_List.iter
              (fun x1  ->
                 FStar_Util.string_builder_append strb ", ";
-                (let uu____2775 = f x1  in
+                (let uu____2775 = f x1 in
                  FStar_Util.string_builder_append strb uu____2775)) xs;
            FStar_Util.string_builder_append strb "}";
            FStar_Util.string_of_string_builder strb)
-  

--- a/src/ocaml-output/FStar_Syntax_Resugar.ml
+++ b/src/ocaml-output/FStar_Syntax_Resugar.ml
@@ -1,39 +1,34 @@
 open Prims
-let (doc_to_string : FStar_Pprint.document -> Prims.string) =
+let doc_to_string: FStar_Pprint.document -> Prims.string =
   fun doc1  ->
     FStar_Pprint.pretty_string (FStar_Util.float_of_string "1.0")
       (Prims.parse_int "100") doc1
-  
-let (parser_term_to_string : FStar_Parser_AST.term -> Prims.string) =
+let parser_term_to_string: FStar_Parser_AST.term -> Prims.string =
   fun t  ->
-    let uu____7 = FStar_Parser_ToDocument.term_to_document t  in
+    let uu____7 = FStar_Parser_ToDocument.term_to_document t in
     doc_to_string uu____7
-  
-let map_opt :
+let map_opt:
   'Auu____12 'Auu____13 .
     Prims.unit ->
       ('Auu____13 -> 'Auu____12 FStar_Pervasives_Native.option) ->
         'Auu____13 Prims.list -> 'Auu____12 Prims.list
-  = fun uu____27  -> FStar_List.filter_map 
-let (bv_as_unique_ident : FStar_Syntax_Syntax.bv -> FStar_Ident.ident) =
+  = fun uu____27  -> FStar_List.filter_map
+let bv_as_unique_ident: FStar_Syntax_Syntax.bv -> FStar_Ident.ident =
   fun x  ->
     let unique_name =
       let uu____32 =
         (FStar_Util.starts_with FStar_Ident.reserved_prefix
            (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText)
-          || (FStar_Options.print_real_names ())
-         in
+          || (FStar_Options.print_real_names ()) in
       if uu____32
       then
-        let uu____33 = FStar_Util.string_of_int x.FStar_Syntax_Syntax.index
-           in
+        let uu____33 = FStar_Util.string_of_int x.FStar_Syntax_Syntax.index in
         Prims.strcat (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
           uu____33
-      else (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText  in
+      else (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText in
     FStar_Ident.mk_ident
       (unique_name, ((x.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
-  
-let filter_imp :
+let filter_imp:
   'Auu____37 .
     ('Auu____37,FStar_Syntax_Syntax.arg_qualifier
                   FStar_Pervasives_Native.option)
@@ -50,9 +45,7 @@ let filter_imp :
             | (uu____98,FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Implicit uu____99)) -> false
             | uu____102 -> true))
-  
-let (label : Prims.string -> FStar_Parser_AST.term -> FStar_Parser_AST.term)
-  =
+let label: Prims.string -> FStar_Parser_AST.term -> FStar_Parser_AST.term =
   fun s  ->
     fun t  ->
       if s = ""
@@ -60,11 +53,10 @@ let (label : Prims.string -> FStar_Parser_AST.term -> FStar_Parser_AST.term)
       else
         FStar_Parser_AST.mk_term (FStar_Parser_AST.Labeled (t, s, true))
           t.FStar_Parser_AST.range FStar_Parser_AST.Un
-  
-let (resugar_arg_qual :
+let resugar_arg_qual:
   FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option ->
     FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun q  ->
     match q with
@@ -79,10 +71,9 @@ let (resugar_arg_qual :
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality ) ->
         FStar_Pervasives_Native.Some
           (FStar_Pervasives_Native.Some FStar_Parser_AST.Equality)
-  
-let (resugar_imp :
+let resugar_imp:
   FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option ->
-    FStar_Parser_AST.imp FStar_Pervasives_Native.option)
+    FStar_Parser_AST.imp FStar_Pervasives_Native.option
   =
   fun q  ->
     match q with
@@ -94,11 +85,10 @@ let (resugar_imp :
         FStar_Pervasives_Native.None
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit (true )) ->
         FStar_Pervasives_Native.None
-  
-let rec (universe_to_int :
+let rec universe_to_int:
   Prims.int ->
     FStar_Syntax_Syntax.universe ->
-      (Prims.int,FStar_Syntax_Syntax.universe) FStar_Pervasives_Native.tuple2)
+      (Prims.int,FStar_Syntax_Syntax.universe) FStar_Pervasives_Native.tuple2
   =
   fun n1  ->
     fun u  ->
@@ -106,30 +96,27 @@ let rec (universe_to_int :
       | FStar_Syntax_Syntax.U_succ u1 ->
           universe_to_int (n1 + (Prims.parse_int "1")) u1
       | uu____177 -> (n1, u)
-  
-let (universe_to_string : FStar_Ident.ident Prims.list -> Prims.string) =
+let universe_to_string: FStar_Ident.ident Prims.list -> Prims.string =
   fun univs1  ->
-    let uu____185 = FStar_Options.print_universes ()  in
+    let uu____185 = FStar_Options.print_universes () in
     if uu____185
     then
-      let uu____186 = FStar_List.map (fun x  -> x.FStar_Ident.idText) univs1
-         in
+      let uu____186 = FStar_List.map (fun x  -> x.FStar_Ident.idText) univs1 in
       FStar_All.pipe_right uu____186 (FStar_String.concat ", ")
     else ""
-  
-let rec (resugar_universe :
-  FStar_Syntax_Syntax.universe -> FStar_Range.range -> FStar_Parser_AST.term)
+let rec resugar_universe:
+  FStar_Syntax_Syntax.universe -> FStar_Range.range -> FStar_Parser_AST.term
   =
   fun u  ->
     fun r  ->
-      let mk1 a r1 = FStar_Parser_AST.mk_term a r1 FStar_Parser_AST.Un  in
+      let mk1 a r1 = FStar_Parser_AST.mk_term a r1 FStar_Parser_AST.Un in
       match u with
       | FStar_Syntax_Syntax.U_zero  ->
           mk1
             (FStar_Parser_AST.Const
                (FStar_Const.Const_int ("0", FStar_Pervasives_Native.None))) r
       | FStar_Syntax_Syntax.U_succ uu____217 ->
-          let uu____218 = universe_to_int (Prims.parse_int "0") u  in
+          let uu____218 = universe_to_int (Prims.parse_int "0") u in
           (match uu____218 with
            | (n1,u1) ->
                (match u1 with
@@ -137,22 +124,22 @@ let rec (resugar_universe :
                     let uu____225 =
                       let uu____226 =
                         let uu____227 =
-                          let uu____238 = FStar_Util.string_of_int n1  in
-                          (uu____238, FStar_Pervasives_Native.None)  in
-                        FStar_Const.Const_int uu____227  in
-                      FStar_Parser_AST.Const uu____226  in
+                          let uu____238 = FStar_Util.string_of_int n1 in
+                          (uu____238, FStar_Pervasives_Native.None) in
+                        FStar_Const.Const_int uu____227 in
+                      FStar_Parser_AST.Const uu____226 in
                     mk1 uu____225 r
                 | uu____249 ->
                     let e1 =
                       let uu____251 =
                         let uu____252 =
                           let uu____253 =
-                            let uu____264 = FStar_Util.string_of_int n1  in
-                            (uu____264, FStar_Pervasives_Native.None)  in
-                          FStar_Const.Const_int uu____253  in
-                        FStar_Parser_AST.Const uu____252  in
-                      mk1 uu____251 r  in
-                    let e2 = resugar_universe u1 r  in
+                            let uu____264 = FStar_Util.string_of_int n1 in
+                            (uu____264, FStar_Pervasives_Native.None) in
+                          FStar_Const.Const_int uu____253 in
+                        FStar_Parser_AST.Const uu____252 in
+                      mk1 uu____251 r in
+                    let e2 = resugar_universe u1 r in
                     mk1
                       (FStar_Parser_AST.Op
                          ((FStar_Ident.id_of_text "+"), [e1; e2])) r))
@@ -162,17 +149,17 @@ let rec (resugar_universe :
            | uu____281 ->
                let t =
                  let uu____285 =
-                   let uu____286 = FStar_Ident.lid_of_path ["max"] r  in
-                   FStar_Parser_AST.Var uu____286  in
-                 mk1 uu____285 r  in
+                   let uu____286 = FStar_Ident.lid_of_path ["max"] r in
+                   FStar_Parser_AST.Var uu____286 in
+                 mk1 uu____285 r in
                FStar_List.fold_left
                  (fun acc  ->
                     fun x  ->
                       let uu____292 =
                         let uu____293 =
-                          let uu____300 = resugar_universe x r  in
-                          (acc, uu____300, FStar_Parser_AST.Nothing)  in
-                        FStar_Parser_AST.App uu____293  in
+                          let uu____300 = resugar_universe x r in
+                          (acc, uu____300, FStar_Parser_AST.Nothing) in
+                        FStar_Parser_AST.App uu____293 in
                       mk1 uu____292 r) t l)
       | FStar_Syntax_Syntax.U_name u1 -> mk1 (FStar_Parser_AST.Uvar u1) r
       | FStar_Syntax_Syntax.U_unif uu____302 -> mk1 FStar_Parser_AST.Wild r
@@ -180,17 +167,16 @@ let rec (resugar_universe :
           let id1 =
             let uu____313 =
               let uu____318 =
-                let uu____319 = FStar_Util.string_of_int x  in
-                FStar_Util.strcat "uu__univ_bvar_" uu____319  in
-              (uu____318, r)  in
-            FStar_Ident.mk_ident uu____313  in
+                let uu____319 = FStar_Util.string_of_int x in
+                FStar_Util.strcat "uu__univ_bvar_" uu____319 in
+              (uu____318, r) in
+            FStar_Ident.mk_ident uu____313 in
           mk1 (FStar_Parser_AST.Uvar id1) r
       | FStar_Syntax_Syntax.U_unknown  -> mk1 FStar_Parser_AST.Wild r
-  
-let (string_to_op :
+let string_to_op:
   Prims.string ->
     (Prims.string,Prims.int) FStar_Pervasives_Native.tuple2
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun s  ->
     let name_of_op uu___67_338 =
@@ -222,7 +208,7 @@ let (string_to_op :
       | "Colon" -> FStar_Pervasives_Native.Some (":", (Prims.parse_int "0"))
       | "Dollar" -> FStar_Pervasives_Native.Some ("$", (Prims.parse_int "0"))
       | "Dot" -> FStar_Pervasives_Native.Some (".", (Prims.parse_int "0"))
-      | uu____429 -> FStar_Pervasives_Native.None  in
+      | uu____429 -> FStar_Pervasives_Native.None in
     match s with
     | "op_String_Assignment" ->
         FStar_Pervasives_Native.Some (".[]<-", (Prims.parse_int "0"))
@@ -237,13 +223,13 @@ let (string_to_op :
         then
           let s1 =
             let uu____466 =
-              FStar_Util.substring_from s (FStar_String.length "op_")  in
-            FStar_Util.split uu____466 "_"  in
+              FStar_Util.substring_from s (FStar_String.length "op_") in
+            FStar_Util.split uu____466 "_" in
           (match s1 with
            | op::[] -> name_of_op op
            | uu____474 ->
                let op =
-                 let uu____478 = FStar_List.map name_of_op s1  in
+                 let uu____478 = FStar_List.map name_of_op s1 in
                  FStar_List.fold_left
                    (fun acc  ->
                       fun x  ->
@@ -252,15 +238,13 @@ let (string_to_op :
                             Prims.strcat acc op
                         | FStar_Pervasives_Native.None  ->
                             failwith "wrong composed operator format") ""
-                   uu____478
-                  in
+                   uu____478 in
                FStar_Pervasives_Native.Some (op, (Prims.parse_int "0")))
         else FStar_Pervasives_Native.None
-  
-let rec (resugar_term_as_op :
+let rec resugar_term_as_op:
   FStar_Syntax_Syntax.term ->
     (Prims.string,Prims.int) FStar_Pervasives_Native.tuple2
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun t  ->
     let infix_prim_ops =
@@ -296,15 +280,14 @@ let rec (resugar_term_as_op :
       (FStar_Parser_Const.eq3_lid, "===");
       (FStar_Parser_Const.forall_lid, "forall");
       (FStar_Parser_Const.exists_lid, "exists");
-      (FStar_Parser_Const.salloc_lid, "alloc")]  in
+      (FStar_Parser_Const.salloc_lid, "alloc")] in
     let fallback fv =
       let uu____698 =
         FStar_All.pipe_right infix_prim_ops
           (FStar_Util.find_opt
              (fun d  ->
                 FStar_Syntax_Syntax.fv_eq_lid fv
-                  (FStar_Pervasives_Native.fst d)))
-         in
+                  (FStar_Pervasives_Native.fst d))) in
       match uu____698 with
       | FStar_Pervasives_Native.Some op ->
           FStar_Pervasives_Native.Some
@@ -312,8 +295,7 @@ let rec (resugar_term_as_op :
       | uu____746 ->
           let length1 =
             FStar_String.length
-              ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr
-             in
+              ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr in
           let str =
             if length1 = (Prims.parse_int "0")
             then
@@ -321,8 +303,7 @@ let rec (resugar_term_as_op :
             else
               FStar_Util.substring_from
                 ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                (length1 + (Prims.parse_int "1"))
-             in
+                (length1 + (Prims.parse_int "1")) in
           if FStar_Util.starts_with str "dtuple"
           then FStar_Pervasives_Native.Some ("dtuple", (Prims.parse_int "0"))
           else
@@ -337,24 +318,21 @@ let rec (resugar_term_as_op :
               else
                 (let uu____799 =
                    FStar_Syntax_Syntax.fv_eq_lid fv
-                     FStar_Parser_Const.sread_lid
-                    in
+                     FStar_Parser_Const.sread_lid in
                  if uu____799
                  then
                    FStar_Pervasives_Native.Some
                      ((((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str),
                        (Prims.parse_int "0"))
-                 else FStar_Pervasives_Native.None)
-       in
+                 else FStar_Pervasives_Native.None) in
     let uu____815 =
-      let uu____816 = FStar_Syntax_Subst.compress t  in
-      uu____816.FStar_Syntax_Syntax.n  in
+      let uu____816 = FStar_Syntax_Subst.compress t in
+      uu____816.FStar_Syntax_Syntax.n in
     match uu____815 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         let length1 =
           FStar_String.length
-            ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr
-           in
+            ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr in
         let s =
           if length1 = (Prims.parse_int "0")
           then
@@ -362,80 +340,71 @@ let rec (resugar_term_as_op :
           else
             FStar_Util.substring_from
               ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-              (length1 + (Prims.parse_int "1"))
-           in
-        let uu____839 = string_to_op s  in
+              (length1 + (Prims.parse_int "1")) in
+        let uu____839 = string_to_op s in
         (match uu____839 with
          | FStar_Pervasives_Native.Some t1 -> FStar_Pervasives_Native.Some t1
          | uu____865 -> fallback fv)
     | FStar_Syntax_Syntax.Tm_uinst (e,us) -> resugar_term_as_op e
     | uu____878 -> FStar_Pervasives_Native.None
-  
-let (is_true_pat : FStar_Syntax_Syntax.pat -> Prims.bool) =
+let is_true_pat: FStar_Syntax_Syntax.pat -> Prims.bool =
   fun p  ->
     match p.FStar_Syntax_Syntax.v with
     | FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool (true )) ->
         true
     | uu____886 -> false
-  
-let (is_wild_pat : FStar_Syntax_Syntax.pat -> Prims.bool) =
+let is_wild_pat: FStar_Syntax_Syntax.pat -> Prims.bool =
   fun p  ->
     match p.FStar_Syntax_Syntax.v with
     | FStar_Syntax_Syntax.Pat_wild uu____890 -> true
     | uu____891 -> false
-  
-let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
+let rec resugar_term: FStar_Syntax_Syntax.term -> FStar_Parser_AST.term =
   fun t  ->
     let mk1 a =
       FStar_Parser_AST.mk_term a t.FStar_Syntax_Syntax.pos
-        FStar_Parser_AST.Un
-       in
+        FStar_Parser_AST.Un in
     let name a r =
-      let uu____922 = FStar_Ident.lid_of_path [a] r  in
-      FStar_Parser_AST.Name uu____922  in
+      let uu____922 = FStar_Ident.lid_of_path [a] r in
+      FStar_Parser_AST.Name uu____922 in
     let var a r =
-      let uu____930 = FStar_Ident.lid_of_path [a] r  in
-      FStar_Parser_AST.Var uu____930  in
+      let uu____930 = FStar_Ident.lid_of_path [a] r in
+      FStar_Parser_AST.Var uu____930 in
     let uu____931 =
-      let uu____932 = FStar_Syntax_Subst.compress t  in
-      uu____932.FStar_Syntax_Syntax.n  in
+      let uu____932 = FStar_Syntax_Subst.compress t in
+      uu____932.FStar_Syntax_Syntax.n in
     match uu____931 with
     | FStar_Syntax_Syntax.Tm_delayed uu____935 ->
         failwith "Tm_delayed is impossible after compress"
     | FStar_Syntax_Syntax.Tm_bvar x ->
         let l =
-          let uu____962 =
-            let uu____965 = bv_as_unique_ident x  in [uu____965]  in
-          FStar_Ident.lid_of_ids uu____962  in
+          let uu____962 = let uu____965 = bv_as_unique_ident x in [uu____965] in
+          FStar_Ident.lid_of_ids uu____962 in
         mk1 (FStar_Parser_AST.Var l)
     | FStar_Syntax_Syntax.Tm_name x ->
         let l =
-          let uu____968 =
-            let uu____971 = bv_as_unique_ident x  in [uu____971]  in
-          FStar_Ident.lid_of_ids uu____968  in
+          let uu____968 = let uu____971 = bv_as_unique_ident x in [uu____971] in
+          FStar_Ident.lid_of_ids uu____968 in
         mk1 (FStar_Parser_AST.Var l)
     | FStar_Syntax_Syntax.Tm_fvar fv ->
-        let a = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
+        let a = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
         let length1 =
           FStar_String.length
-            ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr
-           in
+            ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.nsstr in
         let s =
           if length1 = (Prims.parse_int "0")
           then a.FStar_Ident.str
           else
             FStar_Util.substring_from a.FStar_Ident.str
-              (length1 + (Prims.parse_int "1"))
-           in
-        let is_prefix = Prims.strcat FStar_Ident.reserved_prefix "is_"  in
+              (length1 + (Prims.parse_int "1")) in
+        let is_prefix = Prims.strcat FStar_Ident.reserved_prefix "is_" in
         if FStar_Util.starts_with s is_prefix
         then
           let rest =
-            FStar_Util.substring_from s (FStar_String.length is_prefix)  in
+            FStar_Util.substring_from s (FStar_String.length is_prefix) in
           let uu____989 =
             let uu____990 =
-              FStar_Ident.lid_of_path [rest] t.FStar_Syntax_Syntax.pos  in
-            FStar_Parser_AST.Discrim uu____990  in
+              FStar_Ident.lid_of_path [rest] t.FStar_Syntax_Syntax.pos in
+            FStar_Parser_AST.Discrim uu____990 in
           mk1 uu____989
         else
           if
@@ -444,19 +413,15 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
             (let rest =
                FStar_Util.substring_from s
                  (FStar_String.length
-                    FStar_Syntax_Util.field_projector_prefix)
-                in
+                    FStar_Syntax_Util.field_projector_prefix) in
              let r =
-               FStar_Util.split rest FStar_Syntax_Util.field_projector_sep
-                in
+               FStar_Util.split rest FStar_Syntax_Util.field_projector_sep in
              match r with
              | fst1::snd1::[] ->
                  let l =
-                   FStar_Ident.lid_of_path [fst1] t.FStar_Syntax_Syntax.pos
-                    in
+                   FStar_Ident.lid_of_path [fst1] t.FStar_Syntax_Syntax.pos in
                  let r1 =
-                   FStar_Ident.mk_ident (snd1, (t.FStar_Syntax_Syntax.pos))
-                    in
+                   FStar_Ident.mk_ident (snd1, (t.FStar_Syntax_Syntax.pos)) in
                  mk1 (FStar_Parser_AST.Projector (l, r1))
              | uu____1000 -> failwith "wrong projector format")
           else
@@ -465,131 +430,122 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                   (FStar_Ident.lid_equals a FStar_Parser_Const.assume_lid))
                  ||
                  (let uu____1007 =
-                    let uu____1009 = FStar_String.get s (Prims.parse_int "0")
-                       in
-                    FStar_Char.uppercase uu____1009  in
-                  let uu____1011 = FStar_String.get s (Prims.parse_int "0")
-                     in
-                  uu____1007 <> uu____1011)
-                in
+                    let uu____1009 = FStar_String.get s (Prims.parse_int "0") in
+                    FStar_Char.uppercase uu____1009 in
+                  let uu____1011 = FStar_String.get s (Prims.parse_int "0") in
+                  uu____1007 <> uu____1011) in
              if uu____1004
              then
                let uu____1014 =
-                 var a.FStar_Ident.str t.FStar_Syntax_Syntax.pos  in
+                 var a.FStar_Ident.str t.FStar_Syntax_Syntax.pos in
                mk1 uu____1014
              else
                (let uu____1016 =
-                  name a.FStar_Ident.str t.FStar_Syntax_Syntax.pos  in
+                  name a.FStar_Ident.str t.FStar_Syntax_Syntax.pos in
                 mk1 uu____1016))
     | FStar_Syntax_Syntax.Tm_uinst (e,universes) ->
-        let uu____1023 = FStar_Options.print_universes ()  in
+        let uu____1023 = FStar_Options.print_universes () in
         if uu____1023
         then
-          let e1 = resugar_term e  in
+          let e1 = resugar_term e in
           FStar_List.fold_left
             (fun acc  ->
                fun x  ->
                  let uu____1030 =
                    let uu____1031 =
                      let uu____1038 =
-                       resugar_universe x t.FStar_Syntax_Syntax.pos  in
-                     (acc, uu____1038, FStar_Parser_AST.UnivApp)  in
-                   FStar_Parser_AST.App uu____1031  in
+                       resugar_universe x t.FStar_Syntax_Syntax.pos in
+                     (acc, uu____1038, FStar_Parser_AST.UnivApp) in
+                   FStar_Parser_AST.App uu____1031 in
                  mk1 uu____1030) e1 universes
         else resugar_term e
     | FStar_Syntax_Syntax.Tm_constant c ->
-        let uu____1041 = FStar_Syntax_Syntax.is_teff t  in
+        let uu____1041 = FStar_Syntax_Syntax.is_teff t in
         if uu____1041
         then
-          let uu____1042 = name "Effect" t.FStar_Syntax_Syntax.pos  in
+          let uu____1042 = name "Effect" t.FStar_Syntax_Syntax.pos in
           mk1 uu____1042
         else mk1 (FStar_Parser_AST.Const c)
     | FStar_Syntax_Syntax.Tm_type u ->
         (match u with
          | FStar_Syntax_Syntax.U_zero  ->
-             let uu____1045 = name "Type0" t.FStar_Syntax_Syntax.pos  in
+             let uu____1045 = name "Type0" t.FStar_Syntax_Syntax.pos in
              mk1 uu____1045
          | FStar_Syntax_Syntax.U_unknown  ->
-             let uu____1046 = name "Type" t.FStar_Syntax_Syntax.pos  in
+             let uu____1046 = name "Type" t.FStar_Syntax_Syntax.pos in
              mk1 uu____1046
          | uu____1047 ->
-             let uu____1048 = FStar_Options.print_universes ()  in
+             let uu____1048 = FStar_Options.print_universes () in
              if uu____1048
              then
-               let u1 = resugar_universe u t.FStar_Syntax_Syntax.pos  in
+               let u1 = resugar_universe u t.FStar_Syntax_Syntax.pos in
                let l =
-                 FStar_Ident.lid_of_path ["Type"] t.FStar_Syntax_Syntax.pos
-                  in
+                 FStar_Ident.lid_of_path ["Type"] t.FStar_Syntax_Syntax.pos in
                mk1
                  (FStar_Parser_AST.Construct
                     (l, [(u1, FStar_Parser_AST.UnivApp)]))
              else
-               (let uu____1066 = name "Type" t.FStar_Syntax_Syntax.pos  in
+               (let uu____1066 = name "Type" t.FStar_Syntax_Syntax.pos in
                 mk1 uu____1066))
     | FStar_Syntax_Syntax.Tm_abs (xs,body,uu____1069) ->
-        let uu____1090 = FStar_Syntax_Subst.open_term xs body  in
+        let uu____1090 = FStar_Syntax_Subst.open_term xs body in
         (match uu____1090 with
          | (xs1,body1) ->
              let xs2 =
-               let uu____1098 = FStar_Options.print_implicits ()  in
-               if uu____1098 then xs1 else filter_imp xs1  in
+               let uu____1098 = FStar_Options.print_implicits () in
+               if uu____1098 then xs1 else filter_imp xs1 in
              let patterns =
                FStar_All.pipe_right xs2
                  (FStar_List.choose
                     (fun uu____1112  ->
                        match uu____1112 with
-                       | (x,qual) -> resugar_bv_as_pat x qual))
-                in
-             let body2 = resugar_term body1  in
+                       | (x,qual) -> resugar_bv_as_pat x qual)) in
+             let body2 = resugar_term body1 in
              mk1 (FStar_Parser_AST.Abs (patterns, body2)))
     | FStar_Syntax_Syntax.Tm_arrow (xs,body) ->
-        let uu____1142 = FStar_Syntax_Subst.open_comp xs body  in
+        let uu____1142 = FStar_Syntax_Subst.open_comp xs body in
         (match uu____1142 with
          | (xs1,body1) ->
              let xs2 =
-               let uu____1150 = FStar_Options.print_implicits ()  in
-               if uu____1150 then xs1 else filter_imp xs1  in
-             let body2 = resugar_comp body1  in
+               let uu____1150 = FStar_Options.print_implicits () in
+               if uu____1150 then xs1 else filter_imp xs1 in
+             let body2 = resugar_comp body1 in
              let xs3 =
                let uu____1156 =
                  FStar_All.pipe_right xs2
                    ((map_opt ())
-                      (fun b  -> resugar_binder b t.FStar_Syntax_Syntax.pos))
-                  in
-               FStar_All.pipe_right uu____1156 FStar_List.rev  in
+                      (fun b  -> resugar_binder b t.FStar_Syntax_Syntax.pos)) in
+               FStar_All.pipe_right uu____1156 FStar_List.rev in
              let rec aux body3 uu___68_1175 =
                match uu___68_1175 with
                | [] -> body3
                | hd1::tl1 ->
-                   let body4 = mk1 (FStar_Parser_AST.Product ([hd1], body3))
-                      in
-                   aux body4 tl1
-                in
+                   let body4 = mk1 (FStar_Parser_AST.Product ([hd1], body3)) in
+                   aux body4 tl1 in
              aux body2 xs3)
     | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
         let uu____1191 =
           let uu____1196 =
-            let uu____1197 = FStar_Syntax_Syntax.mk_binder x  in [uu____1197]
-             in
-          FStar_Syntax_Subst.open_term uu____1196 phi  in
+            let uu____1197 = FStar_Syntax_Syntax.mk_binder x in [uu____1197] in
+          FStar_Syntax_Subst.open_term uu____1196 phi in
         (match uu____1191 with
          | (x1,phi1) ->
              let b =
                let uu____1201 =
-                 let uu____1204 = FStar_List.hd x1  in
-                 resugar_binder uu____1204 t.FStar_Syntax_Syntax.pos  in
-               FStar_Util.must uu____1201  in
+                 let uu____1204 = FStar_List.hd x1 in
+                 resugar_binder uu____1204 t.FStar_Syntax_Syntax.pos in
+               FStar_Util.must uu____1201 in
              let uu____1209 =
                let uu____1210 =
-                 let uu____1215 = resugar_term phi1  in (b, uu____1215)  in
-               FStar_Parser_AST.Refine uu____1210  in
+                 let uu____1215 = resugar_term phi1 in (b, uu____1215) in
+               FStar_Parser_AST.Refine uu____1210 in
              mk1 uu____1209)
     | FStar_Syntax_Syntax.Tm_app
         ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
            FStar_Syntax_Syntax.pos = uu____1217;
            FStar_Syntax_Syntax.vars = uu____1218;_},(e,uu____1220)::[])
         when
-        (let uu____1251 = FStar_Options.print_implicits ()  in
+        (let uu____1251 = FStar_Options.print_implicits () in
          Prims.op_Negation uu____1251) &&
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.b2t_lid)
         -> resugar_term e
@@ -598,7 +554,7 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
           match uu___69_1293 with
           | hd1::[] -> [hd1]
           | hd1::tl1 -> last1 tl1
-          | uu____1363 -> failwith "last of an empty list"  in
+          | uu____1363 -> failwith "last of an empty list" in
         let rec last_two uu___70_1399 =
           match uu___70_1399 with
           | [] ->
@@ -608,7 +564,7 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
               failwith
                 "last two elements of a list with less than two elements "
           | a1::a2::[] -> [a1; a2]
-          | uu____1507::t1 -> last_two t1  in
+          | uu____1507::t1 -> last_two t1 in
         let rec last_three uu___71_1548 =
           match uu___71_1548 with
           | [] ->
@@ -621,7 +577,7 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
               failwith
                 "last three elements of a list with less than three elements "
           | a1::a2::a3::[] -> [a1; a2; a3]
-          | uu____1715::t1 -> last_three t1  in
+          | uu____1715::t1 -> last_three t1 in
         let resugar_as_app e1 args1 =
           let args2 =
             FStar_All.pipe_right args1
@@ -629,27 +585,23 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                  (fun uu____1801  ->
                     match uu____1801 with
                     | (e2,qual) ->
-                        let uu____1820 = resugar_term e2  in
-                        (uu____1820, qual)))
-             in
-          let e2 = resugar_term e1  in
+                        let uu____1820 = resugar_term e2 in
+                        (uu____1820, qual))) in
+          let e2 = resugar_term e1 in
           let res_impl desugared_tm qual =
-            let uu____1835 = resugar_imp qual  in
+            let uu____1835 = resugar_imp qual in
             match uu____1835 with
             | FStar_Pervasives_Native.Some imp -> imp
             | FStar_Pervasives_Native.None  ->
                 ((let uu____1840 =
                     let uu____1845 =
-                      let uu____1846 = parser_term_to_string desugared_tm  in
+                      let uu____1846 = parser_term_to_string desugared_tm in
                       FStar_Util.format1
                         "Inaccessible argument %s in function application"
-                        uu____1846
-                       in
-                    (FStar_Errors.Warning_InaccessibleArgument, uu____1845)
-                     in
+                        uu____1846 in
+                    (FStar_Errors.Warning_InaccessibleArgument, uu____1845) in
                   FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____1840);
-                 FStar_Parser_AST.Nothing)
-             in
+                 FStar_Parser_AST.Nothing) in
           FStar_List.fold_left
             (fun acc  ->
                fun uu____1859  ->
@@ -657,15 +609,14 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                  | (x,qual) ->
                      let uu____1872 =
                        let uu____1873 =
-                         let uu____1880 = res_impl x qual  in
-                         (acc, x, uu____1880)  in
-                       FStar_Parser_AST.App uu____1873  in
-                     mk1 uu____1872) e2 args2
-           in
+                         let uu____1880 = res_impl x qual in
+                         (acc, x, uu____1880) in
+                       FStar_Parser_AST.App uu____1873 in
+                     mk1 uu____1872) e2 args2 in
         let args1 =
-          let uu____1890 = FStar_Options.print_implicits ()  in
-          if uu____1890 then args else filter_imp args  in
-        let uu____1902 = resugar_term_as_op e  in
+          let uu____1890 = FStar_Options.print_implicits () in
+          if uu____1890 then args else filter_imp args in
+        let uu____1902 = resugar_term_as_op e in
         (match uu____1902 with
          | FStar_Pervasives_Native.None  -> resugar_as_app e args1
          | FStar_Pervasives_Native.Some ("tuple",uu____1913) ->
@@ -675,14 +626,14 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                     let uu____1952 =
                       let uu____1953 =
                         let uu____1960 =
-                          let uu____1963 = resugar_term fst1  in
+                          let uu____1963 = resugar_term fst1 in
                           let uu____1964 =
-                            let uu____1967 = resugar_term snd1  in
-                            [uu____1967]  in
-                          uu____1963 :: uu____1964  in
-                        ((FStar_Ident.id_of_text "*"), uu____1960)  in
-                      FStar_Parser_AST.Op uu____1953  in
-                    mk1 uu____1952  in
+                            let uu____1967 = resugar_term snd1 in
+                            [uu____1967] in
+                          uu____1963 :: uu____1964 in
+                        ((FStar_Ident.id_of_text "*"), uu____1960) in
+                      FStar_Parser_AST.Op uu____1953 in
+                    mk1 uu____1952 in
                   FStar_List.fold_left
                     (fun acc  ->
                        fun uu____1980  ->
@@ -692,40 +643,37 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                                let uu____1988 =
                                  let uu____1995 =
                                    let uu____1998 =
-                                     let uu____2001 = resugar_term x  in
-                                     [uu____2001]  in
-                                   e1 :: uu____1998  in
-                                 ((FStar_Ident.id_of_text "*"), uu____1995)
-                                  in
-                               FStar_Parser_AST.Op uu____1988  in
+                                     let uu____2001 = resugar_term x in
+                                     [uu____2001] in
+                                   e1 :: uu____1998 in
+                                 ((FStar_Ident.id_of_text "*"), uu____1995) in
+                               FStar_Parser_AST.Op uu____1988 in
                              mk1 uu____1987) e1 rest
               | uu____2004 -> resugar_as_app e args1)
          | FStar_Pervasives_Native.Some ("dtuple",uu____2013) when
              (FStar_List.length args1) > (Prims.parse_int "0") ->
-             let args2 = last1 args1  in
+             let args2 = last1 args1 in
              let body =
                match args2 with
                | (b,uu____2039)::[] -> b
-               | uu____2056 -> failwith "wrong arguments to dtuple"  in
+               | uu____2056 -> failwith "wrong arguments to dtuple" in
              let uu____2067 =
-               let uu____2068 = FStar_Syntax_Subst.compress body  in
-               uu____2068.FStar_Syntax_Syntax.n  in
+               let uu____2068 = FStar_Syntax_Subst.compress body in
+               uu____2068.FStar_Syntax_Syntax.n in
              (match uu____2067 with
               | FStar_Syntax_Syntax.Tm_abs (xs,body1,uu____2073) ->
-                  let uu____2094 = FStar_Syntax_Subst.open_term xs body1  in
+                  let uu____2094 = FStar_Syntax_Subst.open_term xs body1 in
                   (match uu____2094 with
                    | (xs1,body2) ->
                        let xs2 =
-                         let uu____2102 = FStar_Options.print_implicits ()
-                            in
-                         if uu____2102 then xs1 else filter_imp xs1  in
+                         let uu____2102 = FStar_Options.print_implicits () in
+                         if uu____2102 then xs1 else filter_imp xs1 in
                        let xs3 =
                          FStar_All.pipe_right xs2
                            ((map_opt ())
                               (fun b  ->
-                                 resugar_binder b t.FStar_Syntax_Syntax.pos))
-                          in
-                       let body3 = resugar_term body2  in
+                                 resugar_binder b t.FStar_Syntax_Syntax.pos)) in
+                       let body3 = resugar_term body2 in
                        mk1 (FStar_Parser_AST.Sum (xs3, body3)))
               | uu____2114 ->
                   let args3 =
@@ -733,9 +681,8 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                       (FStar_List.map
                          (fun uu____2135  ->
                             match uu____2135 with
-                            | (e1,qual) -> resugar_term e1))
-                     in
-                  let e1 = resugar_term e  in
+                            | (e1,qual) -> resugar_term e1)) in
+                  let e1 = resugar_term e in
                   FStar_List.fold_left
                     (fun acc  ->
                        fun x  ->
@@ -746,12 +693,12 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
              resugar_as_app e args1
          | FStar_Pervasives_Native.Some (ref_read,uu____2153) when
              ref_read = FStar_Parser_Const.sread_lid.FStar_Ident.str ->
-             let uu____2158 = FStar_List.hd args1  in
+             let uu____2158 = FStar_List.hd args1 in
              (match uu____2158 with
               | (t1,uu____2172) ->
                   let uu____2177 =
-                    let uu____2178 = FStar_Syntax_Subst.compress t1  in
-                    uu____2178.FStar_Syntax_Syntax.n  in
+                    let uu____2178 = FStar_Syntax_Subst.compress t1 in
+                    uu____2178.FStar_Syntax_Syntax.n in
                   (match uu____2177 with
                    | FStar_Syntax_Syntax.Tm_fvar fv when
                        FStar_Syntax_Util.field_projector_contains_constructor
@@ -760,42 +707,38 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                        let f =
                          FStar_Ident.lid_of_path
                            [((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str]
-                           t1.FStar_Syntax_Syntax.pos
-                          in
+                           t1.FStar_Syntax_Syntax.pos in
                        let uu____2183 =
                          let uu____2184 =
-                           let uu____2189 = resugar_term t1  in
-                           (uu____2189, f)  in
-                         FStar_Parser_AST.Project uu____2184  in
+                           let uu____2189 = resugar_term t1 in
+                           (uu____2189, f) in
+                         FStar_Parser_AST.Project uu____2184 in
                        mk1 uu____2183
                    | uu____2190 -> resugar_term t1))
          | FStar_Pervasives_Native.Some ("try_with",uu____2191) when
              (FStar_List.length args1) > (Prims.parse_int "1") ->
-             let new_args = last_two args1  in
+             let new_args = last_two args1 in
              let uu____2211 =
                match new_args with
                | (a1,uu____2229)::(a2,uu____2231)::[] -> (a1, a2)
-               | uu____2262 -> failwith "wrong arguments to try_with"  in
+               | uu____2262 -> failwith "wrong arguments to try_with" in
              (match uu____2211 with
               | (body,handler) ->
                   let decomp term =
                     let uu____2293 =
-                      let uu____2294 = FStar_Syntax_Subst.compress term  in
-                      uu____2294.FStar_Syntax_Syntax.n  in
+                      let uu____2294 = FStar_Syntax_Subst.compress term in
+                      uu____2294.FStar_Syntax_Syntax.n in
                     match uu____2293 with
                     | FStar_Syntax_Syntax.Tm_abs (x,e1,uu____2299) ->
-                        let uu____2320 = FStar_Syntax_Subst.open_term x e1
-                           in
+                        let uu____2320 = FStar_Syntax_Subst.open_term x e1 in
                         (match uu____2320 with | (x1,e2) -> e2)
                     | uu____2327 ->
-                        failwith "wrong argument format to try_with"
-                     in
+                        failwith "wrong argument format to try_with" in
                   let body1 =
-                    let uu____2329 = decomp body  in resugar_term uu____2329
-                     in
+                    let uu____2329 = decomp body in resugar_term uu____2329 in
                   let handler1 =
-                    let uu____2331 = decomp handler  in
-                    resugar_term uu____2331  in
+                    let uu____2331 = decomp handler in
+                    resugar_term uu____2331 in
                   let rec resugar_body t1 =
                     match t1.FStar_Parser_AST.tm with
                     | FStar_Parser_AST.Match
@@ -804,21 +747,20 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                     | FStar_Parser_AST.Ascribed (t11,t2,t3) ->
                         let uu____2408 =
                           let uu____2409 =
-                            let uu____2418 = resugar_body t11  in
-                            (uu____2418, t2, t3)  in
-                          FStar_Parser_AST.Ascribed uu____2409  in
+                            let uu____2418 = resugar_body t11 in
+                            (uu____2418, t2, t3) in
+                          FStar_Parser_AST.Ascribed uu____2409 in
                         mk1 uu____2408
                     | uu____2421 ->
-                        failwith "unexpected body format to try_with"
-                     in
-                  let e1 = resugar_body body1  in
+                        failwith "unexpected body format to try_with" in
+                  let e1 = resugar_body body1 in
                   let rec resugar_branches t1 =
                     match t1.FStar_Parser_AST.tm with
                     | FStar_Parser_AST.Match (e2,branches) -> branches
                     | FStar_Parser_AST.Ascribed (t11,t2,t3) ->
                         resugar_branches t11
-                    | uu____2476 -> []  in
-                  let branches = resugar_branches handler1  in
+                    | uu____2476 -> [] in
+                  let branches = resugar_branches handler1 in
                   mk1 (FStar_Parser_AST.TryWith (e1, branches)))
          | FStar_Pervasives_Native.Some ("try_with",uu____2506) ->
              resugar_as_app e args1
@@ -832,34 +774,32 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                | FStar_Parser_AST.QForall (x,p,body) ->
                    uncurry (FStar_List.append x xs) (FStar_List.append p pat)
                      body
-               | uu____2597 -> (xs, pat, t1)  in
+               | uu____2597 -> (xs, pat, t1) in
              let resugar body =
                let uu____2608 =
-                 let uu____2609 = FStar_Syntax_Subst.compress body  in
-                 uu____2609.FStar_Syntax_Syntax.n  in
+                 let uu____2609 = FStar_Syntax_Subst.compress body in
+                 uu____2609.FStar_Syntax_Syntax.n in
                match uu____2608 with
                | FStar_Syntax_Syntax.Tm_abs (xs,body1,uu____2614) ->
-                   let uu____2635 = FStar_Syntax_Subst.open_term xs body1  in
+                   let uu____2635 = FStar_Syntax_Subst.open_term xs body1 in
                    (match uu____2635 with
                     | (xs1,body2) ->
                         let xs2 =
-                          let uu____2643 = FStar_Options.print_implicits ()
-                             in
-                          if uu____2643 then xs1 else filter_imp xs1  in
+                          let uu____2643 = FStar_Options.print_implicits () in
+                          if uu____2643 then xs1 else filter_imp xs1 in
                         let xs3 =
                           FStar_All.pipe_right xs2
                             ((map_opt ())
                                (fun b  ->
-                                  resugar_binder b t.FStar_Syntax_Syntax.pos))
-                           in
+                                  resugar_binder b t.FStar_Syntax_Syntax.pos)) in
                         let uu____2652 =
                           let uu____2661 =
                             let uu____2662 =
-                              FStar_Syntax_Subst.compress body2  in
-                            uu____2662.FStar_Syntax_Syntax.n  in
+                              FStar_Syntax_Subst.compress body2 in
+                            uu____2662.FStar_Syntax_Syntax.n in
                           match uu____2661 with
                           | FStar_Syntax_Syntax.Tm_meta (e1,m) ->
-                              let body3 = resugar_term e1  in
+                              let body3 = resugar_term e1 in
                               let uu____2680 =
                                 match m with
                                 | FStar_Syntax_Syntax.Meta_pattern pats ->
@@ -872,34 +812,29 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                                                    match uu____2744 with
                                                    | (e2,uu____2750) ->
                                                        resugar_term e2)))
-                                        pats
-                                       in
+                                        pats in
                                     (uu____2708, body3)
                                 | FStar_Syntax_Syntax.Meta_labeled (s,r,p) ->
                                     let uu____2758 =
                                       mk1
                                         (FStar_Parser_AST.Labeled
-                                           (body3, s, p))
-                                       in
+                                           (body3, s, p)) in
                                     ([], uu____2758)
                                 | uu____2765 ->
                                     failwith
-                                      "wrong pattern format for QForall/QExists"
-                                 in
+                                      "wrong pattern format for QForall/QExists" in
                               (match uu____2680 with
                                | (pats,body4) -> (pats, body4))
                           | uu____2796 ->
-                              let uu____2797 = resugar_term body2  in
-                              ([], uu____2797)
-                           in
+                              let uu____2797 = resugar_term body2 in
+                              ([], uu____2797) in
                         (match uu____2652 with
                          | (pats,body3) ->
-                             let uu____2814 = uncurry xs3 pats body3  in
+                             let uu____2814 = uncurry xs3 pats body3 in
                              (match uu____2814 with
                               | (xs4,pats1,body4) ->
                                   let xs5 =
-                                    FStar_All.pipe_right xs4 FStar_List.rev
-                                     in
+                                    FStar_All.pipe_right xs4 FStar_List.rev in
                                   if op = "forall"
                                   then
                                     mk1
@@ -914,40 +849,38 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                    then
                      let uu____2863 =
                        let uu____2864 =
-                         let uu____2877 = resugar_term body  in
-                         ([], [[]], uu____2877)  in
-                       FStar_Parser_AST.QForall uu____2864  in
+                         let uu____2877 = resugar_term body in
+                         ([], [[]], uu____2877) in
+                       FStar_Parser_AST.QForall uu____2864 in
                      mk1 uu____2863
                    else
                      (let uu____2889 =
                         let uu____2890 =
-                          let uu____2903 = resugar_term body  in
-                          ([], [[]], uu____2903)  in
-                        FStar_Parser_AST.QExists uu____2890  in
-                      mk1 uu____2889)
-                in
+                          let uu____2903 = resugar_term body in
+                          ([], [[]], uu____2903) in
+                        FStar_Parser_AST.QExists uu____2890 in
+                      mk1 uu____2889) in
              if (FStar_List.length args1) > (Prims.parse_int "0")
              then
-               let args2 = last1 args1  in
+               let args2 = last1 args1 in
                (match args2 with
                 | (b,uu____2930)::[] -> resugar b
                 | uu____2947 -> failwith "wrong args format to QForall")
              else resugar_as_app e args1
          | FStar_Pervasives_Native.Some ("alloc",uu____2957) ->
-             let uu____2962 = FStar_List.hd args1  in
+             let uu____2962 = FStar_List.hd args1 in
              (match uu____2962 with | (e1,uu____2976) -> resugar_term e1)
          | FStar_Pervasives_Native.Some (op,arity) ->
-             let op1 = FStar_Ident.id_of_text op  in
+             let op1 = FStar_Ident.id_of_text op in
              let resugar args2 =
                FStar_All.pipe_right args2
                  (FStar_List.map
                     (fun uu____3021  ->
-                       match uu____3021 with | (e1,qual) -> resugar_term e1))
-                in
+                       match uu____3021 with | (e1,qual) -> resugar_term e1)) in
              (match arity with
               | _0_39 when _0_39 = (Prims.parse_int "0") ->
                   let uu____3028 =
-                    FStar_Parser_ToDocument.handleable_args_length op1  in
+                    FStar_Parser_ToDocument.handleable_args_length op1 in
                   (match uu____3028 with
                    | _0_40 when
                        (_0_40 = (Prims.parse_int "1")) &&
@@ -956,10 +889,10 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                        let uu____3035 =
                          let uu____3036 =
                            let uu____3043 =
-                             let uu____3046 = last1 args1  in
-                             resugar uu____3046  in
-                           (op1, uu____3043)  in
-                         FStar_Parser_AST.Op uu____3036  in
+                             let uu____3046 = last1 args1 in
+                             resugar uu____3046 in
+                           (op1, uu____3043) in
+                         FStar_Parser_AST.Op uu____3036 in
                        mk1 uu____3035
                    | _0_41 when
                        (_0_41 = (Prims.parse_int "2")) &&
@@ -968,10 +901,10 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                        let uu____3061 =
                          let uu____3062 =
                            let uu____3069 =
-                             let uu____3072 = last_two args1  in
-                             resugar uu____3072  in
-                           (op1, uu____3069)  in
-                         FStar_Parser_AST.Op uu____3062  in
+                             let uu____3072 = last_two args1 in
+                             resugar uu____3072 in
+                           (op1, uu____3069) in
+                         FStar_Parser_AST.Op uu____3062 in
                        mk1 uu____3061
                    | _0_42 when
                        (_0_42 = (Prims.parse_int "3")) &&
@@ -980,10 +913,10 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                        let uu____3087 =
                          let uu____3088 =
                            let uu____3095 =
-                             let uu____3098 = last_three args1  in
-                             resugar uu____3098  in
-                           (op1, uu____3095)  in
-                         FStar_Parser_AST.Op uu____3088  in
+                             let uu____3098 = last_three args1 in
+                             resugar uu____3098 in
+                           (op1, uu____3095) in
+                         FStar_Parser_AST.Op uu____3088 in
                        mk1 uu____3087
                    | uu____3107 -> resugar_as_app e args1)
               | _0_43 when
@@ -993,22 +926,20 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                   let uu____3114 =
                     let uu____3115 =
                       let uu____3122 =
-                        let uu____3125 = last_two args1  in
-                        resugar uu____3125  in
-                      (op1, uu____3122)  in
-                    FStar_Parser_AST.Op uu____3115  in
+                        let uu____3125 = last_two args1 in resugar uu____3125 in
+                      (op1, uu____3122) in
+                    FStar_Parser_AST.Op uu____3115 in
                   mk1 uu____3114
               | uu____3134 -> resugar_as_app e args1))
     | FStar_Syntax_Syntax.Tm_match (e,(pat,uu____3137,t1)::[]) ->
         let bnds =
           let uu____3218 =
             let uu____3231 =
-              let uu____3236 = resugar_pat pat  in
-              let uu____3237 = resugar_term e  in (uu____3236, uu____3237)
-               in
-            (FStar_Pervasives_Native.None, uu____3231)  in
-          [uu____3218]  in
-        let body = resugar_term t1  in
+              let uu____3236 = resugar_pat pat in
+              let uu____3237 = resugar_term e in (uu____3236, uu____3237) in
+            (FStar_Pervasives_Native.None, uu____3231) in
+          [uu____3218] in
+        let body = resugar_term t1 in
         mk1
           (FStar_Parser_AST.Let (FStar_Parser_AST.NoLetQualifier, bnds, body))
     | FStar_Syntax_Syntax.Tm_match
@@ -1016,50 +947,47 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
         (is_true_pat pat1) && (is_wild_pat pat2) ->
         let uu____3388 =
           let uu____3389 =
-            let uu____3396 = resugar_term e  in
-            let uu____3397 = resugar_term t1  in
-            let uu____3398 = resugar_term t2  in
-            (uu____3396, uu____3397, uu____3398)  in
-          FStar_Parser_AST.If uu____3389  in
+            let uu____3396 = resugar_term e in
+            let uu____3397 = resugar_term t1 in
+            let uu____3398 = resugar_term t2 in
+            (uu____3396, uu____3397, uu____3398) in
+          FStar_Parser_AST.If uu____3389 in
         mk1 uu____3388
     | FStar_Syntax_Syntax.Tm_match (e,branches) ->
         let resugar_branch uu____3456 =
           match uu____3456 with
           | (pat,wopt,b) ->
-              let pat1 = resugar_pat pat  in
+              let pat1 = resugar_pat pat in
               let wopt1 =
                 match wopt with
                 | FStar_Pervasives_Native.None  ->
                     FStar_Pervasives_Native.None
                 | FStar_Pervasives_Native.Some e1 ->
-                    let uu____3487 = resugar_term e1  in
-                    FStar_Pervasives_Native.Some uu____3487
-                 in
-              let b1 = resugar_term b  in (pat1, wopt1, b1)
-           in
+                    let uu____3487 = resugar_term e1 in
+                    FStar_Pervasives_Native.Some uu____3487 in
+              let b1 = resugar_term b in (pat1, wopt1, b1) in
         let uu____3491 =
           let uu____3492 =
-            let uu____3507 = resugar_term e  in
-            let uu____3508 = FStar_List.map resugar_branch branches  in
-            (uu____3507, uu____3508)  in
-          FStar_Parser_AST.Match uu____3492  in
+            let uu____3507 = resugar_term e in
+            let uu____3508 = FStar_List.map resugar_branch branches in
+            (uu____3507, uu____3508) in
+          FStar_Parser_AST.Match uu____3492 in
         mk1 uu____3491
     | FStar_Syntax_Syntax.Tm_ascribed (e,(asc,tac_opt),uu____3548) ->
         let term =
           match asc with
           | FStar_Util.Inl n1 -> resugar_term n1
-          | FStar_Util.Inr n1 -> resugar_comp n1  in
-        let tac_opt1 = FStar_Option.map resugar_term tac_opt  in
+          | FStar_Util.Inr n1 -> resugar_comp n1 in
+        let tac_opt1 = FStar_Option.map resugar_term tac_opt in
         let uu____3615 =
           let uu____3616 =
-            let uu____3625 = resugar_term e  in (uu____3625, term, tac_opt1)
-             in
-          FStar_Parser_AST.Ascribed uu____3616  in
+            let uu____3625 = resugar_term e in (uu____3625, term, tac_opt1) in
+          FStar_Parser_AST.Ascribed uu____3616 in
         mk1 uu____3615
     | FStar_Syntax_Syntax.Tm_let ((is_rec,source_lbs),body) ->
         let mk_pat a =
-          FStar_Parser_AST.mk_pattern a t.FStar_Syntax_Syntax.pos  in
-        let uu____3649 = FStar_Syntax_Subst.open_let_rec source_lbs body  in
+          FStar_Parser_AST.mk_pattern a t.FStar_Syntax_Syntax.pos in
+        let uu____3649 = FStar_Syntax_Subst.open_let_rec source_lbs body in
         (match uu____3649 with
          | (source_lbs1,body1) ->
              let resugar_one_binding bnd =
@@ -1067,48 +995,43 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                  match bnd.FStar_Syntax_Syntax.lbattrs with
                  | [] -> FStar_Pervasives_Native.None
                  | tms ->
-                     let uu____3700 = FStar_List.map resugar_term tms  in
-                     FStar_Pervasives_Native.Some uu____3700
-                  in
+                     let uu____3700 = FStar_List.map resugar_term tms in
+                     FStar_Pervasives_Native.Some uu____3700 in
                let uu____3705 =
                  let uu____3710 =
                    FStar_Syntax_Util.mk_conj bnd.FStar_Syntax_Syntax.lbtyp
-                     bnd.FStar_Syntax_Syntax.lbdef
-                    in
+                     bnd.FStar_Syntax_Syntax.lbdef in
                  FStar_Syntax_Subst.open_univ_vars
-                   bnd.FStar_Syntax_Syntax.lbunivs uu____3710
-                  in
+                   bnd.FStar_Syntax_Syntax.lbunivs uu____3710 in
                match uu____3705 with
                | (univs1,td) ->
                    let uu____3729 =
                      let uu____3738 =
-                       let uu____3739 = FStar_Syntax_Subst.compress td  in
-                       uu____3739.FStar_Syntax_Syntax.n  in
+                       let uu____3739 = FStar_Syntax_Subst.compress td in
+                       uu____3739.FStar_Syntax_Syntax.n in
                      match uu____3738 with
                      | FStar_Syntax_Syntax.Tm_app
                          (uu____3750,(t1,uu____3752)::(d,uu____3754)::[]) ->
                          (t1, d)
-                     | uu____3797 -> failwith "wrong let binding format"  in
+                     | uu____3797 -> failwith "wrong let binding format" in
                    (match uu____3729 with
                     | (typ,def) ->
                         let uu____3832 =
                           let uu____3839 =
-                            let uu____3840 = FStar_Syntax_Subst.compress def
-                               in
-                            uu____3840.FStar_Syntax_Syntax.n  in
+                            let uu____3840 = FStar_Syntax_Subst.compress def in
+                            uu____3840.FStar_Syntax_Syntax.n in
                           match uu____3839 with
                           | FStar_Syntax_Syntax.Tm_abs (b,t1,uu____3851) ->
                               let uu____3872 =
-                                FStar_Syntax_Subst.open_term b t1  in
+                                FStar_Syntax_Subst.open_term b t1 in
                               (match uu____3872 with
                                | (b1,t2) ->
                                    let b2 =
                                      let uu____3886 =
-                                       FStar_Options.print_implicits ()  in
-                                     if uu____3886 then b1 else filter_imp b1
-                                      in
+                                       FStar_Options.print_implicits () in
+                                     if uu____3886 then b1 else filter_imp b1 in
                                    (b2, t2, true))
-                          | uu____3888 -> ([], def, false)  in
+                          | uu____3888 -> ([], def, false) in
                         (match uu____3832 with
                          | (binders,term,is_pat_app) ->
                              let uu____3920 =
@@ -1123,14 +1046,12 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                                      let uu____3932 =
                                        let uu____3933 =
                                          let uu____3940 =
-                                           bv_as_unique_ident bv  in
+                                           bv_as_unique_ident bv in
                                          (uu____3940,
-                                           FStar_Pervasives_Native.None)
-                                          in
-                                       FStar_Parser_AST.PatVar uu____3933  in
-                                     mk_pat uu____3932  in
-                                   (uu____3931, term)
-                                in
+                                           FStar_Pervasives_Native.None) in
+                                       FStar_Parser_AST.PatVar uu____3933 in
+                                     mk_pat uu____3932 in
+                                   (uu____3931, term) in
                              (match uu____3920 with
                               | (pat,term1) ->
                                   let uu____3961 =
@@ -1143,7 +1064,7 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                                                 match uu____3993 with
                                                 | (bv,q) ->
                                                     let uu____4008 =
-                                                      resugar_arg_qual q  in
+                                                      resugar_arg_qual q in
                                                     FStar_Util.map_opt
                                                       uu____4008
                                                       (fun q1  ->
@@ -1151,53 +1072,43 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                                                            let uu____4021 =
                                                              let uu____4028 =
                                                                bv_as_unique_ident
-                                                                 bv
-                                                                in
-                                                             (uu____4028, q1)
-                                                              in
+                                                                 bv in
+                                                             (uu____4028, q1) in
                                                            FStar_Parser_AST.PatVar
-                                                             uu____4021
-                                                            in
-                                                         mk_pat uu____4020)))
-                                         in
+                                                             uu____4021 in
+                                                         mk_pat uu____4020))) in
                                       let uu____4031 =
-                                        let uu____4036 = resugar_term term1
-                                           in
+                                        let uu____4036 = resugar_term term1 in
                                         ((mk_pat
                                             (FStar_Parser_AST.PatApp
-                                               (pat, args))), uu____4036)
-                                         in
+                                               (pat, args))), uu____4036) in
                                       let uu____4039 =
-                                        universe_to_string univs1  in
+                                        universe_to_string univs1 in
                                       (uu____4031, uu____4039)
                                     else
                                       (let uu____4045 =
-                                         let uu____4050 = resugar_term term1
-                                            in
-                                         (pat, uu____4050)  in
+                                         let uu____4050 = resugar_term term1 in
+                                         (pat, uu____4050) in
                                        let uu____4051 =
-                                         universe_to_string univs1  in
-                                       (uu____4045, uu____4051))
-                                     in
-                                  (attrs_opt, uu____3961))))
-                in
-             let r = FStar_List.map resugar_one_binding source_lbs1  in
+                                         universe_to_string univs1 in
+                                       (uu____4045, uu____4051)) in
+                                  (attrs_opt, uu____3961)))) in
+             let r = FStar_List.map resugar_one_binding source_lbs1 in
              let bnds =
                let f uu____4149 =
                  match uu____4149 with
                  | (attrs,(pb,univs1)) ->
                      let uu____4205 =
-                       let uu____4206 = FStar_Options.print_universes ()  in
-                       Prims.op_Negation uu____4206  in
+                       let uu____4206 = FStar_Options.print_universes () in
+                       Prims.op_Negation uu____4206 in
                      if uu____4205
                      then (attrs, pb)
                      else
                        (attrs,
                          ((FStar_Pervasives_Native.fst pb),
-                           (label univs1 (FStar_Pervasives_Native.snd pb))))
-                  in
-               FStar_List.map f r  in
-             let body2 = resugar_term body1  in
+                           (label univs1 (FStar_Pervasives_Native.snd pb)))) in
+               FStar_List.map f r in
+             let body2 = resugar_term body1 in
              mk1
                (FStar_Parser_AST.Let
                   ((if is_rec
@@ -1206,28 +1117,28 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
     | FStar_Syntax_Syntax.Tm_uvar (u,uu____4281) ->
         let s =
           let uu____4307 =
-            let uu____4308 = FStar_Syntax_Unionfind.uvar_id u  in
-            FStar_All.pipe_right uu____4308 FStar_Util.string_of_int  in
-          Prims.strcat "?u" uu____4307  in
-        let uu____4309 = mk1 FStar_Parser_AST.Wild  in label s uu____4309
+            let uu____4308 = FStar_Syntax_Unionfind.uvar_id u in
+            FStar_All.pipe_right uu____4308 FStar_Util.string_of_int in
+          Prims.strcat "?u" uu____4307 in
+        let uu____4309 = mk1 FStar_Parser_AST.Wild in label s uu____4309
     | FStar_Syntax_Syntax.Tm_meta (e,m) ->
         let resugar_meta_desugared uu___72_4319 =
           match uu___72_4319 with
           | FStar_Syntax_Syntax.Data_app  ->
               let rec head_fv_universes_args h =
                 let uu____4340 =
-                  let uu____4341 = FStar_Syntax_Subst.compress h  in
-                  uu____4341.FStar_Syntax_Syntax.n  in
+                  let uu____4341 = FStar_Syntax_Subst.compress h in
+                  uu____4341.FStar_Syntax_Syntax.n in
                 match uu____4340 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
-                    let uu____4361 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                    let uu____4361 = FStar_Syntax_Syntax.lid_of_fv fv in
                     (uu____4361, [], [])
                 | FStar_Syntax_Syntax.Tm_uinst (h1,u) ->
-                    let uu____4384 = head_fv_universes_args h1  in
+                    let uu____4384 = head_fv_universes_args h1 in
                     (match uu____4384 with
                      | (h2,uvs,args) -> (h2, (FStar_List.append uvs u), args))
                 | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-                    let uu____4472 = head_fv_universes_args head1  in
+                    let uu____4472 = head_fv_universes_args head1 in
                     (match uu____4472 with
                      | (h1,uvs,args') ->
                          (h1, uvs, (FStar_List.append args' args)))
@@ -1235,71 +1146,62 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                     let uu____4545 =
                       let uu____4550 =
                         let uu____4551 =
-                          let uu____4552 = resugar_term h  in
-                          parser_term_to_string uu____4552  in
+                          let uu____4552 = resugar_term h in
+                          parser_term_to_string uu____4552 in
                         FStar_Util.format1 "Not an application or a fv %s"
-                          uu____4551
-                         in
-                      (FStar_Errors.Fatal_NotApplicationOrFv, uu____4550)  in
+                          uu____4551 in
+                      (FStar_Errors.Fatal_NotApplicationOrFv, uu____4550) in
                     FStar_Errors.raise_error uu____4545
-                      e.FStar_Syntax_Syntax.pos
-                 in
+                      e.FStar_Syntax_Syntax.pos in
               let uu____4569 =
                 try
-                  let uu____4621 = FStar_Syntax_Util.unmeta e  in
+                  let uu____4621 = FStar_Syntax_Util.unmeta e in
                   head_fv_universes_args uu____4621
                 with
                 | FStar_Errors.Err uu____4642 ->
                     let uu____4647 =
                       let uu____4652 =
                         let uu____4653 =
-                          let uu____4654 = resugar_term e  in
-                          parser_term_to_string uu____4654  in
+                          let uu____4654 = resugar_term e in
+                          parser_term_to_string uu____4654 in
                         FStar_Util.format1 "wrong Data_app head format %s"
-                          uu____4653
-                         in
-                      (FStar_Errors.Fatal_WrongDataAppHeadFormat, uu____4652)
-                       in
+                          uu____4653 in
+                      (FStar_Errors.Fatal_WrongDataAppHeadFormat, uu____4652) in
                     FStar_Errors.raise_error uu____4647
-                      e.FStar_Syntax_Syntax.pos
-                 in
+                      e.FStar_Syntax_Syntax.pos in
               (match uu____4569 with
                | (head1,universes,args) ->
                    let universes1 =
                      FStar_List.map
                        (fun u  ->
                           let uu____4708 =
-                            resugar_universe u t.FStar_Syntax_Syntax.pos  in
-                          (uu____4708, FStar_Parser_AST.UnivApp)) universes
-                      in
+                            resugar_universe u t.FStar_Syntax_Syntax.pos in
+                          (uu____4708, FStar_Parser_AST.UnivApp)) universes in
                    let args1 =
                      FStar_List.filter_map
                        (fun uu____4732  ->
                           match uu____4732 with
                           | (t1,q) ->
-                              let uu____4751 = resugar_imp q  in
+                              let uu____4751 = resugar_imp q in
                               (match uu____4751 with
                                | FStar_Pervasives_Native.Some rimp ->
                                    let uu____4761 =
-                                     let uu____4766 = resugar_term t1  in
-                                     (uu____4766, rimp)  in
+                                     let uu____4766 = resugar_term t1 in
+                                     (uu____4766, rimp) in
                                    FStar_Pervasives_Native.Some uu____4761
                                | FStar_Pervasives_Native.None  ->
-                                   FStar_Pervasives_Native.None)) args
-                      in
+                                   FStar_Pervasives_Native.None)) args in
                    let args2 =
                      let uu____4782 =
                        (FStar_Parser_Const.is_tuple_data_lid' head1) ||
-                         (let uu____4784 = FStar_Options.print_universes ()
-                             in
-                          Prims.op_Negation uu____4784)
-                        in
+                         (let uu____4784 = FStar_Options.print_universes () in
+                          Prims.op_Negation uu____4784) in
                      if uu____4782
                      then args1
-                     else FStar_List.append universes1 args1  in
+                     else FStar_List.append universes1 args1 in
                    mk1 (FStar_Parser_AST.Construct (head1, args2)))
           | FStar_Syntax_Syntax.Sequence  ->
-              let term = resugar_term e  in
+              let term = resugar_term e in
               let rec resugar_seq t1 =
                 match t1.FStar_Parser_AST.tm with
                 | FStar_Parser_AST.Let
@@ -1308,17 +1210,17 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                 | FStar_Parser_AST.Ascribed (t11,t2,t3) ->
                     let uu____4866 =
                       let uu____4867 =
-                        let uu____4876 = resugar_seq t11  in
-                        (uu____4876, t2, t3)  in
-                      FStar_Parser_AST.Ascribed uu____4867  in
+                        let uu____4876 = resugar_seq t11 in
+                        (uu____4876, t2, t3) in
+                      FStar_Parser_AST.Ascribed uu____4867 in
                     mk1 uu____4866
-                | uu____4879 -> t1  in
+                | uu____4879 -> t1 in
               resugar_seq term
           | FStar_Syntax_Syntax.Primop  -> resugar_term e
           | FStar_Syntax_Syntax.Masked_effect  -> resugar_term e
           | FStar_Syntax_Syntax.Meta_smt_pat  -> resugar_term e
           | FStar_Syntax_Syntax.Mutable_alloc  ->
-              let term = resugar_term e  in
+              let term = resugar_term e in
               (match term.FStar_Parser_AST.tm with
                | FStar_Parser_AST.Let (FStar_Parser_AST.NoLetQualifier ,l,t1)
                    ->
@@ -1331,11 +1233,10 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
               let fv =
                 FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.sread_lid
                   FStar_Syntax_Syntax.Delta_constant
-                  FStar_Pervasives_Native.None
-                 in
+                  FStar_Pervasives_Native.None in
               let uu____4927 =
-                let uu____4928 = FStar_Syntax_Subst.compress e  in
-                uu____4928.FStar_Syntax_Syntax.n  in
+                let uu____4928 = FStar_Syntax_Subst.compress e in
+                uu____4928.FStar_Syntax_Syntax.n in
               (match uu____4927 with
                | FStar_Syntax_Syntax.Tm_app
                    ({
@@ -1343,8 +1244,7 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                       FStar_Syntax_Syntax.pos = uu____4932;
                       FStar_Syntax_Syntax.vars = uu____4933;_},(term,uu____4935)::[])
                    -> resugar_term term
-               | uu____4964 -> failwith "mutable_rval should have app term")
-           in
+               | uu____4964 -> failwith "mutable_rval should have app term") in
         (match m with
          | FStar_Syntax_Syntax.Meta_pattern pats ->
              let pats1 =
@@ -1352,14 +1252,13 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
                  (FStar_List.map
                     (fun uu____5002  ->
                        match uu____5002 with
-                       | (x,uu____5008) -> resugar_term x))
-                in
+                       | (x,uu____5008) -> resugar_term x)) in
              mk1 (FStar_Parser_AST.Attributes pats1)
          | FStar_Syntax_Syntax.Meta_labeled (l,uu____5010,p) ->
              let uu____5012 =
                let uu____5013 =
-                 let uu____5020 = resugar_term e  in (uu____5020, l, p)  in
-               FStar_Parser_AST.Labeled uu____5013  in
+                 let uu____5020 = resugar_term e in (uu____5020, l, p) in
+               FStar_Parser_AST.Labeled uu____5013 in
              mk1 uu____5012
          | FStar_Syntax_Syntax.Meta_desugared i -> resugar_meta_desugared i
          | FStar_Syntax_Syntax.Meta_alien (uu____5022,s,uu____5024) ->
@@ -1380,50 +1279,48 @@ let rec (resugar_term : FStar_Syntax_Syntax.term -> FStar_Parser_AST.term) =
          | FStar_Syntax_Syntax.Meta_monadic (name1,t1) ->
              let uu____5038 =
                let uu____5039 =
-                 let uu____5048 = resugar_term e  in
+                 let uu____5048 = resugar_term e in
                  let uu____5049 =
                    let uu____5050 =
                      let uu____5051 =
                        let uu____5062 =
                          let uu____5069 =
-                           let uu____5074 = resugar_term t1  in
-                           (uu____5074, FStar_Parser_AST.Nothing)  in
-                         [uu____5069]  in
-                       (name1, uu____5062)  in
-                     FStar_Parser_AST.Construct uu____5051  in
-                   mk1 uu____5050  in
-                 (uu____5048, uu____5049, FStar_Pervasives_Native.None)  in
-               FStar_Parser_AST.Ascribed uu____5039  in
+                           let uu____5074 = resugar_term t1 in
+                           (uu____5074, FStar_Parser_AST.Nothing) in
+                         [uu____5069] in
+                       (name1, uu____5062) in
+                     FStar_Parser_AST.Construct uu____5051 in
+                   mk1 uu____5050 in
+                 (uu____5048, uu____5049, FStar_Pervasives_Native.None) in
+               FStar_Parser_AST.Ascribed uu____5039 in
              mk1 uu____5038
          | FStar_Syntax_Syntax.Meta_monadic_lift (name1,uu____5092,t1) ->
              let uu____5098 =
                let uu____5099 =
-                 let uu____5108 = resugar_term e  in
+                 let uu____5108 = resugar_term e in
                  let uu____5109 =
                    let uu____5110 =
                      let uu____5111 =
                        let uu____5122 =
                          let uu____5129 =
-                           let uu____5134 = resugar_term t1  in
-                           (uu____5134, FStar_Parser_AST.Nothing)  in
-                         [uu____5129]  in
-                       (name1, uu____5122)  in
-                     FStar_Parser_AST.Construct uu____5111  in
-                   mk1 uu____5110  in
-                 (uu____5108, uu____5109, FStar_Pervasives_Native.None)  in
-               FStar_Parser_AST.Ascribed uu____5099  in
+                           let uu____5134 = resugar_term t1 in
+                           (uu____5134, FStar_Parser_AST.Nothing) in
+                         [uu____5129] in
+                       (name1, uu____5122) in
+                     FStar_Parser_AST.Construct uu____5111 in
+                   mk1 uu____5110 in
+                 (uu____5108, uu____5109, FStar_Pervasives_Native.None) in
+               FStar_Parser_AST.Ascribed uu____5099 in
              mk1 uu____5098)
     | FStar_Syntax_Syntax.Tm_unknown  -> mk1 FStar_Parser_AST.Wild
-
-and (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
+and resugar_comp: FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term =
   fun c  ->
     let mk1 a =
       FStar_Parser_AST.mk_term a c.FStar_Syntax_Syntax.pos
-        FStar_Parser_AST.Un
-       in
+        FStar_Parser_AST.Un in
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total (typ,u) ->
-        let t = resugar_term typ  in
+        let t = resugar_term typ in
         (match u with
          | FStar_Pervasives_Native.None  ->
              mk1
@@ -1431,10 +1328,10 @@ and (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
                   (FStar_Parser_Const.effect_Tot_lid,
                     [(t, FStar_Parser_AST.Nothing)]))
          | FStar_Pervasives_Native.Some u1 ->
-             let uu____5182 = FStar_Options.print_universes ()  in
+             let uu____5182 = FStar_Options.print_universes () in
              if uu____5182
              then
-               let u2 = resugar_universe u1 c.FStar_Syntax_Syntax.pos  in
+               let u2 = resugar_universe u1 c.FStar_Syntax_Syntax.pos in
                mk1
                  (FStar_Parser_AST.Construct
                     (FStar_Parser_Const.effect_Tot_lid,
@@ -1446,7 +1343,7 @@ and (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
                     (FStar_Parser_Const.effect_Tot_lid,
                       [(t, FStar_Parser_AST.Nothing)])))
     | FStar_Syntax_Syntax.GTotal (typ,u) ->
-        let t = resugar_term typ  in
+        let t = resugar_term typ in
         (match u with
          | FStar_Pervasives_Native.None  ->
              mk1
@@ -1454,10 +1351,10 @@ and (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
                   (FStar_Parser_Const.effect_GTot_lid,
                     [(t, FStar_Parser_AST.Nothing)]))
          | FStar_Pervasives_Native.Some u1 ->
-             let uu____5243 = FStar_Options.print_universes ()  in
+             let uu____5243 = FStar_Options.print_universes () in
              if uu____5243
              then
-               let u2 = resugar_universe u1 c.FStar_Syntax_Syntax.pos  in
+               let u2 = resugar_universe u1 c.FStar_Syntax_Syntax.pos in
                mk1
                  (FStar_Parser_AST.Construct
                     (FStar_Parser_Const.effect_GTot_lid,
@@ -1470,15 +1367,14 @@ and (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
                       [(t, FStar_Parser_AST.Nothing)])))
     | FStar_Syntax_Syntax.Comp c1 ->
         let result =
-          let uu____5284 = resugar_term c1.FStar_Syntax_Syntax.result_typ  in
-          (uu____5284, FStar_Parser_AST.Nothing)  in
-        let uu____5285 = FStar_Options.print_effect_args ()  in
+          let uu____5284 = resugar_term c1.FStar_Syntax_Syntax.result_typ in
+          (uu____5284, FStar_Parser_AST.Nothing) in
+        let uu____5285 = FStar_Options.print_effect_args () in
         if uu____5285
         then
           let universe =
             FStar_List.map (fun u  -> resugar_universe u)
-              c1.FStar_Syntax_Syntax.comp_univs
-             in
+              c1.FStar_Syntax_Syntax.comp_univs in
           let args =
             if
               FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
@@ -1489,34 +1385,30 @@ and (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
                   let post1 =
                     let uu____5372 =
                       FStar_Syntax_Util.unthunk_lemma_post
-                        (FStar_Pervasives_Native.fst post)
-                       in
-                    (uu____5372, (FStar_Pervasives_Native.snd post))  in
+                        (FStar_Pervasives_Native.fst post) in
+                    (uu____5372, (FStar_Pervasives_Native.snd post)) in
                   let uu____5381 =
                     let uu____5390 =
                       FStar_Syntax_Util.is_fvar FStar_Parser_Const.true_lid
-                        (FStar_Pervasives_Native.fst pre)
-                       in
-                    if uu____5390 then [] else [pre]  in
+                        (FStar_Pervasives_Native.fst pre) in
+                    if uu____5390 then [] else [pre] in
                   let uu____5420 =
                     let uu____5429 =
                       let uu____5438 =
                         FStar_Syntax_Util.is_fvar FStar_Parser_Const.nil_lid
-                          (FStar_Pervasives_Native.fst pats)
-                         in
-                      if uu____5438 then [] else [pats]  in
-                    FStar_List.append [post1] uu____5429  in
+                          (FStar_Pervasives_Native.fst pats) in
+                      if uu____5438 then [] else [pats] in
+                    FStar_List.append [post1] uu____5429 in
                   FStar_List.append uu____5381 uu____5420
               | uu____5492 -> c1.FStar_Syntax_Syntax.effect_args
-            else c1.FStar_Syntax_Syntax.effect_args  in
+            else c1.FStar_Syntax_Syntax.effect_args in
           let args1 =
             FStar_List.map
               (fun uu____5521  ->
                  match uu____5521 with
                  | (e,uu____5531) ->
-                     let uu____5532 = resugar_term e  in
-                     (uu____5532, FStar_Parser_AST.Nothing)) args
-             in
+                     let uu____5532 = resugar_term e in
+                     (uu____5532, FStar_Parser_AST.Nothing)) args in
           let rec aux l uu___73_5553 =
             match uu___73_5553 with
             | [] -> l
@@ -1524,12 +1416,11 @@ and (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
                 (match hd1 with
                  | FStar_Syntax_Syntax.DECREASES e ->
                      let e1 =
-                       let uu____5586 = resugar_term e  in
-                       (uu____5586, FStar_Parser_AST.Nothing)  in
+                       let uu____5586 = resugar_term e in
+                       (uu____5586, FStar_Parser_AST.Nothing) in
                      aux (e1 :: l) tl1
-                 | uu____5591 -> aux l tl1)
-             in
-          let decrease = aux [] c1.FStar_Syntax_Syntax.flags  in
+                 | uu____5591 -> aux l tl1) in
+          let decrease = aux [] c1.FStar_Syntax_Syntax.flags in
           mk1
             (FStar_Parser_AST.Construct
                ((c1.FStar_Syntax_Syntax.effect_name),
@@ -1538,30 +1429,29 @@ and (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
           mk1
             (FStar_Parser_AST.Construct
                ((c1.FStar_Syntax_Syntax.effect_name), [result]))
-
-and (resugar_binder :
+and resugar_binder:
   FStar_Syntax_Syntax.binder ->
     FStar_Range.range ->
-      FStar_Parser_AST.binder FStar_Pervasives_Native.option)
+      FStar_Parser_AST.binder FStar_Pervasives_Native.option
   =
   fun b  ->
     fun r  ->
-      let uu____5636 = b  in
+      let uu____5636 = b in
       match uu____5636 with
       | (x,aq) ->
-          let uu____5641 = resugar_arg_qual aq  in
+          let uu____5641 = resugar_arg_qual aq in
           FStar_Util.map_opt uu____5641
             (fun imp  ->
-               let e = resugar_term x.FStar_Syntax_Syntax.sort  in
+               let e = resugar_term x.FStar_Syntax_Syntax.sort in
                match e.FStar_Parser_AST.tm with
                | FStar_Parser_AST.Wild  ->
                    let uu____5655 =
-                     let uu____5656 = bv_as_unique_ident x  in
-                     FStar_Parser_AST.Variable uu____5656  in
+                     let uu____5656 = bv_as_unique_ident x in
+                     FStar_Parser_AST.Variable uu____5656 in
                    FStar_Parser_AST.mk_binder uu____5655 r
                      FStar_Parser_AST.Type_level imp
                | uu____5657 ->
-                   let uu____5658 = FStar_Syntax_Syntax.is_null_bv x  in
+                   let uu____5658 = FStar_Syntax_Syntax.is_null_bv x in
                    if uu____5658
                    then
                      FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName e) r
@@ -1569,84 +1459,80 @@ and (resugar_binder :
                    else
                      (let uu____5660 =
                         let uu____5661 =
-                          let uu____5666 = bv_as_unique_ident x  in
-                          (uu____5666, e)  in
-                        FStar_Parser_AST.Annotated uu____5661  in
+                          let uu____5666 = bv_as_unique_ident x in
+                          (uu____5666, e) in
+                        FStar_Parser_AST.Annotated uu____5661 in
                       FStar_Parser_AST.mk_binder uu____5660 r
                         FStar_Parser_AST.Type_level imp))
-
-and (resugar_bv_as_pat :
+and resugar_bv_as_pat:
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.aqual ->
-      FStar_Parser_AST.pattern FStar_Pervasives_Native.option)
+      FStar_Parser_AST.pattern FStar_Pervasives_Native.option
   =
   fun x  ->
     fun qual  ->
       let mk1 a =
-        let uu____5675 = FStar_Syntax_Syntax.range_of_bv x  in
-        FStar_Parser_AST.mk_pattern a uu____5675  in
+        let uu____5675 = FStar_Syntax_Syntax.range_of_bv x in
+        FStar_Parser_AST.mk_pattern a uu____5675 in
       let uu____5676 =
         let uu____5677 =
-          FStar_Syntax_Subst.compress x.FStar_Syntax_Syntax.sort  in
-        uu____5677.FStar_Syntax_Syntax.n  in
+          FStar_Syntax_Subst.compress x.FStar_Syntax_Syntax.sort in
+        uu____5677.FStar_Syntax_Syntax.n in
       match uu____5676 with
       | FStar_Syntax_Syntax.Tm_unknown  ->
           let i =
             FStar_String.compare
               (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-              FStar_Ident.reserved_prefix
-             in
+              FStar_Ident.reserved_prefix in
           if i = (Prims.parse_int "0")
           then
-            let uu____5685 = mk1 FStar_Parser_AST.PatWild  in
+            let uu____5685 = mk1 FStar_Parser_AST.PatWild in
             FStar_Pervasives_Native.Some uu____5685
           else
-            (let uu____5687 = resugar_arg_qual qual  in
+            (let uu____5687 = resugar_arg_qual qual in
              FStar_Util.bind_opt uu____5687
                (fun aq  ->
                   let uu____5699 =
                     let uu____5700 =
                       let uu____5701 =
-                        let uu____5708 = bv_as_unique_ident x  in
-                        (uu____5708, aq)  in
-                      FStar_Parser_AST.PatVar uu____5701  in
-                    mk1 uu____5700  in
+                        let uu____5708 = bv_as_unique_ident x in
+                        (uu____5708, aq) in
+                      FStar_Parser_AST.PatVar uu____5701 in
+                    mk1 uu____5700 in
                   FStar_Pervasives_Native.Some uu____5699))
       | uu____5711 ->
-          let uu____5712 = resugar_arg_qual qual  in
+          let uu____5712 = resugar_arg_qual qual in
           FStar_Util.bind_opt uu____5712
             (fun aq  ->
                let pat =
                  let uu____5727 =
                    let uu____5728 =
-                     let uu____5735 = bv_as_unique_ident x  in
-                     (uu____5735, aq)  in
-                   FStar_Parser_AST.PatVar uu____5728  in
-                 mk1 uu____5727  in
-               let uu____5738 = FStar_Options.print_bound_var_types ()  in
+                     let uu____5735 = bv_as_unique_ident x in
+                     (uu____5735, aq) in
+                   FStar_Parser_AST.PatVar uu____5728 in
+                 mk1 uu____5727 in
+               let uu____5738 = FStar_Options.print_bound_var_types () in
                if uu____5738
                then
                  let uu____5741 =
                    let uu____5742 =
                      let uu____5743 =
                        let uu____5748 =
-                         resugar_term x.FStar_Syntax_Syntax.sort  in
-                       (pat, uu____5748)  in
-                     FStar_Parser_AST.PatAscribed uu____5743  in
-                   mk1 uu____5742  in
+                         resugar_term x.FStar_Syntax_Syntax.sort in
+                       (pat, uu____5748) in
+                     FStar_Parser_AST.PatAscribed uu____5743 in
+                   mk1 uu____5742 in
                  FStar_Pervasives_Native.Some uu____5741
                else FStar_Pervasives_Native.Some pat)
-
-and (resugar_pat : FStar_Syntax_Syntax.pat -> FStar_Parser_AST.pattern) =
+and resugar_pat: FStar_Syntax_Syntax.pat -> FStar_Parser_AST.pattern =
   fun p  ->
-    let mk1 a = FStar_Parser_AST.mk_pattern a p.FStar_Syntax_Syntax.p  in
+    let mk1 a = FStar_Parser_AST.mk_pattern a p.FStar_Syntax_Syntax.p in
     let to_arg_qual bopt =
       FStar_Util.bind_opt bopt
         (fun b  ->
            if b
            then FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit
-           else FStar_Pervasives_Native.None)
-       in
+           else FStar_Pervasives_Native.None) in
     let rec aux p1 imp_opt =
       match p1.FStar_Syntax_Syntax.v with
       | FStar_Syntax_Syntax.Pat_constant c ->
@@ -1664,8 +1550,7 @@ and (resugar_pat : FStar_Syntax_Syntax.pat -> FStar_Parser_AST.pattern) =
             FStar_List.map
               (fun uu____5825  ->
                  match uu____5825 with
-                 | (p2,b) -> aux p2 (FStar_Pervasives_Native.Some b)) args
-             in
+                 | (p2,b) -> aux p2 (FStar_Pervasives_Native.Some b)) args in
           mk1 (FStar_Parser_AST.PatList args1)
       | FStar_Syntax_Syntax.Pat_cons (fv,args) when
           (FStar_Parser_Const.is_tuple_data_lid'
@@ -1678,12 +1563,10 @@ and (resugar_pat : FStar_Syntax_Syntax.pat -> FStar_Parser_AST.pattern) =
             FStar_List.map
               (fun uu____5860  ->
                  match uu____5860 with
-                 | (p2,b) -> aux p2 (FStar_Pervasives_Native.Some b)) args
-             in
+                 | (p2,b) -> aux p2 (FStar_Pervasives_Native.Some b)) args in
           let uu____5867 =
             FStar_Parser_Const.is_dtuple_data_lid'
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           if uu____5867
           then mk1 (FStar_Parser_AST.PatTuple (args1, true))
           else mk1 (FStar_Parser_AST.PatTuple (args1, false))
@@ -1696,39 +1579,35 @@ and (resugar_pat : FStar_Syntax_Syntax.pat -> FStar_Parser_AST.pattern) =
           let fields1 =
             let uu____5901 =
               FStar_All.pipe_right fields
-                (FStar_List.map (fun f  -> FStar_Ident.lid_of_ids [f]))
-               in
-            FStar_All.pipe_right uu____5901 FStar_List.rev  in
+                (FStar_List.map (fun f  -> FStar_Ident.lid_of_ids [f])) in
+            FStar_All.pipe_right uu____5901 FStar_List.rev in
           let args1 =
             let uu____5917 =
               FStar_All.pipe_right args
                 (FStar_List.map
                    (fun uu____5937  ->
                       match uu____5937 with
-                      | (p2,b) -> aux p2 (FStar_Pervasives_Native.Some b)))
-               in
-            FStar_All.pipe_right uu____5917 FStar_List.rev  in
+                      | (p2,b) -> aux p2 (FStar_Pervasives_Native.Some b))) in
+            FStar_All.pipe_right uu____5917 FStar_List.rev in
           let rec map21 l1 l2 =
             match (l1, l2) with
             | ([],[]) -> []
             | ([],hd1::tl1) -> []
             | (hd1::tl1,[]) ->
-                let uu____6007 = map21 tl1 []  in
+                let uu____6007 = map21 tl1 [] in
                 (hd1, (mk1 FStar_Parser_AST.PatWild)) :: uu____6007
             | (hd1::tl1,hd2::tl2) ->
-                let uu____6030 = map21 tl1 tl2  in (hd1, hd2) :: uu____6030
-             in
+                let uu____6030 = map21 tl1 tl2 in (hd1, hd2) :: uu____6030 in
           let args2 =
-            let uu____6048 = map21 fields1 args1  in
-            FStar_All.pipe_right uu____6048 FStar_List.rev  in
+            let uu____6048 = map21 fields1 args1 in
+            FStar_All.pipe_right uu____6048 FStar_List.rev in
           mk1 (FStar_Parser_AST.PatRecord args2)
       | FStar_Syntax_Syntax.Pat_cons (fv,args) ->
           let args1 =
             FStar_List.map
               (fun uu____6099  ->
                  match uu____6099 with
-                 | (p2,b) -> aux p2 (FStar_Pervasives_Native.Some b)) args
-             in
+                 | (p2,b) -> aux p2 (FStar_Pervasives_Native.Some b)) args in
           mk1
             (FStar_Parser_AST.PatApp
                ((mk1
@@ -1737,8 +1616,7 @@ and (resugar_pat : FStar_Syntax_Syntax.pat -> FStar_Parser_AST.pattern) =
                  args1))
       | FStar_Syntax_Syntax.Pat_var v1 ->
           let uu____6109 =
-            string_to_op (v1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-             in
+            string_to_op (v1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText in
           (match uu____6109 with
            | FStar_Pervasives_Native.Some (op,uu____6117) ->
                mk1
@@ -1749,10 +1627,10 @@ and (resugar_pat : FStar_Syntax_Syntax.pat -> FStar_Parser_AST.pattern) =
            | FStar_Pervasives_Native.None  ->
                let uu____6126 =
                  let uu____6127 =
-                   let uu____6134 = bv_as_unique_ident v1  in
-                   let uu____6135 = to_arg_qual imp_opt  in
-                   (uu____6134, uu____6135)  in
-                 FStar_Parser_AST.PatVar uu____6127  in
+                   let uu____6134 = bv_as_unique_ident v1 in
+                   let uu____6135 = to_arg_qual imp_opt in
+                   (uu____6134, uu____6135) in
+                 FStar_Parser_AST.PatVar uu____6127 in
                mk1 uu____6126)
       | FStar_Syntax_Syntax.Pat_wild uu____6140 ->
           mk1 FStar_Parser_AST.PatWild
@@ -1760,27 +1638,24 @@ and (resugar_pat : FStar_Syntax_Syntax.pat -> FStar_Parser_AST.pattern) =
           let pat =
             let uu____6148 =
               let uu____6149 =
-                let uu____6156 = bv_as_unique_ident bv  in
+                let uu____6156 = bv_as_unique_ident bv in
                 (uu____6156,
-                  (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit))
-                 in
-              FStar_Parser_AST.PatVar uu____6149  in
-            mk1 uu____6148  in
-          let uu____6159 = FStar_Options.print_bound_var_types ()  in
+                  (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)) in
+              FStar_Parser_AST.PatVar uu____6149 in
+            mk1 uu____6148 in
+          let uu____6159 = FStar_Options.print_bound_var_types () in
           if uu____6159
           then
             let uu____6160 =
               let uu____6161 =
-                let uu____6166 = resugar_term term  in (pat, uu____6166)  in
-              FStar_Parser_AST.PatAscribed uu____6161  in
+                let uu____6166 = resugar_term term in (pat, uu____6166) in
+              FStar_Parser_AST.PatAscribed uu____6161 in
             mk1 uu____6160
-          else pat
-       in
+          else pat in
     aux p FStar_Pervasives_Native.None
-
-let (resugar_qualifier :
+let resugar_qualifier:
   FStar_Syntax_Syntax.qualifier ->
-    FStar_Parser_AST.qualifier FStar_Pervasives_Native.option)
+    FStar_Parser_AST.qualifier FStar_Pervasives_Native.option
   =
   fun uu___74_6172  ->
     match uu___74_6172 with
@@ -1834,20 +1709,17 @@ let (resugar_qualifier :
     | FStar_Syntax_Syntax.Effect  ->
         FStar_Pervasives_Native.Some FStar_Parser_AST.Effect_qual
     | FStar_Syntax_Syntax.OnlyName  -> FStar_Pervasives_Native.None
-  
-let (resugar_pragma : FStar_Syntax_Syntax.pragma -> FStar_Parser_AST.pragma)
-  =
+let resugar_pragma: FStar_Syntax_Syntax.pragma -> FStar_Parser_AST.pragma =
   fun uu___75_6209  ->
     match uu___75_6209 with
     | FStar_Syntax_Syntax.SetOptions s -> FStar_Parser_AST.SetOptions s
     | FStar_Syntax_Syntax.ResetOptions s -> FStar_Parser_AST.ResetOptions s
     | FStar_Syntax_Syntax.LightOff  -> FStar_Parser_AST.LightOff
-  
-let (resugar_typ :
+let resugar_typ:
   FStar_Syntax_Syntax.sigelt Prims.list ->
     FStar_Syntax_Syntax.sigelt ->
       (FStar_Syntax_Syntax.sigelts,FStar_Parser_AST.tycon)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun datacon_ses  ->
     fun se  ->
@@ -1862,18 +1734,16 @@ let (resugar_typ :
                     | FStar_Syntax_Syntax.Sig_datacon
                         (uu____6273,uu____6274,uu____6275,inductive_lid,uu____6277,uu____6278)
                         -> FStar_Ident.lid_equals inductive_lid tylid
-                    | uu____6283 -> failwith "unexpected"))
-             in
+                    | uu____6283 -> failwith "unexpected")) in
           (match uu____6246 with
            | (current_datacons,other_datacons) ->
                let bs1 =
-                 let uu____6302 = FStar_Options.print_implicits ()  in
-                 if uu____6302 then bs else filter_imp bs  in
+                 let uu____6302 = FStar_Options.print_implicits () in
+                 if uu____6302 then bs else filter_imp bs in
                let bs2 =
                  FStar_All.pipe_right bs1
                    ((map_opt ())
-                      (fun b  -> resugar_binder b t.FStar_Syntax_Syntax.pos))
-                  in
+                      (fun b  -> resugar_binder b t.FStar_Syntax_Syntax.pos)) in
                let tyc =
                  let uu____6312 =
                    FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
@@ -1882,8 +1752,7 @@ let (resugar_typ :
                            match uu___76_6317 with
                            | FStar_Syntax_Syntax.RecordType uu____6318 ->
                                true
-                           | uu____6327 -> false))
-                    in
+                           | uu____6327 -> false)) in
                  if uu____6312
                  then
                    let resugar_datacon_as_fields fields se1 =
@@ -1892,9 +1761,8 @@ let (resugar_typ :
                          (uu____6375,univs1,term,uu____6378,num,uu____6380)
                          ->
                          let uu____6385 =
-                           let uu____6386 = FStar_Syntax_Subst.compress term
-                              in
-                           uu____6386.FStar_Syntax_Syntax.n  in
+                           let uu____6386 = FStar_Syntax_Subst.compress term in
+                           uu____6386.FStar_Syntax_Syntax.n in
                          (match uu____6385 with
                           | FStar_Syntax_Syntax.Tm_arrow (bs3,uu____6400) ->
                               let mfields =
@@ -1905,24 +1773,20 @@ let (resugar_typ :
                                         | (b,qual) ->
                                             let uu____6476 =
                                               let uu____6477 =
-                                                bv_as_unique_ident b  in
+                                                bv_as_unique_ident b in
                                               FStar_Syntax_Util.unmangle_field_name
-                                                uu____6477
-                                               in
+                                                uu____6477 in
                                             let uu____6478 =
                                               resugar_term
-                                                b.FStar_Syntax_Syntax.sort
-                                               in
+                                                b.FStar_Syntax_Syntax.sort in
                                             (uu____6476, uu____6478,
-                                              FStar_Pervasives_Native.None)))
-                                 in
+                                              FStar_Pervasives_Native.None))) in
                               FStar_List.append mfields fields
                           | uu____6489 -> failwith "unexpected")
-                     | uu____6500 -> failwith "unexpected"  in
+                     | uu____6500 -> failwith "unexpected" in
                    let fields =
                      FStar_List.fold_left resugar_datacon_as_fields []
-                       current_datacons
-                      in
+                       current_datacons in
                    FStar_Parser_AST.TyconRecord
                      ((tylid.FStar_Ident.ident), bs2,
                        FStar_Pervasives_Native.None, fields)
@@ -1933,35 +1797,31 @@ let (resugar_typ :
                           (l,univs1,term,uu____6621,num,uu____6623) ->
                           let c =
                             let uu____6641 =
-                              let uu____6644 = resugar_term term  in
-                              FStar_Pervasives_Native.Some uu____6644  in
+                              let uu____6644 = resugar_term term in
+                              FStar_Pervasives_Native.Some uu____6644 in
                             ((l.FStar_Ident.ident), uu____6641,
-                              FStar_Pervasives_Native.None, false)
-                             in
+                              FStar_Pervasives_Native.None, false) in
                           c :: constructors
-                      | uu____6661 -> failwith "unexpected"  in
+                      | uu____6661 -> failwith "unexpected" in
                     let constructors =
                       FStar_List.fold_left resugar_datacon []
-                        current_datacons
-                       in
+                        current_datacons in
                     FStar_Parser_AST.TyconVariant
                       ((tylid.FStar_Ident.ident), bs2,
-                        FStar_Pervasives_Native.None, constructors))
-                  in
+                        FStar_Pervasives_Native.None, constructors)) in
                (other_datacons, tyc))
       | uu____6737 ->
           failwith
             "Impossible : only Sig_inductive_typ can be resugared as types"
-  
-let (mk_decl :
+let mk_decl:
   FStar_Range.range ->
     FStar_Syntax_Syntax.qualifier Prims.list ->
-      FStar_Parser_AST.decl' -> FStar_Parser_AST.decl)
+      FStar_Parser_AST.decl' -> FStar_Parser_AST.decl
   =
   fun r  ->
     fun q  ->
       fun d'  ->
-        let uu____6755 = FStar_List.choose resugar_qualifier q  in
+        let uu____6755 = FStar_List.choose resugar_qualifier q in
         {
           FStar_Parser_AST.d = d';
           FStar_Parser_AST.drange = r;
@@ -1969,48 +1829,44 @@ let (mk_decl :
           FStar_Parser_AST.quals = uu____6755;
           FStar_Parser_AST.attrs = []
         }
-  
-let (decl'_to_decl :
+let decl'_to_decl:
   FStar_Syntax_Syntax.sigelt ->
-    FStar_Parser_AST.decl' -> FStar_Parser_AST.decl)
+    FStar_Parser_AST.decl' -> FStar_Parser_AST.decl
   =
   fun se  ->
     fun d'  ->
       mk_decl se.FStar_Syntax_Syntax.sigrng se.FStar_Syntax_Syntax.sigquals
         d'
-  
-let (resugar_tscheme' :
-  Prims.string -> FStar_Syntax_Syntax.tscheme -> FStar_Parser_AST.decl) =
+let resugar_tscheme':
+  Prims.string -> FStar_Syntax_Syntax.tscheme -> FStar_Parser_AST.decl =
   fun name  ->
     fun ts  ->
-      let uu____6768 = ts  in
+      let uu____6768 = ts in
       match uu____6768 with
       | (univs1,typ) ->
           let name1 =
-            FStar_Ident.mk_ident (name, (typ.FStar_Syntax_Syntax.pos))  in
+            FStar_Ident.mk_ident (name, (typ.FStar_Syntax_Syntax.pos)) in
           let uu____6776 =
             let uu____6777 =
               let uu____6790 =
                 let uu____6799 =
                   let uu____6806 =
                     let uu____6807 =
-                      let uu____6820 = resugar_term typ  in
-                      (name1, [], FStar_Pervasives_Native.None, uu____6820)
-                       in
-                    FStar_Parser_AST.TyconAbbrev uu____6807  in
-                  (uu____6806, FStar_Pervasives_Native.None)  in
-                [uu____6799]  in
-              (false, uu____6790)  in
-            FStar_Parser_AST.Tycon uu____6777  in
+                      let uu____6820 = resugar_term typ in
+                      (name1, [], FStar_Pervasives_Native.None, uu____6820) in
+                    FStar_Parser_AST.TyconAbbrev uu____6807 in
+                  (uu____6806, FStar_Pervasives_Native.None) in
+                [uu____6799] in
+              (false, uu____6790) in
+            FStar_Parser_AST.Tycon uu____6777 in
           mk_decl typ.FStar_Syntax_Syntax.pos [] uu____6776
-  
-let (resugar_tscheme : FStar_Syntax_Syntax.tscheme -> FStar_Parser_AST.decl)
-  = fun ts  -> resugar_tscheme' "tscheme" ts 
-let (resugar_eff_decl :
+let resugar_tscheme: FStar_Syntax_Syntax.tscheme -> FStar_Parser_AST.decl =
+  fun ts  -> resugar_tscheme' "tscheme" ts
+let resugar_eff_decl:
   Prims.bool ->
     FStar_Range.range ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
-        FStar_Syntax_Syntax.eff_decl -> FStar_Parser_AST.decl)
+        FStar_Syntax_Syntax.eff_decl -> FStar_Parser_AST.decl
   =
   fun for_free  ->
     fun r  ->
@@ -2019,46 +1875,41 @@ let (resugar_eff_decl :
           let resugar_action d for_free1 =
             let action_params =
               FStar_Syntax_Subst.open_binders
-                d.FStar_Syntax_Syntax.action_params
-               in
+                d.FStar_Syntax_Syntax.action_params in
             let uu____6874 =
               FStar_Syntax_Subst.open_term action_params
-                d.FStar_Syntax_Syntax.action_defn
-               in
+                d.FStar_Syntax_Syntax.action_defn in
             match uu____6874 with
             | (bs,action_defn) ->
                 let uu____6881 =
                   FStar_Syntax_Subst.open_term action_params
-                    d.FStar_Syntax_Syntax.action_typ
-                   in
+                    d.FStar_Syntax_Syntax.action_typ in
                 (match uu____6881 with
                  | (bs1,action_typ) ->
                      let action_params1 =
-                       let uu____6889 = FStar_Options.print_implicits ()  in
+                       let uu____6889 = FStar_Options.print_implicits () in
                        if uu____6889
                        then action_params
-                       else filter_imp action_params  in
+                       else filter_imp action_params in
                      let action_params2 =
                        let uu____6894 =
                          FStar_All.pipe_right action_params1
-                           ((map_opt ()) (fun b  -> resugar_binder b r))
-                          in
-                       FStar_All.pipe_right uu____6894 FStar_List.rev  in
-                     let action_defn1 = resugar_term action_defn  in
-                     let action_typ1 = resugar_term action_typ  in
+                           ((map_opt ()) (fun b  -> resugar_binder b r)) in
+                       FStar_All.pipe_right uu____6894 FStar_List.rev in
+                     let action_defn1 = resugar_term action_defn in
+                     let action_typ1 = resugar_term action_typ in
                      if for_free1
                      then
                        let a =
                          let uu____6908 =
                            let uu____6919 =
-                             FStar_Ident.lid_of_str "construct"  in
+                             FStar_Ident.lid_of_str "construct" in
                            (uu____6919,
                              [(action_defn1, FStar_Parser_AST.Nothing);
-                             (action_typ1, FStar_Parser_AST.Nothing)])
-                            in
-                         FStar_Parser_AST.Construct uu____6908  in
+                             (action_typ1, FStar_Parser_AST.Nothing)]) in
+                         FStar_Parser_AST.Construct uu____6908 in
                        let t =
-                         FStar_Parser_AST.mk_term a r FStar_Parser_AST.Un  in
+                         FStar_Parser_AST.mk_term a r FStar_Parser_AST.Un in
                        mk_decl r q
                          (FStar_Parser_AST.Tycon
                             (false,
@@ -2076,62 +1927,50 @@ let (resugar_eff_decl :
                                      action_params2,
                                      FStar_Pervasives_Native.None,
                                      action_defn1)),
-                                 FStar_Pervasives_Native.None)])))
-             in
-          let eff_name = (ed.FStar_Syntax_Syntax.mname).FStar_Ident.ident  in
+                                 FStar_Pervasives_Native.None)]))) in
+          let eff_name = (ed.FStar_Syntax_Syntax.mname).FStar_Ident.ident in
           let uu____6993 =
             FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders
-              ed.FStar_Syntax_Syntax.signature
-             in
+              ed.FStar_Syntax_Syntax.signature in
           match uu____6993 with
           | (eff_binders,eff_typ) ->
               let eff_binders1 =
-                let uu____7001 = FStar_Options.print_implicits ()  in
-                if uu____7001 then eff_binders else filter_imp eff_binders
-                 in
+                let uu____7001 = FStar_Options.print_implicits () in
+                if uu____7001 then eff_binders else filter_imp eff_binders in
               let eff_binders2 =
                 let uu____7006 =
                   FStar_All.pipe_right eff_binders1
-                    ((map_opt ()) (fun b  -> resugar_binder b r))
-                   in
-                FStar_All.pipe_right uu____7006 FStar_List.rev  in
-              let eff_typ1 = resugar_term eff_typ  in
+                    ((map_opt ()) (fun b  -> resugar_binder b r)) in
+                FStar_All.pipe_right uu____7006 FStar_List.rev in
+              let eff_typ1 = resugar_term eff_typ in
               let ret_wp =
-                resugar_tscheme' "ret_wp" ed.FStar_Syntax_Syntax.ret_wp  in
+                resugar_tscheme' "ret_wp" ed.FStar_Syntax_Syntax.ret_wp in
               let bind_wp =
-                resugar_tscheme' "bind_wp" ed.FStar_Syntax_Syntax.ret_wp  in
+                resugar_tscheme' "bind_wp" ed.FStar_Syntax_Syntax.ret_wp in
               let if_then_else1 =
                 resugar_tscheme' "if_then_else"
-                  ed.FStar_Syntax_Syntax.if_then_else
-                 in
+                  ed.FStar_Syntax_Syntax.if_then_else in
               let ite_wp =
-                resugar_tscheme' "ite_wp" ed.FStar_Syntax_Syntax.ite_wp  in
+                resugar_tscheme' "ite_wp" ed.FStar_Syntax_Syntax.ite_wp in
               let stronger =
-                resugar_tscheme' "stronger" ed.FStar_Syntax_Syntax.stronger
-                 in
+                resugar_tscheme' "stronger" ed.FStar_Syntax_Syntax.stronger in
               let close_wp =
-                resugar_tscheme' "close_wp" ed.FStar_Syntax_Syntax.close_wp
-                 in
+                resugar_tscheme' "close_wp" ed.FStar_Syntax_Syntax.close_wp in
               let assert_p =
-                resugar_tscheme' "assert_p" ed.FStar_Syntax_Syntax.assert_p
-                 in
+                resugar_tscheme' "assert_p" ed.FStar_Syntax_Syntax.assert_p in
               let assume_p =
-                resugar_tscheme' "assume_p" ed.FStar_Syntax_Syntax.assume_p
-                 in
+                resugar_tscheme' "assume_p" ed.FStar_Syntax_Syntax.assume_p in
               let null_wp =
-                resugar_tscheme' "null_wp" ed.FStar_Syntax_Syntax.null_wp  in
+                resugar_tscheme' "null_wp" ed.FStar_Syntax_Syntax.null_wp in
               let trivial =
-                resugar_tscheme' "trivial" ed.FStar_Syntax_Syntax.trivial  in
+                resugar_tscheme' "trivial" ed.FStar_Syntax_Syntax.trivial in
               let repr =
-                resugar_tscheme' "repr" ([], (ed.FStar_Syntax_Syntax.repr))
-                 in
+                resugar_tscheme' "repr" ([], (ed.FStar_Syntax_Syntax.repr)) in
               let return_repr =
                 resugar_tscheme' "return_repr"
-                  ed.FStar_Syntax_Syntax.return_repr
-                 in
+                  ed.FStar_Syntax_Syntax.return_repr in
               let bind_repr =
-                resugar_tscheme' "bind_repr" ed.FStar_Syntax_Syntax.bind_repr
-                 in
+                resugar_tscheme' "bind_repr" ed.FStar_Syntax_Syntax.bind_repr in
               let mandatory_members_decls =
                 if for_free
                 then [repr; return_repr; bind_repr]
@@ -2148,22 +1987,18 @@ let (resugar_eff_decl :
                   assert_p;
                   assume_p;
                   null_wp;
-                  trivial]
-                 in
+                  trivial] in
               let actions =
                 FStar_All.pipe_right ed.FStar_Syntax_Syntax.actions
-                  (FStar_List.map (fun a  -> resugar_action a false))
-                 in
-              let decls = FStar_List.append mandatory_members_decls actions
-                 in
+                  (FStar_List.map (fun a  -> resugar_action a false)) in
+              let decls = FStar_List.append mandatory_members_decls actions in
               mk_decl r q
                 (FStar_Parser_AST.NewEffect
                    (FStar_Parser_AST.DefineEffect
                       (eff_name, eff_binders2, eff_typ1, decls)))
-  
-let (resugar_sigelt :
+let resugar_sigelt:
   FStar_Syntax_Syntax.sigelt ->
-    FStar_Parser_AST.decl FStar_Pervasives_Native.option)
+    FStar_Parser_AST.decl FStar_Pervasives_Native.option
   =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
@@ -2178,21 +2013,18 @@ let (resugar_sigelt :
                   | FStar_Syntax_Syntax.Sig_datacon uu____7118 -> false
                   | uu____7133 ->
                       failwith
-                        "Found a sigelt which is neither a type declaration or a data constructor in a sigelt"))
-           in
+                        "Found a sigelt which is neither a type declaration or a data constructor in a sigelt")) in
         (match uu____7072 with
          | (decl_typ_ses,datacon_ses) ->
              let retrieve_datacons_and_resugar uu____7165 se1 =
                match uu____7165 with
                | (datacon_ses1,tycons) ->
-                   let uu____7191 = resugar_typ datacon_ses1 se1  in
+                   let uu____7191 = resugar_typ datacon_ses1 se1 in
                    (match uu____7191 with
-                    | (datacon_ses2,tyc) -> (datacon_ses2, (tyc :: tycons)))
-                in
+                    | (datacon_ses2,tyc) -> (datacon_ses2, (tyc :: tycons))) in
              let uu____7206 =
                FStar_List.fold_left retrieve_datacons_and_resugar
-                 (datacon_ses, []) decl_typ_ses
-                in
+                 (datacon_ses, []) decl_typ_ses in
              (match uu____7206 with
               | (leftover_datacons,tycons) ->
                   (match leftover_datacons with
@@ -2204,11 +2036,10 @@ let (resugar_sigelt :
                                FStar_List.map
                                  (fun tyc  ->
                                     (tyc, FStar_Pervasives_Native.None))
-                                 tycons
-                                in
-                             (false, uu____7256)  in
-                           FStar_Parser_AST.Tycon uu____7243  in
-                         decl'_to_decl se uu____7242  in
+                                 tycons in
+                             (false, uu____7256) in
+                           FStar_Parser_AST.Tycon uu____7243 in
+                         decl'_to_decl se uu____7242 in
                        FStar_Pervasives_Native.Some uu____7241
                    | se1::[] ->
                        (match se1.FStar_Syntax_Syntax.sigel with
@@ -2219,8 +2050,7 @@ let (resugar_sigelt :
                               decl'_to_decl se1
                                 (FStar_Parser_AST.Exception
                                    ((l.FStar_Ident.ident),
-                                     FStar_Pervasives_Native.None))
-                               in
+                                     FStar_Pervasives_Native.None)) in
                             FStar_Pervasives_Native.Some uu____7296
                         | uu____7299 ->
                             failwith "wrong format for resguar to Exception")
@@ -2234,67 +2064,62 @@ let (resugar_sigelt :
                   | FStar_Syntax_Syntax.Projector (uu____7320,uu____7321) ->
                       true
                   | FStar_Syntax_Syntax.Discriminator uu____7322 -> true
-                  | uu____7323 -> false))
-           in
+                  | uu____7323 -> false)) in
         if uu____7313
         then FStar_Pervasives_Native.None
         else
           (let mk1 e =
              FStar_Syntax_Syntax.mk e FStar_Pervasives_Native.None
-               se.FStar_Syntax_Syntax.sigrng
-              in
-           let dummy = mk1 FStar_Syntax_Syntax.Tm_unknown  in
-           let desugared_let = mk1 (FStar_Syntax_Syntax.Tm_let (lbs, dummy))
-              in
-           let t = resugar_term desugared_let  in
+               se.FStar_Syntax_Syntax.sigrng in
+           let dummy = mk1 FStar_Syntax_Syntax.Tm_unknown in
+           let desugared_let = mk1 (FStar_Syntax_Syntax.Tm_let (lbs, dummy)) in
+           let t = resugar_term desugared_let in
            match t.FStar_Parser_AST.tm with
            | FStar_Parser_AST.Let (isrec,lets,uu____7346) ->
                let uu____7375 =
                  let uu____7376 =
                    let uu____7377 =
                      let uu____7388 =
-                       FStar_List.map FStar_Pervasives_Native.snd lets  in
-                     (isrec, uu____7388)  in
-                   FStar_Parser_AST.TopLevelLet uu____7377  in
-                 decl'_to_decl se uu____7376  in
+                       FStar_List.map FStar_Pervasives_Native.snd lets in
+                     (isrec, uu____7388) in
+                   FStar_Parser_AST.TopLevelLet uu____7377 in
+                 decl'_to_decl se uu____7376 in
                FStar_Pervasives_Native.Some uu____7375
            | uu____7425 -> failwith "Should not happen hopefully")
     | FStar_Syntax_Syntax.Sig_assume (lid,uu____7429,fml) ->
         let uu____7431 =
           let uu____7432 =
             let uu____7433 =
-              let uu____7438 = resugar_term fml  in
-              ((lid.FStar_Ident.ident), uu____7438)  in
-            FStar_Parser_AST.Assume uu____7433  in
-          decl'_to_decl se uu____7432  in
+              let uu____7438 = resugar_term fml in
+              ((lid.FStar_Ident.ident), uu____7438) in
+            FStar_Parser_AST.Assume uu____7433 in
+          decl'_to_decl se uu____7432 in
         FStar_Pervasives_Native.Some uu____7431
     | FStar_Syntax_Syntax.Sig_new_effect ed ->
         let uu____7440 =
           resugar_eff_decl false se.FStar_Syntax_Syntax.sigrng
-            se.FStar_Syntax_Syntax.sigquals ed
-           in
+            se.FStar_Syntax_Syntax.sigquals ed in
         FStar_Pervasives_Native.Some uu____7440
     | FStar_Syntax_Syntax.Sig_new_effect_for_free ed ->
         let uu____7442 =
           resugar_eff_decl true se.FStar_Syntax_Syntax.sigrng
-            se.FStar_Syntax_Syntax.sigquals ed
-           in
+            se.FStar_Syntax_Syntax.sigquals ed in
         FStar_Pervasives_Native.Some uu____7442
     | FStar_Syntax_Syntax.Sig_sub_effect e ->
-        let src = e.FStar_Syntax_Syntax.source  in
-        let dst = e.FStar_Syntax_Syntax.target  in
+        let src = e.FStar_Syntax_Syntax.source in
+        let dst = e.FStar_Syntax_Syntax.target in
         let lift_wp =
           match e.FStar_Syntax_Syntax.lift_wp with
           | FStar_Pervasives_Native.Some (uu____7451,t) ->
-              let uu____7463 = resugar_term t  in
+              let uu____7463 = resugar_term t in
               FStar_Pervasives_Native.Some uu____7463
-          | uu____7464 -> FStar_Pervasives_Native.None  in
+          | uu____7464 -> FStar_Pervasives_Native.None in
         let lift =
           match e.FStar_Syntax_Syntax.lift with
           | FStar_Pervasives_Native.Some (uu____7472,t) ->
-              let uu____7484 = resugar_term t  in
+              let uu____7484 = resugar_term t in
               FStar_Pervasives_Native.Some uu____7484
-          | uu____7485 -> FStar_Pervasives_Native.None  in
+          | uu____7485 -> FStar_Pervasives_Native.None in
         let op =
           match (lift_wp, lift) with
           | (FStar_Pervasives_Native.Some t,FStar_Pervasives_Native.None ) ->
@@ -2303,7 +2128,7 @@ let (resugar_sigelt :
               -> FStar_Parser_AST.ReifiableLift (wp, t)
           | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some t) ->
               FStar_Parser_AST.LiftForFree t
-          | uu____7509 -> failwith "Should not happen hopefully"  in
+          | uu____7509 -> failwith "Should not happen hopefully" in
         let uu____7518 =
           decl'_to_decl se
             (FStar_Parser_AST.SubEffect
@@ -2311,21 +2136,19 @@ let (resugar_sigelt :
                  FStar_Parser_AST.msource = src;
                  FStar_Parser_AST.mdest = dst;
                  FStar_Parser_AST.lift_op = op
-               })
-           in
+               }) in
         FStar_Pervasives_Native.Some uu____7518
     | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,vs,bs,c,flags1) ->
-        let uu____7528 = FStar_Syntax_Subst.open_comp bs c  in
+        let uu____7528 = FStar_Syntax_Subst.open_comp bs c in
         (match uu____7528 with
          | (bs1,c1) ->
              let bs2 =
-               let uu____7538 = FStar_Options.print_implicits ()  in
-               if uu____7538 then bs1 else filter_imp bs1  in
+               let uu____7538 = FStar_Options.print_implicits () in
+               if uu____7538 then bs1 else filter_imp bs1 in
              let bs3 =
                FStar_All.pipe_right bs2
                  ((map_opt ())
-                    (fun b  -> resugar_binder b se.FStar_Syntax_Syntax.sigrng))
-                in
+                    (fun b  -> resugar_binder b se.FStar_Syntax_Syntax.sigrng)) in
              let uu____7547 =
                let uu____7548 =
                  let uu____7549 =
@@ -2333,20 +2156,19 @@ let (resugar_sigelt :
                      let uu____7571 =
                        let uu____7578 =
                          let uu____7579 =
-                           let uu____7592 = resugar_comp c1  in
+                           let uu____7592 = resugar_comp c1 in
                            ((lid.FStar_Ident.ident), bs3,
-                             FStar_Pervasives_Native.None, uu____7592)
-                            in
-                         FStar_Parser_AST.TyconAbbrev uu____7579  in
-                       (uu____7578, FStar_Pervasives_Native.None)  in
-                     [uu____7571]  in
-                   (false, uu____7562)  in
-                 FStar_Parser_AST.Tycon uu____7549  in
-               decl'_to_decl se uu____7548  in
+                             FStar_Pervasives_Native.None, uu____7592) in
+                         FStar_Parser_AST.TyconAbbrev uu____7579 in
+                       (uu____7578, FStar_Pervasives_Native.None) in
+                     [uu____7571] in
+                   (false, uu____7562) in
+                 FStar_Parser_AST.Tycon uu____7549 in
+               decl'_to_decl se uu____7548 in
              FStar_Pervasives_Native.Some uu____7547)
     | FStar_Syntax_Syntax.Sig_pragma p ->
         let uu____7620 =
-          decl'_to_decl se (FStar_Parser_AST.Pragma (resugar_pragma p))  in
+          decl'_to_decl se (FStar_Parser_AST.Pragma (resugar_pragma p)) in
         FStar_Pervasives_Native.Some uu____7620
     | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
         let uu____7624 =
@@ -2357,34 +2179,29 @@ let (resugar_sigelt :
                   | FStar_Syntax_Syntax.Projector (uu____7631,uu____7632) ->
                       true
                   | FStar_Syntax_Syntax.Discriminator uu____7633 -> true
-                  | uu____7634 -> false))
-           in
+                  | uu____7634 -> false)) in
         if uu____7624
         then FStar_Pervasives_Native.None
         else
           (let t' =
              let uu____7639 =
-               (let uu____7642 = FStar_Options.print_universes ()  in
-                Prims.op_Negation uu____7642) || (FStar_List.isEmpty uvs)
-                in
+               (let uu____7642 = FStar_Options.print_universes () in
+                Prims.op_Negation uu____7642) || (FStar_List.isEmpty uvs) in
              if uu____7639
              then resugar_term t
              else
-               (let uu____7644 = FStar_Syntax_Subst.open_univ_vars uvs t  in
+               (let uu____7644 = FStar_Syntax_Subst.open_univ_vars uvs t in
                 match uu____7644 with
                 | (uvs1,t1) ->
-                    let universes = universe_to_string uvs1  in
-                    let uu____7652 = resugar_term t1  in
-                    label universes uu____7652)
-              in
+                    let universes = universe_to_string uvs1 in
+                    let uu____7652 = resugar_term t1 in
+                    label universes uu____7652) in
            let uu____7653 =
              decl'_to_decl se
-               (FStar_Parser_AST.Val ((lid.FStar_Ident.ident), t'))
-              in
+               (FStar_Parser_AST.Val ((lid.FStar_Ident.ident), t')) in
            FStar_Pervasives_Native.Some uu____7653)
     | FStar_Syntax_Syntax.Sig_inductive_typ uu____7654 ->
         FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Sig_datacon uu____7671 ->
         FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Sig_main uu____7686 -> FStar_Pervasives_Native.None
-  

--- a/src/ocaml-output/FStar_Syntax_Subst.ml
+++ b/src/ocaml-output/FStar_Syntax_Subst.ml
@@ -1,5 +1,5 @@
 open Prims
-let subst_to_string :
+let subst_to_string:
   'Auu____3 .
     (FStar_Syntax_Syntax.bv,'Auu____3) FStar_Pervasives_Native.tuple2
       Prims.list -> Prims.string
@@ -11,11 +11,9 @@ let subst_to_string :
            (fun uu____38  ->
               match uu____38 with
               | (b,uu____44) ->
-                  (b.FStar_Syntax_Syntax.ppname).FStar_Ident.idText))
-       in
+                  (b.FStar_Syntax_Syntax.ppname).FStar_Ident.idText)) in
     FStar_All.pipe_right uu____20 (FStar_String.concat ", ")
-  
-let rec apply_until_some :
+let rec apply_until_some:
   'Auu____53 'Auu____54 .
     ('Auu____54 -> 'Auu____53 FStar_Pervasives_Native.option) ->
       'Auu____54 Prims.list ->
@@ -27,13 +25,12 @@ let rec apply_until_some :
       match s with
       | [] -> FStar_Pervasives_Native.None
       | s0::rest ->
-          let uu____94 = f s0  in
+          let uu____94 = f s0 in
           (match uu____94 with
            | FStar_Pervasives_Native.None  -> apply_until_some f rest
            | FStar_Pervasives_Native.Some st ->
                FStar_Pervasives_Native.Some (rest, st))
-  
-let map_some_curry :
+let map_some_curry:
   'Auu____120 'Auu____121 'Auu____122 .
     ('Auu____122 -> 'Auu____121 -> 'Auu____120) ->
       'Auu____120 ->
@@ -46,8 +43,7 @@ let map_some_curry :
         match uu___34_146 with
         | FStar_Pervasives_Native.None  -> x
         | FStar_Pervasives_Native.Some (a,b) -> f a b
-  
-let apply_until_some_then_map :
+let apply_until_some_then_map:
   'Auu____174 'Auu____175 'Auu____176 .
     ('Auu____176 -> 'Auu____175 FStar_Pervasives_Native.option) ->
       'Auu____176 Prims.list ->
@@ -58,10 +54,9 @@ let apply_until_some_then_map :
     fun s  ->
       fun g  ->
         fun t  ->
-          let uu____220 = apply_until_some f s  in
+          let uu____220 = apply_until_some f s in
           FStar_All.pipe_right uu____220 (map_some_curry g t)
-  
-let compose_subst :
+let compose_subst:
   'Auu____243 'Auu____244 .
     ('Auu____244 Prims.list,'Auu____243 FStar_Pervasives_Native.option)
       FStar_Pervasives_Native.tuple2 ->
@@ -74,20 +69,18 @@ let compose_subst :
     fun s2  ->
       let s =
         FStar_List.append (FStar_Pervasives_Native.fst s1)
-          (FStar_Pervasives_Native.fst s2)
-         in
+          (FStar_Pervasives_Native.fst s2) in
       let ropt =
         match FStar_Pervasives_Native.snd s2 with
         | FStar_Pervasives_Native.Some uu____313 ->
             FStar_Pervasives_Native.snd s2
-        | uu____318 -> FStar_Pervasives_Native.snd s1  in
+        | uu____318 -> FStar_Pervasives_Native.snd s1 in
       (s, ropt)
-  
-let (delay :
+let delay:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list,FStar_Range.range
                                                            FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2 -> FStar_Syntax_Syntax.term)
+      FStar_Pervasives_Native.tuple2 -> FStar_Syntax_Syntax.term
   =
   fun t  ->
     fun s  ->
@@ -97,32 +90,30 @@ let (delay :
             t.FStar_Syntax_Syntax.pos
       | uu____424 ->
           FStar_Syntax_Syntax.mk_Tm_delayed (t, s) t.FStar_Syntax_Syntax.pos
-  
-let rec (force_uvar' :
+let rec force_uvar':
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,Prims.bool)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_uvar (uv,uu____457) ->
-        let uu____482 = FStar_Syntax_Unionfind.find uv  in
+        let uu____482 = FStar_Syntax_Unionfind.find uv in
         (match uu____482 with
          | FStar_Pervasives_Native.Some t' ->
              let uu____492 =
-               let uu____495 = force_uvar' t'  in
-               FStar_Pervasives_Native.fst uu____495  in
+               let uu____495 = force_uvar' t' in
+               FStar_Pervasives_Native.fst uu____495 in
              (uu____492, true)
          | uu____506 -> (t, false))
     | uu____511 -> (t, false)
-  
-let (force_uvar :
+let force_uvar:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,Prims.bool)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
-    let uu____527 = force_uvar' t  in
+    let uu____527 = force_uvar' t in
     match uu____527 with
     | (t',forced) ->
         if Prims.op_Negation forced
@@ -131,23 +122,21 @@ let (force_uvar :
           (let uu____555 =
              delay t'
                ([],
-                 (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos)))
-              in
+                 (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos))) in
            (uu____555, forced))
-  
-let rec (try_read_memo_aux :
+let rec try_read_memo_aux:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,Prims.bool)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_delayed (f,m) ->
-        let uu____625 = FStar_ST.op_Bang m  in
+        let uu____625 = FStar_ST.op_Bang m in
         (match uu____625 with
          | FStar_Pervasives_Native.None  -> (t, false)
          | FStar_Pervasives_Native.Some t' ->
-             let uu____694 = try_read_memo_aux t'  in
+             let uu____694 = try_read_memo_aux t' in
              (match uu____694 with
               | (t'1,shorten) ->
                   (if shorten
@@ -157,30 +146,27 @@ let rec (try_read_memo_aux :
                    else ();
                    (t'1, true))))
     | uu____768 -> (t, false)
-  
-let (try_read_memo :
+let try_read_memo:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t  ->
-    let uu____780 = try_read_memo_aux t  in
+    let uu____780 = try_read_memo_aux t in
     FStar_Pervasives_Native.fst uu____780
-  
-let rec (compress_univ :
-  FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe) =
+let rec compress_univ:
+  FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe =
   fun u  ->
     match u with
     | FStar_Syntax_Syntax.U_unif u' ->
-        let uu____801 = FStar_Syntax_Unionfind.univ_find u'  in
+        let uu____801 = FStar_Syntax_Unionfind.univ_find u' in
         (match uu____801 with
          | FStar_Pervasives_Native.Some u1 -> compress_univ u1
          | uu____805 -> u)
     | uu____808 -> u
-  
-let (subst_bv :
+let subst_bv:
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
-      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun a  ->
     fun s  ->
@@ -191,16 +177,15 @@ let (subst_bv :
                i = a.FStar_Syntax_Syntax.index ->
                let uu____830 =
                  let uu____831 =
-                   let uu____832 = FStar_Syntax_Syntax.range_of_bv a  in
-                   FStar_Syntax_Syntax.set_range_of_bv x uu____832  in
-                 FStar_Syntax_Syntax.bv_to_name uu____831  in
+                   let uu____832 = FStar_Syntax_Syntax.range_of_bv a in
+                   FStar_Syntax_Syntax.set_range_of_bv x uu____832 in
+                 FStar_Syntax_Syntax.bv_to_name uu____831 in
                FStar_Pervasives_Native.Some uu____830
            | uu____833 -> FStar_Pervasives_Native.None)
-  
-let (subst_nm :
+let subst_nm:
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
-      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun a  ->
     fun s  ->
@@ -211,24 +196,22 @@ let (subst_nm :
                ->
                let uu____855 =
                  FStar_Syntax_Syntax.bv_to_tm
-                   (let uu___40_858 = a  in
+                   (let uu___40_858 = a in
                     {
                       FStar_Syntax_Syntax.ppname =
                         (uu___40_858.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index = i;
                       FStar_Syntax_Syntax.sort =
                         (uu___40_858.FStar_Syntax_Syntax.sort)
-                    })
-                  in
+                    }) in
                FStar_Pervasives_Native.Some uu____855
            | FStar_Syntax_Syntax.NT (x,t) when FStar_Syntax_Syntax.bv_eq a x
                -> FStar_Pervasives_Native.Some t
            | uu____867 -> FStar_Pervasives_Native.None)
-  
-let (subst_univ_bv :
+let subst_univ_bv:
   Prims.int ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
-      FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
   =
   fun x  ->
     fun s  ->
@@ -238,11 +221,10 @@ let (subst_univ_bv :
            | FStar_Syntax_Syntax.UN (y,t) when x = y ->
                FStar_Pervasives_Native.Some t
            | uu____888 -> FStar_Pervasives_Native.None)
-  
-let (subst_univ_nm :
+let subst_univ_nm:
   FStar_Syntax_Syntax.univ_name ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
-      FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
   =
   fun x  ->
     fun s  ->
@@ -253,14 +235,13 @@ let (subst_univ_nm :
                x.FStar_Ident.idText = y.FStar_Ident.idText ->
                FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.U_bvar i)
            | uu____909 -> FStar_Pervasives_Native.None)
-  
-let rec (subst_univ :
+let rec subst_univ:
   FStar_Syntax_Syntax.subst_elt Prims.list Prims.list ->
-    FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe)
+    FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe
   =
   fun s  ->
     fun u  ->
-      let u1 = compress_univ u  in
+      let u1 = compress_univ u in
       match u1 with
       | FStar_Syntax_Syntax.U_bvar x ->
           apply_until_some_then_map (subst_univ_bv x) s subst_univ u1
@@ -270,13 +251,12 @@ let rec (subst_univ :
       | FStar_Syntax_Syntax.U_unknown  -> u1
       | FStar_Syntax_Syntax.U_unif uu____931 -> u1
       | FStar_Syntax_Syntax.U_succ u2 ->
-          let uu____941 = subst_univ s u2  in
+          let uu____941 = subst_univ s u2 in
           FStar_Syntax_Syntax.U_succ uu____941
       | FStar_Syntax_Syntax.U_max us ->
-          let uu____945 = FStar_List.map (subst_univ s) us  in
+          let uu____945 = FStar_List.map (subst_univ s) us in
           FStar_Syntax_Syntax.U_max uu____945
-  
-let tag_with_range :
+let tag_with_range:
   'Auu____951 .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       ('Auu____951,FStar_Range.range FStar_Pervasives_Native.option)
@@ -289,44 +269,43 @@ let tag_with_range :
       | FStar_Pervasives_Native.None  -> t
       | FStar_Pervasives_Native.Some r ->
           let r1 =
-            let uu____982 = FStar_Range.use_range r  in
-            FStar_Range.set_use_range t.FStar_Syntax_Syntax.pos uu____982  in
+            let uu____982 = FStar_Range.use_range r in
+            FStar_Range.set_use_range t.FStar_Syntax_Syntax.pos uu____982 in
           let t' =
             match t.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_bvar bv ->
-                let uu____985 = FStar_Syntax_Syntax.set_range_of_bv bv r1  in
+                let uu____985 = FStar_Syntax_Syntax.set_range_of_bv bv r1 in
                 FStar_Syntax_Syntax.Tm_bvar uu____985
             | FStar_Syntax_Syntax.Tm_name bv ->
-                let uu____987 = FStar_Syntax_Syntax.set_range_of_bv bv r1  in
+                let uu____987 = FStar_Syntax_Syntax.set_range_of_bv bv r1 in
                 FStar_Syntax_Syntax.Tm_name uu____987
             | FStar_Syntax_Syntax.Tm_fvar fv ->
-                let l = FStar_Syntax_Syntax.lid_of_fv fv  in
+                let l = FStar_Syntax_Syntax.lid_of_fv fv in
                 let v1 =
-                  let uu___41_993 = fv.FStar_Syntax_Syntax.fv_name  in
+                  let uu___41_993 = fv.FStar_Syntax_Syntax.fv_name in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Ident.set_lid_range l r1);
                     FStar_Syntax_Syntax.p =
                       (uu___41_993.FStar_Syntax_Syntax.p)
-                  }  in
+                  } in
                 let fv1 =
-                  let uu___42_995 = fv  in
+                  let uu___42_995 = fv in
                   {
                     FStar_Syntax_Syntax.fv_name = v1;
                     FStar_Syntax_Syntax.fv_delta =
                       (uu___42_995.FStar_Syntax_Syntax.fv_delta);
                     FStar_Syntax_Syntax.fv_qual =
                       (uu___42_995.FStar_Syntax_Syntax.fv_qual)
-                  }  in
+                  } in
                 FStar_Syntax_Syntax.Tm_fvar fv1
-            | t' -> t'  in
-          let uu___43_997 = t  in
+            | t' -> t' in
+          let uu___43_997 = t in
           {
             FStar_Syntax_Syntax.n = t';
             FStar_Syntax_Syntax.pos = r1;
             FStar_Syntax_Syntax.vars = (uu___43_997.FStar_Syntax_Syntax.vars)
           }
-  
-let tag_lid_with_range :
+let tag_lid_with_range:
   'Auu____1003 .
     FStar_Ident.lident ->
       ('Auu____1003,FStar_Range.range FStar_Pervasives_Native.option)
@@ -338,34 +317,31 @@ let tag_lid_with_range :
       | FStar_Pervasives_Native.None  -> l
       | FStar_Pervasives_Native.Some r ->
           let uu____1027 =
-            let uu____1028 = FStar_Range.use_range r  in
-            FStar_Range.set_use_range (FStar_Ident.range_of_lid l) uu____1028
-             in
+            let uu____1028 = FStar_Range.use_range r in
+            FStar_Range.set_use_range (FStar_Ident.range_of_lid l) uu____1028 in
           FStar_Ident.set_lid_range l uu____1027
-  
-let (mk_range :
-  FStar_Range.range -> FStar_Syntax_Syntax.subst_ts -> FStar_Range.range) =
+let mk_range:
+  FStar_Range.range -> FStar_Syntax_Syntax.subst_ts -> FStar_Range.range =
   fun r  ->
     fun s  ->
       match FStar_Pervasives_Native.snd s with
       | FStar_Pervasives_Native.None  -> r
       | FStar_Pervasives_Native.Some r' ->
-          let uu____1042 = FStar_Range.use_range r'  in
+          let uu____1042 = FStar_Range.use_range r' in
           FStar_Range.set_use_range r uu____1042
-  
-let rec (subst' :
+let rec subst':
   FStar_Syntax_Syntax.subst_ts ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun s  ->
     fun t  ->
-      let subst_tail tl1 = subst' (tl1, (FStar_Pervasives_Native.snd s))  in
+      let subst_tail tl1 = subst' (tl1, (FStar_Pervasives_Native.snd s)) in
       match s with
       | ([],FStar_Pervasives_Native.None ) -> t
       | ([]::[],FStar_Pervasives_Native.None ) -> t
       | uu____1145 ->
-          let t0 = try_read_memo t  in
+          let t0 = try_read_memo t in
           (match t0.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown  -> tag_with_range t0 s
            | FStar_Syntax_Syntax.Tm_constant uu____1155 ->
@@ -382,22 +358,21 @@ let rec (subst' :
                apply_until_some_then_map (subst_nm a)
                  (FStar_Pervasives_Native.fst s) subst_tail t0
            | FStar_Syntax_Syntax.Tm_type u ->
-               let uu____1274 = mk_range t0.FStar_Syntax_Syntax.pos s  in
+               let uu____1274 = mk_range t0.FStar_Syntax_Syntax.pos s in
                let uu____1275 =
                  let uu____1278 =
                    let uu____1279 =
-                     subst_univ (FStar_Pervasives_Native.fst s) u  in
-                   FStar_Syntax_Syntax.Tm_type uu____1279  in
-                 FStar_Syntax_Syntax.mk uu____1278  in
+                     subst_univ (FStar_Pervasives_Native.fst s) u in
+                   FStar_Syntax_Syntax.Tm_type uu____1279 in
+                 FStar_Syntax_Syntax.mk uu____1278 in
                uu____1275 FStar_Pervasives_Native.None uu____1274
            | uu____1289 ->
-               let uu____1290 = mk_range t.FStar_Syntax_Syntax.pos s  in
+               let uu____1290 = mk_range t.FStar_Syntax_Syntax.pos s in
                FStar_Syntax_Syntax.mk_Tm_delayed (t0, s) uu____1290)
-
-and (subst_flags' :
+and subst_flags':
   FStar_Syntax_Syntax.subst_ts ->
     FStar_Syntax_Syntax.cflags Prims.list ->
-      FStar_Syntax_Syntax.cflags Prims.list)
+      FStar_Syntax_Syntax.cflags Prims.list
   =
   fun s  ->
     fun flags  ->
@@ -406,15 +381,14 @@ and (subst_flags' :
            (fun uu___39_1304  ->
               match uu___39_1304 with
               | FStar_Syntax_Syntax.DECREASES a ->
-                  let uu____1308 = subst' s a  in
+                  let uu____1308 = subst' s a in
                   FStar_Syntax_Syntax.DECREASES uu____1308
               | f -> f))
-
-and (subst_comp_typ' :
+and subst_comp_typ':
   (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list,FStar_Range.range
                                                          FStar_Pervasives_Native.option)
     FStar_Pervasives_Native.tuple2 ->
-    FStar_Syntax_Syntax.comp_typ -> FStar_Syntax_Syntax.comp_typ)
+    FStar_Syntax_Syntax.comp_typ -> FStar_Syntax_Syntax.comp_typ
   =
   fun s  ->
     fun t  ->
@@ -422,23 +396,21 @@ and (subst_comp_typ' :
       | ([],FStar_Pervasives_Native.None ) -> t
       | ([]::[],FStar_Pervasives_Native.None ) -> t
       | uu____1342 ->
-          let uu___44_1353 = t  in
+          let uu___44_1353 = t in
           let uu____1354 =
             FStar_List.map (subst_univ (FStar_Pervasives_Native.fst s))
-              t.FStar_Syntax_Syntax.comp_univs
-             in
+              t.FStar_Syntax_Syntax.comp_univs in
           let uu____1361 =
-            tag_lid_with_range t.FStar_Syntax_Syntax.effect_name s  in
-          let uu____1366 = subst' s t.FStar_Syntax_Syntax.result_typ  in
+            tag_lid_with_range t.FStar_Syntax_Syntax.effect_name s in
+          let uu____1366 = subst' s t.FStar_Syntax_Syntax.result_typ in
           let uu____1369 =
             FStar_List.map
               (fun uu____1394  ->
                  match uu____1394 with
                  | (t1,imp) ->
-                     let uu____1413 = subst' s t1  in (uu____1413, imp))
-              t.FStar_Syntax_Syntax.effect_args
-             in
-          let uu____1418 = subst_flags' s t.FStar_Syntax_Syntax.flags  in
+                     let uu____1413 = subst' s t1 in (uu____1413, imp))
+              t.FStar_Syntax_Syntax.effect_args in
+          let uu____1418 = subst_flags' s t.FStar_Syntax_Syntax.flags in
           {
             FStar_Syntax_Syntax.comp_univs = uu____1354;
             FStar_Syntax_Syntax.effect_name = uu____1361;
@@ -446,13 +418,12 @@ and (subst_comp_typ' :
             FStar_Syntax_Syntax.effect_args = uu____1369;
             FStar_Syntax_Syntax.flags = uu____1418
           }
-
-and (subst_comp' :
+and subst_comp':
   (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list,FStar_Range.range
                                                          FStar_Pervasives_Native.option)
     FStar_Pervasives_Native.tuple2 ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax
   =
   fun s  ->
     fun t  ->
@@ -462,25 +433,22 @@ and (subst_comp' :
       | uu____1455 ->
           (match t.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Total (t1,uopt) ->
-               let uu____1478 = subst' s t1  in
+               let uu____1478 = subst' s t1 in
                let uu____1479 =
                  FStar_Option.map
-                   (subst_univ (FStar_Pervasives_Native.fst s)) uopt
-                  in
+                   (subst_univ (FStar_Pervasives_Native.fst s)) uopt in
                FStar_Syntax_Syntax.mk_Total' uu____1478 uu____1479
            | FStar_Syntax_Syntax.GTotal (t1,uopt) ->
-               let uu____1498 = subst' s t1  in
+               let uu____1498 = subst' s t1 in
                let uu____1499 =
                  FStar_Option.map
-                   (subst_univ (FStar_Pervasives_Native.fst s)) uopt
-                  in
+                   (subst_univ (FStar_Pervasives_Native.fst s)) uopt in
                FStar_Syntax_Syntax.mk_GTotal' uu____1498 uu____1499
            | FStar_Syntax_Syntax.Comp ct ->
-               let uu____1509 = subst_comp_typ' s ct  in
+               let uu____1509 = subst_comp_typ' s ct in
                FStar_Syntax_Syntax.mk_Comp uu____1509)
-
-let (shift :
-  Prims.int -> FStar_Syntax_Syntax.subst_elt -> FStar_Syntax_Syntax.subst_elt)
+let shift:
+  Prims.int -> FStar_Syntax_Syntax.subst_elt -> FStar_Syntax_Syntax.subst_elt
   =
   fun n1  ->
     fun s  ->
@@ -490,11 +458,10 @@ let (shift :
       | FStar_Syntax_Syntax.NM (x,i) -> FStar_Syntax_Syntax.NM (x, (i + n1))
       | FStar_Syntax_Syntax.UD (x,i) -> FStar_Syntax_Syntax.UD (x, (i + n1))
       | FStar_Syntax_Syntax.NT uu____1524 -> s
-  
-let (shift_subst :
-  Prims.int -> FStar_Syntax_Syntax.subst_t -> FStar_Syntax_Syntax.subst_t) =
-  fun n1  -> fun s  -> FStar_List.map (shift n1) s 
-let shift_subst' :
+let shift_subst:
+  Prims.int -> FStar_Syntax_Syntax.subst_t -> FStar_Syntax_Syntax.subst_t =
+  fun n1  -> fun s  -> FStar_List.map (shift n1) s
+let shift_subst':
   'Auu____1540 .
     Prims.int ->
       (FStar_Syntax_Syntax.subst_t Prims.list,'Auu____1540)
@@ -506,11 +473,9 @@ let shift_subst' :
     fun s  ->
       let uu____1567 =
         FStar_All.pipe_right (FStar_Pervasives_Native.fst s)
-          (FStar_List.map (shift_subst n1))
-         in
+          (FStar_List.map (shift_subst n1)) in
       (uu____1567, (FStar_Pervasives_Native.snd s))
-  
-let subst_binder' :
+let subst_binder':
   'Auu____1583 .
     FStar_Syntax_Syntax.subst_ts ->
       (FStar_Syntax_Syntax.bv,'Auu____1583) FStar_Pervasives_Native.tuple2 ->
@@ -521,18 +486,17 @@ let subst_binder' :
       match uu____1599 with
       | (x,imp) ->
           let uu____1606 =
-            let uu___45_1607 = x  in
-            let uu____1608 = subst' s x.FStar_Syntax_Syntax.sort  in
+            let uu___45_1607 = x in
+            let uu____1608 = subst' s x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___45_1607.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___45_1607.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____1608
-            }  in
+            } in
           (uu____1606, imp)
-  
-let subst_binders' :
+let subst_binders':
   'Auu____1614 .
     FStar_Syntax_Syntax.subst_ts ->
       (FStar_Syntax_Syntax.bv,'Auu____1614) FStar_Pervasives_Native.tuple2
@@ -549,15 +513,14 @@ let subst_binders' :
                 if i = (Prims.parse_int "0")
                 then subst_binder' s b
                 else
-                  (let uu____1674 = shift_subst' i s  in
+                  (let uu____1674 = shift_subst' i s in
                    subst_binder' uu____1674 b)))
-  
-let (subst_binders :
+let subst_binders:
   FStar_Syntax_Syntax.subst_elt Prims.list ->
-    FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders)
+    FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders
   =
-  fun s  -> fun bs  -> subst_binders' ([s], FStar_Pervasives_Native.None) bs 
-let subst_arg' :
+  fun s  -> fun bs  -> subst_binders' ([s], FStar_Pervasives_Native.None) bs
+let subst_arg':
   'Auu____1700 .
     FStar_Syntax_Syntax.subst_ts ->
       (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,'Auu____1700)
@@ -568,22 +531,21 @@ let subst_arg' :
   fun s  ->
     fun uu____1720  ->
       match uu____1720 with
-      | (t,imp) -> let uu____1733 = subst' s t  in (uu____1733, imp)
-  
-let subst_args' :
+      | (t,imp) -> let uu____1733 = subst' s t in (uu____1733, imp)
+let subst_args':
   'Auu____1740 .
     FStar_Syntax_Syntax.subst_ts ->
       (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,'Auu____1740)
         FStar_Pervasives_Native.tuple2 Prims.list ->
         (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,'Auu____1740)
           FStar_Pervasives_Native.tuple2 Prims.list
-  = fun s  -> FStar_List.map (subst_arg' s) 
-let (subst_pat' :
+  = fun s  -> FStar_List.map (subst_arg' s)
+let subst_pat':
   (FStar_Syntax_Syntax.subst_t Prims.list,FStar_Range.range
                                             FStar_Pervasives_Native.option)
     FStar_Pervasives_Native.tuple2 ->
     FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t ->
-      (FStar_Syntax_Syntax.pat,Prims.int) FStar_Pervasives_Native.tuple2)
+      (FStar_Syntax_Syntax.pat,Prims.int) FStar_Pervasives_Native.tuple2
   =
   fun s  ->
     fun p  ->
@@ -598,14 +560,13 @@ let (subst_pat' :
                       fun uu____1904  ->
                         match (uu____1903, uu____1904) with
                         | ((pats1,n2),(p2,imp)) ->
-                            let uu____1983 = aux n2 p2  in
+                            let uu____1983 = aux n2 p2 in
                             (match uu____1983 with
                              | (p3,m) -> (((p3, imp) :: pats1), m))) 
-                   ([], n1))
-               in
+                   ([], n1)) in
             (match uu____1849 with
              | (pats1,n2) ->
-                 ((let uu___46_2041 = p1  in
+                 ((let uu___46_2041 = p1 in
                    {
                      FStar_Syntax_Syntax.v =
                        (FStar_Syntax_Syntax.Pat_cons
@@ -614,65 +575,63 @@ let (subst_pat' :
                        (uu___46_2041.FStar_Syntax_Syntax.p)
                    }), n2))
         | FStar_Syntax_Syntax.Pat_var x ->
-            let s1 = shift_subst' n1 s  in
+            let s1 = shift_subst' n1 s in
             let x1 =
-              let uu___47_2067 = x  in
-              let uu____2068 = subst' s1 x.FStar_Syntax_Syntax.sort  in
+              let uu___47_2067 = x in
+              let uu____2068 = subst' s1 x.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
                   (uu___47_2067.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
                   (uu___47_2067.FStar_Syntax_Syntax.index);
                 FStar_Syntax_Syntax.sort = uu____2068
-              }  in
-            ((let uu___48_2074 = p1  in
+              } in
+            ((let uu___48_2074 = p1 in
               {
                 FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
                 FStar_Syntax_Syntax.p = (uu___48_2074.FStar_Syntax_Syntax.p)
               }), (n1 + (Prims.parse_int "1")))
         | FStar_Syntax_Syntax.Pat_wild x ->
-            let s1 = shift_subst' n1 s  in
+            let s1 = shift_subst' n1 s in
             let x1 =
-              let uu___49_2090 = x  in
-              let uu____2091 = subst' s1 x.FStar_Syntax_Syntax.sort  in
+              let uu___49_2090 = x in
+              let uu____2091 = subst' s1 x.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
                   (uu___49_2090.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
                   (uu___49_2090.FStar_Syntax_Syntax.index);
                 FStar_Syntax_Syntax.sort = uu____2091
-              }  in
-            ((let uu___50_2097 = p1  in
+              } in
+            ((let uu___50_2097 = p1 in
               {
                 FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
                 FStar_Syntax_Syntax.p = (uu___50_2097.FStar_Syntax_Syntax.p)
               }), (n1 + (Prims.parse_int "1")))
         | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
-            let s1 = shift_subst' n1 s  in
+            let s1 = shift_subst' n1 s in
             let x1 =
-              let uu___51_2118 = x  in
-              let uu____2119 = subst' s1 x.FStar_Syntax_Syntax.sort  in
+              let uu___51_2118 = x in
+              let uu____2119 = subst' s1 x.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
                   (uu___51_2118.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
                   (uu___51_2118.FStar_Syntax_Syntax.index);
                 FStar_Syntax_Syntax.sort = uu____2119
-              }  in
-            let t01 = subst' s1 t0  in
-            ((let uu___52_2128 = p1  in
+              } in
+            let t01 = subst' s1 t0 in
+            ((let uu___52_2128 = p1 in
               {
                 FStar_Syntax_Syntax.v =
                   (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
                 FStar_Syntax_Syntax.p = (uu___52_2128.FStar_Syntax_Syntax.p)
-              }), n1)
-         in
+              }), n1) in
       aux (Prims.parse_int "0") p
-  
-let (push_subst_lcomp :
+let push_subst_lcomp:
   FStar_Syntax_Syntax.subst_ts ->
     FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
-      FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option
   =
   fun s  ->
     fun lopt  ->
@@ -680,30 +639,28 @@ let (push_subst_lcomp :
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some rc ->
           let uu____2148 =
-            let uu___53_2149 = rc  in
+            let uu___53_2149 = rc in
             let uu____2150 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
-                (subst' s)
-               in
+                (subst' s) in
             {
               FStar_Syntax_Syntax.residual_effect =
                 (uu___53_2149.FStar_Syntax_Syntax.residual_effect);
               FStar_Syntax_Syntax.residual_typ = uu____2150;
               FStar_Syntax_Syntax.residual_flags =
                 (uu___53_2149.FStar_Syntax_Syntax.residual_flags)
-            }  in
+            } in
           FStar_Pervasives_Native.Some uu____2148
-  
-let (push_subst :
+let push_subst:
   FStar_Syntax_Syntax.subst_ts ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun s  ->
     fun t  ->
       let mk1 t' =
-        let uu____2177 = mk_range t.FStar_Syntax_Syntax.pos s  in
-        FStar_Syntax_Syntax.mk t' FStar_Pervasives_Native.None uu____2177  in
+        let uu____2177 = mk_range t.FStar_Syntax_Syntax.pos s in
+        FStar_Syntax_Syntax.mk t' FStar_Pervasives_Native.None uu____2177 in
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_delayed uu____2180 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_constant uu____2207 -> tag_with_range t s
@@ -715,119 +672,112 @@ let (push_subst :
       | FStar_Syntax_Syntax.Tm_name uu____2244 -> subst' s t
       | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
           let us1 =
-            FStar_List.map (subst_univ (FStar_Pervasives_Native.fst s)) us
-             in
-          let uu____2260 = FStar_Syntax_Syntax.mk_Tm_uinst t' us1  in
+            FStar_List.map (subst_univ (FStar_Pervasives_Native.fst s)) us in
+          let uu____2260 = FStar_Syntax_Syntax.mk_Tm_uinst t' us1 in
           tag_with_range uu____2260 s
       | FStar_Syntax_Syntax.Tm_app (t0,args) ->
           let uu____2289 =
             let uu____2290 =
-              let uu____2305 = subst' s t0  in
-              let uu____2308 = subst_args' s args  in
-              (uu____2305, uu____2308)  in
-            FStar_Syntax_Syntax.Tm_app uu____2290  in
+              let uu____2305 = subst' s t0 in
+              let uu____2308 = subst_args' s args in (uu____2305, uu____2308) in
+            FStar_Syntax_Syntax.Tm_app uu____2290 in
           mk1 uu____2289
       | FStar_Syntax_Syntax.Tm_ascribed (t0,(annot,topt),lopt) ->
           let annot1 =
             match annot with
             | FStar_Util.Inl t1 ->
-                let uu____2403 = subst' s t1  in FStar_Util.Inl uu____2403
+                let uu____2403 = subst' s t1 in FStar_Util.Inl uu____2403
             | FStar_Util.Inr c ->
-                let uu____2417 = subst_comp' s c  in
-                FStar_Util.Inr uu____2417
-             in
+                let uu____2417 = subst_comp' s c in FStar_Util.Inr uu____2417 in
           let uu____2424 =
             let uu____2425 =
-              let uu____2452 = subst' s t0  in
+              let uu____2452 = subst' s t0 in
               let uu____2455 =
-                let uu____2472 = FStar_Util.map_opt topt (subst' s)  in
-                (annot1, uu____2472)  in
-              (uu____2452, uu____2455, lopt)  in
-            FStar_Syntax_Syntax.Tm_ascribed uu____2425  in
+                let uu____2472 = FStar_Util.map_opt topt (subst' s) in
+                (annot1, uu____2472) in
+              (uu____2452, uu____2455, lopt) in
+            FStar_Syntax_Syntax.Tm_ascribed uu____2425 in
           mk1 uu____2424
       | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-          let n1 = FStar_List.length bs  in
-          let s' = shift_subst' n1 s  in
+          let n1 = FStar_List.length bs in
+          let s' = shift_subst' n1 s in
           let uu____2556 =
             let uu____2557 =
-              let uu____2574 = subst_binders' s bs  in
-              let uu____2581 = subst' s' body  in
-              let uu____2584 = push_subst_lcomp s' lopt  in
-              (uu____2574, uu____2581, uu____2584)  in
-            FStar_Syntax_Syntax.Tm_abs uu____2557  in
+              let uu____2574 = subst_binders' s bs in
+              let uu____2581 = subst' s' body in
+              let uu____2584 = push_subst_lcomp s' lopt in
+              (uu____2574, uu____2581, uu____2584) in
+            FStar_Syntax_Syntax.Tm_abs uu____2557 in
           mk1 uu____2556
       | FStar_Syntax_Syntax.Tm_arrow (bs,comp) ->
-          let n1 = FStar_List.length bs  in
+          let n1 = FStar_List.length bs in
           let uu____2620 =
             let uu____2621 =
-              let uu____2634 = subst_binders' s bs  in
+              let uu____2634 = subst_binders' s bs in
               let uu____2641 =
-                let uu____2644 = shift_subst' n1 s  in
-                subst_comp' uu____2644 comp  in
-              (uu____2634, uu____2641)  in
-            FStar_Syntax_Syntax.Tm_arrow uu____2621  in
+                let uu____2644 = shift_subst' n1 s in
+                subst_comp' uu____2644 comp in
+              (uu____2634, uu____2641) in
+            FStar_Syntax_Syntax.Tm_arrow uu____2621 in
           mk1 uu____2620
       | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
           let x1 =
-            let uu___54_2676 = x  in
-            let uu____2677 = subst' s x.FStar_Syntax_Syntax.sort  in
+            let uu___54_2676 = x in
+            let uu____2677 = subst' s x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___54_2676.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___54_2676.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____2677
-            }  in
+            } in
           let phi1 =
-            let uu____2683 = shift_subst' (Prims.parse_int "1") s  in
-            subst' uu____2683 phi  in
+            let uu____2683 = shift_subst' (Prims.parse_int "1") s in
+            subst' uu____2683 phi in
           mk1 (FStar_Syntax_Syntax.Tm_refine (x1, phi1))
       | FStar_Syntax_Syntax.Tm_match (t0,pats) ->
-          let t01 = subst' s t0  in
+          let t01 = subst' s t0 in
           let pats1 =
             FStar_All.pipe_right pats
               (FStar_List.map
                  (fun uu____2810  ->
                     match uu____2810 with
                     | (pat,wopt,branch) ->
-                        let uu____2856 = subst_pat' s pat  in
+                        let uu____2856 = subst_pat' s pat in
                         (match uu____2856 with
                          | (pat1,n1) ->
-                             let s1 = shift_subst' n1 s  in
+                             let s1 = shift_subst' n1 s in
                              let wopt1 =
                                match wopt with
                                | FStar_Pervasives_Native.None  ->
                                    FStar_Pervasives_Native.None
                                | FStar_Pervasives_Native.Some w ->
-                                   let uu____2904 = subst' s1 w  in
-                                   FStar_Pervasives_Native.Some uu____2904
-                                in
-                             let branch1 = subst' s1 branch  in
-                             (pat1, wopt1, branch1))))
-             in
+                                   let uu____2904 = subst' s1 w in
+                                   FStar_Pervasives_Native.Some uu____2904 in
+                             let branch1 = subst' s1 branch in
+                             (pat1, wopt1, branch1)))) in
           mk1 (FStar_Syntax_Syntax.Tm_match (t01, pats1))
       | FStar_Syntax_Syntax.Tm_let ((is_rec,lbs),body) ->
-          let n1 = FStar_List.length lbs  in
-          let sn = shift_subst' n1 s  in
-          let body1 = subst' sn body  in
+          let n1 = FStar_List.length lbs in
+          let sn = shift_subst' n1 s in
+          let body1 = subst' sn body in
           let lbs1 =
             FStar_All.pipe_right lbs
               (FStar_List.map
                  (fun lb  ->
-                    let lbt = subst' s lb.FStar_Syntax_Syntax.lbtyp  in
+                    let lbt = subst' s lb.FStar_Syntax_Syntax.lbtyp in
                     let lbd =
                       let uu____2989 =
                         is_rec &&
-                          (FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname)
-                         in
+                          (FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname) in
                       if uu____2989
                       then subst' sn lb.FStar_Syntax_Syntax.lbdef
-                      else subst' s lb.FStar_Syntax_Syntax.lbdef  in
+                      else subst' s lb.FStar_Syntax_Syntax.lbdef in
                     let lbname =
                       match lb.FStar_Syntax_Syntax.lbname with
                       | FStar_Util.Inl x ->
                           FStar_Util.Inl
-                            (let uu___55_3004 = x  in
+                            (let uu___55_3004 = x in
                              {
                                FStar_Syntax_Syntax.ppname =
                                  (uu___55_3004.FStar_Syntax_Syntax.ppname);
@@ -835,8 +785,8 @@ let (push_subst :
                                  (uu___55_3004.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort = lbt
                              })
-                      | FStar_Util.Inr fv -> FStar_Util.Inr fv  in
-                    let uu___56_3006 = lb  in
+                      | FStar_Util.Inr fv -> FStar_Util.Inr fv in
+                    let uu___56_3006 = lb in
                     {
                       FStar_Syntax_Syntax.lbname = lbname;
                       FStar_Syntax_Syntax.lbunivs =
@@ -847,95 +797,88 @@ let (push_subst :
                       FStar_Syntax_Syntax.lbdef = lbd;
                       FStar_Syntax_Syntax.lbattrs =
                         (uu___56_3006.FStar_Syntax_Syntax.lbattrs)
-                    }))
-             in
+                    })) in
           mk1 (FStar_Syntax_Syntax.Tm_let ((is_rec, lbs1), body1))
       | FStar_Syntax_Syntax.Tm_meta (t0,FStar_Syntax_Syntax.Meta_pattern ps)
           ->
           let uu____3033 =
             let uu____3034 =
-              let uu____3041 = subst' s t0  in
+              let uu____3041 = subst' s t0 in
               let uu____3044 =
                 let uu____3045 =
-                  FStar_All.pipe_right ps (FStar_List.map (subst_args' s))
-                   in
-                FStar_Syntax_Syntax.Meta_pattern uu____3045  in
-              (uu____3041, uu____3044)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3034  in
+                  FStar_All.pipe_right ps (FStar_List.map (subst_args' s)) in
+                FStar_Syntax_Syntax.Meta_pattern uu____3045 in
+              (uu____3041, uu____3044) in
+            FStar_Syntax_Syntax.Tm_meta uu____3034 in
           mk1 uu____3033
       | FStar_Syntax_Syntax.Tm_meta
           (t0,FStar_Syntax_Syntax.Meta_monadic (m,t1)) ->
           let uu____3105 =
             let uu____3106 =
-              let uu____3113 = subst' s t0  in
+              let uu____3113 = subst' s t0 in
               let uu____3116 =
                 let uu____3117 =
-                  let uu____3124 = subst' s t1  in (m, uu____3124)  in
-                FStar_Syntax_Syntax.Meta_monadic uu____3117  in
-              (uu____3113, uu____3116)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3106  in
+                  let uu____3124 = subst' s t1 in (m, uu____3124) in
+                FStar_Syntax_Syntax.Meta_monadic uu____3117 in
+              (uu____3113, uu____3116) in
+            FStar_Syntax_Syntax.Tm_meta uu____3106 in
           mk1 uu____3105
       | FStar_Syntax_Syntax.Tm_meta
           (t0,FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,t1)) ->
           let uu____3143 =
             let uu____3144 =
-              let uu____3151 = subst' s t0  in
+              let uu____3151 = subst' s t0 in
               let uu____3154 =
                 let uu____3155 =
-                  let uu____3164 = subst' s t1  in (m1, m2, uu____3164)  in
-                FStar_Syntax_Syntax.Meta_monadic_lift uu____3155  in
-              (uu____3151, uu____3154)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3144  in
+                  let uu____3164 = subst' s t1 in (m1, m2, uu____3164) in
+                FStar_Syntax_Syntax.Meta_monadic_lift uu____3155 in
+              (uu____3151, uu____3154) in
+            FStar_Syntax_Syntax.Tm_meta uu____3144 in
           mk1 uu____3143
       | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
           let uu____3177 =
-            let uu____3178 = let uu____3185 = subst' s t1  in (uu____3185, m)
-               in
-            FStar_Syntax_Syntax.Tm_meta uu____3178  in
+            let uu____3178 = let uu____3185 = subst' s t1 in (uu____3185, m) in
+            FStar_Syntax_Syntax.Tm_meta uu____3178 in
           mk1 uu____3177
-  
-let rec (compress : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let rec compress: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun t  ->
-    let t1 = try_read_memo t  in
+    let t1 = try_read_memo t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_delayed ((t',s),memo) ->
         ((let uu____3248 =
-            let uu____3253 = push_subst s t'  in
-            FStar_Pervasives_Native.Some uu____3253  in
+            let uu____3253 = push_subst s t' in
+            FStar_Pervasives_Native.Some uu____3253 in
           FStar_ST.op_Colon_Equals memo uu____3248);
          compress t1)
     | uu____3307 ->
-        let uu____3308 = force_uvar t1  in
+        let uu____3308 = force_uvar t1 in
         (match uu____3308 with
          | (t',forced) ->
              (match t'.FStar_Syntax_Syntax.n with
               | FStar_Syntax_Syntax.Tm_delayed uu____3321 -> compress t'
               | uu____3346 -> t'))
-  
-let (subst :
+let subst:
   FStar_Syntax_Syntax.subst_elt Prims.list ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  = fun s  -> fun t  -> subst' ([s], FStar_Pervasives_Native.None) t 
-let (set_use_range :
-  FStar_Range.range -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  =
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
+  = fun s  -> fun t  -> subst' ([s], FStar_Pervasives_Native.None) t
+let set_use_range:
+  FStar_Range.range -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun r  ->
     fun t  ->
       let uu____3373 =
         let uu____3374 =
           let uu____3377 =
-            let uu____3378 = FStar_Range.use_range r  in
-            FStar_Range.set_def_range r uu____3378  in
-          FStar_Pervasives_Native.Some uu____3377  in
-        ([], uu____3374)  in
+            let uu____3378 = FStar_Range.use_range r in
+            FStar_Range.set_def_range r uu____3378 in
+          FStar_Pervasives_Native.Some uu____3377 in
+        ([], uu____3374) in
       subst' uu____3373 t
-  
-let (subst_comp :
+let subst_comp:
   FStar_Syntax_Syntax.subst_elt Prims.list ->
-    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
-  = fun s  -> fun t  -> subst_comp' ([s], FStar_Pervasives_Native.None) t 
-let (closing_subst :
-  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_elt Prims.list) =
+    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
+  = fun s  -> fun t  -> subst_comp' ([s], FStar_Pervasives_Native.None) t
+let closing_subst:
+  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_elt Prims.list =
   fun bs  ->
     let uu____3412 =
       FStar_List.fold_right
@@ -945,11 +888,9 @@ let (closing_subst :
              | ((x,uu____3464),(subst1,n1)) ->
                  (((FStar_Syntax_Syntax.NM (x, n1)) :: subst1),
                    (n1 + (Prims.parse_int "1")))) bs
-        ([], (Prims.parse_int "0"))
-       in
+        ([], (Prims.parse_int "0")) in
     FStar_All.pipe_right uu____3412 FStar_Pervasives_Native.fst
-  
-let open_binders' :
+let open_binders':
   'Auu____3497 .
     (FStar_Syntax_Syntax.bv,'Auu____3497) FStar_Pervasives_Native.tuple2
       Prims.list ->
@@ -963,72 +904,65 @@ let open_binders' :
       | [] -> ([], o)
       | (x,imp)::bs' ->
           let x' =
-            let uu___57_3603 = FStar_Syntax_Syntax.freshen_bv x  in
-            let uu____3604 = subst o x.FStar_Syntax_Syntax.sort  in
+            let uu___57_3603 = FStar_Syntax_Syntax.freshen_bv x in
+            let uu____3604 = subst o x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___57_3603.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___57_3603.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____3604
-            }  in
+            } in
           let o1 =
-            let uu____3610 = shift_subst (Prims.parse_int "1") o  in
+            let uu____3610 = shift_subst (Prims.parse_int "1") o in
             (FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x')) ::
-              uu____3610
-             in
-          let uu____3613 = aux bs' o1  in
-          (match uu____3613 with | (bs'1,o2) -> (((x', imp) :: bs'1), o2))
-       in
+              uu____3610 in
+          let uu____3613 = aux bs' o1 in
+          (match uu____3613 with | (bs'1,o2) -> (((x', imp) :: bs'1), o2)) in
     aux bs []
-  
-let (open_binders :
-  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders) =
+let open_binders: FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders
+  =
   fun bs  ->
-    let uu____3671 = open_binders' bs  in
+    let uu____3671 = open_binders' bs in
     FStar_Pervasives_Native.fst uu____3671
-  
-let (open_term' :
+let open_term':
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.subst_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun bs  ->
     fun t  ->
-      let uu____3704 = open_binders' bs  in
+      let uu____3704 = open_binders' bs in
       match uu____3704 with
       | (bs',opening) ->
-          let uu____3741 = subst opening t  in (bs', uu____3741, opening)
-  
-let (open_term :
+          let uu____3741 = subst opening t in (bs', uu____3741, opening)
+let open_term:
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun bs  ->
     fun t  ->
-      let uu____3760 = open_term' bs t  in
+      let uu____3760 = open_term' bs t in
       match uu____3760 with | (b,t1,uu____3773) -> (b, t1)
-  
-let (open_comp :
+let open_comp:
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.comp ->
       (FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.comp)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun bs  ->
     fun t  ->
-      let uu____3784 = open_binders' bs  in
+      let uu____3784 = open_binders' bs in
       match uu____3784 with
       | (bs',opening) ->
-          let uu____3819 = subst_comp opening t  in (bs', uu____3819)
-  
-let (open_pat :
+          let uu____3819 = subst_comp opening t in (bs', uu____3819)
+let open_pat:
   FStar_Syntax_Syntax.pat ->
     (FStar_Syntax_Syntax.pat,FStar_Syntax_Syntax.subst_t)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun p  ->
     let rec open_pat_aux sub1 renaming p1 =
@@ -1042,15 +976,14 @@ let (open_pat :
                     fun uu____4021  ->
                       match (uu____4020, uu____4021) with
                       | ((pats1,sub2,renaming1),(p2,imp)) ->
-                          let uu____4169 = open_pat_aux sub2 renaming1 p2  in
+                          let uu____4169 = open_pat_aux sub2 renaming1 p2 in
                           (match uu____4169 with
                            | (p3,sub3,renaming2) ->
                                (((p3, imp) :: pats1), sub3, renaming2)))
-                 ([], sub1, renaming))
-             in
+                 ([], sub1, renaming)) in
           (match uu____3928 with
            | (pats1,sub2,renaming1) ->
-               ((let uu___58_4339 = p1  in
+               ((let uu___58_4339 = p1 in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons
@@ -1060,74 +993,69 @@ let (open_pat :
                  }), sub2, renaming1))
       | FStar_Syntax_Syntax.Pat_var x ->
           let x' =
-            let uu___59_4358 = FStar_Syntax_Syntax.freshen_bv x  in
-            let uu____4359 = subst sub1 x.FStar_Syntax_Syntax.sort  in
+            let uu___59_4358 = FStar_Syntax_Syntax.freshen_bv x in
+            let uu____4359 = subst sub1 x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___59_4358.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___59_4358.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____4359
-            }  in
+            } in
           let sub2 =
-            let uu____4365 = shift_subst (Prims.parse_int "1") sub1  in
+            let uu____4365 = shift_subst (Prims.parse_int "1") sub1 in
             (FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x')) ::
-              uu____4365
-             in
-          ((let uu___60_4379 = p1  in
+              uu____4365 in
+          ((let uu___60_4379 = p1 in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x');
               FStar_Syntax_Syntax.p = (uu___60_4379.FStar_Syntax_Syntax.p)
             }), sub2, ((x, x') :: renaming))
       | FStar_Syntax_Syntax.Pat_wild x ->
           let x' =
-            let uu___61_4388 = FStar_Syntax_Syntax.freshen_bv x  in
-            let uu____4389 = subst sub1 x.FStar_Syntax_Syntax.sort  in
+            let uu___61_4388 = FStar_Syntax_Syntax.freshen_bv x in
+            let uu____4389 = subst sub1 x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___61_4388.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___61_4388.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____4389
-            }  in
+            } in
           let sub2 =
-            let uu____4395 = shift_subst (Prims.parse_int "1") sub1  in
+            let uu____4395 = shift_subst (Prims.parse_int "1") sub1 in
             (FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x')) ::
-              uu____4395
-             in
-          ((let uu___62_4409 = p1  in
+              uu____4395 in
+          ((let uu___62_4409 = p1 in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x');
               FStar_Syntax_Syntax.p = (uu___62_4409.FStar_Syntax_Syntax.p)
             }), sub2, ((x, x') :: renaming))
       | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
           let x1 =
-            let uu___63_4423 = x  in
-            let uu____4424 = subst sub1 x.FStar_Syntax_Syntax.sort  in
+            let uu___63_4423 = x in
+            let uu____4424 = subst sub1 x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___63_4423.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___63_4423.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____4424
-            }  in
-          let t01 = subst sub1 t0  in
-          ((let uu___64_4439 = p1  in
+            } in
+          let t01 = subst sub1 t0 in
+          ((let uu___64_4439 = p1 in
             {
               FStar_Syntax_Syntax.v =
                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
               FStar_Syntax_Syntax.p = (uu___64_4439.FStar_Syntax_Syntax.p)
-            }), sub1, renaming)
-       in
-    let uu____4442 = open_pat_aux [] [] p  in
+            }), sub1, renaming) in
+    let uu____4442 = open_pat_aux [] [] p in
     match uu____4442 with | (p1,sub1,uu____4469) -> (p1, sub1)
-  
-let (open_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
-  =
+let open_branch: FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch =
   fun uu____4496  ->
     match uu____4496 with
     | (p,wopt,e) ->
-        let uu____4516 = open_pat p  in
+        let uu____4516 = open_pat p in
         (match uu____4516 with
          | (p1,opening) ->
              let wopt1 =
@@ -1135,69 +1063,61 @@ let (open_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some w ->
-                   let uu____4535 = subst opening w  in
-                   FStar_Pervasives_Native.Some uu____4535
-                in
-             let e1 = subst opening e  in (p1, wopt1, e1))
-  
-let (close :
+                   let uu____4535 = subst opening w in
+                   FStar_Pervasives_Native.Some uu____4535 in
+             let e1 = subst opening e in (p1, wopt1, e1))
+let close:
   FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun bs  ->
-    fun t  -> let uu____4545 = closing_subst bs  in subst uu____4545 t
-  
-let (close_comp :
+    fun t  -> let uu____4545 = closing_subst bs in subst uu____4545 t
+let close_comp:
   FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
+    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
   =
   fun bs  ->
-    fun c  -> let uu____4554 = closing_subst bs  in subst_comp uu____4554 c
-  
-let (close_binders :
-  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders) =
+    fun c  -> let uu____4554 = closing_subst bs in subst_comp uu____4554 c
+let close_binders: FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders
+  =
   fun bs  ->
     let rec aux s bs1 =
       match bs1 with
       | [] -> []
       | (x,imp)::tl1 ->
           let x1 =
-            let uu___65_4605 = x  in
-            let uu____4606 = subst s x.FStar_Syntax_Syntax.sort  in
+            let uu___65_4605 = x in
+            let uu____4606 = subst s x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___65_4605.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___65_4605.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____4606
-            }  in
+            } in
           let s' =
-            let uu____4612 = shift_subst (Prims.parse_int "1") s  in
+            let uu____4612 = shift_subst (Prims.parse_int "1") s in
             (FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))) ::
-              uu____4612
-             in
-          let uu____4615 = aux s' tl1  in (x1, imp) :: uu____4615
-       in
+              uu____4612 in
+          let uu____4615 = aux s' tl1 in (x1, imp) :: uu____4615 in
     aux [] bs
-  
-let (close_lcomp :
+let close_lcomp:
   FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp)
+    FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
   =
   fun bs  ->
     fun lc  ->
-      let s = closing_subst bs  in
+      let s = closing_subst bs in
       FStar_Syntax_Syntax.mk_lcomp lc.FStar_Syntax_Syntax.eff_name
         lc.FStar_Syntax_Syntax.res_typ lc.FStar_Syntax_Syntax.cflags
         (fun uu____4637  ->
-           let uu____4638 = FStar_Syntax_Syntax.lcomp_comp lc  in
+           let uu____4638 = FStar_Syntax_Syntax.lcomp_comp lc in
            subst_comp s uu____4638)
-  
-let (close_pat :
+let close_pat:
   FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t ->
     (FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t,FStar_Syntax_Syntax.subst_elt
                                                                Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun p  ->
     let rec aux sub1 p1 =
@@ -1211,14 +1131,13 @@ let (close_pat :
                     fun uu____4775  ->
                       match (uu____4774, uu____4775) with
                       | ((pats1,sub2),(p2,imp)) ->
-                          let uu____4878 = aux sub2 p2  in
+                          let uu____4878 = aux sub2 p2 in
                           (match uu____4878 with
                            | (p3,sub3) -> (((p3, imp) :: pats1), sub3)))
-                 ([], sub1))
-             in
+                 ([], sub1)) in
           (match uu____4708 with
            | (pats1,sub2) ->
-               ((let uu___66_4980 = p1  in
+               ((let uu___66_4980 = p1 in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons
@@ -1228,73 +1147,68 @@ let (close_pat :
                  }), sub2))
       | FStar_Syntax_Syntax.Pat_var x ->
           let x1 =
-            let uu___67_4999 = x  in
-            let uu____5000 = subst sub1 x.FStar_Syntax_Syntax.sort  in
+            let uu___67_4999 = x in
+            let uu____5000 = subst sub1 x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___67_4999.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___67_4999.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____5000
-            }  in
+            } in
           let sub2 =
-            let uu____5006 = shift_subst (Prims.parse_int "1") sub1  in
+            let uu____5006 = shift_subst (Prims.parse_int "1") sub1 in
             (FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))) ::
-              uu____5006
-             in
-          ((let uu___68_5014 = p1  in
+              uu____5006 in
+          ((let uu___68_5014 = p1 in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
               FStar_Syntax_Syntax.p = (uu___68_5014.FStar_Syntax_Syntax.p)
             }), sub2)
       | FStar_Syntax_Syntax.Pat_wild x ->
           let x1 =
-            let uu___69_5019 = x  in
-            let uu____5020 = subst sub1 x.FStar_Syntax_Syntax.sort  in
+            let uu___69_5019 = x in
+            let uu____5020 = subst sub1 x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___69_5019.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___69_5019.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____5020
-            }  in
+            } in
           let sub2 =
-            let uu____5026 = shift_subst (Prims.parse_int "1") sub1  in
+            let uu____5026 = shift_subst (Prims.parse_int "1") sub1 in
             (FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))) ::
-              uu____5026
-             in
-          ((let uu___70_5034 = p1  in
+              uu____5026 in
+          ((let uu___70_5034 = p1 in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
               FStar_Syntax_Syntax.p = (uu___70_5034.FStar_Syntax_Syntax.p)
             }), sub2)
       | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
           let x1 =
-            let uu___71_5044 = x  in
-            let uu____5045 = subst sub1 x.FStar_Syntax_Syntax.sort  in
+            let uu___71_5044 = x in
+            let uu____5045 = subst sub1 x.FStar_Syntax_Syntax.sort in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___71_5044.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___71_5044.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = uu____5045
-            }  in
-          let t01 = subst sub1 t0  in
-          ((let uu___72_5054 = p1  in
+            } in
+          let t01 = subst sub1 t0 in
+          ((let uu___72_5054 = p1 in
             {
               FStar_Syntax_Syntax.v =
                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
               FStar_Syntax_Syntax.p = (uu___72_5054.FStar_Syntax_Syntax.p)
-            }), sub1)
-       in
+            }), sub1) in
     aux [] p
-  
-let (close_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
-  =
+let close_branch: FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch =
   fun uu____5059  ->
     match uu____5059 with
     | (p,wopt,e) ->
-        let uu____5079 = close_pat p  in
+        let uu____5079 = close_pat p in
         (match uu____5079 with
          | (p1,closing) ->
              let wopt1 =
@@ -1302,89 +1216,80 @@ let (close_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some w ->
-                   let uu____5110 = subst closing w  in
-                   FStar_Pervasives_Native.Some uu____5110
-                in
-             let e1 = subst closing e  in (p1, wopt1, e1))
-  
-let (univ_var_opening :
+                   let uu____5110 = subst closing w in
+                   FStar_Pervasives_Native.Some uu____5110 in
+             let e1 = subst closing e in (p1, wopt1, e1))
+let univ_var_opening:
   FStar_Syntax_Syntax.univ_names ->
     (FStar_Syntax_Syntax.subst_elt Prims.list,FStar_Syntax_Syntax.univ_name
                                                 Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun us  ->
-    let n1 = (FStar_List.length us) - (Prims.parse_int "1")  in
+    let n1 = (FStar_List.length us) - (Prims.parse_int "1") in
     let s =
       FStar_All.pipe_right us
         (FStar_List.mapi
            (fun i  ->
               fun u  ->
                 FStar_Syntax_Syntax.UN
-                  ((n1 - i), (FStar_Syntax_Syntax.U_name u))))
-       in
+                  ((n1 - i), (FStar_Syntax_Syntax.U_name u)))) in
     (s, us)
-  
-let (univ_var_closing :
-  FStar_Syntax_Syntax.univ_names -> FStar_Syntax_Syntax.subst_elt Prims.list)
+let univ_var_closing:
+  FStar_Syntax_Syntax.univ_names -> FStar_Syntax_Syntax.subst_elt Prims.list
   =
   fun us  ->
-    let n1 = (FStar_List.length us) - (Prims.parse_int "1")  in
+    let n1 = (FStar_List.length us) - (Prims.parse_int "1") in
     FStar_All.pipe_right us
       (FStar_List.mapi
          (fun i  -> fun u  -> FStar_Syntax_Syntax.UD (u, (n1 - i))))
-  
-let (open_univ_vars :
+let open_univ_vars:
   FStar_Syntax_Syntax.univ_names ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.univ_names,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun us  ->
     fun t  ->
-      let uu____5165 = univ_var_opening us  in
-      match uu____5165 with | (s,us') -> let t1 = subst s t  in (us', t1)
-  
-let (open_univ_vars_comp :
+      let uu____5165 = univ_var_opening us in
+      match uu____5165 with | (s,us') -> let t1 = subst s t in (us', t1)
+let open_univ_vars_comp:
   FStar_Syntax_Syntax.univ_names ->
     FStar_Syntax_Syntax.comp ->
       (FStar_Syntax_Syntax.univ_names,FStar_Syntax_Syntax.comp)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun us  ->
     fun c  ->
-      let uu____5205 = univ_var_opening us  in
+      let uu____5205 = univ_var_opening us in
       match uu____5205 with
-      | (s,us') -> let uu____5228 = subst_comp s c  in (us', uu____5228)
-  
-let (close_univ_vars :
+      | (s,us') -> let uu____5228 = subst_comp s c in (us', uu____5228)
+let close_univ_vars:
   FStar_Syntax_Syntax.univ_names ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  = fun us  -> fun t  -> let s = univ_var_closing us  in subst s t 
-let (close_univ_vars_comp :
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
+  = fun us  -> fun t  -> let s = univ_var_closing us in subst s t
+let close_univ_vars_comp:
   FStar_Syntax_Syntax.univ_names ->
-    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
+    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
   =
   fun us  ->
     fun c  ->
-      let n1 = (FStar_List.length us) - (Prims.parse_int "1")  in
+      let n1 = (FStar_List.length us) - (Prims.parse_int "1") in
       let s =
         FStar_All.pipe_right us
           (FStar_List.mapi
-             (fun i  -> fun u  -> FStar_Syntax_Syntax.UD (u, (n1 - i))))
-         in
+             (fun i  -> fun u  -> FStar_Syntax_Syntax.UD (u, (n1 - i)))) in
       subst_comp s c
-  
-let (open_let_rec :
+let open_let_rec:
   FStar_Syntax_Syntax.letbinding Prims.list ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.letbinding Prims.list,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun lbs  ->
     fun t  ->
       let uu____5272 =
-        let uu____5283 = FStar_Syntax_Syntax.is_top_level lbs  in
+        let uu____5283 = FStar_Syntax_Syntax.is_top_level lbs in
         if uu____5283
         then ((Prims.parse_int "0"), lbs, [])
         else
@@ -1395,10 +1300,10 @@ let (open_let_rec :
                  | (i,lbs1,out) ->
                      let x =
                        let uu____5349 =
-                         FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                       FStar_Syntax_Syntax.freshen_bv uu____5349  in
+                         FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
+                       FStar_Syntax_Syntax.freshen_bv uu____5349 in
                      ((i + (Prims.parse_int "1")),
-                       ((let uu___73_5355 = lb  in
+                       ((let uu___73_5355 = lb in
                          {
                            FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                            FStar_Syntax_Syntax.lbunivs =
@@ -1412,8 +1317,7 @@ let (open_let_rec :
                            FStar_Syntax_Syntax.lbattrs =
                              (uu___73_5355.FStar_Syntax_Syntax.lbattrs)
                          }) :: lbs1), ((FStar_Syntax_Syntax.DB (i, x)) ::
-                       out))) lbs ((Prims.parse_int "0"), [], [])
-         in
+                       out))) lbs ((Prims.parse_int "0"), [], []) in
       match uu____5272 with
       | (n_let_recs,lbs1,let_rec_opening) ->
           let lbs2 =
@@ -1428,25 +1332,21 @@ let (open_let_rec :
                              | (i,us,out) ->
                                  let u1 =
                                    FStar_Syntax_Syntax.new_univ_name
-                                     FStar_Pervasives_Native.None
-                                    in
+                                     FStar_Pervasives_Native.None in
                                  ((i + (Prims.parse_int "1")), (u1 :: us),
                                    ((FStar_Syntax_Syntax.UN
                                        (i, (FStar_Syntax_Syntax.U_name u1)))
                                    :: out))) lb.FStar_Syntax_Syntax.lbunivs
-                        (n_let_recs, [], let_rec_opening)
-                       in
+                        (n_let_recs, [], let_rec_opening) in
                     match uu____5393 with
                     | (uu____5462,us,u_let_rec_opening) ->
-                        let uu___74_5473 = lb  in
+                        let uu___74_5473 = lb in
                         let uu____5474 =
                           subst u_let_rec_opening
-                            lb.FStar_Syntax_Syntax.lbtyp
-                           in
+                            lb.FStar_Syntax_Syntax.lbtyp in
                         let uu____5477 =
                           subst u_let_rec_opening
-                            lb.FStar_Syntax_Syntax.lbdef
-                           in
+                            lb.FStar_Syntax_Syntax.lbdef in
                         {
                           FStar_Syntax_Syntax.lbname =
                             (uu___74_5473.FStar_Syntax_Syntax.lbname);
@@ -1457,20 +1357,18 @@ let (open_let_rec :
                           FStar_Syntax_Syntax.lbdef = uu____5477;
                           FStar_Syntax_Syntax.lbattrs =
                             (uu___74_5473.FStar_Syntax_Syntax.lbattrs)
-                        }))
-             in
-          let t1 = subst let_rec_opening t  in (lbs2, t1)
-  
-let (close_let_rec :
+                        })) in
+          let t1 = subst let_rec_opening t in (lbs2, t1)
+let close_let_rec:
   FStar_Syntax_Syntax.letbinding Prims.list ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.letbinding Prims.list,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun lbs  ->
     fun t  ->
       let uu____5499 =
-        let uu____5506 = FStar_Syntax_Syntax.is_top_level lbs  in
+        let uu____5506 = FStar_Syntax_Syntax.is_top_level lbs in
         if uu____5506
         then ((Prims.parse_int "0"), [])
         else
@@ -1483,14 +1381,12 @@ let (close_let_rec :
                        let uu____5550 =
                          let uu____5551 =
                            let uu____5556 =
-                             FStar_Util.left lb.FStar_Syntax_Syntax.lbname
-                              in
-                           (uu____5556, i)  in
-                         FStar_Syntax_Syntax.NM uu____5551  in
-                       uu____5550 :: out  in
+                             FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
+                           (uu____5556, i) in
+                         FStar_Syntax_Syntax.NM uu____5551 in
+                       uu____5550 :: out in
                      ((i + (Prims.parse_int "1")), uu____5547)) lbs
-            ((Prims.parse_int "0"), [])
-         in
+            ((Prims.parse_int "0"), []) in
       match uu____5499 with
       | (n_let_recs,let_rec_closing) ->
           let lbs1 =
@@ -1506,19 +1402,16 @@ let (close_let_rec :
                                  ((i + (Prims.parse_int "1")),
                                    ((FStar_Syntax_Syntax.UD (u, i)) :: out)))
                         lb.FStar_Syntax_Syntax.lbunivs
-                        (n_let_recs, let_rec_closing)
-                       in
+                        (n_let_recs, let_rec_closing) in
                     match uu____5588 with
                     | (uu____5629,u_let_rec_closing) ->
-                        let uu___75_5635 = lb  in
+                        let uu___75_5635 = lb in
                         let uu____5636 =
                           subst u_let_rec_closing
-                            lb.FStar_Syntax_Syntax.lbtyp
-                           in
+                            lb.FStar_Syntax_Syntax.lbtyp in
                         let uu____5639 =
                           subst u_let_rec_closing
-                            lb.FStar_Syntax_Syntax.lbdef
-                           in
+                            lb.FStar_Syntax_Syntax.lbdef in
                         {
                           FStar_Syntax_Syntax.lbname =
                             (uu___75_5635.FStar_Syntax_Syntax.lbname);
@@ -1530,69 +1423,61 @@ let (close_let_rec :
                           FStar_Syntax_Syntax.lbdef = uu____5639;
                           FStar_Syntax_Syntax.lbattrs =
                             (uu___75_5635.FStar_Syntax_Syntax.lbattrs)
-                        }))
-             in
-          let t1 = subst let_rec_closing t  in (lbs1, t1)
-  
-let (close_tscheme :
+                        })) in
+          let t1 = subst let_rec_closing t in (lbs1, t1)
+let close_tscheme:
   FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
+    FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme
   =
   fun binders  ->
     fun uu____5650  ->
       match uu____5650 with
       | (us,t) ->
-          let n1 = (FStar_List.length binders) - (Prims.parse_int "1")  in
-          let k = FStar_List.length us  in
+          let n1 = (FStar_List.length binders) - (Prims.parse_int "1") in
+          let k = FStar_List.length us in
           let s =
             FStar_List.mapi
               (fun i  ->
                  fun uu____5675  ->
                    match uu____5675 with
                    | (x,uu____5681) ->
-                       FStar_Syntax_Syntax.NM (x, (k + (n1 - i)))) binders
-             in
-          let t1 = subst s t  in (us, t1)
-  
-let (close_univ_vars_tscheme :
+                       FStar_Syntax_Syntax.NM (x, (k + (n1 - i)))) binders in
+          let t1 = subst s t in (us, t1)
+let close_univ_vars_tscheme:
   FStar_Syntax_Syntax.univ_names ->
-    FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
+    FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme
   =
   fun us  ->
     fun uu____5696  ->
       match uu____5696 with
       | (us',t) ->
-          let n1 = (FStar_List.length us) - (Prims.parse_int "1")  in
-          let k = FStar_List.length us'  in
+          let n1 = (FStar_List.length us) - (Prims.parse_int "1") in
+          let k = FStar_List.length us' in
           let s =
             FStar_List.mapi
               (fun i  -> fun x  -> FStar_Syntax_Syntax.UD (x, (k + (n1 - i))))
-              us
-             in
-          let uu____5718 = subst s t  in (us', uu____5718)
-  
-let (subst_tscheme :
+              us in
+          let uu____5718 = subst s t in (us', uu____5718)
+let subst_tscheme:
   FStar_Syntax_Syntax.subst_elt Prims.list ->
-    FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
+    FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme
   =
   fun s  ->
     fun uu____5728  ->
       match uu____5728 with
       | (us,t) ->
-          let s1 = shift_subst (FStar_List.length us) s  in
-          let uu____5738 = subst s1 t  in (us, uu____5738)
-  
-let (opening_of_binders :
-  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
+          let s1 = shift_subst (FStar_List.length us) s in
+          let uu____5738 = subst s1 t in (us, uu____5738)
+let opening_of_binders:
+  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t =
   fun bs  ->
-    let n1 = (FStar_List.length bs) - (Prims.parse_int "1")  in
+    let n1 = (FStar_List.length bs) - (Prims.parse_int "1") in
     FStar_All.pipe_right bs
       (FStar_List.mapi
          (fun i  ->
             fun uu____5760  ->
               match uu____5760 with
               | (x,uu____5766) -> FStar_Syntax_Syntax.DB ((n1 - i), x)))
-  
-let (closing_of_binders :
-  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
-  fun bs  -> closing_subst bs 
+let closing_of_binders:
+  FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t =
+  fun bs  -> closing_subst bs

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -1,118 +1,102 @@
 open Prims
 type 'a withinfo_t = {
-  v: 'a ;
-  p: FStar_Range.range }[@@deriving show]
-let __proj__Mkwithinfo_t__item__v : 'a . 'a withinfo_t -> 'a =
+  v: 'a;
+  p: FStar_Range.range;}[@@deriving show]
+let __proj__Mkwithinfo_t__item__v: 'a . 'a withinfo_t -> 'a =
   fun projectee  ->
     match projectee with | { v = __fname__v; p = __fname__p;_} -> __fname__v
-  
-let __proj__Mkwithinfo_t__item__p : 'a . 'a withinfo_t -> FStar_Range.range =
+let __proj__Mkwithinfo_t__item__p: 'a . 'a withinfo_t -> FStar_Range.range =
   fun projectee  ->
     match projectee with | { v = __fname__v; p = __fname__p;_} -> __fname__p
-  
 type var = FStar_Ident.lident withinfo_t[@@deriving show]
 type sconst = FStar_Const.sconst[@@deriving show]
 type pragma =
-  | SetOptions of Prims.string 
-  | ResetOptions of Prims.string FStar_Pervasives_Native.option 
-  | LightOff [@@deriving show]
-let (uu___is_SetOptions : pragma -> Prims.bool) =
+  | SetOptions of Prims.string
+  | ResetOptions of Prims.string FStar_Pervasives_Native.option
+  | LightOff[@@deriving show]
+let uu___is_SetOptions: pragma -> Prims.bool =
   fun projectee  ->
     match projectee with | SetOptions _0 -> true | uu____55 -> false
-  
-let (__proj__SetOptions__item___0 : pragma -> Prims.string) =
-  fun projectee  -> match projectee with | SetOptions _0 -> _0 
-let (uu___is_ResetOptions : pragma -> Prims.bool) =
+let __proj__SetOptions__item___0: pragma -> Prims.string =
+  fun projectee  -> match projectee with | SetOptions _0 -> _0
+let uu___is_ResetOptions: pragma -> Prims.bool =
   fun projectee  ->
     match projectee with | ResetOptions _0 -> true | uu____69 -> false
-  
-let (__proj__ResetOptions__item___0 :
-  pragma -> Prims.string FStar_Pervasives_Native.option) =
-  fun projectee  -> match projectee with | ResetOptions _0 -> _0 
-let (uu___is_LightOff : pragma -> Prims.bool) =
+let __proj__ResetOptions__item___0:
+  pragma -> Prims.string FStar_Pervasives_Native.option =
+  fun projectee  -> match projectee with | ResetOptions _0 -> _0
+let uu___is_LightOff: pragma -> Prims.bool =
   fun projectee  ->
     match projectee with | LightOff  -> true | uu____86 -> false
-  
 type 'a memo = 'a FStar_Pervasives_Native.option FStar_ST.ref[@@deriving
                                                                show]
 type version = {
-  major: Prims.int ;
-  minor: Prims.int }[@@deriving show]
-let (__proj__Mkversion__item__major : version -> Prims.int) =
+  major: Prims.int;
+  minor: Prims.int;}[@@deriving show]
+let __proj__Mkversion__item__major: version -> Prims.int =
   fun projectee  ->
     match projectee with
     | { major = __fname__major; minor = __fname__minor;_} -> __fname__major
-  
-let (__proj__Mkversion__item__minor : version -> Prims.int) =
+let __proj__Mkversion__item__minor: version -> Prims.int =
   fun projectee  ->
     match projectee with
     | { major = __fname__major; minor = __fname__minor;_} -> __fname__minor
-  
 type arg_qualifier =
-  | Implicit of Prims.bool 
-  | Equality [@@deriving show]
-let (uu___is_Implicit : arg_qualifier -> Prims.bool) =
+  | Implicit of Prims.bool
+  | Equality[@@deriving show]
+let uu___is_Implicit: arg_qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Implicit _0 -> true | uu____121 -> false
-  
-let (__proj__Implicit__item___0 : arg_qualifier -> Prims.bool) =
-  fun projectee  -> match projectee with | Implicit _0 -> _0 
-let (uu___is_Equality : arg_qualifier -> Prims.bool) =
+let __proj__Implicit__item___0: arg_qualifier -> Prims.bool =
+  fun projectee  -> match projectee with | Implicit _0 -> _0
+let uu___is_Equality: arg_qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Equality  -> true | uu____132 -> false
-  
 type aqual = arg_qualifier FStar_Pervasives_Native.option[@@deriving show]
 type universe =
-  | U_zero 
-  | U_succ of universe 
-  | U_max of universe Prims.list 
-  | U_bvar of Prims.int 
-  | U_name of FStar_Ident.ident 
+  | U_zero
+  | U_succ of universe
+  | U_max of universe Prims.list
+  | U_bvar of Prims.int
+  | U_name of FStar_Ident.ident
   | U_unif of
   (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar,version)
-  FStar_Pervasives_Native.tuple2 
-  | U_unknown [@@deriving show]
-let (uu___is_U_zero : universe -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | U_unknown[@@deriving show]
+let uu___is_U_zero: universe -> Prims.bool =
   fun projectee  ->
     match projectee with | U_zero  -> true | uu____168 -> false
-  
-let (uu___is_U_succ : universe -> Prims.bool) =
+let uu___is_U_succ: universe -> Prims.bool =
   fun projectee  ->
     match projectee with | U_succ _0 -> true | uu____173 -> false
-  
-let (__proj__U_succ__item___0 : universe -> universe) =
-  fun projectee  -> match projectee with | U_succ _0 -> _0 
-let (uu___is_U_max : universe -> Prims.bool) =
+let __proj__U_succ__item___0: universe -> universe =
+  fun projectee  -> match projectee with | U_succ _0 -> _0
+let uu___is_U_max: universe -> Prims.bool =
   fun projectee  ->
     match projectee with | U_max _0 -> true | uu____187 -> false
-  
-let (__proj__U_max__item___0 : universe -> universe Prims.list) =
-  fun projectee  -> match projectee with | U_max _0 -> _0 
-let (uu___is_U_bvar : universe -> Prims.bool) =
+let __proj__U_max__item___0: universe -> universe Prims.list =
+  fun projectee  -> match projectee with | U_max _0 -> _0
+let uu___is_U_bvar: universe -> Prims.bool =
   fun projectee  ->
     match projectee with | U_bvar _0 -> true | uu____205 -> false
-  
-let (__proj__U_bvar__item___0 : universe -> Prims.int) =
-  fun projectee  -> match projectee with | U_bvar _0 -> _0 
-let (uu___is_U_name : universe -> Prims.bool) =
+let __proj__U_bvar__item___0: universe -> Prims.int =
+  fun projectee  -> match projectee with | U_bvar _0 -> _0
+let uu___is_U_name: universe -> Prims.bool =
   fun projectee  ->
     match projectee with | U_name _0 -> true | uu____217 -> false
-  
-let (__proj__U_name__item___0 : universe -> FStar_Ident.ident) =
-  fun projectee  -> match projectee with | U_name _0 -> _0 
-let (uu___is_U_unif : universe -> Prims.bool) =
+let __proj__U_name__item___0: universe -> FStar_Ident.ident =
+  fun projectee  -> match projectee with | U_name _0 -> _0
+let uu___is_U_unif: universe -> Prims.bool =
   fun projectee  ->
     match projectee with | U_unif _0 -> true | uu____237 -> false
-  
-let (__proj__U_unif__item___0 :
+let __proj__U_unif__item___0:
   universe ->
     (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar,version)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | U_unif _0 -> _0 
-let (uu___is_U_unknown : universe -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | U_unif _0 -> _0
+let uu___is_U_unknown: universe -> Prims.bool =
   fun projectee  ->
     match projectee with | U_unknown  -> true | uu____272 -> false
-  
 type univ_name = FStar_Ident.ident[@@deriving show]
 type universe_uvar =
   (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar,version)
@@ -121,800 +105,706 @@ type univ_names = univ_name Prims.list[@@deriving show]
 type universes = universe Prims.list[@@deriving show]
 type monad_name = FStar_Ident.lident[@@deriving show]
 type delta_depth =
-  | Delta_constant 
-  | Delta_defined_at_level of Prims.int 
-  | Delta_equational 
-  | Delta_abstract of delta_depth [@@deriving show]
-let (uu___is_Delta_constant : delta_depth -> Prims.bool) =
+  | Delta_constant
+  | Delta_defined_at_level of Prims.int
+  | Delta_equational
+  | Delta_abstract of delta_depth[@@deriving show]
+let uu___is_Delta_constant: delta_depth -> Prims.bool =
   fun projectee  ->
     match projectee with | Delta_constant  -> true | uu____296 -> false
-  
-let (uu___is_Delta_defined_at_level : delta_depth -> Prims.bool) =
+let uu___is_Delta_defined_at_level: delta_depth -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Delta_defined_at_level _0 -> true
     | uu____301 -> false
-  
-let (__proj__Delta_defined_at_level__item___0 : delta_depth -> Prims.int) =
-  fun projectee  -> match projectee with | Delta_defined_at_level _0 -> _0 
-let (uu___is_Delta_equational : delta_depth -> Prims.bool) =
+let __proj__Delta_defined_at_level__item___0: delta_depth -> Prims.int =
+  fun projectee  -> match projectee with | Delta_defined_at_level _0 -> _0
+let uu___is_Delta_equational: delta_depth -> Prims.bool =
   fun projectee  ->
     match projectee with | Delta_equational  -> true | uu____312 -> false
-  
-let (uu___is_Delta_abstract : delta_depth -> Prims.bool) =
+let uu___is_Delta_abstract: delta_depth -> Prims.bool =
   fun projectee  ->
     match projectee with | Delta_abstract _0 -> true | uu____317 -> false
-  
-let (__proj__Delta_abstract__item___0 : delta_depth -> delta_depth) =
-  fun projectee  -> match projectee with | Delta_abstract _0 -> _0 
+let __proj__Delta_abstract__item___0: delta_depth -> delta_depth =
+  fun projectee  -> match projectee with | Delta_abstract _0 -> _0
 type term' =
-  | Tm_bvar of bv 
-  | Tm_name of bv 
-  | Tm_fvar of fv 
-  | Tm_uinst of (term' syntax,universes) FStar_Pervasives_Native.tuple2 
-  | Tm_constant of sconst 
-  | Tm_type of universe 
+  | Tm_bvar of bv
+  | Tm_name of bv
+  | Tm_fvar of fv
+  | Tm_uinst of (term' syntax,universes) FStar_Pervasives_Native.tuple2
+  | Tm_constant of sconst
+  | Tm_type of universe
   | Tm_abs of
   ((bv,aqual) FStar_Pervasives_Native.tuple2 Prims.list,term' syntax,
   residual_comp FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | Tm_arrow of
   ((bv,aqual) FStar_Pervasives_Native.tuple2 Prims.list,comp' syntax)
-  FStar_Pervasives_Native.tuple2 
-  | Tm_refine of (bv,term' syntax) FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
+  | Tm_refine of (bv,term' syntax) FStar_Pervasives_Native.tuple2
   | Tm_app of
   (term' syntax,(term' syntax,aqual) FStar_Pervasives_Native.tuple2
                   Prims.list)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Tm_match of
   (term' syntax,(pat' withinfo_t,term' syntax FStar_Pervasives_Native.option,
                   term' syntax) FStar_Pervasives_Native.tuple3 Prims.list)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Tm_ascribed of
   (term' syntax,((term' syntax,comp' syntax) FStar_Util.either,term' syntax
                                                                  FStar_Pervasives_Native.option)
                   FStar_Pervasives_Native.tuple2,FStar_Ident.lident
                                                    FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | Tm_let of
   ((Prims.bool,letbinding Prims.list) FStar_Pervasives_Native.tuple2,
-  term' syntax) FStar_Pervasives_Native.tuple2 
+  term' syntax) FStar_Pervasives_Native.tuple2
   | Tm_uvar of
   ((term' syntax FStar_Pervasives_Native.option FStar_Unionfind.p_uvar,
      version) FStar_Pervasives_Native.tuple2,term' syntax)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Tm_delayed of
   ((term' syntax,(subst_elt Prims.list Prims.list,FStar_Range.range
                                                     FStar_Pervasives_Native.option)
                    FStar_Pervasives_Native.tuple2)
      FStar_Pervasives_Native.tuple2,term' syntax memo)
-  FStar_Pervasives_Native.tuple2 
-  | Tm_meta of (term' syntax,metadata) FStar_Pervasives_Native.tuple2 
-  | Tm_unknown [@@deriving show]
+  FStar_Pervasives_Native.tuple2
+  | Tm_meta of (term' syntax,metadata) FStar_Pervasives_Native.tuple2
+  | Tm_unknown[@@deriving show]
 and pat' =
-  | Pat_constant of sconst 
+  | Pat_constant of sconst
   | Pat_cons of
   (fv,(pat' withinfo_t,Prims.bool) FStar_Pervasives_Native.tuple2 Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | Pat_var of bv 
-  | Pat_wild of bv 
-  | Pat_dot_term of (bv,term' syntax) FStar_Pervasives_Native.tuple2 
-[@@deriving show]
+  FStar_Pervasives_Native.tuple2
+  | Pat_var of bv
+  | Pat_wild of bv
+  | Pat_dot_term of (bv,term' syntax) FStar_Pervasives_Native.tuple2[@@deriving
+                                                                    show]
 and letbinding =
   {
-  lbname: (bv,fv) FStar_Util.either ;
-  lbunivs: univ_name Prims.list ;
-  lbtyp: term' syntax ;
-  lbeff: FStar_Ident.lident ;
-  lbdef: term' syntax ;
-  lbattrs: term' syntax Prims.list }[@@deriving show]
+  lbname: (bv,fv) FStar_Util.either;
+  lbunivs: univ_name Prims.list;
+  lbtyp: term' syntax;
+  lbeff: FStar_Ident.lident;
+  lbdef: term' syntax;
+  lbattrs: term' syntax Prims.list;}[@@deriving show]
 and comp_typ =
   {
-  comp_univs: universes ;
-  effect_name: FStar_Ident.lident ;
-  result_typ: term' syntax ;
-  effect_args: (term' syntax,aqual) FStar_Pervasives_Native.tuple2 Prims.list ;
-  flags: cflags Prims.list }[@@deriving show]
+  comp_univs: universes;
+  effect_name: FStar_Ident.lident;
+  result_typ: term' syntax;
+  effect_args:
+    (term' syntax,aqual) FStar_Pervasives_Native.tuple2 Prims.list;
+  flags: cflags Prims.list;}[@@deriving show]
 and comp' =
   | Total of (term' syntax,universe FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | GTotal of (term' syntax,universe FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
-  | Comp of comp_typ [@@deriving show]
+  FStar_Pervasives_Native.tuple2
+  | Comp of comp_typ[@@deriving show]
 and cflags =
-  | TOTAL 
-  | MLEFFECT 
-  | RETURN 
-  | PARTIAL_RETURN 
-  | SOMETRIVIAL 
-  | TRIVIAL_POSTCONDITION 
-  | SHOULD_NOT_INLINE 
-  | LEMMA 
-  | CPS 
-  | DECREASES of term' syntax [@@deriving show]
+  | TOTAL
+  | MLEFFECT
+  | RETURN
+  | PARTIAL_RETURN
+  | SOMETRIVIAL
+  | TRIVIAL_POSTCONDITION
+  | SHOULD_NOT_INLINE
+  | LEMMA
+  | CPS
+  | DECREASES of term' syntax[@@deriving show]
 and metadata =
   | Meta_pattern of (term' syntax,aqual) FStar_Pervasives_Native.tuple2
-  Prims.list Prims.list 
-  | Meta_named of FStar_Ident.lident 
+  Prims.list Prims.list
+  | Meta_named of FStar_Ident.lident
   | Meta_labeled of (Prims.string,FStar_Range.range,Prims.bool)
-  FStar_Pervasives_Native.tuple3 
-  | Meta_desugared of meta_source_info 
+  FStar_Pervasives_Native.tuple3
+  | Meta_desugared of meta_source_info
   | Meta_monadic of (monad_name,term' syntax) FStar_Pervasives_Native.tuple2
-  
   | Meta_monadic_lift of (monad_name,monad_name,term' syntax)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | Meta_alien of (FStar_Dyn.dyn,Prims.string,term' syntax)
-  FStar_Pervasives_Native.tuple3 [@@deriving show]
+  FStar_Pervasives_Native.tuple3[@@deriving show]
 and meta_source_info =
-  | Data_app 
-  | Sequence 
-  | Primop 
-  | Masked_effect 
-  | Meta_smt_pat 
-  | Mutable_alloc 
-  | Mutable_rval [@@deriving show]
+  | Data_app
+  | Sequence
+  | Primop
+  | Masked_effect
+  | Meta_smt_pat
+  | Mutable_alloc
+  | Mutable_rval[@@deriving show]
 and fv_qual =
-  | Data_ctor 
+  | Data_ctor
   | Record_projector of (FStar_Ident.lident,FStar_Ident.ident)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Record_ctor of (FStar_Ident.lident,FStar_Ident.ident Prims.list)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
+  FStar_Pervasives_Native.tuple2[@@deriving show]
 and subst_elt =
-  | DB of (Prims.int,bv) FStar_Pervasives_Native.tuple2 
-  | NM of (bv,Prims.int) FStar_Pervasives_Native.tuple2 
-  | NT of (bv,term' syntax) FStar_Pervasives_Native.tuple2 
-  | UN of (Prims.int,universe) FStar_Pervasives_Native.tuple2 
-  | UD of (univ_name,Prims.int) FStar_Pervasives_Native.tuple2 [@@deriving
-                                                                 show]
+  | DB of (Prims.int,bv) FStar_Pervasives_Native.tuple2
+  | NM of (bv,Prims.int) FStar_Pervasives_Native.tuple2
+  | NT of (bv,term' syntax) FStar_Pervasives_Native.tuple2
+  | UN of (Prims.int,universe) FStar_Pervasives_Native.tuple2
+  | UD of (univ_name,Prims.int) FStar_Pervasives_Native.tuple2[@@deriving
+                                                                show]
 and 'a syntax = {
-  n: 'a ;
-  pos: FStar_Range.range ;
-  vars: free_vars memo }[@@deriving show]
+  n: 'a;
+  pos: FStar_Range.range;
+  vars: free_vars memo;}[@@deriving show]
 and bv = {
-  ppname: FStar_Ident.ident ;
-  index: Prims.int ;
-  sort: term' syntax }[@@deriving show]
+  ppname: FStar_Ident.ident;
+  index: Prims.int;
+  sort: term' syntax;}[@@deriving show]
 and fv =
   {
-  fv_name: var ;
-  fv_delta: delta_depth ;
-  fv_qual: fv_qual FStar_Pervasives_Native.option }[@@deriving show]
+  fv_name: var;
+  fv_delta: delta_depth;
+  fv_qual: fv_qual FStar_Pervasives_Native.option;}[@@deriving show]
 and free_vars =
   {
-  free_names: bv Prims.list ;
+  free_names: bv Prims.list;
   free_uvars:
     ((term' syntax FStar_Pervasives_Native.option FStar_Unionfind.p_uvar,
        version) FStar_Pervasives_Native.tuple2,term' syntax)
-      FStar_Pervasives_Native.tuple2 Prims.list
-    ;
-  free_univs: universe_uvar Prims.list ;
-  free_univ_names: univ_name Prims.list }[@@deriving show]
+      FStar_Pervasives_Native.tuple2 Prims.list;
+  free_univs: universe_uvar Prims.list;
+  free_univ_names: univ_name Prims.list;}[@@deriving show]
 and lcomp =
   {
-  eff_name: FStar_Ident.lident ;
-  res_typ: term' syntax ;
-  cflags: cflags Prims.list ;
+  eff_name: FStar_Ident.lident;
+  res_typ: term' syntax;
+  cflags: cflags Prims.list;
   comp_thunk:
-    (Prims.unit -> comp' syntax,comp' syntax) FStar_Util.either FStar_ST.ref }
+    (Prims.unit -> comp' syntax,comp' syntax) FStar_Util.either FStar_ST.ref;}
 [@@deriving show]
 and residual_comp =
   {
-  residual_effect: FStar_Ident.lident ;
-  residual_typ: term' syntax FStar_Pervasives_Native.option ;
-  residual_flags: cflags Prims.list }[@@deriving show]
-let (uu___is_Tm_bvar : term' -> Prims.bool) =
+  residual_effect: FStar_Ident.lident;
+  residual_typ: term' syntax FStar_Pervasives_Native.option;
+  residual_flags: cflags Prims.list;}[@@deriving show]
+let uu___is_Tm_bvar: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_bvar _0 -> true | uu____1011 -> false
-  
-let (__proj__Tm_bvar__item___0 : term' -> bv) =
-  fun projectee  -> match projectee with | Tm_bvar _0 -> _0 
-let (uu___is_Tm_name : term' -> Prims.bool) =
+let __proj__Tm_bvar__item___0: term' -> bv =
+  fun projectee  -> match projectee with | Tm_bvar _0 -> _0
+let uu___is_Tm_name: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_name _0 -> true | uu____1023 -> false
-  
-let (__proj__Tm_name__item___0 : term' -> bv) =
-  fun projectee  -> match projectee with | Tm_name _0 -> _0 
-let (uu___is_Tm_fvar : term' -> Prims.bool) =
+let __proj__Tm_name__item___0: term' -> bv =
+  fun projectee  -> match projectee with | Tm_name _0 -> _0
+let uu___is_Tm_fvar: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_fvar _0 -> true | uu____1035 -> false
-  
-let (__proj__Tm_fvar__item___0 : term' -> fv) =
-  fun projectee  -> match projectee with | Tm_fvar _0 -> _0 
-let (uu___is_Tm_uinst : term' -> Prims.bool) =
+let __proj__Tm_fvar__item___0: term' -> fv =
+  fun projectee  -> match projectee with | Tm_fvar _0 -> _0
+let uu___is_Tm_uinst: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_uinst _0 -> true | uu____1053 -> false
-  
-let (__proj__Tm_uinst__item___0 :
-  term' -> (term' syntax,universes) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Tm_uinst _0 -> _0 
-let (uu___is_Tm_constant : term' -> Prims.bool) =
+let __proj__Tm_uinst__item___0:
+  term' -> (term' syntax,universes) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Tm_uinst _0 -> _0
+let uu___is_Tm_constant: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_constant _0 -> true | uu____1083 -> false
-  
-let (__proj__Tm_constant__item___0 : term' -> sconst) =
-  fun projectee  -> match projectee with | Tm_constant _0 -> _0 
-let (uu___is_Tm_type : term' -> Prims.bool) =
+let __proj__Tm_constant__item___0: term' -> sconst =
+  fun projectee  -> match projectee with | Tm_constant _0 -> _0
+let uu___is_Tm_type: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_type _0 -> true | uu____1095 -> false
-  
-let (__proj__Tm_type__item___0 : term' -> universe) =
-  fun projectee  -> match projectee with | Tm_type _0 -> _0 
-let (uu___is_Tm_abs : term' -> Prims.bool) =
+let __proj__Tm_type__item___0: term' -> universe =
+  fun projectee  -> match projectee with | Tm_type _0 -> _0
+let uu___is_Tm_abs: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_abs _0 -> true | uu____1123 -> false
-  
-let (__proj__Tm_abs__item___0 :
+let __proj__Tm_abs__item___0:
   term' ->
     ((bv,aqual) FStar_Pervasives_Native.tuple2 Prims.list,term' syntax,
       residual_comp FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Tm_abs _0 -> _0 
-let (uu___is_Tm_arrow : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Tm_abs _0 -> _0
+let uu___is_Tm_arrow: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_arrow _0 -> true | uu____1195 -> false
-  
-let (__proj__Tm_arrow__item___0 :
+let __proj__Tm_arrow__item___0:
   term' ->
     ((bv,aqual) FStar_Pervasives_Native.tuple2 Prims.list,comp' syntax)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tm_arrow _0 -> _0 
-let (uu___is_Tm_refine : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tm_arrow _0 -> _0
+let uu___is_Tm_refine: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_refine _0 -> true | uu____1249 -> false
-  
-let (__proj__Tm_refine__item___0 :
-  term' -> (bv,term' syntax) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Tm_refine _0 -> _0 
-let (uu___is_Tm_app : term' -> Prims.bool) =
+let __proj__Tm_refine__item___0:
+  term' -> (bv,term' syntax) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Tm_refine _0 -> _0
+let uu___is_Tm_app: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_app _0 -> true | uu____1293 -> false
-  
-let (__proj__Tm_app__item___0 :
+let __proj__Tm_app__item___0:
   term' ->
     (term' syntax,(term' syntax,aqual) FStar_Pervasives_Native.tuple2
                     Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tm_app _0 -> _0 
-let (uu___is_Tm_match : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tm_app _0 -> _0
+let uu___is_Tm_match: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_match _0 -> true | uu____1369 -> false
-  
-let (__proj__Tm_match__item___0 :
+let __proj__Tm_match__item___0:
   term' ->
     (term' syntax,(pat' withinfo_t,term' syntax
                                      FStar_Pervasives_Native.option,term'
                                                                     syntax)
                     FStar_Pervasives_Native.tuple3 Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tm_match _0 -> _0 
-let (uu___is_Tm_ascribed : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tm_match _0 -> _0
+let uu___is_Tm_ascribed: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_ascribed _0 -> true | uu____1473 -> false
-  
-let (__proj__Tm_ascribed__item___0 :
+let __proj__Tm_ascribed__item___0:
   term' ->
     (term' syntax,((term' syntax,comp' syntax) FStar_Util.either,term' syntax
                                                                    FStar_Pervasives_Native.option)
                     FStar_Pervasives_Native.tuple2,FStar_Ident.lident
                                                      FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Tm_ascribed _0 -> _0 
-let (uu___is_Tm_let : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Tm_ascribed _0 -> _0
+let uu___is_Tm_let: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_let _0 -> true | uu____1575 -> false
-  
-let (__proj__Tm_let__item___0 :
+let __proj__Tm_let__item___0:
   term' ->
     ((Prims.bool,letbinding Prims.list) FStar_Pervasives_Native.tuple2,
-      term' syntax) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tm_let _0 -> _0 
-let (uu___is_Tm_uvar : term' -> Prims.bool) =
+      term' syntax) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tm_let _0 -> _0
+let uu___is_Tm_uvar: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_uvar _0 -> true | uu____1639 -> false
-  
-let (__proj__Tm_uvar__item___0 :
+let __proj__Tm_uvar__item___0:
   term' ->
     ((term' syntax FStar_Pervasives_Native.option FStar_Unionfind.p_uvar,
        version) FStar_Pervasives_Native.tuple2,term' syntax)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tm_uvar _0 -> _0 
-let (uu___is_Tm_delayed : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tm_uvar _0 -> _0
+let uu___is_Tm_delayed: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_delayed _0 -> true | uu____1723 -> false
-  
-let (__proj__Tm_delayed__item___0 :
+let __proj__Tm_delayed__item___0:
   term' ->
     ((term' syntax,(subst_elt Prims.list Prims.list,FStar_Range.range
                                                       FStar_Pervasives_Native.option)
                      FStar_Pervasives_Native.tuple2)
        FStar_Pervasives_Native.tuple2,term' syntax memo)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Tm_delayed _0 -> _0 
-let (uu___is_Tm_meta : term' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Tm_delayed _0 -> _0
+let uu___is_Tm_meta: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_meta _0 -> true | uu____1813 -> false
-  
-let (__proj__Tm_meta__item___0 :
-  term' -> (term' syntax,metadata) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Tm_meta _0 -> _0 
-let (uu___is_Tm_unknown : term' -> Prims.bool) =
+let __proj__Tm_meta__item___0:
+  term' -> (term' syntax,metadata) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Tm_meta _0 -> _0
+let uu___is_Tm_unknown: term' -> Prims.bool =
   fun projectee  ->
     match projectee with | Tm_unknown  -> true | uu____1842 -> false
-  
-let (uu___is_Pat_constant : pat' -> Prims.bool) =
+let uu___is_Pat_constant: pat' -> Prims.bool =
   fun projectee  ->
     match projectee with | Pat_constant _0 -> true | uu____1847 -> false
-  
-let (__proj__Pat_constant__item___0 : pat' -> sconst) =
-  fun projectee  -> match projectee with | Pat_constant _0 -> _0 
-let (uu___is_Pat_cons : pat' -> Prims.bool) =
+let __proj__Pat_constant__item___0: pat' -> sconst =
+  fun projectee  -> match projectee with | Pat_constant _0 -> _0
+let uu___is_Pat_cons: pat' -> Prims.bool =
   fun projectee  ->
     match projectee with | Pat_cons _0 -> true | uu____1871 -> false
-  
-let (__proj__Pat_cons__item___0 :
+let __proj__Pat_cons__item___0:
   pat' ->
     (fv,(pat' withinfo_t,Prims.bool) FStar_Pervasives_Native.tuple2
           Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Pat_cons _0 -> _0 
-let (uu___is_Pat_var : pat' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Pat_cons _0 -> _0
+let uu___is_Pat_var: pat' -> Prims.bool =
   fun projectee  ->
     match projectee with | Pat_var _0 -> true | uu____1919 -> false
-  
-let (__proj__Pat_var__item___0 : pat' -> bv) =
-  fun projectee  -> match projectee with | Pat_var _0 -> _0 
-let (uu___is_Pat_wild : pat' -> Prims.bool) =
+let __proj__Pat_var__item___0: pat' -> bv =
+  fun projectee  -> match projectee with | Pat_var _0 -> _0
+let uu___is_Pat_wild: pat' -> Prims.bool =
   fun projectee  ->
     match projectee with | Pat_wild _0 -> true | uu____1931 -> false
-  
-let (__proj__Pat_wild__item___0 : pat' -> bv) =
-  fun projectee  -> match projectee with | Pat_wild _0 -> _0 
-let (uu___is_Pat_dot_term : pat' -> Prims.bool) =
+let __proj__Pat_wild__item___0: pat' -> bv =
+  fun projectee  -> match projectee with | Pat_wild _0 -> _0
+let uu___is_Pat_dot_term: pat' -> Prims.bool =
   fun projectee  ->
     match projectee with | Pat_dot_term _0 -> true | uu____1949 -> false
-  
-let (__proj__Pat_dot_term__item___0 :
-  pat' -> (bv,term' syntax) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Pat_dot_term _0 -> _0 
-let (__proj__Mkletbinding__item__lbname :
-  letbinding -> (bv,fv) FStar_Util.either) =
+let __proj__Pat_dot_term__item___0:
+  pat' -> (bv,term' syntax) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Pat_dot_term _0 -> _0
+let __proj__Mkletbinding__item__lbname:
+  letbinding -> (bv,fv) FStar_Util.either =
   fun projectee  ->
     match projectee with
     | { lbname = __fname__lbname; lbunivs = __fname__lbunivs;
         lbtyp = __fname__lbtyp; lbeff = __fname__lbeff;
         lbdef = __fname__lbdef; lbattrs = __fname__lbattrs;_} ->
         __fname__lbname
-  
-let (__proj__Mkletbinding__item__lbunivs :
-  letbinding -> univ_name Prims.list) =
+let __proj__Mkletbinding__item__lbunivs: letbinding -> univ_name Prims.list =
   fun projectee  ->
     match projectee with
     | { lbname = __fname__lbname; lbunivs = __fname__lbunivs;
         lbtyp = __fname__lbtyp; lbeff = __fname__lbeff;
         lbdef = __fname__lbdef; lbattrs = __fname__lbattrs;_} ->
         __fname__lbunivs
-  
-let (__proj__Mkletbinding__item__lbtyp : letbinding -> term' syntax) =
+let __proj__Mkletbinding__item__lbtyp: letbinding -> term' syntax =
   fun projectee  ->
     match projectee with
     | { lbname = __fname__lbname; lbunivs = __fname__lbunivs;
         lbtyp = __fname__lbtyp; lbeff = __fname__lbeff;
         lbdef = __fname__lbdef; lbattrs = __fname__lbattrs;_} ->
         __fname__lbtyp
-  
-let (__proj__Mkletbinding__item__lbeff : letbinding -> FStar_Ident.lident) =
+let __proj__Mkletbinding__item__lbeff: letbinding -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { lbname = __fname__lbname; lbunivs = __fname__lbunivs;
         lbtyp = __fname__lbtyp; lbeff = __fname__lbeff;
         lbdef = __fname__lbdef; lbattrs = __fname__lbattrs;_} ->
         __fname__lbeff
-  
-let (__proj__Mkletbinding__item__lbdef : letbinding -> term' syntax) =
+let __proj__Mkletbinding__item__lbdef: letbinding -> term' syntax =
   fun projectee  ->
     match projectee with
     | { lbname = __fname__lbname; lbunivs = __fname__lbunivs;
         lbtyp = __fname__lbtyp; lbeff = __fname__lbeff;
         lbdef = __fname__lbdef; lbattrs = __fname__lbattrs;_} ->
         __fname__lbdef
-  
-let (__proj__Mkletbinding__item__lbattrs :
-  letbinding -> term' syntax Prims.list) =
+let __proj__Mkletbinding__item__lbattrs:
+  letbinding -> term' syntax Prims.list =
   fun projectee  ->
     match projectee with
     | { lbname = __fname__lbname; lbunivs = __fname__lbunivs;
         lbtyp = __fname__lbtyp; lbeff = __fname__lbeff;
         lbdef = __fname__lbdef; lbattrs = __fname__lbattrs;_} ->
         __fname__lbattrs
-  
-let (__proj__Mkcomp_typ__item__comp_univs : comp_typ -> universes) =
+let __proj__Mkcomp_typ__item__comp_univs: comp_typ -> universes =
   fun projectee  ->
     match projectee with
     | { comp_univs = __fname__comp_univs; effect_name = __fname__effect_name;
         result_typ = __fname__result_typ; effect_args = __fname__effect_args;
         flags = __fname__flags;_} -> __fname__comp_univs
-  
-let (__proj__Mkcomp_typ__item__effect_name : comp_typ -> FStar_Ident.lident)
-  =
+let __proj__Mkcomp_typ__item__effect_name: comp_typ -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { comp_univs = __fname__comp_univs; effect_name = __fname__effect_name;
         result_typ = __fname__result_typ; effect_args = __fname__effect_args;
         flags = __fname__flags;_} -> __fname__effect_name
-  
-let (__proj__Mkcomp_typ__item__result_typ : comp_typ -> term' syntax) =
+let __proj__Mkcomp_typ__item__result_typ: comp_typ -> term' syntax =
   fun projectee  ->
     match projectee with
     | { comp_univs = __fname__comp_univs; effect_name = __fname__effect_name;
         result_typ = __fname__result_typ; effect_args = __fname__effect_args;
         flags = __fname__flags;_} -> __fname__result_typ
-  
-let (__proj__Mkcomp_typ__item__effect_args :
-  comp_typ -> (term' syntax,aqual) FStar_Pervasives_Native.tuple2 Prims.list)
+let __proj__Mkcomp_typ__item__effect_args:
+  comp_typ -> (term' syntax,aqual) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
     | { comp_univs = __fname__comp_univs; effect_name = __fname__effect_name;
         result_typ = __fname__result_typ; effect_args = __fname__effect_args;
         flags = __fname__flags;_} -> __fname__effect_args
-  
-let (__proj__Mkcomp_typ__item__flags : comp_typ -> cflags Prims.list) =
+let __proj__Mkcomp_typ__item__flags: comp_typ -> cflags Prims.list =
   fun projectee  ->
     match projectee with
     | { comp_univs = __fname__comp_univs; effect_name = __fname__effect_name;
         result_typ = __fname__result_typ; effect_args = __fname__effect_args;
         flags = __fname__flags;_} -> __fname__flags
-  
-let (uu___is_Total : comp' -> Prims.bool) =
+let uu___is_Total: comp' -> Prims.bool =
   fun projectee  ->
     match projectee with | Total _0 -> true | uu____2277 -> false
-  
-let (__proj__Total__item___0 :
+let __proj__Total__item___0:
   comp' ->
     (term' syntax,universe FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Total _0 -> _0 
-let (uu___is_GTotal : comp' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Total _0 -> _0
+let uu___is_GTotal: comp' -> Prims.bool =
   fun projectee  ->
     match projectee with | GTotal _0 -> true | uu____2321 -> false
-  
-let (__proj__GTotal__item___0 :
+let __proj__GTotal__item___0:
   comp' ->
     (term' syntax,universe FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | GTotal _0 -> _0 
-let (uu___is_Comp : comp' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | GTotal _0 -> _0
+let uu___is_Comp: comp' -> Prims.bool =
   fun projectee  ->
     match projectee with | Comp _0 -> true | uu____2357 -> false
-  
-let (__proj__Comp__item___0 : comp' -> comp_typ) =
-  fun projectee  -> match projectee with | Comp _0 -> _0 
-let (uu___is_TOTAL : cflags -> Prims.bool) =
+let __proj__Comp__item___0: comp' -> comp_typ =
+  fun projectee  -> match projectee with | Comp _0 -> _0
+let uu___is_TOTAL: cflags -> Prims.bool =
   fun projectee  ->
     match projectee with | TOTAL  -> true | uu____2368 -> false
-  
-let (uu___is_MLEFFECT : cflags -> Prims.bool) =
+let uu___is_MLEFFECT: cflags -> Prims.bool =
   fun projectee  ->
     match projectee with | MLEFFECT  -> true | uu____2372 -> false
-  
-let (uu___is_RETURN : cflags -> Prims.bool) =
+let uu___is_RETURN: cflags -> Prims.bool =
   fun projectee  ->
     match projectee with | RETURN  -> true | uu____2376 -> false
-  
-let (uu___is_PARTIAL_RETURN : cflags -> Prims.bool) =
+let uu___is_PARTIAL_RETURN: cflags -> Prims.bool =
   fun projectee  ->
     match projectee with | PARTIAL_RETURN  -> true | uu____2380 -> false
-  
-let (uu___is_SOMETRIVIAL : cflags -> Prims.bool) =
+let uu___is_SOMETRIVIAL: cflags -> Prims.bool =
   fun projectee  ->
     match projectee with | SOMETRIVIAL  -> true | uu____2384 -> false
-  
-let (uu___is_TRIVIAL_POSTCONDITION : cflags -> Prims.bool) =
+let uu___is_TRIVIAL_POSTCONDITION: cflags -> Prims.bool =
   fun projectee  ->
     match projectee with
     | TRIVIAL_POSTCONDITION  -> true
     | uu____2388 -> false
-  
-let (uu___is_SHOULD_NOT_INLINE : cflags -> Prims.bool) =
+let uu___is_SHOULD_NOT_INLINE: cflags -> Prims.bool =
   fun projectee  ->
     match projectee with | SHOULD_NOT_INLINE  -> true | uu____2392 -> false
-  
-let (uu___is_LEMMA : cflags -> Prims.bool) =
+let uu___is_LEMMA: cflags -> Prims.bool =
   fun projectee  ->
     match projectee with | LEMMA  -> true | uu____2396 -> false
-  
-let (uu___is_CPS : cflags -> Prims.bool) =
-  fun projectee  -> match projectee with | CPS  -> true | uu____2400 -> false 
-let (uu___is_DECREASES : cflags -> Prims.bool) =
+let uu___is_CPS: cflags -> Prims.bool =
+  fun projectee  -> match projectee with | CPS  -> true | uu____2400 -> false
+let uu___is_DECREASES: cflags -> Prims.bool =
   fun projectee  ->
     match projectee with | DECREASES _0 -> true | uu____2407 -> false
-  
-let (__proj__DECREASES__item___0 : cflags -> term' syntax) =
-  fun projectee  -> match projectee with | DECREASES _0 -> _0 
-let (uu___is_Meta_pattern : metadata -> Prims.bool) =
+let __proj__DECREASES__item___0: cflags -> term' syntax =
+  fun projectee  -> match projectee with | DECREASES _0 -> _0
+let uu___is_Meta_pattern: metadata -> Prims.bool =
   fun projectee  ->
     match projectee with | Meta_pattern _0 -> true | uu____2435 -> false
-  
-let (__proj__Meta_pattern__item___0 :
+let __proj__Meta_pattern__item___0:
   metadata ->
-    (term' syntax,aqual) FStar_Pervasives_Native.tuple2 Prims.list Prims.list)
-  = fun projectee  -> match projectee with | Meta_pattern _0 -> _0 
-let (uu___is_Meta_named : metadata -> Prims.bool) =
+    (term' syntax,aqual) FStar_Pervasives_Native.tuple2 Prims.list Prims.list
+  = fun projectee  -> match projectee with | Meta_pattern _0 -> _0
+let uu___is_Meta_named: metadata -> Prims.bool =
   fun projectee  ->
     match projectee with | Meta_named _0 -> true | uu____2477 -> false
-  
-let (__proj__Meta_named__item___0 : metadata -> FStar_Ident.lident) =
-  fun projectee  -> match projectee with | Meta_named _0 -> _0 
-let (uu___is_Meta_labeled : metadata -> Prims.bool) =
+let __proj__Meta_named__item___0: metadata -> FStar_Ident.lident =
+  fun projectee  -> match projectee with | Meta_named _0 -> _0
+let uu___is_Meta_labeled: metadata -> Prims.bool =
   fun projectee  ->
     match projectee with | Meta_labeled _0 -> true | uu____2495 -> false
-  
-let (__proj__Meta_labeled__item___0 :
+let __proj__Meta_labeled__item___0:
   metadata ->
     (Prims.string,FStar_Range.range,Prims.bool)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Meta_labeled _0 -> _0 
-let (uu___is_Meta_desugared : metadata -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Meta_labeled _0 -> _0
+let uu___is_Meta_desugared: metadata -> Prims.bool =
   fun projectee  ->
     match projectee with | Meta_desugared _0 -> true | uu____2525 -> false
-  
-let (__proj__Meta_desugared__item___0 : metadata -> meta_source_info) =
-  fun projectee  -> match projectee with | Meta_desugared _0 -> _0 
-let (uu___is_Meta_monadic : metadata -> Prims.bool) =
+let __proj__Meta_desugared__item___0: metadata -> meta_source_info =
+  fun projectee  -> match projectee with | Meta_desugared _0 -> _0
+let uu___is_Meta_monadic: metadata -> Prims.bool =
   fun projectee  ->
     match projectee with | Meta_monadic _0 -> true | uu____2543 -> false
-  
-let (__proj__Meta_monadic__item___0 :
-  metadata -> (monad_name,term' syntax) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | Meta_monadic _0 -> _0 
-let (uu___is_Meta_monadic_lift : metadata -> Prims.bool) =
+let __proj__Meta_monadic__item___0:
+  metadata -> (monad_name,term' syntax) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | Meta_monadic _0 -> _0
+let uu___is_Meta_monadic_lift: metadata -> Prims.bool =
   fun projectee  ->
     match projectee with | Meta_monadic_lift _0 -> true | uu____2581 -> false
-  
-let (__proj__Meta_monadic_lift__item___0 :
+let __proj__Meta_monadic_lift__item___0:
   metadata ->
-    (monad_name,monad_name,term' syntax) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Meta_monadic_lift _0 -> _0 
-let (uu___is_Meta_alien : metadata -> Prims.bool) =
+    (monad_name,monad_name,term' syntax) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Meta_monadic_lift _0 -> _0
+let uu___is_Meta_alien: metadata -> Prims.bool =
   fun projectee  ->
     match projectee with | Meta_alien _0 -> true | uu____2625 -> false
-  
-let (__proj__Meta_alien__item___0 :
+let __proj__Meta_alien__item___0:
   metadata ->
-    (FStar_Dyn.dyn,Prims.string,term' syntax) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Meta_alien _0 -> _0 
-let (uu___is_Data_app : meta_source_info -> Prims.bool) =
+    (FStar_Dyn.dyn,Prims.string,term' syntax) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Meta_alien _0 -> _0
+let uu___is_Data_app: meta_source_info -> Prims.bool =
   fun projectee  ->
     match projectee with | Data_app  -> true | uu____2660 -> false
-  
-let (uu___is_Sequence : meta_source_info -> Prims.bool) =
+let uu___is_Sequence: meta_source_info -> Prims.bool =
   fun projectee  ->
     match projectee with | Sequence  -> true | uu____2664 -> false
-  
-let (uu___is_Primop : meta_source_info -> Prims.bool) =
+let uu___is_Primop: meta_source_info -> Prims.bool =
   fun projectee  ->
     match projectee with | Primop  -> true | uu____2668 -> false
-  
-let (uu___is_Masked_effect : meta_source_info -> Prims.bool) =
+let uu___is_Masked_effect: meta_source_info -> Prims.bool =
   fun projectee  ->
     match projectee with | Masked_effect  -> true | uu____2672 -> false
-  
-let (uu___is_Meta_smt_pat : meta_source_info -> Prims.bool) =
+let uu___is_Meta_smt_pat: meta_source_info -> Prims.bool =
   fun projectee  ->
     match projectee with | Meta_smt_pat  -> true | uu____2676 -> false
-  
-let (uu___is_Mutable_alloc : meta_source_info -> Prims.bool) =
+let uu___is_Mutable_alloc: meta_source_info -> Prims.bool =
   fun projectee  ->
     match projectee with | Mutable_alloc  -> true | uu____2680 -> false
-  
-let (uu___is_Mutable_rval : meta_source_info -> Prims.bool) =
+let uu___is_Mutable_rval: meta_source_info -> Prims.bool =
   fun projectee  ->
     match projectee with | Mutable_rval  -> true | uu____2684 -> false
-  
-let (uu___is_Data_ctor : fv_qual -> Prims.bool) =
+let uu___is_Data_ctor: fv_qual -> Prims.bool =
   fun projectee  ->
     match projectee with | Data_ctor  -> true | uu____2688 -> false
-  
-let (uu___is_Record_projector : fv_qual -> Prims.bool) =
+let uu___is_Record_projector: fv_qual -> Prims.bool =
   fun projectee  ->
     match projectee with | Record_projector _0 -> true | uu____2697 -> false
-  
-let (__proj__Record_projector__item___0 :
+let __proj__Record_projector__item___0:
   fv_qual ->
-    (FStar_Ident.lident,FStar_Ident.ident) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Record_projector _0 -> _0 
-let (uu___is_Record_ctor : fv_qual -> Prims.bool) =
+    (FStar_Ident.lident,FStar_Ident.ident) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Record_projector _0 -> _0
+let uu___is_Record_ctor: fv_qual -> Prims.bool =
   fun projectee  ->
     match projectee with | Record_ctor _0 -> true | uu____2727 -> false
-  
-let (__proj__Record_ctor__item___0 :
+let __proj__Record_ctor__item___0:
   fv_qual ->
     (FStar_Ident.lident,FStar_Ident.ident Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Record_ctor _0 -> _0 
-let (uu___is_DB : subst_elt -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Record_ctor _0 -> _0
+let uu___is_DB: subst_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | DB _0 -> true | uu____2761 -> false
-  
-let (__proj__DB__item___0 :
-  subst_elt -> (Prims.int,bv) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | DB _0 -> _0 
-let (uu___is_NM : subst_elt -> Prims.bool) =
+let __proj__DB__item___0:
+  subst_elt -> (Prims.int,bv) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | DB _0 -> _0
+let uu___is_NM: subst_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | NM _0 -> true | uu____2789 -> false
-  
-let (__proj__NM__item___0 :
-  subst_elt -> (bv,Prims.int) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | NM _0 -> _0 
-let (uu___is_NT : subst_elt -> Prims.bool) =
+let __proj__NM__item___0:
+  subst_elt -> (bv,Prims.int) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | NM _0 -> _0
+let uu___is_NT: subst_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | NT _0 -> true | uu____2819 -> false
-  
-let (__proj__NT__item___0 :
-  subst_elt -> (bv,term' syntax) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | NT _0 -> _0 
-let (uu___is_UN : subst_elt -> Prims.bool) =
+let __proj__NT__item___0:
+  subst_elt -> (bv,term' syntax) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | NT _0 -> _0
+let uu___is_UN: subst_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | UN _0 -> true | uu____2853 -> false
-  
-let (__proj__UN__item___0 :
-  subst_elt -> (Prims.int,universe) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | UN _0 -> _0 
-let (uu___is_UD : subst_elt -> Prims.bool) =
+let __proj__UN__item___0:
+  subst_elt -> (Prims.int,universe) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | UN _0 -> _0
+let uu___is_UD: subst_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | UD _0 -> true | uu____2881 -> false
-  
-let (__proj__UD__item___0 :
-  subst_elt -> (univ_name,Prims.int) FStar_Pervasives_Native.tuple2) =
-  fun projectee  -> match projectee with | UD _0 -> _0 
-let __proj__Mksyntax__item__n : 'a . 'a syntax -> 'a =
+let __proj__UD__item___0:
+  subst_elt -> (univ_name,Prims.int) FStar_Pervasives_Native.tuple2 =
+  fun projectee  -> match projectee with | UD _0 -> _0
+let __proj__Mksyntax__item__n: 'a . 'a syntax -> 'a =
   fun projectee  ->
     match projectee with
     | { n = __fname__n; pos = __fname__pos; vars = __fname__vars;_} ->
         __fname__n
-  
-let __proj__Mksyntax__item__pos : 'a . 'a syntax -> FStar_Range.range =
+let __proj__Mksyntax__item__pos: 'a . 'a syntax -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { n = __fname__n; pos = __fname__pos; vars = __fname__vars;_} ->
         __fname__pos
-  
-let __proj__Mksyntax__item__vars : 'a . 'a syntax -> free_vars memo =
+let __proj__Mksyntax__item__vars: 'a . 'a syntax -> free_vars memo =
   fun projectee  ->
     match projectee with
     | { n = __fname__n; pos = __fname__pos; vars = __fname__vars;_} ->
         __fname__vars
-  
-let (__proj__Mkbv__item__ppname : bv -> FStar_Ident.ident) =
+let __proj__Mkbv__item__ppname: bv -> FStar_Ident.ident =
   fun projectee  ->
     match projectee with
     | { ppname = __fname__ppname; index = __fname__index;
         sort = __fname__sort;_} -> __fname__ppname
-  
-let (__proj__Mkbv__item__index : bv -> Prims.int) =
+let __proj__Mkbv__item__index: bv -> Prims.int =
   fun projectee  ->
     match projectee with
     | { ppname = __fname__ppname; index = __fname__index;
         sort = __fname__sort;_} -> __fname__index
-  
-let (__proj__Mkbv__item__sort : bv -> term' syntax) =
+let __proj__Mkbv__item__sort: bv -> term' syntax =
   fun projectee  ->
     match projectee with
     | { ppname = __fname__ppname; index = __fname__index;
         sort = __fname__sort;_} -> __fname__sort
-  
-let (__proj__Mkfv__item__fv_name : fv -> var) =
+let __proj__Mkfv__item__fv_name: fv -> var =
   fun projectee  ->
     match projectee with
     | { fv_name = __fname__fv_name; fv_delta = __fname__fv_delta;
         fv_qual = __fname__fv_qual;_} -> __fname__fv_name
-  
-let (__proj__Mkfv__item__fv_delta : fv -> delta_depth) =
+let __proj__Mkfv__item__fv_delta: fv -> delta_depth =
   fun projectee  ->
     match projectee with
     | { fv_name = __fname__fv_name; fv_delta = __fname__fv_delta;
         fv_qual = __fname__fv_qual;_} -> __fname__fv_delta
-  
-let (__proj__Mkfv__item__fv_qual :
-  fv -> fv_qual FStar_Pervasives_Native.option) =
+let __proj__Mkfv__item__fv_qual: fv -> fv_qual FStar_Pervasives_Native.option
+  =
   fun projectee  ->
     match projectee with
     | { fv_name = __fname__fv_name; fv_delta = __fname__fv_delta;
         fv_qual = __fname__fv_qual;_} -> __fname__fv_qual
-  
-let (__proj__Mkfree_vars__item__free_names : free_vars -> bv Prims.list) =
+let __proj__Mkfree_vars__item__free_names: free_vars -> bv Prims.list =
   fun projectee  ->
     match projectee with
     | { free_names = __fname__free_names; free_uvars = __fname__free_uvars;
         free_univs = __fname__free_univs;
         free_univ_names = __fname__free_univ_names;_} -> __fname__free_names
-  
-let (__proj__Mkfree_vars__item__free_uvars :
+let __proj__Mkfree_vars__item__free_uvars:
   free_vars ->
     ((term' syntax FStar_Pervasives_Native.option FStar_Unionfind.p_uvar,
        version) FStar_Pervasives_Native.tuple2,term' syntax)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
     | { free_names = __fname__free_names; free_uvars = __fname__free_uvars;
         free_univs = __fname__free_univs;
         free_univ_names = __fname__free_univ_names;_} -> __fname__free_uvars
-  
-let (__proj__Mkfree_vars__item__free_univs :
-  free_vars -> universe_uvar Prims.list) =
+let __proj__Mkfree_vars__item__free_univs:
+  free_vars -> universe_uvar Prims.list =
   fun projectee  ->
     match projectee with
     | { free_names = __fname__free_names; free_uvars = __fname__free_uvars;
         free_univs = __fname__free_univs;
         free_univ_names = __fname__free_univ_names;_} -> __fname__free_univs
-  
-let (__proj__Mkfree_vars__item__free_univ_names :
-  free_vars -> univ_name Prims.list) =
+let __proj__Mkfree_vars__item__free_univ_names:
+  free_vars -> univ_name Prims.list =
   fun projectee  ->
     match projectee with
     | { free_names = __fname__free_names; free_uvars = __fname__free_uvars;
         free_univs = __fname__free_univs;
         free_univ_names = __fname__free_univ_names;_} ->
         __fname__free_univ_names
-  
-let (__proj__Mklcomp__item__eff_name : lcomp -> FStar_Ident.lident) =
+let __proj__Mklcomp__item__eff_name: lcomp -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { eff_name = __fname__eff_name; res_typ = __fname__res_typ;
         cflags = __fname__cflags; comp_thunk = __fname__comp_thunk;_} ->
         __fname__eff_name
-  
-let (__proj__Mklcomp__item__res_typ : lcomp -> term' syntax) =
+let __proj__Mklcomp__item__res_typ: lcomp -> term' syntax =
   fun projectee  ->
     match projectee with
     | { eff_name = __fname__eff_name; res_typ = __fname__res_typ;
         cflags = __fname__cflags; comp_thunk = __fname__comp_thunk;_} ->
         __fname__res_typ
-  
-let (__proj__Mklcomp__item__cflags : lcomp -> cflags Prims.list) =
+let __proj__Mklcomp__item__cflags: lcomp -> cflags Prims.list =
   fun projectee  ->
     match projectee with
     | { eff_name = __fname__eff_name; res_typ = __fname__res_typ;
         cflags = __fname__cflags; comp_thunk = __fname__comp_thunk;_} ->
         __fname__cflags
-  
-let (__proj__Mklcomp__item__comp_thunk :
+let __proj__Mklcomp__item__comp_thunk:
   lcomp ->
-    (Prims.unit -> comp' syntax,comp' syntax) FStar_Util.either FStar_ST.ref)
+    (Prims.unit -> comp' syntax,comp' syntax) FStar_Util.either FStar_ST.ref
   =
   fun projectee  ->
     match projectee with
     | { eff_name = __fname__eff_name; res_typ = __fname__res_typ;
         cflags = __fname__cflags; comp_thunk = __fname__comp_thunk;_} ->
         __fname__comp_thunk
-  
-let (__proj__Mkresidual_comp__item__residual_effect :
-  residual_comp -> FStar_Ident.lident) =
+let __proj__Mkresidual_comp__item__residual_effect:
+  residual_comp -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { residual_effect = __fname__residual_effect;
         residual_typ = __fname__residual_typ;
         residual_flags = __fname__residual_flags;_} ->
         __fname__residual_effect
-  
-let (__proj__Mkresidual_comp__item__residual_typ :
-  residual_comp -> term' syntax FStar_Pervasives_Native.option) =
+let __proj__Mkresidual_comp__item__residual_typ:
+  residual_comp -> term' syntax FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { residual_effect = __fname__residual_effect;
         residual_typ = __fname__residual_typ;
         residual_flags = __fname__residual_flags;_} -> __fname__residual_typ
-  
-let (__proj__Mkresidual_comp__item__residual_flags :
-  residual_comp -> cflags Prims.list) =
+let __proj__Mkresidual_comp__item__residual_flags:
+  residual_comp -> cflags Prims.list =
   fun projectee  ->
     match projectee with
     | { residual_effect = __fname__residual_effect;
         residual_typ = __fname__residual_typ;
         residual_flags = __fname__residual_flags;_} ->
         __fname__residual_flags
-  
 type pat = pat' withinfo_t[@@deriving show]
 type term = term' syntax[@@deriving show]
 type branch =
@@ -950,249 +840,217 @@ type uvars =
      version) FStar_Pervasives_Native.tuple2,term' syntax)
     FStar_Pervasives_Native.tuple2 FStar_Util.set[@@deriving show]
 type attribute = term' syntax[@@deriving show]
-let (mk_lcomp :
+let mk_lcomp:
   FStar_Ident.lident ->
-    typ -> cflags Prims.list -> (Prims.unit -> comp) -> lcomp)
+    typ -> cflags Prims.list -> (Prims.unit -> comp) -> lcomp
   =
   fun eff_name  ->
     fun res_typ  ->
       fun cflags  ->
         fun comp_thunk  ->
-          let uu____3552 = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk)  in
+          let uu____3552 = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk) in
           { eff_name; res_typ; cflags; comp_thunk = uu____3552 }
-  
-let (lcomp_comp : lcomp -> comp) =
+let lcomp_comp: lcomp -> comp =
   fun lc  ->
-    let uu____3602 = FStar_ST.op_Bang lc.comp_thunk  in
+    let uu____3602 = FStar_ST.op_Bang lc.comp_thunk in
     match uu____3602 with
     | FStar_Util.Inl thunk ->
-        let c = thunk ()  in
+        let c = thunk () in
         (FStar_ST.op_Colon_Equals lc.comp_thunk (FStar_Util.Inr c); c)
     | FStar_Util.Inr c -> c
-  
 type tscheme = (univ_name Prims.list,typ) FStar_Pervasives_Native.tuple2
 [@@deriving show]
 type freenames_l = bv Prims.list[@@deriving show]
 type formula = typ[@@deriving show]
 type formulae = typ Prims.list[@@deriving show]
 type qualifier =
-  | Assumption 
-  | New 
-  | Private 
-  | Unfold_for_unification_and_vcgen 
-  | Visible_default 
-  | Irreducible 
-  | Abstract 
-  | Inline_for_extraction 
-  | NoExtract 
-  | Noeq 
-  | Unopteq 
-  | TotalEffect 
-  | Logic 
-  | Reifiable 
-  | Reflectable of FStar_Ident.lident 
-  | Discriminator of FStar_Ident.lident 
+  | Assumption
+  | New
+  | Private
+  | Unfold_for_unification_and_vcgen
+  | Visible_default
+  | Irreducible
+  | Abstract
+  | Inline_for_extraction
+  | NoExtract
+  | Noeq
+  | Unopteq
+  | TotalEffect
+  | Logic
+  | Reifiable
+  | Reflectable of FStar_Ident.lident
+  | Discriminator of FStar_Ident.lident
   | Projector of (FStar_Ident.lident,FStar_Ident.ident)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | RecordType of (FStar_Ident.ident Prims.list,FStar_Ident.ident Prims.list)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | RecordConstructor of
   (FStar_Ident.ident Prims.list,FStar_Ident.ident Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | Action of FStar_Ident.lident 
-  | ExceptionConstructor 
-  | HasMaskedEffect 
-  | Effect 
-  | OnlyName [@@deriving show]
-let (uu___is_Assumption : qualifier -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | Action of FStar_Ident.lident
+  | ExceptionConstructor
+  | HasMaskedEffect
+  | Effect
+  | OnlyName[@@deriving show]
+let uu___is_Assumption: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Assumption  -> true | uu____3778 -> false
-  
-let (uu___is_New : qualifier -> Prims.bool) =
-  fun projectee  -> match projectee with | New  -> true | uu____3782 -> false 
-let (uu___is_Private : qualifier -> Prims.bool) =
+let uu___is_New: qualifier -> Prims.bool =
+  fun projectee  -> match projectee with | New  -> true | uu____3782 -> false
+let uu___is_Private: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Private  -> true | uu____3786 -> false
-  
-let (uu___is_Unfold_for_unification_and_vcgen : qualifier -> Prims.bool) =
+let uu___is_Unfold_for_unification_and_vcgen: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Unfold_for_unification_and_vcgen  -> true
     | uu____3790 -> false
-  
-let (uu___is_Visible_default : qualifier -> Prims.bool) =
+let uu___is_Visible_default: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Visible_default  -> true | uu____3794 -> false
-  
-let (uu___is_Irreducible : qualifier -> Prims.bool) =
+let uu___is_Irreducible: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Irreducible  -> true | uu____3798 -> false
-  
-let (uu___is_Abstract : qualifier -> Prims.bool) =
+let uu___is_Abstract: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Abstract  -> true | uu____3802 -> false
-  
-let (uu___is_Inline_for_extraction : qualifier -> Prims.bool) =
+let uu___is_Inline_for_extraction: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Inline_for_extraction  -> true
     | uu____3806 -> false
-  
-let (uu___is_NoExtract : qualifier -> Prims.bool) =
+let uu___is_NoExtract: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | NoExtract  -> true | uu____3810 -> false
-  
-let (uu___is_Noeq : qualifier -> Prims.bool) =
+let uu___is_Noeq: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Noeq  -> true | uu____3814 -> false
-  
-let (uu___is_Unopteq : qualifier -> Prims.bool) =
+let uu___is_Unopteq: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Unopteq  -> true | uu____3818 -> false
-  
-let (uu___is_TotalEffect : qualifier -> Prims.bool) =
+let uu___is_TotalEffect: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | TotalEffect  -> true | uu____3822 -> false
-  
-let (uu___is_Logic : qualifier -> Prims.bool) =
+let uu___is_Logic: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Logic  -> true | uu____3826 -> false
-  
-let (uu___is_Reifiable : qualifier -> Prims.bool) =
+let uu___is_Reifiable: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Reifiable  -> true | uu____3830 -> false
-  
-let (uu___is_Reflectable : qualifier -> Prims.bool) =
+let uu___is_Reflectable: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Reflectable _0 -> true | uu____3835 -> false
-  
-let (__proj__Reflectable__item___0 : qualifier -> FStar_Ident.lident) =
-  fun projectee  -> match projectee with | Reflectable _0 -> _0 
-let (uu___is_Discriminator : qualifier -> Prims.bool) =
+let __proj__Reflectable__item___0: qualifier -> FStar_Ident.lident =
+  fun projectee  -> match projectee with | Reflectable _0 -> _0
+let uu___is_Discriminator: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Discriminator _0 -> true | uu____3847 -> false
-  
-let (__proj__Discriminator__item___0 : qualifier -> FStar_Ident.lident) =
-  fun projectee  -> match projectee with | Discriminator _0 -> _0 
-let (uu___is_Projector : qualifier -> Prims.bool) =
+let __proj__Discriminator__item___0: qualifier -> FStar_Ident.lident =
+  fun projectee  -> match projectee with | Discriminator _0 -> _0
+let uu___is_Projector: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Projector _0 -> true | uu____3863 -> false
-  
-let (__proj__Projector__item___0 :
+let __proj__Projector__item___0:
   qualifier ->
-    (FStar_Ident.lident,FStar_Ident.ident) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Projector _0 -> _0 
-let (uu___is_RecordType : qualifier -> Prims.bool) =
+    (FStar_Ident.lident,FStar_Ident.ident) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Projector _0 -> _0
+let uu___is_RecordType: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | RecordType _0 -> true | uu____3895 -> false
-  
-let (__proj__RecordType__item___0 :
+let __proj__RecordType__item___0:
   qualifier ->
     (FStar_Ident.ident Prims.list,FStar_Ident.ident Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | RecordType _0 -> _0 
-let (uu___is_RecordConstructor : qualifier -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | RecordType _0 -> _0
+let uu___is_RecordConstructor: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | RecordConstructor _0 -> true | uu____3939 -> false
-  
-let (__proj__RecordConstructor__item___0 :
+let __proj__RecordConstructor__item___0:
   qualifier ->
     (FStar_Ident.ident Prims.list,FStar_Ident.ident Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | RecordConstructor _0 -> _0 
-let (uu___is_Action : qualifier -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | RecordConstructor _0 -> _0
+let uu___is_Action: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Action _0 -> true | uu____3975 -> false
-  
-let (__proj__Action__item___0 : qualifier -> FStar_Ident.lident) =
-  fun projectee  -> match projectee with | Action _0 -> _0 
-let (uu___is_ExceptionConstructor : qualifier -> Prims.bool) =
+let __proj__Action__item___0: qualifier -> FStar_Ident.lident =
+  fun projectee  -> match projectee with | Action _0 -> _0
+let uu___is_ExceptionConstructor: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with
     | ExceptionConstructor  -> true
     | uu____3986 -> false
-  
-let (uu___is_HasMaskedEffect : qualifier -> Prims.bool) =
+let uu___is_HasMaskedEffect: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | HasMaskedEffect  -> true | uu____3990 -> false
-  
-let (uu___is_Effect : qualifier -> Prims.bool) =
+let uu___is_Effect: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | Effect  -> true | uu____3994 -> false
-  
-let (uu___is_OnlyName : qualifier -> Prims.bool) =
+let uu___is_OnlyName: qualifier -> Prims.bool =
   fun projectee  ->
     match projectee with | OnlyName  -> true | uu____3998 -> false
-  
 type tycon = (FStar_Ident.lident,binders,typ) FStar_Pervasives_Native.tuple3
 [@@deriving show]
 type monad_abbrev = {
-  mabbrev: FStar_Ident.lident ;
-  parms: binders ;
-  def: typ }[@@deriving show]
-let (__proj__Mkmonad_abbrev__item__mabbrev :
-  monad_abbrev -> FStar_Ident.lident) =
+  mabbrev: FStar_Ident.lident;
+  parms: binders;
+  def: typ;}[@@deriving show]
+let __proj__Mkmonad_abbrev__item__mabbrev: monad_abbrev -> FStar_Ident.lident
+  =
   fun projectee  ->
     match projectee with
     | { mabbrev = __fname__mabbrev; parms = __fname__parms;
         def = __fname__def;_} -> __fname__mabbrev
-  
-let (__proj__Mkmonad_abbrev__item__parms : monad_abbrev -> binders) =
+let __proj__Mkmonad_abbrev__item__parms: monad_abbrev -> binders =
   fun projectee  ->
     match projectee with
     | { mabbrev = __fname__mabbrev; parms = __fname__parms;
         def = __fname__def;_} -> __fname__parms
-  
-let (__proj__Mkmonad_abbrev__item__def : monad_abbrev -> typ) =
+let __proj__Mkmonad_abbrev__item__def: monad_abbrev -> typ =
   fun projectee  ->
     match projectee with
     | { mabbrev = __fname__mabbrev; parms = __fname__parms;
         def = __fname__def;_} -> __fname__def
-  
 type sub_eff =
   {
-  source: FStar_Ident.lident ;
-  target: FStar_Ident.lident ;
-  lift_wp: tscheme FStar_Pervasives_Native.option ;
-  lift: tscheme FStar_Pervasives_Native.option }[@@deriving show]
-let (__proj__Mksub_eff__item__source : sub_eff -> FStar_Ident.lident) =
+  source: FStar_Ident.lident;
+  target: FStar_Ident.lident;
+  lift_wp: tscheme FStar_Pervasives_Native.option;
+  lift: tscheme FStar_Pervasives_Native.option;}[@@deriving show]
+let __proj__Mksub_eff__item__source: sub_eff -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { source = __fname__source; target = __fname__target;
         lift_wp = __fname__lift_wp; lift = __fname__lift;_} ->
         __fname__source
-  
-let (__proj__Mksub_eff__item__target : sub_eff -> FStar_Ident.lident) =
+let __proj__Mksub_eff__item__target: sub_eff -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { source = __fname__source; target = __fname__target;
         lift_wp = __fname__lift_wp; lift = __fname__lift;_} ->
         __fname__target
-  
-let (__proj__Mksub_eff__item__lift_wp :
-  sub_eff -> tscheme FStar_Pervasives_Native.option) =
+let __proj__Mksub_eff__item__lift_wp:
+  sub_eff -> tscheme FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { source = __fname__source; target = __fname__target;
         lift_wp = __fname__lift_wp; lift = __fname__lift;_} ->
         __fname__lift_wp
-  
-let (__proj__Mksub_eff__item__lift :
-  sub_eff -> tscheme FStar_Pervasives_Native.option) =
+let __proj__Mksub_eff__item__lift:
+  sub_eff -> tscheme FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { source = __fname__source; target = __fname__target;
         lift_wp = __fname__lift_wp; lift = __fname__lift;_} -> __fname__lift
-  
 type action =
   {
-  action_name: FStar_Ident.lident ;
-  action_unqualified_name: FStar_Ident.ident ;
-  action_univs: univ_names ;
-  action_params: binders ;
-  action_defn: term ;
-  action_typ: typ }[@@deriving show]
-let (__proj__Mkaction__item__action_name : action -> FStar_Ident.lident) =
+  action_name: FStar_Ident.lident;
+  action_unqualified_name: FStar_Ident.ident;
+  action_univs: univ_names;
+  action_params: binders;
+  action_defn: term;
+  action_typ: typ;}[@@deriving show]
+let __proj__Mkaction__item__action_name: action -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { action_name = __fname__action_name;
@@ -1201,9 +1059,8 @@ let (__proj__Mkaction__item__action_name : action -> FStar_Ident.lident) =
         action_params = __fname__action_params;
         action_defn = __fname__action_defn;
         action_typ = __fname__action_typ;_} -> __fname__action_name
-  
-let (__proj__Mkaction__item__action_unqualified_name :
-  action -> FStar_Ident.ident) =
+let __proj__Mkaction__item__action_unqualified_name:
+  action -> FStar_Ident.ident =
   fun projectee  ->
     match projectee with
     | { action_name = __fname__action_name;
@@ -1213,8 +1070,7 @@ let (__proj__Mkaction__item__action_unqualified_name :
         action_defn = __fname__action_defn;
         action_typ = __fname__action_typ;_} ->
         __fname__action_unqualified_name
-  
-let (__proj__Mkaction__item__action_univs : action -> univ_names) =
+let __proj__Mkaction__item__action_univs: action -> univ_names =
   fun projectee  ->
     match projectee with
     | { action_name = __fname__action_name;
@@ -1223,8 +1079,7 @@ let (__proj__Mkaction__item__action_univs : action -> univ_names) =
         action_params = __fname__action_params;
         action_defn = __fname__action_defn;
         action_typ = __fname__action_typ;_} -> __fname__action_univs
-  
-let (__proj__Mkaction__item__action_params : action -> binders) =
+let __proj__Mkaction__item__action_params: action -> binders =
   fun projectee  ->
     match projectee with
     | { action_name = __fname__action_name;
@@ -1233,8 +1088,7 @@ let (__proj__Mkaction__item__action_params : action -> binders) =
         action_params = __fname__action_params;
         action_defn = __fname__action_defn;
         action_typ = __fname__action_typ;_} -> __fname__action_params
-  
-let (__proj__Mkaction__item__action_defn : action -> term) =
+let __proj__Mkaction__item__action_defn: action -> term =
   fun projectee  ->
     match projectee with
     | { action_name = __fname__action_name;
@@ -1243,8 +1097,7 @@ let (__proj__Mkaction__item__action_defn : action -> term) =
         action_params = __fname__action_params;
         action_defn = __fname__action_defn;
         action_typ = __fname__action_typ;_} -> __fname__action_defn
-  
-let (__proj__Mkaction__item__action_typ : action -> typ) =
+let __proj__Mkaction__item__action_typ: action -> typ =
   fun projectee  ->
     match projectee with
     | { action_name = __fname__action_name;
@@ -1253,29 +1106,28 @@ let (__proj__Mkaction__item__action_typ : action -> typ) =
         action_params = __fname__action_params;
         action_defn = __fname__action_defn;
         action_typ = __fname__action_typ;_} -> __fname__action_typ
-  
 type eff_decl =
   {
-  cattributes: cflags Prims.list ;
-  mname: FStar_Ident.lident ;
-  univs: univ_names ;
-  binders: binders ;
-  signature: term ;
-  ret_wp: tscheme ;
-  bind_wp: tscheme ;
-  if_then_else: tscheme ;
-  ite_wp: tscheme ;
-  stronger: tscheme ;
-  close_wp: tscheme ;
-  assert_p: tscheme ;
-  assume_p: tscheme ;
-  null_wp: tscheme ;
-  trivial: tscheme ;
-  repr: term ;
-  return_repr: tscheme ;
-  bind_repr: tscheme ;
-  actions: action Prims.list }[@@deriving show]
-let (__proj__Mkeff_decl__item__cattributes : eff_decl -> cflags Prims.list) =
+  cattributes: cflags Prims.list;
+  mname: FStar_Ident.lident;
+  univs: univ_names;
+  binders: binders;
+  signature: term;
+  ret_wp: tscheme;
+  bind_wp: tscheme;
+  if_then_else: tscheme;
+  ite_wp: tscheme;
+  stronger: tscheme;
+  close_wp: tscheme;
+  assert_p: tscheme;
+  assume_p: tscheme;
+  null_wp: tscheme;
+  trivial: tscheme;
+  repr: term;
+  return_repr: tscheme;
+  bind_repr: tscheme;
+  actions: action Prims.list;}[@@deriving show]
+let __proj__Mkeff_decl__item__cattributes: eff_decl -> cflags Prims.list =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1288,8 +1140,7 @@ let (__proj__Mkeff_decl__item__cattributes : eff_decl -> cflags Prims.list) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__cattributes
-  
-let (__proj__Mkeff_decl__item__mname : eff_decl -> FStar_Ident.lident) =
+let __proj__Mkeff_decl__item__mname: eff_decl -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1302,8 +1153,7 @@ let (__proj__Mkeff_decl__item__mname : eff_decl -> FStar_Ident.lident) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__mname
-  
-let (__proj__Mkeff_decl__item__univs : eff_decl -> univ_names) =
+let __proj__Mkeff_decl__item__univs: eff_decl -> univ_names =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1316,8 +1166,7 @@ let (__proj__Mkeff_decl__item__univs : eff_decl -> univ_names) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__univs
-  
-let (__proj__Mkeff_decl__item__binders : eff_decl -> binders) =
+let __proj__Mkeff_decl__item__binders: eff_decl -> binders =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1330,8 +1179,7 @@ let (__proj__Mkeff_decl__item__binders : eff_decl -> binders) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__binders
-  
-let (__proj__Mkeff_decl__item__signature : eff_decl -> term) =
+let __proj__Mkeff_decl__item__signature: eff_decl -> term =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1344,8 +1192,7 @@ let (__proj__Mkeff_decl__item__signature : eff_decl -> term) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__signature
-  
-let (__proj__Mkeff_decl__item__ret_wp : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__ret_wp: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1358,8 +1205,7 @@ let (__proj__Mkeff_decl__item__ret_wp : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__ret_wp
-  
-let (__proj__Mkeff_decl__item__bind_wp : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__bind_wp: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1372,8 +1218,7 @@ let (__proj__Mkeff_decl__item__bind_wp : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__bind_wp
-  
-let (__proj__Mkeff_decl__item__if_then_else : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__if_then_else: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1386,8 +1231,7 @@ let (__proj__Mkeff_decl__item__if_then_else : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__if_then_else
-  
-let (__proj__Mkeff_decl__item__ite_wp : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__ite_wp: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1400,8 +1244,7 @@ let (__proj__Mkeff_decl__item__ite_wp : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__ite_wp
-  
-let (__proj__Mkeff_decl__item__stronger : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__stronger: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1414,8 +1257,7 @@ let (__proj__Mkeff_decl__item__stronger : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__stronger
-  
-let (__proj__Mkeff_decl__item__close_wp : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__close_wp: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1428,8 +1270,7 @@ let (__proj__Mkeff_decl__item__close_wp : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__close_wp
-  
-let (__proj__Mkeff_decl__item__assert_p : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__assert_p: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1442,8 +1283,7 @@ let (__proj__Mkeff_decl__item__assert_p : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__assert_p
-  
-let (__proj__Mkeff_decl__item__assume_p : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__assume_p: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1456,8 +1296,7 @@ let (__proj__Mkeff_decl__item__assume_p : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__assume_p
-  
-let (__proj__Mkeff_decl__item__null_wp : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__null_wp: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1470,8 +1309,7 @@ let (__proj__Mkeff_decl__item__null_wp : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__null_wp
-  
-let (__proj__Mkeff_decl__item__trivial : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__trivial: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1484,8 +1322,7 @@ let (__proj__Mkeff_decl__item__trivial : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__trivial
-  
-let (__proj__Mkeff_decl__item__repr : eff_decl -> term) =
+let __proj__Mkeff_decl__item__repr: eff_decl -> term =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1498,8 +1335,7 @@ let (__proj__Mkeff_decl__item__repr : eff_decl -> term) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__repr
-  
-let (__proj__Mkeff_decl__item__return_repr : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__return_repr: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1512,8 +1348,7 @@ let (__proj__Mkeff_decl__item__return_repr : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__return_repr
-  
-let (__proj__Mkeff_decl__item__bind_repr : eff_decl -> tscheme) =
+let __proj__Mkeff_decl__item__bind_repr: eff_decl -> tscheme =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1526,8 +1361,7 @@ let (__proj__Mkeff_decl__item__bind_repr : eff_decl -> tscheme) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__bind_repr
-  
-let (__proj__Mkeff_decl__item__actions : eff_decl -> action Prims.list) =
+let __proj__Mkeff_decl__item__actions: eff_decl -> action Prims.list =
   fun projectee  ->
     match projectee with
     | { cattributes = __fname__cattributes; mname = __fname__mname;
@@ -1540,331 +1374,295 @@ let (__proj__Mkeff_decl__item__actions : eff_decl -> action Prims.list) =
         trivial = __fname__trivial; repr = __fname__repr;
         return_repr = __fname__return_repr; bind_repr = __fname__bind_repr;
         actions = __fname__actions;_} -> __fname__actions
-  
 type sig_metadata =
   {
-  sigmeta_active: Prims.bool ;
-  sigmeta_fact_db_ids: Prims.string Prims.list }[@@deriving show]
-let (__proj__Mksig_metadata__item__sigmeta_active :
-  sig_metadata -> Prims.bool) =
+  sigmeta_active: Prims.bool;
+  sigmeta_fact_db_ids: Prims.string Prims.list;}[@@deriving show]
+let __proj__Mksig_metadata__item__sigmeta_active: sig_metadata -> Prims.bool
+  =
   fun projectee  ->
     match projectee with
     | { sigmeta_active = __fname__sigmeta_active;
         sigmeta_fact_db_ids = __fname__sigmeta_fact_db_ids;_} ->
         __fname__sigmeta_active
-  
-let (__proj__Mksig_metadata__item__sigmeta_fact_db_ids :
-  sig_metadata -> Prims.string Prims.list) =
+let __proj__Mksig_metadata__item__sigmeta_fact_db_ids:
+  sig_metadata -> Prims.string Prims.list =
   fun projectee  ->
     match projectee with
     | { sigmeta_active = __fname__sigmeta_active;
         sigmeta_fact_db_ids = __fname__sigmeta_fact_db_ids;_} ->
         __fname__sigmeta_fact_db_ids
-  
 type sigelt' =
   | Sig_inductive_typ of
   (FStar_Ident.lident,univ_names,binders,typ,FStar_Ident.lident Prims.list,
-  FStar_Ident.lident Prims.list) FStar_Pervasives_Native.tuple6 
+  FStar_Ident.lident Prims.list) FStar_Pervasives_Native.tuple6
   | Sig_bundle of (sigelt Prims.list,FStar_Ident.lident Prims.list)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Sig_datacon of
   (FStar_Ident.lident,univ_names,typ,FStar_Ident.lident,Prims.int,FStar_Ident.lident
                                                                     Prims.list)
-  FStar_Pervasives_Native.tuple6 
+  FStar_Pervasives_Native.tuple6
   | Sig_declare_typ of (FStar_Ident.lident,univ_names,typ)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | Sig_let of (letbindings,FStar_Ident.lident Prims.list)
-  FStar_Pervasives_Native.tuple2 
-  | Sig_main of term 
+  FStar_Pervasives_Native.tuple2
+  | Sig_main of term
   | Sig_assume of (FStar_Ident.lident,univ_names,formula)
-  FStar_Pervasives_Native.tuple3 
-  | Sig_new_effect of eff_decl 
-  | Sig_new_effect_for_free of eff_decl 
-  | Sig_sub_effect of sub_eff 
+  FStar_Pervasives_Native.tuple3
+  | Sig_new_effect of eff_decl
+  | Sig_new_effect_for_free of eff_decl
+  | Sig_sub_effect of sub_eff
   | Sig_effect_abbrev of
   (FStar_Ident.lident,univ_names,binders,comp,cflags Prims.list)
-  FStar_Pervasives_Native.tuple5 
-  | Sig_pragma of pragma [@@deriving show]
+  FStar_Pervasives_Native.tuple5
+  | Sig_pragma of pragma[@@deriving show]
 and sigelt =
   {
-  sigel: sigelt' ;
-  sigrng: FStar_Range.range ;
-  sigquals: qualifier Prims.list ;
-  sigmeta: sig_metadata ;
-  sigattrs: attribute Prims.list }[@@deriving show]
-let (uu___is_Sig_inductive_typ : sigelt' -> Prims.bool) =
+  sigel: sigelt';
+  sigrng: FStar_Range.range;
+  sigquals: qualifier Prims.list;
+  sigmeta: sig_metadata;
+  sigattrs: attribute Prims.list;}[@@deriving show]
+let uu___is_Sig_inductive_typ: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_inductive_typ _0 -> true | uu____4955 -> false
-  
-let (__proj__Sig_inductive_typ__item___0 :
+let __proj__Sig_inductive_typ__item___0:
   sigelt' ->
     (FStar_Ident.lident,univ_names,binders,typ,FStar_Ident.lident Prims.list,
-      FStar_Ident.lident Prims.list) FStar_Pervasives_Native.tuple6)
-  = fun projectee  -> match projectee with | Sig_inductive_typ _0 -> _0 
-let (uu___is_Sig_bundle : sigelt' -> Prims.bool) =
+      FStar_Ident.lident Prims.list) FStar_Pervasives_Native.tuple6
+  = fun projectee  -> match projectee with | Sig_inductive_typ _0 -> _0
+let uu___is_Sig_bundle: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_bundle _0 -> true | uu____5023 -> false
-  
-let (__proj__Sig_bundle__item___0 :
+let __proj__Sig_bundle__item___0:
   sigelt' ->
     (sigelt Prims.list,FStar_Ident.lident Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Sig_bundle _0 -> _0 
-let (uu___is_Sig_datacon : sigelt' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Sig_bundle _0 -> _0
+let uu___is_Sig_datacon: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_datacon _0 -> true | uu____5073 -> false
-  
-let (__proj__Sig_datacon__item___0 :
+let __proj__Sig_datacon__item___0:
   sigelt' ->
     (FStar_Ident.lident,univ_names,typ,FStar_Ident.lident,Prims.int,FStar_Ident.lident
                                                                     Prims.list)
-      FStar_Pervasives_Native.tuple6)
-  = fun projectee  -> match projectee with | Sig_datacon _0 -> _0 
-let (uu___is_Sig_declare_typ : sigelt' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple6
+  = fun projectee  -> match projectee with | Sig_datacon _0 -> _0
+let uu___is_Sig_declare_typ: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_declare_typ _0 -> true | uu____5133 -> false
-  
-let (__proj__Sig_declare_typ__item___0 :
+let __proj__Sig_declare_typ__item___0:
   sigelt' ->
-    (FStar_Ident.lident,univ_names,typ) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Sig_declare_typ _0 -> _0 
-let (uu___is_Sig_let : sigelt' -> Prims.bool) =
+    (FStar_Ident.lident,univ_names,typ) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Sig_declare_typ _0 -> _0
+let uu___is_Sig_let: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_let _0 -> true | uu____5169 -> false
-  
-let (__proj__Sig_let__item___0 :
+let __proj__Sig_let__item___0:
   sigelt' ->
     (letbindings,FStar_Ident.lident Prims.list)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Sig_let _0 -> _0 
-let (uu___is_Sig_main : sigelt' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Sig_let _0 -> _0
+let uu___is_Sig_main: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_main _0 -> true | uu____5199 -> false
-  
-let (__proj__Sig_main__item___0 : sigelt' -> term) =
-  fun projectee  -> match projectee with | Sig_main _0 -> _0 
-let (uu___is_Sig_assume : sigelt' -> Prims.bool) =
+let __proj__Sig_main__item___0: sigelt' -> term =
+  fun projectee  -> match projectee with | Sig_main _0 -> _0
+let uu___is_Sig_assume: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_assume _0 -> true | uu____5217 -> false
-  
-let (__proj__Sig_assume__item___0 :
+let __proj__Sig_assume__item___0:
   sigelt' ->
-    (FStar_Ident.lident,univ_names,formula) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Sig_assume _0 -> _0 
-let (uu___is_Sig_new_effect : sigelt' -> Prims.bool) =
+    (FStar_Ident.lident,univ_names,formula) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Sig_assume _0 -> _0
+let uu___is_Sig_new_effect: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_new_effect _0 -> true | uu____5247 -> false
-  
-let (__proj__Sig_new_effect__item___0 : sigelt' -> eff_decl) =
-  fun projectee  -> match projectee with | Sig_new_effect _0 -> _0 
-let (uu___is_Sig_new_effect_for_free : sigelt' -> Prims.bool) =
+let __proj__Sig_new_effect__item___0: sigelt' -> eff_decl =
+  fun projectee  -> match projectee with | Sig_new_effect _0 -> _0
+let uu___is_Sig_new_effect_for_free: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Sig_new_effect_for_free _0 -> true
     | uu____5259 -> false
-  
-let (__proj__Sig_new_effect_for_free__item___0 : sigelt' -> eff_decl) =
-  fun projectee  -> match projectee with | Sig_new_effect_for_free _0 -> _0 
-let (uu___is_Sig_sub_effect : sigelt' -> Prims.bool) =
+let __proj__Sig_new_effect_for_free__item___0: sigelt' -> eff_decl =
+  fun projectee  -> match projectee with | Sig_new_effect_for_free _0 -> _0
+let uu___is_Sig_sub_effect: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_sub_effect _0 -> true | uu____5271 -> false
-  
-let (__proj__Sig_sub_effect__item___0 : sigelt' -> sub_eff) =
-  fun projectee  -> match projectee with | Sig_sub_effect _0 -> _0 
-let (uu___is_Sig_effect_abbrev : sigelt' -> Prims.bool) =
+let __proj__Sig_sub_effect__item___0: sigelt' -> sub_eff =
+  fun projectee  -> match projectee with | Sig_sub_effect _0 -> _0
+let uu___is_Sig_effect_abbrev: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_effect_abbrev _0 -> true | uu____5295 -> false
-  
-let (__proj__Sig_effect_abbrev__item___0 :
+let __proj__Sig_effect_abbrev__item___0:
   sigelt' ->
     (FStar_Ident.lident,univ_names,binders,comp,cflags Prims.list)
-      FStar_Pervasives_Native.tuple5)
-  = fun projectee  -> match projectee with | Sig_effect_abbrev _0 -> _0 
-let (uu___is_Sig_pragma : sigelt' -> Prims.bool) =
+      FStar_Pervasives_Native.tuple5
+  = fun projectee  -> match projectee with | Sig_effect_abbrev _0 -> _0
+let uu___is_Sig_pragma: sigelt' -> Prims.bool =
   fun projectee  ->
     match projectee with | Sig_pragma _0 -> true | uu____5343 -> false
-  
-let (__proj__Sig_pragma__item___0 : sigelt' -> pragma) =
-  fun projectee  -> match projectee with | Sig_pragma _0 -> _0 
-let (__proj__Mksigelt__item__sigel : sigelt -> sigelt') =
+let __proj__Sig_pragma__item___0: sigelt' -> pragma =
+  fun projectee  -> match projectee with | Sig_pragma _0 -> _0
+let __proj__Mksigelt__item__sigel: sigelt -> sigelt' =
   fun projectee  ->
     match projectee with
     | { sigel = __fname__sigel; sigrng = __fname__sigrng;
         sigquals = __fname__sigquals; sigmeta = __fname__sigmeta;
         sigattrs = __fname__sigattrs;_} -> __fname__sigel
-  
-let (__proj__Mksigelt__item__sigrng : sigelt -> FStar_Range.range) =
+let __proj__Mksigelt__item__sigrng: sigelt -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { sigel = __fname__sigel; sigrng = __fname__sigrng;
         sigquals = __fname__sigquals; sigmeta = __fname__sigmeta;
         sigattrs = __fname__sigattrs;_} -> __fname__sigrng
-  
-let (__proj__Mksigelt__item__sigquals : sigelt -> qualifier Prims.list) =
+let __proj__Mksigelt__item__sigquals: sigelt -> qualifier Prims.list =
   fun projectee  ->
     match projectee with
     | { sigel = __fname__sigel; sigrng = __fname__sigrng;
         sigquals = __fname__sigquals; sigmeta = __fname__sigmeta;
         sigattrs = __fname__sigattrs;_} -> __fname__sigquals
-  
-let (__proj__Mksigelt__item__sigmeta : sigelt -> sig_metadata) =
+let __proj__Mksigelt__item__sigmeta: sigelt -> sig_metadata =
   fun projectee  ->
     match projectee with
     | { sigel = __fname__sigel; sigrng = __fname__sigrng;
         sigquals = __fname__sigquals; sigmeta = __fname__sigmeta;
         sigattrs = __fname__sigattrs;_} -> __fname__sigmeta
-  
-let (__proj__Mksigelt__item__sigattrs : sigelt -> attribute Prims.list) =
+let __proj__Mksigelt__item__sigattrs: sigelt -> attribute Prims.list =
   fun projectee  ->
     match projectee with
     | { sigel = __fname__sigel; sigrng = __fname__sigrng;
         sigquals = __fname__sigquals; sigmeta = __fname__sigmeta;
         sigattrs = __fname__sigattrs;_} -> __fname__sigattrs
-  
 type sigelts = sigelt Prims.list[@@deriving show]
 type modul =
   {
-  name: FStar_Ident.lident ;
-  declarations: sigelts ;
-  exports: sigelts ;
-  is_interface: Prims.bool }[@@deriving show]
-let (__proj__Mkmodul__item__name : modul -> FStar_Ident.lident) =
+  name: FStar_Ident.lident;
+  declarations: sigelts;
+  exports: sigelts;
+  is_interface: Prims.bool;}[@@deriving show]
+let __proj__Mkmodul__item__name: modul -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; declarations = __fname__declarations;
         exports = __fname__exports; is_interface = __fname__is_interface;_}
         -> __fname__name
-  
-let (__proj__Mkmodul__item__declarations : modul -> sigelts) =
+let __proj__Mkmodul__item__declarations: modul -> sigelts =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; declarations = __fname__declarations;
         exports = __fname__exports; is_interface = __fname__is_interface;_}
         -> __fname__declarations
-  
-let (__proj__Mkmodul__item__exports : modul -> sigelts) =
+let __proj__Mkmodul__item__exports: modul -> sigelts =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; declarations = __fname__declarations;
         exports = __fname__exports; is_interface = __fname__is_interface;_}
         -> __fname__exports
-  
-let (__proj__Mkmodul__item__is_interface : modul -> Prims.bool) =
+let __proj__Mkmodul__item__is_interface: modul -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; declarations = __fname__declarations;
         exports = __fname__exports; is_interface = __fname__is_interface;_}
         -> __fname__is_interface
-  
-let (mod_name : modul -> FStar_Ident.lident) = fun m  -> m.name 
+let mod_name: modul -> FStar_Ident.lident = fun m  -> m.name
 type path = Prims.string Prims.list[@@deriving show]
 type subst_t = subst_elt Prims.list[@@deriving show]
 type 'a mk_t_a =
   Prims.unit FStar_Pervasives_Native.option -> FStar_Range.range -> 'a syntax
 [@@deriving show]
 type mk_t = term' mk_t_a[@@deriving show]
-let (contains_reflectable : qualifier Prims.list -> Prims.bool) =
+let contains_reflectable: qualifier Prims.list -> Prims.bool =
   fun l  ->
     FStar_Util.for_some
       (fun uu___30_5495  ->
          match uu___30_5495 with
          | Reflectable uu____5496 -> true
          | uu____5497 -> false) l
-  
-let withinfo : 'a . 'a -> FStar_Range.range -> 'a withinfo_t =
-  fun v1  -> fun r  -> { v = v1; p = r } 
-let withsort : 'a . 'a -> 'a withinfo_t =
-  fun v1  -> withinfo v1 FStar_Range.dummyRange 
-let (bv_eq : bv -> bv -> Prims.bool) =
+let withinfo: 'a . 'a -> FStar_Range.range -> 'a withinfo_t =
+  fun v1  -> fun r  -> { v = v1; p = r }
+let withsort: 'a . 'a -> 'a withinfo_t =
+  fun v1  -> withinfo v1 FStar_Range.dummyRange
+let bv_eq: bv -> bv -> Prims.bool =
   fun bv1  ->
     fun bv2  ->
       ((bv1.ppname).FStar_Ident.idText = (bv2.ppname).FStar_Ident.idText) &&
         (bv1.index = bv2.index)
-  
-let (order_bv : bv -> bv -> Prims.int) =
+let order_bv: bv -> bv -> Prims.int =
   fun x  ->
     fun y  ->
       let i =
         FStar_String.compare (x.ppname).FStar_Ident.idText
-          (y.ppname).FStar_Ident.idText
-         in
+          (y.ppname).FStar_Ident.idText in
       if i = (Prims.parse_int "0") then x.index - y.index else i
-  
-let (order_fv : FStar_Ident.lident -> FStar_Ident.lident -> Prims.int) =
+let order_fv: FStar_Ident.lident -> FStar_Ident.lident -> Prims.int =
   fun x  ->
     fun y  -> FStar_String.compare x.FStar_Ident.str y.FStar_Ident.str
-  
-let (range_of_lbname : lbname -> FStar_Range.range) =
+let range_of_lbname: lbname -> FStar_Range.range =
   fun l  ->
     match l with
     | FStar_Util.Inl x -> (x.ppname).FStar_Ident.idRange
     | FStar_Util.Inr fv -> FStar_Ident.range_of_lid (fv.fv_name).v
-  
-let (range_of_bv : bv -> FStar_Range.range) =
-  fun x  -> (x.ppname).FStar_Ident.idRange 
-let (set_range_of_bv : bv -> FStar_Range.range -> bv) =
+let range_of_bv: bv -> FStar_Range.range =
+  fun x  -> (x.ppname).FStar_Ident.idRange
+let set_range_of_bv: bv -> FStar_Range.range -> bv =
   fun x  ->
     fun r  ->
-      let uu___37_5555 = x  in
+      let uu___37_5555 = x in
       {
         ppname = (FStar_Ident.mk_ident (((x.ppname).FStar_Ident.idText), r));
         index = (uu___37_5555.index);
         sort = (uu___37_5555.sort)
       }
-  
-let syn :
+let syn:
   'Auu____5562 'Auu____5563 'Auu____5564 .
     'Auu____5564 ->
       'Auu____5563 ->
         ('Auu____5563 -> 'Auu____5564 -> 'Auu____5562) -> 'Auu____5562
-  = fun p  -> fun k  -> fun f  -> f k p 
-let mk_fvs :
+  = fun p  -> fun k  -> fun f  -> f k p
+let mk_fvs:
   'Auu____5600 .
     Prims.unit -> 'Auu____5600 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____5608  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
-let mk_uvs :
+  = fun uu____5608  -> FStar_Util.mk_ref FStar_Pervasives_Native.None
+let mk_uvs:
   'Auu____5624 .
     Prims.unit -> 'Auu____5624 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____5632  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
-let (new_bv_set : Prims.unit -> bv FStar_Util.set) =
-  fun uu____5639  -> FStar_Util.new_set order_bv 
-let (new_fv_set : Prims.unit -> FStar_Ident.lident FStar_Util.set) =
-  fun uu____5646  -> FStar_Util.new_set order_fv 
-let (order_univ_name : univ_name -> univ_name -> Prims.int) =
+  = fun uu____5632  -> FStar_Util.mk_ref FStar_Pervasives_Native.None
+let new_bv_set: Prims.unit -> bv FStar_Util.set =
+  fun uu____5639  -> FStar_Util.new_set order_bv
+let new_fv_set: Prims.unit -> FStar_Ident.lident FStar_Util.set =
+  fun uu____5646  -> FStar_Util.new_set order_fv
+let order_univ_name: univ_name -> univ_name -> Prims.int =
   fun x  ->
     fun y  ->
       FStar_String.compare (FStar_Ident.text_of_id x)
         (FStar_Ident.text_of_id y)
-  
-let (new_universe_names_fifo_set :
-  Prims.unit -> univ_name FStar_Util.fifo_set) =
-  fun uu____5659  -> FStar_Util.new_fifo_set order_univ_name 
-let (no_names : bv FStar_Util.set) = new_bv_set () 
-let (no_fvars : FStar_Ident.lident FStar_Util.set) = new_fv_set () 
-let (no_universe_names : univ_name FStar_Util.fifo_set) =
-  new_universe_names_fifo_set () 
-let (freenames_of_list : bv Prims.list -> freenames) =
-  fun l  -> FStar_List.fold_right FStar_Util.set_add l no_names 
-let (list_of_freenames : freenames -> bv Prims.list) =
-  fun fvs  -> FStar_Util.set_elements fvs 
-let mk : 'a . 'a -> 'a mk_t_a =
+let new_universe_names_fifo_set: Prims.unit -> univ_name FStar_Util.fifo_set
+  = fun uu____5659  -> FStar_Util.new_fifo_set order_univ_name
+let no_names: bv FStar_Util.set = new_bv_set ()
+let no_fvars: FStar_Ident.lident FStar_Util.set = new_fv_set ()
+let no_universe_names: univ_name FStar_Util.fifo_set =
+  new_universe_names_fifo_set ()
+let freenames_of_list: bv Prims.list -> freenames =
+  fun l  -> FStar_List.fold_right FStar_Util.set_add l no_names
+let list_of_freenames: freenames -> bv Prims.list =
+  fun fvs  -> FStar_Util.set_elements fvs
+let mk: 'a . 'a -> 'a mk_t_a =
   fun t  ->
     fun uu____5699  ->
       fun r  ->
-        let uu____5703 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+        let uu____5703 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
         { n = t; pos = r; vars = uu____5703 }
-  
-let (bv_to_tm : bv -> term) =
+let bv_to_tm: bv -> term =
   fun bv  ->
-    let uu____5733 = range_of_bv bv  in
+    let uu____5733 = range_of_bv bv in
     mk (Tm_bvar bv) FStar_Pervasives_Native.None uu____5733
-  
-let (bv_to_name : bv -> term) =
+let bv_to_name: bv -> term =
   fun bv  ->
-    let uu____5737 = range_of_bv bv  in
+    let uu____5737 = range_of_bv bv in
     mk (Tm_name bv) FStar_Pervasives_Native.None uu____5737
-  
-let (mk_Tm_app : term -> args -> mk_t) =
+let mk_Tm_app: term -> args -> mk_t =
   fun t1  ->
     fun args  ->
       fun k  ->
@@ -1873,8 +1671,7 @@ let (mk_Tm_app : term -> args -> mk_t) =
           | [] -> t1
           | uu____5756 ->
               mk (Tm_app (t1, args)) FStar_Pervasives_Native.None p
-  
-let (mk_Tm_uinst : term -> universes -> term) =
+let mk_Tm_uinst: term -> universes -> term =
   fun t  ->
     fun uu___31_5766  ->
       match uu___31_5766 with
@@ -1884,8 +1681,7 @@ let (mk_Tm_uinst : term -> universes -> term) =
            | Tm_fvar uu____5768 ->
                mk (Tm_uinst (t, us)) FStar_Pervasives_Native.None t.pos
            | uu____5769 -> failwith "Unexpected universe instantiation")
-  
-let (extend_app_n : term -> args -> mk_t) =
+let extend_app_n: term -> args -> mk_t =
   fun t  ->
     fun args'  ->
       fun kopt  ->
@@ -1894,37 +1690,34 @@ let (extend_app_n : term -> args -> mk_t) =
           | Tm_app (head1,args) ->
               mk_Tm_app head1 (FStar_List.append args args') kopt r
           | uu____5814 -> mk_Tm_app t args' kopt r
-  
-let (extend_app : term -> arg -> mk_t) =
-  fun t  -> fun arg  -> fun kopt  -> fun r  -> extend_app_n t [arg] kopt r 
-let (mk_Tm_delayed :
-  (term,subst_ts) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term)
+let extend_app: term -> arg -> mk_t =
+  fun t  -> fun arg  -> fun kopt  -> fun r  -> extend_app_n t [arg] kopt r
+let mk_Tm_delayed:
+  (term,subst_ts) FStar_Pervasives_Native.tuple2 -> FStar_Range.range -> term
   =
   fun lr  ->
     fun pos  ->
       let uu____5843 =
         let uu____5846 =
           let uu____5847 =
-            let uu____5872 = FStar_Util.mk_ref FStar_Pervasives_Native.None
-               in
-            (lr, uu____5872)  in
-          Tm_delayed uu____5847  in
-        mk uu____5846  in
+            let uu____5872 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+            (lr, uu____5872) in
+          Tm_delayed uu____5847 in
+        mk uu____5846 in
       uu____5843 FStar_Pervasives_Native.None pos
-  
-let (mk_Total' : typ -> universe FStar_Pervasives_Native.option -> comp) =
-  fun t  -> fun u  -> mk (Total (t, u)) FStar_Pervasives_Native.None t.pos 
-let (mk_GTotal' : typ -> universe FStar_Pervasives_Native.option -> comp) =
-  fun t  -> fun u  -> mk (GTotal (t, u)) FStar_Pervasives_Native.None t.pos 
-let (mk_Total : typ -> comp) =
-  fun t  -> mk_Total' t FStar_Pervasives_Native.None 
-let (mk_GTotal : typ -> comp) =
-  fun t  -> mk_GTotal' t FStar_Pervasives_Native.None 
-let (mk_Comp : comp_typ -> comp) =
-  fun ct  -> mk (Comp ct) FStar_Pervasives_Native.None (ct.result_typ).pos 
-let (mk_lb :
+let mk_Total': typ -> universe FStar_Pervasives_Native.option -> comp =
+  fun t  -> fun u  -> mk (Total (t, u)) FStar_Pervasives_Native.None t.pos
+let mk_GTotal': typ -> universe FStar_Pervasives_Native.option -> comp =
+  fun t  -> fun u  -> mk (GTotal (t, u)) FStar_Pervasives_Native.None t.pos
+let mk_Total: typ -> comp =
+  fun t  -> mk_Total' t FStar_Pervasives_Native.None
+let mk_GTotal: typ -> comp =
+  fun t  -> mk_GTotal' t FStar_Pervasives_Native.None
+let mk_Comp: comp_typ -> comp =
+  fun ct  -> mk (Comp ct) FStar_Pervasives_Native.None (ct.result_typ).pos
+let mk_lb:
   (lbname,univ_name Prims.list,FStar_Ident.lident,typ,term)
-    FStar_Pervasives_Native.tuple5 -> letbinding)
+    FStar_Pervasives_Native.tuple5 -> letbinding
   =
   fun uu____5967  ->
     match uu____5967 with
@@ -1937,10 +1730,9 @@ let (mk_lb :
           lbdef = e;
           lbattrs = []
         }
-  
-let (default_sigmeta : sig_metadata) =
-  { sigmeta_active = true; sigmeta_fact_db_ids = [] } 
-let (mk_sigelt : sigelt' -> sigelt) =
+let default_sigmeta: sig_metadata =
+  { sigmeta_active = true; sigmeta_fact_db_ids = [] }
+let mk_sigelt: sigelt' -> sigelt =
   fun e  ->
     {
       sigel = e;
@@ -1949,82 +1741,71 @@ let (mk_sigelt : sigelt' -> sigelt) =
       sigmeta = default_sigmeta;
       sigattrs = []
     }
-  
-let (mk_subst : subst_t -> subst_t) = fun s  -> s 
-let (extend_subst : subst_elt -> subst_elt Prims.list -> subst_t) =
-  fun x  -> fun s  -> x :: s 
-let (argpos : arg -> FStar_Range.range) =
-  fun x  -> (FStar_Pervasives_Native.fst x).pos 
-let (tun : term' syntax) =
-  mk Tm_unknown FStar_Pervasives_Native.None FStar_Range.dummyRange 
-let (teff : term' syntax) =
+let mk_subst: subst_t -> subst_t = fun s  -> s
+let extend_subst: subst_elt -> subst_elt Prims.list -> subst_t =
+  fun x  -> fun s  -> x :: s
+let argpos: arg -> FStar_Range.range =
+  fun x  -> (FStar_Pervasives_Native.fst x).pos
+let tun: term' syntax =
+  mk Tm_unknown FStar_Pervasives_Native.None FStar_Range.dummyRange
+let teff: term' syntax =
   mk (Tm_constant FStar_Const.Const_effect) FStar_Pervasives_Native.None
     FStar_Range.dummyRange
-  
-let (is_teff : term -> Prims.bool) =
+let is_teff: term -> Prims.bool =
   fun t  ->
     match t.n with
     | Tm_constant (FStar_Const.Const_effect ) -> true
     | uu____6019 -> false
-  
-let (is_type : term -> Prims.bool) =
-  fun t  -> match t.n with | Tm_type uu____6023 -> true | uu____6024 -> false 
-let (null_id : FStar_Ident.ident) =
-  FStar_Ident.mk_ident ("_", FStar_Range.dummyRange) 
-let (null_bv : term -> bv) =
-  fun k  -> { ppname = null_id; index = (Prims.parse_int "0"); sort = k } 
-let (mk_binder : bv -> binder) = fun a  -> (a, FStar_Pervasives_Native.None) 
-let (null_binder : term -> binder) =
+let is_type: term -> Prims.bool =
+  fun t  -> match t.n with | Tm_type uu____6023 -> true | uu____6024 -> false
+let null_id: FStar_Ident.ident =
+  FStar_Ident.mk_ident ("_", FStar_Range.dummyRange)
+let null_bv: term -> bv =
+  fun k  -> { ppname = null_id; index = (Prims.parse_int "0"); sort = k }
+let mk_binder: bv -> binder = fun a  -> (a, FStar_Pervasives_Native.None)
+let null_binder: term -> binder =
   fun t  ->
-    let uu____6036 = null_bv t  in (uu____6036, FStar_Pervasives_Native.None)
-  
-let (imp_tag : arg_qualifier) = Implicit false 
-let (iarg : term -> arg) =
-  fun t  -> (t, (FStar_Pervasives_Native.Some imp_tag)) 
-let (as_arg : term -> arg) = fun t  -> (t, FStar_Pervasives_Native.None) 
-let (is_null_bv : bv -> Prims.bool) =
-  fun b  -> (b.ppname).FStar_Ident.idText = null_id.FStar_Ident.idText 
-let (is_null_binder : binder -> Prims.bool) =
-  fun b  -> is_null_bv (FStar_Pervasives_Native.fst b) 
-let (is_top_level : letbinding Prims.list -> Prims.bool) =
+    let uu____6036 = null_bv t in (uu____6036, FStar_Pervasives_Native.None)
+let imp_tag: arg_qualifier = Implicit false
+let iarg: term -> arg = fun t  -> (t, (FStar_Pervasives_Native.Some imp_tag))
+let as_arg: term -> arg = fun t  -> (t, FStar_Pervasives_Native.None)
+let is_null_bv: bv -> Prims.bool =
+  fun b  -> (b.ppname).FStar_Ident.idText = null_id.FStar_Ident.idText
+let is_null_binder: binder -> Prims.bool =
+  fun b  -> is_null_bv (FStar_Pervasives_Native.fst b)
+let is_top_level: letbinding Prims.list -> Prims.bool =
   fun uu___32_6059  ->
     match uu___32_6059 with
     | { lbname = FStar_Util.Inr uu____6062; lbunivs = uu____6063;
         lbtyp = uu____6064; lbeff = uu____6065; lbdef = uu____6066;
         lbattrs = uu____6067;_}::uu____6068 -> true
     | uu____6081 -> false
-  
-let (freenames_of_binders : binders -> freenames) =
+let freenames_of_binders: binders -> freenames =
   fun bs  ->
     FStar_List.fold_right
       (fun uu____6097  ->
          fun out  ->
            match uu____6097 with | (x,uu____6108) -> FStar_Util.set_add x out)
       bs no_names
-  
-let (binders_of_list : bv Prims.list -> binders) =
+let binders_of_list: bv Prims.list -> binders =
   fun fvs  ->
     FStar_All.pipe_right fvs
       (FStar_List.map (fun t  -> (t, FStar_Pervasives_Native.None)))
-  
-let (binders_of_freenames : freenames -> binders) =
+let binders_of_freenames: freenames -> binders =
   fun fvs  ->
-    let uu____6139 = FStar_Util.set_elements fvs  in
+    let uu____6139 = FStar_Util.set_elements fvs in
     FStar_All.pipe_right uu____6139 binders_of_list
-  
-let (is_implicit : aqual -> Prims.bool) =
+let is_implicit: aqual -> Prims.bool =
   fun uu___33_6146  ->
     match uu___33_6146 with
     | FStar_Pervasives_Native.Some (Implicit uu____6147) -> true
     | uu____6148 -> false
-  
-let (as_implicit : Prims.bool -> aqual) =
+let as_implicit: Prims.bool -> aqual =
   fun uu___34_6151  ->
     if uu___34_6151
     then FStar_Pervasives_Native.Some imp_tag
     else FStar_Pervasives_Native.None
-  
-let (pat_bvs : pat -> bv Prims.list) =
+let pat_bvs: pat -> bv Prims.list =
   fun p  ->
     let rec aux b p1 =
       match p1.v with
@@ -2036,77 +1817,70 @@ let (pat_bvs : pat -> bv Prims.list) =
           FStar_List.fold_left
             (fun b1  ->
                fun uu____6220  ->
-                 match uu____6220 with | (p2,uu____6232) -> aux b1 p2) b pats
-       in
-    let uu____6237 = aux [] p  in
+                 match uu____6220 with | (p2,uu____6232) -> aux b1 p2) b pats in
+    let uu____6237 = aux [] p in
     FStar_All.pipe_left FStar_List.rev uu____6237
-  
-let (gen_reset :
+let gen_reset:
   (Prims.unit -> Prims.int,Prims.unit -> Prims.unit)
-    FStar_Pervasives_Native.tuple2)
+    FStar_Pervasives_Native.tuple2
   =
-  let x = FStar_Util.mk_ref (Prims.parse_int "0")  in
-  let gen1 uu____6258 = FStar_Util.incr x; FStar_ST.op_Bang x  in
-  let reset uu____6337 = FStar_ST.op_Colon_Equals x (Prims.parse_int "0")  in
-  (gen1, reset) 
-let (next_id : Prims.unit -> Prims.int) =
-  FStar_Pervasives_Native.fst gen_reset 
-let (reset_gensym : Prims.unit -> Prims.unit) =
-  FStar_Pervasives_Native.snd gen_reset 
-let (range_of_ropt :
-  FStar_Range.range FStar_Pervasives_Native.option -> FStar_Range.range) =
+  let x = FStar_Util.mk_ref (Prims.parse_int "0") in
+  let gen1 uu____6258 = FStar_Util.incr x; FStar_ST.op_Bang x in
+  let reset uu____6337 = FStar_ST.op_Colon_Equals x (Prims.parse_int "0") in
+  (gen1, reset)
+let next_id: Prims.unit -> Prims.int = FStar_Pervasives_Native.fst gen_reset
+let reset_gensym: Prims.unit -> Prims.unit =
+  FStar_Pervasives_Native.snd gen_reset
+let range_of_ropt:
+  FStar_Range.range FStar_Pervasives_Native.option -> FStar_Range.range =
   fun uu___35_6399  ->
     match uu___35_6399 with
     | FStar_Pervasives_Native.None  -> FStar_Range.dummyRange
     | FStar_Pervasives_Native.Some r -> r
-  
-let (gen_bv :
+let gen_bv:
   Prims.string ->
-    FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv)
+    FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv
   =
   fun s  ->
     fun r  ->
       fun t  ->
-        let id1 = FStar_Ident.mk_ident (s, (range_of_ropt r))  in
-        let uu____6425 = next_id ()  in
+        let id1 = FStar_Ident.mk_ident (s, (range_of_ropt r)) in
+        let uu____6425 = next_id () in
         { ppname = id1; index = uu____6425; sort = t }
-  
-let (new_bv : FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv)
-  = fun ropt  -> fun t  -> gen_bv FStar_Ident.reserved_prefix ropt t 
-let (freshen_bv : bv -> bv) =
+let new_bv: FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv =
+  fun ropt  -> fun t  -> gen_bv FStar_Ident.reserved_prefix ropt t
+let freshen_bv: bv -> bv =
   fun bv  ->
-    let uu____6439 = is_null_bv bv  in
+    let uu____6439 = is_null_bv bv in
     if uu____6439
     then
       let uu____6440 =
-        let uu____6443 = range_of_bv bv  in
-        FStar_Pervasives_Native.Some uu____6443  in
+        let uu____6443 = range_of_bv bv in
+        FStar_Pervasives_Native.Some uu____6443 in
       new_bv uu____6440 bv.sort
     else
-      (let uu___38_6445 = bv  in
-       let uu____6446 = next_id ()  in
+      (let uu___38_6445 = bv in
+       let uu____6446 = next_id () in
        {
          ppname = (uu___38_6445.ppname);
          index = uu____6446;
          sort = (uu___38_6445.sort)
        })
-  
-let (new_univ_name :
-  FStar_Range.range FStar_Pervasives_Native.option -> univ_name) =
+let new_univ_name:
+  FStar_Range.range FStar_Pervasives_Native.option -> univ_name =
   fun ropt  ->
-    let id1 = next_id ()  in
+    let id1 = next_id () in
     let uu____6455 =
       let uu____6460 =
-        let uu____6461 = FStar_Util.string_of_int id1  in
-        Prims.strcat FStar_Ident.reserved_prefix uu____6461  in
-      (uu____6460, (range_of_ropt ropt))  in
+        let uu____6461 = FStar_Util.string_of_int id1 in
+        Prims.strcat FStar_Ident.reserved_prefix uu____6461 in
+      (uu____6460, (range_of_ropt ropt)) in
     FStar_Ident.mk_ident uu____6455
-  
-let (mkbv : FStar_Ident.ident -> Prims.int -> term' syntax -> bv) =
-  fun x  -> fun y  -> fun t  -> { ppname = x; index = y; sort = t } 
-let (lbname_eq :
+let mkbv: FStar_Ident.ident -> Prims.int -> term' syntax -> bv =
+  fun x  -> fun y  -> fun t  -> { ppname = x; index = y; sort = t }
+let lbname_eq:
   (bv,FStar_Ident.lident) FStar_Util.either ->
-    (bv,FStar_Ident.lident) FStar_Util.either -> Prims.bool)
+    (bv,FStar_Ident.lident) FStar_Util.either -> Prims.bool
   =
   fun l1  ->
     fun l2  ->
@@ -2114,68 +1888,60 @@ let (lbname_eq :
       | (FStar_Util.Inl x,FStar_Util.Inl y) -> bv_eq x y
       | (FStar_Util.Inr l,FStar_Util.Inr m) -> FStar_Ident.lid_equals l m
       | uu____6525 -> false
-  
-let (fv_eq : fv -> fv -> Prims.bool) =
+let fv_eq: fv -> fv -> Prims.bool =
   fun fv1  ->
     fun fv2  -> FStar_Ident.lid_equals (fv1.fv_name).v (fv2.fv_name).v
-  
-let (fv_eq_lid : fv -> FStar_Ident.lident -> Prims.bool) =
-  fun fv  -> fun lid  -> FStar_Ident.lid_equals (fv.fv_name).v lid 
-let (set_bv_range : bv -> FStar_Range.range -> bv) =
+let fv_eq_lid: fv -> FStar_Ident.lident -> Prims.bool =
+  fun fv  -> fun lid  -> FStar_Ident.lid_equals (fv.fv_name).v lid
+let set_bv_range: bv -> FStar_Range.range -> bv =
   fun bv  ->
     fun r  ->
-      let uu___39_6556 = bv  in
+      let uu___39_6556 = bv in
       {
         ppname = (FStar_Ident.mk_ident (((bv.ppname).FStar_Ident.idText), r));
         index = (uu___39_6556.index);
         sort = (uu___39_6556.sort)
       }
-  
-let (lid_as_fv :
+let lid_as_fv:
   FStar_Ident.lident ->
-    delta_depth -> fv_qual FStar_Pervasives_Native.option -> fv)
+    delta_depth -> fv_qual FStar_Pervasives_Native.option -> fv
   =
   fun l  ->
     fun dd  ->
       fun dq  ->
-        let uu____6570 = withinfo l (FStar_Ident.range_of_lid l)  in
+        let uu____6570 = withinfo l (FStar_Ident.range_of_lid l) in
         { fv_name = uu____6570; fv_delta = dd; fv_qual = dq }
-  
-let (fv_to_tm : fv -> term) =
+let fv_to_tm: fv -> term =
   fun fv  ->
     mk (Tm_fvar fv) FStar_Pervasives_Native.None
       (FStar_Ident.range_of_lid (fv.fv_name).v)
-  
-let (fvar :
+let fvar:
   FStar_Ident.lident ->
-    delta_depth -> fv_qual FStar_Pervasives_Native.option -> term)
+    delta_depth -> fv_qual FStar_Pervasives_Native.option -> term
   =
   fun l  ->
     fun dd  ->
-      fun dq  -> let uu____6587 = lid_as_fv l dd dq  in fv_to_tm uu____6587
-  
-let (lid_of_fv : fv -> FStar_Ident.lid) = fun fv  -> (fv.fv_name).v 
-let (range_of_fv : fv -> FStar_Range.range) =
+      fun dq  -> let uu____6587 = lid_as_fv l dd dq in fv_to_tm uu____6587
+let lid_of_fv: fv -> FStar_Ident.lid = fun fv  -> (fv.fv_name).v
+let range_of_fv: fv -> FStar_Range.range =
   fun fv  ->
-    let uu____6594 = lid_of_fv fv  in FStar_Ident.range_of_lid uu____6594
-  
-let (set_range_of_fv : fv -> FStar_Range.range -> fv) =
+    let uu____6594 = lid_of_fv fv in FStar_Ident.range_of_lid uu____6594
+let set_range_of_fv: fv -> FStar_Range.range -> fv =
   fun fv  ->
     fun r  ->
-      let uu___40_6601 = fv  in
+      let uu___40_6601 = fv in
       let uu____6602 =
-        let uu___41_6603 = fv.fv_name  in
+        let uu___41_6603 = fv.fv_name in
         let uu____6604 =
-          let uu____6605 = lid_of_fv fv  in
-          FStar_Ident.set_lid_range uu____6605 r  in
-        { v = uu____6604; p = (uu___41_6603.p) }  in
+          let uu____6605 = lid_of_fv fv in
+          FStar_Ident.set_lid_range uu____6605 r in
+        { v = uu____6604; p = (uu___41_6603.p) } in
       {
         fv_name = uu____6602;
         fv_delta = (uu___40_6601.fv_delta);
         fv_qual = (uu___40_6601.fv_qual)
       }
-  
-let (has_simple_attribute : term Prims.list -> Prims.string -> Prims.bool) =
+let has_simple_attribute: term Prims.list -> Prims.string -> Prims.bool =
   fun l  ->
     fun s  ->
       FStar_List.existsb
@@ -2184,17 +1950,16 @@ let (has_simple_attribute : term Prims.list -> Prims.string -> Prims.bool) =
            | { n = Tm_constant (FStar_Const.Const_string (data,uu____6627));
                pos = uu____6628; vars = uu____6629;_} when data = s -> true
            | uu____6632 -> false) l
-  
-let rec (eq_pat : pat -> pat -> Prims.bool) =
+let rec eq_pat: pat -> pat -> Prims.bool =
   fun p1  ->
     fun p2  ->
       match ((p1.v), (p2.v)) with
       | (Pat_constant c1,Pat_constant c2) -> FStar_Const.eq_const c1 c2
       | (Pat_cons (fv1,as1),Pat_cons (fv2,as2)) ->
-          let uu____6679 = fv_eq fv1 fv2  in
+          let uu____6679 = fv_eq fv1 fv2 in
           if uu____6679
           then
-            let uu____6683 = FStar_List.zip as1 as2  in
+            let uu____6683 = FStar_List.zip as1 as2 in
             FStar_All.pipe_right uu____6683
               (FStar_List.for_all
                  (fun uu____6749  ->
@@ -2205,80 +1970,72 @@ let rec (eq_pat : pat -> pat -> Prims.bool) =
       | (Pat_wild uu____6777,Pat_wild uu____6778) -> true
       | (Pat_dot_term (bv1,t1),Pat_dot_term (bv2,t2)) -> true
       | (uu____6791,uu____6792) -> false
-  
-let (tconst : FStar_Ident.lident -> term) =
+let tconst: FStar_Ident.lident -> term =
   fun l  ->
     let uu____6796 =
       let uu____6799 =
         let uu____6800 =
-          lid_as_fv l Delta_constant FStar_Pervasives_Native.None  in
-        Tm_fvar uu____6800  in
-      mk uu____6799  in
+          lid_as_fv l Delta_constant FStar_Pervasives_Native.None in
+        Tm_fvar uu____6800 in
+      mk uu____6799 in
     uu____6796 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (tabbrev : FStar_Ident.lident -> term) =
+let tabbrev: FStar_Ident.lident -> term =
   fun l  ->
     let uu____6807 =
       let uu____6810 =
         let uu____6811 =
           lid_as_fv l (Delta_defined_at_level (Prims.parse_int "1"))
-            FStar_Pervasives_Native.None
-           in
-        Tm_fvar uu____6811  in
-      mk uu____6810  in
+            FStar_Pervasives_Native.None in
+        Tm_fvar uu____6811 in
+      mk uu____6810 in
     uu____6807 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (tdataconstr : FStar_Ident.lident -> term) =
+let tdataconstr: FStar_Ident.lident -> term =
   fun l  ->
     let uu____6818 =
-      lid_as_fv l Delta_constant (FStar_Pervasives_Native.Some Data_ctor)  in
+      lid_as_fv l Delta_constant (FStar_Pervasives_Native.Some Data_ctor) in
     fv_to_tm uu____6818
-  
-let (t_unit : term) = tconst FStar_Parser_Const.unit_lid 
-let (t_bool : term) = tconst FStar_Parser_Const.bool_lid 
-let (t_int : term) = tconst FStar_Parser_Const.int_lid 
-let (t_string : term) = tconst FStar_Parser_Const.string_lid 
-let (t_float : term) = tconst FStar_Parser_Const.float_lid 
-let (t_char : term) = tabbrev FStar_Parser_Const.char_lid 
-let (t_range : term) = tconst FStar_Parser_Const.range_lid 
-let (t_term : term) = tconst FStar_Parser_Const.term_lid 
-let (t_tactic_unit : term' syntax) =
+let t_unit: term = tconst FStar_Parser_Const.unit_lid
+let t_bool: term = tconst FStar_Parser_Const.bool_lid
+let t_int: term = tconst FStar_Parser_Const.int_lid
+let t_string: term = tconst FStar_Parser_Const.string_lid
+let t_float: term = tconst FStar_Parser_Const.float_lid
+let t_char: term = tabbrev FStar_Parser_Const.char_lid
+let t_range: term = tconst FStar_Parser_Const.range_lid
+let t_term: term = tconst FStar_Parser_Const.term_lid
+let t_tactic_unit: term' syntax =
   let uu____6821 =
     let uu____6822 =
-      let uu____6823 = tabbrev FStar_Parser_Const.tactic_lid  in
-      mk_Tm_uinst uu____6823 [U_zero]  in
-    let uu____6824 = let uu____6825 = as_arg t_unit  in [uu____6825]  in
-    mk_Tm_app uu____6822 uu____6824  in
-  uu____6821 FStar_Pervasives_Native.None FStar_Range.dummyRange 
-let (t_tac_unit : term' syntax) =
+      let uu____6823 = tabbrev FStar_Parser_Const.tactic_lid in
+      mk_Tm_uinst uu____6823 [U_zero] in
+    let uu____6824 = let uu____6825 = as_arg t_unit in [uu____6825] in
+    mk_Tm_app uu____6822 uu____6824 in
+  uu____6821 FStar_Pervasives_Native.None FStar_Range.dummyRange
+let t_tac_unit: term' syntax =
   let uu____6830 =
     let uu____6831 =
-      let uu____6832 = tabbrev FStar_Parser_Const.u_tac_lid  in
-      mk_Tm_uinst uu____6832 [U_zero]  in
-    let uu____6833 = let uu____6834 = as_arg t_unit  in [uu____6834]  in
-    mk_Tm_app uu____6831 uu____6833  in
-  uu____6830 FStar_Pervasives_Native.None FStar_Range.dummyRange 
-let (t_list_of : term -> term) =
+      let uu____6832 = tabbrev FStar_Parser_Const.u_tac_lid in
+      mk_Tm_uinst uu____6832 [U_zero] in
+    let uu____6833 = let uu____6834 = as_arg t_unit in [uu____6834] in
+    mk_Tm_app uu____6831 uu____6833 in
+  uu____6830 FStar_Pervasives_Native.None FStar_Range.dummyRange
+let t_list_of: term -> term =
   fun t  ->
     let uu____6840 =
       let uu____6841 =
-        let uu____6842 = tabbrev FStar_Parser_Const.list_lid  in
-        mk_Tm_uinst uu____6842 [U_zero]  in
-      let uu____6843 = let uu____6844 = as_arg t  in [uu____6844]  in
-      mk_Tm_app uu____6841 uu____6843  in
+        let uu____6842 = tabbrev FStar_Parser_Const.list_lid in
+        mk_Tm_uinst uu____6842 [U_zero] in
+      let uu____6843 = let uu____6844 = as_arg t in [uu____6844] in
+      mk_Tm_app uu____6841 uu____6843 in
     uu____6840 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (t_option_of : term -> term) =
+let t_option_of: term -> term =
   fun t  ->
     let uu____6850 =
       let uu____6851 =
-        let uu____6852 = tabbrev FStar_Parser_Const.option_lid  in
-        mk_Tm_uinst uu____6852 [U_zero]  in
-      let uu____6853 = let uu____6854 = as_arg t  in [uu____6854]  in
-      mk_Tm_app uu____6851 uu____6853  in
+        let uu____6852 = tabbrev FStar_Parser_Const.option_lid in
+        mk_Tm_uinst uu____6852 [U_zero] in
+      let uu____6853 = let uu____6854 = as_arg t in [uu____6854] in
+      mk_Tm_app uu____6851 uu____6853 in
     uu____6850 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (unit_const : term' syntax) =
+let unit_const: term' syntax =
   mk (Tm_constant FStar_Const.Const_unit) FStar_Pervasives_Native.None
     FStar_Range.dummyRange
-  

--- a/src/ocaml-output/FStar_Syntax_Unionfind.ml
+++ b/src/ocaml-output/FStar_Syntax_Unionfind.ml
@@ -1,41 +1,38 @@
 open Prims
 type vops_t =
   {
-  next_major: Prims.unit -> FStar_Syntax_Syntax.version ;
-  next_minor: Prims.unit -> FStar_Syntax_Syntax.version }[@@deriving show]
-let (__proj__Mkvops_t__item__next_major :
-  vops_t -> Prims.unit -> FStar_Syntax_Syntax.version) =
+  next_major: Prims.unit -> FStar_Syntax_Syntax.version;
+  next_minor: Prims.unit -> FStar_Syntax_Syntax.version;}[@@deriving show]
+let __proj__Mkvops_t__item__next_major:
+  vops_t -> Prims.unit -> FStar_Syntax_Syntax.version =
   fun projectee  ->
     match projectee with
     | { next_major = __fname__next_major; next_minor = __fname__next_minor;_}
         -> __fname__next_major
-  
-let (__proj__Mkvops_t__item__next_minor :
-  vops_t -> Prims.unit -> FStar_Syntax_Syntax.version) =
+let __proj__Mkvops_t__item__next_minor:
+  vops_t -> Prims.unit -> FStar_Syntax_Syntax.version =
   fun projectee  ->
     match projectee with
     | { next_major = __fname__next_major; next_minor = __fname__next_minor;_}
         -> __fname__next_minor
-  
-let (vops : vops_t) =
-  let major = FStar_Util.mk_ref (Prims.parse_int "0")  in
-  let minor = FStar_Util.mk_ref (Prims.parse_int "0")  in
+let vops: vops_t =
+  let major = FStar_Util.mk_ref (Prims.parse_int "0") in
+  let minor = FStar_Util.mk_ref (Prims.parse_int "0") in
   let next_major uu____52 =
     FStar_ST.op_Colon_Equals minor (Prims.parse_int "0");
-    (let uu____95 = FStar_Util.incr major; FStar_ST.op_Bang major  in
+    (let uu____95 = FStar_Util.incr major; FStar_ST.op_Bang major in
      {
        FStar_Syntax_Syntax.major = uu____95;
        FStar_Syntax_Syntax.minor = (Prims.parse_int "0")
-     })
-     in
+     }) in
   let next_minor uu____174 =
-    let uu____175 = FStar_ST.op_Bang major  in
-    let uu____217 = FStar_Util.incr minor; FStar_ST.op_Bang minor  in
+    let uu____175 = FStar_ST.op_Bang major in
+    let uu____217 = FStar_Util.incr minor; FStar_ST.op_Bang minor in
     {
       FStar_Syntax_Syntax.major = uu____175;
       FStar_Syntax_Syntax.minor = uu____217
-    }  in
-  { next_major; next_minor } 
+    } in
+  { next_major; next_minor }
 type tgraph =
   FStar_Syntax_Syntax.term FStar_Pervasives_Native.option FStar_Unionfind.puf
 [@@deriving show]
@@ -44,89 +41,80 @@ type ugraph =
     FStar_Unionfind.puf[@@deriving show]
 type uf =
   {
-  term_graph: tgraph ;
-  univ_graph: ugraph ;
-  version: FStar_Syntax_Syntax.version }[@@deriving show]
-let (__proj__Mkuf__item__term_graph : uf -> tgraph) =
+  term_graph: tgraph;
+  univ_graph: ugraph;
+  version: FStar_Syntax_Syntax.version;}[@@deriving show]
+let __proj__Mkuf__item__term_graph: uf -> tgraph =
   fun projectee  ->
     match projectee with
     | { term_graph = __fname__term_graph; univ_graph = __fname__univ_graph;
         version = __fname__version;_} -> __fname__term_graph
-  
-let (__proj__Mkuf__item__univ_graph : uf -> ugraph) =
+let __proj__Mkuf__item__univ_graph: uf -> ugraph =
   fun projectee  ->
     match projectee with
     | { term_graph = __fname__term_graph; univ_graph = __fname__univ_graph;
         version = __fname__version;_} -> __fname__univ_graph
-  
-let (__proj__Mkuf__item__version : uf -> FStar_Syntax_Syntax.version) =
+let __proj__Mkuf__item__version: uf -> FStar_Syntax_Syntax.version =
   fun projectee  ->
     match projectee with
     | { term_graph = __fname__term_graph; univ_graph = __fname__univ_graph;
         version = __fname__version;_} -> __fname__version
-  
-let (empty : FStar_Syntax_Syntax.version -> uf) =
+let empty: FStar_Syntax_Syntax.version -> uf =
   fun v1  ->
-    let uu____334 = FStar_Unionfind.puf_empty ()  in
-    let uu____337 = FStar_Unionfind.puf_empty ()  in
+    let uu____334 = FStar_Unionfind.puf_empty () in
+    let uu____337 = FStar_Unionfind.puf_empty () in
     { term_graph = uu____334; univ_graph = uu____337; version = v1 }
-  
-let (version_to_string : FStar_Syntax_Syntax.version -> Prims.string) =
+let version_to_string: FStar_Syntax_Syntax.version -> Prims.string =
   fun v1  ->
-    let uu____343 = FStar_Util.string_of_int v1.FStar_Syntax_Syntax.major  in
-    let uu____344 = FStar_Util.string_of_int v1.FStar_Syntax_Syntax.minor  in
+    let uu____343 = FStar_Util.string_of_int v1.FStar_Syntax_Syntax.major in
+    let uu____344 = FStar_Util.string_of_int v1.FStar_Syntax_Syntax.minor in
     FStar_Util.format2 "%s.%s" uu____343 uu____344
-  
-let (state : uf FStar_ST.ref) =
-  let uu____358 = let uu____359 = vops.next_major ()  in empty uu____359  in
-  FStar_Util.mk_ref uu____358 
+let state: uf FStar_ST.ref =
+  let uu____358 = let uu____359 = vops.next_major () in empty uu____359 in
+  FStar_Util.mk_ref uu____358
 type tx =
-  | TX of uf [@@deriving show]
-let (uu___is_TX : tx -> Prims.bool) = fun projectee  -> true 
-let (__proj__TX__item___0 : tx -> uf) =
-  fun projectee  -> match projectee with | TX _0 -> _0 
-let (get : Prims.unit -> uf) = fun uu____373  -> FStar_ST.op_Bang state 
-let (set : uf -> Prims.unit) = fun u  -> FStar_ST.op_Colon_Equals state u 
-let (reset : Prims.unit -> Prims.unit) =
+  | TX of uf[@@deriving show]
+let uu___is_TX: tx -> Prims.bool = fun projectee  -> true
+let __proj__TX__item___0: tx -> uf =
+  fun projectee  -> match projectee with | TX _0 -> _0
+let get: Prims.unit -> uf = fun uu____373  -> FStar_ST.op_Bang state
+let set: uf -> Prims.unit = fun u  -> FStar_ST.op_Colon_Equals state u
+let reset: Prims.unit -> Prims.unit =
   fun uu____417  ->
-    let v1 = vops.next_major ()  in
-    let uu____419 = empty v1  in set uu____419
-  
-let (new_transaction : Prims.unit -> tx) =
+    let v1 = vops.next_major () in let uu____419 = empty v1 in set uu____419
+let new_transaction: Prims.unit -> tx =
   fun uu____422  ->
-    let tx = let uu____424 = get ()  in TX uu____424  in
+    let tx = let uu____424 = get () in TX uu____424 in
     (let uu____426 =
-       let uu___23_427 = get ()  in
-       let uu____428 = vops.next_minor ()  in
+       let uu___23_427 = get () in
+       let uu____428 = vops.next_minor () in
        {
          term_graph = (uu___23_427.term_graph);
          univ_graph = (uu___23_427.univ_graph);
          version = uu____428
-       }  in
+       } in
      set uu____426);
     tx
-  
-let (commit : tx -> Prims.unit) = fun tx  -> () 
-let (rollback : tx -> Prims.unit) =
-  fun uu____434  -> match uu____434 with | TX uf -> set uf 
-let update_in_tx : 'a . 'a FStar_ST.ref -> 'a -> Prims.unit =
-  fun r  -> fun x  -> () 
-let (get_term_graph : Prims.unit -> tgraph) =
-  fun uu____487  -> let uu____488 = get ()  in uu____488.term_graph 
-let (get_version : Prims.unit -> FStar_Syntax_Syntax.version) =
-  fun uu____491  -> let uu____492 = get ()  in uu____492.version 
-let (set_term_graph : tgraph -> Prims.unit) =
+let commit: tx -> Prims.unit = fun tx  -> ()
+let rollback: tx -> Prims.unit =
+  fun uu____434  -> match uu____434 with | TX uf -> set uf
+let update_in_tx: 'a . 'a FStar_ST.ref -> 'a -> Prims.unit =
+  fun r  -> fun x  -> ()
+let get_term_graph: Prims.unit -> tgraph =
+  fun uu____487  -> let uu____488 = get () in uu____488.term_graph
+let get_version: Prims.unit -> FStar_Syntax_Syntax.version =
+  fun uu____491  -> let uu____492 = get () in uu____492.version
+let set_term_graph: tgraph -> Prims.unit =
   fun tg  ->
     let uu____496 =
-      let uu___24_497 = get ()  in
+      let uu___24_497 = get () in
       {
         term_graph = tg;
         univ_graph = (uu___24_497.univ_graph);
         version = (uu___24_497.version)
-      }  in
+      } in
     set uu____496
-  
-let chk_v :
+let chk_v:
   'Auu____500 .
     ('Auu____500,FStar_Syntax_Syntax.version) FStar_Pervasives_Native.tuple2
       -> 'Auu____500
@@ -134,7 +122,7 @@ let chk_v :
   fun uu____508  ->
     match uu____508 with
     | (u,v1) ->
-        let expected = get_version ()  in
+        let expected = get_version () in
         if
           (v1.FStar_Syntax_Syntax.major = expected.FStar_Syntax_Syntax.major)
             &&
@@ -143,148 +131,129 @@ let chk_v :
         then u
         else
           (let uu____517 =
-             let uu____518 = version_to_string expected  in
-             let uu____519 = version_to_string v1  in
+             let uu____518 = version_to_string expected in
+             let uu____519 = version_to_string v1 in
              FStar_Util.format2
                "Incompatible version for unification variable: current version is %s; got version %s"
-               uu____518 uu____519
-              in
+               uu____518 uu____519 in
            failwith uu____517)
-  
-let (uvar_id : FStar_Syntax_Syntax.uvar -> Prims.int) =
+let uvar_id: FStar_Syntax_Syntax.uvar -> Prims.int =
   fun u  ->
-    let uu____523 = get_term_graph ()  in
-    let uu____528 = chk_v u  in FStar_Unionfind.puf_id uu____523 uu____528
-  
-let (from_id : Prims.int -> FStar_Syntax_Syntax.uvar) =
+    let uu____523 = get_term_graph () in
+    let uu____528 = chk_v u in FStar_Unionfind.puf_id uu____523 uu____528
+let from_id: Prims.int -> FStar_Syntax_Syntax.uvar =
   fun n1  ->
     let uu____544 =
-      let uu____549 = get_term_graph ()  in
-      FStar_Unionfind.puf_fromid uu____549 n1  in
-    let uu____556 = get_version ()  in (uu____544, uu____556)
-  
-let (fresh : Prims.unit -> FStar_Syntax_Syntax.uvar) =
+      let uu____549 = get_term_graph () in
+      FStar_Unionfind.puf_fromid uu____549 n1 in
+    let uu____556 = get_version () in (uu____544, uu____556)
+let fresh: Prims.unit -> FStar_Syntax_Syntax.uvar =
   fun uu____563  ->
     let uu____564 =
-      let uu____569 = get_term_graph ()  in
-      FStar_Unionfind.puf_fresh uu____569 FStar_Pervasives_Native.None  in
-    let uu____576 = get_version ()  in (uu____564, uu____576)
-  
-let (find :
+      let uu____569 = get_term_graph () in
+      FStar_Unionfind.puf_fresh uu____569 FStar_Pervasives_Native.None in
+    let uu____576 = get_version () in (uu____564, uu____576)
+let find:
   FStar_Syntax_Syntax.uvar ->
-    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun u  ->
-    let uu____586 = get_term_graph ()  in
-    let uu____591 = chk_v u  in FStar_Unionfind.puf_find uu____586 uu____591
-  
-let (change :
-  FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> Prims.unit) =
+    let uu____586 = get_term_graph () in
+    let uu____591 = chk_v u in FStar_Unionfind.puf_find uu____586 uu____591
+let change:
+  FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> Prims.unit =
   fun u  ->
     fun t  ->
       let uu____610 =
-        let uu____611 = get_term_graph ()  in
-        let uu____616 = chk_v u  in
+        let uu____611 = get_term_graph () in
+        let uu____616 = chk_v u in
         FStar_Unionfind.puf_change uu____611 uu____616
-          (FStar_Pervasives_Native.Some t)
-         in
+          (FStar_Pervasives_Native.Some t) in
       set_term_graph uu____610
-  
-let (equiv :
-  FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.uvar -> Prims.bool) =
+let equiv: FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.uvar -> Prims.bool
+  =
   fun u  ->
     fun v1  ->
-      let uu____635 = get_term_graph ()  in
-      let uu____640 = chk_v u  in
-      let uu____651 = chk_v v1  in
+      let uu____635 = get_term_graph () in
+      let uu____640 = chk_v u in
+      let uu____651 = chk_v v1 in
       FStar_Unionfind.puf_equivalent uu____635 uu____640 uu____651
-  
-let (union :
-  FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.uvar -> Prims.unit) =
+let union: FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.uvar -> Prims.unit
+  =
   fun u  ->
     fun v1  ->
       let uu____670 =
-        let uu____671 = get_term_graph ()  in
-        let uu____676 = chk_v u  in
-        let uu____687 = chk_v v1  in
-        FStar_Unionfind.puf_union uu____671 uu____676 uu____687  in
+        let uu____671 = get_term_graph () in
+        let uu____676 = chk_v u in
+        let uu____687 = chk_v v1 in
+        FStar_Unionfind.puf_union uu____671 uu____676 uu____687 in
       set_term_graph uu____670
-  
-let (get_univ_graph : Prims.unit -> ugraph) =
-  fun uu____702  -> let uu____703 = get ()  in uu____703.univ_graph 
-let (set_univ_graph : ugraph -> Prims.unit) =
+let get_univ_graph: Prims.unit -> ugraph =
+  fun uu____702  -> let uu____703 = get () in uu____703.univ_graph
+let set_univ_graph: ugraph -> Prims.unit =
   fun ug  ->
     let uu____707 =
-      let uu___25_708 = get ()  in
+      let uu___25_708 = get () in
       {
         term_graph = (uu___25_708.term_graph);
         univ_graph = ug;
         version = (uu___25_708.version)
-      }  in
+      } in
     set uu____707
-  
-let (univ_uvar_id : FStar_Syntax_Syntax.universe_uvar -> Prims.int) =
+let univ_uvar_id: FStar_Syntax_Syntax.universe_uvar -> Prims.int =
   fun u  ->
-    let uu____712 = get_univ_graph ()  in
-    let uu____717 = chk_v u  in FStar_Unionfind.puf_id uu____712 uu____717
-  
-let (univ_from_id : Prims.int -> FStar_Syntax_Syntax.universe_uvar) =
+    let uu____712 = get_univ_graph () in
+    let uu____717 = chk_v u in FStar_Unionfind.puf_id uu____712 uu____717
+let univ_from_id: Prims.int -> FStar_Syntax_Syntax.universe_uvar =
   fun n1  ->
     let uu____731 =
-      let uu____736 = get_univ_graph ()  in
-      FStar_Unionfind.puf_fromid uu____736 n1  in
-    let uu____743 = get_version ()  in (uu____731, uu____743)
-  
-let (univ_fresh : Prims.unit -> FStar_Syntax_Syntax.universe_uvar) =
+      let uu____736 = get_univ_graph () in
+      FStar_Unionfind.puf_fromid uu____736 n1 in
+    let uu____743 = get_version () in (uu____731, uu____743)
+let univ_fresh: Prims.unit -> FStar_Syntax_Syntax.universe_uvar =
   fun uu____750  ->
     let uu____751 =
-      let uu____756 = get_univ_graph ()  in
-      FStar_Unionfind.puf_fresh uu____756 FStar_Pervasives_Native.None  in
-    let uu____763 = get_version ()  in (uu____751, uu____763)
-  
-let (univ_find :
+      let uu____756 = get_univ_graph () in
+      FStar_Unionfind.puf_fresh uu____756 FStar_Pervasives_Native.None in
+    let uu____763 = get_version () in (uu____751, uu____763)
+let univ_find:
   FStar_Syntax_Syntax.universe_uvar ->
-    FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
   =
   fun u  ->
-    let uu____773 = get_univ_graph ()  in
-    let uu____778 = chk_v u  in FStar_Unionfind.puf_find uu____773 uu____778
-  
-let (univ_change :
+    let uu____773 = get_univ_graph () in
+    let uu____778 = chk_v u in FStar_Unionfind.puf_find uu____773 uu____778
+let univ_change:
   FStar_Syntax_Syntax.universe_uvar ->
-    FStar_Syntax_Syntax.universe -> Prims.unit)
+    FStar_Syntax_Syntax.universe -> Prims.unit
   =
   fun u  ->
     fun t  ->
       let uu____795 =
-        let uu____796 = get_univ_graph ()  in
-        let uu____801 = chk_v u  in
+        let uu____796 = get_univ_graph () in
+        let uu____801 = chk_v u in
         FStar_Unionfind.puf_change uu____796 uu____801
-          (FStar_Pervasives_Native.Some t)
-         in
+          (FStar_Pervasives_Native.Some t) in
       set_univ_graph uu____795
-  
-let (univ_equiv :
+let univ_equiv:
   FStar_Syntax_Syntax.universe_uvar ->
-    FStar_Syntax_Syntax.universe_uvar -> Prims.bool)
+    FStar_Syntax_Syntax.universe_uvar -> Prims.bool
   =
   fun u  ->
     fun v1  ->
-      let uu____818 = get_univ_graph ()  in
-      let uu____823 = chk_v u  in
-      let uu____832 = chk_v v1  in
+      let uu____818 = get_univ_graph () in
+      let uu____823 = chk_v u in
+      let uu____832 = chk_v v1 in
       FStar_Unionfind.puf_equivalent uu____818 uu____823 uu____832
-  
-let (univ_union :
+let univ_union:
   FStar_Syntax_Syntax.universe_uvar ->
-    FStar_Syntax_Syntax.universe_uvar -> Prims.unit)
+    FStar_Syntax_Syntax.universe_uvar -> Prims.unit
   =
   fun u  ->
     fun v1  ->
       let uu____849 =
-        let uu____850 = get_univ_graph ()  in
-        let uu____855 = chk_v u  in
-        let uu____864 = chk_v v1  in
-        FStar_Unionfind.puf_union uu____850 uu____855 uu____864  in
+        let uu____850 = get_univ_graph () in
+        let uu____855 = chk_v u in
+        let uu____864 = chk_v v1 in
+        FStar_Unionfind.puf_union uu____850 uu____855 uu____864 in
       set_univ_graph uu____849
-  

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -1,15 +1,12 @@
 open Prims
-let (qual_id : FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident)
-  =
+let qual_id: FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident =
   fun lid  ->
     fun id1  ->
       let uu____7 =
         FStar_Ident.lid_of_ids
-          (FStar_List.append lid.FStar_Ident.ns [lid.FStar_Ident.ident; id1])
-         in
+          (FStar_List.append lid.FStar_Ident.ns [lid.FStar_Ident.ident; id1]) in
       FStar_Ident.set_lid_range uu____7 id1.FStar_Ident.idRange
-  
-let (mk_discriminator : FStar_Ident.lident -> FStar_Ident.lident) =
+let mk_discriminator: FStar_Ident.lident -> FStar_Ident.lident =
   fun lid  ->
     FStar_Ident.lid_of_ids
       (FStar_List.append lid.FStar_Ident.ns
@@ -18,16 +15,13 @@ let (mk_discriminator : FStar_Ident.lident -> FStar_Ident.lident) =
                 (Prims.strcat "is_"
                    (lid.FStar_Ident.ident).FStar_Ident.idText)),
               ((lid.FStar_Ident.ident).FStar_Ident.idRange))])
-  
-let (is_name : FStar_Ident.lident -> Prims.bool) =
+let is_name: FStar_Ident.lident -> Prims.bool =
   fun lid  ->
     let c =
       FStar_Util.char_at (lid.FStar_Ident.ident).FStar_Ident.idText
-        (Prims.parse_int "0")
-       in
+        (Prims.parse_int "0") in
     FStar_Util.is_upper c
-  
-let arg_of_non_null_binder :
+let arg_of_non_null_binder:
   'Auu____17 .
     (FStar_Syntax_Syntax.bv,'Auu____17) FStar_Pervasives_Native.tuple2 ->
       (FStar_Syntax_Syntax.term,'Auu____17) FStar_Pervasives_Native.tuple2
@@ -35,81 +29,75 @@ let arg_of_non_null_binder :
   fun uu____29  ->
     match uu____29 with
     | (b,imp) ->
-        let uu____36 = FStar_Syntax_Syntax.bv_to_name b  in (uu____36, imp)
-  
-let (args_of_non_null_binders :
+        let uu____36 = FStar_Syntax_Syntax.bv_to_name b in (uu____36, imp)
+let args_of_non_null_binders:
   FStar_Syntax_Syntax.binders ->
     (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun binders  ->
     FStar_All.pipe_right binders
       (FStar_List.collect
          (fun b  ->
-            let uu____59 = FStar_Syntax_Syntax.is_null_binder b  in
+            let uu____59 = FStar_Syntax_Syntax.is_null_binder b in
             if uu____59
             then []
-            else (let uu____71 = arg_of_non_null_binder b  in [uu____71])))
-  
-let (args_of_binders :
+            else (let uu____71 = arg_of_non_null_binder b in [uu____71])))
+let args_of_binders:
   FStar_Syntax_Syntax.binders ->
     (FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.args)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun binders  ->
     let uu____95 =
       FStar_All.pipe_right binders
         (FStar_List.map
            (fun b  ->
-              let uu____141 = FStar_Syntax_Syntax.is_null_binder b  in
+              let uu____141 = FStar_Syntax_Syntax.is_null_binder b in
               if uu____141
               then
                 let b1 =
                   let uu____159 =
                     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                      (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                     in
-                  (uu____159, (FStar_Pervasives_Native.snd b))  in
-                let uu____160 = arg_of_non_null_binder b1  in (b1, uu____160)
+                      (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
+                  (uu____159, (FStar_Pervasives_Native.snd b)) in
+                let uu____160 = arg_of_non_null_binder b1 in (b1, uu____160)
               else
-                (let uu____174 = arg_of_non_null_binder b  in (b, uu____174))))
-       in
+                (let uu____174 = arg_of_non_null_binder b in (b, uu____174)))) in
     FStar_All.pipe_right uu____95 FStar_List.unzip
-  
-let (name_binders :
+let name_binders:
   FStar_Syntax_Syntax.binder Prims.list ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun binders  ->
     FStar_All.pipe_right binders
       (FStar_List.mapi
          (fun i  ->
             fun b  ->
-              let uu____256 = FStar_Syntax_Syntax.is_null_binder b  in
+              let uu____256 = FStar_Syntax_Syntax.is_null_binder b in
               if uu____256
               then
-                let uu____261 = b  in
+                let uu____261 = b in
                 match uu____261 with
                 | (a,imp) ->
                     let b1 =
                       let uu____269 =
-                        let uu____270 = FStar_Util.string_of_int i  in
-                        Prims.strcat "_" uu____270  in
-                      FStar_Ident.id_of_text uu____269  in
+                        let uu____270 = FStar_Util.string_of_int i in
+                        Prims.strcat "_" uu____270 in
+                      FStar_Ident.id_of_text uu____269 in
                     let b2 =
                       {
                         FStar_Syntax_Syntax.ppname = b1;
                         FStar_Syntax_Syntax.index = (Prims.parse_int "0");
                         FStar_Syntax_Syntax.sort =
                           (a.FStar_Syntax_Syntax.sort)
-                      }  in
+                      } in
                     (b2, imp)
               else b))
-  
-let (name_function_binders :
+let name_function_binders:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
@@ -117,15 +105,14 @@ let (name_function_binders :
         let uu____302 =
           let uu____305 =
             let uu____306 =
-              let uu____319 = name_binders binders  in (uu____319, comp)  in
-            FStar_Syntax_Syntax.Tm_arrow uu____306  in
-          FStar_Syntax_Syntax.mk uu____305  in
+              let uu____319 = name_binders binders in (uu____319, comp) in
+            FStar_Syntax_Syntax.Tm_arrow uu____306 in
+          FStar_Syntax_Syntax.mk uu____305 in
         uu____302 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
     | uu____337 -> t
-  
-let (null_binders_of_tks :
+let null_binders_of_tks:
   (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.aqual)
-    FStar_Pervasives_Native.tuple2 Prims.list -> FStar_Syntax_Syntax.binders)
+    FStar_Pervasives_Native.tuple2 Prims.list -> FStar_Syntax_Syntax.binders
   =
   fun tks  ->
     FStar_All.pipe_right tks
@@ -134,14 +121,12 @@ let (null_binders_of_tks :
             match uu____377 with
             | (t,imp) ->
                 let uu____388 =
-                  let uu____389 = FStar_Syntax_Syntax.null_binder t  in
-                  FStar_All.pipe_left FStar_Pervasives_Native.fst uu____389
-                   in
+                  let uu____389 = FStar_Syntax_Syntax.null_binder t in
+                  FStar_All.pipe_left FStar_Pervasives_Native.fst uu____389 in
                 (uu____388, imp)))
-  
-let (binders_of_tks :
+let binders_of_tks:
   (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.aqual)
-    FStar_Pervasives_Native.tuple2 Prims.list -> FStar_Syntax_Syntax.binders)
+    FStar_Pervasives_Native.tuple2 Prims.list -> FStar_Syntax_Syntax.binders
   =
   fun tks  ->
     FStar_All.pipe_right tks
@@ -152,24 +137,21 @@ let (binders_of_tks :
                 let uu____456 =
                   FStar_Syntax_Syntax.new_bv
                     (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos))
-                    t
-                   in
+                    t in
                 (uu____456, imp)))
-  
-let (binders_of_freevars :
+let binders_of_freevars:
   FStar_Syntax_Syntax.bv FStar_Util.set ->
-    FStar_Syntax_Syntax.binder Prims.list)
+    FStar_Syntax_Syntax.binder Prims.list
   =
   fun fvs  ->
-    let uu____466 = FStar_Util.set_elements fvs  in
+    let uu____466 = FStar_Util.set_elements fvs in
     FStar_All.pipe_right uu____466
       (FStar_List.map FStar_Syntax_Syntax.mk_binder)
-  
-let mk_subst : 'Auu____475 . 'Auu____475 -> 'Auu____475 Prims.list =
-  fun s  -> [s] 
-let (subst_of_list :
+let mk_subst: 'Auu____475 . 'Auu____475 -> 'Auu____475 Prims.list =
+  fun s  -> [s]
+let subst_of_list:
   FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.subst_t)
+    FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.subst_t
   =
   fun formals  ->
     fun actuals  ->
@@ -184,10 +166,9 @@ let (subst_of_list :
                       (FStar_Pervasives_Native.fst a)))
                  :: out) formals actuals []
       else failwith "Ill-formed substitution"
-  
-let (rename_binders :
+let rename_binders:
   FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t)
+    FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t
   =
   fun replace_xs  ->
     fun with_ys  ->
@@ -199,23 +180,20 @@ let (rename_binders :
                match (uu____562, uu____563) with
                | ((x,uu____581),(y,uu____583)) ->
                    let uu____592 =
-                     let uu____599 = FStar_Syntax_Syntax.bv_to_name y  in
-                     (x, uu____599)  in
+                     let uu____599 = FStar_Syntax_Syntax.bv_to_name y in
+                     (x, uu____599) in
                    FStar_Syntax_Syntax.NT uu____592) replace_xs with_ys
       else failwith "Ill-formed substitution"
-  
-let rec (unmeta : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let rec unmeta: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun e  ->
-    let e1 = FStar_Syntax_Subst.compress e  in
+    let e1 = FStar_Syntax_Subst.compress e in
     match e1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_meta (e2,uu____606) -> unmeta e2
     | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____612,uu____613) -> unmeta e2
     | uu____654 -> e1
-  
-let rec (unmeta_safe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  =
+let rec unmeta_safe: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun e  ->
-    let e1 = FStar_Syntax_Subst.compress e  in
+    let e1 = FStar_Syntax_Subst.compress e in
     match e1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_meta (e',m) ->
         (match m with
@@ -226,10 +204,9 @@ let rec (unmeta_safe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
     | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____692,uu____693) ->
         unmeta_safe e2
     | uu____734 -> e1
-  
-let rec (univ_kernel :
+let rec univ_kernel:
   FStar_Syntax_Syntax.universe ->
-    (FStar_Syntax_Syntax.universe,Prims.int) FStar_Pervasives_Native.tuple2)
+    (FStar_Syntax_Syntax.universe,Prims.int) FStar_Pervasives_Native.tuple2
   =
   fun u  ->
     match u with
@@ -238,20 +215,17 @@ let rec (univ_kernel :
     | FStar_Syntax_Syntax.U_unif uu____747 -> (u, (Prims.parse_int "0"))
     | FStar_Syntax_Syntax.U_zero  -> (u, (Prims.parse_int "0"))
     | FStar_Syntax_Syntax.U_succ u1 ->
-        let uu____757 = univ_kernel u1  in
+        let uu____757 = univ_kernel u1 in
         (match uu____757 with | (k,n1) -> (k, (n1 + (Prims.parse_int "1"))))
     | FStar_Syntax_Syntax.U_max uu____768 ->
         failwith "Imposible: univ_kernel (U_max _)"
     | FStar_Syntax_Syntax.U_bvar uu____775 ->
         failwith "Imposible: univ_kernel (U_bvar _)"
-  
-let (constant_univ_as_nat : FStar_Syntax_Syntax.universe -> Prims.int) =
+let constant_univ_as_nat: FStar_Syntax_Syntax.universe -> Prims.int =
   fun u  ->
-    let uu____783 = univ_kernel u  in FStar_Pervasives_Native.snd uu____783
-  
-let rec (compare_univs :
-  FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.int)
-  =
+    let uu____783 = univ_kernel u in FStar_Pervasives_Native.snd uu____783
+let rec compare_univs:
+  FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.int =
   fun u1  ->
     fun u2  ->
       match (u1, u2) with
@@ -260,69 +234,65 @@ let rec (compare_univs :
       | (uu____796,FStar_Syntax_Syntax.U_bvar uu____797) ->
           failwith "Impossible: compare_univs"
       | (FStar_Syntax_Syntax.U_unknown ,FStar_Syntax_Syntax.U_unknown ) ->
-          (Prims.parse_int "0")
-      | (FStar_Syntax_Syntax.U_unknown ,uu____798) ->
-          ~- (Prims.parse_int "1")
-      | (uu____799,FStar_Syntax_Syntax.U_unknown ) -> (Prims.parse_int "1")
+          Prims.parse_int "0"
+      | (FStar_Syntax_Syntax.U_unknown ,uu____798) -> - (Prims.parse_int "1")
+      | (uu____799,FStar_Syntax_Syntax.U_unknown ) -> Prims.parse_int "1"
       | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_zero ) ->
-          (Prims.parse_int "0")
-      | (FStar_Syntax_Syntax.U_zero ,uu____800) -> ~- (Prims.parse_int "1")
-      | (uu____801,FStar_Syntax_Syntax.U_zero ) -> (Prims.parse_int "1")
+          Prims.parse_int "0"
+      | (FStar_Syntax_Syntax.U_zero ,uu____800) -> - (Prims.parse_int "1")
+      | (uu____801,FStar_Syntax_Syntax.U_zero ) -> Prims.parse_int "1"
       | (FStar_Syntax_Syntax.U_name u11,FStar_Syntax_Syntax.U_name u21) ->
           FStar_String.compare u11.FStar_Ident.idText u21.FStar_Ident.idText
       | (FStar_Syntax_Syntax.U_name uu____804,FStar_Syntax_Syntax.U_unif
-         uu____805) -> ~- (Prims.parse_int "1")
+         uu____805) -> - (Prims.parse_int "1")
       | (FStar_Syntax_Syntax.U_unif uu____814,FStar_Syntax_Syntax.U_name
-         uu____815) -> (Prims.parse_int "1")
+         uu____815) -> Prims.parse_int "1"
       | (FStar_Syntax_Syntax.U_unif u11,FStar_Syntax_Syntax.U_unif u21) ->
-          let uu____842 = FStar_Syntax_Unionfind.univ_uvar_id u11  in
-          let uu____843 = FStar_Syntax_Unionfind.univ_uvar_id u21  in
+          let uu____842 = FStar_Syntax_Unionfind.univ_uvar_id u11 in
+          let uu____843 = FStar_Syntax_Unionfind.univ_uvar_id u21 in
           uu____842 - uu____843
       | (FStar_Syntax_Syntax.U_max us1,FStar_Syntax_Syntax.U_max us2) ->
-          let n1 = FStar_List.length us1  in
-          let n2 = FStar_List.length us2  in
+          let n1 = FStar_List.length us1 in
+          let n2 = FStar_List.length us2 in
           if n1 <> n2
           then n1 - n2
           else
             (let copt =
-               let uu____874 = FStar_List.zip us1 us2  in
+               let uu____874 = FStar_List.zip us1 us2 in
                FStar_Util.find_map uu____874
                  (fun uu____889  ->
                     match uu____889 with
                     | (u11,u21) ->
-                        let c = compare_univs u11 u21  in
+                        let c = compare_univs u11 u21 in
                         if c <> (Prims.parse_int "0")
                         then FStar_Pervasives_Native.Some c
-                        else FStar_Pervasives_Native.None)
-                in
+                        else FStar_Pervasives_Native.None) in
              match copt with
-             | FStar_Pervasives_Native.None  -> (Prims.parse_int "0")
+             | FStar_Pervasives_Native.None  -> Prims.parse_int "0"
              | FStar_Pervasives_Native.Some c -> c)
       | (FStar_Syntax_Syntax.U_max uu____903,uu____904) ->
-          ~- (Prims.parse_int "1")
+          - (Prims.parse_int "1")
       | (uu____907,FStar_Syntax_Syntax.U_max uu____908) ->
-          (Prims.parse_int "1")
+          Prims.parse_int "1"
       | uu____911 ->
-          let uu____916 = univ_kernel u1  in
+          let uu____916 = univ_kernel u1 in
           (match uu____916 with
            | (k1,n1) ->
-               let uu____923 = univ_kernel u2  in
+               let uu____923 = univ_kernel u2 in
                (match uu____923 with
                 | (k2,n2) ->
-                    let r = compare_univs k1 k2  in
+                    let r = compare_univs k1 k2 in
                     if r = (Prims.parse_int "0") then n1 - n2 else r))
-  
-let (eq_univs :
-  FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.bool)
+let eq_univs:
+  FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.bool
   =
   fun u1  ->
     fun u2  ->
-      let uu____938 = compare_univs u1 u2  in
+      let uu____938 = compare_univs u1 u2 in
       uu____938 = (Prims.parse_int "0")
-  
-let (ml_comp :
+let ml_comp:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-    FStar_Range.range -> FStar_Syntax_Syntax.comp)
+    FStar_Range.range -> FStar_Syntax_Syntax.comp
   =
   fun t  ->
     fun r  ->
@@ -335,9 +305,8 @@ let (ml_comp :
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = [FStar_Syntax_Syntax.MLEFFECT]
         }
-  
-let (comp_effect_name :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> FStar_Ident.lident)
+let comp_effect_name:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> FStar_Ident.lident
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
@@ -346,10 +315,9 @@ let (comp_effect_name :
         FStar_Parser_Const.effect_Tot_lid
     | FStar_Syntax_Syntax.GTotal uu____972 ->
         FStar_Parser_Const.effect_GTot_lid
-  
-let (comp_flags :
+let comp_flags:
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.cflags Prims.list)
+    FStar_Syntax_Syntax.cflags Prims.list
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
@@ -357,11 +325,10 @@ let (comp_flags :
     | FStar_Syntax_Syntax.GTotal uu____1001 ->
         [FStar_Syntax_Syntax.SOMETRIVIAL]
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.flags
-  
-let (comp_set_flags :
+let comp_set_flags:
   FStar_Syntax_Syntax.comp ->
     FStar_Syntax_Syntax.cflags Prims.list ->
-      FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax
   =
   fun c  ->
     fun f  ->
@@ -370,8 +337,8 @@ let (comp_set_flags :
         | FStar_Syntax_Syntax.Comp c2 -> c2
         | FStar_Syntax_Syntax.Total (t,u_opt) ->
             let uu____1038 =
-              let uu____1039 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
-              FStar_Util.dflt [] uu____1039  in
+              let uu____1039 = FStar_Util.map_opt u_opt (fun x  -> [x]) in
+              FStar_Util.dflt [] uu____1039 in
             {
               FStar_Syntax_Syntax.comp_univs = uu____1038;
               FStar_Syntax_Syntax.effect_name = (comp_effect_name c1);
@@ -381,20 +348,19 @@ let (comp_set_flags :
             }
         | FStar_Syntax_Syntax.GTotal (t,u_opt) ->
             let uu____1066 =
-              let uu____1067 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
-              FStar_Util.dflt [] uu____1067  in
+              let uu____1067 = FStar_Util.map_opt u_opt (fun x  -> [x]) in
+              FStar_Util.dflt [] uu____1067 in
             {
               FStar_Syntax_Syntax.comp_univs = uu____1066;
               FStar_Syntax_Syntax.effect_name = (comp_effect_name c1);
               FStar_Syntax_Syntax.result_typ = t;
               FStar_Syntax_Syntax.effect_args = [];
               FStar_Syntax_Syntax.flags = (comp_flags c1)
-            }
-         in
-      let uu___50_1084 = c  in
+            } in
+      let uu___50_1084 = c in
       let uu____1085 =
         let uu____1086 =
-          let uu___51_1087 = comp_to_comp_typ c  in
+          let uu___51_1087 = comp_to_comp_typ c in
           {
             FStar_Syntax_Syntax.comp_univs =
               (uu___51_1087.FStar_Syntax_Syntax.comp_univs);
@@ -405,17 +371,16 @@ let (comp_set_flags :
             FStar_Syntax_Syntax.effect_args =
               (uu___51_1087.FStar_Syntax_Syntax.effect_args);
             FStar_Syntax_Syntax.flags = f
-          }  in
-        FStar_Syntax_Syntax.Comp uu____1086  in
+          } in
+        FStar_Syntax_Syntax.Comp uu____1086 in
       {
         FStar_Syntax_Syntax.n = uu____1085;
         FStar_Syntax_Syntax.pos = (uu___50_1084.FStar_Syntax_Syntax.pos);
         FStar_Syntax_Syntax.vars = (uu___50_1084.FStar_Syntax_Syntax.vars)
       }
-  
-let (lcomp_set_flags :
+let lcomp_set_flags:
   FStar_Syntax_Syntax.lcomp ->
-    FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.lcomp)
+    FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.lcomp
   =
   fun lc  ->
     fun fs  ->
@@ -425,7 +390,7 @@ let (lcomp_set_flags :
         | FStar_Syntax_Syntax.GTotal uu____1111 -> c
         | FStar_Syntax_Syntax.Comp ct ->
             let ct1 =
-              let uu___52_1122 = ct  in
+              let uu___52_1122 = ct in
               {
                 FStar_Syntax_Syntax.comp_univs =
                   (uu___52_1122.FStar_Syntax_Syntax.comp_univs);
@@ -436,24 +401,22 @@ let (lcomp_set_flags :
                 FStar_Syntax_Syntax.effect_args =
                   (uu___52_1122.FStar_Syntax_Syntax.effect_args);
                 FStar_Syntax_Syntax.flags = fs
-              }  in
-            let uu___53_1123 = c  in
+              } in
+            let uu___53_1123 = c in
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
               FStar_Syntax_Syntax.pos =
                 (uu___53_1123.FStar_Syntax_Syntax.pos);
               FStar_Syntax_Syntax.vars =
                 (uu___53_1123.FStar_Syntax_Syntax.vars)
-            }
-         in
+            } in
       FStar_Syntax_Syntax.mk_lcomp lc.FStar_Syntax_Syntax.eff_name
         lc.FStar_Syntax_Syntax.res_typ fs
         (fun uu____1126  ->
-           let uu____1127 = FStar_Syntax_Syntax.lcomp_comp lc  in
+           let uu____1127 = FStar_Syntax_Syntax.lcomp_comp lc in
            comp_typ_set_flags uu____1127)
-  
-let (comp_to_comp_typ :
-  FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ) =
+let comp_to_comp_typ:
+  FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp c1 -> c1
@@ -475,9 +438,8 @@ let (comp_to_comp_typ :
         }
     | uu____1160 ->
         failwith "Assertion failed: Computation type without universe"
-  
-let (is_named_tot :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_named_tot:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp c1 ->
@@ -485,9 +447,8 @@ let (is_named_tot :
           FStar_Parser_Const.effect_Tot_lid
     | FStar_Syntax_Syntax.Total uu____1169 -> true
     | FStar_Syntax_Syntax.GTotal uu____1178 -> false
-  
-let (is_total_comp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_total_comp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     (FStar_Ident.lid_equals (comp_effect_name c)
        FStar_Parser_Const.effect_Tot_lid)
@@ -499,8 +460,7 @@ let (is_total_comp :
                | FStar_Syntax_Syntax.TOTAL  -> true
                | FStar_Syntax_Syntax.RETURN  -> true
                | uu____1198 -> false)))
-  
-let (is_total_lcomp : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+let is_total_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
   fun c  ->
     (FStar_Ident.lid_equals c.FStar_Syntax_Syntax.eff_name
        FStar_Parser_Const.effect_Tot_lid)
@@ -512,8 +472,7 @@ let (is_total_lcomp : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
                | FStar_Syntax_Syntax.TOTAL  -> true
                | FStar_Syntax_Syntax.RETURN  -> true
                | uu____1206 -> false)))
-  
-let (is_tot_or_gtot_lcomp : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+let is_tot_or_gtot_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
   fun c  ->
     ((FStar_Ident.lid_equals c.FStar_Syntax_Syntax.eff_name
         FStar_Parser_Const.effect_Tot_lid)
@@ -528,14 +487,12 @@ let (is_tot_or_gtot_lcomp : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
                | FStar_Syntax_Syntax.TOTAL  -> true
                | FStar_Syntax_Syntax.RETURN  -> true
                | uu____1214 -> false)))
-  
-let (is_tac_lcomp : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+let is_tac_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
   fun c  ->
     FStar_Ident.lid_equals c.FStar_Syntax_Syntax.eff_name
       FStar_Parser_Const.effect_Tac_lid
-  
-let (is_partial_return :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_partial_return:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     FStar_All.pipe_right (comp_flags c)
       (FStar_Util.for_some
@@ -544,8 +501,7 @@ let (is_partial_return :
             | FStar_Syntax_Syntax.RETURN  -> true
             | FStar_Syntax_Syntax.PARTIAL_RETURN  -> true
             | uu____1229 -> false))
-  
-let (is_lcomp_partial_return : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+let is_lcomp_partial_return: FStar_Syntax_Syntax.lcomp -> Prims.bool =
   fun c  ->
     FStar_All.pipe_right c.FStar_Syntax_Syntax.cflags
       (FStar_Util.for_some
@@ -554,28 +510,24 @@ let (is_lcomp_partial_return : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
             | FStar_Syntax_Syntax.RETURN  -> true
             | FStar_Syntax_Syntax.PARTIAL_RETURN  -> true
             | uu____1237 -> false))
-  
-let (is_tot_or_gtot_comp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_tot_or_gtot_comp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     (is_total_comp c) ||
       (FStar_Ident.lid_equals FStar_Parser_Const.effect_GTot_lid
          (comp_effect_name c))
-  
-let (is_tac_comp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_tac_comp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     FStar_Ident.lid_equals FStar_Parser_Const.effect_Tac_lid
       (comp_effect_name c)
-  
-let (is_pure_effect : FStar_Ident.lident -> Prims.bool) =
+let is_pure_effect: FStar_Ident.lident -> Prims.bool =
   fun l  ->
     ((FStar_Ident.lid_equals l FStar_Parser_Const.effect_Tot_lid) ||
        (FStar_Ident.lid_equals l FStar_Parser_Const.effect_PURE_lid))
       || (FStar_Ident.lid_equals l FStar_Parser_Const.effect_Pure_lid)
-  
-let (is_pure_comp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_pure_comp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total uu____1262 -> true
@@ -590,17 +542,15 @@ let (is_pure_comp :
                    match uu___43_1284 with
                    | FStar_Syntax_Syntax.LEMMA  -> true
                    | uu____1285 -> false)))
-  
-let (is_ghost_effect : FStar_Ident.lident -> Prims.bool) =
+let is_ghost_effect: FStar_Ident.lident -> Prims.bool =
   fun l  ->
     ((FStar_Ident.lid_equals FStar_Parser_Const.effect_GTot_lid l) ||
        (FStar_Ident.lid_equals FStar_Parser_Const.effect_GHOST_lid l))
       || (FStar_Ident.lid_equals FStar_Parser_Const.effect_Ghost_lid l)
-  
-let (is_pure_or_ghost_comp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
-  fun c  -> (is_pure_comp c) || (is_ghost_effect (comp_effect_name c)) 
-let (is_pure_lcomp : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+let is_pure_or_ghost_comp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
+  fun c  -> (is_pure_comp c) || (is_ghost_effect (comp_effect_name c))
+let is_pure_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
   fun lc  ->
     ((is_total_lcomp lc) || (is_pure_effect lc.FStar_Syntax_Syntax.eff_name))
       ||
@@ -610,82 +560,74 @@ let (is_pure_lcomp : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
                match uu___44_1302 with
                | FStar_Syntax_Syntax.LEMMA  -> true
                | uu____1303 -> false)))
-  
-let (is_pure_or_ghost_lcomp : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+let is_pure_or_ghost_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
   fun lc  ->
     (is_pure_lcomp lc) || (is_ghost_effect lc.FStar_Syntax_Syntax.eff_name)
-  
-let (is_pure_or_ghost_function : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_pure_or_ghost_function: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____1310 =
-      let uu____1311 = FStar_Syntax_Subst.compress t  in
-      uu____1311.FStar_Syntax_Syntax.n  in
+      let uu____1311 = FStar_Syntax_Subst.compress t in
+      uu____1311.FStar_Syntax_Syntax.n in
     match uu____1310 with
     | FStar_Syntax_Syntax.Tm_arrow (uu____1314,c) -> is_pure_or_ghost_comp c
     | uu____1332 -> true
-  
-let (is_lemma_comp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_lemma_comp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp ct ->
         FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
           FStar_Parser_Const.effect_Lemma_lid
     | uu____1341 -> false
-  
-let (is_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_lemma: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____1345 =
-      let uu____1346 = FStar_Syntax_Subst.compress t  in
-      uu____1346.FStar_Syntax_Syntax.n  in
+      let uu____1346 = FStar_Syntax_Subst.compress t in
+      uu____1346.FStar_Syntax_Syntax.n in
     match uu____1345 with
     | FStar_Syntax_Syntax.Tm_arrow (uu____1349,c) -> is_lemma_comp c
     | uu____1367 -> false
-  
-let (head_and_args :
+let head_and_args:
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,(FStar_Syntax_Syntax.term'
                                                              FStar_Syntax_Syntax.syntax,
                                                             FStar_Syntax_Syntax.aqual)
                                                             FStar_Pervasives_Native.tuple2
                                                             Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t  in
+    let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head1,args) -> (head1, args)
     | uu____1432 -> (t1, [])
-  
-let rec (head_and_args' :
+let rec head_and_args':
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.term,(FStar_Syntax_Syntax.term'
                                  FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
                                 FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t  in
+    let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-        let uu____1497 = head_and_args' head1  in
+        let uu____1497 = head_and_args' head1 in
         (match uu____1497 with
          | (head2,args') -> (head2, (FStar_List.append args' args)))
     | uu____1554 -> (t1, [])
-  
-let (un_uinst : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let un_uinst: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t  in
+    let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_uinst (t2,uu____1574) ->
         FStar_Syntax_Subst.compress t2
     | uu____1579 -> t1
-  
-let (is_smt_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_smt_lemma: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____1583 =
-      let uu____1584 = FStar_Syntax_Subst.compress t  in
-      uu____1584.FStar_Syntax_Syntax.n  in
+      let uu____1584 = FStar_Syntax_Subst.compress t in
+      uu____1584.FStar_Syntax_Syntax.n in
     match uu____1583 with
     | FStar_Syntax_Syntax.Tm_arrow (uu____1587,c) ->
         (match c.FStar_Syntax_Syntax.n with
@@ -695,13 +637,13 @@ let (is_smt_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
              ->
              (match ct.FStar_Syntax_Syntax.effect_args with
               | _req::_ens::(pats,uu____1609)::uu____1610 ->
-                  let pats' = unmeta pats  in
-                  let uu____1654 = head_and_args pats'  in
+                  let pats' = unmeta pats in
+                  let uu____1654 = head_and_args pats' in
                   (match uu____1654 with
                    | (head1,uu____1670) ->
                        let uu____1691 =
-                         let uu____1692 = un_uinst head1  in
-                         uu____1692.FStar_Syntax_Syntax.n  in
+                         let uu____1692 = un_uinst head1 in
+                         uu____1692.FStar_Syntax_Syntax.n in
                        (match uu____1691 with
                         | FStar_Syntax_Syntax.Tm_fvar fv ->
                             FStar_Syntax_Syntax.fv_eq_lid fv
@@ -710,9 +652,8 @@ let (is_smt_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
               | uu____1697 -> false)
          | uu____1706 -> false)
     | uu____1707 -> false
-  
-let (is_ml_comp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_ml_comp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp c1 ->
@@ -726,20 +667,18 @@ let (is_ml_comp :
                    | FStar_Syntax_Syntax.MLEFFECT  -> true
                    | uu____1720 -> false)))
     | uu____1721 -> false
-  
-let (comp_result :
+let comp_result:
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total (t,uu____1734) -> t
     | FStar_Syntax_Syntax.GTotal (t,uu____1744) -> t
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.result_typ
-  
-let (set_result_typ :
+let set_result_typ:
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.comp)
+    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.comp
   =
   fun c  ->
     fun t  ->
@@ -750,7 +689,7 @@ let (set_result_typ :
           FStar_Syntax_Syntax.mk_GTotal t
       | FStar_Syntax_Syntax.Comp ct ->
           FStar_Syntax_Syntax.mk_Comp
-            (let uu___54_1785 = ct  in
+            (let uu___54_1785 = ct in
              {
                FStar_Syntax_Syntax.comp_univs =
                  (uu___54_1785.FStar_Syntax_Syntax.comp_univs);
@@ -762,9 +701,8 @@ let (set_result_typ :
                FStar_Syntax_Syntax.flags =
                  (uu___54_1785.FStar_Syntax_Syntax.flags)
              })
-  
-let (is_trivial_wp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_trivial_wp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     FStar_All.pipe_right (comp_flags c)
       (FStar_Util.for_some
@@ -773,8 +711,7 @@ let (is_trivial_wp :
             | FStar_Syntax_Syntax.TOTAL  -> true
             | FStar_Syntax_Syntax.RETURN  -> true
             | uu____1797 -> false))
-  
-let (primops : FStar_Ident.lident Prims.list) =
+let primops: FStar_Ident.lident Prims.list =
   [FStar_Parser_Const.op_Eq;
   FStar_Parser_Const.op_notEq;
   FStar_Parser_Const.op_LT;
@@ -789,36 +726,33 @@ let (primops : FStar_Ident.lident Prims.list) =
   FStar_Parser_Const.op_Modulus;
   FStar_Parser_Const.op_And;
   FStar_Parser_Const.op_Or;
-  FStar_Parser_Const.op_Negation] 
-let (is_primop_lid : FStar_Ident.lident -> Prims.bool) =
+  FStar_Parser_Const.op_Negation]
+let is_primop_lid: FStar_Ident.lident -> Prims.bool =
   fun l  ->
     FStar_All.pipe_right primops
       (FStar_Util.for_some (FStar_Ident.lid_equals l))
-  
-let (is_primop :
-  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_primop:
+  FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun f  ->
     match f.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         is_primop_lid (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
     | uu____1813 -> false
-  
-let rec (unascribe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let rec unascribe: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun e  ->
-    let e1 = FStar_Syntax_Subst.compress e  in
+    let e1 = FStar_Syntax_Subst.compress e in
     match e1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____1819,uu____1820) ->
         unascribe e2
     | uu____1861 -> e1
-  
-let rec (ascribe :
+let rec ascribe:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.comp'
                                                              FStar_Syntax_Syntax.syntax)
        FStar_Util.either,FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
                            FStar_Pervasives_Native.option)
       FStar_Pervasives_Native.tuple2 ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t  ->
     fun k  ->
@@ -830,24 +764,20 @@ let rec (ascribe :
             (FStar_Syntax_Syntax.Tm_ascribed
                (t, k, FStar_Pervasives_Native.None))
             FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-  
 type eq_result =
-  | Equal 
-  | NotEqual 
-  | Unknown [@@deriving show]
-let (uu___is_Equal : eq_result -> Prims.bool) =
+  | Equal
+  | NotEqual
+  | Unknown[@@deriving show]
+let uu___is_Equal: eq_result -> Prims.bool =
   fun projectee  ->
     match projectee with | Equal  -> true | uu____1975 -> false
-  
-let (uu___is_NotEqual : eq_result -> Prims.bool) =
+let uu___is_NotEqual: eq_result -> Prims.bool =
   fun projectee  ->
     match projectee with | NotEqual  -> true | uu____1979 -> false
-  
-let (uu___is_Unknown : eq_result -> Prims.bool) =
+let uu___is_Unknown: eq_result -> Prims.bool =
   fun projectee  ->
     match projectee with | Unknown  -> true | uu____1983 -> false
-  
-let (injectives : Prims.string Prims.list) =
+let injectives: Prims.string Prims.list =
   ["FStar.Int8.int_to_t";
   "FStar.Int16.int_to_t";
   "FStar.Int32.int_to_t";
@@ -863,47 +793,44 @@ let (injectives : Prims.string Prims.list) =
   "FStar.UInt8.__uint_to_t";
   "FStar.UInt16.__uint_to_t";
   "FStar.UInt32.__uint_to_t";
-  "FStar.UInt64.__uint_to_t"] 
-let rec (eq_tm :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> eq_result) =
+  "FStar.UInt64.__uint_to_t"]
+let rec eq_tm:
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> eq_result =
   fun t1  ->
     fun t2  ->
       let canon_app t =
         let uu____2006 =
-          let uu____2019 = unascribe t  in head_and_args' uu____2019  in
+          let uu____2019 = unascribe t in head_and_args' uu____2019 in
         match uu____2006 with
         | (hd1,args) ->
             FStar_Syntax_Syntax.mk_Tm_app hd1 args
-              FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-         in
-      let t11 = canon_app t1  in
-      let t21 = canon_app t2  in
-      let equal_if uu___47_2049 = if uu___47_2049 then Equal else Unknown  in
-      let equal_iff uu___48_2054 = if uu___48_2054 then Equal else NotEqual
-         in
-      let eq_and f g = match f with | Equal  -> g () | uu____2068 -> Unknown
-         in
+              FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos in
+      let t11 = canon_app t1 in
+      let t21 = canon_app t2 in
+      let equal_if uu___47_2049 = if uu___47_2049 then Equal else Unknown in
+      let equal_iff uu___48_2054 = if uu___48_2054 then Equal else NotEqual in
+      let eq_and f g = match f with | Equal  -> g () | uu____2068 -> Unknown in
       let eq_inj f g =
         match (f, g) with
         | (Equal ,Equal ) -> Equal
         | (NotEqual ,uu____2076) -> NotEqual
         | (uu____2077,NotEqual ) -> NotEqual
         | (Unknown ,uu____2078) -> Unknown
-        | (uu____2079,Unknown ) -> Unknown  in
+        | (uu____2079,Unknown ) -> Unknown in
       let equal_data f1 args1 f2 args2 =
-        let uu____2117 = FStar_Syntax_Syntax.fv_eq f1 f2  in
+        let uu____2117 = FStar_Syntax_Syntax.fv_eq f1 f2 in
         if uu____2117
         then
-          let uu____2121 = FStar_List.zip args1 args2  in
+          let uu____2121 = FStar_List.zip args1 args2 in
           FStar_All.pipe_left
             (FStar_List.fold_left
                (fun acc  ->
                   fun uu____2179  ->
                     match uu____2179 with
                     | ((a1,q1),(a2,q2)) ->
-                        let uu____2207 = eq_tm a1 a2  in
-                        eq_inj acc uu____2207) Equal) uu____2121
-        else NotEqual  in
+                        let uu____2207 = eq_tm a1 a2 in eq_inj acc uu____2207)
+               Equal) uu____2121
+        else NotEqual in
       match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
       | (FStar_Syntax_Syntax.Tm_bvar bv1,FStar_Syntax_Syntax.Tm_bvar bv2) ->
           equal_if
@@ -919,35 +846,35 @@ let rec (eq_tm :
                  (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor))
           then equal_data f [] g []
           else
-            (let uu____2228 = FStar_Syntax_Syntax.fv_eq f g  in
+            (let uu____2228 = FStar_Syntax_Syntax.fv_eq f g in
              equal_if uu____2228)
       | (FStar_Syntax_Syntax.Tm_uinst (f,us),FStar_Syntax_Syntax.Tm_uinst
          (g,vs)) ->
-          let uu____2241 = eq_tm f g  in
+          let uu____2241 = eq_tm f g in
           eq_and uu____2241
             (fun uu____2244  ->
-               let uu____2245 = eq_univs_list us vs  in equal_if uu____2245)
+               let uu____2245 = eq_univs_list us vs in equal_if uu____2245)
       | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
          uu____2246),uu____2247) -> Unknown
       | (uu____2248,FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
          uu____2249)) -> Unknown
       | (FStar_Syntax_Syntax.Tm_constant c,FStar_Syntax_Syntax.Tm_constant d)
           ->
-          let uu____2252 = FStar_Const.eq_const c d  in equal_iff uu____2252
+          let uu____2252 = FStar_Const.eq_const c d in equal_iff uu____2252
       | (FStar_Syntax_Syntax.Tm_uvar
          (u1,uu____2254),FStar_Syntax_Syntax.Tm_uvar (u2,uu____2256)) ->
-          let uu____2305 = FStar_Syntax_Unionfind.equiv u1 u2  in
+          let uu____2305 = FStar_Syntax_Unionfind.equiv u1 u2 in
           equal_if uu____2305
       | (FStar_Syntax_Syntax.Tm_app (h1,args1),FStar_Syntax_Syntax.Tm_app
          (h2,args2)) ->
           let uu____2350 =
             let uu____2355 =
-              let uu____2356 = un_uinst h1  in
-              uu____2356.FStar_Syntax_Syntax.n  in
+              let uu____2356 = un_uinst h1 in
+              uu____2356.FStar_Syntax_Syntax.n in
             let uu____2359 =
-              let uu____2360 = un_uinst h2  in
-              uu____2360.FStar_Syntax_Syntax.n  in
-            (uu____2355, uu____2359)  in
+              let uu____2360 = un_uinst h2 in
+              uu____2360.FStar_Syntax_Syntax.n in
+            (uu____2355, uu____2359) in
           (match uu____2350 with
            | (FStar_Syntax_Syntax.Tm_fvar f1,FStar_Syntax_Syntax.Tm_fvar f2)
                when
@@ -962,57 +889,53 @@ let rec (eq_tm :
                when
                (FStar_Syntax_Syntax.fv_eq f1 f2) &&
                  (let uu____2372 =
-                    let uu____2373 = FStar_Syntax_Syntax.lid_of_fv f1  in
-                    FStar_Ident.string_of_lid uu____2373  in
+                    let uu____2373 = FStar_Syntax_Syntax.lid_of_fv f1 in
+                    FStar_Ident.string_of_lid uu____2373 in
                   FStar_List.mem uu____2372 injectives)
                -> equal_data f1 args1 f2 args2
            | uu____2374 ->
-               let uu____2379 = eq_tm h1 h2  in
+               let uu____2379 = eq_tm h1 h2 in
                eq_and uu____2379 (fun uu____2381  -> eq_args args1 args2))
       | (FStar_Syntax_Syntax.Tm_type u,FStar_Syntax_Syntax.Tm_type v1) ->
-          let uu____2384 = eq_univs u v1  in equal_if uu____2384
+          let uu____2384 = eq_univs u v1 in equal_if uu____2384
       | (FStar_Syntax_Syntax.Tm_meta (t12,uu____2386),uu____2387) ->
           eq_tm t12 t21
       | (uu____2392,FStar_Syntax_Syntax.Tm_meta (t22,uu____2394)) ->
           eq_tm t11 t22
       | uu____2399 -> Unknown
-
-and (eq_args :
-  FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.args -> eq_result) =
+and eq_args:
+  FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.args -> eq_result =
   fun a1  ->
     fun a2  ->
       match (a1, a2) with
       | ([],[]) -> Equal
       | ((a,uu____2435)::a11,(b,uu____2438)::b1) ->
-          let uu____2492 = eq_tm a b  in
+          let uu____2492 = eq_tm a b in
           (match uu____2492 with
            | Equal  -> eq_args a11 b1
            | uu____2493 -> Unknown)
       | uu____2494 -> Unknown
-
-and (eq_univs_list :
+and eq_univs_list:
   FStar_Syntax_Syntax.universes ->
-    FStar_Syntax_Syntax.universes -> Prims.bool)
+    FStar_Syntax_Syntax.universes -> Prims.bool
   =
   fun us  ->
     fun vs  ->
       ((FStar_List.length us) = (FStar_List.length vs)) &&
         (FStar_List.forall2 eq_univs us vs)
-
-let rec (unrefine : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let rec unrefine: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t  in
+    let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_refine (x,uu____2506) ->
         unrefine x.FStar_Syntax_Syntax.sort
     | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____2512,uu____2513) ->
         unrefine t2
     | uu____2554 -> t1
-  
-let rec (is_unit : FStar_Syntax_Syntax.term -> Prims.bool) =
+let rec is_unit: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____2558 =
-      let uu____2559 = unrefine t  in uu____2559.FStar_Syntax_Syntax.n  in
+      let uu____2559 = unrefine t in uu____2559.FStar_Syntax_Syntax.n in
     match uu____2558 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         ((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
@@ -1022,11 +945,10 @@ let rec (is_unit : FStar_Syntax_Syntax.term -> Prims.bool) =
              FStar_Parser_Const.auto_squash_lid)
     | FStar_Syntax_Syntax.Tm_uinst (t1,uu____2564) -> is_unit t1
     | uu____2569 -> false
-  
-let rec (non_informative : FStar_Syntax_Syntax.term -> Prims.bool) =
+let rec non_informative: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____2573 =
-      let uu____2574 = unrefine t  in uu____2574.FStar_Syntax_Syntax.n  in
+      let uu____2574 = unrefine t in uu____2574.FStar_Syntax_Syntax.n in
     match uu____2573 with
     | FStar_Syntax_Syntax.Tm_type uu____2577 -> true
     | FStar_Syntax_Syntax.Tm_fvar fv ->
@@ -1038,51 +960,46 @@ let rec (non_informative : FStar_Syntax_Syntax.term -> Prims.bool) =
     | FStar_Syntax_Syntax.Tm_arrow (uu____2607,c) ->
         (is_tot_or_gtot_comp c) && (non_informative (comp_result c))
     | uu____2625 -> false
-  
-let (is_fun : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_fun: FStar_Syntax_Syntax.term -> Prims.bool =
   fun e  ->
     let uu____2629 =
-      let uu____2630 = FStar_Syntax_Subst.compress e  in
-      uu____2630.FStar_Syntax_Syntax.n  in
+      let uu____2630 = FStar_Syntax_Subst.compress e in
+      uu____2630.FStar_Syntax_Syntax.n in
     match uu____2629 with
     | FStar_Syntax_Syntax.Tm_abs uu____2633 -> true
     | uu____2650 -> false
-  
-let (is_function_typ : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_function_typ: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____2654 =
-      let uu____2655 = FStar_Syntax_Subst.compress t  in
-      uu____2655.FStar_Syntax_Syntax.n  in
+      let uu____2655 = FStar_Syntax_Subst.compress t in
+      uu____2655.FStar_Syntax_Syntax.n in
     match uu____2654 with
     | FStar_Syntax_Syntax.Tm_arrow uu____2658 -> true
     | uu____2671 -> false
-  
-let rec (pre_typ : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let rec pre_typ: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t  in
+    let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_refine (x,uu____2677) ->
         pre_typ x.FStar_Syntax_Syntax.sort
     | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____2683,uu____2684) ->
         pre_typ t2
     | uu____2725 -> t1
-  
-let (destruct :
+let destruct:
   FStar_Syntax_Syntax.term ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
         FStar_Pervasives_Native.tuple2 Prims.list
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
   fun typ  ->
     fun lid  ->
-      let typ1 = FStar_Syntax_Subst.compress typ  in
+      let typ1 = FStar_Syntax_Subst.compress typ in
       let uu____2743 =
-        let uu____2744 = un_uinst typ1  in uu____2744.FStar_Syntax_Syntax.n
-         in
+        let uu____2744 = un_uinst typ1 in uu____2744.FStar_Syntax_Syntax.n in
       match uu____2743 with
       | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-          let head2 = un_uinst head1  in
+          let head2 = un_uinst head1 in
           (match head2.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_fvar tc when
                FStar_Syntax_Syntax.fv_eq_lid tc lid ->
@@ -1092,9 +1009,8 @@ let (destruct :
           FStar_Syntax_Syntax.fv_eq_lid tc lid ->
           FStar_Pervasives_Native.Some []
       | uu____2823 -> FStar_Pervasives_Native.None
-  
-let (lids_of_sigelt :
-  FStar_Syntax_Syntax.sigelt -> FStar_Ident.lident Prims.list) =
+let lids_of_sigelt:
+  FStar_Syntax_Syntax.sigelt -> FStar_Ident.lident Prims.list =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_let (uu____2839,lids) -> lids
@@ -1116,22 +1032,20 @@ let (lids_of_sigelt :
     | FStar_Syntax_Syntax.Sig_sub_effect uu____2896 -> []
     | FStar_Syntax_Syntax.Sig_pragma uu____2897 -> []
     | FStar_Syntax_Syntax.Sig_main uu____2898 -> []
-  
-let (lid_of_sigelt :
+let lid_of_sigelt:
   FStar_Syntax_Syntax.sigelt ->
-    FStar_Ident.lident FStar_Pervasives_Native.option)
+    FStar_Ident.lident FStar_Pervasives_Native.option
   =
   fun se  ->
     match lids_of_sigelt se with
     | l::[] -> FStar_Pervasives_Native.Some l
     | uu____2909 -> FStar_Pervasives_Native.None
-  
-let (quals_of_sigelt :
-  FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.qualifier Prims.list) =
-  fun x  -> x.FStar_Syntax_Syntax.sigquals 
-let (range_of_sigelt : FStar_Syntax_Syntax.sigelt -> FStar_Range.range) =
-  fun x  -> x.FStar_Syntax_Syntax.sigrng 
-let range_of_lb :
+let quals_of_sigelt:
+  FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.qualifier Prims.list =
+  fun x  -> x.FStar_Syntax_Syntax.sigquals
+let range_of_sigelt: FStar_Syntax_Syntax.sigelt -> FStar_Range.range =
+  fun x  -> x.FStar_Syntax_Syntax.sigrng
+let range_of_lb:
   'Auu____2923 'Auu____2924 .
     ((FStar_Syntax_Syntax.bv,FStar_Ident.lid) FStar_Util.either,'Auu____2924,
       'Auu____2923) FStar_Pervasives_Native.tuple3 -> FStar_Range.range
@@ -1141,16 +1055,14 @@ let range_of_lb :
     | (FStar_Util.Inl x,uu____2950,uu____2951) ->
         FStar_Syntax_Syntax.range_of_bv x
     | (FStar_Util.Inr l,uu____2957,uu____2958) -> FStar_Ident.range_of_lid l
-  
-let range_of_arg :
+let range_of_arg:
   'Auu____2966 'Auu____2967 .
     ('Auu____2967 FStar_Syntax_Syntax.syntax,'Auu____2966)
       FStar_Pervasives_Native.tuple2 -> FStar_Range.range
   =
   fun uu____2977  ->
     match uu____2977 with | (hd1,uu____2985) -> hd1.FStar_Syntax_Syntax.pos
-  
-let range_of_args :
+let range_of_args:
   'Auu____2994 'Auu____2995 .
     ('Auu____2995 FStar_Syntax_Syntax.syntax,'Auu____2994)
       FStar_Pervasives_Native.tuple2 Prims.list ->
@@ -1162,24 +1074,22 @@ let range_of_args :
         (FStar_List.fold_left
            (fun r1  -> fun a  -> FStar_Range.union_ranges r1 (range_of_arg a))
            r)
-  
-let (mk_app :
+let mk_app:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
       FStar_Pervasives_Native.tuple2 Prims.list ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun f  ->
     fun args  ->
-      let r = range_of_args args f.FStar_Syntax_Syntax.pos  in
+      let r = range_of_args args f.FStar_Syntax_Syntax.pos in
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (f, args))
         FStar_Pervasives_Native.None r
-  
-let (mk_data :
+let mk_data:
   FStar_Ident.lident ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
       FStar_Pervasives_Native.tuple2 Prims.list ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun l  ->
     fun args  ->
@@ -1192,66 +1102,58 @@ let (mk_data :
                   FStar_Syntax_Syntax.fvar l
                     FStar_Syntax_Syntax.Delta_constant
                     (FStar_Pervasives_Native.Some
-                       FStar_Syntax_Syntax.Data_ctor)
-                   in
+                       FStar_Syntax_Syntax.Data_ctor) in
                 (uu____3126,
                   (FStar_Syntax_Syntax.Meta_desugared
-                     FStar_Syntax_Syntax.Data_app))
-                 in
-              FStar_Syntax_Syntax.Tm_meta uu____3119  in
-            FStar_Syntax_Syntax.mk uu____3118  in
+                     FStar_Syntax_Syntax.Data_app)) in
+              FStar_Syntax_Syntax.Tm_meta uu____3119 in
+            FStar_Syntax_Syntax.mk uu____3118 in
           uu____3115 FStar_Pervasives_Native.None
             (FStar_Ident.range_of_lid l)
       | uu____3130 ->
           let e =
             let uu____3142 =
               FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.Delta_constant
-                (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-               in
-            mk_app uu____3142 args  in
+                (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
+            mk_app uu____3142 args in
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_meta
                (e,
                  (FStar_Syntax_Syntax.Meta_desugared
                     FStar_Syntax_Syntax.Data_app)))
             FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-  
-let (mangle_field_name : FStar_Ident.ident -> FStar_Ident.ident) =
+let mangle_field_name: FStar_Ident.ident -> FStar_Ident.ident =
   fun x  ->
     FStar_Ident.mk_ident
       ((Prims.strcat "__fname__" x.FStar_Ident.idText),
         (x.FStar_Ident.idRange))
-  
-let (unmangle_field_name : FStar_Ident.ident -> FStar_Ident.ident) =
+let unmangle_field_name: FStar_Ident.ident -> FStar_Ident.ident =
   fun x  ->
     if FStar_Util.starts_with x.FStar_Ident.idText "__fname__"
     then
       let uu____3153 =
         let uu____3158 =
           FStar_Util.substring_from x.FStar_Ident.idText
-            (Prims.parse_int "9")
-           in
-        (uu____3158, (x.FStar_Ident.idRange))  in
+            (Prims.parse_int "9") in
+        (uu____3158, (x.FStar_Ident.idRange)) in
       FStar_Ident.mk_ident uu____3153
     else x
-  
-let (field_projector_prefix : Prims.string) = "__proj__" 
-let (field_projector_sep : Prims.string) = "__item__" 
-let (field_projector_contains_constructor : Prims.string -> Prims.bool) =
-  fun s  -> FStar_Util.starts_with s field_projector_prefix 
-let (mk_field_projector_name_from_string :
-  Prims.string -> Prims.string -> Prims.string) =
+let field_projector_prefix: Prims.string = "__proj__"
+let field_projector_sep: Prims.string = "__item__"
+let field_projector_contains_constructor: Prims.string -> Prims.bool =
+  fun s  -> FStar_Util.starts_with s field_projector_prefix
+let mk_field_projector_name_from_string:
+  Prims.string -> Prims.string -> Prims.string =
   fun constr  ->
     fun field  ->
       Prims.strcat field_projector_prefix
         (Prims.strcat constr (Prims.strcat field_projector_sep field))
-  
-let (mk_field_projector_name_from_ident :
-  FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident) =
+let mk_field_projector_name_from_ident:
+  FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident =
   fun lid  ->
     fun i  ->
-      let j = unmangle_field_name i  in
-      let jtext = j.FStar_Ident.idText  in
+      let j = unmangle_field_name i in
+      let jtext = j.FStar_Ident.idText in
       let newi =
         if field_projector_contains_constructor jtext
         then j
@@ -1259,62 +1161,58 @@ let (mk_field_projector_name_from_ident :
           FStar_Ident.mk_ident
             ((mk_field_projector_name_from_string
                 (lid.FStar_Ident.ident).FStar_Ident.idText jtext),
-              (i.FStar_Ident.idRange))
-         in
+              (i.FStar_Ident.idRange)) in
       FStar_Ident.lid_of_ids (FStar_List.append lid.FStar_Ident.ns [newi])
-  
-let (mk_field_projector_name :
+let mk_field_projector_name:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.bv ->
       Prims.int ->
         (FStar_Ident.lident,FStar_Syntax_Syntax.bv)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun lid  ->
     fun x  ->
       fun i  ->
         let nm =
-          let uu____3193 = FStar_Syntax_Syntax.is_null_bv x  in
+          let uu____3193 = FStar_Syntax_Syntax.is_null_bv x in
           if uu____3193
           then
             let uu____3194 =
               let uu____3199 =
-                let uu____3200 = FStar_Util.string_of_int i  in
-                Prims.strcat "_" uu____3200  in
-              let uu____3201 = FStar_Syntax_Syntax.range_of_bv x  in
-              (uu____3199, uu____3201)  in
+                let uu____3200 = FStar_Util.string_of_int i in
+                Prims.strcat "_" uu____3200 in
+              let uu____3201 = FStar_Syntax_Syntax.range_of_bv x in
+              (uu____3199, uu____3201) in
             FStar_Ident.mk_ident uu____3194
-          else x.FStar_Syntax_Syntax.ppname  in
+          else x.FStar_Syntax_Syntax.ppname in
         let y =
-          let uu___55_3204 = x  in
+          let uu___55_3204 = x in
           {
             FStar_Syntax_Syntax.ppname = nm;
             FStar_Syntax_Syntax.index =
               (uu___55_3204.FStar_Syntax_Syntax.index);
             FStar_Syntax_Syntax.sort =
               (uu___55_3204.FStar_Syntax_Syntax.sort)
-          }  in
-        let uu____3205 = mk_field_projector_name_from_ident lid nm  in
+          } in
+        let uu____3205 = mk_field_projector_name_from_ident lid nm in
         (uu____3205, y)
-  
-let (set_uvar :
-  FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> Prims.unit) =
+let set_uvar:
+  FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> Prims.unit =
   fun uv  ->
     fun t  ->
-      let uu____3212 = FStar_Syntax_Unionfind.find uv  in
+      let uu____3212 = FStar_Syntax_Unionfind.find uv in
       match uu____3212 with
       | FStar_Pervasives_Native.Some uu____3215 ->
           let uu____3216 =
             let uu____3217 =
-              let uu____3218 = FStar_Syntax_Unionfind.uvar_id uv  in
-              FStar_All.pipe_left FStar_Util.string_of_int uu____3218  in
-            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____3217  in
+              let uu____3218 = FStar_Syntax_Unionfind.uvar_id uv in
+              FStar_All.pipe_left FStar_Util.string_of_int uu____3218 in
+            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____3217 in
           failwith uu____3216
       | uu____3219 -> FStar_Syntax_Unionfind.change uv t
-  
-let (qualifier_equal :
+let qualifier_equal:
   FStar_Syntax_Syntax.qualifier ->
-    FStar_Syntax_Syntax.qualifier -> Prims.bool)
+    FStar_Syntax_Syntax.qualifier -> Prims.bool
   =
   fun q1  ->
     fun q2  ->
@@ -1353,12 +1251,11 @@ let (qualifier_equal :
                   fun x2  -> x1.FStar_Ident.idText = x2.FStar_Ident.idText)
                f1 f2)
       | uu____3290 -> q1 = q2
-  
-let (abs :
+let abs:
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
-        FStar_Syntax_Syntax.term)
+        FStar_Syntax_Syntax.term
   =
   fun bs  ->
     fun t  ->
@@ -1368,26 +1265,24 @@ let (abs :
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some rc ->
               let uu____3321 =
-                let uu___56_3322 = rc  in
+                let uu___56_3322 = rc in
                 let uu____3323 =
                   FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
-                    (FStar_Syntax_Subst.close bs)
-                   in
+                    (FStar_Syntax_Subst.close bs) in
                 {
                   FStar_Syntax_Syntax.residual_effect =
                     (uu___56_3322.FStar_Syntax_Syntax.residual_effect);
                   FStar_Syntax_Syntax.residual_typ = uu____3323;
                   FStar_Syntax_Syntax.residual_flags =
                     (uu___56_3322.FStar_Syntax_Syntax.residual_flags)
-                }  in
-              FStar_Pervasives_Native.Some uu____3321
-           in
+                } in
+              FStar_Pervasives_Native.Some uu____3321 in
         match bs with
         | [] -> t
         | uu____3334 ->
             let body =
-              let uu____3336 = FStar_Syntax_Subst.close bs t  in
-              FStar_Syntax_Subst.compress uu____3336  in
+              let uu____3336 = FStar_Syntax_Subst.close bs t in
+              FStar_Syntax_Subst.compress uu____3336 in
             (match ((body.FStar_Syntax_Syntax.n), lopt) with
              | (FStar_Syntax_Syntax.Tm_abs
                 (bs',t1,lopt'),FStar_Pervasives_Native.None ) ->
@@ -1395,33 +1290,30 @@ let (abs :
                    let uu____3367 =
                      let uu____3368 =
                        let uu____3385 =
-                         let uu____3392 = FStar_Syntax_Subst.close_binders bs
-                            in
-                         FStar_List.append uu____3392 bs'  in
-                       let uu____3403 = close_lopt lopt'  in
-                       (uu____3385, t1, uu____3403)  in
-                     FStar_Syntax_Syntax.Tm_abs uu____3368  in
-                   FStar_Syntax_Syntax.mk uu____3367  in
+                         let uu____3392 = FStar_Syntax_Subst.close_binders bs in
+                         FStar_List.append uu____3392 bs' in
+                       let uu____3403 = close_lopt lopt' in
+                       (uu____3385, t1, uu____3403) in
+                     FStar_Syntax_Syntax.Tm_abs uu____3368 in
+                   FStar_Syntax_Syntax.mk uu____3367 in
                  uu____3364 FStar_Pervasives_Native.None
                    t1.FStar_Syntax_Syntax.pos
              | uu____3419 ->
                  let uu____3426 =
                    let uu____3429 =
                      let uu____3430 =
-                       let uu____3447 = FStar_Syntax_Subst.close_binders bs
-                          in
-                       let uu____3448 = close_lopt lopt  in
-                       (uu____3447, body, uu____3448)  in
-                     FStar_Syntax_Syntax.Tm_abs uu____3430  in
-                   FStar_Syntax_Syntax.mk uu____3429  in
+                       let uu____3447 = FStar_Syntax_Subst.close_binders bs in
+                       let uu____3448 = close_lopt lopt in
+                       (uu____3447, body, uu____3448) in
+                     FStar_Syntax_Syntax.Tm_abs uu____3430 in
+                   FStar_Syntax_Syntax.mk uu____3429 in
                  uu____3426 FStar_Pervasives_Native.None
                    t.FStar_Syntax_Syntax.pos)
-  
-let (arrow :
+let arrow:
   (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
     FStar_Pervasives_Native.tuple2 Prims.list ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun bs  ->
     fun c  ->
@@ -1431,32 +1323,31 @@ let (arrow :
           let uu____3493 =
             let uu____3496 =
               let uu____3497 =
-                let uu____3510 = FStar_Syntax_Subst.close_binders bs  in
-                let uu____3511 = FStar_Syntax_Subst.close_comp bs c  in
-                (uu____3510, uu____3511)  in
-              FStar_Syntax_Syntax.Tm_arrow uu____3497  in
-            FStar_Syntax_Syntax.mk uu____3496  in
+                let uu____3510 = FStar_Syntax_Subst.close_binders bs in
+                let uu____3511 = FStar_Syntax_Subst.close_comp bs c in
+                (uu____3510, uu____3511) in
+              FStar_Syntax_Syntax.Tm_arrow uu____3497 in
+            FStar_Syntax_Syntax.mk uu____3496 in
           uu____3493 FStar_Pervasives_Native.None c.FStar_Syntax_Syntax.pos
-  
-let (flat_arrow :
+let flat_arrow:
   (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
     FStar_Pervasives_Native.tuple2 Prims.list ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun bs  ->
     fun c  ->
-      let t = arrow bs c  in
+      let t = arrow bs c in
       let uu____3542 =
-        let uu____3543 = FStar_Syntax_Subst.compress t  in
-        uu____3543.FStar_Syntax_Syntax.n  in
+        let uu____3543 = FStar_Syntax_Subst.compress t in
+        uu____3543.FStar_Syntax_Syntax.n in
       match uu____3542 with
       | FStar_Syntax_Syntax.Tm_arrow (bs1,c1) ->
           (match c1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Total (tres,uu____3569) ->
                let uu____3578 =
-                 let uu____3579 = FStar_Syntax_Subst.compress tres  in
-                 uu____3579.FStar_Syntax_Syntax.n  in
+                 let uu____3579 = FStar_Syntax_Subst.compress tres in
+                 uu____3579.FStar_Syntax_Syntax.n in
                (match uu____3578 with
                 | FStar_Syntax_Syntax.Tm_arrow (bs',c') ->
                     FStar_Syntax_Syntax.mk
@@ -1466,49 +1357,47 @@ let (flat_arrow :
                 | uu____3614 -> t)
            | uu____3615 -> t)
       | uu____3616 -> t
-  
-let (refine :
+let refine:
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun b  ->
     fun t  ->
       let uu____3625 =
-        let uu____3626 = FStar_Syntax_Syntax.range_of_bv b  in
-        FStar_Range.union_ranges uu____3626 t.FStar_Syntax_Syntax.pos  in
+        let uu____3626 = FStar_Syntax_Syntax.range_of_bv b in
+        FStar_Range.union_ranges uu____3626 t.FStar_Syntax_Syntax.pos in
       let uu____3627 =
         let uu____3630 =
           let uu____3631 =
             let uu____3638 =
               let uu____3639 =
-                let uu____3640 = FStar_Syntax_Syntax.mk_binder b  in
-                [uu____3640]  in
-              FStar_Syntax_Subst.close uu____3639 t  in
-            (b, uu____3638)  in
-          FStar_Syntax_Syntax.Tm_refine uu____3631  in
-        FStar_Syntax_Syntax.mk uu____3630  in
+                let uu____3640 = FStar_Syntax_Syntax.mk_binder b in
+                [uu____3640] in
+              FStar_Syntax_Subst.close uu____3639 t in
+            (b, uu____3638) in
+          FStar_Syntax_Syntax.Tm_refine uu____3631 in
+        FStar_Syntax_Syntax.mk uu____3630 in
       uu____3627 FStar_Pervasives_Native.None uu____3625
-  
-let (branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch) =
-  fun b  -> FStar_Syntax_Subst.close_branch b 
-let rec (arrow_formals_comp :
+let branch: FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch =
+  fun b  -> FStar_Syntax_Subst.close_branch b
+let rec arrow_formals_comp:
   FStar_Syntax_Syntax.term ->
     ((FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
        FStar_Pervasives_Native.tuple2 Prims.list,FStar_Syntax_Syntax.comp)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun k  ->
-    let k1 = FStar_Syntax_Subst.compress k  in
+    let k1 = FStar_Syntax_Subst.compress k in
     match k1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____3689 = FStar_Syntax_Subst.open_comp bs c  in
+        let uu____3689 = FStar_Syntax_Subst.open_comp bs c in
         (match uu____3689 with
          | (bs1,c1) ->
-             let uu____3706 = is_tot_or_gtot_comp c1  in
+             let uu____3706 = is_tot_or_gtot_comp c1 in
              if uu____3706
              then
-               let uu____3717 = arrow_formals_comp (comp_result c1)  in
+               let uu____3717 = arrow_formals_comp (comp_result c1) in
                (match uu____3717 with
                 | (bs',k2) -> ((FStar_List.append bs1 bs'), k2))
              else (bs1, c1))
@@ -1518,73 +1407,69 @@ let rec (arrow_formals_comp :
            FStar_Syntax_Syntax.sort = k2;_},uu____3766)
         -> arrow_formals_comp k2
     | uu____3773 ->
-        let uu____3774 = FStar_Syntax_Syntax.mk_Total k1  in ([], uu____3774)
-  
-let rec (arrow_formals :
+        let uu____3774 = FStar_Syntax_Syntax.mk_Total k1 in ([], uu____3774)
+let rec arrow_formals:
   FStar_Syntax_Syntax.term ->
     ((FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
        FStar_Pervasives_Native.tuple2 Prims.list,FStar_Syntax_Syntax.term'
                                                    FStar_Syntax_Syntax.syntax)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun k  ->
-    let uu____3800 = arrow_formals_comp k  in
+    let uu____3800 = arrow_formals_comp k in
     match uu____3800 with | (bs,c) -> (bs, (comp_result c))
-  
-let (abs_formals :
+let abs_formals:
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.residual_comp
                                                             FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple3)
+      FStar_Pervasives_Native.tuple3
   =
   fun t  ->
     let subst_lcomp_opt s l =
       match l with
       | FStar_Pervasives_Native.Some rc ->
           let uu____3876 =
-            let uu___57_3877 = rc  in
+            let uu___57_3877 = rc in
             let uu____3878 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
-                (FStar_Syntax_Subst.subst s)
-               in
+                (FStar_Syntax_Subst.subst s) in
             {
               FStar_Syntax_Syntax.residual_effect =
                 (uu___57_3877.FStar_Syntax_Syntax.residual_effect);
               FStar_Syntax_Syntax.residual_typ = uu____3878;
               FStar_Syntax_Syntax.residual_flags =
                 (uu___57_3877.FStar_Syntax_Syntax.residual_flags)
-            }  in
+            } in
           FStar_Pervasives_Native.Some uu____3876
-      | uu____3885 -> l  in
+      | uu____3885 -> l in
     let rec aux t1 abs_body_lcomp =
       let uu____3913 =
         let uu____3914 =
-          let uu____3917 = FStar_Syntax_Subst.compress t1  in
-          FStar_All.pipe_left unascribe uu____3917  in
-        uu____3914.FStar_Syntax_Syntax.n  in
+          let uu____3917 = FStar_Syntax_Subst.compress t1 in
+          FStar_All.pipe_left unascribe uu____3917 in
+        uu____3914.FStar_Syntax_Syntax.n in
       match uu____3913 with
       | FStar_Syntax_Syntax.Tm_abs (bs,t2,what) ->
-          let uu____3955 = aux t2 what  in
+          let uu____3955 = aux t2 what in
           (match uu____3955 with
            | (bs',t3,what1) -> ((FStar_List.append bs bs'), t3, what1))
-      | uu____4015 -> ([], t1, abs_body_lcomp)  in
-    let uu____4028 = aux t FStar_Pervasives_Native.None  in
+      | uu____4015 -> ([], t1, abs_body_lcomp) in
+    let uu____4028 = aux t FStar_Pervasives_Native.None in
     match uu____4028 with
     | (bs,t1,abs_body_lcomp) ->
-        let uu____4070 = FStar_Syntax_Subst.open_term' bs t1  in
+        let uu____4070 = FStar_Syntax_Subst.open_term' bs t1 in
         (match uu____4070 with
          | (bs1,t2,opening) ->
-             let abs_body_lcomp1 = subst_lcomp_opt opening abs_body_lcomp  in
+             let abs_body_lcomp1 = subst_lcomp_opt opening abs_body_lcomp in
              (bs1, t2, abs_body_lcomp1))
-  
-let (mk_letbinding :
+let mk_letbinding:
   (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
     FStar_Syntax_Syntax.univ_name Prims.list ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
         FStar_Ident.lident ->
           FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
             FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list
-              -> FStar_Syntax_Syntax.letbinding)
+              -> FStar_Syntax_Syntax.letbinding
   =
   fun lbname  ->
     fun univ_vars  ->
@@ -1600,8 +1485,7 @@ let (mk_letbinding :
                 FStar_Syntax_Syntax.lbdef = def;
                 FStar_Syntax_Syntax.lbattrs = lbattrs
               }
-  
-let (close_univs_and_mk_letbinding :
+let close_univs_and_mk_letbinding:
   FStar_Syntax_Syntax.fv Prims.list FStar_Pervasives_Native.option ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
       FStar_Ident.ident Prims.list ->
@@ -1609,7 +1493,7 @@ let (close_univs_and_mk_letbinding :
           FStar_Ident.lident ->
             FStar_Syntax_Syntax.term ->
               FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list
-                -> FStar_Syntax_Syntax.letbinding)
+                -> FStar_Syntax_Syntax.letbinding
   =
   fun recs  ->
     fun lbname  ->
@@ -1626,24 +1510,18 @@ let (close_univs_and_mk_letbinding :
                       let universes =
                         FStar_All.pipe_right univ_vars
                           (FStar_List.map
-                             (fun _0_27  -> FStar_Syntax_Syntax.U_name _0_27))
-                         in
+                             (fun _0_27  -> FStar_Syntax_Syntax.U_name _0_27)) in
                       let inst1 =
                         FStar_All.pipe_right fvs
                           (FStar_List.map
                              (fun fv  ->
                                 (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v),
-                                  universes)))
-                         in
-                      FStar_Syntax_InstFV.instantiate inst1 def
-                   in
-                let typ1 = FStar_Syntax_Subst.close_univ_vars univ_vars typ
-                   in
-                let def2 = FStar_Syntax_Subst.close_univ_vars univ_vars def1
-                   in
+                                  universes))) in
+                      FStar_Syntax_InstFV.instantiate inst1 def in
+                let typ1 = FStar_Syntax_Subst.close_univ_vars univ_vars typ in
+                let def2 = FStar_Syntax_Subst.close_univ_vars univ_vars def1 in
                 mk_letbinding lbname univ_vars typ1 eff def2 attrs
-  
-let (open_univ_vars_binders_and_comp :
+let open_univ_vars_binders_and_comp:
   FStar_Syntax_Syntax.univ_names ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
       FStar_Pervasives_Native.tuple2 Prims.list ->
@@ -1651,81 +1529,77 @@ let (open_univ_vars_binders_and_comp :
         (FStar_Syntax_Syntax.univ_names,(FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
                                           FStar_Pervasives_Native.tuple2
                                           Prims.list,FStar_Syntax_Syntax.comp)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun uvs  ->
     fun binders  ->
       fun c  ->
         match binders with
         | [] ->
-            let uu____4318 = FStar_Syntax_Subst.open_univ_vars_comp uvs c  in
+            let uu____4318 = FStar_Syntax_Subst.open_univ_vars_comp uvs c in
             (match uu____4318 with | (uvs1,c1) -> (uvs1, [], c1))
         | uu____4347 ->
-            let t' = arrow binders c  in
-            let uu____4357 = FStar_Syntax_Subst.open_univ_vars uvs t'  in
+            let t' = arrow binders c in
+            let uu____4357 = FStar_Syntax_Subst.open_univ_vars uvs t' in
             (match uu____4357 with
              | (uvs1,t'1) ->
                  let uu____4376 =
-                   let uu____4377 = FStar_Syntax_Subst.compress t'1  in
-                   uu____4377.FStar_Syntax_Syntax.n  in
+                   let uu____4377 = FStar_Syntax_Subst.compress t'1 in
+                   uu____4377.FStar_Syntax_Syntax.n in
                  (match uu____4376 with
                   | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
                       (uvs1, binders1, c1)
                   | uu____4418 -> failwith "Impossible"))
-  
-let (is_tuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
+let is_tuple_constructor: FStar_Syntax_Syntax.typ -> Prims.bool =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Parser_Const.is_tuple_constructor_string
           ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
     | uu____4435 -> false
-  
-let (is_dtuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
+let is_dtuple_constructor: FStar_Syntax_Syntax.typ -> Prims.bool =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Parser_Const.is_dtuple_constructor_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
     | uu____4440 -> false
-  
-let (is_lid_equality : FStar_Ident.lident -> Prims.bool) =
-  fun x  -> FStar_Ident.lid_equals x FStar_Parser_Const.eq2_lid 
-let (is_forall : FStar_Ident.lident -> Prims.bool) =
-  fun lid  -> FStar_Ident.lid_equals lid FStar_Parser_Const.forall_lid 
-let (is_exists : FStar_Ident.lident -> Prims.bool) =
-  fun lid  -> FStar_Ident.lid_equals lid FStar_Parser_Const.exists_lid 
-let (is_qlid : FStar_Ident.lident -> Prims.bool) =
-  fun lid  -> (is_forall lid) || (is_exists lid) 
-let (is_equality :
-  FStar_Ident.lident FStar_Syntax_Syntax.withinfo_t -> Prims.bool) =
-  fun x  -> is_lid_equality x.FStar_Syntax_Syntax.v 
-let (lid_is_connective : FStar_Ident.lident -> Prims.bool) =
+let is_lid_equality: FStar_Ident.lident -> Prims.bool =
+  fun x  -> FStar_Ident.lid_equals x FStar_Parser_Const.eq2_lid
+let is_forall: FStar_Ident.lident -> Prims.bool =
+  fun lid  -> FStar_Ident.lid_equals lid FStar_Parser_Const.forall_lid
+let is_exists: FStar_Ident.lident -> Prims.bool =
+  fun lid  -> FStar_Ident.lid_equals lid FStar_Parser_Const.exists_lid
+let is_qlid: FStar_Ident.lident -> Prims.bool =
+  fun lid  -> (is_forall lid) || (is_exists lid)
+let is_equality:
+  FStar_Ident.lident FStar_Syntax_Syntax.withinfo_t -> Prims.bool =
+  fun x  -> is_lid_equality x.FStar_Syntax_Syntax.v
+let lid_is_connective: FStar_Ident.lident -> Prims.bool =
   let lst =
     [FStar_Parser_Const.and_lid;
     FStar_Parser_Const.or_lid;
     FStar_Parser_Const.not_lid;
     FStar_Parser_Const.iff_lid;
-    FStar_Parser_Const.imp_lid]  in
-  fun lid  -> FStar_Util.for_some (FStar_Ident.lid_equals lid) lst 
-let (is_constructor :
-  FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
+    FStar_Parser_Const.imp_lid] in
+  fun lid  -> FStar_Util.for_some (FStar_Ident.lid_equals lid) lst
+let is_constructor:
+  FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool =
   fun t  ->
     fun lid  ->
       let uu____4472 =
-        let uu____4473 = pre_typ t  in uu____4473.FStar_Syntax_Syntax.n  in
+        let uu____4473 = pre_typ t in uu____4473.FStar_Syntax_Syntax.n in
       match uu____4472 with
       | FStar_Syntax_Syntax.Tm_fvar tc ->
           FStar_Ident.lid_equals
             (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v lid
       | uu____4477 -> false
-  
-let rec (is_constructed_typ :
-  FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
+let rec is_constructed_typ:
+  FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool =
   fun t  ->
     fun lid  ->
       let uu____4484 =
-        let uu____4485 = pre_typ t  in uu____4485.FStar_Syntax_Syntax.n  in
+        let uu____4485 = pre_typ t in uu____4485.FStar_Syntax_Syntax.n in
       match uu____4484 with
       | FStar_Syntax_Syntax.Tm_fvar uu____4488 -> is_constructor t lid
       | FStar_Syntax_Syntax.Tm_app (t1,uu____4490) ->
@@ -1733,13 +1607,12 @@ let rec (is_constructed_typ :
       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____4512) ->
           is_constructed_typ t1 lid
       | uu____4517 -> false
-  
-let rec (get_tycon :
+let rec get_tycon:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun t  ->
-    let t1 = pre_typ t  in
+    let t1 = pre_typ t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_bvar uu____4526 ->
         FStar_Pervasives_Native.Some t1
@@ -1749,8 +1622,7 @@ let rec (get_tycon :
         FStar_Pervasives_Native.Some t1
     | FStar_Syntax_Syntax.Tm_app (t2,uu____4530) -> get_tycon t2
     | uu____4551 -> FStar_Pervasives_Native.None
-  
-let (is_interpreted : FStar_Ident.lident -> Prims.bool) =
+let is_interpreted: FStar_Ident.lident -> Prims.bool =
   fun l  ->
     let theory_syms =
       [FStar_Parser_Const.op_Eq;
@@ -1767,160 +1639,134 @@ let (is_interpreted : FStar_Ident.lident -> Prims.bool) =
       FStar_Parser_Const.op_Modulus;
       FStar_Parser_Const.op_And;
       FStar_Parser_Const.op_Or;
-      FStar_Parser_Const.op_Negation]  in
+      FStar_Parser_Const.op_Negation] in
     FStar_Util.for_some (FStar_Ident.lid_equals l) theory_syms
-  
-let (is_fstar_tactics_embed : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_fstar_tactics_embed: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____4561 =
-      let uu____4562 = un_uinst t  in uu____4562.FStar_Syntax_Syntax.n  in
+      let uu____4562 = un_uinst t in uu____4562.FStar_Syntax_Syntax.n in
     match uu____4561 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Parser_Const.fstar_refl_embed_lid
     | uu____4566 -> false
-  
-let (is_fstar_tactics_quote : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_fstar_tactics_quote: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____4570 =
-      let uu____4571 = un_uinst t  in uu____4571.FStar_Syntax_Syntax.n  in
+      let uu____4571 = un_uinst t in uu____4571.FStar_Syntax_Syntax.n in
     match uu____4570 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.quote_lid
     | uu____4575 -> false
-  
-let (is_fstar_tactics_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_fstar_tactics_by_tactic: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____4579 =
-      let uu____4580 = un_uinst t  in uu____4580.FStar_Syntax_Syntax.n  in
+      let uu____4580 = un_uinst t in uu____4580.FStar_Syntax_Syntax.n in
     match uu____4579 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.by_tactic_lid
     | uu____4584 -> false
-  
-let (is_builtin_tactic : FStar_Ident.lident -> Prims.bool) =
+let is_builtin_tactic: FStar_Ident.lident -> Prims.bool =
   fun md  ->
-    let path = FStar_Ident.path_of_lid md  in
+    let path = FStar_Ident.path_of_lid md in
     if (FStar_List.length path) > (Prims.parse_int "2")
     then
       let uu____4591 =
-        let uu____4594 = FStar_List.splitAt (Prims.parse_int "2") path  in
-        FStar_Pervasives_Native.fst uu____4594  in
+        let uu____4594 = FStar_List.splitAt (Prims.parse_int "2") path in
+        FStar_Pervasives_Native.fst uu____4594 in
       match uu____4591 with
       | "FStar"::"Tactics"::[] -> true
       | "FStar"::"Reflection"::[] -> true
       | uu____4607 -> false
     else false
-  
-let (ktype : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
+let ktype: FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
     FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (ktype0 : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
+let ktype0: FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_zero)
     FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (type_u :
+let type_u:
   Prims.unit ->
     (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.universe)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun uu____4621  ->
     let u =
-      let uu____4627 = FStar_Syntax_Unionfind.univ_fresh ()  in
+      let uu____4627 = FStar_Syntax_Unionfind.univ_fresh () in
       FStar_All.pipe_left (fun _0_28  -> FStar_Syntax_Syntax.U_unif _0_28)
-        uu____4627
-       in
+        uu____4627 in
     let uu____4644 =
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
-        FStar_Pervasives_Native.None FStar_Range.dummyRange
-       in
+        FStar_Pervasives_Native.None FStar_Range.dummyRange in
     (uu____4644, u)
-  
-let (attr_substitute : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  =
+let attr_substitute: FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax =
   let uu____4651 =
     let uu____4654 =
       let uu____4655 =
         let uu____4656 =
           FStar_Ident.lid_of_path ["FStar"; "Pervasives"; "Substitute"]
-            FStar_Range.dummyRange
-           in
+            FStar_Range.dummyRange in
         FStar_Syntax_Syntax.lid_as_fv uu____4656
-          FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None
-         in
-      FStar_Syntax_Syntax.Tm_fvar uu____4655  in
-    FStar_Syntax_Syntax.mk uu____4654  in
-  uu____4651 FStar_Pervasives_Native.None FStar_Range.dummyRange 
-let (exp_true_bool : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
+          FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None in
+      FStar_Syntax_Syntax.Tm_fvar uu____4655 in
+    FStar_Syntax_Syntax.mk uu____4654 in
+  uu____4651 FStar_Pervasives_Native.None FStar_Range.dummyRange
+let exp_true_bool: FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true))
     FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (exp_false_bool : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
+let exp_false_bool: FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool false))
     FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (exp_unit : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
+let exp_unit: FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_unit)
     FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (exp_int : Prims.string -> FStar_Syntax_Syntax.term) =
+let exp_int: Prims.string -> FStar_Syntax_Syntax.term =
   fun s  ->
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_constant
          (FStar_Const.Const_int (s, FStar_Pervasives_Native.None)))
       FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (exp_char : FStar_BaseTypes.char -> FStar_Syntax_Syntax.term) =
+let exp_char: FStar_BaseTypes.char -> FStar_Syntax_Syntax.term =
   fun c  ->
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c))
       FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (exp_string : Prims.string -> FStar_Syntax_Syntax.term) =
+let exp_string: Prims.string -> FStar_Syntax_Syntax.term =
   fun s  ->
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_constant
          (FStar_Const.Const_string (s, FStar_Range.dummyRange)))
       FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (fvar_const : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
+let fvar_const: FStar_Ident.lident -> FStar_Syntax_Syntax.term =
   fun l  ->
     FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.Delta_constant
       FStar_Pervasives_Native.None
-  
-let (tand : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.and_lid 
-let (tor : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.or_lid 
-let (timp : FStar_Syntax_Syntax.term) =
+let tand: FStar_Syntax_Syntax.term = fvar_const FStar_Parser_Const.and_lid
+let tor: FStar_Syntax_Syntax.term = fvar_const FStar_Parser_Const.or_lid
+let timp: FStar_Syntax_Syntax.term =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.imp_lid
     (FStar_Syntax_Syntax.Delta_defined_at_level (Prims.parse_int "1"))
     FStar_Pervasives_Native.None
-  
-let (tiff : FStar_Syntax_Syntax.term) =
+let tiff: FStar_Syntax_Syntax.term =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.iff_lid
     (FStar_Syntax_Syntax.Delta_defined_at_level (Prims.parse_int "2"))
     FStar_Pervasives_Native.None
-  
-let (t_bool : FStar_Syntax_Syntax.term) =
-  fvar_const FStar_Parser_Const.bool_lid 
-let (t_false : FStar_Syntax_Syntax.term) =
-  fvar_const FStar_Parser_Const.false_lid 
-let (t_true : FStar_Syntax_Syntax.term) =
-  fvar_const FStar_Parser_Const.true_lid 
-let (b2t_v : FStar_Syntax_Syntax.term) =
-  fvar_const FStar_Parser_Const.b2t_lid 
-let (t_not : FStar_Syntax_Syntax.term) =
-  fvar_const FStar_Parser_Const.not_lid 
-let (tac_opaque_attr : FStar_Syntax_Syntax.term) = exp_string "tac_opaque" 
-let (mk_conj_opt :
+let t_bool: FStar_Syntax_Syntax.term = fvar_const FStar_Parser_Const.bool_lid
+let t_false: FStar_Syntax_Syntax.term =
+  fvar_const FStar_Parser_Const.false_lid
+let t_true: FStar_Syntax_Syntax.term = fvar_const FStar_Parser_Const.true_lid
+let b2t_v: FStar_Syntax_Syntax.term = fvar_const FStar_Parser_Const.b2t_lid
+let t_not: FStar_Syntax_Syntax.term = fvar_const FStar_Parser_Const.not_lid
+let tac_opaque_attr: FStar_Syntax_Syntax.term = exp_string "tac_opaque"
+let mk_conj_opt:
   FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun phi1  ->
     fun phi2  ->
@@ -1930,272 +1776,248 @@ let (mk_conj_opt :
           let uu____4703 =
             let uu____4706 =
               FStar_Range.union_ranges phi11.FStar_Syntax_Syntax.pos
-                phi2.FStar_Syntax_Syntax.pos
-               in
+                phi2.FStar_Syntax_Syntax.pos in
             let uu____4707 =
               let uu____4710 =
                 let uu____4711 =
                   let uu____4726 =
-                    let uu____4729 = FStar_Syntax_Syntax.as_arg phi11  in
+                    let uu____4729 = FStar_Syntax_Syntax.as_arg phi11 in
                     let uu____4730 =
-                      let uu____4733 = FStar_Syntax_Syntax.as_arg phi2  in
-                      [uu____4733]  in
-                    uu____4729 :: uu____4730  in
-                  (tand, uu____4726)  in
-                FStar_Syntax_Syntax.Tm_app uu____4711  in
-              FStar_Syntax_Syntax.mk uu____4710  in
-            uu____4707 FStar_Pervasives_Native.None uu____4706  in
+                      let uu____4733 = FStar_Syntax_Syntax.as_arg phi2 in
+                      [uu____4733] in
+                    uu____4729 :: uu____4730 in
+                  (tand, uu____4726) in
+                FStar_Syntax_Syntax.Tm_app uu____4711 in
+              FStar_Syntax_Syntax.mk uu____4710 in
+            uu____4707 FStar_Pervasives_Native.None uu____4706 in
           FStar_Pervasives_Native.Some uu____4703
-  
-let (mk_binop :
+let mk_binop:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun op_t  ->
     fun phi1  ->
       fun phi2  ->
         let uu____4756 =
           FStar_Range.union_ranges phi1.FStar_Syntax_Syntax.pos
-            phi2.FStar_Syntax_Syntax.pos
-           in
+            phi2.FStar_Syntax_Syntax.pos in
         let uu____4757 =
           let uu____4760 =
             let uu____4761 =
               let uu____4776 =
-                let uu____4779 = FStar_Syntax_Syntax.as_arg phi1  in
+                let uu____4779 = FStar_Syntax_Syntax.as_arg phi1 in
                 let uu____4780 =
-                  let uu____4783 = FStar_Syntax_Syntax.as_arg phi2  in
-                  [uu____4783]  in
-                uu____4779 :: uu____4780  in
-              (op_t, uu____4776)  in
-            FStar_Syntax_Syntax.Tm_app uu____4761  in
-          FStar_Syntax_Syntax.mk uu____4760  in
+                  let uu____4783 = FStar_Syntax_Syntax.as_arg phi2 in
+                  [uu____4783] in
+                uu____4779 :: uu____4780 in
+              (op_t, uu____4776) in
+            FStar_Syntax_Syntax.Tm_app uu____4761 in
+          FStar_Syntax_Syntax.mk uu____4760 in
         uu____4757 FStar_Pervasives_Native.None uu____4756
-  
-let (mk_neg :
+let mk_neg:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun phi  ->
     let uu____4796 =
       let uu____4799 =
         let uu____4800 =
           let uu____4815 =
-            let uu____4818 = FStar_Syntax_Syntax.as_arg phi  in [uu____4818]
-             in
-          (t_not, uu____4815)  in
-        FStar_Syntax_Syntax.Tm_app uu____4800  in
-      FStar_Syntax_Syntax.mk uu____4799  in
+            let uu____4818 = FStar_Syntax_Syntax.as_arg phi in [uu____4818] in
+          (t_not, uu____4815) in
+        FStar_Syntax_Syntax.Tm_app uu____4800 in
+      FStar_Syntax_Syntax.mk uu____4799 in
     uu____4796 FStar_Pervasives_Native.None phi.FStar_Syntax_Syntax.pos
-  
-let (mk_conj :
+let mk_conj:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  = fun phi1  -> fun phi2  -> mk_binop tand phi1 phi2 
-let (mk_conj_l :
-  FStar_Syntax_Syntax.term Prims.list -> FStar_Syntax_Syntax.term) =
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
+  = fun phi1  -> fun phi2  -> mk_binop tand phi1 phi2
+let mk_conj_l:
+  FStar_Syntax_Syntax.term Prims.list -> FStar_Syntax_Syntax.term =
   fun phi  ->
     match phi with
     | [] ->
         FStar_Syntax_Syntax.fvar FStar_Parser_Const.true_lid
           FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None
     | hd1::tl1 -> FStar_List.fold_right mk_conj tl1 hd1
-  
-let (mk_disj :
+let mk_disj:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  = fun phi1  -> fun phi2  -> mk_binop tor phi1 phi2 
-let (mk_disj_l :
-  FStar_Syntax_Syntax.term Prims.list -> FStar_Syntax_Syntax.term) =
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
+  = fun phi1  -> fun phi2  -> mk_binop tor phi1 phi2
+let mk_disj_l:
+  FStar_Syntax_Syntax.term Prims.list -> FStar_Syntax_Syntax.term =
   fun phi  ->
     match phi with
     | [] -> t_false
     | hd1::tl1 -> FStar_List.fold_right mk_disj tl1 hd1
-  
-let (mk_imp :
+let mk_imp:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  = fun phi1  -> fun phi2  -> mk_binop timp phi1 phi2 
-let (mk_iff :
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
+  = fun phi1  -> fun phi2  -> mk_binop timp phi1 phi2
+let mk_iff:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  = fun phi1  -> fun phi2  -> mk_binop tiff phi1 phi2 
-let (b2t :
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
+  = fun phi1  -> fun phi2  -> mk_binop tiff phi1 phi2
+let b2t:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun e  ->
     let uu____4879 =
       let uu____4882 =
         let uu____4883 =
           let uu____4898 =
-            let uu____4901 = FStar_Syntax_Syntax.as_arg e  in [uu____4901]
-             in
-          (b2t_v, uu____4898)  in
-        FStar_Syntax_Syntax.Tm_app uu____4883  in
-      FStar_Syntax_Syntax.mk uu____4882  in
+            let uu____4901 = FStar_Syntax_Syntax.as_arg e in [uu____4901] in
+          (b2t_v, uu____4898) in
+        FStar_Syntax_Syntax.Tm_app uu____4883 in
+      FStar_Syntax_Syntax.mk uu____4882 in
     uu____4879 FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-  
-let (teq : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.eq2_lid 
-let (mk_untyped_eq2 :
+let teq: FStar_Syntax_Syntax.term = fvar_const FStar_Parser_Const.eq2_lid
+let mk_untyped_eq2:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun e1  ->
     fun e2  ->
       let uu____4915 =
         FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
-          e2.FStar_Syntax_Syntax.pos
-         in
+          e2.FStar_Syntax_Syntax.pos in
       let uu____4916 =
         let uu____4919 =
           let uu____4920 =
             let uu____4935 =
-              let uu____4938 = FStar_Syntax_Syntax.as_arg e1  in
+              let uu____4938 = FStar_Syntax_Syntax.as_arg e1 in
               let uu____4939 =
-                let uu____4942 = FStar_Syntax_Syntax.as_arg e2  in
-                [uu____4942]  in
-              uu____4938 :: uu____4939  in
-            (teq, uu____4935)  in
-          FStar_Syntax_Syntax.Tm_app uu____4920  in
-        FStar_Syntax_Syntax.mk uu____4919  in
+                let uu____4942 = FStar_Syntax_Syntax.as_arg e2 in
+                [uu____4942] in
+              uu____4938 :: uu____4939 in
+            (teq, uu____4935) in
+          FStar_Syntax_Syntax.Tm_app uu____4920 in
+        FStar_Syntax_Syntax.mk uu____4919 in
       uu____4916 FStar_Pervasives_Native.None uu____4915
-  
-let (mk_eq2 :
+let mk_eq2:
   FStar_Syntax_Syntax.universe ->
     FStar_Syntax_Syntax.typ ->
       FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun u  ->
     fun t  ->
       fun e1  ->
         fun e2  ->
-          let eq_inst = FStar_Syntax_Syntax.mk_Tm_uinst teq [u]  in
+          let eq_inst = FStar_Syntax_Syntax.mk_Tm_uinst teq [u] in
           let uu____4961 =
             FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
-              e2.FStar_Syntax_Syntax.pos
-             in
+              e2.FStar_Syntax_Syntax.pos in
           let uu____4962 =
             let uu____4965 =
               let uu____4966 =
                 let uu____4981 =
-                  let uu____4984 = FStar_Syntax_Syntax.iarg t  in
+                  let uu____4984 = FStar_Syntax_Syntax.iarg t in
                   let uu____4985 =
-                    let uu____4988 = FStar_Syntax_Syntax.as_arg e1  in
+                    let uu____4988 = FStar_Syntax_Syntax.as_arg e1 in
                     let uu____4989 =
-                      let uu____4992 = FStar_Syntax_Syntax.as_arg e2  in
-                      [uu____4992]  in
-                    uu____4988 :: uu____4989  in
-                  uu____4984 :: uu____4985  in
-                (eq_inst, uu____4981)  in
-              FStar_Syntax_Syntax.Tm_app uu____4966  in
-            FStar_Syntax_Syntax.mk uu____4965  in
+                      let uu____4992 = FStar_Syntax_Syntax.as_arg e2 in
+                      [uu____4992] in
+                    uu____4988 :: uu____4989 in
+                  uu____4984 :: uu____4985 in
+                (eq_inst, uu____4981) in
+              FStar_Syntax_Syntax.Tm_app uu____4966 in
+            FStar_Syntax_Syntax.mk uu____4965 in
           uu____4962 FStar_Pervasives_Native.None uu____4961
-  
-let (mk_has_type :
+let mk_has_type:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t  ->
     fun x  ->
       fun t'  ->
-        let t_has_type = fvar_const FStar_Parser_Const.has_type_lid  in
+        let t_has_type = fvar_const FStar_Parser_Const.has_type_lid in
         let t_has_type1 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_uinst
                (t_has_type,
                  [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]))
-            FStar_Pervasives_Native.None FStar_Range.dummyRange
-           in
+            FStar_Pervasives_Native.None FStar_Range.dummyRange in
         let uu____5015 =
           let uu____5018 =
             let uu____5019 =
               let uu____5034 =
-                let uu____5037 = FStar_Syntax_Syntax.iarg t  in
+                let uu____5037 = FStar_Syntax_Syntax.iarg t in
                 let uu____5038 =
-                  let uu____5041 = FStar_Syntax_Syntax.as_arg x  in
+                  let uu____5041 = FStar_Syntax_Syntax.as_arg x in
                   let uu____5042 =
-                    let uu____5045 = FStar_Syntax_Syntax.as_arg t'  in
-                    [uu____5045]  in
-                  uu____5041 :: uu____5042  in
-                uu____5037 :: uu____5038  in
-              (t_has_type1, uu____5034)  in
-            FStar_Syntax_Syntax.Tm_app uu____5019  in
-          FStar_Syntax_Syntax.mk uu____5018  in
+                    let uu____5045 = FStar_Syntax_Syntax.as_arg t' in
+                    [uu____5045] in
+                  uu____5041 :: uu____5042 in
+                uu____5037 :: uu____5038 in
+              (t_has_type1, uu____5034) in
+            FStar_Syntax_Syntax.Tm_app uu____5019 in
+          FStar_Syntax_Syntax.mk uu____5018 in
         uu____5015 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (mk_with_type :
+let mk_with_type:
   FStar_Syntax_Syntax.universe ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun u  ->
     fun t  ->
       fun e  ->
         let t_with_type =
           FStar_Syntax_Syntax.fvar FStar_Parser_Const.with_type_lid
-            FStar_Syntax_Syntax.Delta_equational FStar_Pervasives_Native.None
-           in
+            FStar_Syntax_Syntax.Delta_equational FStar_Pervasives_Native.None in
         let t_with_type1 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_uinst (t_with_type, [u]))
-            FStar_Pervasives_Native.None FStar_Range.dummyRange
-           in
+            FStar_Pervasives_Native.None FStar_Range.dummyRange in
         let uu____5070 =
           let uu____5073 =
             let uu____5074 =
               let uu____5089 =
-                let uu____5092 = FStar_Syntax_Syntax.iarg t  in
+                let uu____5092 = FStar_Syntax_Syntax.iarg t in
                 let uu____5093 =
-                  let uu____5096 = FStar_Syntax_Syntax.as_arg e  in
-                  [uu____5096]  in
-                uu____5092 :: uu____5093  in
-              (t_with_type1, uu____5089)  in
-            FStar_Syntax_Syntax.Tm_app uu____5074  in
-          FStar_Syntax_Syntax.mk uu____5073  in
+                  let uu____5096 = FStar_Syntax_Syntax.as_arg e in
+                  [uu____5096] in
+                uu____5092 :: uu____5093 in
+              (t_with_type1, uu____5089) in
+            FStar_Syntax_Syntax.Tm_app uu____5074 in
+          FStar_Syntax_Syntax.mk uu____5073 in
         uu____5070 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (lex_t : FStar_Syntax_Syntax.term) =
-  fvar_const FStar_Parser_Const.lex_t_lid 
-let (lex_top : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
+let lex_t: FStar_Syntax_Syntax.term = fvar_const FStar_Parser_Const.lex_t_lid
+let lex_top: FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax =
   let uu____5106 =
     let uu____5109 =
       let uu____5110 =
         let uu____5117 =
           FStar_Syntax_Syntax.fvar FStar_Parser_Const.lextop_lid
             FStar_Syntax_Syntax.Delta_constant
-            (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-           in
-        (uu____5117, [FStar_Syntax_Syntax.U_zero])  in
-      FStar_Syntax_Syntax.Tm_uinst uu____5110  in
-    FStar_Syntax_Syntax.mk uu____5109  in
-  uu____5106 FStar_Pervasives_Native.None FStar_Range.dummyRange 
-let (lex_pair : FStar_Syntax_Syntax.term) =
+            (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
+        (uu____5117, [FStar_Syntax_Syntax.U_zero]) in
+      FStar_Syntax_Syntax.Tm_uinst uu____5110 in
+    FStar_Syntax_Syntax.mk uu____5109 in
+  uu____5106 FStar_Pervasives_Native.None FStar_Range.dummyRange
+let lex_pair: FStar_Syntax_Syntax.term =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.lexcons_lid
     FStar_Syntax_Syntax.Delta_constant
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-  
-let (tforall : FStar_Syntax_Syntax.term) =
+let tforall: FStar_Syntax_Syntax.term =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.forall_lid
     (FStar_Syntax_Syntax.Delta_defined_at_level (Prims.parse_int "1"))
     FStar_Pervasives_Native.None
-  
-let (t_haseq : FStar_Syntax_Syntax.term) =
+let t_haseq: FStar_Syntax_Syntax.term =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.haseq_lid
     FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None
-  
-let (lcomp_of_comp :
+let lcomp_of_comp:
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.lcomp)
+    FStar_Syntax_Syntax.lcomp
   =
   fun c0  ->
     let uu____5130 =
@@ -2207,19 +2029,17 @@ let (lcomp_of_comp :
             [FStar_Syntax_Syntax.SOMETRIVIAL])
       | FStar_Syntax_Syntax.Comp c ->
           ((c.FStar_Syntax_Syntax.effect_name),
-            (c.FStar_Syntax_Syntax.flags))
-       in
+            (c.FStar_Syntax_Syntax.flags)) in
     match uu____5130 with
     | (eff_name,flags1) ->
         FStar_Syntax_Syntax.mk_lcomp eff_name (comp_result c0) flags1
           (fun uu____5175  -> c0)
-  
-let (mk_residual_comp :
+let mk_residual_comp:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
       FStar_Pervasives_Native.option ->
       FStar_Syntax_Syntax.cflags Prims.list ->
-        FStar_Syntax_Syntax.residual_comp)
+        FStar_Syntax_Syntax.residual_comp
   =
   fun l  ->
     fun t  ->
@@ -2229,10 +2049,9 @@ let (mk_residual_comp :
           FStar_Syntax_Syntax.residual_typ = t;
           FStar_Syntax_Syntax.residual_flags = f
         }
-  
-let (residual_tot :
+let residual_tot:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.residual_comp)
+    FStar_Syntax_Syntax.residual_comp
   =
   fun t  ->
     {
@@ -2240,9 +2059,8 @@ let (residual_tot :
       FStar_Syntax_Syntax.residual_typ = (FStar_Pervasives_Native.Some t);
       FStar_Syntax_Syntax.residual_flags = [FStar_Syntax_Syntax.TOTAL]
     }
-  
-let (residual_comp_of_comp :
-  FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.residual_comp) =
+let residual_comp_of_comp:
+  FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.residual_comp =
   fun c  ->
     {
       FStar_Syntax_Syntax.residual_effect = (comp_effect_name c);
@@ -2250,9 +2068,8 @@ let (residual_comp_of_comp :
         (FStar_Pervasives_Native.Some (comp_result c));
       FStar_Syntax_Syntax.residual_flags = (comp_flags c)
     }
-  
-let (residual_comp_of_lcomp :
-  FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.residual_comp) =
+let residual_comp_of_lcomp:
+  FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.residual_comp =
   fun lc  ->
     {
       FStar_Syntax_Syntax.residual_effect = (lc.FStar_Syntax_Syntax.eff_name);
@@ -2260,12 +2077,11 @@ let (residual_comp_of_lcomp :
         (FStar_Pervasives_Native.Some (lc.FStar_Syntax_Syntax.res_typ));
       FStar_Syntax_Syntax.residual_flags = (lc.FStar_Syntax_Syntax.cflags)
     }
-  
-let (mk_forall_aux :
+let mk_forall_aux:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.bv ->
       FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun fa  ->
     fun x  ->
@@ -2275,65 +2091,60 @@ let (mk_forall_aux :
             let uu____5235 =
               let uu____5250 =
                 let uu____5253 =
-                  FStar_Syntax_Syntax.iarg x.FStar_Syntax_Syntax.sort  in
+                  FStar_Syntax_Syntax.iarg x.FStar_Syntax_Syntax.sort in
                 let uu____5254 =
                   let uu____5257 =
                     let uu____5258 =
                       let uu____5259 =
-                        let uu____5260 = FStar_Syntax_Syntax.mk_binder x  in
-                        [uu____5260]  in
+                        let uu____5260 = FStar_Syntax_Syntax.mk_binder x in
+                        [uu____5260] in
                       abs uu____5259 body
-                        (FStar_Pervasives_Native.Some (residual_tot ktype0))
-                       in
-                    FStar_Syntax_Syntax.as_arg uu____5258  in
-                  [uu____5257]  in
-                uu____5253 :: uu____5254  in
-              (fa, uu____5250)  in
-            FStar_Syntax_Syntax.Tm_app uu____5235  in
-          FStar_Syntax_Syntax.mk uu____5234  in
+                        (FStar_Pervasives_Native.Some (residual_tot ktype0)) in
+                    FStar_Syntax_Syntax.as_arg uu____5258 in
+                  [uu____5257] in
+                uu____5253 :: uu____5254 in
+              (fa, uu____5250) in
+            FStar_Syntax_Syntax.Tm_app uu____5235 in
+          FStar_Syntax_Syntax.mk uu____5234 in
         uu____5231 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (mk_forall_no_univ :
+let mk_forall_no_univ:
   FStar_Syntax_Syntax.bv ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
-  = fun x  -> fun body  -> mk_forall_aux tforall x body 
-let (mk_forall :
+    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
+  = fun x  -> fun body  -> mk_forall_aux tforall x body
+let mk_forall:
   FStar_Syntax_Syntax.universe ->
     FStar_Syntax_Syntax.bv ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
+      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
   =
   fun u  ->
     fun x  ->
       fun body  ->
-        let tforall1 = FStar_Syntax_Syntax.mk_Tm_uinst tforall [u]  in
+        let tforall1 = FStar_Syntax_Syntax.mk_Tm_uinst tforall [u] in
         mk_forall_aux tforall1 x body
-  
-let (close_forall_no_univs :
+let close_forall_no_univs:
   FStar_Syntax_Syntax.binder Prims.list ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
+    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
   =
   fun bs  ->
     fun f  ->
       FStar_List.fold_right
         (fun b  ->
            fun f1  ->
-             let uu____5299 = FStar_Syntax_Syntax.is_null_binder b  in
+             let uu____5299 = FStar_Syntax_Syntax.is_null_binder b in
              if uu____5299
              then f1
              else mk_forall_no_univ (FStar_Pervasives_Native.fst b) f1) bs f
-  
-let rec (is_wild_pat :
-  FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t -> Prims.bool) =
+let rec is_wild_pat:
+  FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t -> Prims.bool =
   fun p  ->
     match p.FStar_Syntax_Syntax.v with
     | FStar_Syntax_Syntax.Pat_wild uu____5308 -> true
     | uu____5309 -> false
-  
-let (if_then_else :
+let if_then_else:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun b  ->
     fun t1  ->
@@ -2342,74 +2153,66 @@ let (if_then_else :
           let uu____5348 =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool true))
-              t1.FStar_Syntax_Syntax.pos
-             in
-          (uu____5348, FStar_Pervasives_Native.None, t1)  in
+              t1.FStar_Syntax_Syntax.pos in
+          (uu____5348, FStar_Pervasives_Native.None, t1) in
         let else_branch =
           let uu____5376 =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant
-                 (FStar_Const.Const_bool false)) t2.FStar_Syntax_Syntax.pos
-             in
-          (uu____5376, FStar_Pervasives_Native.None, t2)  in
+                 (FStar_Const.Const_bool false)) t2.FStar_Syntax_Syntax.pos in
+          (uu____5376, FStar_Pervasives_Native.None, t2) in
         let uu____5389 =
           let uu____5390 =
             FStar_Range.union_ranges t1.FStar_Syntax_Syntax.pos
-              t2.FStar_Syntax_Syntax.pos
-             in
-          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____5390  in
+              t2.FStar_Syntax_Syntax.pos in
+          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____5390 in
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_match (b, [then_branch; else_branch]))
           FStar_Pervasives_Native.None uu____5389
-  
-let (mk_squash :
+let mk_squash:
   FStar_Syntax_Syntax.universe ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun u  ->
     fun p  ->
       let sq =
         FStar_Syntax_Syntax.fvar FStar_Parser_Const.squash_lid
           (FStar_Syntax_Syntax.Delta_defined_at_level (Prims.parse_int "1"))
-          FStar_Pervasives_Native.None
-         in
-      let uu____5460 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
+          FStar_Pervasives_Native.None in
+      let uu____5460 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u] in
       let uu____5463 =
-        let uu____5472 = FStar_Syntax_Syntax.as_arg p  in [uu____5472]  in
+        let uu____5472 = FStar_Syntax_Syntax.as_arg p in [uu____5472] in
       mk_app uu____5460 uu____5463
-  
-let (mk_auto_squash :
+let mk_auto_squash:
   FStar_Syntax_Syntax.universe ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun u  ->
     fun p  ->
       let sq =
         FStar_Syntax_Syntax.fvar FStar_Parser_Const.auto_squash_lid
           (FStar_Syntax_Syntax.Delta_defined_at_level (Prims.parse_int "2"))
-          FStar_Pervasives_Native.None
-         in
-      let uu____5482 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
+          FStar_Pervasives_Native.None in
+      let uu____5482 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u] in
       let uu____5485 =
-        let uu____5494 = FStar_Syntax_Syntax.as_arg p  in [uu____5494]  in
+        let uu____5494 = FStar_Syntax_Syntax.as_arg p in [uu____5494] in
       mk_app uu____5482 uu____5485
-  
-let (un_squash :
+let un_squash:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun t  ->
-    let uu____5502 = head_and_args t  in
+    let uu____5502 = head_and_args t in
     match uu____5502 with
     | (head1,args) ->
         let uu____5543 =
           let uu____5556 =
-            let uu____5557 = un_uinst head1  in
-            uu____5557.FStar_Syntax_Syntax.n  in
-          (uu____5556, args)  in
+            let uu____5557 = un_uinst head1 in
+            uu____5557.FStar_Syntax_Syntax.n in
+          (uu____5556, args) in
         (match uu____5543 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,(p,uu____5574)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
@@ -2422,41 +2225,39 @@ let (un_squash :
                   ->
                   let uu____5626 =
                     let uu____5631 =
-                      let uu____5632 = FStar_Syntax_Syntax.mk_binder b  in
-                      [uu____5632]  in
-                    FStar_Syntax_Subst.open_term uu____5631 p  in
+                      let uu____5632 = FStar_Syntax_Syntax.mk_binder b in
+                      [uu____5632] in
+                    FStar_Syntax_Subst.open_term uu____5631 p in
                   (match uu____5626 with
                    | (bs,p1) ->
                        let b1 =
                          match bs with
                          | b1::[] -> b1
-                         | uu____5661 -> failwith "impossible"  in
+                         | uu____5661 -> failwith "impossible" in
                        let uu____5666 =
-                         let uu____5667 = FStar_Syntax_Free.names p1  in
+                         let uu____5667 = FStar_Syntax_Free.names p1 in
                          FStar_Util.set_mem (FStar_Pervasives_Native.fst b1)
-                           uu____5667
-                          in
+                           uu____5667 in
                        if uu____5666
                        then FStar_Pervasives_Native.None
                        else FStar_Pervasives_Native.Some p1)
               | uu____5677 -> FStar_Pervasives_Native.None)
          | uu____5680 -> FStar_Pervasives_Native.None)
-  
-let (is_squash :
+let is_squash:
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.universe,FStar_Syntax_Syntax.term'
                                     FStar_Syntax_Syntax.syntax)
-      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun t  ->
-    let uu____5706 = head_and_args t  in
+    let uu____5706 = head_and_args t in
     match uu____5706 with
     | (head1,args) ->
         let uu____5751 =
           let uu____5764 =
-            let uu____5765 = FStar_Syntax_Subst.compress head1  in
-            uu____5765.FStar_Syntax_Syntax.n  in
-          (uu____5764, args)  in
+            let uu____5765 = FStar_Syntax_Subst.compress head1 in
+            uu____5765.FStar_Syntax_Syntax.n in
+          (uu____5764, args) in
         (match uu____5751 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
@@ -2466,22 +2267,21 @@ let (is_squash :
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
          | uu____5828 -> FStar_Pervasives_Native.None)
-  
-let (is_auto_squash :
+let is_auto_squash:
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.universe,FStar_Syntax_Syntax.term'
                                     FStar_Syntax_Syntax.syntax)
-      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun t  ->
-    let uu____5858 = head_and_args t  in
+    let uu____5858 = head_and_args t in
     match uu____5858 with
     | (head1,args) ->
         let uu____5903 =
           let uu____5916 =
-            let uu____5917 = FStar_Syntax_Subst.compress head1  in
-            uu____5917.FStar_Syntax_Syntax.n  in
-          (uu____5916, args)  in
+            let uu____5917 = FStar_Syntax_Subst.compress head1 in
+            uu____5917.FStar_Syntax_Syntax.n in
+          (uu____5916, args) in
         (match uu____5903 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
@@ -2492,16 +2292,13 @@ let (is_auto_squash :
                FStar_Parser_Const.auto_squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
          | uu____5980 -> FStar_Pervasives_Native.None)
-  
-let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_sub_singleton: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
-    let uu____6002 = let uu____6017 = unmeta t  in head_and_args uu____6017
-       in
+    let uu____6002 = let uu____6017 = unmeta t in head_and_args uu____6017 in
     match uu____6002 with
     | (head1,uu____6019) ->
         let uu____6040 =
-          let uu____6041 = un_uinst head1  in
-          uu____6041.FStar_Syntax_Syntax.n  in
+          let uu____6041 = un_uinst head1 in uu____6041.FStar_Syntax_Syntax.n in
         (match uu____6040 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              (((((((((((((((((FStar_Syntax_Syntax.fv_eq_lid fv
@@ -2558,17 +2355,16 @@ let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
                (FStar_Syntax_Syntax.fv_eq_lid fv
                   FStar_Parser_Const.precedes_lid)
          | uu____6045 -> false)
-  
-let (arrow_one :
+let arrow_one:
   FStar_Syntax_Syntax.typ ->
     (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.comp)
-      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun t  ->
     let uu____6061 =
       let uu____6074 =
-        let uu____6075 = FStar_Syntax_Subst.compress t  in
-        uu____6075.FStar_Syntax_Syntax.n  in
+        let uu____6075 = FStar_Syntax_Subst.compress t in
+        uu____6075.FStar_Syntax_Syntax.n in
       match uu____6074 with
       | FStar_Syntax_Syntax.Tm_arrow ([],c) ->
           failwith "fatal: empty binders on arrow?"
@@ -2577,16 +2373,16 @@ let (arrow_one :
       | FStar_Syntax_Syntax.Tm_arrow (b::bs,c) ->
           let uu____6184 =
             let uu____6193 =
-              let uu____6194 = arrow bs c  in
-              FStar_Syntax_Syntax.mk_Total uu____6194  in
-            (b, uu____6193)  in
+              let uu____6194 = arrow bs c in
+              FStar_Syntax_Syntax.mk_Total uu____6194 in
+            (b, uu____6193) in
           FStar_Pervasives_Native.Some uu____6184
-      | uu____6207 -> FStar_Pervasives_Native.None  in
+      | uu____6207 -> FStar_Pervasives_Native.None in
     FStar_Util.bind_opt uu____6061
       (fun uu____6243  ->
          match uu____6243 with
          | (b,c) ->
-             let uu____6278 = FStar_Syntax_Subst.open_comp [b] c  in
+             let uu____6278 = FStar_Syntax_Subst.open_comp [b] c in
              (match uu____6278 with
               | (bs,c1) ->
                   let b1 =
@@ -2594,64 +2390,58 @@ let (arrow_one :
                     | b1::[] -> b1
                     | uu____6325 ->
                         failwith
-                          "impossible: open_comp returned different amount of binders"
-                     in
+                          "impossible: open_comp returned different amount of binders" in
                   FStar_Pervasives_Native.Some (b1, c1)))
-  
-let (is_free_in :
-  FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_free_in:
+  FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun bv  ->
     fun t  ->
-      let uu____6348 = FStar_Syntax_Free.names t  in
+      let uu____6348 = FStar_Syntax_Free.names t in
       FStar_Util.set_mem bv uu____6348
-  
 type qpats = FStar_Syntax_Syntax.args Prims.list[@@deriving show]
 type connective =
   | QAll of (FStar_Syntax_Syntax.binders,qpats,FStar_Syntax_Syntax.typ)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | QEx of (FStar_Syntax_Syntax.binders,qpats,FStar_Syntax_Syntax.typ)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | BaseConn of (FStar_Ident.lident,FStar_Syntax_Syntax.args)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let (uu___is_QAll : connective -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_QAll: connective -> Prims.bool =
   fun projectee  ->
     match projectee with | QAll _0 -> true | uu____6391 -> false
-  
-let (__proj__QAll__item___0 :
+let __proj__QAll__item___0:
   connective ->
     (FStar_Syntax_Syntax.binders,qpats,FStar_Syntax_Syntax.typ)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | QAll _0 -> _0 
-let (uu___is_QEx : connective -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | QAll _0 -> _0
+let uu___is_QEx: connective -> Prims.bool =
   fun projectee  ->
     match projectee with | QEx _0 -> true | uu____6427 -> false
-  
-let (__proj__QEx__item___0 :
+let __proj__QEx__item___0:
   connective ->
     (FStar_Syntax_Syntax.binders,qpats,FStar_Syntax_Syntax.typ)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | QEx _0 -> _0 
-let (uu___is_BaseConn : connective -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | QEx _0 -> _0
+let uu___is_BaseConn: connective -> Prims.bool =
   fun projectee  ->
     match projectee with | BaseConn _0 -> true | uu____6461 -> false
-  
-let (__proj__BaseConn__item___0 :
+let __proj__BaseConn__item___0:
   connective ->
     (FStar_Ident.lident,FStar_Syntax_Syntax.args)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | BaseConn _0 -> _0 
-let (destruct_typ_as_formula :
-  FStar_Syntax_Syntax.term -> connective FStar_Pervasives_Native.option) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | BaseConn _0 -> _0
+let destruct_typ_as_formula:
+  FStar_Syntax_Syntax.term -> connective FStar_Pervasives_Native.option =
   fun f  ->
     let rec unmeta_monadic f1 =
-      let f2 = FStar_Syntax_Subst.compress f1  in
+      let f2 = FStar_Syntax_Subst.compress f1 in
       match f2.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
           (t,FStar_Syntax_Syntax.Meta_monadic uu____6494) -> unmeta_monadic t
       | FStar_Syntax_Syntax.Tm_meta
           (t,FStar_Syntax_Syntax.Meta_monadic_lift uu____6506) ->
           unmeta_monadic t
-      | uu____6519 -> f2  in
+      | uu____6519 -> f2 in
     let destruct_base_conn f1 =
       let connectives =
         [(FStar_Parser_Const.true_lid, (Prims.parse_int "0"));
@@ -2665,56 +2455,50 @@ let (destruct_typ_as_formula :
         (FStar_Parser_Const.eq2_lid, (Prims.parse_int "3"));
         (FStar_Parser_Const.eq2_lid, (Prims.parse_int "2"));
         (FStar_Parser_Const.eq3_lid, (Prims.parse_int "4"));
-        (FStar_Parser_Const.eq3_lid, (Prims.parse_int "2"))]  in
+        (FStar_Parser_Const.eq3_lid, (Prims.parse_int "2"))] in
       let aux f2 uu____6597 =
         match uu____6597 with
         | (lid,arity) ->
             let uu____6606 =
-              let uu____6621 = unmeta_monadic f2  in head_and_args uu____6621
-               in
+              let uu____6621 = unmeta_monadic f2 in head_and_args uu____6621 in
             (match uu____6606 with
              | (t,args) ->
-                 let t1 = un_uinst t  in
+                 let t1 = un_uinst t in
                  let uu____6647 =
                    (is_constructor t1 lid) &&
-                     ((FStar_List.length args) = arity)
-                    in
+                     ((FStar_List.length args) = arity) in
                  if uu____6647
                  then FStar_Pervasives_Native.Some (BaseConn (lid, args))
-                 else FStar_Pervasives_Native.None)
-         in
-      FStar_Util.find_map connectives (aux f1)  in
+                 else FStar_Pervasives_Native.None) in
+      FStar_Util.find_map connectives (aux f1) in
     let patterns t =
-      let t1 = FStar_Syntax_Subst.compress t  in
+      let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
           (t2,FStar_Syntax_Syntax.Meta_pattern pats) ->
-          let uu____6722 = FStar_Syntax_Subst.compress t2  in
+          let uu____6722 = FStar_Syntax_Subst.compress t2 in
           (pats, uu____6722)
-      | uu____6733 -> ([], t1)  in
+      | uu____6733 -> ([], t1) in
     let destruct_q_conn t =
       let is_q fa fv =
         if fa
         then is_forall (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-        else is_exists (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-         in
+        else is_exists (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
       let flat t1 =
-        let uu____6780 = head_and_args t1  in
+        let uu____6780 = head_and_args t1 in
         match uu____6780 with
         | (t2,args) ->
-            let uu____6827 = un_uinst t2  in
+            let uu____6827 = un_uinst t2 in
             let uu____6828 =
               FStar_All.pipe_right args
                 (FStar_List.map
                    (fun uu____6861  ->
                       match uu____6861 with
                       | (t3,imp) ->
-                          let uu____6872 = unascribe t3  in (uu____6872, imp)))
-               in
-            (uu____6827, uu____6828)
-         in
+                          let uu____6872 = unascribe t3 in (uu____6872, imp))) in
+            (uu____6827, uu____6828) in
       let rec aux qopt out t1 =
-        let uu____6907 = let uu____6924 = flat t1  in (qopt, uu____6924)  in
+        let uu____6907 = let uu____6924 = flat t1 in (qopt, uu____6924) in
         match uu____6907 with
         | (FStar_Pervasives_Native.Some
            fa,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
@@ -2780,11 +2564,11 @@ let (destruct_typ_as_formula :
                     (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v))
               (b :: out) t2
         | (FStar_Pervasives_Native.Some b,uu____7310) ->
-            let bs = FStar_List.rev out  in
-            let uu____7344 = FStar_Syntax_Subst.open_term bs t1  in
+            let bs = FStar_List.rev out in
+            let uu____7344 = FStar_Syntax_Subst.open_term bs t1 in
             (match uu____7344 with
              | (bs1,t2) ->
-                 let uu____7353 = patterns t2  in
+                 let uu____7353 = patterns t2 in
                  (match uu____7353 with
                   | (pats,body) ->
                       if b
@@ -2792,8 +2576,8 @@ let (destruct_typ_as_formula :
                         FStar_Pervasives_Native.Some (QAll (bs1, pats, body))
                       else
                         FStar_Pervasives_Native.Some (QEx (bs1, pats, body))))
-        | uu____7415 -> FStar_Pervasives_Native.None  in
-      aux FStar_Pervasives_Native.None [] t  in
+        | uu____7415 -> FStar_Pervasives_Native.None in
+      aux FStar_Pervasives_Native.None [] t in
     let u_connectives =
       [(FStar_Parser_Const.true_lid, FStar_Parser_Const.c_true_lid,
          (Prims.parse_int "0"));
@@ -2802,20 +2586,19 @@ let (destruct_typ_as_formula :
       (FStar_Parser_Const.and_lid, FStar_Parser_Const.c_and_lid,
         (Prims.parse_int "2"));
       (FStar_Parser_Const.or_lid, FStar_Parser_Const.c_or_lid,
-        (Prims.parse_int "2"))]
-       in
+        (Prims.parse_int "2"))] in
     let destruct_sq_base_conn t =
-      let uu____7481 = un_squash t  in
+      let uu____7481 = un_squash t in
       FStar_Util.bind_opt uu____7481
         (fun t1  ->
-           let uu____7497 = head_and_args' t1  in
+           let uu____7497 = head_and_args' t1 in
            match uu____7497 with
            | (hd1,args) ->
                let uu____7530 =
                  let uu____7535 =
-                   let uu____7536 = un_uinst hd1  in
-                   uu____7536.FStar_Syntax_Syntax.n  in
-                 (uu____7535, (FStar_List.length args))  in
+                   let uu____7536 = un_uinst hd1 in
+                   uu____7536.FStar_Syntax_Syntax.n in
+                 (uu____7535, (FStar_List.length args)) in
                (match uu____7530 with
                 | (FStar_Syntax_Syntax.Tm_fvar fv,_0_29) when
                     (_0_29 = (Prims.parse_int "2")) &&
@@ -2873,29 +2656,28 @@ let (destruct_typ_as_formula :
                     ->
                     FStar_Pervasives_Native.Some
                       (BaseConn (FStar_Parser_Const.false_lid, args))
-                | uu____7619 -> FStar_Pervasives_Native.None))
-       in
+                | uu____7619 -> FStar_Pervasives_Native.None)) in
     let rec destruct_sq_forall t =
-      let uu____7642 = un_squash t  in
+      let uu____7642 = un_squash t in
       FStar_Util.bind_opt uu____7642
         (fun t1  ->
-           let uu____7657 = arrow_one t1  in
+           let uu____7657 = arrow_one t1 in
            match uu____7657 with
            | FStar_Pervasives_Native.Some (b,c) ->
                let uu____7672 =
-                 let uu____7673 = is_tot_or_gtot_comp c  in
-                 Prims.op_Negation uu____7673  in
+                 let uu____7673 = is_tot_or_gtot_comp c in
+                 Prims.op_Negation uu____7673 in
                if uu____7672
                then FStar_Pervasives_Native.None
                else
                  (let q =
-                    let uu____7680 = comp_to_comp_typ c  in
-                    uu____7680.FStar_Syntax_Syntax.result_typ  in
+                    let uu____7680 = comp_to_comp_typ c in
+                    uu____7680.FStar_Syntax_Syntax.result_typ in
                   let uu____7681 =
-                    is_free_in (FStar_Pervasives_Native.fst b) q  in
+                    is_free_in (FStar_Pervasives_Native.fst b) q in
                   if uu____7681
                   then
-                    let uu____7684 = patterns q  in
+                    let uu____7684 = patterns q in
                     match uu____7684 with
                     | (pats,q1) ->
                         FStar_All.pipe_left maybe_collect
@@ -2907,30 +2689,27 @@ let (destruct_typ_as_formula :
                          let uu____7746 =
                            let uu____7749 =
                              FStar_Syntax_Syntax.as_arg
-                               (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                              in
+                               (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
                            let uu____7750 =
-                             let uu____7753 = FStar_Syntax_Syntax.as_arg q
-                                in
-                             [uu____7753]  in
-                           uu____7749 :: uu____7750  in
-                         (FStar_Parser_Const.imp_lid, uu____7746)  in
-                       BaseConn uu____7741  in
+                             let uu____7753 = FStar_Syntax_Syntax.as_arg q in
+                             [uu____7753] in
+                           uu____7749 :: uu____7750 in
+                         (FStar_Parser_Const.imp_lid, uu____7746) in
+                       BaseConn uu____7741 in
                      FStar_Pervasives_Native.Some uu____7740))
            | uu____7756 -> FStar_Pervasives_Native.None)
-    
     and destruct_sq_exists t =
-      let uu____7764 = un_squash t  in
+      let uu____7764 = un_squash t in
       FStar_Util.bind_opt uu____7764
         (fun t1  ->
-           let uu____7795 = head_and_args' t1  in
+           let uu____7795 = head_and_args' t1 in
            match uu____7795 with
            | (hd1,args) ->
                let uu____7828 =
                  let uu____7841 =
-                   let uu____7842 = un_uinst hd1  in
-                   uu____7842.FStar_Syntax_Syntax.n  in
-                 (uu____7841, args)  in
+                   let uu____7842 = un_uinst hd1 in
+                   uu____7842.FStar_Syntax_Syntax.n in
+                 (uu____7841, args) in
                (match uu____7828 with
                 | (FStar_Syntax_Syntax.Tm_fvar
                    fv,(a1,uu____7857)::(a2,uu____7859)::[]) when
@@ -2938,19 +2717,18 @@ let (destruct_typ_as_formula :
                       FStar_Parser_Const.dtuple2_lid
                     ->
                     let uu____7894 =
-                      let uu____7895 = FStar_Syntax_Subst.compress a2  in
-                      uu____7895.FStar_Syntax_Syntax.n  in
+                      let uu____7895 = FStar_Syntax_Subst.compress a2 in
+                      uu____7895.FStar_Syntax_Syntax.n in
                     (match uu____7894 with
                      | FStar_Syntax_Syntax.Tm_abs (b::[],q,uu____7902) ->
-                         let uu____7929 = FStar_Syntax_Subst.open_term [b] q
-                            in
+                         let uu____7929 = FStar_Syntax_Subst.open_term [b] q in
                          (match uu____7929 with
                           | (bs,q1) ->
                               let b1 =
                                 match bs with
                                 | b1::[] -> b1
-                                | uu____7968 -> failwith "impossible"  in
-                              let uu____7973 = patterns q1  in
+                                | uu____7968 -> failwith "impossible" in
+                              let uu____7973 = patterns q1 in
                               (match uu____7973 with
                                | (pats,q2) ->
                                    FStar_All.pipe_left maybe_collect
@@ -2958,11 +2736,10 @@ let (destruct_typ_as_formula :
                                         (QEx ([b1], pats, q2)))))
                      | uu____8040 -> FStar_Pervasives_Native.None)
                 | uu____8041 -> FStar_Pervasives_Native.None))
-    
     and maybe_collect f1 =
       match f1 with
       | FStar_Pervasives_Native.Some (QAll (bs,pats,phi)) ->
-          let uu____8062 = destruct_sq_forall phi  in
+          let uu____8062 = destruct_sq_forall phi in
           (match uu____8062 with
            | FStar_Pervasives_Native.Some (QAll (bs',pats',psi)) ->
                FStar_All.pipe_left
@@ -2972,7 +2749,7 @@ let (destruct_typ_as_formula :
                       (FStar_List.append pats pats'), psi))
            | uu____8084 -> f1)
       | FStar_Pervasives_Native.Some (QEx (bs,pats,phi)) ->
-          let uu____8090 = destruct_sq_exists phi  in
+          let uu____8090 = destruct_sq_exists phi in
           (match uu____8090 with
            | FStar_Pervasives_Native.Some (QEx (bs',pats',psi)) ->
                FStar_All.pipe_left
@@ -2981,57 +2758,53 @@ let (destruct_typ_as_formula :
                     ((FStar_List.append bs bs'),
                       (FStar_List.append pats pats'), psi))
            | uu____8112 -> f1)
-      | uu____8115 -> f1
-     in
-    let phi = unmeta_monadic f  in
-    let uu____8119 = destruct_base_conn phi  in
+      | uu____8115 -> f1 in
+    let phi = unmeta_monadic f in
+    let uu____8119 = destruct_base_conn phi in
     FStar_Util.catch_opt uu____8119
       (fun uu____8124  ->
-         let uu____8125 = destruct_q_conn phi  in
+         let uu____8125 = destruct_q_conn phi in
          FStar_Util.catch_opt uu____8125
            (fun uu____8130  ->
-              let uu____8131 = destruct_sq_base_conn phi  in
+              let uu____8131 = destruct_sq_base_conn phi in
               FStar_Util.catch_opt uu____8131
                 (fun uu____8136  ->
-                   let uu____8137 = destruct_sq_forall phi  in
+                   let uu____8137 = destruct_sq_forall phi in
                    FStar_Util.catch_opt uu____8137
                      (fun uu____8142  ->
-                        let uu____8143 = destruct_sq_exists phi  in
+                        let uu____8143 = destruct_sq_exists phi in
                         FStar_Util.catch_opt uu____8143
                           (fun uu____8147  -> FStar_Pervasives_Native.None)))))
-  
-let (unthunk_lemma_post :
+let unthunk_lemma_post:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t  ->
     let uu____8153 =
-      let uu____8154 = FStar_Syntax_Subst.compress t  in
-      uu____8154.FStar_Syntax_Syntax.n  in
+      let uu____8154 = FStar_Syntax_Subst.compress t in
+      uu____8154.FStar_Syntax_Syntax.n in
     match uu____8153 with
     | FStar_Syntax_Syntax.Tm_abs (b::[],e,uu____8161) ->
-        let uu____8188 = FStar_Syntax_Subst.open_term [b] e  in
+        let uu____8188 = FStar_Syntax_Subst.open_term [b] e in
         (match uu____8188 with
          | (bs,e1) ->
-             let b1 = FStar_List.hd bs  in
-             let uu____8214 = is_free_in (FStar_Pervasives_Native.fst b1) e1
-                in
+             let b1 = FStar_List.hd bs in
+             let uu____8214 = is_free_in (FStar_Pervasives_Native.fst b1) e1 in
              if uu____8214
              then
                let uu____8217 =
-                 let uu____8226 = FStar_Syntax_Syntax.as_arg exp_unit  in
-                 [uu____8226]  in
+                 let uu____8226 = FStar_Syntax_Syntax.as_arg exp_unit in
+                 [uu____8226] in
                mk_app t uu____8217
              else e1)
     | uu____8228 ->
         let uu____8229 =
-          let uu____8238 = FStar_Syntax_Syntax.as_arg exp_unit  in
-          [uu____8238]  in
+          let uu____8238 = FStar_Syntax_Syntax.as_arg exp_unit in
+          [uu____8238] in
         mk_app t uu____8229
-  
-let (action_as_lb :
+let action_as_lb:
   FStar_Ident.lident ->
-    FStar_Syntax_Syntax.action -> FStar_Syntax_Syntax.sigelt)
+    FStar_Syntax_Syntax.action -> FStar_Syntax_Syntax.sigelt
   =
   fun eff_lid  ->
     fun a  ->
@@ -3040,21 +2813,18 @@ let (action_as_lb :
           let uu____8251 =
             FStar_Syntax_Syntax.lid_as_fv a.FStar_Syntax_Syntax.action_name
               FStar_Syntax_Syntax.Delta_equational
-              FStar_Pervasives_Native.None
-             in
-          FStar_Util.Inr uu____8251  in
+              FStar_Pervasives_Native.None in
+          FStar_Util.Inr uu____8251 in
         let uu____8252 =
           let uu____8253 =
-            FStar_Syntax_Syntax.mk_Total a.FStar_Syntax_Syntax.action_typ  in
-          arrow a.FStar_Syntax_Syntax.action_params uu____8253  in
+            FStar_Syntax_Syntax.mk_Total a.FStar_Syntax_Syntax.action_typ in
+          arrow a.FStar_Syntax_Syntax.action_params uu____8253 in
         let uu____8256 =
           abs a.FStar_Syntax_Syntax.action_params
-            a.FStar_Syntax_Syntax.action_defn FStar_Pervasives_Native.None
-           in
+            a.FStar_Syntax_Syntax.action_defn FStar_Pervasives_Native.None in
         close_univs_and_mk_letbinding FStar_Pervasives_Native.None uu____8246
           a.FStar_Syntax_Syntax.action_univs uu____8252
-          FStar_Parser_Const.effect_Tot_lid uu____8256 []
-         in
+          FStar_Parser_Const.effect_Tot_lid uu____8256 [] in
       {
         FStar_Syntax_Syntax.sigel =
           (FStar_Syntax_Syntax.Sig_let
@@ -3067,32 +2837,28 @@ let (action_as_lb :
         FStar_Syntax_Syntax.sigmeta = FStar_Syntax_Syntax.default_sigmeta;
         FStar_Syntax_Syntax.sigattrs = []
       }
-  
-let (mk_reify :
+let mk_reify:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t  ->
     let reify_ =
       FStar_Syntax_Syntax.mk
         (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_reify)
-        FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-       in
+        FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos in
     let uu____8283 =
       let uu____8286 =
         let uu____8287 =
           let uu____8302 =
-            let uu____8305 = FStar_Syntax_Syntax.as_arg t  in [uu____8305]
-             in
-          (reify_, uu____8302)  in
-        FStar_Syntax_Syntax.Tm_app uu____8287  in
-      FStar_Syntax_Syntax.mk uu____8286  in
+            let uu____8305 = FStar_Syntax_Syntax.as_arg t in [uu____8305] in
+          (reify_, uu____8302) in
+        FStar_Syntax_Syntax.Tm_app uu____8287 in
+      FStar_Syntax_Syntax.mk uu____8286 in
     uu____8283 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-  
-let rec (delta_qualifier :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
+let rec delta_qualifier:
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth =
   fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t  in
+    let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_delayed uu____8317 -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_fvar fv -> fv.FStar_Syntax_Syntax.fv_delta
@@ -3124,9 +2890,8 @@ let rec (delta_qualifier :
     | FStar_Syntax_Syntax.Tm_abs (uu____8487,t2,uu____8489) ->
         delta_qualifier t2
     | FStar_Syntax_Syntax.Tm_let (uu____8510,t2) -> delta_qualifier t2
-  
-let rec (incr_delta_depth :
-  FStar_Syntax_Syntax.delta_depth -> FStar_Syntax_Syntax.delta_depth) =
+let rec incr_delta_depth:
+  FStar_Syntax_Syntax.delta_depth -> FStar_Syntax_Syntax.delta_depth =
   fun d  ->
     match d with
     | FStar_Syntax_Syntax.Delta_equational  -> d
@@ -3136,35 +2901,30 @@ let rec (incr_delta_depth :
         FStar_Syntax_Syntax.Delta_defined_at_level
           (i + (Prims.parse_int "1"))
     | FStar_Syntax_Syntax.Delta_abstract d1 -> incr_delta_depth d1
-  
-let (incr_delta_qualifier :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
-  fun t  ->
-    let uu____8536 = delta_qualifier t  in incr_delta_depth uu____8536
-  
-let (is_unknown : FStar_Syntax_Syntax.term -> Prims.bool) =
+let incr_delta_qualifier:
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth =
+  fun t  -> let uu____8536 = delta_qualifier t in incr_delta_depth uu____8536
+let is_unknown: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____8540 =
-      let uu____8541 = FStar_Syntax_Subst.compress t  in
-      uu____8541.FStar_Syntax_Syntax.n  in
+      let uu____8541 = FStar_Syntax_Subst.compress t in
+      uu____8541.FStar_Syntax_Syntax.n in
     match uu____8540 with
     | FStar_Syntax_Syntax.Tm_unknown  -> true
     | uu____8544 -> false
-  
-let rec (list_elements :
+let rec list_elements:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term Prims.list FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.term Prims.list FStar_Pervasives_Native.option
   =
   fun e  ->
-    let uu____8556 = let uu____8571 = unmeta e  in head_and_args uu____8571
-       in
+    let uu____8556 = let uu____8571 = unmeta e in head_and_args uu____8571 in
     match uu____8556 with
     | (head1,args) ->
         let uu____8598 =
           let uu____8611 =
-            let uu____8612 = un_uinst head1  in
-            uu____8612.FStar_Syntax_Syntax.n  in
-          (uu____8611, args)  in
+            let uu____8612 = un_uinst head1 in
+            uu____8612.FStar_Syntax_Syntax.n in
+          (uu____8611, args) in
         (match uu____8598 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,uu____8628) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid ->
@@ -3174,13 +2934,12 @@ let rec (list_elements :
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid ->
              let uu____8699 =
                let uu____8704 =
-                 let uu____8709 = list_elements tl1  in
-                 FStar_Util.must uu____8709  in
-               hd1 :: uu____8704  in
+                 let uu____8709 = list_elements tl1 in
+                 FStar_Util.must uu____8709 in
+               hd1 :: uu____8704 in
              FStar_Pervasives_Native.Some uu____8699
          | uu____8722 -> FStar_Pervasives_Native.None)
-  
-let rec apply_last :
+let rec apply_last:
   'Auu____8740 .
     ('Auu____8740 -> 'Auu____8740) ->
       'Auu____8740 Prims.list -> 'Auu____8740 Prims.list
@@ -3189,26 +2948,23 @@ let rec apply_last :
     fun l  ->
       match l with
       | [] -> failwith "apply_last: got empty list"
-      | a::[] -> let uu____8763 = f a  in [uu____8763]
-      | x::xs -> let uu____8768 = apply_last f xs  in x :: uu____8768
-  
-let (dm4f_lid :
-  FStar_Syntax_Syntax.eff_decl -> Prims.string -> FStar_Ident.lident) =
+      | a::[] -> let uu____8763 = f a in [uu____8763]
+      | x::xs -> let uu____8768 = apply_last f xs in x :: uu____8768
+let dm4f_lid:
+  FStar_Syntax_Syntax.eff_decl -> Prims.string -> FStar_Ident.lident =
   fun ed  ->
     fun name  ->
-      let p = FStar_Ident.path_of_lid ed.FStar_Syntax_Syntax.mname  in
+      let p = FStar_Ident.path_of_lid ed.FStar_Syntax_Syntax.mname in
       let p' =
         apply_last
           (fun s  ->
              Prims.strcat "_dm4f_" (Prims.strcat s (Prims.strcat "_" name)))
-          p
-         in
+          p in
       FStar_Ident.lid_of_path p' FStar_Range.dummyRange
-  
-let rec (mk_list :
+let rec mk_list:
   FStar_Syntax_Syntax.term ->
     FStar_Range.range ->
-      FStar_Syntax_Syntax.term Prims.list -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term Prims.list -> FStar_Syntax_Syntax.term
   =
   fun typ  ->
     fun rng  ->
@@ -3219,65 +2975,59 @@ let rec (mk_list :
               let uu____8808 =
                 FStar_Syntax_Syntax.lid_as_fv l1
                   FStar_Syntax_Syntax.Delta_constant
-                  (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-                 in
-              FStar_Syntax_Syntax.Tm_fvar uu____8808  in
-            FStar_Syntax_Syntax.mk uu____8807  in
-          uu____8804 FStar_Pervasives_Native.None rng  in
+                  (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
+              FStar_Syntax_Syntax.Tm_fvar uu____8808 in
+            FStar_Syntax_Syntax.mk uu____8807 in
+          uu____8804 FStar_Pervasives_Native.None rng in
         let cons1 args pos =
           let uu____8821 =
             let uu____8822 =
-              let uu____8823 = ctor FStar_Parser_Const.cons_lid  in
+              let uu____8823 = ctor FStar_Parser_Const.cons_lid in
               FStar_Syntax_Syntax.mk_Tm_uinst uu____8823
-                [FStar_Syntax_Syntax.U_zero]
-               in
-            FStar_Syntax_Syntax.mk_Tm_app uu____8822 args  in
-          uu____8821 FStar_Pervasives_Native.None pos  in
+                [FStar_Syntax_Syntax.U_zero] in
+            FStar_Syntax_Syntax.mk_Tm_app uu____8822 args in
+          uu____8821 FStar_Pervasives_Native.None pos in
         let nil args pos =
           let uu____8835 =
             let uu____8836 =
-              let uu____8837 = ctor FStar_Parser_Const.nil_lid  in
+              let uu____8837 = ctor FStar_Parser_Const.nil_lid in
               FStar_Syntax_Syntax.mk_Tm_uinst uu____8837
-                [FStar_Syntax_Syntax.U_zero]
-               in
-            FStar_Syntax_Syntax.mk_Tm_app uu____8836 args  in
-          uu____8835 FStar_Pervasives_Native.None pos  in
+                [FStar_Syntax_Syntax.U_zero] in
+            FStar_Syntax_Syntax.mk_Tm_app uu____8836 args in
+          uu____8835 FStar_Pervasives_Native.None pos in
         let uu____8840 =
           let uu____8841 =
-            let uu____8842 = FStar_Syntax_Syntax.iarg typ  in [uu____8842]
-             in
-          nil uu____8841 rng  in
+            let uu____8842 = FStar_Syntax_Syntax.iarg typ in [uu____8842] in
+          nil uu____8841 rng in
         FStar_List.fold_right
           (fun t  ->
              fun a  ->
                let uu____8848 =
-                 let uu____8849 = FStar_Syntax_Syntax.iarg typ  in
+                 let uu____8849 = FStar_Syntax_Syntax.iarg typ in
                  let uu____8850 =
-                   let uu____8853 = FStar_Syntax_Syntax.as_arg t  in
+                   let uu____8853 = FStar_Syntax_Syntax.as_arg t in
                    let uu____8854 =
-                     let uu____8857 = FStar_Syntax_Syntax.as_arg a  in
-                     [uu____8857]  in
-                   uu____8853 :: uu____8854  in
-                 uu____8849 :: uu____8850  in
+                     let uu____8857 = FStar_Syntax_Syntax.as_arg a in
+                     [uu____8857] in
+                   uu____8853 :: uu____8854 in
+                 uu____8849 :: uu____8850 in
                cons1 uu____8848 t.FStar_Syntax_Syntax.pos) l uu____8840
-  
-let (uvar_from_id :
+let uvar_from_id:
   Prims.int ->
     FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun id1  ->
     fun t  ->
       let uu____8866 =
         let uu____8869 =
           let uu____8870 =
-            let uu____8887 = FStar_Syntax_Unionfind.from_id id1  in
-            (uu____8887, t)  in
-          FStar_Syntax_Syntax.Tm_uvar uu____8870  in
-        FStar_Syntax_Syntax.mk uu____8869  in
+            let uu____8887 = FStar_Syntax_Unionfind.from_id id1 in
+            (uu____8887, t) in
+          FStar_Syntax_Syntax.Tm_uvar uu____8870 in
+        FStar_Syntax_Syntax.mk uu____8869 in
       uu____8866 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let rec eqlist :
+let rec eqlist:
   'a .
     ('a -> 'a -> Prims.bool) -> 'a Prims.list -> 'a Prims.list -> Prims.bool
   =
@@ -3288,8 +3038,7 @@ let rec eqlist :
         | ([],[]) -> true
         | (x::xs1,y::ys1) -> (eq1 x y) && (eqlist eq1 xs1 ys1)
         | uu____8947 -> false
-  
-let eqsum :
+let eqsum:
   'a 'b .
     ('a -> 'a -> Prims.bool) ->
       ('b -> 'b -> Prims.bool) ->
@@ -3303,8 +3052,7 @@ let eqsum :
           | (FStar_Util.Inl x1,FStar_Util.Inl y1) -> e1 x1 y1
           | (FStar_Util.Inr x1,FStar_Util.Inr y1) -> e2 x1 y1
           | uu____9044 -> false
-  
-let eqprod :
+let eqprod:
   'a 'b .
     ('a -> 'a -> Prims.bool) ->
       ('b -> 'b -> Prims.bool) ->
@@ -3316,8 +3064,7 @@ let eqprod :
       fun x  ->
         fun y  ->
           match (x, y) with | ((x1,x2),(y1,y2)) -> (e1 x1 y1) && (e2 x2 y2)
-  
-let eqopt :
+let eqopt:
   'a .
     ('a -> 'a -> Prims.bool) ->
       'a FStar_Pervasives_Native.option ->
@@ -3330,18 +3077,17 @@ let eqopt :
         | (FStar_Pervasives_Native.Some x1,FStar_Pervasives_Native.Some y1)
             -> e x1 y1
         | uu____9182 -> false
-  
-let rec (term_eq :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let rec term_eq:
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun t1  ->
     fun t2  ->
       let canon_app t =
         match t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_app uu____9297 ->
-            let uu____9312 = head_and_args' t  in
+            let uu____9312 = head_and_args' t in
             (match uu____9312 with
              | (hd1,args) ->
-                 let uu___58_9345 = t  in
+                 let uu___58_9345 = t in
                  {
                    FStar_Syntax_Syntax.n =
                      (FStar_Syntax_Syntax.Tm_app (hd1, args));
@@ -3350,17 +3096,17 @@ let rec (term_eq :
                    FStar_Syntax_Syntax.vars =
                      (uu___58_9345.FStar_Syntax_Syntax.vars)
                  })
-        | uu____9356 -> t  in
-      let t11 = let uu____9360 = unmeta_safe t1  in canon_app uu____9360  in
-      let t21 = let uu____9366 = unmeta_safe t2  in canon_app uu____9366  in
+        | uu____9356 -> t in
+      let t11 = let uu____9360 = unmeta_safe t1 in canon_app uu____9360 in
+      let t21 = let uu____9366 = unmeta_safe t2 in canon_app uu____9366 in
       let uu____9369 =
         let uu____9374 =
-          let uu____9375 = FStar_Syntax_Subst.compress t11  in
-          uu____9375.FStar_Syntax_Syntax.n  in
+          let uu____9375 = FStar_Syntax_Subst.compress t11 in
+          uu____9375.FStar_Syntax_Syntax.n in
         let uu____9378 =
-          let uu____9379 = FStar_Syntax_Subst.compress t21  in
-          uu____9379.FStar_Syntax_Syntax.n  in
-        (uu____9374, uu____9378)  in
+          let uu____9379 = FStar_Syntax_Subst.compress t21 in
+          uu____9379.FStar_Syntax_Syntax.n in
+        (uu____9374, uu____9378) in
       match uu____9369 with
       | (FStar_Syntax_Syntax.Tm_bvar x,FStar_Syntax_Syntax.Tm_bvar y) ->
           x.FStar_Syntax_Syntax.index = y.FStar_Syntax_Syntax.index
@@ -3414,20 +3160,18 @@ let rec (term_eq :
       | (FStar_Syntax_Syntax.Tm_unknown ,FStar_Syntax_Syntax.Tm_unknown ) ->
           false
       | (uu____9920,uu____9921) -> false
-
-and (arg_eq :
+and arg_eq:
   (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
     FStar_Pervasives_Native.tuple2 ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2 -> Prims.bool)
+      FStar_Pervasives_Native.tuple2 -> Prims.bool
   =
   fun a1  -> fun a2  -> eqprod term_eq (fun q1  -> fun q2  -> q1 = q2) a1 a2
-
-and (binder_eq :
+and binder_eq:
   (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
     FStar_Pervasives_Native.tuple2 ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2 -> Prims.bool)
+      FStar_Pervasives_Native.tuple2 -> Prims.bool
   =
   fun b1  ->
     fun b2  ->
@@ -3437,19 +3181,16 @@ and (binder_eq :
              term_eq b11.FStar_Syntax_Syntax.sort
                b21.FStar_Syntax_Syntax.sort) (fun q1  -> fun q2  -> q1 = q2)
         b1 b2
-
-and (lcomp_eq :
-  FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+and lcomp_eq:
+  FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp -> Prims.bool =
   fun c1  -> fun c2  -> false
-
-and (residual_eq :
+and residual_eq:
   FStar_Syntax_Syntax.residual_comp ->
-    FStar_Syntax_Syntax.residual_comp -> Prims.bool)
+    FStar_Syntax_Syntax.residual_comp -> Prims.bool
   = fun r1  -> fun r2  -> false
-
-and (comp_eq :
+and comp_eq:
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool)
+    FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool
   =
   fun c1  ->
     fun c2  ->
@@ -3474,13 +3215,11 @@ and (comp_eq :
             (eq_flags c11.FStar_Syntax_Syntax.flags
                c21.FStar_Syntax_Syntax.flags)
       | (uu____10016,uu____10017) -> false
-
-and (eq_flags :
+and eq_flags:
   FStar_Syntax_Syntax.cflags Prims.list ->
-    FStar_Syntax_Syntax.cflags Prims.list -> Prims.bool)
+    FStar_Syntax_Syntax.cflags Prims.list -> Prims.bool
   = fun f1  -> fun f2  -> true
-
-and (branch_eq :
+and branch_eq:
   (FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t,FStar_Syntax_Syntax.term'
                                                              FStar_Syntax_Syntax.syntax
                                                              FStar_Pervasives_Native.option,
@@ -3490,13 +3229,13 @@ and (branch_eq :
                                                                FStar_Syntax_Syntax.syntax
                                                                FStar_Pervasives_Native.option,
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-      FStar_Pervasives_Native.tuple3 -> Prims.bool)
+      FStar_Pervasives_Native.tuple3 -> Prims.bool
   =
   fun uu____10024  ->
     fun uu____10025  ->
       match (uu____10024, uu____10025) with
       | ((p1,w1,t1),(p2,w2,t2)) ->
-          let uu____10148 = FStar_Syntax_Syntax.eq_pat p1 p2  in
+          let uu____10148 = FStar_Syntax_Syntax.eq_pat p1 p2 in
           if uu____10148
           then
             (term_eq t1 t2) &&
@@ -3507,10 +3246,9 @@ and (branch_eq :
                    ) -> true
                 | uu____10189 -> false))
           else false
-
-and (letbinding_eq :
+and letbinding_eq:
   FStar_Syntax_Syntax.letbinding ->
-    FStar_Syntax_Syntax.letbinding -> Prims.bool)
+    FStar_Syntax_Syntax.letbinding -> Prims.bool
   =
   fun lb1  ->
     fun lb2  ->
@@ -3522,112 +3260,102 @@ and (letbinding_eq :
          (term_eq lb1.FStar_Syntax_Syntax.lbtyp lb2.FStar_Syntax_Syntax.lbtyp))
         &&
         (term_eq lb1.FStar_Syntax_Syntax.lbdef lb2.FStar_Syntax_Syntax.lbdef)
-
-let rec (bottom_fold :
+let rec bottom_fold:
   (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun f  ->
     fun t  ->
-      let ff = bottom_fold f  in
+      let ff = bottom_fold f in
       let tn =
-        let uu____10222 = FStar_Syntax_Subst.compress t  in
-        uu____10222.FStar_Syntax_Syntax.n  in
+        let uu____10222 = FStar_Syntax_Subst.compress t in
+        uu____10222.FStar_Syntax_Syntax.n in
       let tn1 =
         match tn with
         | FStar_Syntax_Syntax.Tm_app (f1,args) ->
             let uu____10248 =
-              let uu____10263 = ff f1  in
+              let uu____10263 = ff f1 in
               let uu____10264 =
                 FStar_List.map
                   (fun uu____10283  ->
                      match uu____10283 with
-                     | (a,q) -> let uu____10294 = ff a  in (uu____10294, q))
-                  args
-                 in
-              (uu____10263, uu____10264)  in
+                     | (a,q) -> let uu____10294 = ff a in (uu____10294, q))
+                  args in
+              (uu____10263, uu____10264) in
             FStar_Syntax_Syntax.Tm_app uu____10248
         | FStar_Syntax_Syntax.Tm_abs (bs,t1,k) ->
-            let uu____10324 = FStar_Syntax_Subst.open_term bs t1  in
+            let uu____10324 = FStar_Syntax_Subst.open_term bs t1 in
             (match uu____10324 with
              | (bs1,t') ->
-                 let t'' = ff t'  in
+                 let t'' = ff t' in
                  let uu____10332 =
-                   let uu____10349 = FStar_Syntax_Subst.close bs1 t''  in
-                   (bs1, uu____10349, k)  in
+                   let uu____10349 = FStar_Syntax_Subst.close bs1 t'' in
+                   (bs1, uu____10349, k) in
                  FStar_Syntax_Syntax.Tm_abs uu____10332)
         | FStar_Syntax_Syntax.Tm_arrow (bs,k) -> tn
         | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
-            let uu____10376 = let uu____10383 = ff t1  in (uu____10383, us)
-               in
+            let uu____10376 = let uu____10383 = ff t1 in (uu____10383, us) in
             FStar_Syntax_Syntax.Tm_uinst uu____10376
-        | uu____10384 -> tn  in
+        | uu____10384 -> tn in
       f
-        (let uu___59_10387 = t  in
+        (let uu___59_10387 = t in
          {
            FStar_Syntax_Syntax.n = tn1;
            FStar_Syntax_Syntax.pos = (uu___59_10387.FStar_Syntax_Syntax.pos);
            FStar_Syntax_Syntax.vars =
              (uu___59_10387.FStar_Syntax_Syntax.vars)
          })
-  
-let rec (sizeof : FStar_Syntax_Syntax.term -> Prims.int) =
+let rec sizeof: FStar_Syntax_Syntax.term -> Prims.int =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_delayed uu____10391 ->
         let uu____10416 =
-          let uu____10417 = FStar_Syntax_Subst.compress t  in
-          sizeof uu____10417  in
+          let uu____10417 = FStar_Syntax_Subst.compress t in
+          sizeof uu____10417 in
         (Prims.parse_int "1") + uu____10416
     | FStar_Syntax_Syntax.Tm_bvar bv ->
-        let uu____10419 = sizeof bv.FStar_Syntax_Syntax.sort  in
+        let uu____10419 = sizeof bv.FStar_Syntax_Syntax.sort in
         (Prims.parse_int "1") + uu____10419
     | FStar_Syntax_Syntax.Tm_name bv ->
-        let uu____10421 = sizeof bv.FStar_Syntax_Syntax.sort  in
+        let uu____10421 = sizeof bv.FStar_Syntax_Syntax.sort in
         (Prims.parse_int "1") + uu____10421
     | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
-        let uu____10428 = sizeof t1  in (FStar_List.length us) + uu____10428
+        let uu____10428 = sizeof t1 in (FStar_List.length us) + uu____10428
     | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____10431) ->
-        let uu____10452 = sizeof t1  in
+        let uu____10452 = sizeof t1 in
         let uu____10453 =
           FStar_List.fold_left
             (fun acc  ->
                fun uu____10464  ->
                  match uu____10464 with
                  | (bv,uu____10470) ->
-                     let uu____10471 = sizeof bv.FStar_Syntax_Syntax.sort  in
-                     acc + uu____10471) (Prims.parse_int "0") bs
-           in
+                     let uu____10471 = sizeof bv.FStar_Syntax_Syntax.sort in
+                     acc + uu____10471) (Prims.parse_int "0") bs in
         uu____10452 + uu____10453
     | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-        let uu____10494 = sizeof hd1  in
+        let uu____10494 = sizeof hd1 in
         let uu____10495 =
           FStar_List.fold_left
             (fun acc  ->
                fun uu____10506  ->
                  match uu____10506 with
                  | (arg,uu____10512) ->
-                     let uu____10513 = sizeof arg  in acc + uu____10513)
-            (Prims.parse_int "0") args
-           in
+                     let uu____10513 = sizeof arg in acc + uu____10513)
+            (Prims.parse_int "0") args in
         uu____10494 + uu____10495
-    | uu____10514 -> (Prims.parse_int "1")
-  
-let (is_fvar : FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool)
-  =
+    | uu____10514 -> Prims.parse_int "1"
+let is_fvar: FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun lid  ->
     fun t  ->
       let uu____10521 =
-        let uu____10522 = un_uinst t  in uu____10522.FStar_Syntax_Syntax.n
-         in
+        let uu____10522 = un_uinst t in uu____10522.FStar_Syntax_Syntax.n in
       match uu____10521 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_Syntax_Syntax.fv_eq_lid fv lid
       | uu____10526 -> false
-  
-let (is_synth_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
-  fun t  -> is_fvar FStar_Parser_Const.synth_lid t 
-let mk_alien :
+let is_synth_by_tactic: FStar_Syntax_Syntax.term -> Prims.bool =
+  fun t  -> is_fvar FStar_Parser_Const.synth_lid t
+let mk_alien:
   'a .
     FStar_Syntax_Syntax.typ ->
       'a ->
@@ -3644,33 +3372,31 @@ let mk_alien :
               let uu____10560 =
                 let uu____10567 =
                   let uu____10568 =
-                    let uu____10577 = FStar_Dyn.mkdyn b  in
-                    (uu____10577, s, ty)  in
-                  FStar_Syntax_Syntax.Meta_alien uu____10568  in
-                (FStar_Syntax_Syntax.tun, uu____10567)  in
-              FStar_Syntax_Syntax.Tm_meta uu____10560  in
-            FStar_Syntax_Syntax.mk uu____10559  in
+                    let uu____10577 = FStar_Dyn.mkdyn b in
+                    (uu____10577, s, ty) in
+                  FStar_Syntax_Syntax.Meta_alien uu____10568 in
+                (FStar_Syntax_Syntax.tun, uu____10567) in
+              FStar_Syntax_Syntax.Tm_meta uu____10560 in
+            FStar_Syntax_Syntax.mk uu____10559 in
           uu____10556 FStar_Pervasives_Native.None
             (match r with
              | FStar_Pervasives_Native.Some r1 -> r1
              | FStar_Pervasives_Native.None  -> FStar_Range.dummyRange)
-  
-let (un_alien : FStar_Syntax_Syntax.term -> FStar_Dyn.dyn) =
+let un_alien: FStar_Syntax_Syntax.term -> FStar_Dyn.dyn =
   fun t  ->
-    let t1 = FStar_Syntax_Subst.compress t  in
+    let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_meta
         (uu____10587,FStar_Syntax_Syntax.Meta_alien
          (blob,uu____10589,uu____10590))
         -> blob
     | uu____10599 -> failwith "unexpected: term was not an alien embedding"
-  
-let (process_pragma :
-  FStar_Syntax_Syntax.pragma -> FStar_Range.range -> Prims.unit) =
+let process_pragma:
+  FStar_Syntax_Syntax.pragma -> FStar_Range.range -> Prims.unit =
   fun p  ->
     fun r  ->
       let set_options1 t s =
-        let uu____10613 = FStar_Options.set_options t s  in
+        let uu____10613 = FStar_Options.set_options t s in
         match uu____10613 with
         | FStar_Getopt.Success  -> ()
         | FStar_Getopt.Help  ->
@@ -3681,8 +3407,7 @@ let (process_pragma :
         | FStar_Getopt.Error s1 ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_FailToProcessPragma,
-                (Prims.strcat "Failed to process pragma: " s1)) r
-         in
+                (Prims.strcat "Failed to process pragma: " s1)) r in
       match p with
       | FStar_Syntax_Syntax.LightOff  ->
           if p = FStar_Syntax_Syntax.LightOff
@@ -3690,11 +3415,9 @@ let (process_pragma :
           else ()
       | FStar_Syntax_Syntax.SetOptions o -> set_options1 FStar_Options.Set o
       | FStar_Syntax_Syntax.ResetOptions sopt ->
-          ((let uu____10621 = FStar_Options.restore_cmd_line_options false
-               in
+          ((let uu____10621 = FStar_Options.restore_cmd_line_options false in
             FStar_All.pipe_right uu____10621 FStar_Pervasives.ignore);
            (match sopt with
             | FStar_Pervasives_Native.None  -> ()
             | FStar_Pervasives_Native.Some s ->
                 set_options1 FStar_Options.Reset s))
-  

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -3,141 +3,124 @@ type goal = FStar_Tactics_Types.goal[@@deriving show]
 type name = FStar_Syntax_Syntax.bv[@@deriving show]
 type env = FStar_TypeChecker_Env.env[@@deriving show]
 type implicits = FStar_TypeChecker_Env.implicits[@@deriving show]
-let (normalize :
+let normalize:
   FStar_TypeChecker_Normalize.step Prims.list ->
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun s  ->
     fun e  ->
       fun t  ->
         FStar_TypeChecker_Normalize.normalize_with_primitive_steps
           FStar_Reflection_Interpreter.reflection_primops s e t
-  
-let (bnorm :
+let bnorm:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  = fun e  -> fun t  -> normalize [] e t 
-let (tts :
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.string) =
-  FStar_TypeChecker_Normalize.term_to_string 
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
+  = fun e  -> fun t  -> normalize [] e t
+let tts:
+  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.string =
+  FStar_TypeChecker_Normalize.term_to_string
 type 'a tac =
   {
-  tac_f: FStar_Tactics_Types.proofstate -> 'a FStar_Tactics_Result.__result }
+  tac_f: FStar_Tactics_Types.proofstate -> 'a FStar_Tactics_Result.__result;}
 [@@deriving show]
-let __proj__Mktac__item__tac_f :
+let __proj__Mktac__item__tac_f:
   'a .
     'a tac ->
       FStar_Tactics_Types.proofstate -> 'a FStar_Tactics_Result.__result
   =
   fun projectee  ->
     match projectee with | { tac_f = __fname__tac_f;_} -> __fname__tac_f
-  
-let mk_tac :
+let mk_tac:
   'a .
     (FStar_Tactics_Types.proofstate -> 'a FStar_Tactics_Result.__result) ->
       'a tac
-  = fun f  -> { tac_f = f } 
-let run :
+  = fun f  -> { tac_f = f }
+let run:
   'a .
     'a tac ->
       FStar_Tactics_Types.proofstate -> 'a FStar_Tactics_Result.__result
-  = fun t  -> fun p  -> t.tac_f p 
-let ret : 'a . 'a -> 'a tac =
-  fun x  -> mk_tac (fun p  -> FStar_Tactics_Result.Success (x, p)) 
-let bind : 'a 'b . 'a tac -> ('a -> 'b tac) -> 'b tac =
+  = fun t  -> fun p  -> t.tac_f p
+let ret: 'a . 'a -> 'a tac =
+  fun x  -> mk_tac (fun p  -> FStar_Tactics_Result.Success (x, p))
+let bind: 'a 'b . 'a tac -> ('a -> 'b tac) -> 'b tac =
   fun t1  ->
     fun t2  ->
       mk_tac
         (fun p  ->
-           let uu____140 = run t1 p  in
+           let uu____140 = run t1 p in
            match uu____140 with
            | FStar_Tactics_Result.Success (a,q) ->
-               let uu____147 = t2 a  in run uu____147 q
+               let uu____147 = t2 a in run uu____147 q
            | FStar_Tactics_Result.Failed (msg,q) ->
                FStar_Tactics_Result.Failed (msg, q))
-  
-let (idtac : Prims.unit tac) = ret () 
-let (goal_to_string : FStar_Tactics_Types.goal -> Prims.string) =
+let idtac: Prims.unit tac = ret ()
+let goal_to_string: FStar_Tactics_Types.goal -> Prims.string =
   fun g  ->
     let g_binders =
       let uu____158 =
-        FStar_TypeChecker_Env.all_binders g.FStar_Tactics_Types.context  in
+        FStar_TypeChecker_Env.all_binders g.FStar_Tactics_Types.context in
       FStar_All.pipe_right uu____158
-        (FStar_Syntax_Print.binders_to_string ", ")
-       in
-    let w = bnorm g.FStar_Tactics_Types.context g.FStar_Tactics_Types.witness
-       in
-    let t = bnorm g.FStar_Tactics_Types.context g.FStar_Tactics_Types.goal_ty
-       in
-    let uu____161 = tts g.FStar_Tactics_Types.context w  in
-    let uu____162 = tts g.FStar_Tactics_Types.context t  in
+        (FStar_Syntax_Print.binders_to_string ", ") in
+    let w = bnorm g.FStar_Tactics_Types.context g.FStar_Tactics_Types.witness in
+    let t = bnorm g.FStar_Tactics_Types.context g.FStar_Tactics_Types.goal_ty in
+    let uu____161 = tts g.FStar_Tactics_Types.context w in
+    let uu____162 = tts g.FStar_Tactics_Types.context t in
     FStar_Util.format3 "%s |- %s : %s" g_binders uu____161 uu____162
-  
-let (tacprint : Prims.string -> Prims.unit) =
-  fun s  -> FStar_Util.print1 "TAC>> %s\n" s 
-let (tacprint1 : Prims.string -> Prims.string -> Prims.unit) =
+let tacprint: Prims.string -> Prims.unit =
+  fun s  -> FStar_Util.print1 "TAC>> %s\n" s
+let tacprint1: Prims.string -> Prims.string -> Prims.unit =
   fun s  ->
     fun x  ->
-      let uu____172 = FStar_Util.format1 s x  in
+      let uu____172 = FStar_Util.format1 s x in
       FStar_Util.print1 "TAC>> %s\n" uu____172
-  
-let (tacprint2 : Prims.string -> Prims.string -> Prims.string -> Prims.unit)
-  =
+let tacprint2: Prims.string -> Prims.string -> Prims.string -> Prims.unit =
   fun s  ->
     fun x  ->
       fun y  ->
-        let uu____182 = FStar_Util.format2 s x y  in
+        let uu____182 = FStar_Util.format2 s x y in
         FStar_Util.print1 "TAC>> %s\n" uu____182
-  
-let (tacprint3 :
-  Prims.string -> Prims.string -> Prims.string -> Prims.string -> Prims.unit)
+let tacprint3:
+  Prims.string -> Prims.string -> Prims.string -> Prims.string -> Prims.unit
   =
   fun s  ->
     fun x  ->
       fun y  ->
         fun z  ->
-          let uu____195 = FStar_Util.format3 s x y z  in
+          let uu____195 = FStar_Util.format3 s x y z in
           FStar_Util.print1 "TAC>> %s\n" uu____195
-  
-let (comp_to_typ : FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.typ) =
+let comp_to_typ: FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.typ =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total (t,uu____200) -> t
     | FStar_Syntax_Syntax.GTotal (t,uu____210) -> t
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.result_typ
-  
-let (is_irrelevant : FStar_Tactics_Types.goal -> Prims.bool) =
+let is_irrelevant: FStar_Tactics_Types.goal -> Prims.bool =
   fun g  ->
     let uu____223 =
       let uu____228 =
         FStar_TypeChecker_Normalize.unfold_whnf g.FStar_Tactics_Types.context
-          g.FStar_Tactics_Types.goal_ty
-         in
-      FStar_Syntax_Util.un_squash uu____228  in
+          g.FStar_Tactics_Types.goal_ty in
+      FStar_Syntax_Util.un_squash uu____228 in
     match uu____223 with
     | FStar_Pervasives_Native.Some t -> true
     | uu____234 -> false
-  
-let dump_goal :
+let dump_goal:
   'Auu____242 . 'Auu____242 -> FStar_Tactics_Types.goal -> Prims.unit =
   fun ps  ->
-    fun goal  -> let uu____252 = goal_to_string goal  in tacprint uu____252
-  
-let (dump_cur : FStar_Tactics_Types.proofstate -> Prims.string -> Prims.unit)
-  =
+    fun goal  -> let uu____252 = goal_to_string goal in tacprint uu____252
+let dump_cur: FStar_Tactics_Types.proofstate -> Prims.string -> Prims.unit =
   fun ps  ->
     fun msg  ->
       match ps.FStar_Tactics_Types.goals with
       | [] -> tacprint1 "No more goals (%s)" msg
       | h::uu____260 ->
           (tacprint1 "Current goal (%s):" msg;
-           (let uu____264 = FStar_List.hd ps.FStar_Tactics_Types.goals  in
+           (let uu____264 = FStar_List.hd ps.FStar_Tactics_Types.goals in
             dump_goal ps uu____264))
-  
-let (ps_to_string :
+let ps_to_string:
   (Prims.string,FStar_Tactics_Types.proofstate)
-    FStar_Pervasives_Native.tuple2 -> Prims.string)
+    FStar_Pervasives_Native.tuple2 -> Prims.string
   =
   fun uu____271  ->
     match uu____271 with
@@ -145,58 +128,49 @@ let (ps_to_string :
         let uu____278 =
           let uu____281 =
             let uu____282 =
-              FStar_Util.string_of_int ps.FStar_Tactics_Types.depth  in
-            FStar_Util.format2 "State dump @ depth %s (%s):\n" uu____282 msg
-             in
+              FStar_Util.string_of_int ps.FStar_Tactics_Types.depth in
+            FStar_Util.format2 "State dump @ depth %s (%s):\n" uu____282 msg in
           let uu____283 =
             let uu____286 =
               let uu____287 =
                 FStar_Range.string_of_range
-                  ps.FStar_Tactics_Types.entry_range
-                 in
-              FStar_Util.format1 "Position: %s\n" uu____287  in
+                  ps.FStar_Tactics_Types.entry_range in
+              FStar_Util.format1 "Position: %s\n" uu____287 in
             let uu____288 =
               let uu____291 =
                 let uu____292 =
                   FStar_Util.string_of_int
-                    (FStar_List.length ps.FStar_Tactics_Types.goals)
-                   in
+                    (FStar_List.length ps.FStar_Tactics_Types.goals) in
                 let uu____293 =
                   let uu____294 =
                     FStar_List.map goal_to_string
-                      ps.FStar_Tactics_Types.goals
-                     in
-                  FStar_String.concat "\n" uu____294  in
+                      ps.FStar_Tactics_Types.goals in
+                  FStar_String.concat "\n" uu____294 in
                 FStar_Util.format2 "ACTIVE goals (%s):\n%s\n" uu____292
-                  uu____293
-                 in
+                  uu____293 in
               let uu____297 =
                 let uu____300 =
                   let uu____301 =
                     FStar_Util.string_of_int
-                      (FStar_List.length ps.FStar_Tactics_Types.smt_goals)
-                     in
+                      (FStar_List.length ps.FStar_Tactics_Types.smt_goals) in
                   let uu____302 =
                     let uu____303 =
                       FStar_List.map goal_to_string
-                        ps.FStar_Tactics_Types.smt_goals
-                       in
-                    FStar_String.concat "\n" uu____303  in
+                        ps.FStar_Tactics_Types.smt_goals in
+                    FStar_String.concat "\n" uu____303 in
                   FStar_Util.format2 "SMT goals (%s):\n%s\n" uu____301
-                    uu____302
-                   in
-                [uu____300]  in
-              uu____291 :: uu____297  in
-            uu____286 :: uu____288  in
-          uu____281 :: uu____283  in
+                    uu____302 in
+                [uu____300] in
+              uu____291 :: uu____297 in
+            uu____286 :: uu____288 in
+          uu____281 :: uu____283 in
         FStar_String.concat "" uu____278
-  
-let (goal_to_json : FStar_Tactics_Types.goal -> FStar_Util.json) =
+let goal_to_json: FStar_Tactics_Types.goal -> FStar_Util.json =
   fun g  ->
     let g_binders =
       let uu____310 =
-        FStar_TypeChecker_Env.all_binders g.FStar_Tactics_Types.context  in
-      FStar_All.pipe_right uu____310 FStar_Syntax_Print.binders_to_json  in
+        FStar_TypeChecker_Env.all_binders g.FStar_Tactics_Types.context in
+      FStar_All.pipe_right uu____310 FStar_Syntax_Print.binders_to_json in
     let uu____311 =
       let uu____318 =
         let uu____325 =
@@ -206,30 +180,27 @@ let (goal_to_json : FStar_Tactics_Types.goal -> FStar_Util.json) =
                 let uu____343 =
                   let uu____344 =
                     tts g.FStar_Tactics_Types.context
-                      g.FStar_Tactics_Types.witness
-                     in
-                  FStar_Util.JsonStr uu____344  in
-                ("witness", uu____343)  in
+                      g.FStar_Tactics_Types.witness in
+                  FStar_Util.JsonStr uu____344 in
+                ("witness", uu____343) in
               let uu____345 =
                 let uu____352 =
                   let uu____357 =
                     let uu____358 =
                       tts g.FStar_Tactics_Types.context
-                        g.FStar_Tactics_Types.goal_ty
-                       in
-                    FStar_Util.JsonStr uu____358  in
-                  ("type", uu____357)  in
-                [uu____352]  in
-              uu____338 :: uu____345  in
-            FStar_Util.JsonAssoc uu____331  in
-          ("goal", uu____330)  in
-        [uu____325]  in
-      ("hyps", g_binders) :: uu____318  in
+                        g.FStar_Tactics_Types.goal_ty in
+                    FStar_Util.JsonStr uu____358 in
+                  ("type", uu____357) in
+                [uu____352] in
+              uu____338 :: uu____345 in
+            FStar_Util.JsonAssoc uu____331 in
+          ("goal", uu____330) in
+        [uu____325] in
+      ("hyps", g_binders) :: uu____318 in
     FStar_Util.JsonAssoc uu____311
-  
-let (ps_to_json :
+let ps_to_json:
   (Prims.string,FStar_Tactics_Types.proofstate)
-    FStar_Pervasives_Native.tuple2 -> FStar_Util.json)
+    FStar_Pervasives_Native.tuple2 -> FStar_Util.json
   =
   fun uu____389  ->
     match uu____389 with
@@ -239,26 +210,23 @@ let (ps_to_json :
             let uu____410 =
               let uu____415 =
                 let uu____416 =
-                  FStar_List.map goal_to_json ps.FStar_Tactics_Types.goals
-                   in
-                FStar_Util.JsonList uu____416  in
-              ("goals", uu____415)  in
+                  FStar_List.map goal_to_json ps.FStar_Tactics_Types.goals in
+                FStar_Util.JsonList uu____416 in
+              ("goals", uu____415) in
             let uu____419 =
               let uu____426 =
                 let uu____431 =
                   let uu____432 =
                     FStar_List.map goal_to_json
-                      ps.FStar_Tactics_Types.smt_goals
-                     in
-                  FStar_Util.JsonList uu____432  in
-                ("smt-goals", uu____431)  in
-              [uu____426]  in
-            uu____410 :: uu____419  in
-          ("label", (FStar_Util.JsonStr msg)) :: uu____403  in
+                      ps.FStar_Tactics_Types.smt_goals in
+                  FStar_Util.JsonList uu____432 in
+                ("smt-goals", uu____431) in
+              [uu____426] in
+            uu____410 :: uu____419 in
+          ("label", (FStar_Util.JsonStr msg)) :: uu____403 in
         FStar_Util.JsonAssoc uu____396
-  
-let (dump_proofstate :
-  FStar_Tactics_Types.proofstate -> Prims.string -> Prims.unit) =
+let dump_proofstate:
+  FStar_Tactics_Types.proofstate -> Prims.string -> Prims.unit =
   fun ps  ->
     fun msg  ->
       FStar_Options.with_saved_options
@@ -267,80 +235,70 @@ let (dump_proofstate :
              (FStar_Options.Bool true);
            FStar_Util.print_generic "proof-state" ps_to_string ps_to_json
              (msg, ps))
-  
-let (print_proof_state1 : Prims.string -> Prims.unit tac) =
+let print_proof_state1: Prims.string -> Prims.unit tac =
   fun msg  ->
     mk_tac
       (fun ps  ->
-         let psc = ps.FStar_Tactics_Types.psc  in
-         let subst1 = FStar_TypeChecker_Normalize.psc_subst psc  in
-         (let uu____480 = FStar_Tactics_Types.subst_proof_state subst1 ps  in
+         let psc = ps.FStar_Tactics_Types.psc in
+         let subst1 = FStar_TypeChecker_Normalize.psc_subst psc in
+         (let uu____480 = FStar_Tactics_Types.subst_proof_state subst1 ps in
           dump_cur uu____480 msg);
          FStar_Tactics_Result.Success ((), ps))
-  
-let (print_proof_state : Prims.string -> Prims.unit tac) =
+let print_proof_state: Prims.string -> Prims.unit tac =
   fun msg  ->
     mk_tac
       (fun ps  ->
-         let psc = ps.FStar_Tactics_Types.psc  in
-         let subst1 = FStar_TypeChecker_Normalize.psc_subst psc  in
-         (let uu____496 = FStar_Tactics_Types.subst_proof_state subst1 ps  in
+         let psc = ps.FStar_Tactics_Types.psc in
+         let subst1 = FStar_TypeChecker_Normalize.psc_subst psc in
+         (let uu____496 = FStar_Tactics_Types.subst_proof_state subst1 ps in
           dump_proofstate uu____496 msg);
          FStar_Tactics_Result.Success ((), ps))
-  
-let (get : FStar_Tactics_Types.proofstate tac) =
-  mk_tac (fun p  -> FStar_Tactics_Result.Success (p, p)) 
-let (tac_verb_dbg : Prims.bool FStar_Pervasives_Native.option FStar_ST.ref) =
-  FStar_Util.mk_ref FStar_Pervasives_Native.None 
-let rec (log :
-  FStar_Tactics_Types.proofstate -> (Prims.unit -> Prims.unit) -> Prims.unit)
+let get: FStar_Tactics_Types.proofstate tac =
+  mk_tac (fun p  -> FStar_Tactics_Result.Success (p, p))
+let tac_verb_dbg: Prims.bool FStar_Pervasives_Native.option FStar_ST.ref =
+  FStar_Util.mk_ref FStar_Pervasives_Native.None
+let rec log:
+  FStar_Tactics_Types.proofstate -> (Prims.unit -> Prims.unit) -> Prims.unit
   =
   fun ps  ->
     fun f  ->
-      let uu____531 = FStar_ST.op_Bang tac_verb_dbg  in
+      let uu____531 = FStar_ST.op_Bang tac_verb_dbg in
       match uu____531 with
       | FStar_Pervasives_Native.None  ->
           ((let uu____558 =
               let uu____561 =
                 FStar_TypeChecker_Env.debug
                   ps.FStar_Tactics_Types.main_context
-                  (FStar_Options.Other "TacVerbose")
-                 in
-              FStar_Pervasives_Native.Some uu____561  in
+                  (FStar_Options.Other "TacVerbose") in
+              FStar_Pervasives_Native.Some uu____561 in
             FStar_ST.op_Colon_Equals tac_verb_dbg uu____558);
            log ps f)
       | FStar_Pervasives_Native.Some (true ) -> f ()
       | FStar_Pervasives_Native.Some (false ) -> ()
-  
-let mlog :
-  'a . (Prims.unit -> Prims.unit) -> (Prims.unit -> 'a tac) -> 'a tac =
-  fun f  -> fun cont  -> bind get (fun ps  -> log ps f; cont ()) 
-let fail : 'a . Prims.string -> 'a tac =
+let mlog: 'a . (Prims.unit -> Prims.unit) -> (Prims.unit -> 'a tac) -> 'a tac
+  = fun f  -> fun cont  -> bind get (fun ps  -> log ps f; cont ())
+let fail: 'a . Prims.string -> 'a tac =
   fun msg  ->
     mk_tac
       (fun ps  ->
          (let uu____630 =
             FStar_TypeChecker_Env.debug ps.FStar_Tactics_Types.main_context
-              (FStar_Options.Other "TacFail")
-             in
+              (FStar_Options.Other "TacFail") in
           if uu____630
           then dump_proofstate ps (Prims.strcat "TACTING FAILING: " msg)
           else ());
          FStar_Tactics_Result.Failed (msg, ps))
-  
-let fail1 : 'Auu____635 . Prims.string -> Prims.string -> 'Auu____635 tac =
+let fail1: 'Auu____635 . Prims.string -> Prims.string -> 'Auu____635 tac =
   fun msg  ->
-    fun x  -> let uu____646 = FStar_Util.format1 msg x  in fail uu____646
-  
-let fail2 :
+    fun x  -> let uu____646 = FStar_Util.format1 msg x in fail uu____646
+let fail2:
   'Auu____651 .
     Prims.string -> Prims.string -> Prims.string -> 'Auu____651 tac
   =
   fun msg  ->
     fun x  ->
-      fun y  -> let uu____666 = FStar_Util.format2 msg x y  in fail uu____666
-  
-let fail3 :
+      fun y  -> let uu____666 = FStar_Util.format2 msg x y in fail uu____666
+let fail3:
   'Auu____672 .
     Prims.string ->
       Prims.string -> Prims.string -> Prims.string -> 'Auu____672 tac
@@ -349,9 +307,8 @@ let fail3 :
     fun x  ->
       fun y  ->
         fun z  ->
-          let uu____691 = FStar_Util.format3 msg x y z  in fail uu____691
-  
-let fail4 :
+          let uu____691 = FStar_Util.format3 msg x y z in fail uu____691
+let fail4:
   'Auu____698 .
     Prims.string ->
       Prims.string ->
@@ -362,14 +319,13 @@ let fail4 :
       fun y  ->
         fun z  ->
           fun w  ->
-            let uu____721 = FStar_Util.format4 msg x y z w  in fail uu____721
-  
-let trytac' : 'a . 'a tac -> (Prims.string,'a) FStar_Util.either tac =
+            let uu____721 = FStar_Util.format4 msg x y z w in fail uu____721
+let trytac': 'a . 'a tac -> (Prims.string,'a) FStar_Util.either tac =
   fun t  ->
     mk_tac
       (fun ps  ->
-         let tx = FStar_Syntax_Unionfind.new_transaction ()  in
-         let uu____751 = run t ps  in
+         let tx = FStar_Syntax_Unionfind.new_transaction () in
+         let uu____751 = run t ps in
          match uu____751 with
          | FStar_Tactics_Result.Success (a,q) ->
              (FStar_Syntax_Unionfind.commit tx;
@@ -377,75 +333,67 @@ let trytac' : 'a . 'a tac -> (Prims.string,'a) FStar_Util.either tac =
          | FStar_Tactics_Result.Failed (m,uu____772) ->
              (FStar_Syntax_Unionfind.rollback tx;
               FStar_Tactics_Result.Success ((FStar_Util.Inl m), ps)))
-  
-let trytac : 'a . 'a tac -> 'a FStar_Pervasives_Native.option tac =
+let trytac: 'a . 'a tac -> 'a FStar_Pervasives_Native.option tac =
   fun t  ->
-    let uu____797 = trytac' t  in
+    let uu____797 = trytac' t in
     bind uu____797
       (fun r  ->
          match r with
          | FStar_Util.Inr v1 -> ret (FStar_Pervasives_Native.Some v1)
          | FStar_Util.Inl uu____824 -> ret FStar_Pervasives_Native.None)
-  
-let wrap_err : 'a . Prims.string -> 'a tac -> 'a tac =
+let wrap_err: 'a . Prims.string -> 'a tac -> 'a tac =
   fun pref  ->
     fun t  ->
       mk_tac
         (fun ps  ->
-           let uu____850 = run t ps  in
+           let uu____850 = run t ps in
            match uu____850 with
            | FStar_Tactics_Result.Success (a,q) ->
                FStar_Tactics_Result.Success (a, q)
            | FStar_Tactics_Result.Failed (msg,q) ->
                FStar_Tactics_Result.Failed
                  ((Prims.strcat pref (Prims.strcat ": " msg)), q))
-  
-let (set : FStar_Tactics_Types.proofstate -> Prims.unit tac) =
-  fun p  -> mk_tac (fun uu____867  -> FStar_Tactics_Result.Success ((), p)) 
-let (do_unify :
-  env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool)
-  =
+let set: FStar_Tactics_Types.proofstate -> Prims.unit tac =
+  fun p  -> mk_tac (fun uu____867  -> FStar_Tactics_Result.Success ((), p))
+let do_unify:
+  env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun env  ->
     fun t1  ->
       fun t2  ->
         let debug_on uu____880 =
           let uu____881 =
             FStar_Options.set_options FStar_Options.Set
-              "--debug_level Rel --debug_level RelCheck"
-             in
-          ()  in
+              "--debug_level Rel --debug_level RelCheck" in
+          () in
         let debug_off uu____885 =
-          let uu____886 = FStar_Options.set_options FStar_Options.Reset ""
-             in
-          ()  in
+          let uu____886 = FStar_Options.set_options FStar_Options.Reset "" in
+          () in
         (let uu____888 =
-           FStar_TypeChecker_Env.debug env (FStar_Options.Other "1346")  in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "1346") in
          if uu____888
          then
            (debug_on ();
-            (let uu____890 = FStar_Syntax_Print.term_to_string t1  in
-             let uu____891 = FStar_Syntax_Print.term_to_string t2  in
+            (let uu____890 = FStar_Syntax_Print.term_to_string t1 in
+             let uu____891 = FStar_Syntax_Print.term_to_string t2 in
              FStar_Util.print2 "%%%%%%%%do_unify %s =? %s\n" uu____890
                uu____891))
          else ());
         (try
-           let res = FStar_TypeChecker_Rel.teq_nosmt env t1 t2  in
+           let res = FStar_TypeChecker_Rel.teq_nosmt env t1 t2 in
            debug_off (); res
          with | uu____903 -> (debug_off (); false))
-  
-let (trysolve :
-  FStar_Tactics_Types.goal -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let trysolve:
+  FStar_Tactics_Types.goal -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun goal  ->
     fun solution  ->
       do_unify goal.FStar_Tactics_Types.context solution
         goal.FStar_Tactics_Types.witness
-  
-let (dismiss : Prims.unit tac) =
+let dismiss: Prims.unit tac =
   bind get
     (fun p  ->
        let uu____916 =
-         let uu___63_917 = p  in
-         let uu____918 = FStar_List.tl p.FStar_Tactics_Types.goals  in
+         let uu___63_917 = p in
+         let uu____918 = FStar_List.tl p.FStar_Tactics_Types.goals in
          {
            FStar_Tactics_Types.main_context =
              (uu___63_917.FStar_Tactics_Types.main_context);
@@ -463,37 +411,32 @@ let (dismiss : Prims.unit tac) =
            FStar_Tactics_Types.psc = (uu___63_917.FStar_Tactics_Types.psc);
            FStar_Tactics_Types.entry_range =
              (uu___63_917.FStar_Tactics_Types.entry_range)
-         }  in
+         } in
        set uu____916)
-  
-let (solve :
-  FStar_Tactics_Types.goal -> FStar_Syntax_Syntax.term -> Prims.unit tac) =
+let solve:
+  FStar_Tactics_Types.goal -> FStar_Syntax_Syntax.term -> Prims.unit tac =
   fun goal  ->
     fun solution  ->
-      let uu____931 = trysolve goal solution  in
+      let uu____931 = trysolve goal solution in
       if uu____931
       then dismiss
       else
         (let uu____935 =
-           let uu____936 = tts goal.FStar_Tactics_Types.context solution  in
+           let uu____936 = tts goal.FStar_Tactics_Types.context solution in
            let uu____937 =
              tts goal.FStar_Tactics_Types.context
-               goal.FStar_Tactics_Types.witness
-              in
+               goal.FStar_Tactics_Types.witness in
            let uu____938 =
              tts goal.FStar_Tactics_Types.context
-               goal.FStar_Tactics_Types.goal_ty
-              in
+               goal.FStar_Tactics_Types.goal_ty in
            FStar_Util.format3 "%s does not solve %s : %s" uu____936 uu____937
-             uu____938
-            in
+             uu____938 in
          fail uu____935)
-  
-let (dismiss_all : Prims.unit tac) =
+let dismiss_all: Prims.unit tac =
   bind get
     (fun p  ->
        set
-         (let uu___64_945 = p  in
+         (let uu___64_945 = p in
           {
             FStar_Tactics_Types.main_context =
               (uu___64_945.FStar_Tactics_Types.main_context);
@@ -512,60 +455,51 @@ let (dismiss_all : Prims.unit tac) =
             FStar_Tactics_Types.entry_range =
               (uu___64_945.FStar_Tactics_Types.entry_range)
           }))
-  
-let (nwarn : Prims.int FStar_ST.ref) =
-  FStar_Util.mk_ref (Prims.parse_int "0") 
-let (check_valid_goal : FStar_Tactics_Types.goal -> Prims.unit) =
+let nwarn: Prims.int FStar_ST.ref = FStar_Util.mk_ref (Prims.parse_int "0")
+let check_valid_goal: FStar_Tactics_Types.goal -> Prims.unit =
   fun g  ->
-    let b = true  in
-    let env = g.FStar_Tactics_Types.context  in
+    let b = true in
+    let env = g.FStar_Tactics_Types.context in
     let b1 =
-      b && (FStar_TypeChecker_Env.closed env g.FStar_Tactics_Types.witness)
-       in
+      b && (FStar_TypeChecker_Env.closed env g.FStar_Tactics_Types.witness) in
     let b2 =
-      b1 && (FStar_TypeChecker_Env.closed env g.FStar_Tactics_Types.goal_ty)
-       in
+      b1 && (FStar_TypeChecker_Env.closed env g.FStar_Tactics_Types.goal_ty) in
     let rec aux b3 e =
-      let uu____973 = FStar_TypeChecker_Env.pop_bv e  in
+      let uu____973 = FStar_TypeChecker_Env.pop_bv e in
       match uu____973 with
       | FStar_Pervasives_Native.None  -> b3
       | FStar_Pervasives_Native.Some (bv,e1) ->
           let b4 =
             b3 &&
-              (FStar_TypeChecker_Env.closed e1 bv.FStar_Syntax_Syntax.sort)
-             in
-          aux b4 e1
-       in
+              (FStar_TypeChecker_Env.closed e1 bv.FStar_Syntax_Syntax.sort) in
+          aux b4 e1 in
     let uu____991 =
-      (let uu____994 = aux b2 env  in Prims.op_Negation uu____994) &&
-        (let uu____996 = FStar_ST.op_Bang nwarn  in
-         uu____996 < (Prims.parse_int "5"))
-       in
+      (let uu____994 = aux b2 env in Prims.op_Negation uu____994) &&
+        (let uu____996 = FStar_ST.op_Bang nwarn in
+         uu____996 < (Prims.parse_int "5")) in
     if uu____991
     then
       ((let uu____1017 =
           let uu____1022 =
-            let uu____1023 = goal_to_string g  in
+            let uu____1023 = goal_to_string g in
             FStar_Util.format1
               "The following goal is ill-formed. Keeping calm and carrying on...\n<%s>\n\n"
-              uu____1023
-             in
-          (FStar_Errors.Warning_IllFormedGoal, uu____1022)  in
+              uu____1023 in
+          (FStar_Errors.Warning_IllFormedGoal, uu____1022) in
         FStar_Errors.log_issue
           (g.FStar_Tactics_Types.goal_ty).FStar_Syntax_Syntax.pos uu____1017);
        (let uu____1024 =
-          let uu____1025 = FStar_ST.op_Bang nwarn  in
-          uu____1025 + (Prims.parse_int "1")  in
+          let uu____1025 = FStar_ST.op_Bang nwarn in
+          uu____1025 + (Prims.parse_int "1") in
         FStar_ST.op_Colon_Equals nwarn uu____1024))
     else ()
-  
-let (add_goals : FStar_Tactics_Types.goal Prims.list -> Prims.unit tac) =
+let add_goals: FStar_Tactics_Types.goal Prims.list -> Prims.unit tac =
   fun gs  ->
     bind get
       (fun p  ->
          FStar_List.iter check_valid_goal gs;
          set
-           (let uu___65_1082 = p  in
+           (let uu___65_1082 = p in
             {
               FStar_Tactics_Types.main_context =
                 (uu___65_1082.FStar_Tactics_Types.main_context);
@@ -586,14 +520,13 @@ let (add_goals : FStar_Tactics_Types.goal Prims.list -> Prims.unit tac) =
               FStar_Tactics_Types.entry_range =
                 (uu___65_1082.FStar_Tactics_Types.entry_range)
             }))
-  
-let (add_smt_goals : FStar_Tactics_Types.goal Prims.list -> Prims.unit tac) =
+let add_smt_goals: FStar_Tactics_Types.goal Prims.list -> Prims.unit tac =
   fun gs  ->
     bind get
       (fun p  ->
          FStar_List.iter check_valid_goal gs;
          set
-           (let uu___66_1100 = p  in
+           (let uu___66_1100 = p in
             {
               FStar_Tactics_Types.main_context =
                 (uu___66_1100.FStar_Tactics_Types.main_context);
@@ -614,14 +547,13 @@ let (add_smt_goals : FStar_Tactics_Types.goal Prims.list -> Prims.unit tac) =
               FStar_Tactics_Types.entry_range =
                 (uu___66_1100.FStar_Tactics_Types.entry_range)
             }))
-  
-let (push_goals : FStar_Tactics_Types.goal Prims.list -> Prims.unit tac) =
+let push_goals: FStar_Tactics_Types.goal Prims.list -> Prims.unit tac =
   fun gs  ->
     bind get
       (fun p  ->
          FStar_List.iter check_valid_goal gs;
          set
-           (let uu___67_1118 = p  in
+           (let uu___67_1118 = p in
             {
               FStar_Tactics_Types.main_context =
                 (uu___67_1118.FStar_Tactics_Types.main_context);
@@ -642,15 +574,13 @@ let (push_goals : FStar_Tactics_Types.goal Prims.list -> Prims.unit tac) =
               FStar_Tactics_Types.entry_range =
                 (uu___67_1118.FStar_Tactics_Types.entry_range)
             }))
-  
-let (push_smt_goals : FStar_Tactics_Types.goal Prims.list -> Prims.unit tac)
-  =
+let push_smt_goals: FStar_Tactics_Types.goal Prims.list -> Prims.unit tac =
   fun gs  ->
     bind get
       (fun p  ->
          FStar_List.iter check_valid_goal gs;
          set
-           (let uu___68_1136 = p  in
+           (let uu___68_1136 = p in
             {
               FStar_Tactics_Types.main_context =
                 (uu___68_1136.FStar_Tactics_Types.main_context);
@@ -671,15 +601,14 @@ let (push_smt_goals : FStar_Tactics_Types.goal Prims.list -> Prims.unit tac)
               FStar_Tactics_Types.entry_range =
                 (uu___68_1136.FStar_Tactics_Types.entry_range)
             }))
-  
-let (replace_cur : FStar_Tactics_Types.goal -> Prims.unit tac) =
-  fun g  -> bind dismiss (fun uu____1145  -> add_goals [g]) 
-let (add_implicits : implicits -> Prims.unit tac) =
+let replace_cur: FStar_Tactics_Types.goal -> Prims.unit tac =
+  fun g  -> bind dismiss (fun uu____1145  -> add_goals [g])
+let add_implicits: implicits -> Prims.unit tac =
   fun i  ->
     bind get
       (fun p  ->
          set
-           (let uu___69_1157 = p  in
+           (let uu___69_1157 = p in
             {
               FStar_Tactics_Types.main_context =
                 (uu___69_1157.FStar_Tactics_Types.main_context);
@@ -700,76 +629,69 @@ let (add_implicits : implicits -> Prims.unit tac) =
               FStar_Tactics_Types.entry_range =
                 (uu___69_1157.FStar_Tactics_Types.entry_range)
             }))
-  
-let (new_uvar :
+let new_uvar:
   Prims.string ->
-    env -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term tac)
+    env -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term tac
   =
   fun reason  ->
     fun env  ->
       fun typ  ->
         let uu____1183 =
           FStar_TypeChecker_Util.new_implicit_var reason
-            typ.FStar_Syntax_Syntax.pos env typ
-           in
+            typ.FStar_Syntax_Syntax.pos env typ in
         match uu____1183 with
         | (u,uu____1199,g_u) ->
             let uu____1213 =
-              add_implicits g_u.FStar_TypeChecker_Env.implicits  in
+              add_implicits g_u.FStar_TypeChecker_Env.implicits in
             bind uu____1213 (fun uu____1217  -> ret u)
-  
-let (is_true : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_true: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
-    let uu____1221 = FStar_Syntax_Util.un_squash t  in
+    let uu____1221 = FStar_Syntax_Util.un_squash t in
     match uu____1221 with
     | FStar_Pervasives_Native.Some t' ->
         let uu____1231 =
-          let uu____1232 = FStar_Syntax_Subst.compress t'  in
-          uu____1232.FStar_Syntax_Syntax.n  in
+          let uu____1232 = FStar_Syntax_Subst.compress t' in
+          uu____1232.FStar_Syntax_Syntax.n in
         (match uu____1231 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid
          | uu____1236 -> false)
     | uu____1237 -> false
-  
-let (is_false : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_false: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
-    let uu____1245 = FStar_Syntax_Util.un_squash t  in
+    let uu____1245 = FStar_Syntax_Util.un_squash t in
     match uu____1245 with
     | FStar_Pervasives_Native.Some t' ->
         let uu____1255 =
-          let uu____1256 = FStar_Syntax_Subst.compress t'  in
-          uu____1256.FStar_Syntax_Syntax.n  in
+          let uu____1256 = FStar_Syntax_Subst.compress t' in
+          uu____1256.FStar_Syntax_Syntax.n in
         (match uu____1255 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.false_lid
          | uu____1260 -> false)
     | uu____1261 -> false
-  
-let (cur_goal : FStar_Tactics_Types.goal tac) =
+let cur_goal: FStar_Tactics_Types.goal tac =
   bind get
     (fun p  ->
        match p.FStar_Tactics_Types.goals with
        | [] -> fail "No more goals (1)"
        | hd1::tl1 -> ret hd1)
-  
-let (is_guard : Prims.bool tac) =
-  bind cur_goal (fun g  -> ret g.FStar_Tactics_Types.is_guard) 
-let (mk_irrelevant_goal :
+let is_guard: Prims.bool tac =
+  bind cur_goal (fun g  -> ret g.FStar_Tactics_Types.is_guard)
+let mk_irrelevant_goal:
   Prims.string ->
     env ->
       FStar_Syntax_Syntax.typ ->
-        FStar_Options.optionstate -> FStar_Tactics_Types.goal tac)
+        FStar_Options.optionstate -> FStar_Tactics_Types.goal tac
   =
   fun reason  ->
     fun env  ->
       fun phi  ->
         fun opts  ->
           let typ =
-            let uu____1301 = env.FStar_TypeChecker_Env.universe_of env phi
-               in
-            FStar_Syntax_Util.mk_squash uu____1301 phi  in
-          let uu____1302 = new_uvar reason env typ  in
+            let uu____1301 = env.FStar_TypeChecker_Env.universe_of env phi in
+            FStar_Syntax_Util.mk_squash uu____1301 phi in
+          let uu____1302 = new_uvar reason env typ in
           bind uu____1302
             (fun u  ->
                let goal =
@@ -779,14 +701,13 @@ let (mk_irrelevant_goal :
                    FStar_Tactics_Types.goal_ty = typ;
                    FStar_Tactics_Types.opts = opts;
                    FStar_Tactics_Types.is_guard = false
-                 }  in
+                 } in
                ret goal)
-  
-let (__tc :
+let __tc:
   env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.typ,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3 tac)
+        FStar_Pervasives_Native.tuple3 tac
   =
   fun e  ->
     fun t  ->
@@ -795,54 +716,46 @@ let (__tc :
            try
              let uu____1358 =
                (ps.FStar_Tactics_Types.main_context).FStar_TypeChecker_Env.type_of
-                 e t
-                in
+                 e t in
              ret uu____1358
            with | e1 -> fail "not typeable")
-  
-let (must_trivial : env -> FStar_TypeChecker_Env.guard_t -> Prims.unit tac) =
+let must_trivial: env -> FStar_TypeChecker_Env.guard_t -> Prims.unit tac =
   fun e  ->
     fun g  ->
       try
         let uu____1406 =
           let uu____1407 =
-            let uu____1408 = FStar_TypeChecker_Rel.discharge_guard_no_smt e g
-               in
-            FStar_All.pipe_left FStar_TypeChecker_Rel.is_trivial uu____1408
-             in
-          Prims.op_Negation uu____1407  in
+            let uu____1408 = FStar_TypeChecker_Rel.discharge_guard_no_smt e g in
+            FStar_All.pipe_left FStar_TypeChecker_Rel.is_trivial uu____1408 in
+          Prims.op_Negation uu____1407 in
         if uu____1406 then fail "got non-trivial guard" else ret ()
       with | uu____1417 -> fail "got non-trivial guard"
-  
-let (tc : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.typ tac) =
+let tc: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.typ tac =
   fun t  ->
     let uu____1425 =
       bind cur_goal
         (fun goal  ->
-           let uu____1431 = __tc goal.FStar_Tactics_Types.context t  in
+           let uu____1431 = __tc goal.FStar_Tactics_Types.context t in
            bind uu____1431
              (fun uu____1451  ->
                 match uu____1451 with
                 | (t1,typ,guard) ->
                     let uu____1463 =
-                      must_trivial goal.FStar_Tactics_Types.context guard  in
-                    bind uu____1463 (fun uu____1467  -> ret typ)))
-       in
+                      must_trivial goal.FStar_Tactics_Types.context guard in
+                    bind uu____1463 (fun uu____1467  -> ret typ))) in
     FStar_All.pipe_left (wrap_err "tc") uu____1425
-  
-let (add_irrelevant_goal :
+let add_irrelevant_goal:
   Prims.string ->
     env ->
-      FStar_Syntax_Syntax.typ -> FStar_Options.optionstate -> Prims.unit tac)
+      FStar_Syntax_Syntax.typ -> FStar_Options.optionstate -> Prims.unit tac
   =
   fun reason  ->
     fun env  ->
       fun phi  ->
         fun opts  ->
-          let uu____1488 = mk_irrelevant_goal reason env phi opts  in
+          let uu____1488 = mk_irrelevant_goal reason env phi opts in
           bind uu____1488 (fun goal  -> add_goals [goal])
-  
-let (istrivial : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let istrivial: env -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun e  ->
     fun t  ->
       let steps =
@@ -852,50 +765,46 @@ let (istrivial : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
         FStar_TypeChecker_Normalize.Primops;
         FStar_TypeChecker_Normalize.Simplify;
         FStar_TypeChecker_Normalize.UnfoldTac;
-        FStar_TypeChecker_Normalize.Unmeta]  in
-      let t1 = normalize steps e t  in is_true t1
-  
-let (trivial : Prims.unit tac) =
+        FStar_TypeChecker_Normalize.Unmeta] in
+      let t1 = normalize steps e t in is_true t1
+let trivial: Prims.unit tac =
   bind cur_goal
     (fun goal  ->
        let uu____1510 =
          istrivial goal.FStar_Tactics_Types.context
-           goal.FStar_Tactics_Types.goal_ty
-          in
+           goal.FStar_Tactics_Types.goal_ty in
        if uu____1510
        then solve goal FStar_Syntax_Util.exp_unit
        else
          (let uu____1514 =
             tts goal.FStar_Tactics_Types.context
-              goal.FStar_Tactics_Types.goal_ty
-             in
+              goal.FStar_Tactics_Types.goal_ty in
           fail1 "Not a trivial goal: %s" uu____1514))
-  
-let (add_goal_from_guard :
+let add_goal_from_guard:
   Prims.string ->
     env ->
       FStar_TypeChecker_Env.guard_t ->
-        FStar_Options.optionstate -> Prims.unit tac)
+        FStar_Options.optionstate -> Prims.unit tac
   =
   fun reason  ->
     fun e  ->
       fun g  ->
         fun opts  ->
           let uu____1531 =
-            let uu____1532 = FStar_TypeChecker_Rel.simplify_guard e g  in
-            uu____1532.FStar_TypeChecker_Env.guard_f  in
+            let uu____1532 = FStar_TypeChecker_Rel.simplify_guard e g in
+            uu____1532.FStar_TypeChecker_Env.guard_f in
           match uu____1531 with
           | FStar_TypeChecker_Common.Trivial  -> ret ()
           | FStar_TypeChecker_Common.NonTrivial f ->
-              let uu____1536 = istrivial e f  in
+              let uu____1536 = istrivial e f in
               if uu____1536
               then ret ()
               else
-                (let uu____1540 = mk_irrelevant_goal reason e f opts  in
+                (let uu____1540 = mk_irrelevant_goal reason e f opts in
                  bind uu____1540
                    (fun goal  ->
                       let goal1 =
-                        let uu___74_1547 = goal  in
+                        let uu___74_1547 = goal in
                         {
                           FStar_Tactics_Types.context =
                             (uu___74_1547.FStar_Tactics_Types.context);
@@ -906,37 +815,36 @@ let (add_goal_from_guard :
                           FStar_Tactics_Types.opts =
                             (uu___74_1547.FStar_Tactics_Types.opts);
                           FStar_Tactics_Types.is_guard = true
-                        }  in
+                        } in
                       push_goals [goal1]))
-  
-let (goal_from_guard :
+let goal_from_guard:
   Prims.string ->
     env ->
       FStar_TypeChecker_Env.guard_t ->
         FStar_Options.optionstate ->
-          FStar_Tactics_Types.goal FStar_Pervasives_Native.option tac)
+          FStar_Tactics_Types.goal FStar_Pervasives_Native.option tac
   =
   fun reason  ->
     fun e  ->
       fun g  ->
         fun opts  ->
           let uu____1568 =
-            let uu____1569 = FStar_TypeChecker_Rel.simplify_guard e g  in
-            uu____1569.FStar_TypeChecker_Env.guard_f  in
+            let uu____1569 = FStar_TypeChecker_Rel.simplify_guard e g in
+            uu____1569.FStar_TypeChecker_Env.guard_f in
           match uu____1568 with
           | FStar_TypeChecker_Common.Trivial  ->
               ret FStar_Pervasives_Native.None
           | FStar_TypeChecker_Common.NonTrivial f ->
-              let uu____1577 = istrivial e f  in
+              let uu____1577 = istrivial e f in
               if uu____1577
               then ret FStar_Pervasives_Native.None
               else
-                (let uu____1585 = mk_irrelevant_goal reason e f opts  in
+                (let uu____1585 = mk_irrelevant_goal reason e f opts in
                  bind uu____1585
                    (fun goal  ->
                       ret
                         (FStar_Pervasives_Native.Some
-                           (let uu___75_1595 = goal  in
+                           (let uu___75_1595 = goal in
                             {
                               FStar_Tactics_Types.context =
                                 (uu___75_1595.FStar_Tactics_Types.context);
@@ -948,21 +856,18 @@ let (goal_from_guard :
                                 (uu___75_1595.FStar_Tactics_Types.opts);
                               FStar_Tactics_Types.is_guard = true
                             }))))
-  
-let (smt : Prims.unit tac) =
+let smt: Prims.unit tac =
   bind cur_goal
     (fun g  ->
-       let uu____1603 = is_irrelevant g  in
+       let uu____1603 = is_irrelevant g in
        if uu____1603
        then bind dismiss (fun uu____1607  -> add_smt_goals [g])
        else
          (let uu____1609 =
-            tts g.FStar_Tactics_Types.context g.FStar_Tactics_Types.goal_ty
-             in
+            tts g.FStar_Tactics_Types.context g.FStar_Tactics_Types.goal_ty in
           fail1 "goal is not irrelevant: cannot dispatch to smt (%s)"
             uu____1609))
-  
-let divide :
+let divide:
   'a 'b .
     FStar_BigInt.t ->
       'a tac -> 'b tac -> ('a,'b) FStar_Pervasives_Native.tuple2 tac
@@ -975,17 +880,16 @@ let divide :
              let uu____1650 =
                try
                  let uu____1684 =
-                   let uu____1693 = FStar_BigInt.to_int_fs n1  in
-                   FStar_List.splitAt uu____1693 p.FStar_Tactics_Types.goals
-                    in
+                   let uu____1693 = FStar_BigInt.to_int_fs n1 in
+                   FStar_List.splitAt uu____1693 p.FStar_Tactics_Types.goals in
                  ret uu____1684
-               with | uu____1715 -> fail "divide: not enough goals"  in
+               with | uu____1715 -> fail "divide: not enough goals" in
              bind uu____1650
                (fun uu____1742  ->
                   match uu____1742 with
                   | (lgs,rgs) ->
                       let lp =
-                        let uu___76_1768 = p  in
+                        let uu___76_1768 = p in
                         {
                           FStar_Tactics_Types.main_context =
                             (uu___76_1768.FStar_Tactics_Types.main_context);
@@ -1003,9 +907,9 @@ let divide :
                             (uu___76_1768.FStar_Tactics_Types.psc);
                           FStar_Tactics_Types.entry_range =
                             (uu___76_1768.FStar_Tactics_Types.entry_range)
-                        }  in
+                        } in
                       let rp =
-                        let uu___77_1770 = p  in
+                        let uu___77_1770 = p in
                         {
                           FStar_Tactics_Types.main_context =
                             (uu___77_1770.FStar_Tactics_Types.main_context);
@@ -1023,15 +927,15 @@ let divide :
                             (uu___77_1770.FStar_Tactics_Types.psc);
                           FStar_Tactics_Types.entry_range =
                             (uu___77_1770.FStar_Tactics_Types.entry_range)
-                        }  in
-                      let uu____1771 = set lp  in
+                        } in
+                      let uu____1771 = set lp in
                       bind uu____1771
                         (fun uu____1779  ->
                            bind l
                              (fun a  ->
                                 bind get
                                   (fun lp'  ->
-                                     let uu____1793 = set rp  in
+                                     let uu____1793 = set rp in
                                      bind uu____1793
                                        (fun uu____1801  ->
                                           bind r
@@ -1039,8 +943,7 @@ let divide :
                                                bind get
                                                  (fun rp'  ->
                                                     let p' =
-                                                      let uu___78_1817 = p
-                                                         in
+                                                      let uu___78_1817 = p in
                                                       {
                                                         FStar_Tactics_Types.main_context
                                                           =
@@ -1075,20 +978,17 @@ let divide :
                                                         FStar_Tactics_Types.entry_range
                                                           =
                                                           (uu___78_1817.FStar_Tactics_Types.entry_range)
-                                                      }  in
-                                                    let uu____1818 = set p'
-                                                       in
+                                                      } in
+                                                    let uu____1818 = set p' in
                                                     bind uu____1818
                                                       (fun uu____1826  ->
                                                          ret (a, b))))))))))
-  
-let focus : 'a . 'a tac -> 'a tac =
+let focus: 'a . 'a tac -> 'a tac =
   fun f  ->
-    let uu____1844 = divide FStar_BigInt.one f idtac  in
+    let uu____1844 = divide FStar_BigInt.one f idtac in
     bind uu____1844
       (fun uu____1857  -> match uu____1857 with | (a,()) -> ret a)
-  
-let rec map : 'a . 'a tac -> 'a Prims.list tac =
+let rec map: 'a . 'a tac -> 'a Prims.list tac =
   fun tau  ->
     bind get
       (fun p  ->
@@ -1096,57 +996,52 @@ let rec map : 'a . 'a tac -> 'a Prims.list tac =
          | [] -> ret []
          | uu____1891::uu____1892 ->
              let uu____1895 =
-               let uu____1904 = map tau  in
-               divide FStar_BigInt.one tau uu____1904  in
+               let uu____1904 = map tau in
+               divide FStar_BigInt.one tau uu____1904 in
              bind uu____1895
                (fun uu____1922  ->
                   match uu____1922 with | (h,t) -> ret (h :: t)))
-  
-let (seq : Prims.unit tac -> Prims.unit tac -> Prims.unit tac) =
+let seq: Prims.unit tac -> Prims.unit tac -> Prims.unit tac =
   fun t1  ->
     fun t2  ->
       let uu____1959 =
         bind t1
           (fun uu____1964  ->
-             let uu____1965 = map t2  in
-             bind uu____1965 (fun uu____1973  -> ret ()))
-         in
+             let uu____1965 = map t2 in
+             bind uu____1965 (fun uu____1973  -> ret ())) in
       focus uu____1959
-  
-let (intro : FStar_Syntax_Syntax.binder tac) =
+let intro: FStar_Syntax_Syntax.binder tac =
   bind cur_goal
     (fun goal  ->
        let uu____1986 =
-         FStar_Syntax_Util.arrow_one goal.FStar_Tactics_Types.goal_ty  in
+         FStar_Syntax_Util.arrow_one goal.FStar_Tactics_Types.goal_ty in
        match uu____1986 with
        | FStar_Pervasives_Native.Some (b,c) ->
            let uu____2001 =
-             let uu____2002 = FStar_Syntax_Util.is_total_comp c  in
-             Prims.op_Negation uu____2002  in
+             let uu____2002 = FStar_Syntax_Util.is_total_comp c in
+             Prims.op_Negation uu____2002 in
            if uu____2001
            then fail "Codomain is effectful"
            else
              (let env' =
                 FStar_TypeChecker_Env.push_binders
-                  goal.FStar_Tactics_Types.context [b]
-                 in
-              let typ' = comp_to_typ c  in
-              let uu____2008 = new_uvar "intro" env' typ'  in
+                  goal.FStar_Tactics_Types.context [b] in
+              let typ' = comp_to_typ c in
+              let uu____2008 = new_uvar "intro" env' typ' in
               bind uu____2008
                 (fun u  ->
                    let uu____2015 =
                      let uu____2016 =
                        FStar_Syntax_Util.abs [b] u
-                         FStar_Pervasives_Native.None
-                        in
-                     trysolve goal uu____2016  in
+                         FStar_Pervasives_Native.None in
+                     trysolve goal uu____2016 in
                    if uu____2015
                    then
                      let uu____2019 =
                        let uu____2022 =
-                         let uu___81_2023 = goal  in
-                         let uu____2024 = bnorm env' u  in
-                         let uu____2025 = bnorm env' typ'  in
+                         let uu___81_2023 = goal in
+                         let uu____2024 = bnorm env' u in
+                         let uu____2025 = bnorm env' typ' in
                          {
                            FStar_Tactics_Types.context = env';
                            FStar_Tactics_Types.witness = uu____2024;
@@ -1155,20 +1050,18 @@ let (intro : FStar_Syntax_Syntax.binder tac) =
                              (uu___81_2023.FStar_Tactics_Types.opts);
                            FStar_Tactics_Types.is_guard =
                              (uu___81_2023.FStar_Tactics_Types.is_guard)
-                         }  in
-                       replace_cur uu____2022  in
+                         } in
+                       replace_cur uu____2022 in
                      bind uu____2019 (fun uu____2027  -> ret b)
                    else fail "intro: unification failed"))
        | FStar_Pervasives_Native.None  ->
            let uu____2033 =
              tts goal.FStar_Tactics_Types.context
-               goal.FStar_Tactics_Types.goal_ty
-              in
+               goal.FStar_Tactics_Types.goal_ty in
            fail1 "intro: goal is not an arrow (%s)" uu____2033)
-  
-let (intro_rec :
+let intro_rec:
   (FStar_Syntax_Syntax.binder,FStar_Syntax_Syntax.binder)
-    FStar_Pervasives_Native.tuple2 tac)
+    FStar_Pervasives_Native.tuple2 tac
   =
   bind cur_goal
     (fun goal  ->
@@ -1177,62 +1070,57 @@ let (intro_rec :
        FStar_Util.print_string
          "WARNING (intro_rec): proceed at your own risk...\n";
        (let uu____2060 =
-          FStar_Syntax_Util.arrow_one goal.FStar_Tactics_Types.goal_ty  in
+          FStar_Syntax_Util.arrow_one goal.FStar_Tactics_Types.goal_ty in
         match uu____2060 with
         | FStar_Pervasives_Native.Some (b,c) ->
             let uu____2079 =
-              let uu____2080 = FStar_Syntax_Util.is_total_comp c  in
-              Prims.op_Negation uu____2080  in
+              let uu____2080 = FStar_Syntax_Util.is_total_comp c in
+              Prims.op_Negation uu____2080 in
             if uu____2079
             then fail "Codomain is effectful"
             else
               (let bv =
                  FStar_Syntax_Syntax.gen_bv "__recf"
                    FStar_Pervasives_Native.None
-                   goal.FStar_Tactics_Types.goal_ty
-                  in
+                   goal.FStar_Tactics_Types.goal_ty in
                let bs =
-                 let uu____2096 = FStar_Syntax_Syntax.mk_binder bv  in
-                 [uu____2096; b]  in
+                 let uu____2096 = FStar_Syntax_Syntax.mk_binder bv in
+                 [uu____2096; b] in
                let env' =
                  FStar_TypeChecker_Env.push_binders
-                   goal.FStar_Tactics_Types.context bs
-                  in
+                   goal.FStar_Tactics_Types.context bs in
                let uu____2098 =
-                 let uu____2101 = comp_to_typ c  in
-                 new_uvar "intro_rec" env' uu____2101  in
+                 let uu____2101 = comp_to_typ c in
+                 new_uvar "intro_rec" env' uu____2101 in
                bind uu____2098
                  (fun u  ->
                     let lb =
                       let uu____2117 =
                         FStar_Syntax_Util.abs [b] u
-                          FStar_Pervasives_Native.None
-                         in
+                          FStar_Pervasives_Native.None in
                       FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
                         goal.FStar_Tactics_Types.goal_ty
-                        FStar_Parser_Const.effect_Tot_lid uu____2117 []
-                       in
-                    let body = FStar_Syntax_Syntax.bv_to_name bv  in
+                        FStar_Parser_Const.effect_Tot_lid uu____2117 [] in
+                    let body = FStar_Syntax_Syntax.bv_to_name bv in
                     let uu____2123 =
-                      FStar_Syntax_Subst.close_let_rec [lb] body  in
+                      FStar_Syntax_Subst.close_let_rec [lb] body in
                     match uu____2123 with
                     | (lbs,body1) ->
                         let tm =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_let ((true, lbs), body1))
                             FStar_Pervasives_Native.None
-                            (goal.FStar_Tactics_Types.witness).FStar_Syntax_Syntax.pos
-                           in
-                        let res = trysolve goal tm  in
+                            (goal.FStar_Tactics_Types.witness).FStar_Syntax_Syntax.pos in
+                        let res = trysolve goal tm in
                         if res
                         then
                           let uu____2160 =
                             let uu____2163 =
-                              let uu___82_2164 = goal  in
-                              let uu____2165 = bnorm env' u  in
+                              let uu___82_2164 = goal in
+                              let uu____2165 = bnorm env' u in
                               let uu____2166 =
-                                let uu____2167 = comp_to_typ c  in
-                                bnorm env' uu____2167  in
+                                let uu____2167 = comp_to_typ c in
+                                bnorm env' uu____2167 in
                               {
                                 FStar_Tactics_Types.context = env';
                                 FStar_Tactics_Types.witness = uu____2165;
@@ -1241,24 +1129,22 @@ let (intro_rec :
                                   (uu___82_2164.FStar_Tactics_Types.opts);
                                 FStar_Tactics_Types.is_guard =
                                   (uu___82_2164.FStar_Tactics_Types.is_guard)
-                              }  in
-                            replace_cur uu____2163  in
+                              } in
+                            replace_cur uu____2163 in
                           bind uu____2160
                             (fun uu____2174  ->
                                let uu____2175 =
                                  let uu____2180 =
-                                   FStar_Syntax_Syntax.mk_binder bv  in
-                                 (uu____2180, b)  in
+                                   FStar_Syntax_Syntax.mk_binder bv in
+                                 (uu____2180, b) in
                                ret uu____2175)
                         else fail "intro_rec: unification failed"))
         | FStar_Pervasives_Native.None  ->
             let uu____2194 =
               tts goal.FStar_Tactics_Types.context
-                goal.FStar_Tactics_Types.goal_ty
-               in
+                goal.FStar_Tactics_Types.goal_ty in
             fail1 "intro_rec: goal is not an arrow (%s)" uu____2194))
-  
-let (norm : FStar_Syntax_Embeddings.norm_step Prims.list -> Prims.unit tac) =
+let norm: FStar_Syntax_Embeddings.norm_step Prims.list -> Prims.unit tac =
   fun s  ->
     bind cur_goal
       (fun goal  ->
@@ -1266,27 +1152,22 @@ let (norm : FStar_Syntax_Embeddings.norm_step Prims.list -> Prims.unit tac) =
            (fun uu____2214  ->
               let uu____2215 =
                 FStar_Syntax_Print.term_to_string
-                  goal.FStar_Tactics_Types.witness
-                 in
+                  goal.FStar_Tactics_Types.witness in
               FStar_Util.print1 "norm: witness = %s\n" uu____2215)
            (fun uu____2220  ->
               let steps =
-                let uu____2224 = FStar_TypeChecker_Normalize.tr_norm_steps s
-                   in
+                let uu____2224 = FStar_TypeChecker_Normalize.tr_norm_steps s in
                 FStar_List.append
                   [FStar_TypeChecker_Normalize.Reify;
-                  FStar_TypeChecker_Normalize.UnfoldTac] uu____2224
-                 in
+                  FStar_TypeChecker_Normalize.UnfoldTac] uu____2224 in
               let w =
                 normalize steps goal.FStar_Tactics_Types.context
-                  goal.FStar_Tactics_Types.witness
-                 in
+                  goal.FStar_Tactics_Types.witness in
               let t =
                 normalize steps goal.FStar_Tactics_Types.context
-                  goal.FStar_Tactics_Types.goal_ty
-                 in
+                  goal.FStar_Tactics_Types.goal_ty in
               replace_cur
-                (let uu___83_2231 = goal  in
+                (let uu___83_2231 = goal in
                  {
                    FStar_Tactics_Types.context =
                      (uu___83_2231.FStar_Tactics_Types.context);
@@ -1297,11 +1178,10 @@ let (norm : FStar_Syntax_Embeddings.norm_step Prims.list -> Prims.unit tac) =
                    FStar_Tactics_Types.is_guard =
                      (uu___83_2231.FStar_Tactics_Types.is_guard)
                  })))
-  
-let (norm_term_env :
+let norm_term_env:
   env ->
     FStar_Syntax_Embeddings.norm_step Prims.list ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term tac)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term tac
   =
   fun e  ->
     fun s  ->
@@ -1309,12 +1189,12 @@ let (norm_term_env :
         let uu____2249 =
           mlog
             (fun uu____2254  ->
-               let uu____2255 = FStar_Syntax_Print.term_to_string t  in
+               let uu____2255 = FStar_Syntax_Print.term_to_string t in
                FStar_Util.print1 "norm_term: tm = %s\n" uu____2255)
             (fun uu____2257  ->
                bind get
                  (fun ps  ->
-                    let uu____2261 = __tc e t  in
+                    let uu____2261 = __tc e t in
                     bind uu____2261
                       (fun uu____2283  ->
                          match uu____2283 with
@@ -1324,35 +1204,29 @@ let (norm_term_env :
                               (let steps =
                                  let uu____2299 =
                                    FStar_TypeChecker_Normalize.tr_norm_steps
-                                     s
-                                    in
+                                     s in
                                  FStar_List.append
                                    [FStar_TypeChecker_Normalize.Reify;
                                    FStar_TypeChecker_Normalize.UnfoldTac]
-                                   uu____2299
-                                  in
+                                   uu____2299 in
                                let t2 =
                                  normalize steps
-                                   ps.FStar_Tactics_Types.main_context t1
-                                  in
-                               ret t2)))))
-           in
+                                   ps.FStar_Tactics_Types.main_context t1 in
+                               ret t2))))) in
         FStar_All.pipe_left (wrap_err "norm_term") uu____2249
-  
-let (refine_intro : Prims.unit tac) =
+let refine_intro: Prims.unit tac =
   let uu____2311 =
     bind cur_goal
       (fun g  ->
          let uu____2318 =
            FStar_TypeChecker_Rel.base_and_refinement
-             g.FStar_Tactics_Types.context g.FStar_Tactics_Types.goal_ty
-            in
+             g.FStar_Tactics_Types.context g.FStar_Tactics_Types.goal_ty in
          match uu____2318 with
          | (uu____2331,FStar_Pervasives_Native.None ) ->
              fail "not a refinement"
          | (t,FStar_Pervasives_Native.Some (bv,phi)) ->
              let g1 =
-               let uu___84_2356 = g  in
+               let uu___84_2356 = g in
                {
                  FStar_Tactics_Types.context =
                    (uu___84_2356.FStar_Tactics_Types.context);
@@ -1363,39 +1237,35 @@ let (refine_intro : Prims.unit tac) =
                    (uu___84_2356.FStar_Tactics_Types.opts);
                  FStar_Tactics_Types.is_guard =
                    (uu___84_2356.FStar_Tactics_Types.is_guard)
-               }  in
+               } in
              let uu____2357 =
                let uu____2362 =
                  let uu____2367 =
-                   let uu____2368 = FStar_Syntax_Syntax.mk_binder bv  in
-                   [uu____2368]  in
-                 FStar_Syntax_Subst.open_term uu____2367 phi  in
+                   let uu____2368 = FStar_Syntax_Syntax.mk_binder bv in
+                   [uu____2368] in
+                 FStar_Syntax_Subst.open_term uu____2367 phi in
                match uu____2362 with
                | (bvs,phi1) ->
                    let uu____2375 =
-                     let uu____2376 = FStar_List.hd bvs  in
-                     FStar_Pervasives_Native.fst uu____2376  in
-                   (uu____2375, phi1)
-                in
+                     let uu____2376 = FStar_List.hd bvs in
+                     FStar_Pervasives_Native.fst uu____2376 in
+                   (uu____2375, phi1) in
              (match uu____2357 with
               | (bv1,phi1) ->
                   let uu____2389 =
                     let uu____2392 =
                       FStar_Syntax_Subst.subst
                         [FStar_Syntax_Syntax.NT
-                           (bv1, (g.FStar_Tactics_Types.witness))] phi1
-                       in
+                           (bv1, (g.FStar_Tactics_Types.witness))] phi1 in
                     mk_irrelevant_goal "refine_intro refinement"
                       g.FStar_Tactics_Types.context uu____2392
-                      g.FStar_Tactics_Types.opts
-                     in
+                      g.FStar_Tactics_Types.opts in
                   bind uu____2389
                     (fun g2  ->
-                       bind dismiss (fun uu____2396  -> add_goals [g1; g2]))))
-     in
-  FStar_All.pipe_left (wrap_err "refine_intro") uu____2311 
-let (__exact_now :
-  Prims.bool -> Prims.bool -> FStar_Syntax_Syntax.term -> Prims.unit tac) =
+                       bind dismiss (fun uu____2396  -> add_goals [g1; g2])))) in
+  FStar_All.pipe_left (wrap_err "refine_intro") uu____2311
+let __exact_now:
+  Prims.bool -> Prims.bool -> FStar_Syntax_Syntax.term -> Prims.unit tac =
   fun set_expected_typ1  ->
     fun force_guard  ->
       fun t  ->
@@ -1407,8 +1277,8 @@ let (__exact_now :
                  FStar_TypeChecker_Env.set_expected_typ
                    goal.FStar_Tactics_Types.context
                    goal.FStar_Tactics_Types.goal_ty
-               else goal.FStar_Tactics_Types.context  in
-             let uu____2420 = __tc env t  in
+               else goal.FStar_Tactics_Types.context in
+             let uu____2420 = __tc env t in
              bind uu____2420
                (fun uu____2440  ->
                   match uu____2440 with
@@ -1420,64 +1290,55 @@ let (__exact_now :
                         else
                           add_goal_from_guard "__exact typing"
                             goal.FStar_Tactics_Types.context guard
-                            goal.FStar_Tactics_Types.opts
-                         in
+                            goal.FStar_Tactics_Types.opts in
                       bind uu____2452
                         (fun uu____2459  ->
                            mlog
                              (fun uu____2463  ->
                                 let uu____2464 =
-                                  tts goal.FStar_Tactics_Types.context typ
-                                   in
+                                  tts goal.FStar_Tactics_Types.context typ in
                                 let uu____2465 =
                                   tts goal.FStar_Tactics_Types.context
-                                    goal.FStar_Tactics_Types.goal_ty
-                                   in
+                                    goal.FStar_Tactics_Types.goal_ty in
                                 FStar_Util.print2
                                   "exact: unifying %s and %s\n" uu____2464
                                   uu____2465)
                              (fun uu____2468  ->
                                 let uu____2469 =
                                   do_unify goal.FStar_Tactics_Types.context
-                                    typ goal.FStar_Tactics_Types.goal_ty
-                                   in
+                                    typ goal.FStar_Tactics_Types.goal_ty in
                                 if uu____2469
                                 then solve goal t1
                                 else
                                   (let uu____2473 =
-                                     tts goal.FStar_Tactics_Types.context t1
-                                      in
+                                     tts goal.FStar_Tactics_Types.context t1 in
                                    let uu____2474 =
-                                     tts goal.FStar_Tactics_Types.context typ
-                                      in
+                                     tts goal.FStar_Tactics_Types.context typ in
                                    let uu____2475 =
                                      tts goal.FStar_Tactics_Types.context
-                                       goal.FStar_Tactics_Types.goal_ty
-                                      in
+                                       goal.FStar_Tactics_Types.goal_ty in
                                    let uu____2476 =
                                      tts goal.FStar_Tactics_Types.context
-                                       goal.FStar_Tactics_Types.witness
-                                      in
+                                       goal.FStar_Tactics_Types.witness in
                                    fail4
                                      "%s : %s does not exactly solve the goal %s (witness = %s)"
                                      uu____2473 uu____2474 uu____2475
                                      uu____2476)))))
-  
-let (t_exact :
-  Prims.bool -> Prims.bool -> FStar_Syntax_Syntax.term -> Prims.unit tac) =
+let t_exact:
+  Prims.bool -> Prims.bool -> FStar_Syntax_Syntax.term -> Prims.unit tac =
   fun set_expected_typ1  ->
     fun force_guard  ->
       fun tm  ->
         let uu____2490 =
           mlog
             (fun uu____2495  ->
-               let uu____2496 = FStar_Syntax_Print.term_to_string tm  in
+               let uu____2496 = FStar_Syntax_Print.term_to_string tm in
                FStar_Util.print1 "t_exact: tm = %s\n" uu____2496)
             (fun uu____2499  ->
                let uu____2500 =
                  let uu____2507 =
-                   __exact_now set_expected_typ1 force_guard tm  in
-                 trytac' uu____2507  in
+                   __exact_now set_expected_typ1 force_guard tm in
+                 trytac' uu____2507 in
                bind uu____2500
                  (fun uu___58_2516  ->
                     match uu___58_2516 with
@@ -1486,25 +1347,22 @@ let (t_exact :
                         let uu____2525 =
                           let uu____2532 =
                             let uu____2535 =
-                              norm [FStar_Syntax_Embeddings.Delta]  in
+                              norm [FStar_Syntax_Embeddings.Delta] in
                             bind uu____2535
                               (fun uu____2539  ->
                                  bind refine_intro
                                    (fun uu____2541  ->
                                       __exact_now set_expected_typ1
-                                        force_guard tm))
-                             in
-                          trytac' uu____2532  in
+                                        force_guard tm)) in
+                          trytac' uu____2532 in
                         bind uu____2525
                           (fun uu___57_2548  ->
                              match uu___57_2548 with
                              | FStar_Util.Inr r -> ret ()
-                             | FStar_Util.Inl uu____2556 -> fail e)))
-           in
+                             | FStar_Util.Inl uu____2556 -> fail e))) in
         FStar_All.pipe_left (wrap_err "exact") uu____2490
-  
-let (uvar_free_in_goal :
-  FStar_Syntax_Syntax.uvar -> FStar_Tactics_Types.goal -> Prims.bool) =
+let uvar_free_in_goal:
+  FStar_Syntax_Syntax.uvar -> FStar_Tactics_Types.goal -> Prims.bool =
   fun u  ->
     fun g  ->
       if g.FStar_Tactics_Types.is_guard
@@ -1513,37 +1371,33 @@ let (uvar_free_in_goal :
         (let free_uvars =
            let uu____2571 =
              let uu____2578 =
-               FStar_Syntax_Free.uvars g.FStar_Tactics_Types.goal_ty  in
-             FStar_Util.set_elements uu____2578  in
-           FStar_List.map FStar_Pervasives_Native.fst uu____2571  in
+               FStar_Syntax_Free.uvars g.FStar_Tactics_Types.goal_ty in
+             FStar_Util.set_elements uu____2578 in
+           FStar_List.map FStar_Pervasives_Native.fst uu____2571 in
          FStar_List.existsML (FStar_Syntax_Unionfind.equiv u) free_uvars)
-  
-let (uvar_free :
-  FStar_Syntax_Syntax.uvar -> FStar_Tactics_Types.proofstate -> Prims.bool) =
+let uvar_free:
+  FStar_Syntax_Syntax.uvar -> FStar_Tactics_Types.proofstate -> Prims.bool =
   fun u  ->
     fun ps  ->
       FStar_List.existsML (uvar_free_in_goal u) ps.FStar_Tactics_Types.goals
-  
-let rec mapM : 'a 'b . ('a -> 'b tac) -> 'a Prims.list -> 'b Prims.list tac =
+let rec mapM: 'a 'b . ('a -> 'b tac) -> 'a Prims.list -> 'b Prims.list tac =
   fun f  ->
     fun l  ->
       match l with
       | [] -> ret []
       | x::xs ->
-          let uu____2638 = f x  in
+          let uu____2638 = f x in
           bind uu____2638
             (fun y  ->
-               let uu____2646 = mapM f xs  in
+               let uu____2646 = mapM f xs in
                bind uu____2646 (fun ys  -> ret (y :: ys)))
-  
-exception NoUnif 
-let (uu___is_NoUnif : Prims.exn -> Prims.bool) =
+exception NoUnif
+let uu___is_NoUnif: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | NoUnif  -> true | uu____2664 -> false
-  
-let rec (__apply :
+let rec __apply:
   Prims.bool ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.typ -> Prims.unit tac)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.typ -> Prims.unit tac
   =
   fun uopt  ->
     fun tm  ->
@@ -1551,14 +1405,13 @@ let rec (__apply :
         bind cur_goal
           (fun goal  ->
              let uu____2681 =
-               let uu____2686 = t_exact false true tm  in trytac uu____2686
-                in
+               let uu____2686 = t_exact false true tm in trytac uu____2686 in
              bind uu____2681
                (fun uu___59_2693  ->
                   match uu___59_2693 with
                   | FStar_Pervasives_Native.Some r -> ret ()
                   | FStar_Pervasives_Native.None  ->
-                      let uu____2699 = FStar_Syntax_Util.arrow_one typ  in
+                      let uu____2699 = FStar_Syntax_Util.arrow_one typ in
                       (match uu____2699 with
                        | FStar_Pervasives_Native.None  ->
                            FStar_Exn.raise NoUnif
@@ -1567,62 +1420,53 @@ let rec (__apply :
                              (fun uu____2731  ->
                                 let uu____2732 =
                                   FStar_Syntax_Print.binder_to_string
-                                    (bv, aq)
-                                   in
+                                    (bv, aq) in
                                 FStar_Util.print1
                                   "__apply: pushing binder %s\n" uu____2732)
                              (fun uu____2735  ->
                                 let uu____2736 =
                                   let uu____2737 =
-                                    FStar_Syntax_Util.is_total_comp c  in
-                                  Prims.op_Negation uu____2737  in
+                                    FStar_Syntax_Util.is_total_comp c in
+                                  Prims.op_Negation uu____2737 in
                                 if uu____2736
                                 then fail "apply: not total codomain"
                                 else
                                   (let uu____2741 =
                                      new_uvar "apply"
                                        goal.FStar_Tactics_Types.context
-                                       bv.FStar_Syntax_Syntax.sort
-                                      in
+                                       bv.FStar_Syntax_Syntax.sort in
                                    bind uu____2741
                                      (fun u  ->
                                         let tm' =
                                           FStar_Syntax_Syntax.mk_Tm_app tm
                                             [(u, aq)]
                                             FStar_Pervasives_Native.None
-                                            (goal.FStar_Tactics_Types.context).FStar_TypeChecker_Env.range
-                                           in
+                                            (goal.FStar_Tactics_Types.context).FStar_TypeChecker_Env.range in
                                         let typ' =
-                                          let uu____2761 = comp_to_typ c  in
+                                          let uu____2761 = comp_to_typ c in
                                           FStar_All.pipe_left
                                             (FStar_Syntax_Subst.subst
                                                [FStar_Syntax_Syntax.NT
-                                                  (bv, u)]) uu____2761
-                                           in
+                                                  (bv, u)]) uu____2761 in
                                         let uu____2762 =
-                                          __apply uopt tm' typ'  in
+                                          __apply uopt tm' typ' in
                                         bind uu____2762
                                           (fun uu____2770  ->
                                              let u1 =
                                                bnorm
                                                  goal.FStar_Tactics_Types.context
-                                                 u
-                                                in
+                                                 u in
                                              let uu____2772 =
                                                let uu____2773 =
                                                  let uu____2776 =
                                                    let uu____2777 =
                                                      FStar_Syntax_Util.head_and_args
-                                                       u1
-                                                      in
+                                                       u1 in
                                                    FStar_Pervasives_Native.fst
-                                                     uu____2777
-                                                    in
+                                                     uu____2777 in
                                                  FStar_Syntax_Subst.compress
-                                                   uu____2776
-                                                  in
-                                               uu____2773.FStar_Syntax_Syntax.n
-                                                in
+                                                   uu____2776 in
+                                               uu____2773.FStar_Syntax_Syntax.n in
                                              match uu____2772 with
                                              | FStar_Syntax_Syntax.Tm_uvar
                                                  (uvar,uu____2805) ->
@@ -1630,25 +1474,22 @@ let rec (__apply :
                                                    (fun ps  ->
                                                       let uu____2833 =
                                                         uopt &&
-                                                          (uvar_free uvar ps)
-                                                         in
+                                                          (uvar_free uvar ps) in
                                                       if uu____2833
                                                       then ret ()
                                                       else
                                                         (let uu____2837 =
                                                            let uu____2840 =
                                                              let uu___85_2841
-                                                               = goal  in
+                                                               = goal in
                                                              let uu____2842 =
                                                                bnorm
                                                                  goal.FStar_Tactics_Types.context
-                                                                 u1
-                                                                in
+                                                                 u1 in
                                                              let uu____2843 =
                                                                bnorm
                                                                  goal.FStar_Tactics_Types.context
-                                                                 bv.FStar_Syntax_Syntax.sort
-                                                                in
+                                                                 bv.FStar_Syntax_Syntax.sort in
                                                              {
                                                                FStar_Tactics_Types.context
                                                                  =
@@ -1662,88 +1503,79 @@ let rec (__apply :
                                                                  (uu___85_2841.FStar_Tactics_Types.opts);
                                                                FStar_Tactics_Types.is_guard
                                                                  = false
-                                                             }  in
-                                                           [uu____2840]  in
+                                                             } in
+                                                           [uu____2840] in
                                                          add_goals uu____2837))
                                              | t -> ret ())))))))
-  
-let try_unif : 'a . 'a tac -> 'a tac -> 'a tac =
+let try_unif: 'a . 'a tac -> 'a tac -> 'a tac =
   fun t  ->
     fun t'  -> mk_tac (fun ps  -> try run t ps with | NoUnif  -> run t' ps)
-  
-let (apply : Prims.bool -> FStar_Syntax_Syntax.term -> Prims.unit tac) =
+let apply: Prims.bool -> FStar_Syntax_Syntax.term -> Prims.unit tac =
   fun uopt  ->
     fun tm  ->
       let uu____2889 =
         mlog
           (fun uu____2894  ->
-             let uu____2895 = FStar_Syntax_Print.term_to_string tm  in
+             let uu____2895 = FStar_Syntax_Print.term_to_string tm in
              FStar_Util.print1 "apply: tm = %s\n" uu____2895)
           (fun uu____2897  ->
              bind cur_goal
                (fun goal  ->
-                  let uu____2901 = __tc goal.FStar_Tactics_Types.context tm
-                     in
+                  let uu____2901 = __tc goal.FStar_Tactics_Types.context tm in
                   bind uu____2901
                     (fun uu____2922  ->
                        match uu____2922 with
                        | (tm1,typ,guard) ->
                            let uu____2934 =
                              let uu____2937 =
-                               let uu____2940 = __apply uopt tm1 typ  in
+                               let uu____2940 = __apply uopt tm1 typ in
                                bind uu____2940
                                  (fun uu____2944  ->
                                     add_goal_from_guard "apply guard"
                                       goal.FStar_Tactics_Types.context guard
-                                      goal.FStar_Tactics_Types.opts)
-                                in
-                             focus uu____2937  in
+                                      goal.FStar_Tactics_Types.opts) in
+                             focus uu____2937 in
                            let uu____2945 =
                              let uu____2948 =
-                               tts goal.FStar_Tactics_Types.context tm1  in
+                               tts goal.FStar_Tactics_Types.context tm1 in
                              let uu____2949 =
-                               tts goal.FStar_Tactics_Types.context typ  in
+                               tts goal.FStar_Tactics_Types.context typ in
                              let uu____2950 =
                                tts goal.FStar_Tactics_Types.context
-                                 goal.FStar_Tactics_Types.goal_ty
-                                in
+                                 goal.FStar_Tactics_Types.goal_ty in
                              fail3
                                "Cannot instantiate %s (of type %s) to match goal (%s)"
-                               uu____2948 uu____2949 uu____2950
-                              in
-                           try_unif uu____2934 uu____2945)))
-         in
+                               uu____2948 uu____2949 uu____2950 in
+                           try_unif uu____2934 uu____2945))) in
       FStar_All.pipe_left (wrap_err "apply") uu____2889
-  
-let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
+let apply_lemma: FStar_Syntax_Syntax.term -> Prims.unit tac =
   fun tm  ->
     let uu____2962 =
       let uu____2965 =
         mlog
           (fun uu____2970  ->
-             let uu____2971 = FStar_Syntax_Print.term_to_string tm  in
+             let uu____2971 = FStar_Syntax_Print.term_to_string tm in
              FStar_Util.print1 "apply_lemma: tm = %s\n" uu____2971)
           (fun uu____2974  ->
              let is_unit_t t =
                let uu____2979 =
-                 let uu____2980 = FStar_Syntax_Subst.compress t  in
-                 uu____2980.FStar_Syntax_Syntax.n  in
+                 let uu____2980 = FStar_Syntax_Subst.compress t in
+                 uu____2980.FStar_Syntax_Syntax.n in
                match uu____2979 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.unit_lid
                    -> true
-               | uu____2984 -> false  in
+               | uu____2984 -> false in
              bind cur_goal
                (fun goal  ->
-                  let uu____2988 = __tc goal.FStar_Tactics_Types.context tm
-                     in
+                  let uu____2988 = __tc goal.FStar_Tactics_Types.context tm in
                   bind uu____2988
                     (fun uu____3010  ->
                        match uu____3010 with
                        | (tm1,t,guard) ->
                            let uu____3022 =
-                             FStar_Syntax_Util.arrow_formals_comp t  in
+                             FStar_Syntax_Util.arrow_formals_comp t in
                            (match uu____3022 with
                             | (bs,comp) ->
                                 if
@@ -1761,10 +1593,9 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                 let b_t =
                                                   FStar_Syntax_Subst.subst
                                                     subst1
-                                                    b.FStar_Syntax_Syntax.sort
-                                                   in
+                                                    b.FStar_Syntax_Syntax.sort in
                                                 let uu____3202 =
-                                                  is_unit_t b_t  in
+                                                  is_unit_t b_t in
                                                 if uu____3202
                                                 then
                                                   (((FStar_Syntax_Util.exp_unit,
@@ -1779,36 +1610,30 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                        "apply_lemma"
                                                        (goal.FStar_Tactics_Types.goal_ty).FStar_Syntax_Syntax.pos
                                                        goal.FStar_Tactics_Types.context
-                                                       b_t
-                                                      in
+                                                       b_t in
                                                    match uu____3240 with
                                                    | (u,uu____3270,g_u) ->
                                                        let uu____3284 =
                                                          FStar_TypeChecker_Rel.conj_guard
-                                                           guard1 g_u
-                                                          in
+                                                           guard1 g_u in
                                                        (((u, aq) :: uvs),
                                                          uu____3284,
                                                          ((FStar_Syntax_Syntax.NT
                                                              (b, u)) ::
                                                          subst1))))
-                                       ([], guard, []) bs
-                                      in
+                                       ([], guard, []) bs in
                                    match uu____3052 with
                                    | (uvs,implicits,subst1) ->
-                                       let uvs1 = FStar_List.rev uvs  in
+                                       let uvs1 = FStar_List.rev uvs in
                                        let comp1 =
                                          FStar_Syntax_Subst.subst_comp subst1
-                                           comp
-                                          in
+                                           comp in
                                        let uu____3354 =
                                          let uu____3363 =
                                            let uu____3372 =
                                              FStar_Syntax_Util.comp_to_comp_typ
-                                               comp1
-                                              in
-                                           uu____3372.FStar_Syntax_Syntax.effect_args
-                                            in
+                                               comp1 in
+                                           uu____3372.FStar_Syntax_Syntax.effect_args in
                                          match uu____3363 with
                                          | pre::post::uu____3383 ->
                                              ((FStar_Pervasives_Native.fst
@@ -1817,56 +1642,46 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                   post))
                                          | uu____3424 ->
                                              failwith
-                                               "apply_lemma: impossible: not a lemma"
-                                          in
+                                               "apply_lemma: impossible: not a lemma" in
                                        (match uu____3354 with
                                         | (pre,post) ->
                                             let post1 =
                                               let uu____3456 =
                                                 let uu____3465 =
                                                   FStar_Syntax_Syntax.as_arg
-                                                    FStar_Syntax_Util.exp_unit
-                                                   in
-                                                [uu____3465]  in
+                                                    FStar_Syntax_Util.exp_unit in
+                                                [uu____3465] in
                                               FStar_Syntax_Util.mk_app post
-                                                uu____3456
-                                               in
+                                                uu____3456 in
                                             let uu____3466 =
                                               let uu____3467 =
                                                 let uu____3468 =
                                                   FStar_Syntax_Util.mk_squash
                                                     FStar_Syntax_Syntax.U_zero
-                                                    post1
-                                                   in
+                                                    post1 in
                                                 do_unify
                                                   goal.FStar_Tactics_Types.context
                                                   uu____3468
-                                                  goal.FStar_Tactics_Types.goal_ty
-                                                 in
-                                              Prims.op_Negation uu____3467
-                                               in
+                                                  goal.FStar_Tactics_Types.goal_ty in
+                                              Prims.op_Negation uu____3467 in
                                             if uu____3466
                                             then
                                               let uu____3471 =
                                                 tts
                                                   goal.FStar_Tactics_Types.context
-                                                  tm1
-                                                 in
+                                                  tm1 in
                                               let uu____3472 =
                                                 let uu____3473 =
                                                   FStar_Syntax_Util.mk_squash
                                                     FStar_Syntax_Syntax.U_zero
-                                                    post1
-                                                   in
+                                                    post1 in
                                                 tts
                                                   goal.FStar_Tactics_Types.context
-                                                  uu____3473
-                                                 in
+                                                  uu____3473 in
                                               let uu____3474 =
                                                 tts
                                                   goal.FStar_Tactics_Types.context
-                                                  goal.FStar_Tactics_Types.goal_ty
-                                                 in
+                                                  goal.FStar_Tactics_Types.goal_ty in
                                               fail3
                                                 "Cannot instantiate lemma %s (with postcondition: %s) to match goal (%s)"
                                                 uu____3471 uu____3472
@@ -1874,14 +1689,12 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                             else
                                               (let uu____3476 =
                                                  add_implicits
-                                                   implicits.FStar_TypeChecker_Env.implicits
-                                                  in
+                                                   implicits.FStar_TypeChecker_Env.implicits in
                                                bind uu____3476
                                                  (fun uu____3481  ->
                                                     let uu____3482 =
                                                       solve goal
-                                                        FStar_Syntax_Util.exp_unit
-                                                       in
+                                                        FStar_Syntax_Util.exp_unit in
                                                     bind uu____3482
                                                       (fun uu____3490  ->
                                                          let is_free_uvar uv
@@ -1891,21 +1704,17 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                let uu____3508
                                                                  =
                                                                  FStar_Syntax_Free.uvars
-                                                                   t1
-                                                                  in
+                                                                   t1 in
                                                                FStar_Util.set_elements
-                                                                 uu____3508
-                                                                in
+                                                                 uu____3508 in
                                                              FStar_List.map
                                                                FStar_Pervasives_Native.fst
-                                                               uu____3501
-                                                              in
+                                                               uu____3501 in
                                                            FStar_List.existsML
                                                              (fun u  ->
                                                                 FStar_Syntax_Unionfind.equiv
                                                                   u uv)
-                                                             free_uvars
-                                                            in
+                                                             free_uvars in
                                                          let appears uv goals
                                                            =
                                                            FStar_List.existsML
@@ -1913,14 +1722,12 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                 is_free_uvar
                                                                   uv
                                                                   g'.FStar_Tactics_Types.goal_ty)
-                                                             goals
-                                                            in
+                                                             goals in
                                                          let checkone t1
                                                            goals =
                                                            let uu____3549 =
                                                              FStar_Syntax_Util.head_and_args
-                                                               t1
-                                                              in
+                                                               t1 in
                                                            match uu____3549
                                                            with
                                                            | (hd1,uu____3565)
@@ -1934,8 +1741,7 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     appears
                                                                     uv goals
                                                                 | uu____3612
-                                                                    -> false)
-                                                            in
+                                                                    -> false) in
                                                          let uu____3613 =
                                                            FStar_All.pipe_right
                                                              implicits.FStar_TypeChecker_Env.implicits
@@ -1951,7 +1757,7 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     let uu____3714
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
-                                                                    term  in
+                                                                    term in
                                                                     (match uu____3714
                                                                     with
                                                                     | 
@@ -1962,9 +1768,8 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     let uu____3762
                                                                     =
                                                                     FStar_Syntax_Subst.compress
-                                                                    hd1  in
-                                                                    uu____3762.FStar_Syntax_Syntax.n
-                                                                     in
+                                                                    hd1 in
+                                                                    uu____3762.FStar_Syntax_Syntax.n in
                                                                     (match uu____3761
                                                                     with
                                                                     | 
@@ -1978,18 +1783,17 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     let uu____3804
                                                                     =
                                                                     let uu___88_3805
-                                                                    = goal
-                                                                     in
+                                                                    = goal in
                                                                     let uu____3806
                                                                     =
                                                                     bnorm
                                                                     goal.FStar_Tactics_Types.context
-                                                                    term  in
+                                                                    term in
                                                                     let uu____3807
                                                                     =
                                                                     bnorm
                                                                     goal.FStar_Tactics_Types.context
-                                                                    typ  in
+                                                                    typ in
                                                                     {
                                                                     FStar_Tactics_Types.context
                                                                     =
@@ -2006,11 +1810,10 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     FStar_Tactics_Types.is_guard
                                                                     =
                                                                     (uu___88_3805.FStar_Tactics_Types.is_guard)
-                                                                    }  in
-                                                                    [uu____3804]
-                                                                     in
+                                                                    } in
+                                                                    [uu____3804] in
                                                                     (uu____3801,
-                                                                    [])  in
+                                                                    []) in
                                                                     ret
                                                                     uu____3792
                                                                     | 
@@ -2021,7 +1824,7 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     let uu____3822
                                                                     =
                                                                     FStar_Options.__temp_fast_implicits
-                                                                    ()  in
+                                                                    () in
                                                                     if
                                                                     uu____3822
                                                                     then
@@ -2032,31 +1835,28 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     (let term1
                                                                     =
                                                                     bnorm env
-                                                                    term  in
+                                                                    term in
                                                                     let uu____3825
                                                                     =
                                                                     let uu____3832
                                                                     =
                                                                     FStar_TypeChecker_Env.set_expected_typ
-                                                                    env typ
-                                                                     in
+                                                                    env typ in
                                                                     env.FStar_TypeChecker_Env.type_of
                                                                     uu____3832
-                                                                    term1  in
+                                                                    term1 in
                                                                     match uu____3825
                                                                     with
                                                                     | 
                                                                     (uu____3833,uu____3834,g_typ)
-                                                                    -> g_typ)
-                                                                     in
+                                                                    -> g_typ) in
                                                                     let uu____3836
                                                                     =
                                                                     goal_from_guard
                                                                     "apply_lemma solved arg"
                                                                     goal.FStar_Tactics_Types.context
                                                                     g_typ
-                                                                    goal.FStar_Tactics_Types.opts
-                                                                     in
+                                                                    goal.FStar_Tactics_Types.opts in
                                                                     bind
                                                                     uu____3836
                                                                     (fun
@@ -2073,8 +1873,7 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     FStar_Pervasives_Native.Some
                                                                     g ->
                                                                     ret
-                                                                    ([], [g]))))))
-                                                            in
+                                                                    ([], [g])))))) in
                                                          bind uu____3613
                                                            (fun goals_  ->
                                                               let sub_goals =
@@ -2082,42 +1881,36 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                   =
                                                                   FStar_List.map
                                                                     FStar_Pervasives_Native.fst
-                                                                    goals_
-                                                                   in
+                                                                    goals_ in
                                                                 FStar_List.flatten
-                                                                  uu____3920
-                                                                 in
+                                                                  uu____3920 in
                                                               let smt_goals =
                                                                 let uu____3942
                                                                   =
                                                                   FStar_List.map
                                                                     FStar_Pervasives_Native.snd
-                                                                    goals_
-                                                                   in
+                                                                    goals_ in
                                                                 FStar_List.flatten
-                                                                  uu____3942
-                                                                 in
+                                                                  uu____3942 in
                                                               let rec filter'
                                                                 a f xs =
                                                                 match xs with
                                                                 | [] -> []
                                                                 | x::xs1 ->
                                                                     let uu____3997
-                                                                    = f x xs1
-                                                                     in
+                                                                    = f x xs1 in
                                                                     if
                                                                     uu____3997
                                                                     then
                                                                     let uu____4000
                                                                     =
                                                                     filter'
-                                                                    () f xs1
-                                                                     in x ::
+                                                                    () f xs1 in
+                                                                    x ::
                                                                     uu____4000
                                                                     else
                                                                     filter'
-                                                                    () f xs1
-                                                                 in
+                                                                    () f xs1 in
                                                               let sub_goals1
                                                                 =
                                                                 Obj.magic
@@ -2135,21 +1928,19 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     =
                                                                     checkone
                                                                     g.FStar_Tactics_Types.witness
-                                                                    goals  in
+                                                                    goals in
                                                                     Prims.op_Negation
                                                                     uu____4014))
                                                                     a434 a435)
                                                                     (Obj.magic
-                                                                    sub_goals))
-                                                                 in
+                                                                    sub_goals)) in
                                                               let uu____4015
                                                                 =
                                                                 add_goal_from_guard
                                                                   "apply_lemma guard"
                                                                   goal.FStar_Tactics_Types.context
                                                                   guard
-                                                                  goal.FStar_Tactics_Types.opts
-                                                                 in
+                                                                  goal.FStar_Tactics_Types.opts in
                                                               bind uu____4015
                                                                 (fun
                                                                    uu____4020
@@ -2164,14 +1955,12 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     =
                                                                     FStar_Syntax_Util.mk_squash
                                                                     FStar_Syntax_Syntax.U_zero
-                                                                    pre  in
+                                                                    pre in
                                                                     istrivial
                                                                     goal.FStar_Tactics_Types.context
-                                                                    uu____4026
-                                                                     in
+                                                                    uu____4026 in
                                                                     Prims.op_Negation
-                                                                    uu____4025
-                                                                     in
+                                                                    uu____4025 in
                                                                     if
                                                                     uu____4024
                                                                     then
@@ -2181,8 +1970,7 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     pre
                                                                     goal.FStar_Tactics_Types.opts
                                                                     else
-                                                                    ret ()
-                                                                     in
+                                                                    ret () in
                                                                    bind
                                                                     uu____4021
                                                                     (fun
@@ -2191,120 +1979,109 @@ let (apply_lemma : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                                                     let uu____4033
                                                                     =
                                                                     add_smt_goals
-                                                                    smt_goals
-                                                                     in
+                                                                    smt_goals in
                                                                     bind
                                                                     uu____4033
                                                                     (fun
                                                                     uu____4037
                                                                      ->
                                                                     add_goals
-                                                                    sub_goals1)))))))))))))
-         in
-      focus uu____2965  in
+                                                                    sub_goals1))))))))))))) in
+      focus uu____2965 in
     FStar_All.pipe_left (wrap_err "apply_lemma") uu____2962
-  
-let (destruct_eq' :
+let destruct_eq':
   FStar_Syntax_Syntax.typ ->
     (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun typ  ->
-    let uu____4057 = FStar_Syntax_Util.destruct_typ_as_formula typ  in
+    let uu____4057 = FStar_Syntax_Util.destruct_typ_as_formula typ in
     match uu____4057 with
     | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn
         (l,uu____4067::(e1,uu____4069)::(e2,uu____4071)::[])) when
         FStar_Ident.lid_equals l FStar_Parser_Const.eq2_lid ->
         FStar_Pervasives_Native.Some (e1, e2)
     | uu____4130 -> FStar_Pervasives_Native.None
-  
-let (destruct_eq :
+let destruct_eq:
   FStar_Syntax_Syntax.typ ->
     (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun typ  ->
-    let uu____4152 = destruct_eq' typ  in
+    let uu____4152 = destruct_eq' typ in
     match uu____4152 with
     | FStar_Pervasives_Native.Some t -> FStar_Pervasives_Native.Some t
     | FStar_Pervasives_Native.None  ->
-        let uu____4182 = FStar_Syntax_Util.un_squash typ  in
+        let uu____4182 = FStar_Syntax_Util.un_squash typ in
         (match uu____4182 with
          | FStar_Pervasives_Native.Some typ1 -> destruct_eq' typ1
          | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None)
-  
-let (split_env :
+let split_env:
   FStar_Syntax_Syntax.bv ->
     env ->
       (env,FStar_Syntax_Syntax.bv Prims.list) FStar_Pervasives_Native.tuple2
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
   fun bvar  ->
     fun e  ->
       let rec aux e1 =
-        let uu____4238 = FStar_TypeChecker_Env.pop_bv e1  in
+        let uu____4238 = FStar_TypeChecker_Env.pop_bv e1 in
         match uu____4238 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (bv',e') ->
             if FStar_Syntax_Syntax.bv_eq bvar bv'
             then FStar_Pervasives_Native.Some (e', [])
             else
-              (let uu____4286 = aux e'  in
+              (let uu____4286 = aux e' in
                FStar_Util.map_opt uu____4286
                  (fun uu____4310  ->
-                    match uu____4310 with | (e'',bvs) -> (e'', (bv' :: bvs))))
-         in
-      let uu____4331 = aux e  in
+                    match uu____4310 with | (e'',bvs) -> (e'', (bv' :: bvs)))) in
+      let uu____4331 = aux e in
       FStar_Util.map_opt uu____4331
         (fun uu____4355  ->
            match uu____4355 with | (e',bvs) -> (e', (FStar_List.rev bvs)))
-  
-let (push_bvs :
+let push_bvs:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.bv Prims.list -> FStar_TypeChecker_Env.env)
+    FStar_Syntax_Syntax.bv Prims.list -> FStar_TypeChecker_Env.env
   =
   fun e  ->
     fun bvs  ->
       FStar_List.fold_left
         (fun e1  -> fun b  -> FStar_TypeChecker_Env.push_bv e1 b) e bvs
-  
-let (subst_goal :
+let subst_goal:
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.bv ->
       FStar_Syntax_Syntax.subst_elt Prims.list ->
         FStar_Tactics_Types.goal ->
-          FStar_Tactics_Types.goal FStar_Pervasives_Native.option)
+          FStar_Tactics_Types.goal FStar_Pervasives_Native.option
   =
   fun b1  ->
     fun b2  ->
       fun s  ->
         fun g  ->
-          let uu____4410 = split_env b1 g.FStar_Tactics_Types.context  in
+          let uu____4410 = split_env b1 g.FStar_Tactics_Types.context in
           FStar_Util.map_opt uu____4410
             (fun uu____4434  ->
                match uu____4434 with
                | (e0,bvs) ->
                    let s1 bv =
-                     let uu___89_4451 = bv  in
+                     let uu___89_4451 = bv in
                      let uu____4452 =
-                       FStar_Syntax_Subst.subst s bv.FStar_Syntax_Syntax.sort
-                        in
+                       FStar_Syntax_Subst.subst s bv.FStar_Syntax_Syntax.sort in
                      {
                        FStar_Syntax_Syntax.ppname =
                          (uu___89_4451.FStar_Syntax_Syntax.ppname);
                        FStar_Syntax_Syntax.index =
                          (uu___89_4451.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort = uu____4452
-                     }  in
-                   let bvs1 = FStar_List.map s1 bvs  in
-                   let c = push_bvs e0 (b2 :: bvs1)  in
+                     } in
+                   let bvs1 = FStar_List.map s1 bvs in
+                   let c = push_bvs e0 (b2 :: bvs1) in
                    let w =
-                     FStar_Syntax_Subst.subst s g.FStar_Tactics_Types.witness
-                      in
+                     FStar_Syntax_Subst.subst s g.FStar_Tactics_Types.witness in
                    let t =
-                     FStar_Syntax_Subst.subst s g.FStar_Tactics_Types.goal_ty
-                      in
-                   let uu___90_4461 = g  in
+                     FStar_Syntax_Subst.subst s g.FStar_Tactics_Types.goal_ty in
+                   let uu___90_4461 = g in
                    {
                      FStar_Tactics_Types.context = c;
                      FStar_Tactics_Types.witness = w;
@@ -2314,67 +2091,60 @@ let (subst_goal :
                      FStar_Tactics_Types.is_guard =
                        (uu___90_4461.FStar_Tactics_Types.is_guard)
                    })
-  
-let (rewrite : FStar_Syntax_Syntax.binder -> Prims.unit tac) =
+let rewrite: FStar_Syntax_Syntax.binder -> Prims.unit tac =
   fun h  ->
     bind cur_goal
       (fun goal  ->
-         let uu____4474 = h  in
+         let uu____4474 = h in
          match uu____4474 with
          | (bv,uu____4478) ->
              mlog
                (fun uu____4482  ->
-                  let uu____4483 = FStar_Syntax_Print.bv_to_string bv  in
+                  let uu____4483 = FStar_Syntax_Print.bv_to_string bv in
                   let uu____4484 =
                     tts goal.FStar_Tactics_Types.context
-                      bv.FStar_Syntax_Syntax.sort
-                     in
+                      bv.FStar_Syntax_Syntax.sort in
                   FStar_Util.print2 "+++Rewrite %s : %s\n" uu____4483
                     uu____4484)
                (fun uu____4487  ->
                   let uu____4488 =
-                    split_env bv goal.FStar_Tactics_Types.context  in
+                    split_env bv goal.FStar_Tactics_Types.context in
                   match uu____4488 with
                   | FStar_Pervasives_Native.None  ->
                       fail "rewrite: binder not found in environment"
                   | FStar_Pervasives_Native.Some (e0,bvs) ->
                       let uu____4517 =
-                        destruct_eq bv.FStar_Syntax_Syntax.sort  in
+                        destruct_eq bv.FStar_Syntax_Syntax.sort in
                       (match uu____4517 with
                        | FStar_Pervasives_Native.Some (x,e) ->
                            let uu____4532 =
-                             let uu____4533 = FStar_Syntax_Subst.compress x
-                                in
-                             uu____4533.FStar_Syntax_Syntax.n  in
+                             let uu____4533 = FStar_Syntax_Subst.compress x in
+                             uu____4533.FStar_Syntax_Syntax.n in
                            (match uu____4532 with
                             | FStar_Syntax_Syntax.Tm_name x1 ->
-                                let s = [FStar_Syntax_Syntax.NT (x1, e)]  in
+                                let s = [FStar_Syntax_Syntax.NT (x1, e)] in
                                 let s1 bv1 =
-                                  let uu___91_4546 = bv1  in
+                                  let uu___91_4546 = bv1 in
                                   let uu____4547 =
                                     FStar_Syntax_Subst.subst s
-                                      bv1.FStar_Syntax_Syntax.sort
-                                     in
+                                      bv1.FStar_Syntax_Syntax.sort in
                                   {
                                     FStar_Syntax_Syntax.ppname =
                                       (uu___91_4546.FStar_Syntax_Syntax.ppname);
                                     FStar_Syntax_Syntax.index =
                                       (uu___91_4546.FStar_Syntax_Syntax.index);
                                     FStar_Syntax_Syntax.sort = uu____4547
-                                  }  in
-                                let bvs1 = FStar_List.map s1 bvs  in
+                                  } in
+                                let bvs1 = FStar_List.map s1 bvs in
                                 let uu____4553 =
-                                  let uu___92_4554 = goal  in
-                                  let uu____4555 = push_bvs e0 (bv :: bvs1)
-                                     in
+                                  let uu___92_4554 = goal in
+                                  let uu____4555 = push_bvs e0 (bv :: bvs1) in
                                   let uu____4556 =
                                     FStar_Syntax_Subst.subst s
-                                      goal.FStar_Tactics_Types.witness
-                                     in
+                                      goal.FStar_Tactics_Types.witness in
                                   let uu____4557 =
                                     FStar_Syntax_Subst.subst s
-                                      goal.FStar_Tactics_Types.goal_ty
-                                     in
+                                      goal.FStar_Tactics_Types.goal_ty in
                                   {
                                     FStar_Tactics_Types.context = uu____4555;
                                     FStar_Tactics_Types.witness = uu____4556;
@@ -2383,26 +2153,24 @@ let (rewrite : FStar_Syntax_Syntax.binder -> Prims.unit tac) =
                                       (uu___92_4554.FStar_Tactics_Types.opts);
                                     FStar_Tactics_Types.is_guard =
                                       (uu___92_4554.FStar_Tactics_Types.is_guard)
-                                  }  in
+                                  } in
                                 replace_cur uu____4553
                             | uu____4558 ->
                                 fail
                                   "rewrite: Not an equality hypothesis with a variable on the LHS")
                        | uu____4559 ->
                            fail "rewrite: Not an equality hypothesis")))
-  
-let (rename_to :
-  FStar_Syntax_Syntax.binder -> Prims.string -> Prims.unit tac) =
+let rename_to: FStar_Syntax_Syntax.binder -> Prims.string -> Prims.unit tac =
   fun b  ->
     fun s  ->
       bind cur_goal
         (fun goal  ->
-           let uu____4584 = b  in
+           let uu____4584 = b in
            match uu____4584 with
            | (bv,uu____4588) ->
                let bv' =
                  FStar_Syntax_Syntax.freshen_bv
-                   (let uu___93_4592 = bv  in
+                   (let uu___93_4592 = bv in
                     {
                       FStar_Syntax_Syntax.ppname =
                         (FStar_Ident.mk_ident
@@ -2412,88 +2180,81 @@ let (rename_to :
                         (uu___93_4592.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort =
                         (uu___93_4592.FStar_Syntax_Syntax.sort)
-                    })
-                  in
+                    }) in
                let s1 =
                  let uu____4596 =
                    let uu____4597 =
-                     let uu____4604 = FStar_Syntax_Syntax.bv_to_name bv'  in
-                     (bv, uu____4604)  in
-                   FStar_Syntax_Syntax.NT uu____4597  in
-                 [uu____4596]  in
-               let uu____4605 = subst_goal bv bv' s1 goal  in
+                     let uu____4604 = FStar_Syntax_Syntax.bv_to_name bv' in
+                     (bv, uu____4604) in
+                   FStar_Syntax_Syntax.NT uu____4597 in
+                 [uu____4596] in
+               let uu____4605 = subst_goal bv bv' s1 goal in
                (match uu____4605 with
                 | FStar_Pervasives_Native.None  ->
                     fail "rename_to: binder not found in environment"
                 | FStar_Pervasives_Native.Some goal1 -> replace_cur goal1))
-  
-let (binder_retype : FStar_Syntax_Syntax.binder -> Prims.unit tac) =
+let binder_retype: FStar_Syntax_Syntax.binder -> Prims.unit tac =
   fun b  ->
     bind cur_goal
       (fun goal  ->
-         let uu____4624 = b  in
+         let uu____4624 = b in
          match uu____4624 with
          | (bv,uu____4628) ->
-             let uu____4629 = split_env bv goal.FStar_Tactics_Types.context
-                in
+             let uu____4629 = split_env bv goal.FStar_Tactics_Types.context in
              (match uu____4629 with
               | FStar_Pervasives_Native.None  ->
                   fail "binder_retype: binder is not present in environment"
               | FStar_Pervasives_Native.Some (e0,bvs) ->
-                  let uu____4658 = FStar_Syntax_Util.type_u ()  in
+                  let uu____4658 = FStar_Syntax_Util.type_u () in
                   (match uu____4658 with
                    | (ty,u) ->
-                       let uu____4667 = new_uvar "binder_retype" e0 ty  in
+                       let uu____4667 = new_uvar "binder_retype" e0 ty in
                        bind uu____4667
                          (fun t'  ->
                             let bv'' =
-                              let uu___94_4677 = bv  in
+                              let uu___94_4677 = bv in
                               {
                                 FStar_Syntax_Syntax.ppname =
                                   (uu___94_4677.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
                                   (uu___94_4677.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t'
-                              }  in
+                              } in
                             let s =
                               let uu____4681 =
                                 let uu____4682 =
                                   let uu____4689 =
-                                    FStar_Syntax_Syntax.bv_to_name bv''  in
-                                  (bv, uu____4689)  in
-                                FStar_Syntax_Syntax.NT uu____4682  in
-                              [uu____4681]  in
+                                    FStar_Syntax_Syntax.bv_to_name bv'' in
+                                  (bv, uu____4689) in
+                                FStar_Syntax_Syntax.NT uu____4682 in
+                              [uu____4681] in
                             let bvs1 =
                               FStar_List.map
                                 (fun b1  ->
-                                   let uu___95_4697 = b1  in
+                                   let uu___95_4697 = b1 in
                                    let uu____4698 =
                                      FStar_Syntax_Subst.subst s
-                                       b1.FStar_Syntax_Syntax.sort
-                                      in
+                                       b1.FStar_Syntax_Syntax.sort in
                                    {
                                      FStar_Syntax_Syntax.ppname =
                                        (uu___95_4697.FStar_Syntax_Syntax.ppname);
                                      FStar_Syntax_Syntax.index =
                                        (uu___95_4697.FStar_Syntax_Syntax.index);
                                      FStar_Syntax_Syntax.sort = uu____4698
-                                   }) bvs
-                               in
-                            let env' = push_bvs e0 (bv'' :: bvs1)  in
+                                   }) bvs in
+                            let env' = push_bvs e0 (bv'' :: bvs1) in
                             bind dismiss
                               (fun uu____4704  ->
                                  let uu____4705 =
                                    let uu____4708 =
                                      let uu____4711 =
-                                       let uu___96_4712 = goal  in
+                                       let uu___96_4712 = goal in
                                        let uu____4713 =
                                          FStar_Syntax_Subst.subst s
-                                           goal.FStar_Tactics_Types.witness
-                                          in
+                                           goal.FStar_Tactics_Types.witness in
                                        let uu____4714 =
                                          FStar_Syntax_Subst.subst s
-                                           goal.FStar_Tactics_Types.goal_ty
-                                          in
+                                           goal.FStar_Tactics_Types.goal_ty in
                                        {
                                          FStar_Tactics_Types.context = env';
                                          FStar_Tactics_Types.witness =
@@ -2504,34 +2265,31 @@ let (binder_retype : FStar_Syntax_Syntax.binder -> Prims.unit tac) =
                                            (uu___96_4712.FStar_Tactics_Types.opts);
                                          FStar_Tactics_Types.is_guard =
                                            (uu___96_4712.FStar_Tactics_Types.is_guard)
-                                       }  in
-                                     [uu____4711]  in
-                                   add_goals uu____4708  in
+                                       } in
+                                     [uu____4711] in
+                                   add_goals uu____4708 in
                                  bind uu____4705
                                    (fun uu____4717  ->
                                       let uu____4718 =
                                         FStar_Syntax_Util.mk_eq2
                                           (FStar_Syntax_Syntax.U_succ u) ty
-                                          bv.FStar_Syntax_Syntax.sort t'
-                                         in
+                                          bv.FStar_Syntax_Syntax.sort t' in
                                       add_irrelevant_goal
                                         "binder_retype equation" e0
                                         uu____4718
                                         goal.FStar_Tactics_Types.opts))))))
-  
-let (norm_binder_type :
+let norm_binder_type:
   FStar_Syntax_Embeddings.norm_step Prims.list ->
-    FStar_Syntax_Syntax.binder -> Prims.unit tac)
+    FStar_Syntax_Syntax.binder -> Prims.unit tac
   =
   fun s  ->
     fun b  ->
       bind cur_goal
         (fun goal  ->
-           let uu____4739 = b  in
+           let uu____4739 = b in
            match uu____4739 with
            | (bv,uu____4743) ->
-               let uu____4744 = split_env bv goal.FStar_Tactics_Types.context
-                  in
+               let uu____4744 = split_env bv goal.FStar_Tactics_Types.context in
                (match uu____4744 with
                 | FStar_Pervasives_Native.None  ->
                     fail
@@ -2539,25 +2297,24 @@ let (norm_binder_type :
                 | FStar_Pervasives_Native.Some (e0,bvs) ->
                     let steps =
                       let uu____4776 =
-                        FStar_TypeChecker_Normalize.tr_norm_steps s  in
+                        FStar_TypeChecker_Normalize.tr_norm_steps s in
                       FStar_List.append
                         [FStar_TypeChecker_Normalize.Reify;
-                        FStar_TypeChecker_Normalize.UnfoldTac] uu____4776
-                       in
+                        FStar_TypeChecker_Normalize.UnfoldTac] uu____4776 in
                     let sort' =
-                      normalize steps e0 bv.FStar_Syntax_Syntax.sort  in
+                      normalize steps e0 bv.FStar_Syntax_Syntax.sort in
                     let bv' =
-                      let uu___97_4781 = bv  in
+                      let uu___97_4781 = bv in
                       {
                         FStar_Syntax_Syntax.ppname =
                           (uu___97_4781.FStar_Syntax_Syntax.ppname);
                         FStar_Syntax_Syntax.index =
                           (uu___97_4781.FStar_Syntax_Syntax.index);
                         FStar_Syntax_Syntax.sort = sort'
-                      }  in
-                    let env' = push_bvs e0 (bv' :: bvs)  in
+                      } in
+                    let env' = push_bvs e0 (bv' :: bvs) in
                     replace_cur
-                      (let uu___98_4785 = goal  in
+                      (let uu___98_4785 = goal in
                        {
                          FStar_Tactics_Types.context = env';
                          FStar_Tactics_Types.witness =
@@ -2569,28 +2326,24 @@ let (norm_binder_type :
                          FStar_Tactics_Types.is_guard =
                            (uu___98_4785.FStar_Tactics_Types.is_guard)
                        })))
-  
-let (revert : Prims.unit tac) =
+let revert: Prims.unit tac =
   bind cur_goal
     (fun goal  ->
        let uu____4793 =
-         FStar_TypeChecker_Env.pop_bv goal.FStar_Tactics_Types.context  in
+         FStar_TypeChecker_Env.pop_bv goal.FStar_Tactics_Types.context in
        match uu____4793 with
        | FStar_Pervasives_Native.None  -> fail "Cannot revert; empty context"
        | FStar_Pervasives_Native.Some (x,env') ->
            let typ' =
              let uu____4815 =
-               FStar_Syntax_Syntax.mk_Total goal.FStar_Tactics_Types.goal_ty
-                in
+               FStar_Syntax_Syntax.mk_Total goal.FStar_Tactics_Types.goal_ty in
              FStar_Syntax_Util.arrow [(x, FStar_Pervasives_Native.None)]
-               uu____4815
-              in
+               uu____4815 in
            let w' =
              FStar_Syntax_Util.abs [(x, FStar_Pervasives_Native.None)]
-               goal.FStar_Tactics_Types.witness FStar_Pervasives_Native.None
-              in
+               goal.FStar_Tactics_Types.witness FStar_Pervasives_Native.None in
            replace_cur
-             (let uu___99_4849 = goal  in
+             (let uu___99_4849 = goal in
               {
                 FStar_Tactics_Types.context = env';
                 FStar_Tactics_Types.witness = w';
@@ -2600,35 +2353,31 @@ let (revert : Prims.unit tac) =
                 FStar_Tactics_Types.is_guard =
                   (uu___99_4849.FStar_Tactics_Types.is_guard)
               }))
-  
-let (free_in :
-  FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let free_in: FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool
+  =
   fun bv  ->
     fun t  ->
-      let uu____4856 = FStar_Syntax_Free.names t  in
+      let uu____4856 = FStar_Syntax_Free.names t in
       FStar_Util.set_mem bv uu____4856
-  
-let rec (clear : FStar_Syntax_Syntax.binder -> Prims.unit tac) =
+let rec clear: FStar_Syntax_Syntax.binder -> Prims.unit tac =
   fun b  ->
-    let bv = FStar_Pervasives_Native.fst b  in
+    let bv = FStar_Pervasives_Native.fst b in
     bind cur_goal
       (fun goal  ->
          mlog
            (fun uu____4872  ->
-              let uu____4873 = FStar_Syntax_Print.binder_to_string b  in
+              let uu____4873 = FStar_Syntax_Print.binder_to_string b in
               let uu____4874 =
                 let uu____4875 =
                   let uu____4876 =
                     FStar_TypeChecker_Env.all_binders
-                      goal.FStar_Tactics_Types.context
-                     in
-                  FStar_All.pipe_right uu____4876 FStar_List.length  in
-                FStar_All.pipe_right uu____4875 FStar_Util.string_of_int  in
+                      goal.FStar_Tactics_Types.context in
+                  FStar_All.pipe_right uu____4876 FStar_List.length in
+                FStar_All.pipe_right uu____4875 FStar_Util.string_of_int in
               FStar_Util.print2 "Clear of (%s), env has %s binders\n"
                 uu____4873 uu____4874)
            (fun uu____4887  ->
-              let uu____4888 = split_env bv goal.FStar_Tactics_Types.context
-                 in
+              let uu____4888 = split_env bv goal.FStar_Tactics_Types.context in
               match uu____4888 with
               | FStar_Pervasives_Native.None  ->
                   fail "Cannot clear; binder not in environment"
@@ -2638,42 +2387,38 @@ let rec (clear : FStar_Syntax_Syntax.binder -> Prims.unit tac) =
                     | [] -> ret ()
                     | bv'::bvs2 ->
                         let uu____4933 =
-                          free_in bv bv'.FStar_Syntax_Syntax.sort  in
+                          free_in bv bv'.FStar_Syntax_Syntax.sort in
                         if uu____4933
                         then
                           let uu____4936 =
                             let uu____4937 =
-                              FStar_Syntax_Print.bv_to_string bv'  in
+                              FStar_Syntax_Print.bv_to_string bv' in
                             FStar_Util.format1
                               "Cannot clear; binder present in the type of %s"
-                              uu____4937
-                             in
+                              uu____4937 in
                           fail uu____4936
-                        else check bvs2
-                     in
+                        else check bvs2 in
                   let uu____4939 =
-                    free_in bv goal.FStar_Tactics_Types.goal_ty  in
+                    free_in bv goal.FStar_Tactics_Types.goal_ty in
                   if uu____4939
                   then fail "Cannot clear; binder present in goal"
                   else
-                    (let uu____4943 = check bvs  in
+                    (let uu____4943 = check bvs in
                      bind uu____4943
                        (fun uu____4949  ->
-                          let env' = push_bvs e' bvs  in
+                          let env' = push_bvs e' bvs in
                           let uu____4951 =
                             new_uvar "clear.witness" env'
-                              goal.FStar_Tactics_Types.goal_ty
-                             in
+                              goal.FStar_Tactics_Types.goal_ty in
                           bind uu____4951
                             (fun ut  ->
                                let uu____4957 =
                                  do_unify goal.FStar_Tactics_Types.context
-                                   goal.FStar_Tactics_Types.witness ut
-                                  in
+                                   goal.FStar_Tactics_Types.witness ut in
                                if uu____4957
                                then
                                  replace_cur
-                                   (let uu___100_4962 = goal  in
+                                   (let uu___100_4962 = goal in
                                     {
                                       FStar_Tactics_Types.context = env';
                                       FStar_Tactics_Types.witness = ut;
@@ -2687,29 +2432,26 @@ let rec (clear : FStar_Syntax_Syntax.binder -> Prims.unit tac) =
                                else
                                  fail
                                    "Cannot clear; binder appears in witness")))))
-  
-let (clear_top : Prims.unit tac) =
+let clear_top: Prims.unit tac =
   bind cur_goal
     (fun goal  ->
        let uu____4971 =
-         FStar_TypeChecker_Env.pop_bv goal.FStar_Tactics_Types.context  in
+         FStar_TypeChecker_Env.pop_bv goal.FStar_Tactics_Types.context in
        match uu____4971 with
        | FStar_Pervasives_Native.None  -> fail "Cannot clear; empty context"
        | FStar_Pervasives_Native.Some (x,uu____4985) ->
-           let uu____4990 = FStar_Syntax_Syntax.mk_binder x  in
+           let uu____4990 = FStar_Syntax_Syntax.mk_binder x in
            clear uu____4990)
-  
-let (prune : Prims.string -> Prims.unit tac) =
+let prune: Prims.string -> Prims.unit tac =
   fun s  ->
     bind cur_goal
       (fun g  ->
-         let ctx = g.FStar_Tactics_Types.context  in
+         let ctx = g.FStar_Tactics_Types.context in
          let ctx' =
            FStar_TypeChecker_Env.rem_proof_ns ctx
-             (FStar_Ident.path_of_text s)
-            in
+             (FStar_Ident.path_of_text s) in
          let g' =
-           let uu___101_5006 = g  in
+           let uu___101_5006 = g in
            {
              FStar_Tactics_Types.context = ctx';
              FStar_Tactics_Types.witness =
@@ -2720,20 +2462,18 @@ let (prune : Prims.string -> Prims.unit tac) =
                (uu___101_5006.FStar_Tactics_Types.opts);
              FStar_Tactics_Types.is_guard =
                (uu___101_5006.FStar_Tactics_Types.is_guard)
-           }  in
+           } in
          bind dismiss (fun uu____5008  -> add_goals [g']))
-  
-let (addns : Prims.string -> Prims.unit tac) =
+let addns: Prims.string -> Prims.unit tac =
   fun s  ->
     bind cur_goal
       (fun g  ->
-         let ctx = g.FStar_Tactics_Types.context  in
+         let ctx = g.FStar_Tactics_Types.context in
          let ctx' =
            FStar_TypeChecker_Env.add_proof_ns ctx
-             (FStar_Ident.path_of_text s)
-            in
+             (FStar_Ident.path_of_text s) in
          let g' =
-           let uu___102_5024 = g  in
+           let uu___102_5024 = g in
            {
              FStar_Tactics_Types.context = ctx';
              FStar_Tactics_Types.witness =
@@ -2744,26 +2484,25 @@ let (addns : Prims.string -> Prims.unit tac) =
                (uu___102_5024.FStar_Tactics_Types.opts);
              FStar_Tactics_Types.is_guard =
                (uu___102_5024.FStar_Tactics_Types.is_guard)
-           }  in
+           } in
          bind dismiss (fun uu____5026  -> add_goals [g']))
-  
-let rec (tac_fold_env :
+let rec tac_fold_env:
   FStar_Tactics_Types.direction ->
     (env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term tac) ->
-      env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term tac)
+      env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term tac
   =
   fun d  ->
     fun f  ->
       fun env  ->
         fun t  ->
           let tn =
-            let uu____5058 = FStar_Syntax_Subst.compress t  in
-            uu____5058.FStar_Syntax_Syntax.n  in
+            let uu____5058 = FStar_Syntax_Subst.compress t in
+            uu____5058.FStar_Syntax_Syntax.n in
           let uu____5061 =
             if d = FStar_Tactics_Types.TopDown
             then
               f env
-                (let uu___104_5067 = t  in
+                (let uu___104_5067 = t in
                  {
                    FStar_Syntax_Syntax.n = tn;
                    FStar_Syntax_Syntax.pos =
@@ -2771,114 +2510,108 @@ let rec (tac_fold_env :
                    FStar_Syntax_Syntax.vars =
                      (uu___104_5067.FStar_Syntax_Syntax.vars)
                  })
-            else ret t  in
+            else ret t in
           bind uu____5061
             (fun t1  ->
                let tn1 =
                  let uu____5075 =
-                   let uu____5076 = FStar_Syntax_Subst.compress t1  in
-                   uu____5076.FStar_Syntax_Syntax.n  in
+                   let uu____5076 = FStar_Syntax_Subst.compress t1 in
+                   uu____5076.FStar_Syntax_Syntax.n in
                  match uu____5075 with
                  | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-                     let ff = tac_fold_env d f env  in
-                     let uu____5108 = ff hd1  in
+                     let ff = tac_fold_env d f env in
+                     let uu____5108 = ff hd1 in
                      bind uu____5108
                        (fun hd2  ->
                           let fa uu____5128 =
                             match uu____5128 with
                             | (a,q) ->
-                                let uu____5141 = ff a  in
-                                bind uu____5141 (fun a1  -> ret (a1, q))
-                             in
-                          let uu____5154 = mapM fa args  in
+                                let uu____5141 = ff a in
+                                bind uu____5141 (fun a1  -> ret (a1, q)) in
+                          let uu____5154 = mapM fa args in
                           bind uu____5154
                             (fun args1  ->
                                ret (FStar_Syntax_Syntax.Tm_app (hd2, args1))))
                  | FStar_Syntax_Syntax.Tm_abs (bs,t2,k) ->
-                     let uu____5214 = FStar_Syntax_Subst.open_term bs t2  in
+                     let uu____5214 = FStar_Syntax_Subst.open_term bs t2 in
                      (match uu____5214 with
                       | (bs1,t') ->
                           let uu____5223 =
                             let uu____5226 =
-                              FStar_TypeChecker_Env.push_binders env bs1  in
-                            tac_fold_env d f uu____5226 t'  in
+                              FStar_TypeChecker_Env.push_binders env bs1 in
+                            tac_fold_env d f uu____5226 t' in
                           bind uu____5223
                             (fun t''  ->
                                let uu____5230 =
                                  let uu____5231 =
                                    let uu____5248 =
-                                     FStar_Syntax_Subst.close_binders bs1  in
+                                     FStar_Syntax_Subst.close_binders bs1 in
                                    let uu____5249 =
-                                     FStar_Syntax_Subst.close bs1 t''  in
-                                   (uu____5248, uu____5249, k)  in
-                                 FStar_Syntax_Syntax.Tm_abs uu____5231  in
+                                     FStar_Syntax_Subst.close bs1 t'' in
+                                   (uu____5248, uu____5249, k) in
+                                 FStar_Syntax_Syntax.Tm_abs uu____5231 in
                                ret uu____5230))
                  | FStar_Syntax_Syntax.Tm_arrow (bs,k) -> ret tn
-                 | uu____5270 -> ret tn  in
+                 | uu____5270 -> ret tn in
                bind tn1
                  (fun tn2  ->
                     let t' =
-                      let uu___103_5277 = t1  in
+                      let uu___103_5277 = t1 in
                       {
                         FStar_Syntax_Syntax.n = tn2;
                         FStar_Syntax_Syntax.pos =
                           (uu___103_5277.FStar_Syntax_Syntax.pos);
                         FStar_Syntax_Syntax.vars =
                           (uu___103_5277.FStar_Syntax_Syntax.vars)
-                      }  in
+                      } in
                     if d = FStar_Tactics_Types.BottomUp
                     then f env t'
                     else ret t'))
-  
-let (pointwise_rec :
+let pointwise_rec:
   FStar_Tactics_Types.proofstate ->
     Prims.unit tac ->
       FStar_Options.optionstate ->
         FStar_TypeChecker_Env.env ->
-          FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term tac)
+          FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term tac
   =
   fun ps  ->
     fun tau  ->
       fun opts  ->
         fun env  ->
           fun t  ->
-            let uu____5306 = FStar_TypeChecker_TcTerm.tc_term env t  in
+            let uu____5306 = FStar_TypeChecker_TcTerm.tc_term env t in
             match uu____5306 with
             | (t1,lcomp,g) ->
                 let uu____5318 =
                   (let uu____5321 =
-                     FStar_Syntax_Util.is_pure_or_ghost_lcomp lcomp  in
+                     FStar_Syntax_Util.is_pure_or_ghost_lcomp lcomp in
                    Prims.op_Negation uu____5321) ||
-                    (let uu____5323 = FStar_TypeChecker_Rel.is_trivial g  in
-                     Prims.op_Negation uu____5323)
-                   in
+                    (let uu____5323 = FStar_TypeChecker_Rel.is_trivial g in
+                     Prims.op_Negation uu____5323) in
                 if uu____5318
                 then ret t1
                 else
                   (let rewrite_eq =
-                     let typ = lcomp.FStar_Syntax_Syntax.res_typ  in
-                     let uu____5333 = new_uvar "pointwise_rec" env typ  in
+                     let typ = lcomp.FStar_Syntax_Syntax.res_typ in
+                     let uu____5333 = new_uvar "pointwise_rec" env typ in
                      bind uu____5333
                        (fun ut  ->
                           log ps
                             (fun uu____5344  ->
                                let uu____5345 =
-                                 FStar_Syntax_Print.term_to_string t1  in
+                                 FStar_Syntax_Print.term_to_string t1 in
                                let uu____5346 =
-                                 FStar_Syntax_Print.term_to_string ut  in
+                                 FStar_Syntax_Print.term_to_string ut in
                                FStar_Util.print2
                                  "Pointwise_rec: making equality\n\t%s ==\n\t%s\n"
                                  uu____5345 uu____5346);
                           (let uu____5347 =
                              let uu____5350 =
                                let uu____5351 =
-                                 FStar_TypeChecker_TcTerm.universe_of env typ
-                                  in
-                               FStar_Syntax_Util.mk_eq2 uu____5351 typ t1 ut
-                                in
+                                 FStar_TypeChecker_TcTerm.universe_of env typ in
+                               FStar_Syntax_Util.mk_eq2 uu____5351 typ t1 ut in
                              add_irrelevant_goal "pointwise_rec equation" env
-                               uu____5350 opts
-                              in
+                               uu____5350 opts in
                            bind uu____5347
                              (fun uu____5354  ->
                                 let uu____5355 =
@@ -2886,35 +2619,29 @@ let (pointwise_rec :
                                     (fun uu____5361  ->
                                        let ut1 =
                                          FStar_TypeChecker_Normalize.reduce_uvar_solutions
-                                           env ut
-                                          in
+                                           env ut in
                                        log ps
                                          (fun uu____5367  ->
                                             let uu____5368 =
                                               FStar_Syntax_Print.term_to_string
-                                                t1
-                                               in
+                                                t1 in
                                             let uu____5369 =
                                               FStar_Syntax_Print.term_to_string
-                                                ut1
-                                               in
+                                                ut1 in
                                             FStar_Util.print2
                                               "Pointwise_rec: succeeded rewriting\n\t%s to\n\t%s\n"
                                               uu____5368 uu____5369);
-                                       ret ut1)
-                                   in
-                                focus uu____5355)))
-                      in
-                   let uu____5370 = trytac' rewrite_eq  in
+                                       ret ut1) in
+                                focus uu____5355))) in
+                   let uu____5370 = trytac' rewrite_eq in
                    bind uu____5370
                      (fun x  ->
                         match x with
                         | FStar_Util.Inl "SKIP" -> ret t1
                         | FStar_Util.Inl e -> fail e
                         | FStar_Util.Inr x1 -> ret x1))
-  
-let (pointwise :
-  FStar_Tactics_Types.direction -> Prims.unit tac -> Prims.unit tac) =
+let pointwise:
+  FStar_Tactics_Types.direction -> Prims.unit tac -> Prims.unit tac =
   fun d  ->
     fun tau  ->
       bind get
@@ -2922,14 +2649,13 @@ let (pointwise :
            let uu____5412 =
              match ps.FStar_Tactics_Types.goals with
              | g::gs -> (g, gs)
-             | [] -> failwith "Pointwise: no goals"  in
+             | [] -> failwith "Pointwise: no goals" in
            match uu____5412 with
            | (g,gs) ->
-               let gt1 = g.FStar_Tactics_Types.goal_ty  in
+               let gt1 = g.FStar_Tactics_Types.goal_ty in
                (log ps
                   (fun uu____5449  ->
-                     let uu____5450 = FStar_Syntax_Print.term_to_string gt1
-                        in
+                     let uu____5450 = FStar_Syntax_Print.term_to_string gt1 in
                      FStar_Util.print1 "Pointwise starting with %s\n"
                        uu____5450);
                 bind dismiss_all
@@ -2937,22 +2663,21 @@ let (pointwise :
                      let uu____5454 =
                        tac_fold_env d
                          (pointwise_rec ps tau g.FStar_Tactics_Types.opts)
-                         g.FStar_Tactics_Types.context gt1
-                        in
+                         g.FStar_Tactics_Types.context gt1 in
                      bind uu____5454
                        (fun gt'  ->
                           log ps
                             (fun uu____5464  ->
                                let uu____5465 =
-                                 FStar_Syntax_Print.term_to_string gt'  in
+                                 FStar_Syntax_Print.term_to_string gt' in
                                FStar_Util.print1
                                  "Pointwise seems to have succeded with %s\n"
                                  uu____5465);
-                          (let uu____5466 = push_goals gs  in
+                          (let uu____5466 = push_goals gs in
                            bind uu____5466
                              (fun uu____5470  ->
                                 add_goals
-                                  [(let uu___105_5472 = g  in
+                                  [(let uu___105_5472 = g in
                                     {
                                       FStar_Tactics_Types.context =
                                         (uu___105_5472.FStar_Tactics_Types.context);
@@ -2964,22 +2689,21 @@ let (pointwise :
                                       FStar_Tactics_Types.is_guard =
                                         (uu___105_5472.FStar_Tactics_Types.is_guard)
                                     })]))))))
-  
-let (trefl : Prims.unit tac) =
+let trefl: Prims.unit tac =
   bind cur_goal
     (fun g  ->
        let uu____5494 =
-         FStar_Syntax_Util.un_squash g.FStar_Tactics_Types.goal_ty  in
+         FStar_Syntax_Util.un_squash g.FStar_Tactics_Types.goal_ty in
        match uu____5494 with
        | FStar_Pervasives_Native.Some t ->
-           let uu____5506 = FStar_Syntax_Util.head_and_args' t  in
+           let uu____5506 = FStar_Syntax_Util.head_and_args' t in
            (match uu____5506 with
             | (hd1,args) ->
                 let uu____5539 =
                   let uu____5552 =
-                    let uu____5553 = FStar_Syntax_Util.un_uinst hd1  in
-                    uu____5553.FStar_Syntax_Syntax.n  in
-                  (uu____5552, args)  in
+                    let uu____5553 = FStar_Syntax_Util.un_uinst hd1 in
+                    uu____5553.FStar_Syntax_Syntax.n in
+                  (uu____5552, args) in
                 (match uu____5539 with
                  | (FStar_Syntax_Syntax.Tm_fvar
                     fv,uu____5567::(l,uu____5569)::(r,uu____5571)::[]) when
@@ -2988,33 +2712,29 @@ let (trefl : Prims.unit tac) =
                      ->
                      let uu____5618 =
                        let uu____5619 =
-                         do_unify g.FStar_Tactics_Types.context l r  in
-                       Prims.op_Negation uu____5619  in
+                         do_unify g.FStar_Tactics_Types.context l r in
+                       Prims.op_Negation uu____5619 in
                      if uu____5618
                      then
-                       let uu____5622 = tts g.FStar_Tactics_Types.context l
-                          in
-                       let uu____5623 = tts g.FStar_Tactics_Types.context r
-                          in
+                       let uu____5622 = tts g.FStar_Tactics_Types.context l in
+                       let uu____5623 = tts g.FStar_Tactics_Types.context r in
                        fail2 "trefl: not a trivial equality (%s vs %s)"
                          uu____5622 uu____5623
                      else solve g FStar_Syntax_Util.exp_unit
                  | (hd2,uu____5626) ->
-                     let uu____5643 = tts g.FStar_Tactics_Types.context t  in
+                     let uu____5643 = tts g.FStar_Tactics_Types.context t in
                      fail1 "trefl: not an equality (%s)" uu____5643))
        | FStar_Pervasives_Native.None  -> fail "not an irrelevant goal")
-  
-let (dup : Prims.unit tac) =
+let dup: Prims.unit tac =
   bind cur_goal
     (fun g  ->
        let uu____5653 =
          new_uvar "dup" g.FStar_Tactics_Types.context
-           g.FStar_Tactics_Types.goal_ty
-          in
+           g.FStar_Tactics_Types.goal_ty in
        bind uu____5653
          (fun u  ->
             let g' =
-              let uu___106_5660 = g  in
+              let uu___106_5660 = g in
               {
                 FStar_Tactics_Types.context =
                   (uu___106_5660.FStar_Tactics_Types.context);
@@ -3025,7 +2745,7 @@ let (dup : Prims.unit tac) =
                   (uu___106_5660.FStar_Tactics_Types.opts);
                 FStar_Tactics_Types.is_guard =
                   (uu___106_5660.FStar_Tactics_Types.is_guard)
-              }  in
+              } in
             bind dismiss
               (fun uu____5663  ->
                  let uu____5664 =
@@ -3033,28 +2753,24 @@ let (dup : Prims.unit tac) =
                      let uu____5668 =
                        FStar_TypeChecker_TcTerm.universe_of
                          g.FStar_Tactics_Types.context
-                         g.FStar_Tactics_Types.goal_ty
-                        in
+                         g.FStar_Tactics_Types.goal_ty in
                      FStar_Syntax_Util.mk_eq2 uu____5668
                        g.FStar_Tactics_Types.goal_ty u
-                       g.FStar_Tactics_Types.witness
-                      in
+                       g.FStar_Tactics_Types.witness in
                    add_irrelevant_goal "dup equation"
                      g.FStar_Tactics_Types.context uu____5667
-                     g.FStar_Tactics_Types.opts
-                    in
+                     g.FStar_Tactics_Types.opts in
                  bind uu____5664
                    (fun uu____5671  ->
-                      let uu____5672 = add_goals [g']  in
+                      let uu____5672 = add_goals [g'] in
                       bind uu____5672 (fun uu____5676  -> ret ())))))
-  
-let (flip : Prims.unit tac) =
+let flip: Prims.unit tac =
   bind get
     (fun ps  ->
        match ps.FStar_Tactics_Types.goals with
        | g1::g2::gs ->
            set
-             (let uu___107_5695 = ps  in
+             (let uu___107_5695 = ps in
               {
                 FStar_Tactics_Types.main_context =
                   (uu___107_5695.FStar_Tactics_Types.main_context);
@@ -3075,15 +2791,14 @@ let (flip : Prims.unit tac) =
                   (uu___107_5695.FStar_Tactics_Types.entry_range)
               })
        | uu____5696 -> fail "flip: less than 2 goals")
-  
-let (later : Prims.unit tac) =
+let later: Prims.unit tac =
   bind get
     (fun ps  ->
        match ps.FStar_Tactics_Types.goals with
        | [] -> ret ()
        | g::gs ->
            set
-             (let uu___108_5713 = ps  in
+             (let uu___108_5713 = ps in
               {
                 FStar_Tactics_Types.main_context =
                   (uu___108_5713.FStar_Tactics_Types.main_context);
@@ -3103,37 +2818,34 @@ let (later : Prims.unit tac) =
                 FStar_Tactics_Types.entry_range =
                   (uu___108_5713.FStar_Tactics_Types.entry_range)
               }))
-  
-let (qed : Prims.unit tac) =
+let qed: Prims.unit tac =
   bind get
     (fun ps  ->
        match ps.FStar_Tactics_Types.goals with
        | [] -> ret ()
        | uu____5722 -> fail "Not done!")
-  
-let (cases :
+let cases:
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2 tac)
+      FStar_Pervasives_Native.tuple2 tac
   =
   fun t  ->
     let uu____5740 =
       bind cur_goal
         (fun g  ->
-           let uu____5754 = __tc g.FStar_Tactics_Types.context t  in
+           let uu____5754 = __tc g.FStar_Tactics_Types.context t in
            bind uu____5754
              (fun uu____5790  ->
                 match uu____5790 with
                 | (t1,typ,guard) ->
-                    let uu____5806 = FStar_Syntax_Util.head_and_args typ  in
+                    let uu____5806 = FStar_Syntax_Util.head_and_args typ in
                     (match uu____5806 with
                      | (hd1,args) ->
                          let uu____5849 =
                            let uu____5862 =
-                             let uu____5863 = FStar_Syntax_Util.un_uinst hd1
-                                in
-                             uu____5863.FStar_Syntax_Syntax.n  in
-                           (uu____5862, args)  in
+                             let uu____5863 = FStar_Syntax_Util.un_uinst hd1 in
+                             uu____5863.FStar_Syntax_Syntax.n in
+                           (uu____5862, args) in
                          (match uu____5849 with
                           | (FStar_Syntax_Syntax.Tm_fvar
                              fv,(p,uu____5882)::(q,uu____5884)::[]) when
@@ -3142,18 +2854,15 @@ let (cases :
                               ->
                               let v_p =
                                 FStar_Syntax_Syntax.new_bv
-                                  FStar_Pervasives_Native.None p
-                                 in
+                                  FStar_Pervasives_Native.None p in
                               let v_q =
                                 FStar_Syntax_Syntax.new_bv
-                                  FStar_Pervasives_Native.None q
-                                 in
+                                  FStar_Pervasives_Native.None q in
                               let g1 =
-                                let uu___109_5922 = g  in
+                                let uu___109_5922 = g in
                                 let uu____5923 =
                                   FStar_TypeChecker_Env.push_bv
-                                    g.FStar_Tactics_Types.context v_p
-                                   in
+                                    g.FStar_Tactics_Types.context v_p in
                                 {
                                   FStar_Tactics_Types.context = uu____5923;
                                   FStar_Tactics_Types.witness =
@@ -3164,13 +2873,12 @@ let (cases :
                                     (uu___109_5922.FStar_Tactics_Types.opts);
                                   FStar_Tactics_Types.is_guard =
                                     (uu___109_5922.FStar_Tactics_Types.is_guard)
-                                }  in
+                                } in
                               let g2 =
-                                let uu___110_5925 = g  in
+                                let uu___110_5925 = g in
                                 let uu____5926 =
                                   FStar_TypeChecker_Env.push_bv
-                                    g.FStar_Tactics_Types.context v_q
-                                   in
+                                    g.FStar_Tactics_Types.context v_q in
                                 {
                                   FStar_Tactics_Types.context = uu____5926;
                                   FStar_Tactics_Types.witness =
@@ -3181,45 +2889,40 @@ let (cases :
                                     (uu___110_5925.FStar_Tactics_Types.opts);
                                   FStar_Tactics_Types.is_guard =
                                     (uu___110_5925.FStar_Tactics_Types.is_guard)
-                                }  in
+                                } in
                               bind dismiss
                                 (fun uu____5933  ->
-                                   let uu____5934 = add_goals [g1; g2]  in
+                                   let uu____5934 = add_goals [g1; g2] in
                                    bind uu____5934
                                      (fun uu____5943  ->
                                         let uu____5944 =
                                           let uu____5949 =
                                             FStar_Syntax_Syntax.bv_to_name
-                                              v_p
-                                             in
+                                              v_p in
                                           let uu____5950 =
                                             FStar_Syntax_Syntax.bv_to_name
-                                              v_q
-                                             in
-                                          (uu____5949, uu____5950)  in
+                                              v_q in
+                                          (uu____5949, uu____5950) in
                                         ret uu____5944))
                           | uu____5955 ->
                               let uu____5968 =
-                                tts g.FStar_Tactics_Types.context typ  in
-                              fail1 "Not a disjunction: %s" uu____5968))))
-       in
+                                tts g.FStar_Tactics_Types.context typ in
+                              fail1 "Not a disjunction: %s" uu____5968)))) in
     FStar_All.pipe_left (wrap_err "cases") uu____5740
-  
-let (set_options : Prims.string -> Prims.unit tac) =
+let set_options: Prims.string -> Prims.unit tac =
   fun s  ->
     bind cur_goal
       (fun g  ->
          FStar_Options.push ();
-         (let uu____6006 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts
-             in
+         (let uu____6006 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts in
           FStar_Options.set uu____6006);
-         (let res = FStar_Options.set_options FStar_Options.Set s  in
-          let opts' = FStar_Options.peek ()  in
+         (let res = FStar_Options.set_options FStar_Options.Set s in
+          let opts' = FStar_Options.peek () in
           FStar_Options.pop ();
           (match res with
            | FStar_Getopt.Success  ->
                let g' =
-                 let uu___111_6013 = g  in
+                 let uu___111_6013 = g in
                  {
                    FStar_Tactics_Types.context =
                      (uu___111_6013.FStar_Tactics_Types.context);
@@ -3230,32 +2933,27 @@ let (set_options : Prims.string -> Prims.unit tac) =
                    FStar_Tactics_Types.opts = opts';
                    FStar_Tactics_Types.is_guard =
                      (uu___111_6013.FStar_Tactics_Types.is_guard)
-                 }  in
+                 } in
                replace_cur g'
            | FStar_Getopt.Error err ->
                fail2 "Setting options `%s` failed: %s" s err
            | FStar_Getopt.Help  ->
                fail1 "Setting options `%s` failed (got `Help`?)" s)))
-  
-let (top_env : FStar_TypeChecker_Env.env tac) =
+let top_env: FStar_TypeChecker_Env.env tac =
   bind get
     (fun ps  -> FStar_All.pipe_left ret ps.FStar_Tactics_Types.main_context)
-  
-let (cur_env : FStar_TypeChecker_Env.env tac) =
+let cur_env: FStar_TypeChecker_Env.env tac =
   bind cur_goal
     (fun g  -> FStar_All.pipe_left ret g.FStar_Tactics_Types.context)
-  
-let (cur_goal' : FStar_Syntax_Syntax.typ tac) =
+let cur_goal': FStar_Syntax_Syntax.typ tac =
   bind cur_goal
     (fun g  -> FStar_All.pipe_left ret g.FStar_Tactics_Types.goal_ty)
-  
-let (cur_witness : FStar_Syntax_Syntax.term tac) =
+let cur_witness: FStar_Syntax_Syntax.term tac =
   bind cur_goal
     (fun g  -> FStar_All.pipe_left ret g.FStar_Tactics_Types.witness)
-  
-let (unquote :
+let unquote:
   FStar_Syntax_Syntax.typ ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term tac)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term tac
   =
   fun ty  ->
     fun tm  ->
@@ -3264,22 +2962,19 @@ let (unquote :
           (fun goal  ->
              let env =
                FStar_TypeChecker_Env.set_expected_typ
-                 goal.FStar_Tactics_Types.context ty
-                in
-             let uu____6065 = __tc env tm  in
+                 goal.FStar_Tactics_Types.context ty in
+             let uu____6065 = __tc env tm in
              bind uu____6065
                (fun uu____6085  ->
                   match uu____6085 with
                   | (tm1,typ,guard) ->
                       (FStar_TypeChecker_Rel.force_trivial_guard env guard;
-                       ret tm1)))
-         in
+                       ret tm1))) in
       FStar_All.pipe_left (wrap_err "unquote") uu____6057
-  
-let (uvar_env :
+let uvar_env:
   env ->
     FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option ->
-      FStar_Syntax_Syntax.term tac)
+      FStar_Syntax_Syntax.term tac
   =
   fun env  ->
     fun ty  ->
@@ -3288,36 +2983,34 @@ let (uvar_env :
         | FStar_Pervasives_Native.Some ty1 -> ret ty1
         | FStar_Pervasives_Native.None  ->
             let uu____6122 =
-              let uu____6123 = FStar_Syntax_Util.type_u ()  in
-              FStar_All.pipe_left FStar_Pervasives_Native.fst uu____6123  in
-            new_uvar "uvar_env.2" env uu____6122
-         in
+              let uu____6123 = FStar_Syntax_Util.type_u () in
+              FStar_All.pipe_left FStar_Pervasives_Native.fst uu____6123 in
+            new_uvar "uvar_env.2" env uu____6122 in
       bind uu____6116
         (fun typ  ->
-           let uu____6135 = new_uvar "uvar_env" env typ  in
+           let uu____6135 = new_uvar "uvar_env" env typ in
            bind uu____6135 (fun t  -> ret t))
-  
-let (unshelve : FStar_Syntax_Syntax.term -> Prims.unit tac) =
+let unshelve: FStar_Syntax_Syntax.term -> Prims.unit tac =
   fun t  ->
     let uu____6147 =
       bind cur_goal
         (fun goal  ->
-           let uu____6153 = __tc goal.FStar_Tactics_Types.context t  in
+           let uu____6153 = __tc goal.FStar_Tactics_Types.context t in
            bind uu____6153
              (fun uu____6173  ->
                 match uu____6173 with
                 | (t1,typ,guard) ->
                     let uu____6185 =
-                      must_trivial goal.FStar_Tactics_Types.context guard  in
+                      must_trivial goal.FStar_Tactics_Types.context guard in
                     bind uu____6185
                       (fun uu____6190  ->
                          let uu____6191 =
                            let uu____6194 =
-                             let uu___112_6195 = goal  in
+                             let uu___112_6195 = goal in
                              let uu____6196 =
-                               bnorm goal.FStar_Tactics_Types.context t1  in
+                               bnorm goal.FStar_Tactics_Types.context t1 in
                              let uu____6197 =
-                               bnorm goal.FStar_Tactics_Types.context typ  in
+                               bnorm goal.FStar_Tactics_Types.context typ in
                              {
                                FStar_Tactics_Types.context =
                                  (uu___112_6195.FStar_Tactics_Types.context);
@@ -3326,75 +3019,68 @@ let (unshelve : FStar_Syntax_Syntax.term -> Prims.unit tac) =
                                FStar_Tactics_Types.opts =
                                  (uu___112_6195.FStar_Tactics_Types.opts);
                                FStar_Tactics_Types.is_guard = false
-                             }  in
-                           [uu____6194]  in
-                         add_goals uu____6191)))
-       in
+                             } in
+                           [uu____6194] in
+                         add_goals uu____6191))) in
     FStar_All.pipe_left (wrap_err "unshelve") uu____6147
-  
-let (unify :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool tac) =
+let unify:
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool tac =
   fun t1  ->
     fun t2  ->
       bind get
         (fun ps  ->
            let uu____6215 =
-             do_unify ps.FStar_Tactics_Types.main_context t1 t2  in
+             do_unify ps.FStar_Tactics_Types.main_context t1 t2 in
            ret uu____6215)
-  
-let (launch_process :
-  Prims.string -> Prims.string -> Prims.string -> Prims.string tac) =
+let launch_process:
+  Prims.string -> Prims.string -> Prims.string -> Prims.string tac =
   fun prog  ->
     fun args  ->
       fun input  ->
         bind idtac
           (fun uu____6232  ->
-             let uu____6233 = FStar_Options.unsafe_tactic_exec ()  in
+             let uu____6233 = FStar_Options.unsafe_tactic_exec () in
              if uu____6233
              then
                let s =
                  FStar_Util.launch_process true "tactic_launch" prog args
-                   input (fun uu____6239  -> fun uu____6240  -> false)
-                  in
+                   input (fun uu____6239  -> fun uu____6240  -> false) in
                ret s
              else
                fail
                  "launch_process: will not run anything unless --unsafe_tactic_exec is provided")
-  
-let (goal_of_goal_ty :
+let goal_of_goal_ty:
   env ->
     FStar_Syntax_Syntax.typ ->
       (FStar_Tactics_Types.goal,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun typ  ->
       let uu____6256 =
         FStar_TypeChecker_Util.new_implicit_var "proofstate_of_goal_ty"
-          typ.FStar_Syntax_Syntax.pos env typ
-         in
+          typ.FStar_Syntax_Syntax.pos env typ in
       match uu____6256 with
       | (u,uu____6274,g_u) ->
           let g =
-            let uu____6289 = FStar_Options.peek ()  in
+            let uu____6289 = FStar_Options.peek () in
             {
               FStar_Tactics_Types.context = env;
               FStar_Tactics_Types.witness = u;
               FStar_Tactics_Types.goal_ty = typ;
               FStar_Tactics_Types.opts = uu____6289;
               FStar_Tactics_Types.is_guard = false
-            }  in
+            } in
           (g, g_u)
-  
-let (proofstate_of_goal_ty :
+let proofstate_of_goal_ty:
   env ->
     FStar_Syntax_Syntax.typ ->
       (FStar_Tactics_Types.proofstate,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun typ  ->
-      let uu____6300 = goal_of_goal_ty env typ  in
+      let uu____6300 = goal_of_goal_ty env typ in
       match uu____6300 with
       | (g,g_u) ->
           let ps =
@@ -3410,6 +3096,5 @@ let (proofstate_of_goal_ty :
                 (fun ps  -> fun msg  -> dump_proofstate ps msg);
               FStar_Tactics_Types.psc = FStar_TypeChecker_Normalize.null_psc;
               FStar_Tactics_Types.entry_range = FStar_Range.dummyRange
-            }  in
+            } in
           (ps, (g.FStar_Tactics_Types.witness))
-  

--- a/src/ocaml-output/FStar_Tactics_Embedding.ml
+++ b/src/ocaml-output/FStar_Tactics_Embedding.ml
@@ -1,105 +1,93 @@
 open Prims
 type name = FStar_Syntax_Syntax.bv[@@deriving show]
-let (fstar_tactics_lid' : Prims.string Prims.list -> FStar_Ident.lid) =
-  fun s  -> FStar_Parser_Const.fstar_tactics_lid' s 
-let (lid_as_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
+let fstar_tactics_lid': Prims.string Prims.list -> FStar_Ident.lid =
+  fun s  -> FStar_Parser_Const.fstar_tactics_lid' s
+let lid_as_tm: FStar_Ident.lident -> FStar_Syntax_Syntax.term =
   fun l  ->
     let uu____11 =
       FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant
-        FStar_Pervasives_Native.None
-       in
+        FStar_Pervasives_Native.None in
     FStar_All.pipe_right uu____11 FStar_Syntax_Syntax.fv_to_tm
-  
-let (mk_tactic_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
+let mk_tactic_lid_as_term: Prims.string -> FStar_Syntax_Syntax.term =
   fun s  ->
-    let uu____15 = fstar_tactics_lid' ["Effect"; s]  in lid_as_tm uu____15
-  
-let (lid_as_data_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
+    let uu____15 = fstar_tactics_lid' ["Effect"; s] in lid_as_tm uu____15
+let lid_as_data_tm: FStar_Ident.lident -> FStar_Syntax_Syntax.term =
   fun l  ->
     let uu____19 =
       FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant
-        (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-       in
+        (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
     FStar_Syntax_Syntax.fv_to_tm uu____19
-  
-let (fstar_tactics_lid_as_data_tm : Prims.string -> FStar_Syntax_Syntax.term)
-  =
+let fstar_tactics_lid_as_data_tm: Prims.string -> FStar_Syntax_Syntax.term =
   fun s  ->
-    let uu____23 = fstar_tactics_lid' ["Effect"; s]  in
+    let uu____23 = fstar_tactics_lid' ["Effect"; s] in
     lid_as_data_tm uu____23
-  
-let (fstar_tactics_Failed_lid : FStar_Ident.lid) =
-  fstar_tactics_lid' ["Result"; "Failed"] 
-let (fstar_tactics_Success_lid : FStar_Ident.lid) =
-  fstar_tactics_lid' ["Result"; "Success"] 
-let (fstar_tactics_Failed_tm : FStar_Syntax_Syntax.term) =
-  lid_as_data_tm fstar_tactics_Failed_lid 
-let (fstar_tactics_Success_tm : FStar_Syntax_Syntax.term) =
-  lid_as_data_tm fstar_tactics_Success_lid 
-let (fstar_tactics_topdown_lid : FStar_Ident.lid) =
-  fstar_tactics_lid' ["Types"; "TopDown"] 
-let (fstar_tactics_bottomup_lid : FStar_Ident.lid) =
-  fstar_tactics_lid' ["Types"; "BottomUp"] 
-let (fstar_tactics_topdown : FStar_Syntax_Syntax.term) =
-  lid_as_data_tm fstar_tactics_topdown_lid 
-let (fstar_tactics_bottomup : FStar_Syntax_Syntax.term) =
-  lid_as_data_tm fstar_tactics_bottomup_lid 
-let (mktuple2_tm : FStar_Syntax_Syntax.term) =
-  lid_as_data_tm FStar_Parser_Const.lid_Mktuple2 
-let (t_proofstate : FStar_Syntax_Syntax.term) =
-  let uu____24 = fstar_tactics_lid' ["Types"; "proofstate"]  in
-  FStar_Syntax_Syntax.tconst uu____24 
-let (pair_typ :
+let fstar_tactics_Failed_lid: FStar_Ident.lid =
+  fstar_tactics_lid' ["Result"; "Failed"]
+let fstar_tactics_Success_lid: FStar_Ident.lid =
+  fstar_tactics_lid' ["Result"; "Success"]
+let fstar_tactics_Failed_tm: FStar_Syntax_Syntax.term =
+  lid_as_data_tm fstar_tactics_Failed_lid
+let fstar_tactics_Success_tm: FStar_Syntax_Syntax.term =
+  lid_as_data_tm fstar_tactics_Success_lid
+let fstar_tactics_topdown_lid: FStar_Ident.lid =
+  fstar_tactics_lid' ["Types"; "TopDown"]
+let fstar_tactics_bottomup_lid: FStar_Ident.lid =
+  fstar_tactics_lid' ["Types"; "BottomUp"]
+let fstar_tactics_topdown: FStar_Syntax_Syntax.term =
+  lid_as_data_tm fstar_tactics_topdown_lid
+let fstar_tactics_bottomup: FStar_Syntax_Syntax.term =
+  lid_as_data_tm fstar_tactics_bottomup_lid
+let mktuple2_tm: FStar_Syntax_Syntax.term =
+  lid_as_data_tm FStar_Parser_Const.lid_Mktuple2
+let t_proofstate: FStar_Syntax_Syntax.term =
+  let uu____24 = fstar_tactics_lid' ["Types"; "proofstate"] in
+  FStar_Syntax_Syntax.tconst uu____24
+let pair_typ:
   FStar_Reflection_Data.typ ->
-    FStar_Reflection_Data.typ -> FStar_Reflection_Data.typ)
+    FStar_Reflection_Data.typ -> FStar_Reflection_Data.typ
   =
   fun t  ->
     fun s  ->
       let uu____31 =
         let uu____32 =
-          let uu____33 = lid_as_tm FStar_Parser_Const.lid_tuple2  in
+          let uu____33 = lid_as_tm FStar_Parser_Const.lid_tuple2 in
           FStar_Syntax_Syntax.mk_Tm_uinst uu____33
-            [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
-           in
+            [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero] in
         let uu____34 =
-          let uu____35 = FStar_Syntax_Syntax.as_arg t  in
+          let uu____35 = FStar_Syntax_Syntax.as_arg t in
           let uu____36 =
-            let uu____39 = FStar_Syntax_Syntax.as_arg s  in [uu____39]  in
-          uu____35 :: uu____36  in
-        FStar_Syntax_Syntax.mk_Tm_app uu____32 uu____34  in
+            let uu____39 = FStar_Syntax_Syntax.as_arg s in [uu____39] in
+          uu____35 :: uu____36 in
+        FStar_Syntax_Syntax.mk_Tm_app uu____32 uu____34 in
       uu____31 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (embed_proofstate :
+let embed_proofstate:
   FStar_Range.range ->
-    FStar_Tactics_Types.proofstate -> FStar_Syntax_Syntax.term)
+    FStar_Tactics_Types.proofstate -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun ps  ->
       FStar_Syntax_Util.mk_alien t_proofstate ps "tactics.embed_proofstate"
         (FStar_Pervasives_Native.Some rng)
-  
-let (unembed_proofstate :
+let unembed_proofstate:
   FStar_Syntax_Syntax.term ->
-    FStar_Tactics_Types.proofstate FStar_Pervasives_Native.option)
+    FStar_Tactics_Types.proofstate FStar_Pervasives_Native.option
   =
   fun t  ->
     try
       let uu____67 =
-        let uu____68 = FStar_Syntax_Util.un_alien t  in
-        FStar_All.pipe_right uu____68 FStar_Dyn.undyn  in
+        let uu____68 = FStar_Syntax_Util.un_alien t in
+        FStar_All.pipe_right uu____68 FStar_Dyn.undyn in
       FStar_Pervasives_Native.Some uu____67
     with
     | uu____75 ->
         ((let uu____77 =
             let uu____82 =
-              let uu____83 = FStar_Syntax_Print.term_to_string t  in
-              FStar_Util.format1 "Not an embedded proofstate: %s" uu____83
-               in
-            (FStar_Errors.Warning_NotEmbedded, uu____82)  in
+              let uu____83 = FStar_Syntax_Print.term_to_string t in
+              FStar_Util.format1 "Not an embedded proofstate: %s" uu____83 in
+            (FStar_Errors.Warning_NotEmbedded, uu____82) in
           FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____77);
          FStar_Pervasives_Native.None)
-  
-let embed_result :
+let embed_result:
   'a .
     'a FStar_Syntax_Embeddings.embedder ->
       FStar_Reflection_Data.typ ->
@@ -114,10 +102,9 @@ let embed_result :
               let uu____127 =
                 let uu____128 =
                   FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Failed_tm
-                    [FStar_Syntax_Syntax.U_zero]
-                   in
+                    [FStar_Syntax_Syntax.U_zero] in
                 let uu____129 =
-                  let uu____130 = FStar_Syntax_Syntax.iarg t_a  in
+                  let uu____130 = FStar_Syntax_Syntax.iarg t_a in
                   let uu____131 =
                     let uu____134 =
                       let uu____135 =
@@ -125,48 +112,42 @@ let embed_result :
                           let uu____137 =
                             FStar_Syntax_Syntax.mk_Tm_uinst mktuple2_tm
                               [FStar_Syntax_Syntax.U_zero;
-                              FStar_Syntax_Syntax.U_zero]
-                             in
+                              FStar_Syntax_Syntax.U_zero] in
                           let uu____138 =
                             let uu____139 =
                               FStar_Syntax_Syntax.iarg
-                                FStar_Syntax_Syntax.t_string
-                               in
+                                FStar_Syntax_Syntax.t_string in
                             let uu____140 =
                               let uu____143 =
-                                FStar_Syntax_Syntax.iarg t_proofstate  in
+                                FStar_Syntax_Syntax.iarg t_proofstate in
                               let uu____144 =
                                 let uu____147 =
                                   let uu____148 =
                                     FStar_Syntax_Embeddings.embed_string rng
-                                      msg
-                                     in
-                                  FStar_Syntax_Syntax.as_arg uu____148  in
+                                      msg in
+                                  FStar_Syntax_Syntax.as_arg uu____148 in
                                 let uu____149 =
                                   let uu____152 =
-                                    let uu____153 = embed_proofstate rng ps
-                                       in
-                                    FStar_Syntax_Syntax.as_arg uu____153  in
-                                  [uu____152]  in
-                                uu____147 :: uu____149  in
-                              uu____143 :: uu____144  in
-                            uu____139 :: uu____140  in
-                          FStar_Syntax_Syntax.mk_Tm_app uu____137 uu____138
-                           in
-                        uu____136 FStar_Pervasives_Native.None rng  in
-                      FStar_Syntax_Syntax.as_arg uu____135  in
-                    [uu____134]  in
-                  uu____130 :: uu____131  in
-                FStar_Syntax_Syntax.mk_Tm_app uu____128 uu____129  in
+                                    let uu____153 = embed_proofstate rng ps in
+                                    FStar_Syntax_Syntax.as_arg uu____153 in
+                                  [uu____152] in
+                                uu____147 :: uu____149 in
+                              uu____143 :: uu____144 in
+                            uu____139 :: uu____140 in
+                          FStar_Syntax_Syntax.mk_Tm_app uu____137 uu____138 in
+                        uu____136 FStar_Pervasives_Native.None rng in
+                      FStar_Syntax_Syntax.as_arg uu____135 in
+                    [uu____134] in
+                  uu____130 :: uu____131 in
+                FStar_Syntax_Syntax.mk_Tm_app uu____128 uu____129 in
               uu____127 FStar_Pervasives_Native.None rng
           | FStar_Tactics_Result.Success (a,ps) ->
               let uu____160 =
                 let uu____161 =
                   FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Success_tm
-                    [FStar_Syntax_Syntax.U_zero]
-                   in
+                    [FStar_Syntax_Syntax.U_zero] in
                 let uu____162 =
-                  let uu____163 = FStar_Syntax_Syntax.iarg t_a  in
+                  let uu____163 = FStar_Syntax_Syntax.iarg t_a in
                   let uu____164 =
                     let uu____167 =
                       let uu____168 =
@@ -174,36 +155,32 @@ let embed_result :
                           let uu____170 =
                             FStar_Syntax_Syntax.mk_Tm_uinst mktuple2_tm
                               [FStar_Syntax_Syntax.U_zero;
-                              FStar_Syntax_Syntax.U_zero]
-                             in
+                              FStar_Syntax_Syntax.U_zero] in
                           let uu____171 =
-                            let uu____172 = FStar_Syntax_Syntax.iarg t_a  in
+                            let uu____172 = FStar_Syntax_Syntax.iarg t_a in
                             let uu____173 =
                               let uu____176 =
-                                FStar_Syntax_Syntax.iarg t_proofstate  in
+                                FStar_Syntax_Syntax.iarg t_proofstate in
                               let uu____177 =
                                 let uu____180 =
-                                  let uu____181 = embed_a rng a  in
-                                  FStar_Syntax_Syntax.as_arg uu____181  in
+                                  let uu____181 = embed_a rng a in
+                                  FStar_Syntax_Syntax.as_arg uu____181 in
                                 let uu____185 =
                                   let uu____188 =
-                                    let uu____189 = embed_proofstate rng ps
-                                       in
-                                    FStar_Syntax_Syntax.as_arg uu____189  in
-                                  [uu____188]  in
-                                uu____180 :: uu____185  in
-                              uu____176 :: uu____177  in
-                            uu____172 :: uu____173  in
-                          FStar_Syntax_Syntax.mk_Tm_app uu____170 uu____171
-                           in
-                        uu____169 FStar_Pervasives_Native.None rng  in
-                      FStar_Syntax_Syntax.as_arg uu____168  in
-                    [uu____167]  in
-                  uu____163 :: uu____164  in
-                FStar_Syntax_Syntax.mk_Tm_app uu____161 uu____162  in
+                                    let uu____189 = embed_proofstate rng ps in
+                                    FStar_Syntax_Syntax.as_arg uu____189 in
+                                  [uu____188] in
+                                uu____180 :: uu____185 in
+                              uu____176 :: uu____177 in
+                            uu____172 :: uu____173 in
+                          FStar_Syntax_Syntax.mk_Tm_app uu____170 uu____171 in
+                        uu____169 FStar_Pervasives_Native.None rng in
+                      FStar_Syntax_Syntax.as_arg uu____168 in
+                    [uu____167] in
+                  uu____163 :: uu____164 in
+                FStar_Syntax_Syntax.mk_Tm_app uu____161 uu____162 in
               uu____160 FStar_Pervasives_Native.None rng
-  
-let unembed_result :
+let unembed_result:
   'a .
     FStar_Syntax_Syntax.term ->
       'a FStar_Syntax_Embeddings.unembedder ->
@@ -215,25 +192,23 @@ let unembed_result :
   fun t  ->
     fun unembed_a  ->
       let hd'_and_args tm =
-        let tm1 = FStar_Syntax_Util.unascribe tm  in
-        let uu____245 = FStar_Syntax_Util.head_and_args tm1  in
+        let tm1 = FStar_Syntax_Util.unascribe tm in
+        let uu____245 = FStar_Syntax_Util.head_and_args tm1 in
         match uu____245 with
         | (hd1,args) ->
             let uu____294 =
-              let uu____295 = FStar_Syntax_Util.un_uinst hd1  in
-              uu____295.FStar_Syntax_Syntax.n  in
-            (uu____294, args)
-         in
-      let uu____306 = hd'_and_args t  in
+              let uu____295 = FStar_Syntax_Util.un_uinst hd1 in
+              uu____295.FStar_Syntax_Syntax.n in
+            (uu____294, args) in
+      let uu____306 = hd'_and_args t in
       match uu____306 with
       | (FStar_Syntax_Syntax.Tm_fvar fv,_t::(tuple2,uu____336)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Success_lid ->
           let uu____373 =
             let uu____380 =
               FStar_Syntax_Embeddings.unembed_pair unembed_a
-                unembed_proofstate
-               in
-            uu____380 tuple2  in
+                unembed_proofstate in
+            uu____380 tuple2 in
           FStar_Util.bind_opt uu____373
             (fun x  -> FStar_Pervasives_Native.Some (FStar_Util.Inl x))
       | (FStar_Syntax_Syntax.Tm_fvar fv,_t::(tuple2,uu____438)::[]) when
@@ -241,40 +216,36 @@ let unembed_result :
           let uu____475 =
             let uu____482 =
               FStar_Syntax_Embeddings.unembed_pair
-                FStar_Syntax_Embeddings.unembed_string unembed_proofstate
-               in
-            uu____482 tuple2  in
+                FStar_Syntax_Embeddings.unembed_string unembed_proofstate in
+            uu____482 tuple2 in
           FStar_Util.bind_opt uu____475
             (fun x  -> FStar_Pervasives_Native.Some (FStar_Util.Inr x))
       | uu____533 ->
           ((let uu____547 =
               let uu____552 =
-                let uu____553 = FStar_Syntax_Print.term_to_string t  in
+                let uu____553 = FStar_Syntax_Print.term_to_string t in
                 FStar_Util.format1 "Not an embedded tactic result: %s"
-                  uu____553
-                 in
-              (FStar_Errors.Warning_NotEmbedded, uu____552)  in
+                  uu____553 in
+              (FStar_Errors.Warning_NotEmbedded, uu____552) in
             FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____547);
            FStar_Pervasives_Native.None)
-  
-let (embed_direction :
+let embed_direction:
   FStar_Range.range ->
-    FStar_Tactics_Types.direction -> FStar_Syntax_Syntax.term)
+    FStar_Tactics_Types.direction -> FStar_Syntax_Syntax.term
   =
   fun rng  ->
     fun d  ->
       match d with
       | FStar_Tactics_Types.TopDown  -> fstar_tactics_topdown
       | FStar_Tactics_Types.BottomUp  -> fstar_tactics_bottomup
-  
-let (unembed_direction :
+let unembed_direction:
   FStar_Syntax_Syntax.term ->
-    FStar_Tactics_Types.direction FStar_Pervasives_Native.option)
+    FStar_Tactics_Types.direction FStar_Pervasives_Native.option
   =
   fun t  ->
     let uu____584 =
-      let uu____585 = FStar_Syntax_Subst.compress t  in
-      uu____585.FStar_Syntax_Syntax.n  in
+      let uu____585 = FStar_Syntax_Subst.compress t in
+      uu____585.FStar_Syntax_Syntax.n in
     match uu____584 with
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_topdown_lid ->
@@ -285,10 +256,8 @@ let (unembed_direction :
     | uu____592 ->
         ((let uu____594 =
             let uu____599 =
-              let uu____600 = FStar_Syntax_Print.term_to_string t  in
-              FStar_Util.format1 "Not an embedded direction: %s" uu____600
-               in
-            (FStar_Errors.Warning_NotEmbedded, uu____599)  in
+              let uu____600 = FStar_Syntax_Print.term_to_string t in
+              FStar_Util.format1 "Not an embedded direction: %s" uu____600 in
+            (FStar_Errors.Warning_NotEmbedded, uu____599) in
           FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____594);
          FStar_Pervasives_Native.None)
-  

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1,6 +1,6 @@
 open Prims
-let (tacdbg : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false 
-let mk_tactic_interpretation_0 :
+let tacdbg: Prims.bool FStar_ST.ref = FStar_Util.mk_ref false
+let mk_tactic_interpretation_0:
   'r .
     'r FStar_Tactics_Basic.tac ->
       'r FStar_Syntax_Embeddings.embedder ->
@@ -19,31 +19,28 @@ let mk_tactic_interpretation_0 :
               match args with
               | (embedded_state,uu____63)::[] ->
                   let uu____80 =
-                    FStar_Tactics_Embedding.unembed_proofstate embedded_state
-                     in
+                    FStar_Tactics_Embedding.unembed_proofstate embedded_state in
                   FStar_Util.bind_opt uu____80
                     (fun ps  ->
-                       let ps1 = FStar_Tactics_Types.set_ps_psc psc ps  in
+                       let ps1 = FStar_Tactics_Types.set_ps_psc psc ps in
                        FStar_Tactics_Basic.log ps1
                          (fun uu____94  ->
-                            let uu____95 = FStar_Ident.string_of_lid nm  in
+                            let uu____95 = FStar_Ident.string_of_lid nm in
                             let uu____96 =
-                              FStar_Syntax_Print.args_to_string args  in
+                              FStar_Syntax_Print.args_to_string args in
                             FStar_Util.print2 "Reached %s, args are: %s\n"
                               uu____95 uu____96);
-                       (let res = FStar_Tactics_Basic.run t ps1  in
+                       (let res = FStar_Tactics_Basic.run t ps1 in
                         let uu____100 =
                           let uu____101 =
-                            FStar_TypeChecker_Normalize.psc_range psc  in
+                            FStar_TypeChecker_Normalize.psc_range psc in
                           let uu____102 =
-                            FStar_Tactics_Embedding.embed_result embed_r t_r
-                             in
-                          uu____102 uu____101 res  in
+                            FStar_Tactics_Embedding.embed_result embed_r t_r in
+                          uu____102 uu____101 res in
                         FStar_Pervasives_Native.Some uu____100))
               | uu____116 ->
                   failwith "Unexpected application of tactic primitive"
-  
-let mk_tactic_interpretation_1 :
+let mk_tactic_interpretation_1:
   'a 'r .
     ('a -> 'r FStar_Tactics_Basic.tac) ->
       'a FStar_Syntax_Embeddings.unembedder ->
@@ -65,49 +62,41 @@ let mk_tactic_interpretation_1 :
                 | (a,uu____188)::(embedded_state,uu____190)::[] ->
                     let uu____217 =
                       FStar_Tactics_Embedding.unembed_proofstate
-                        embedded_state
-                       in
+                        embedded_state in
                     FStar_Util.bind_opt uu____217
                       (fun ps  ->
-                         let ps1 = FStar_Tactics_Types.set_ps_psc psc ps  in
+                         let ps1 = FStar_Tactics_Types.set_ps_psc psc ps in
                          FStar_Tactics_Basic.log ps1
                            (fun uu____230  ->
-                              let uu____231 = FStar_Ident.string_of_lid nm
-                                 in
+                              let uu____231 = FStar_Ident.string_of_lid nm in
                               let uu____232 =
                                 FStar_Syntax_Print.term_to_string
-                                  embedded_state
-                                 in
+                                  embedded_state in
                               FStar_Util.print2 "Reached %s, goals are: %s\n"
                                 uu____231 uu____232);
-                         (let uu____233 = unembed_a a  in
+                         (let uu____233 = unembed_a a in
                           FStar_Util.bind_opt uu____233
                             (fun a1  ->
                                let res =
-                                 let uu____245 = t a1  in
-                                 FStar_Tactics_Basic.run uu____245 ps1  in
+                                 let uu____245 = t a1 in
+                                 FStar_Tactics_Basic.run uu____245 ps1 in
                                let uu____248 =
                                  let uu____249 =
-                                   FStar_TypeChecker_Normalize.psc_range psc
-                                    in
+                                   FStar_TypeChecker_Normalize.psc_range psc in
                                  let uu____250 =
                                    FStar_Tactics_Embedding.embed_result
-                                     embed_r t_r
-                                    in
-                                 uu____250 uu____249 res  in
+                                     embed_r t_r in
+                                 uu____250 uu____249 res in
                                FStar_Pervasives_Native.Some uu____248)))
                 | uu____264 ->
                     let uu____265 =
-                      let uu____266 = FStar_Ident.string_of_lid nm  in
-                      let uu____267 = FStar_Syntax_Print.args_to_string args
-                         in
+                      let uu____266 = FStar_Ident.string_of_lid nm in
+                      let uu____267 = FStar_Syntax_Print.args_to_string args in
                       FStar_Util.format2
                         "Unexpected application of tactic primitive %s %s"
-                        uu____266 uu____267
-                       in
+                        uu____266 uu____267 in
                     failwith uu____265
-  
-let mk_tactic_interpretation_1_env :
+let mk_tactic_interpretation_1_env:
   'a 'r .
     (FStar_TypeChecker_Normalize.psc -> 'a -> 'r FStar_Tactics_Basic.tac) ->
       'a FStar_Syntax_Embeddings.unembedder ->
@@ -129,49 +118,41 @@ let mk_tactic_interpretation_1_env :
                 | (a,uu____344)::(embedded_state,uu____346)::[] ->
                     let uu____373 =
                       FStar_Tactics_Embedding.unembed_proofstate
-                        embedded_state
-                       in
+                        embedded_state in
                     FStar_Util.bind_opt uu____373
                       (fun ps  ->
-                         let ps1 = FStar_Tactics_Types.set_ps_psc psc ps  in
+                         let ps1 = FStar_Tactics_Types.set_ps_psc psc ps in
                          FStar_Tactics_Basic.log ps1
                            (fun uu____386  ->
-                              let uu____387 = FStar_Ident.string_of_lid nm
-                                 in
+                              let uu____387 = FStar_Ident.string_of_lid nm in
                               let uu____388 =
                                 FStar_Syntax_Print.term_to_string
-                                  embedded_state
-                                 in
+                                  embedded_state in
                               FStar_Util.print2 "Reached %s, goals are: %s\n"
                                 uu____387 uu____388);
-                         (let uu____389 = unembed_a a  in
+                         (let uu____389 = unembed_a a in
                           FStar_Util.bind_opt uu____389
                             (fun a1  ->
                                let res =
-                                 let uu____401 = t psc a1  in
-                                 FStar_Tactics_Basic.run uu____401 ps1  in
+                                 let uu____401 = t psc a1 in
+                                 FStar_Tactics_Basic.run uu____401 ps1 in
                                let uu____404 =
                                  let uu____405 =
-                                   FStar_TypeChecker_Normalize.psc_range psc
-                                    in
+                                   FStar_TypeChecker_Normalize.psc_range psc in
                                  let uu____406 =
                                    FStar_Tactics_Embedding.embed_result
-                                     embed_r t_r
-                                    in
-                                 uu____406 uu____405 res  in
+                                     embed_r t_r in
+                                 uu____406 uu____405 res in
                                FStar_Pervasives_Native.Some uu____404)))
                 | uu____420 ->
                     let uu____421 =
-                      let uu____422 = FStar_Ident.string_of_lid nm  in
-                      let uu____423 = FStar_Syntax_Print.args_to_string args
-                         in
+                      let uu____422 = FStar_Ident.string_of_lid nm in
+                      let uu____423 = FStar_Syntax_Print.args_to_string args in
                       FStar_Util.format2
                         "Unexpected application of tactic primitive %s %s"
-                        uu____422 uu____423
-                       in
+                        uu____422 uu____423 in
                     failwith uu____421
-  
-let mk_tactic_interpretation_2 :
+let mk_tactic_interpretation_2:
   'a 'b 'r .
     ('a -> 'b -> 'r FStar_Tactics_Basic.tac) ->
       'a FStar_Syntax_Embeddings.unembedder ->
@@ -196,56 +177,47 @@ let mk_tactic_interpretation_2 :
                       ->
                       let uu____556 =
                         FStar_Tactics_Embedding.unembed_proofstate
-                          embedded_state
-                         in
+                          embedded_state in
                       FStar_Util.bind_opt uu____556
                         (fun ps  ->
-                           let ps1 = FStar_Tactics_Types.set_ps_psc psc ps
-                              in
+                           let ps1 = FStar_Tactics_Types.set_ps_psc psc ps in
                            FStar_Tactics_Basic.log ps1
                              (fun uu____569  ->
-                                let uu____570 = FStar_Ident.string_of_lid nm
-                                   in
+                                let uu____570 = FStar_Ident.string_of_lid nm in
                                 let uu____571 =
                                   FStar_Syntax_Print.term_to_string
-                                    embedded_state
-                                   in
+                                    embedded_state in
                                 FStar_Util.print2
                                   "Reached %s, goals are: %s\n" uu____570
                                   uu____571);
-                           (let uu____572 = unembed_a a  in
+                           (let uu____572 = unembed_a a in
                             FStar_Util.bind_opt uu____572
                               (fun a1  ->
-                                 let uu____580 = unembed_b b  in
+                                 let uu____580 = unembed_b b in
                                  FStar_Util.bind_opt uu____580
                                    (fun b1  ->
                                       let res =
-                                        let uu____592 = t a1 b1  in
-                                        FStar_Tactics_Basic.run uu____592 ps1
-                                         in
+                                        let uu____592 = t a1 b1 in
+                                        FStar_Tactics_Basic.run uu____592 ps1 in
                                       let uu____595 =
                                         let uu____596 =
                                           FStar_TypeChecker_Normalize.psc_range
-                                            psc
-                                           in
+                                            psc in
                                         let uu____597 =
                                           FStar_Tactics_Embedding.embed_result
-                                            embed_r t_r
-                                           in
-                                        uu____597 uu____596 res  in
+                                            embed_r t_r in
+                                        uu____597 uu____596 res in
                                       FStar_Pervasives_Native.Some uu____595))))
                   | uu____611 ->
                       let uu____612 =
-                        let uu____613 = FStar_Ident.string_of_lid nm  in
+                        let uu____613 = FStar_Ident.string_of_lid nm in
                         let uu____614 =
-                          FStar_Syntax_Print.args_to_string args  in
+                          FStar_Syntax_Print.args_to_string args in
                         FStar_Util.format2
                           "Unexpected application of tactic primitive %s %s"
-                          uu____613 uu____614
-                         in
+                          uu____613 uu____614 in
                       failwith uu____612
-  
-let mk_tactic_interpretation_3 :
+let mk_tactic_interpretation_3:
   'a 'b 'c 'r .
     ('a -> 'b -> 'c -> 'r FStar_Tactics_Basic.tac) ->
       'a FStar_Syntax_Embeddings.unembedder ->
@@ -272,61 +244,53 @@ let mk_tactic_interpretation_3 :
                         ->
                         let uu____779 =
                           FStar_Tactics_Embedding.unembed_proofstate
-                            embedded_state
-                           in
+                            embedded_state in
                         FStar_Util.bind_opt uu____779
                           (fun ps  ->
-                             let ps1 = FStar_Tactics_Types.set_ps_psc psc ps
-                                in
+                             let ps1 = FStar_Tactics_Types.set_ps_psc psc ps in
                              FStar_Tactics_Basic.log ps1
                                (fun uu____792  ->
                                   let uu____793 =
-                                    FStar_Ident.string_of_lid nm  in
+                                    FStar_Ident.string_of_lid nm in
                                   let uu____794 =
                                     FStar_Syntax_Print.term_to_string
-                                      embedded_state
-                                     in
+                                      embedded_state in
                                   FStar_Util.print2
                                     "Reached %s, goals are: %s\n" uu____793
                                     uu____794);
-                             (let uu____795 = unembed_a a  in
+                             (let uu____795 = unembed_a a in
                               FStar_Util.bind_opt uu____795
                                 (fun a1  ->
-                                   let uu____803 = unembed_b b  in
+                                   let uu____803 = unembed_b b in
                                    FStar_Util.bind_opt uu____803
                                      (fun b1  ->
-                                        let uu____811 = unembed_c c  in
+                                        let uu____811 = unembed_c c in
                                         FStar_Util.bind_opt uu____811
                                           (fun c1  ->
                                              let res =
-                                               let uu____823 = t a1 b1 c1  in
+                                               let uu____823 = t a1 b1 c1 in
                                                FStar_Tactics_Basic.run
-                                                 uu____823 ps1
-                                                in
+                                                 uu____823 ps1 in
                                              let uu____826 =
                                                let uu____827 =
                                                  FStar_TypeChecker_Normalize.psc_range
-                                                   psc
-                                                  in
+                                                   psc in
                                                let uu____828 =
                                                  FStar_Tactics_Embedding.embed_result
-                                                   embed_r t_r
-                                                  in
-                                               uu____828 uu____827 res  in
+                                                   embed_r t_r in
+                                               uu____828 uu____827 res in
                                              FStar_Pervasives_Native.Some
                                                uu____826)))))
                     | uu____842 ->
                         let uu____843 =
-                          let uu____844 = FStar_Ident.string_of_lid nm  in
+                          let uu____844 = FStar_Ident.string_of_lid nm in
                           let uu____845 =
-                            FStar_Syntax_Print.args_to_string args  in
+                            FStar_Syntax_Print.args_to_string args in
                           FStar_Util.format2
                             "Unexpected application of tactic primitive %s %s"
-                            uu____844 uu____845
-                           in
+                            uu____844 uu____845 in
                         failwith uu____843
-  
-let mk_tactic_interpretation_5 :
+let mk_tactic_interpretation_5:
   'a 'b 'c 'd 'e 'r .
     ('a -> 'b -> 'c -> 'd -> 'e -> 'r FStar_Tactics_Basic.tac) ->
       'a FStar_Syntax_Embeddings.unembedder ->
@@ -359,79 +323,68 @@ let mk_tactic_interpretation_5 :
                             ->
                             let uu____1074 =
                               FStar_Tactics_Embedding.unembed_proofstate
-                                embedded_state
-                               in
+                                embedded_state in
                             FStar_Util.bind_opt uu____1074
                               (fun ps  ->
                                  let ps1 =
-                                   FStar_Tactics_Types.set_ps_psc psc ps  in
+                                   FStar_Tactics_Types.set_ps_psc psc ps in
                                  FStar_Tactics_Basic.log ps1
                                    (fun uu____1087  ->
                                       let uu____1088 =
-                                        FStar_Ident.string_of_lid nm  in
+                                        FStar_Ident.string_of_lid nm in
                                       let uu____1089 =
                                         FStar_Syntax_Print.term_to_string
-                                          embedded_state
-                                         in
+                                          embedded_state in
                                       FStar_Util.print2
                                         "Reached %s, goals are: %s\n"
                                         uu____1088 uu____1089);
-                                 (let uu____1090 = unembed_a a  in
+                                 (let uu____1090 = unembed_a a in
                                   FStar_Util.bind_opt uu____1090
                                     (fun a1  ->
-                                       let uu____1098 = unembed_b b  in
+                                       let uu____1098 = unembed_b b in
                                        FStar_Util.bind_opt uu____1098
                                          (fun b1  ->
-                                            let uu____1106 = unembed_c c  in
+                                            let uu____1106 = unembed_c c in
                                             FStar_Util.bind_opt uu____1106
                                               (fun c1  ->
-                                                 let uu____1114 = unembed_d d
-                                                    in
+                                                 let uu____1114 = unembed_d d in
                                                  FStar_Util.bind_opt
                                                    uu____1114
                                                    (fun d1  ->
                                                       let uu____1122 =
-                                                        unembed_e e  in
+                                                        unembed_e e in
                                                       FStar_Util.bind_opt
                                                         uu____1122
                                                         (fun e1  ->
                                                            let res =
                                                              let uu____1134 =
                                                                t a1 b1 c1 d1
-                                                                 e1
-                                                                in
+                                                                 e1 in
                                                              FStar_Tactics_Basic.run
-                                                               uu____1134 ps1
-                                                              in
+                                                               uu____1134 ps1 in
                                                            let uu____1137 =
                                                              let uu____1138 =
                                                                FStar_TypeChecker_Normalize.psc_range
-                                                                 psc
-                                                                in
+                                                                 psc in
                                                              let uu____1139 =
                                                                FStar_Tactics_Embedding.embed_result
-                                                                 embed_r t_r
-                                                                in
+                                                                 embed_r t_r in
                                                              uu____1139
-                                                               uu____1138 res
-                                                              in
+                                                               uu____1138 res in
                                                            FStar_Pervasives_Native.Some
                                                              uu____1137)))))))
                         | uu____1153 ->
                             let uu____1154 =
-                              let uu____1155 = FStar_Ident.string_of_lid nm
-                                 in
+                              let uu____1155 = FStar_Ident.string_of_lid nm in
                               let uu____1156 =
-                                FStar_Syntax_Print.args_to_string args  in
+                                FStar_Syntax_Print.args_to_string args in
                               FStar_Util.format2
                                 "Unexpected application of tactic primitive %s %s"
-                                uu____1155 uu____1156
-                               in
+                                uu____1155 uu____1156 in
                             failwith uu____1154
-  
-let (step_from_native_step :
+let step_from_native_step:
   FStar_Tactics_Native.native_primitive_step ->
-    FStar_TypeChecker_Normalize.primitive_step)
+    FStar_TypeChecker_Normalize.primitive_step
   =
   fun s  ->
     {
@@ -443,13 +396,11 @@ let (step_from_native_step :
       FStar_TypeChecker_Normalize.interpretation =
         (fun psc  -> fun args  -> s.FStar_Tactics_Native.tactic psc args)
     }
-  
-let rec (primitive_steps :
-  Prims.unit -> FStar_TypeChecker_Normalize.primitive_step Prims.list) =
+let rec primitive_steps:
+  Prims.unit -> FStar_TypeChecker_Normalize.primitive_step Prims.list =
   fun uu____1208  ->
     let mk1 nm arity interpretation =
-      let nm1 = FStar_Tactics_Embedding.fstar_tactics_lid' ["Builtins"; nm]
-         in
+      let nm1 = FStar_Tactics_Embedding.fstar_tactics_lid' ["Builtins"; nm] in
       {
         FStar_TypeChecker_Normalize.name = nm1;
         FStar_TypeChecker_Normalize.arity = arity;
@@ -457,114 +408,102 @@ let rec (primitive_steps :
         FStar_TypeChecker_Normalize.requires_binder_substitution = true;
         FStar_TypeChecker_Normalize.interpretation =
           (fun psc  -> fun args  -> interpretation nm1 psc args)
-      }  in
-    let native_tactics = FStar_Tactics_Native.list_all ()  in
+      } in
+    let native_tactics = FStar_Tactics_Native.list_all () in
     let native_tactics_steps =
-      FStar_List.map step_from_native_step native_tactics  in
+      FStar_List.map step_from_native_step native_tactics in
     let mktac0 r name f e_r tr =
-      mk1 name (Prims.parse_int "1") (mk_tactic_interpretation_0 f e_r tr)
-       in
+      mk1 name (Prims.parse_int "1") (mk_tactic_interpretation_0 f e_r tr) in
     let mktac1 a r name f u_a e_r tr =
       mk1 name (Prims.parse_int "2")
-        (mk_tactic_interpretation_1 f u_a e_r tr)
-       in
+        (mk_tactic_interpretation_1 f u_a e_r tr) in
     let mktac2 a b r name f u_a u_b e_r tr =
       mk1 name (Prims.parse_int "3")
-        (mk_tactic_interpretation_2 f u_a u_b e_r tr)
-       in
+        (mk_tactic_interpretation_2 f u_a u_b e_r tr) in
     let mktac3 a b c r name f u_a u_b u_c e_r tr =
       mk1 name (Prims.parse_int "4")
-        (mk_tactic_interpretation_3 f u_a u_b u_c e_r tr)
-       in
+        (mk_tactic_interpretation_3 f u_a u_b u_c e_r tr) in
     let mktac5 a b c d e r name f u_a u_b u_c u_d u_e e_r tr =
       mk1 name (Prims.parse_int "6")
-        (mk_tactic_interpretation_5 f u_a u_b u_c u_d u_e e_r tr)
-       in
+        (mk_tactic_interpretation_5 f u_a u_b u_c u_d u_e e_r tr) in
     let decr_depth_interp psc args =
       match args with
       | (ps,uu____1696)::[] ->
-          let uu____1713 = FStar_Tactics_Embedding.unembed_proofstate ps  in
+          let uu____1713 = FStar_Tactics_Embedding.unembed_proofstate ps in
           FStar_Util.bind_opt uu____1713
             (fun ps1  ->
-               let ps2 = FStar_Tactics_Types.set_ps_psc psc ps1  in
+               let ps2 = FStar_Tactics_Types.set_ps_psc psc ps1 in
                let uu____1721 =
-                 let uu____1722 = FStar_TypeChecker_Normalize.psc_range psc
-                    in
-                 let uu____1723 = FStar_Tactics_Types.decr_depth ps2  in
+                 let uu____1722 = FStar_TypeChecker_Normalize.psc_range psc in
+                 let uu____1723 = FStar_Tactics_Types.decr_depth ps2 in
                  FStar_Tactics_Embedding.embed_proofstate uu____1722
-                   uu____1723
-                  in
+                   uu____1723 in
                FStar_Pervasives_Native.Some uu____1721)
-      | uu____1724 -> failwith "Unexpected application of decr_depth"  in
+      | uu____1724 -> failwith "Unexpected application of decr_depth" in
     let decr_depth_step =
       let uu____1728 =
-        FStar_Ident.lid_of_str "FStar.Tactics.Types.decr_depth"  in
+        FStar_Ident.lid_of_str "FStar.Tactics.Types.decr_depth" in
       {
         FStar_TypeChecker_Normalize.name = uu____1728;
         FStar_TypeChecker_Normalize.arity = (Prims.parse_int "1");
         FStar_TypeChecker_Normalize.strong_reduction_ok = false;
         FStar_TypeChecker_Normalize.requires_binder_substitution = false;
         FStar_TypeChecker_Normalize.interpretation = decr_depth_interp
-      }  in
+      } in
     let incr_depth_interp psc args =
       match args with
       | (ps,uu____1741)::[] ->
-          let uu____1758 = FStar_Tactics_Embedding.unembed_proofstate ps  in
+          let uu____1758 = FStar_Tactics_Embedding.unembed_proofstate ps in
           FStar_Util.bind_opt uu____1758
             (fun ps1  ->
-               let ps2 = FStar_Tactics_Types.set_ps_psc psc ps1  in
+               let ps2 = FStar_Tactics_Types.set_ps_psc psc ps1 in
                let uu____1766 =
-                 let uu____1767 = FStar_TypeChecker_Normalize.psc_range psc
-                    in
-                 let uu____1768 = FStar_Tactics_Types.incr_depth ps2  in
+                 let uu____1767 = FStar_TypeChecker_Normalize.psc_range psc in
+                 let uu____1768 = FStar_Tactics_Types.incr_depth ps2 in
                  FStar_Tactics_Embedding.embed_proofstate uu____1767
-                   uu____1768
-                  in
+                   uu____1768 in
                FStar_Pervasives_Native.Some uu____1766)
-      | uu____1769 -> failwith "Unexpected application of incr_depth"  in
+      | uu____1769 -> failwith "Unexpected application of incr_depth" in
     let incr_depth_step =
       let uu____1773 =
-        FStar_Ident.lid_of_str "FStar.Tactics.Types.incr_depth"  in
+        FStar_Ident.lid_of_str "FStar.Tactics.Types.incr_depth" in
       {
         FStar_TypeChecker_Normalize.name = uu____1773;
         FStar_TypeChecker_Normalize.arity = (Prims.parse_int "1");
         FStar_TypeChecker_Normalize.strong_reduction_ok = false;
         FStar_TypeChecker_Normalize.requires_binder_substitution = false;
         FStar_TypeChecker_Normalize.interpretation = incr_depth_interp
-      }  in
+      } in
     let tracepoint_interp psc args =
       match args with
       | (ps,uu____1790)::[] ->
-          let uu____1807 = FStar_Tactics_Embedding.unembed_proofstate ps  in
+          let uu____1807 = FStar_Tactics_Embedding.unembed_proofstate ps in
           FStar_Util.bind_opt uu____1807
             (fun ps1  ->
-               let ps2 = FStar_Tactics_Types.set_ps_psc psc ps1  in
+               let ps2 = FStar_Tactics_Types.set_ps_psc psc ps1 in
                FStar_Tactics_Types.tracepoint ps2;
                FStar_Pervasives_Native.Some FStar_Syntax_Util.exp_unit)
-      | uu____1820 -> failwith "Unexpected application of tracepoint"  in
+      | uu____1820 -> failwith "Unexpected application of tracepoint" in
     let set_proofstate_range_interp psc args =
       match args with
       | (ps,uu____1837)::(r,uu____1839)::[] ->
-          let uu____1866 = FStar_Tactics_Embedding.unembed_proofstate ps  in
+          let uu____1866 = FStar_Tactics_Embedding.unembed_proofstate ps in
           FStar_Util.bind_opt uu____1866
             (fun ps1  ->
-               let uu____1872 = FStar_Syntax_Embeddings.unembed_range r  in
+               let uu____1872 = FStar_Syntax_Embeddings.unembed_range r in
                FStar_Util.bind_opt uu____1872
                  (fun r1  ->
-                    let ps' = FStar_Tactics_Types.set_proofstate_range ps1 r1
-                       in
+                    let ps' = FStar_Tactics_Types.set_proofstate_range ps1 r1 in
                     let uu____1880 =
                       let uu____1881 =
-                        FStar_TypeChecker_Normalize.psc_range psc  in
-                      FStar_Tactics_Embedding.embed_proofstate uu____1881 ps'
-                       in
+                        FStar_TypeChecker_Normalize.psc_range psc in
+                      FStar_Tactics_Embedding.embed_proofstate uu____1881 ps' in
                     FStar_Pervasives_Native.Some uu____1880))
       | uu____1882 ->
-          failwith "Unexpected application of set_proofstate_range"
-       in
+          failwith "Unexpected application of set_proofstate_range" in
     let set_proofstate_range_step =
       let nm =
-        FStar_Ident.lid_of_str "FStar.Tactics.Types.set_proofstate_range"  in
+        FStar_Ident.lid_of_str "FStar.Tactics.Types.set_proofstate_range" in
       {
         FStar_TypeChecker_Normalize.name = nm;
         FStar_TypeChecker_Normalize.arity = (Prims.parse_int "2");
@@ -572,24 +511,24 @@ let rec (primitive_steps :
         FStar_TypeChecker_Normalize.requires_binder_substitution = false;
         FStar_TypeChecker_Normalize.interpretation =
           set_proofstate_range_interp
-      }  in
+      } in
     let tracepoint_step =
-      let nm = FStar_Ident.lid_of_str "FStar.Tactics.Types.tracepoint"  in
+      let nm = FStar_Ident.lid_of_str "FStar.Tactics.Types.tracepoint" in
       {
         FStar_TypeChecker_Normalize.name = nm;
         FStar_TypeChecker_Normalize.arity = (Prims.parse_int "1");
         FStar_TypeChecker_Normalize.strong_reduction_ok = false;
         FStar_TypeChecker_Normalize.requires_binder_substitution = true;
         FStar_TypeChecker_Normalize.interpretation = tracepoint_interp
-      }  in
+      } in
     let put1 rng t =
-      let uu___60_1896 = t  in
+      let uu___60_1896 = t in
       {
         FStar_Syntax_Syntax.n = (uu___60_1896.FStar_Syntax_Syntax.n);
         FStar_Syntax_Syntax.pos = rng;
         FStar_Syntax_Syntax.vars = (uu___60_1896.FStar_Syntax_Syntax.vars)
-      }  in
-    let get1 t = FStar_Pervasives_Native.Some t  in
+      } in
+    let get1 t = FStar_Pervasives_Native.Some t in
     let uu____1903 =
       let uu____1906 =
         mktac2 () () () "__fail"
@@ -598,34 +537,29 @@ let rec (primitive_steps :
                (Obj.magic (fun uu____1908  -> FStar_Tactics_Basic.fail)) a434
                  a435) (Obj.magic get1)
           (Obj.magic FStar_Syntax_Embeddings.unembed_string) (Obj.magic put1)
-          FStar_Syntax_Syntax.t_unit
-         in
+          FStar_Syntax_Syntax.t_unit in
       let uu____1909 =
         let uu____1912 =
           mktac0 () "__trivial" (Obj.magic FStar_Tactics_Basic.trivial)
             (Obj.magic FStar_Syntax_Embeddings.embed_unit)
-            FStar_Syntax_Syntax.t_unit
-           in
+            FStar_Syntax_Syntax.t_unit in
         let uu____1913 =
           let uu____1916 =
             let uu____1917 =
               FStar_Syntax_Embeddings.embed_option put1
-                FStar_Syntax_Syntax.t_unit
-               in
+                FStar_Syntax_Syntax.t_unit in
             mktac2 () () () "__trytac"
               (fun a436  ->
                  fun a437  ->
                    (Obj.magic (fun uu____1923  -> FStar_Tactics_Basic.trytac))
                      a436 a437) (Obj.magic get1)
               (Obj.magic (unembed_tactic_0' get1)) (Obj.magic uu____1917)
-              FStar_Syntax_Syntax.t_unit
-             in
+              FStar_Syntax_Syntax.t_unit in
           let uu____1930 =
             let uu____1933 =
               mktac0 () "__intro" (Obj.magic FStar_Tactics_Basic.intro)
                 (Obj.magic FStar_Reflection_Basic.embed_binder)
-                FStar_Reflection_Data.fstar_refl_binder
-               in
+                FStar_Reflection_Data.fstar_refl_binder in
             let uu____1934 =
               let uu____1937 =
                 let uu____1938 =
@@ -633,35 +567,29 @@ let rec (primitive_steps :
                     FStar_Reflection_Basic.embed_binder
                     FStar_Reflection_Data.fstar_refl_binder
                     FStar_Reflection_Basic.embed_binder
-                    FStar_Reflection_Data.fstar_refl_binder
-                   in
+                    FStar_Reflection_Data.fstar_refl_binder in
                 let uu____1945 =
                   FStar_Tactics_Embedding.pair_typ
                     FStar_Reflection_Data.fstar_refl_binder
-                    FStar_Reflection_Data.fstar_refl_binder
-                   in
+                    FStar_Reflection_Data.fstar_refl_binder in
                 mktac0 () "__intro_rec"
                   (Obj.magic FStar_Tactics_Basic.intro_rec)
-                  (Obj.magic uu____1938) uu____1945
-                 in
+                  (Obj.magic uu____1938) uu____1945 in
               let uu____1952 =
                 let uu____1955 =
                   let uu____1956 =
                     FStar_Syntax_Embeddings.unembed_list
-                      FStar_Syntax_Embeddings.unembed_norm_step
-                     in
+                      FStar_Syntax_Embeddings.unembed_norm_step in
                   mktac1 () () "__norm"
                     (fun a438  -> (Obj.magic FStar_Tactics_Basic.norm) a438)
                     (Obj.magic uu____1956)
                     (Obj.magic FStar_Syntax_Embeddings.embed_unit)
-                    FStar_Syntax_Syntax.t_unit
-                   in
+                    FStar_Syntax_Syntax.t_unit in
                 let uu____1965 =
                   let uu____1968 =
                     let uu____1969 =
                       FStar_Syntax_Embeddings.unembed_list
-                        FStar_Syntax_Embeddings.unembed_norm_step
-                       in
+                        FStar_Syntax_Embeddings.unembed_norm_step in
                     mktac3 () () () () "__norm_term_env"
                       (fun a439  ->
                          fun a440  ->
@@ -672,14 +600,12 @@ let rec (primitive_steps :
                       (Obj.magic uu____1969)
                       (Obj.magic FStar_Reflection_Basic.unembed_term)
                       (Obj.magic FStar_Reflection_Basic.embed_term)
-                      FStar_Syntax_Syntax.t_term
-                     in
+                      FStar_Syntax_Syntax.t_term in
                   let uu____1978 =
                     let uu____1981 =
                       let uu____1982 =
                         FStar_Syntax_Embeddings.unembed_list
-                          FStar_Syntax_Embeddings.unembed_norm_step
-                         in
+                          FStar_Syntax_Embeddings.unembed_norm_step in
                       mktac2 () () () "__norm_binder_type"
                         (fun a442  ->
                            fun a443  ->
@@ -687,8 +613,7 @@ let rec (primitive_steps :
                                a442 a443) (Obj.magic uu____1982)
                         (Obj.magic FStar_Reflection_Basic.unembed_binder)
                         (Obj.magic FStar_Syntax_Embeddings.embed_unit)
-                        FStar_Syntax_Syntax.t_unit
-                       in
+                        FStar_Syntax_Syntax.t_unit in
                     let uu____1991 =
                       let uu____1994 =
                         mktac2 () () () "__rename_to"
@@ -699,8 +624,7 @@ let rec (primitive_steps :
                           (Obj.magic FStar_Reflection_Basic.unembed_binder)
                           (Obj.magic FStar_Syntax_Embeddings.unembed_string)
                           (Obj.magic FStar_Syntax_Embeddings.embed_unit)
-                          FStar_Syntax_Syntax.t_unit
-                         in
+                          FStar_Syntax_Syntax.t_unit in
                       let uu____1995 =
                         let uu____1998 =
                           mktac1 () () "__binder_retype"
@@ -709,22 +633,19 @@ let rec (primitive_steps :
                                  a446)
                             (Obj.magic FStar_Reflection_Basic.unembed_binder)
                             (Obj.magic FStar_Syntax_Embeddings.embed_unit)
-                            FStar_Syntax_Syntax.t_unit
-                           in
+                            FStar_Syntax_Syntax.t_unit in
                         let uu____1999 =
                           let uu____2002 =
                             mktac0 () "__revert"
                               (Obj.magic FStar_Tactics_Basic.revert)
                               (Obj.magic FStar_Syntax_Embeddings.embed_unit)
-                              FStar_Syntax_Syntax.t_unit
-                             in
+                              FStar_Syntax_Syntax.t_unit in
                           let uu____2003 =
                             let uu____2006 =
                               mktac0 () "__clear_top"
                                 (Obj.magic FStar_Tactics_Basic.clear_top)
                                 (Obj.magic FStar_Syntax_Embeddings.embed_unit)
-                                FStar_Syntax_Syntax.t_unit
-                               in
+                                FStar_Syntax_Syntax.t_unit in
                             let uu____2007 =
                               let uu____2010 =
                                 mktac1 () () "__clear"
@@ -735,8 +656,7 @@ let rec (primitive_steps :
                                      FStar_Reflection_Basic.unembed_binder)
                                   (Obj.magic
                                      FStar_Syntax_Embeddings.embed_unit)
-                                  FStar_Syntax_Syntax.t_unit
-                                 in
+                                  FStar_Syntax_Syntax.t_unit in
                               let uu____2011 =
                                 let uu____2014 =
                                   mktac1 () () "__rewrite"
@@ -747,16 +667,14 @@ let rec (primitive_steps :
                                        FStar_Reflection_Basic.unembed_binder)
                                     (Obj.magic
                                        FStar_Syntax_Embeddings.embed_unit)
-                                    FStar_Syntax_Syntax.t_unit
-                                   in
+                                    FStar_Syntax_Syntax.t_unit in
                                 let uu____2015 =
                                   let uu____2018 =
                                     mktac0 () "__smt"
                                       (Obj.magic FStar_Tactics_Basic.smt)
                                       (Obj.magic
                                          FStar_Syntax_Embeddings.embed_unit)
-                                      FStar_Syntax_Syntax.t_unit
-                                     in
+                                      FStar_Syntax_Syntax.t_unit in
                                   let uu____2019 =
                                     let uu____2022 =
                                       mktac0 () "__refine_intro"
@@ -764,8 +682,7 @@ let rec (primitive_steps :
                                            FStar_Tactics_Basic.refine_intro)
                                         (Obj.magic
                                            FStar_Syntax_Embeddings.embed_unit)
-                                        FStar_Syntax_Syntax.t_unit
-                                       in
+                                        FStar_Syntax_Syntax.t_unit in
                                     let uu____2023 =
                                       let uu____2026 =
                                         mktac3 () () () () "__t_exact"
@@ -783,8 +700,7 @@ let rec (primitive_steps :
                                              FStar_Reflection_Basic.unembed_term)
                                           (Obj.magic
                                              FStar_Syntax_Embeddings.embed_unit)
-                                          FStar_Syntax_Syntax.t_unit
-                                         in
+                                          FStar_Syntax_Syntax.t_unit in
                                       let uu____2027 =
                                         let uu____2030 =
                                           mktac1 () () "__apply"
@@ -796,8 +712,7 @@ let rec (primitive_steps :
                                                FStar_Reflection_Basic.unembed_term)
                                             (Obj.magic
                                                FStar_Syntax_Embeddings.embed_unit)
-                                            FStar_Syntax_Syntax.t_unit
-                                           in
+                                            FStar_Syntax_Syntax.t_unit in
                                         let uu____2031 =
                                           let uu____2034 =
                                             mktac1 () () "__apply_raw"
@@ -809,8 +724,7 @@ let rec (primitive_steps :
                                                  FStar_Reflection_Basic.unembed_term)
                                               (Obj.magic
                                                  FStar_Syntax_Embeddings.embed_unit)
-                                              FStar_Syntax_Syntax.t_unit
-                                             in
+                                              FStar_Syntax_Syntax.t_unit in
                                           let uu____2035 =
                                             let uu____2038 =
                                               mktac1 () () "__apply_lemma"
@@ -822,8 +736,7 @@ let rec (primitive_steps :
                                                    FStar_Reflection_Basic.unembed_term)
                                                 (Obj.magic
                                                    FStar_Syntax_Embeddings.embed_unit)
-                                                FStar_Syntax_Syntax.t_unit
-                                               in
+                                                FStar_Syntax_Syntax.t_unit in
                                             let uu____2039 =
                                               let uu____2042 =
                                                 let uu____2043 =
@@ -831,8 +744,7 @@ let rec (primitive_steps :
                                                     put1
                                                     FStar_Syntax_Syntax.t_unit
                                                     put1
-                                                    FStar_Syntax_Syntax.t_unit
-                                                   in
+                                                    FStar_Syntax_Syntax.t_unit in
                                                 mktac5 () () () () () ()
                                                   "__divide"
                                                   (fun a455  ->
@@ -859,8 +771,7 @@ let rec (primitive_steps :
                                                   (Obj.magic
                                                      (unembed_tactic_0' get1))
                                                   (Obj.magic uu____2043)
-                                                  FStar_Syntax_Syntax.t_unit
-                                                 in
+                                                  FStar_Syntax_Syntax.t_unit in
                                               let uu____2060 =
                                                 let uu____2063 =
                                                   mktac1 () ()
@@ -873,8 +784,7 @@ let rec (primitive_steps :
                                                        FStar_Syntax_Embeddings.unembed_string)
                                                     (Obj.magic
                                                        FStar_Syntax_Embeddings.embed_unit)
-                                                    FStar_Syntax_Syntax.t_unit
-                                                   in
+                                                    FStar_Syntax_Syntax.t_unit in
                                                 let uu____2064 =
                                                   let uu____2067 =
                                                     mktac2 () () () "__seq"
@@ -891,8 +801,7 @@ let rec (primitive_steps :
                                                             FStar_Syntax_Embeddings.unembed_unit))
                                                       (Obj.magic
                                                          FStar_Syntax_Embeddings.embed_unit)
-                                                      FStar_Syntax_Syntax.t_unit
-                                                     in
+                                                      FStar_Syntax_Syntax.t_unit in
                                                   let uu____2068 =
                                                     let uu____2071 =
                                                       mktac1 () () "__tc"
@@ -904,8 +813,7 @@ let rec (primitive_steps :
                                                            FStar_Reflection_Basic.unembed_term)
                                                         (Obj.magic
                                                            FStar_Reflection_Basic.embed_term)
-                                                        FStar_Syntax_Syntax.t_term
-                                                       in
+                                                        FStar_Syntax_Syntax.t_term in
                                                     let uu____2072 =
                                                       let uu____2075 =
                                                         mktac1 () ()
@@ -918,8 +826,7 @@ let rec (primitive_steps :
                                                              FStar_Reflection_Basic.unembed_term)
                                                           (Obj.magic
                                                              FStar_Syntax_Embeddings.embed_unit)
-                                                          FStar_Syntax_Syntax.t_unit
-                                                         in
+                                                          FStar_Syntax_Syntax.t_unit in
                                                       let uu____2076 =
                                                         let uu____2079 =
                                                           mktac2 () () ()
@@ -933,8 +840,7 @@ let rec (primitive_steps :
                                                             (Obj.magic
                                                                FStar_Reflection_Basic.unembed_term)
                                                             (Obj.magic put1)
-                                                            FStar_Syntax_Syntax.t_unit
-                                                           in
+                                                            FStar_Syntax_Syntax.t_unit in
                                                         let uu____2080 =
                                                           let uu____2083 =
                                                             mktac1 () ()
@@ -947,8 +853,7 @@ let rec (primitive_steps :
                                                                  FStar_Syntax_Embeddings.unembed_string)
                                                               (Obj.magic
                                                                  FStar_Syntax_Embeddings.embed_unit)
-                                                              FStar_Syntax_Syntax.t_unit
-                                                             in
+                                                              FStar_Syntax_Syntax.t_unit in
                                                           let uu____2084 =
                                                             let uu____2087 =
                                                               mktac1 () ()
@@ -961,8 +866,7 @@ let rec (primitive_steps :
                                                                    FStar_Syntax_Embeddings.unembed_string)
                                                                 (Obj.magic
                                                                    FStar_Syntax_Embeddings.embed_unit)
-                                                                FStar_Syntax_Syntax.t_unit
-                                                               in
+                                                                FStar_Syntax_Syntax.t_unit in
                                                             let uu____2088 =
                                                               let uu____2091
                                                                 =
@@ -981,8 +885,7 @@ let rec (primitive_steps :
                                                                     FStar_Syntax_Embeddings.unembed_string)
                                                                   (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_unit)
-                                                                  FStar_Syntax_Syntax.t_unit
-                                                                 in
+                                                                  FStar_Syntax_Syntax.t_unit in
                                                               let uu____2096
                                                                 =
                                                                 let uu____2099
@@ -1002,8 +905,7 @@ let rec (primitive_steps :
                                                                     (
                                                                     Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_unit)
-                                                                    FStar_Syntax_Syntax.t_unit
-                                                                   in
+                                                                    FStar_Syntax_Syntax.t_unit in
                                                                 let uu____2100
                                                                   =
                                                                   let uu____2103
@@ -1020,8 +922,7 @@ let rec (primitive_steps :
                                                                     FStar_Syntax_Embeddings.unembed_string)
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_unit)
-                                                                    FStar_Syntax_Syntax.t_unit
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_unit in
                                                                   let uu____2104
                                                                     =
                                                                     let uu____2107
@@ -1043,8 +944,7 @@ let rec (primitive_steps :
                                                                     FStar_Syntax_Embeddings.unembed_unit))
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_unit)
-                                                                    FStar_Syntax_Syntax.t_unit
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_unit in
                                                                     let uu____2108
                                                                     =
                                                                     let uu____2111
@@ -1055,8 +955,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.trefl)
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_unit)
-                                                                    FStar_Syntax_Syntax.t_unit
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_unit in
                                                                     let uu____2112
                                                                     =
                                                                     let uu____2115
@@ -1067,8 +966,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.later)
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_unit)
-                                                                    FStar_Syntax_Syntax.t_unit
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_unit in
                                                                     let uu____2116
                                                                     =
                                                                     let uu____2119
@@ -1079,8 +977,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.dup)
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_unit)
-                                                                    FStar_Syntax_Syntax.t_unit
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_unit in
                                                                     let uu____2120
                                                                     =
                                                                     let uu____2123
@@ -1091,8 +988,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.flip)
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_unit)
-                                                                    FStar_Syntax_Syntax.t_unit
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_unit in
                                                                     let uu____2124
                                                                     =
                                                                     let uu____2127
@@ -1103,8 +999,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.qed)
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_unit)
-                                                                    FStar_Syntax_Syntax.t_unit
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_unit in
                                                                     let uu____2128
                                                                     =
                                                                     let uu____2131
@@ -1115,14 +1010,12 @@ let rec (primitive_steps :
                                                                     FStar_Reflection_Basic.embed_term
                                                                     FStar_Syntax_Syntax.t_term
                                                                     FStar_Reflection_Basic.embed_term
-                                                                    FStar_Syntax_Syntax.t_term
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_term in
                                                                     let uu____2139
                                                                     =
                                                                     FStar_Tactics_Embedding.pair_typ
                                                                     FStar_Syntax_Syntax.t_term
-                                                                    FStar_Syntax_Syntax.t_term
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_term in
                                                                     mktac1 ()
                                                                     ()
                                                                     "__cases"
@@ -1135,8 +1028,7 @@ let rec (primitive_steps :
                                                                     FStar_Reflection_Basic.unembed_term)
                                                                     (Obj.magic
                                                                     uu____2132)
-                                                                    uu____2139
-                                                                     in
+                                                                    uu____2139 in
                                                                     let uu____2146
                                                                     =
                                                                     let uu____2149
@@ -1147,8 +1039,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.top_env)
                                                                     (Obj.magic
                                                                     FStar_Reflection_Basic.embed_env)
-                                                                    FStar_Reflection_Data.fstar_refl_env
-                                                                     in
+                                                                    FStar_Reflection_Data.fstar_refl_env in
                                                                     let uu____2150
                                                                     =
                                                                     let uu____2153
@@ -1159,8 +1050,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.cur_env)
                                                                     (Obj.magic
                                                                     FStar_Reflection_Basic.embed_env)
-                                                                    FStar_Reflection_Data.fstar_refl_env
-                                                                     in
+                                                                    FStar_Reflection_Data.fstar_refl_env in
                                                                     let uu____2154
                                                                     =
                                                                     let uu____2157
@@ -1171,8 +1061,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.cur_goal')
                                                                     (Obj.magic
                                                                     FStar_Reflection_Basic.embed_term)
-                                                                    FStar_Syntax_Syntax.t_term
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_term in
                                                                     let uu____2158
                                                                     =
                                                                     let uu____2161
@@ -1183,8 +1072,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.cur_witness)
                                                                     (Obj.magic
                                                                     FStar_Reflection_Basic.embed_term)
-                                                                    FStar_Syntax_Syntax.t_term
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_term in
                                                                     let uu____2162
                                                                     =
                                                                     let uu____2165
@@ -1195,8 +1083,7 @@ let rec (primitive_steps :
                                                                     FStar_Tactics_Basic.is_guard)
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_bool)
-                                                                    FStar_Syntax_Syntax.t_bool
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_bool in
                                                                     let uu____2166
                                                                     =
                                                                     let uu____2169
@@ -1204,8 +1091,7 @@ let rec (primitive_steps :
                                                                     let uu____2170
                                                                     =
                                                                     FStar_Syntax_Embeddings.unembed_option
-                                                                    FStar_Reflection_Basic.unembed_term
-                                                                     in
+                                                                    FStar_Reflection_Basic.unembed_term in
                                                                     mktac2 ()
                                                                     () ()
                                                                     "__uvar_env"
@@ -1222,8 +1108,7 @@ let rec (primitive_steps :
                                                                     uu____2170)
                                                                     (Obj.magic
                                                                     FStar_Reflection_Basic.embed_term)
-                                                                    FStar_Syntax_Syntax.t_term
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_term in
                                                                     let uu____2179
                                                                     =
                                                                     let uu____2182
@@ -1244,8 +1129,7 @@ let rec (primitive_steps :
                                                                     FStar_Reflection_Basic.unembed_term)
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_bool)
-                                                                    FStar_Syntax_Syntax.t_bool
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_bool in
                                                                     let uu____2183
                                                                     =
                                                                     let uu____2186
@@ -1271,123 +1155,97 @@ let rec (primitive_steps :
                                                                     FStar_Syntax_Embeddings.unembed_string)
                                                                     (Obj.magic
                                                                     FStar_Syntax_Embeddings.embed_string)
-                                                                    FStar_Syntax_Syntax.t_string
-                                                                     in
+                                                                    FStar_Syntax_Syntax.t_string in
                                                                     [uu____2186;
                                                                     decr_depth_step;
                                                                     incr_depth_step;
                                                                     tracepoint_step;
-                                                                    set_proofstate_range_step]
-                                                                     in
+                                                                    set_proofstate_range_step] in
                                                                     uu____2182
                                                                     ::
-                                                                    uu____2183
-                                                                     in
+                                                                    uu____2183 in
                                                                     uu____2169
                                                                     ::
-                                                                    uu____2179
-                                                                     in
+                                                                    uu____2179 in
                                                                     uu____2165
                                                                     ::
-                                                                    uu____2166
-                                                                     in
+                                                                    uu____2166 in
                                                                     uu____2161
                                                                     ::
-                                                                    uu____2162
-                                                                     in
+                                                                    uu____2162 in
                                                                     uu____2157
                                                                     ::
-                                                                    uu____2158
-                                                                     in
+                                                                    uu____2158 in
                                                                     uu____2153
                                                                     ::
-                                                                    uu____2154
-                                                                     in
+                                                                    uu____2154 in
                                                                     uu____2149
                                                                     ::
-                                                                    uu____2150
-                                                                     in
+                                                                    uu____2150 in
                                                                     uu____2131
                                                                     ::
-                                                                    uu____2146
-                                                                     in
+                                                                    uu____2146 in
                                                                     uu____2127
                                                                     ::
-                                                                    uu____2128
-                                                                     in
+                                                                    uu____2128 in
                                                                     uu____2123
                                                                     ::
-                                                                    uu____2124
-                                                                     in
+                                                                    uu____2124 in
                                                                     uu____2119
                                                                     ::
-                                                                    uu____2120
-                                                                     in
+                                                                    uu____2120 in
                                                                     uu____2115
                                                                     ::
-                                                                    uu____2116
-                                                                     in
+                                                                    uu____2116 in
                                                                     uu____2111
                                                                     ::
-                                                                    uu____2112
-                                                                     in
+                                                                    uu____2112 in
                                                                     uu____2107
                                                                     ::
-                                                                    uu____2108
-                                                                     in
+                                                                    uu____2108 in
                                                                   uu____2103
                                                                     ::
-                                                                    uu____2104
-                                                                   in
+                                                                    uu____2104 in
                                                                 uu____2099 ::
-                                                                  uu____2100
-                                                                 in
+                                                                  uu____2100 in
                                                               uu____2091 ::
-                                                                uu____2096
-                                                               in
+                                                                uu____2096 in
                                                             uu____2087 ::
-                                                              uu____2088
-                                                             in
+                                                              uu____2088 in
                                                           uu____2083 ::
-                                                            uu____2084
-                                                           in
+                                                            uu____2084 in
                                                         uu____2079 ::
-                                                          uu____2080
-                                                         in
+                                                          uu____2080 in
                                                       uu____2075 ::
-                                                        uu____2076
-                                                       in
-                                                    uu____2071 :: uu____2072
-                                                     in
-                                                  uu____2067 :: uu____2068
-                                                   in
-                                                uu____2063 :: uu____2064  in
-                                              uu____2042 :: uu____2060  in
-                                            uu____2038 :: uu____2039  in
-                                          uu____2034 :: uu____2035  in
-                                        uu____2030 :: uu____2031  in
-                                      uu____2026 :: uu____2027  in
-                                    uu____2022 :: uu____2023  in
-                                  uu____2018 :: uu____2019  in
-                                uu____2014 :: uu____2015  in
-                              uu____2010 :: uu____2011  in
-                            uu____2006 :: uu____2007  in
-                          uu____2002 :: uu____2003  in
-                        uu____1998 :: uu____1999  in
-                      uu____1994 :: uu____1995  in
-                    uu____1981 :: uu____1991  in
-                  uu____1968 :: uu____1978  in
-                uu____1955 :: uu____1965  in
-              uu____1937 :: uu____1952  in
-            uu____1933 :: uu____1934  in
-          uu____1916 :: uu____1930  in
-        uu____1912 :: uu____1913  in
-      uu____1906 :: uu____1909  in
+                                                        uu____2076 in
+                                                    uu____2071 :: uu____2072 in
+                                                  uu____2067 :: uu____2068 in
+                                                uu____2063 :: uu____2064 in
+                                              uu____2042 :: uu____2060 in
+                                            uu____2038 :: uu____2039 in
+                                          uu____2034 :: uu____2035 in
+                                        uu____2030 :: uu____2031 in
+                                      uu____2026 :: uu____2027 in
+                                    uu____2022 :: uu____2023 in
+                                  uu____2018 :: uu____2019 in
+                                uu____2014 :: uu____2015 in
+                              uu____2010 :: uu____2011 in
+                            uu____2006 :: uu____2007 in
+                          uu____2002 :: uu____2003 in
+                        uu____1998 :: uu____1999 in
+                      uu____1994 :: uu____1995 in
+                    uu____1981 :: uu____1991 in
+                  uu____1968 :: uu____1978 in
+                uu____1955 :: uu____1965 in
+              uu____1937 :: uu____1952 in
+            uu____1933 :: uu____1934 in
+          uu____1916 :: uu____1930 in
+        uu____1912 :: uu____1913 in
+      uu____1906 :: uu____1909 in
     FStar_List.append uu____1903
       (FStar_List.append FStar_Reflection_Interpreter.reflection_primops
          native_tactics_steps)
-
-and unembed_tactic_0 :
+and unembed_tactic_0:
   'Ab .
     'Ab FStar_Syntax_Embeddings.unembedder ->
       FStar_Syntax_Syntax.term -> 'Ab FStar_Tactics_Basic.tac
@@ -1396,18 +1254,17 @@ and unembed_tactic_0 :
     fun embedded_tac_b  ->
       FStar_Tactics_Basic.bind FStar_Tactics_Basic.get
         (fun proof_state  ->
-           let rng = embedded_tac_b.FStar_Syntax_Syntax.pos  in
+           let rng = embedded_tac_b.FStar_Syntax_Syntax.pos in
            let tm =
              let uu____2209 =
                let uu____2210 =
                  let uu____2211 =
                    let uu____2212 =
-                     FStar_Tactics_Embedding.embed_proofstate rng proof_state
-                      in
-                   FStar_Syntax_Syntax.as_arg uu____2212  in
-                 [uu____2211]  in
-               FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b uu____2210  in
-             uu____2209 FStar_Pervasives_Native.None rng  in
+                     FStar_Tactics_Embedding.embed_proofstate rng proof_state in
+                   FStar_Syntax_Syntax.as_arg uu____2212 in
+                 [uu____2211] in
+               FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b uu____2210 in
+             uu____2209 FStar_Pervasives_Native.None rng in
            let steps =
              [FStar_TypeChecker_Normalize.Weak;
              FStar_TypeChecker_Normalize.Reify;
@@ -1415,58 +1272,53 @@ and unembed_tactic_0 :
                FStar_Syntax_Syntax.Delta_constant;
              FStar_TypeChecker_Normalize.UnfoldTac;
              FStar_TypeChecker_Normalize.Primops;
-             FStar_TypeChecker_Normalize.Unascribe]  in
+             FStar_TypeChecker_Normalize.Unascribe] in
            (let uu____2219 =
               FStar_TypeChecker_Env.debug
                 proof_state.FStar_Tactics_Types.main_context
-                (FStar_Options.Other "TacVerbose")
-               in
+                (FStar_Options.Other "TacVerbose") in
             if uu____2219
             then
-              let uu____2220 = FStar_Syntax_Print.term_to_string tm  in
+              let uu____2220 = FStar_Syntax_Print.term_to_string tm in
               FStar_Util.print1 "Starting normalizer with %s\n" uu____2220
             else ());
            (let result =
-              let uu____2223 = primitive_steps ()  in
+              let uu____2223 = primitive_steps () in
               FStar_TypeChecker_Normalize.normalize_with_primitive_steps
                 uu____2223 steps proof_state.FStar_Tactics_Types.main_context
-                tm
-               in
+                tm in
             (let uu____2227 =
                FStar_TypeChecker_Env.debug
                  proof_state.FStar_Tactics_Types.main_context
-                 (FStar_Options.Other "TacVerbose")
-                in
+                 (FStar_Options.Other "TacVerbose") in
              if uu____2227
              then
-               let uu____2228 = FStar_Syntax_Print.term_to_string result  in
+               let uu____2228 = FStar_Syntax_Print.term_to_string result in
                FStar_Util.print1 "Reduced tactic: got %s\n" uu____2228
              else ());
             (let res =
-               FStar_Tactics_Embedding.unembed_result result unembed_b  in
+               FStar_Tactics_Embedding.unembed_result result unembed_b in
              match res with
              | FStar_Pervasives_Native.Some (FStar_Util.Inl (b,ps)) ->
-                 let uu____2273 = FStar_Tactics_Basic.set ps  in
+                 let uu____2273 = FStar_Tactics_Basic.set ps in
                  FStar_Tactics_Basic.bind uu____2273
                    (fun uu____2277  -> FStar_Tactics_Basic.ret b)
              | FStar_Pervasives_Native.Some (FStar_Util.Inr (msg,ps)) ->
-                 let uu____2300 = FStar_Tactics_Basic.set ps  in
+                 let uu____2300 = FStar_Tactics_Basic.set ps in
                  FStar_Tactics_Basic.bind uu____2300
                    (fun uu____2304  -> FStar_Tactics_Basic.fail msg)
              | FStar_Pervasives_Native.None  ->
                  let uu____2317 =
                    let uu____2322 =
                      let uu____2323 =
-                       FStar_Syntax_Print.term_to_string result  in
+                       FStar_Syntax_Print.term_to_string result in
                      FStar_Util.format1
                        "Tactic got stuck! Please file a bug report with a minimal reproduction of this issue.\n%s"
-                       uu____2323
-                      in
-                   (FStar_Errors.Fatal_TacticGotStuck, uu____2322)  in
+                       uu____2323 in
+                   (FStar_Errors.Fatal_TacticGotStuck, uu____2322) in
                  FStar_Errors.raise_error uu____2317
                    (proof_state.FStar_Tactics_Types.main_context).FStar_TypeChecker_Env.range)))
-
-and unembed_tactic_0' :
+and unembed_tactic_0':
   'Ab .
     'Ab FStar_Syntax_Embeddings.unembedder ->
       FStar_Syntax_Syntax.term ->
@@ -1474,13 +1326,12 @@ and unembed_tactic_0' :
   =
   fun unembed_b  ->
     fun embedded_tac_b  ->
-      let uu____2332 = unembed_tactic_0 unembed_b embedded_tac_b  in
+      let uu____2332 = unembed_tactic_0 unembed_b embedded_tac_b in
       FStar_All.pipe_left (fun _0_64  -> FStar_Pervasives_Native.Some _0_64)
         uu____2332
-
-let (report_implicits :
+let report_implicits:
   FStar_Tactics_Types.proofstate ->
-    FStar_TypeChecker_Env.implicits -> Prims.unit)
+    FStar_TypeChecker_Env.implicits -> Prims.unit
   =
   fun ps  ->
     fun is  ->
@@ -1490,15 +1341,13 @@ let (report_implicits :
              match uu____2388 with
              | (r,uu____2408,uv,uu____2410,ty,rng) ->
                  let uu____2413 =
-                   let uu____2414 = FStar_Syntax_Print.uvar_to_string uv  in
-                   let uu____2415 = FStar_Syntax_Print.term_to_string ty  in
+                   let uu____2414 = FStar_Syntax_Print.uvar_to_string uv in
+                   let uu____2415 = FStar_Syntax_Print.term_to_string ty in
                    FStar_Util.format3
                      "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
-                     uu____2414 uu____2415 r
-                    in
+                     uu____2414 uu____2415 r in
                  (FStar_Errors.Fatal_UninstantiatedUnificationVarInTactic,
-                   uu____2413, rng)) is
-         in
+                   uu____2413, rng)) is in
       match errs with
       | [] -> ()
       | (e,msg,r)::tl1 ->
@@ -1506,47 +1355,44 @@ let (report_implicits :
              "failing due to uninstantiated implicits";
            FStar_Errors.add_errors tl1;
            FStar_Errors.raise_error (e, msg) r)
-  
-let (run_tactic_on_typ :
+let run_tactic_on_typ:
   FStar_Syntax_Syntax.term ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.typ ->
         (FStar_Tactics_Basic.goal Prims.list,FStar_Syntax_Syntax.term)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun tactic  ->
     fun env  ->
       fun typ  ->
-        (let uu____2464 = FStar_ST.op_Bang tacdbg  in
+        (let uu____2464 = FStar_ST.op_Bang tacdbg in
          if uu____2464
          then
-           let uu____2484 = FStar_Syntax_Print.term_to_string tactic  in
+           let uu____2484 = FStar_Syntax_Print.term_to_string tactic in
            FStar_Util.print1 "About to reduce uvars on: %s\n" uu____2484
          else ());
         (let tactic1 =
-           FStar_TypeChecker_Normalize.reduce_uvar_solutions env tactic  in
-         (let uu____2488 = FStar_ST.op_Bang tacdbg  in
+           FStar_TypeChecker_Normalize.reduce_uvar_solutions env tactic in
+         (let uu____2488 = FStar_ST.op_Bang tacdbg in
           if uu____2488
           then
-            let uu____2508 = FStar_Syntax_Print.term_to_string tactic1  in
+            let uu____2508 = FStar_Syntax_Print.term_to_string tactic1 in
             FStar_Util.print1 "About to check tactic term: %s\n" uu____2508
           else ());
          (let uu____2510 =
-            FStar_TypeChecker_TcTerm.tc_reified_tactic env tactic1  in
+            FStar_TypeChecker_TcTerm.tc_reified_tactic env tactic1 in
           match uu____2510 with
           | (uu____2523,uu____2524,g) ->
               (FStar_TypeChecker_Rel.force_trivial_guard env g;
                FStar_Errors.stop_if_err ();
                (let tau =
                   unembed_tactic_0 FStar_Syntax_Embeddings.unembed_unit
-                    tactic1
-                   in
-                let uu____2531 = FStar_TypeChecker_Env.clear_expected_typ env
-                   in
+                    tactic1 in
+                let uu____2531 = FStar_TypeChecker_Env.clear_expected_typ env in
                 match uu____2531 with
                 | (env1,uu____2545) ->
                     let env2 =
-                      let uu___61_2551 = env1  in
+                      let uu___61_2551 = env1 in
                       {
                         FStar_TypeChecker_Env.solver =
                           (uu___61_2551.FStar_TypeChecker_Env.solver);
@@ -1617,31 +1463,30 @@ let (run_tactic_on_typ :
                           (uu___61_2551.FStar_TypeChecker_Env.dsenv);
                         FStar_TypeChecker_Env.dep_graph =
                           (uu___61_2551.FStar_TypeChecker_Env.dep_graph)
-                      }  in
+                      } in
                     let uu____2552 =
-                      FStar_Tactics_Basic.proofstate_of_goal_ty env2 typ  in
+                      FStar_Tactics_Basic.proofstate_of_goal_ty env2 typ in
                     (match uu____2552 with
                      | (ps,w) ->
-                         ((let uu____2566 = FStar_ST.op_Bang tacdbg  in
+                         ((let uu____2566 = FStar_ST.op_Bang tacdbg in
                            if uu____2566
                            then
                              let uu____2586 =
-                               FStar_Syntax_Print.term_to_string typ  in
+                               FStar_Syntax_Print.term_to_string typ in
                              FStar_Util.print1
                                "Running tactic with goal = %s\n" uu____2586
                            else ());
                           (let uu____2588 =
                              FStar_Util.record_time
                                (fun uu____2598  ->
-                                  FStar_Tactics_Basic.run tau ps)
-                              in
+                                  FStar_Tactics_Basic.run tau ps) in
                            match uu____2588 with
                            | (res,ms) ->
-                               ((let uu____2612 = FStar_ST.op_Bang tacdbg  in
+                               ((let uu____2612 = FStar_ST.op_Bang tacdbg in
                                  if uu____2612
                                  then
                                    let uu____2632 =
-                                     FStar_Util.string_of_int ms  in
+                                     FStar_Util.string_of_int ms in
                                    FStar_Util.print1
                                      "Tactic ran in %s milliseconds\n"
                                      uu____2632
@@ -1650,13 +1495,12 @@ let (run_tactic_on_typ :
                                  | FStar_Tactics_Result.Success
                                      (uu____2640,ps1) ->
                                      ((let uu____2643 =
-                                         FStar_ST.op_Bang tacdbg  in
+                                         FStar_ST.op_Bang tacdbg in
                                        if uu____2643
                                        then
                                          let uu____2663 =
                                            FStar_Syntax_Print.term_to_string
-                                             w
-                                            in
+                                             w in
                                          FStar_Util.print1
                                            "Tactic generated proofterm %s\n"
                                            uu____2663
@@ -1665,28 +1509,24 @@ let (run_tactic_on_typ :
                                         (fun g1  ->
                                            let uu____2670 =
                                              FStar_Tactics_Basic.is_irrelevant
-                                               g1
-                                              in
+                                               g1 in
                                            if uu____2670
                                            then
                                              let uu____2671 =
                                                FStar_TypeChecker_Rel.teq_nosmt
                                                  g1.FStar_Tactics_Types.context
                                                  g1.FStar_Tactics_Types.witness
-                                                 FStar_Syntax_Util.exp_unit
-                                                in
+                                                 FStar_Syntax_Util.exp_unit in
                                              (if uu____2671
                                               then ()
                                               else
                                                 (let uu____2673 =
                                                    let uu____2674 =
                                                      FStar_Syntax_Print.term_to_string
-                                                       g1.FStar_Tactics_Types.witness
-                                                      in
+                                                       g1.FStar_Tactics_Types.witness in
                                                    FStar_Util.format1
                                                      "Irrelevant tactic witness does not unify with (): %s"
-                                                     uu____2674
-                                                    in
+                                                     uu____2674 in
                                                  failwith uu____2673))
                                            else ())
                                         (FStar_List.append
@@ -1694,8 +1534,7 @@ let (run_tactic_on_typ :
                                            ps1.FStar_Tactics_Types.smt_goals);
                                       (let g1 =
                                          let uu___62_2677 =
-                                           FStar_TypeChecker_Rel.trivial_guard
-                                            in
+                                           FStar_TypeChecker_Rel.trivial_guard in
                                          {
                                            FStar_TypeChecker_Env.guard_f =
                                              (uu___62_2677.FStar_TypeChecker_Env.guard_f);
@@ -1705,15 +1544,13 @@ let (run_tactic_on_typ :
                                              (uu___62_2677.FStar_TypeChecker_Env.univ_ineqs);
                                            FStar_TypeChecker_Env.implicits =
                                              (ps1.FStar_Tactics_Types.all_implicits)
-                                         }  in
+                                         } in
                                        let g2 =
                                          let uu____2679 =
                                            FStar_TypeChecker_Rel.solve_deferred_constraints
-                                             env2 g1
-                                            in
+                                             env2 g1 in
                                          FStar_All.pipe_right uu____2679
-                                           FStar_TypeChecker_Rel.resolve_implicits_tac
-                                          in
+                                           FStar_TypeChecker_Rel.resolve_implicits_tac in
                                        report_implicits ps1
                                          g2.FStar_TypeChecker_Env.implicits;
                                        ((FStar_List.append
@@ -1724,85 +1561,76 @@ let (run_tactic_on_typ :
                                      ((let uu____2686 =
                                          let uu____2687 =
                                            FStar_TypeChecker_Normalize.psc_subst
-                                             ps1.FStar_Tactics_Types.psc
-                                            in
+                                             ps1.FStar_Tactics_Types.psc in
                                          FStar_Tactics_Types.subst_proof_state
-                                           uu____2687 ps1
-                                          in
+                                           uu____2687 ps1 in
                                        FStar_Tactics_Basic.dump_proofstate
                                          uu____2686 "at the time of failure");
                                       (let uu____2688 =
                                          let uu____2693 =
                                            FStar_Util.format1
-                                             "user tactic failed: %s" s
-                                            in
+                                             "user tactic failed: %s" s in
                                          (FStar_Errors.Fatal_ArgumentLengthMismatch,
-                                           uu____2693)
-                                          in
+                                           uu____2693) in
                                        FStar_Errors.raise_error uu____2688
                                          typ.FStar_Syntax_Syntax.pos)))))))))))
-  
 type pol =
-  | Pos 
-  | Neg 
-  | Both [@@deriving show]
-let (uu___is_Pos : pol -> Prims.bool) =
-  fun projectee  -> match projectee with | Pos  -> true | uu____2703 -> false 
-let (uu___is_Neg : pol -> Prims.bool) =
-  fun projectee  -> match projectee with | Neg  -> true | uu____2707 -> false 
-let (uu___is_Both : pol -> Prims.bool) =
+  | Pos
+  | Neg
+  | Both[@@deriving show]
+let uu___is_Pos: pol -> Prims.bool =
+  fun projectee  -> match projectee with | Pos  -> true | uu____2703 -> false
+let uu___is_Neg: pol -> Prims.bool =
+  fun projectee  -> match projectee with | Neg  -> true | uu____2707 -> false
+let uu___is_Both: pol -> Prims.bool =
   fun projectee  ->
     match projectee with | Both  -> true | uu____2711 -> false
-  
 type 'a tres_m =
-  | Unchanged of 'a 
+  | Unchanged of 'a
   | Simplified of ('a,FStar_Tactics_Basic.goal Prims.list)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Dual of ('a,'a,FStar_Tactics_Basic.goal Prims.list)
-  FStar_Pervasives_Native.tuple3 [@@deriving show]
-let uu___is_Unchanged : 'a . 'a tres_m -> Prims.bool =
+  FStar_Pervasives_Native.tuple3[@@deriving show]
+let uu___is_Unchanged: 'a . 'a tres_m -> Prims.bool =
   fun projectee  ->
     match projectee with | Unchanged _0 -> true | uu____2760 -> false
-  
-let __proj__Unchanged__item___0 : 'a . 'a tres_m -> 'a =
-  fun projectee  -> match projectee with | Unchanged _0 -> _0 
-let uu___is_Simplified : 'a . 'a tres_m -> Prims.bool =
+let __proj__Unchanged__item___0: 'a . 'a tres_m -> 'a =
+  fun projectee  -> match projectee with | Unchanged _0 -> _0
+let uu___is_Simplified: 'a . 'a tres_m -> Prims.bool =
   fun projectee  ->
     match projectee with | Simplified _0 -> true | uu____2796 -> false
-  
-let __proj__Simplified__item___0 :
+let __proj__Simplified__item___0:
   'a .
     'a tres_m ->
       ('a,FStar_Tactics_Basic.goal Prims.list) FStar_Pervasives_Native.tuple2
-  = fun projectee  -> match projectee with | Simplified _0 -> _0 
-let uu___is_Dual : 'a . 'a tres_m -> Prims.bool =
+  = fun projectee  -> match projectee with | Simplified _0 -> _0
+let uu___is_Dual: 'a . 'a tres_m -> Prims.bool =
   fun projectee  ->
     match projectee with | Dual _0 -> true | uu____2846 -> false
-  
-let __proj__Dual__item___0 :
+let __proj__Dual__item___0:
   'a .
     'a tres_m ->
       ('a,'a,FStar_Tactics_Basic.goal Prims.list)
         FStar_Pervasives_Native.tuple3
-  = fun projectee  -> match projectee with | Dual _0 -> _0 
+  = fun projectee  -> match projectee with | Dual _0 -> _0
 type tres = FStar_Syntax_Syntax.term tres_m[@@deriving show]
-let tpure : 'Auu____2884 . 'Auu____2884 -> 'Auu____2884 tres_m =
-  fun x  -> Unchanged x 
-let (flip : pol -> pol) =
-  fun p  -> match p with | Pos  -> Neg | Neg  -> Pos | Both  -> Both 
-let (by_tactic_interp :
-  pol -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> tres) =
+let tpure: 'Auu____2884 . 'Auu____2884 -> 'Auu____2884 tres_m =
+  fun x  -> Unchanged x
+let flip: pol -> pol =
+  fun p  -> match p with | Pos  -> Neg | Neg  -> Pos | Both  -> Both
+let by_tactic_interp:
+  pol -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> tres =
   fun pol  ->
     fun e  ->
       fun t  ->
-        let uu____2903 = FStar_Syntax_Util.head_and_args t  in
+        let uu____2903 = FStar_Syntax_Util.head_and_args t in
         match uu____2903 with
         | (hd1,args) ->
             let uu____2940 =
               let uu____2953 =
-                let uu____2954 = FStar_Syntax_Util.un_uinst hd1  in
-                uu____2954.FStar_Syntax_Syntax.n  in
-              (uu____2953, args)  in
+                let uu____2954 = FStar_Syntax_Util.un_uinst hd1 in
+                uu____2954.FStar_Syntax_Syntax.n in
+              (uu____2953, args) in
             (match uu____2940 with
              | (FStar_Syntax_Syntax.Tm_fvar
                 fv,(rett,FStar_Pervasives_Native.Some
@@ -1815,14 +1643,12 @@ let (by_tactic_interp :
                  ->
                  (match pol with
                   | Pos  ->
-                      let uu____3030 = run_tactic_on_typ tactic e assertion
-                         in
+                      let uu____3030 = run_tactic_on_typ tactic e assertion in
                       (match uu____3030 with
                        | (gs,uu____3038) ->
                            Simplified (FStar_Syntax_Util.t_true, gs))
                   | Both  ->
-                      let uu____3045 = run_tactic_on_typ tactic e assertion
-                         in
+                      let uu____3045 = run_tactic_on_typ tactic e assertion in
                       (match uu____3045 with
                        | (gs,uu____3053) ->
                            Dual (assertion, FStar_Syntax_Util.t_true, gs))
@@ -1838,31 +1664,26 @@ let (by_tactic_interp :
                         let uu____3111 =
                           let uu____3114 =
                             let uu____3115 =
-                              FStar_Tactics_Basic.goal_of_goal_ty e assertion
-                               in
+                              FStar_Tactics_Basic.goal_of_goal_ty e assertion in
                             FStar_All.pipe_left FStar_Pervasives_Native.fst
-                              uu____3115
-                             in
-                          [uu____3114]  in
-                        (FStar_Syntax_Util.t_true, uu____3111)  in
+                              uu____3115 in
+                          [uu____3114] in
+                        (FStar_Syntax_Util.t_true, uu____3111) in
                       Simplified uu____3104
                   | Both  ->
                       let uu____3126 =
                         let uu____3139 =
                           let uu____3142 =
                             let uu____3143 =
-                              FStar_Tactics_Basic.goal_of_goal_ty e assertion
-                               in
+                              FStar_Tactics_Basic.goal_of_goal_ty e assertion in
                             FStar_All.pipe_left FStar_Pervasives_Native.fst
-                              uu____3143
-                             in
-                          [uu____3142]  in
-                        (assertion, FStar_Syntax_Util.t_true, uu____3139)  in
+                              uu____3143 in
+                          [uu____3142] in
+                        (assertion, FStar_Syntax_Util.t_true, uu____3139) in
                       Dual uu____3126
                   | Neg  -> Simplified (assertion, []))
              | uu____3164 -> Unchanged t)
-  
-let explode :
+let explode:
   'a .
     'a tres_m ->
       ('a,'a,FStar_Tactics_Basic.goal Prims.list)
@@ -1873,75 +1694,66 @@ let explode :
     | Unchanged t1 -> (t1, t1, [])
     | Simplified (t1,gs) -> (t1, t1, gs)
     | Dual (tn,tp,gs) -> (tn, tp, gs)
-  
-let comb1 : 'a 'b . ('a -> 'b) -> 'a tres_m -> 'b tres_m =
+let comb1: 'a 'b . ('a -> 'b) -> 'a tres_m -> 'b tres_m =
   fun f  ->
     fun uu___59_3244  ->
       match uu___59_3244 with
-      | Unchanged t -> let uu____3250 = f t  in Unchanged uu____3250
+      | Unchanged t -> let uu____3250 = f t in Unchanged uu____3250
       | Simplified (t,gs) ->
-          let uu____3257 = let uu____3264 = f t  in (uu____3264, gs)  in
+          let uu____3257 = let uu____3264 = f t in (uu____3264, gs) in
           Simplified uu____3257
       | Dual (tn,tp,gs) ->
           let uu____3274 =
-            let uu____3283 = f tn  in
-            let uu____3284 = f tp  in (uu____3283, uu____3284, gs)  in
+            let uu____3283 = f tn in
+            let uu____3284 = f tp in (uu____3283, uu____3284, gs) in
           Dual uu____3274
-  
-let comb2 :
-  'a 'b 'c . ('a -> 'b -> 'c) -> 'a tres_m -> 'b tres_m -> 'c tres_m =
+let comb2: 'a 'b 'c . ('a -> 'b -> 'c) -> 'a tres_m -> 'b tres_m -> 'c tres_m
+  =
   fun f  ->
     fun x  ->
       fun y  ->
         match (x, y) with
         | (Unchanged t1,Unchanged t2) ->
-            let uu____3338 = f t1 t2  in Unchanged uu____3338
+            let uu____3338 = f t1 t2 in Unchanged uu____3338
         | (Unchanged t1,Simplified (t2,gs)) ->
-            let uu____3350 = let uu____3357 = f t1 t2  in (uu____3357, gs)
-               in
+            let uu____3350 = let uu____3357 = f t1 t2 in (uu____3357, gs) in
             Simplified uu____3350
         | (Simplified (t1,gs),Unchanged t2) ->
-            let uu____3371 = let uu____3378 = f t1 t2  in (uu____3378, gs)
-               in
+            let uu____3371 = let uu____3378 = f t1 t2 in (uu____3378, gs) in
             Simplified uu____3371
         | (Simplified (t1,gs1),Simplified (t2,gs2)) ->
             let uu____3397 =
-              let uu____3404 = f t1 t2  in
-              (uu____3404, (FStar_List.append gs1 gs2))  in
+              let uu____3404 = f t1 t2 in
+              (uu____3404, (FStar_List.append gs1 gs2)) in
             Simplified uu____3397
         | uu____3407 ->
-            let uu____3416 = explode x  in
+            let uu____3416 = explode x in
             (match uu____3416 with
              | (n1,p1,gs1) ->
-                 let uu____3434 = explode y  in
+                 let uu____3434 = explode y in
                  (match uu____3434 with
                   | (n2,p2,gs2) ->
                       let uu____3452 =
-                        let uu____3461 = f n1 n2  in
-                        let uu____3462 = f p1 p2  in
-                        (uu____3461, uu____3462, (FStar_List.append gs1 gs2))
-                         in
+                        let uu____3461 = f n1 n2 in
+                        let uu____3462 = f p1 p2 in
+                        (uu____3461, uu____3462, (FStar_List.append gs1 gs2)) in
                       Dual uu____3452))
-  
-let comb_list : 'a . 'a tres_m Prims.list -> 'a Prims.list tres_m =
+let comb_list: 'a . 'a tres_m Prims.list -> 'a Prims.list tres_m =
   fun rs  ->
     let rec aux rs1 acc =
       match rs1 with
       | [] -> acc
       | hd1::tl1 ->
-          let uu____3527 = comb2 (fun l  -> fun r  -> l :: r) hd1 acc  in
-          aux tl1 uu____3527
-       in
+          let uu____3527 = comb2 (fun l  -> fun r  -> l :: r) hd1 acc in
+          aux tl1 uu____3527 in
     aux (FStar_List.rev rs) (tpure [])
-  
-let emit : 'a . FStar_Tactics_Basic.goal Prims.list -> 'a tres_m -> 'a tres_m
+let emit: 'a . FStar_Tactics_Basic.goal Prims.list -> 'a tres_m -> 'a tres_m
   =
   fun gs  ->
     fun m  -> comb2 (fun uu____3570  -> fun x  -> x) (Simplified ((), gs)) m
-  
-let rec (traverse :
+let rec traverse:
   (pol -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> tres) ->
-    pol -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> tres)
+    pol -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> tres
   =
   fun f  ->
     fun pol  ->
@@ -1949,19 +1761,18 @@ let rec (traverse :
         fun t  ->
           let r =
             let uu____3604 =
-              let uu____3605 = FStar_Syntax_Subst.compress t  in
-              uu____3605.FStar_Syntax_Syntax.n  in
+              let uu____3605 = FStar_Syntax_Subst.compress t in
+              uu____3605.FStar_Syntax_Syntax.n in
             match uu____3604 with
             | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
-                let tr = traverse f pol e t1  in
+                let tr = traverse f pol e t1 in
                 let uu____3617 =
-                  comb1 (fun t'  -> FStar_Syntax_Syntax.Tm_uinst (t', us))
-                   in
+                  comb1 (fun t'  -> FStar_Syntax_Syntax.Tm_uinst (t', us)) in
                 uu____3617 tr
             | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
-                let tr = traverse f pol e t1  in
+                let tr = traverse f pol e t1 in
                 let uu____3641 =
-                  comb1 (fun t'  -> FStar_Syntax_Syntax.Tm_meta (t', m))  in
+                  comb1 (fun t'  -> FStar_Syntax_Syntax.Tm_meta (t', m)) in
                 uu____3641 tr
             | FStar_Syntax_Syntax.Tm_app
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
@@ -1973,19 +1784,17 @@ let rec (traverse :
                 ->
                 let x =
                   let uu____3704 =
-                    FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero p
-                     in
+                    FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero p in
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                    uu____3704
-                   in
-                let r1 = traverse f (flip pol) e p  in
+                    uu____3704 in
+                let r1 = traverse f (flip pol) e p in
                 let r2 =
-                  let uu____3707 = FStar_TypeChecker_Env.push_bv e x  in
-                  traverse f pol uu____3707 q  in
+                  let uu____3707 = FStar_TypeChecker_Env.push_bv e x in
+                  traverse f pol uu____3707 q in
                 comb2
                   (fun l  ->
                      fun r  ->
-                       let uu____3713 = FStar_Syntax_Util.mk_imp l r  in
+                       let uu____3713 = FStar_Syntax_Util.mk_imp l r in
                        uu____3713.FStar_Syntax_Syntax.n) r1 r2
             | FStar_Syntax_Syntax.Tm_app
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
@@ -1997,71 +1806,65 @@ let rec (traverse :
                 ->
                 let xp =
                   let uu____3762 =
-                    FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero p
-                     in
+                    FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero p in
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                    uu____3762
-                   in
+                    uu____3762 in
                 let xq =
                   let uu____3764 =
-                    FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero q
-                     in
+                    FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero q in
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                    uu____3764
-                   in
+                    uu____3764 in
                 let r1 =
-                  let uu____3766 = FStar_TypeChecker_Env.push_bv e xq  in
-                  traverse f Both uu____3766 p  in
+                  let uu____3766 = FStar_TypeChecker_Env.push_bv e xq in
+                  traverse f Both uu____3766 p in
                 let r2 =
-                  let uu____3768 = FStar_TypeChecker_Env.push_bv e xp  in
-                  traverse f Both uu____3768 q  in
+                  let uu____3768 = FStar_TypeChecker_Env.push_bv e xp in
+                  traverse f Both uu____3768 q in
                 (match (r1, r2) with
                  | (Unchanged uu____3771,Unchanged uu____3772) ->
                      comb2
                        (fun l  ->
                           fun r  ->
-                            let uu____3782 = FStar_Syntax_Util.mk_iff l r  in
+                            let uu____3782 = FStar_Syntax_Util.mk_iff l r in
                             uu____3782.FStar_Syntax_Syntax.n) r1 r2
                  | uu____3785 ->
-                     let uu____3790 = explode r1  in
+                     let uu____3790 = explode r1 in
                      (match uu____3790 with
                       | (pn,pp,gs1) ->
-                          let uu____3808 = explode r2  in
+                          let uu____3808 = explode r2 in
                           (match uu____3808 with
                            | (qn,qp,gs2) ->
                                let t1 =
                                  let uu____3829 =
-                                   FStar_Syntax_Util.mk_imp pn qp  in
+                                   FStar_Syntax_Util.mk_imp pn qp in
                                  let uu____3830 =
-                                   FStar_Syntax_Util.mk_imp qn pp  in
+                                   FStar_Syntax_Util.mk_imp qn pp in
                                  FStar_Syntax_Util.mk_conj uu____3829
-                                   uu____3830
-                                  in
+                                   uu____3830 in
                                Simplified
                                  ((t1.FStar_Syntax_Syntax.n),
                                    (FStar_List.append gs1 gs2)))))
             | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-                let r0 = traverse f pol e hd1  in
+                let r0 = traverse f pol e hd1 in
                 let r1 =
                   FStar_List.fold_right
                     (fun uu____3882  ->
                        fun r  ->
                          match uu____3882 with
                          | (a,q) ->
-                             let r' = traverse f pol e a  in
+                             let r' = traverse f pol e a in
                              comb2
                                (fun a1  -> fun args1  -> (a1, q) :: args1) r'
-                               r) args (tpure [])
-                   in
+                               r) args (tpure []) in
                 comb2
                   (fun hd2  ->
                      fun args1  -> FStar_Syntax_Syntax.Tm_app (hd2, args1))
                   r0 r1
             | FStar_Syntax_Syntax.Tm_abs (bs,t1,k) ->
-                let uu____4000 = FStar_Syntax_Subst.open_term bs t1  in
+                let uu____4000 = FStar_Syntax_Subst.open_term bs t1 in
                 (match uu____4000 with
                  | (bs1,topen) ->
-                     let e' = FStar_TypeChecker_Env.push_binders e bs1  in
+                     let e' = FStar_TypeChecker_Env.push_binders e bs1 in
                      let r0 =
                        FStar_List.map
                          (fun uu____4034  ->
@@ -2069,42 +1872,37 @@ let rec (traverse :
                             | (bv,aq) ->
                                 let r =
                                   traverse f (flip pol) e
-                                    bv.FStar_Syntax_Syntax.sort
-                                   in
+                                    bv.FStar_Syntax_Syntax.sort in
                                 let uu____4048 =
                                   comb1
                                     (fun s'  ->
-                                       ((let uu___63_4072 = bv  in
+                                       ((let uu___63_4072 = bv in
                                          {
                                            FStar_Syntax_Syntax.ppname =
                                              (uu___63_4072.FStar_Syntax_Syntax.ppname);
                                            FStar_Syntax_Syntax.index =
                                              (uu___63_4072.FStar_Syntax_Syntax.index);
                                            FStar_Syntax_Syntax.sort = s'
-                                         }), aq))
-                                   in
-                                uu____4048 r) bs1
-                        in
-                     let rbs = comb_list r0  in
-                     let rt = traverse f pol e' topen  in
+                                         }), aq)) in
+                                uu____4048 r) bs1 in
+                     let rbs = comb_list r0 in
+                     let rt = traverse f pol e' topen in
                      comb2
                        (fun bs2  ->
                           fun t2  ->
-                            let uu____4092 = FStar_Syntax_Util.abs bs2 t2 k
-                               in
+                            let uu____4092 = FStar_Syntax_Util.abs bs2 t2 k in
                             uu____4092.FStar_Syntax_Syntax.n) rbs rt)
             | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,ef) ->
-                let uu____4138 = traverse f pol e t1  in
+                let uu____4138 = traverse f pol e t1 in
                 let uu____4143 =
                   comb1
-                    (fun t2  -> FStar_Syntax_Syntax.Tm_ascribed (t2, asc, ef))
-                   in
+                    (fun t2  -> FStar_Syntax_Syntax.Tm_ascribed (t2, asc, ef)) in
                 uu____4143 uu____4138
-            | x -> tpure x  in
+            | x -> tpure x in
           match r with
           | Unchanged tn' ->
               f pol e
-                (let uu___64_4181 = t  in
+                (let uu___64_4181 = t in
                  {
                    FStar_Syntax_Syntax.n = tn';
                    FStar_Syntax_Syntax.pos =
@@ -2115,33 +1913,31 @@ let rec (traverse :
           | Simplified (tn',gs) ->
               let uu____4188 =
                 f pol e
-                  (let uu___65_4192 = t  in
+                  (let uu___65_4192 = t in
                    {
                      FStar_Syntax_Syntax.n = tn';
                      FStar_Syntax_Syntax.pos =
                        (uu___65_4192.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
                        (uu___65_4192.FStar_Syntax_Syntax.vars)
-                   })
-                 in
+                   }) in
               emit gs uu____4188
           | Dual (tn,tp,gs) ->
               let rp =
                 f pol e
-                  (let uu___66_4202 = t  in
+                  (let uu___66_4202 = t in
                    {
                      FStar_Syntax_Syntax.n = tp;
                      FStar_Syntax_Syntax.pos =
                        (uu___66_4202.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
                        (uu___66_4202.FStar_Syntax_Syntax.vars)
-                   })
-                 in
-              let uu____4203 = explode rp  in
+                   }) in
+              let uu____4203 = explode rp in
               (match uu____4203 with
                | (uu____4212,p',gs') ->
                    Dual
-                     ((let uu___67_4226 = t  in
+                     ((let uu___67_4226 = t in
                        {
                          FStar_Syntax_Syntax.n = tn;
                          FStar_Syntax_Syntax.pos =
@@ -2149,11 +1945,10 @@ let rec (traverse :
                          FStar_Syntax_Syntax.vars =
                            (uu___67_4226.FStar_Syntax_Syntax.vars)
                        }), p', (FStar_List.append gs gs')))
-  
-let (getprop :
+let getprop:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun e  ->
     fun t  ->
@@ -2162,55 +1957,51 @@ let (getprop :
           [FStar_TypeChecker_Normalize.Weak;
           FStar_TypeChecker_Normalize.HNF;
           FStar_TypeChecker_Normalize.UnfoldUntil
-            FStar_Syntax_Syntax.Delta_constant] e t
-         in
+            FStar_Syntax_Syntax.Delta_constant] e t in
       FStar_Syntax_Util.un_squash tn
-  
-let (preprocess :
+let preprocess:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_TypeChecker_Env.env,FStar_Syntax_Syntax.term,FStar_Options.optionstate)
-        FStar_Pervasives_Native.tuple3 Prims.list)
+        FStar_Pervasives_Native.tuple3 Prims.list
   =
   fun env  ->
     fun goal  ->
       (let uu____4261 =
-         FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")  in
+         FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac") in
        FStar_ST.op_Colon_Equals tacdbg uu____4261);
-      (let uu____4282 = FStar_ST.op_Bang tacdbg  in
+      (let uu____4282 = FStar_ST.op_Bang tacdbg in
        if uu____4282
        then
          let uu____4302 =
-           let uu____4303 = FStar_TypeChecker_Env.all_binders env  in
+           let uu____4303 = FStar_TypeChecker_Env.all_binders env in
            FStar_All.pipe_right uu____4303
-             (FStar_Syntax_Print.binders_to_string ",")
-            in
-         let uu____4304 = FStar_Syntax_Print.term_to_string goal  in
+             (FStar_Syntax_Print.binders_to_string ",") in
+         let uu____4304 = FStar_Syntax_Print.term_to_string goal in
          FStar_Util.print2 "About to preprocess %s |= %s\n" uu____4302
            uu____4304
        else ());
-      (let initial = ((Prims.parse_int "1"), [])  in
+      (let initial = ((Prims.parse_int "1"), []) in
        let uu____4333 =
-         let uu____4340 = traverse by_tactic_interp Pos env goal  in
+         let uu____4340 = traverse by_tactic_interp Pos env goal in
          match uu____4340 with
          | Unchanged t' -> (t', [])
          | Simplified (t',gs) -> (t', gs)
-         | uu____4358 -> failwith "no"  in
+         | uu____4358 -> failwith "no" in
        match uu____4333 with
        | (t',gs) ->
-           ((let uu____4380 = FStar_ST.op_Bang tacdbg  in
+           ((let uu____4380 = FStar_ST.op_Bang tacdbg in
              if uu____4380
              then
                let uu____4400 =
-                 let uu____4401 = FStar_TypeChecker_Env.all_binders env  in
+                 let uu____4401 = FStar_TypeChecker_Env.all_binders env in
                  FStar_All.pipe_right uu____4401
-                   (FStar_Syntax_Print.binders_to_string ", ")
-                  in
-               let uu____4402 = FStar_Syntax_Print.term_to_string t'  in
+                   (FStar_Syntax_Print.binders_to_string ", ") in
+               let uu____4402 = FStar_Syntax_Print.term_to_string t' in
                FStar_Util.print2 "Main goal simplified to: %s |- %s\n"
                  uu____4400 uu____4402
              else ());
-            (let s = initial  in
+            (let s = initial in
              let s1 =
                FStar_List.fold_left
                  (fun uu____4449  ->
@@ -2220,89 +2011,76 @@ let (preprocess :
                           let phi =
                             let uu____4494 =
                               getprop g.FStar_Tactics_Types.context
-                                g.FStar_Tactics_Types.goal_ty
-                               in
+                                g.FStar_Tactics_Types.goal_ty in
                             match uu____4494 with
                             | FStar_Pervasives_Native.None  ->
                                 let uu____4497 =
                                   let uu____4498 =
                                     FStar_Syntax_Print.term_to_string
-                                      g.FStar_Tactics_Types.goal_ty
-                                     in
+                                      g.FStar_Tactics_Types.goal_ty in
                                   FStar_Util.format1
                                     "Tactic returned proof-relevant goal: %s"
-                                    uu____4498
-                                   in
+                                    uu____4498 in
                                 failwith uu____4497
-                            | FStar_Pervasives_Native.Some phi -> phi  in
-                          ((let uu____4501 = FStar_ST.op_Bang tacdbg  in
+                            | FStar_Pervasives_Native.Some phi -> phi in
+                          ((let uu____4501 = FStar_ST.op_Bang tacdbg in
                             if uu____4501
                             then
-                              let uu____4521 = FStar_Util.string_of_int n1
-                                 in
+                              let uu____4521 = FStar_Util.string_of_int n1 in
                               let uu____4522 =
-                                FStar_Tactics_Basic.goal_to_string g  in
+                                FStar_Tactics_Basic.goal_to_string g in
                               FStar_Util.print2 "Got goal #%s: %s\n"
                                 uu____4521 uu____4522
                             else ());
                            (let gt' =
                               let uu____4525 =
-                                let uu____4526 = FStar_Util.string_of_int n1
-                                   in
+                                let uu____4526 = FStar_Util.string_of_int n1 in
                                 Prims.strcat "Could not prove goal #"
-                                  uu____4526
-                                 in
+                                  uu____4526 in
                               FStar_TypeChecker_Util.label uu____4525
-                                goal.FStar_Syntax_Syntax.pos phi
-                               in
+                                goal.FStar_Syntax_Syntax.pos phi in
                             ((n1 + (Prims.parse_int "1")),
                               (((g.FStar_Tactics_Types.context), gt',
                                  (g.FStar_Tactics_Types.opts)) :: gs1))))) s
-                 gs
-                in
-             let uu____4541 = s1  in
+                 gs in
+             let uu____4541 = s1 in
              match uu____4541 with
              | (uu____4562,gs1) ->
                  let uu____4580 =
-                   let uu____4587 = FStar_Options.peek ()  in
-                   (env, t', uu____4587)  in
+                   let uu____4587 = FStar_Options.peek () in
+                   (env, t', uu____4587) in
                  uu____4580 :: gs1)))
-  
-let (reify_tactic : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let reify_tactic: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun a  ->
     let r =
       let uu____4598 =
         let uu____4599 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.reify_tactic_lid
-            FStar_Syntax_Syntax.Delta_equational FStar_Pervasives_Native.None
-           in
-        FStar_Syntax_Syntax.fv_to_tm uu____4599  in
-      FStar_Syntax_Syntax.mk_Tm_uinst uu____4598 [FStar_Syntax_Syntax.U_zero]
-       in
+            FStar_Syntax_Syntax.Delta_equational FStar_Pervasives_Native.None in
+        FStar_Syntax_Syntax.fv_to_tm uu____4599 in
+      FStar_Syntax_Syntax.mk_Tm_uinst uu____4598 [FStar_Syntax_Syntax.U_zero] in
     let uu____4600 =
       let uu____4601 =
-        let uu____4602 = FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_unit
-           in
+        let uu____4602 = FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_unit in
         let uu____4603 =
-          let uu____4606 = FStar_Syntax_Syntax.as_arg a  in [uu____4606]  in
-        uu____4602 :: uu____4603  in
-      FStar_Syntax_Syntax.mk_Tm_app r uu____4601  in
+          let uu____4606 = FStar_Syntax_Syntax.as_arg a in [uu____4606] in
+        uu____4602 :: uu____4603 in
+      FStar_Syntax_Syntax.mk_Tm_app r uu____4601 in
     uu____4600 FStar_Pervasives_Native.None a.FStar_Syntax_Syntax.pos
-  
-let (synth :
+let synth:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun typ  ->
       fun tau  ->
         (let uu____4619 =
-           FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")  in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac") in
          FStar_ST.op_Colon_Equals tacdbg uu____4619);
         (let uu____4639 =
-           let uu____4646 = reify_tactic tau  in
-           run_tactic_on_typ uu____4646 env typ  in
+           let uu____4646 = reify_tactic tau in
+           run_tactic_on_typ uu____4646 env typ in
          match uu____4639 with
          | (gs,w) ->
              let uu____4653 =
@@ -2311,15 +2089,12 @@ let (synth :
                     let uu____4657 =
                       let uu____4658 =
                         getprop g.FStar_Tactics_Types.context
-                          g.FStar_Tactics_Types.goal_ty
-                         in
-                      FStar_Option.isSome uu____4658  in
-                    Prims.op_Negation uu____4657) gs
-                in
+                          g.FStar_Tactics_Types.goal_ty in
+                      FStar_Option.isSome uu____4658 in
+                    Prims.op_Negation uu____4657) gs in
              if uu____4653
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_OpenGoalsInSynthesis,
                    "synthesis left open goals") typ.FStar_Syntax_Syntax.pos
              else w)
-  

--- a/src/ocaml-output/FStar_Tactics_Result.ml
+++ b/src/ocaml-output/FStar_Tactics_Result.ml
@@ -1,25 +1,23 @@
 open Prims
 type 'a __result =
   | Success of ('a,FStar_Tactics_Types.proofstate)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Failed of (Prims.string,FStar_Tactics_Types.proofstate)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let uu___is_Success : 'a . 'a __result -> Prims.bool =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_Success: 'a . 'a __result -> Prims.bool =
   fun projectee  ->
     match projectee with | Success _0 -> true | uu____40 -> false
-  
-let __proj__Success__item___0 :
+let __proj__Success__item___0:
   'a .
     'a __result ->
       ('a,FStar_Tactics_Types.proofstate) FStar_Pervasives_Native.tuple2
-  = fun projectee  -> match projectee with | Success _0 -> _0 
-let uu___is_Failed : 'a . 'a __result -> Prims.bool =
+  = fun projectee  -> match projectee with | Success _0 -> _0
+let uu___is_Failed: 'a . 'a __result -> Prims.bool =
   fun projectee  ->
     match projectee with | Failed _0 -> true | uu____82 -> false
-  
-let __proj__Failed__item___0 :
+let __proj__Failed__item___0:
   'a .
     'a __result ->
       (Prims.string,FStar_Tactics_Types.proofstate)
         FStar_Pervasives_Native.tuple2
-  = fun projectee  -> match projectee with | Failed _0 -> _0 
+  = fun projectee  -> match projectee with | Failed _0 -> _0

--- a/src/ocaml-output/FStar_Tactics_Types.ml
+++ b/src/ocaml-output/FStar_Tactics_Types.ml
@@ -1,53 +1,48 @@
 open Prims
 type goal =
   {
-  context: FStar_TypeChecker_Env.env ;
-  witness: FStar_Syntax_Syntax.term ;
-  goal_ty: FStar_Syntax_Syntax.typ ;
-  opts: FStar_Options.optionstate ;
-  is_guard: Prims.bool }[@@deriving show]
-let (__proj__Mkgoal__item__context : goal -> FStar_TypeChecker_Env.env) =
+  context: FStar_TypeChecker_Env.env;
+  witness: FStar_Syntax_Syntax.term;
+  goal_ty: FStar_Syntax_Syntax.typ;
+  opts: FStar_Options.optionstate;
+  is_guard: Prims.bool;}[@@deriving show]
+let __proj__Mkgoal__item__context: goal -> FStar_TypeChecker_Env.env =
   fun projectee  ->
     match projectee with
     | { context = __fname__context; witness = __fname__witness;
         goal_ty = __fname__goal_ty; opts = __fname__opts;
         is_guard = __fname__is_guard;_} -> __fname__context
-  
-let (__proj__Mkgoal__item__witness : goal -> FStar_Syntax_Syntax.term) =
+let __proj__Mkgoal__item__witness: goal -> FStar_Syntax_Syntax.term =
   fun projectee  ->
     match projectee with
     | { context = __fname__context; witness = __fname__witness;
         goal_ty = __fname__goal_ty; opts = __fname__opts;
         is_guard = __fname__is_guard;_} -> __fname__witness
-  
-let (__proj__Mkgoal__item__goal_ty : goal -> FStar_Syntax_Syntax.typ) =
+let __proj__Mkgoal__item__goal_ty: goal -> FStar_Syntax_Syntax.typ =
   fun projectee  ->
     match projectee with
     | { context = __fname__context; witness = __fname__witness;
         goal_ty = __fname__goal_ty; opts = __fname__opts;
         is_guard = __fname__is_guard;_} -> __fname__goal_ty
-  
-let (__proj__Mkgoal__item__opts : goal -> FStar_Options.optionstate) =
+let __proj__Mkgoal__item__opts: goal -> FStar_Options.optionstate =
   fun projectee  ->
     match projectee with
     | { context = __fname__context; witness = __fname__witness;
         goal_ty = __fname__goal_ty; opts = __fname__opts;
         is_guard = __fname__is_guard;_} -> __fname__opts
-  
-let (__proj__Mkgoal__item__is_guard : goal -> Prims.bool) =
+let __proj__Mkgoal__item__is_guard: goal -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { context = __fname__context; witness = __fname__witness;
         goal_ty = __fname__goal_ty; opts = __fname__opts;
         is_guard = __fname__is_guard;_} -> __fname__is_guard
-  
-let (subst_goal : FStar_Syntax_Syntax.subst_t -> goal -> goal) =
+let subst_goal: FStar_Syntax_Syntax.subst_t -> goal -> goal =
   fun subst1  ->
     fun goal  ->
-      let uu___51_67 = goal  in
-      let uu____68 = FStar_TypeChecker_Env.rename_env subst1 goal.context  in
-      let uu____69 = FStar_Syntax_Subst.subst subst1 goal.witness  in
-      let uu____70 = FStar_Syntax_Subst.subst subst1 goal.goal_ty  in
+      let uu___51_67 = goal in
+      let uu____68 = FStar_TypeChecker_Env.rename_env subst1 goal.context in
+      let uu____69 = FStar_Syntax_Subst.subst subst1 goal.witness in
+      let uu____70 = FStar_Syntax_Subst.subst subst1 goal.goal_ty in
       {
         context = uu____68;
         witness = uu____69;
@@ -55,20 +50,19 @@ let (subst_goal : FStar_Syntax_Syntax.subst_t -> goal -> goal) =
         opts = (uu___51_67.opts);
         is_guard = (uu___51_67.is_guard)
       }
-  
 type proofstate =
   {
-  main_context: FStar_TypeChecker_Env.env ;
-  main_goal: goal ;
-  all_implicits: FStar_TypeChecker_Env.implicits ;
-  goals: goal Prims.list ;
-  smt_goals: goal Prims.list ;
-  depth: Prims.int ;
-  __dump: proofstate -> Prims.string -> Prims.unit ;
-  psc: FStar_TypeChecker_Normalize.psc ;
-  entry_range: FStar_Range.range }[@@deriving show]
-let (__proj__Mkproofstate__item__main_context :
-  proofstate -> FStar_TypeChecker_Env.env) =
+  main_context: FStar_TypeChecker_Env.env;
+  main_goal: goal;
+  all_implicits: FStar_TypeChecker_Env.implicits;
+  goals: goal Prims.list;
+  smt_goals: goal Prims.list;
+  depth: Prims.int;
+  __dump: proofstate -> Prims.string -> Prims.unit;
+  psc: FStar_TypeChecker_Normalize.psc;
+  entry_range: FStar_Range.range;}[@@deriving show]
+let __proj__Mkproofstate__item__main_context:
+  proofstate -> FStar_TypeChecker_Env.env =
   fun projectee  ->
     match projectee with
     | { main_context = __fname__main_context; main_goal = __fname__main_goal;
@@ -76,8 +70,7 @@ let (__proj__Mkproofstate__item__main_context :
         smt_goals = __fname__smt_goals; depth = __fname__depth;
         __dump = __fname____dump; psc = __fname__psc;
         entry_range = __fname__entry_range;_} -> __fname__main_context
-  
-let (__proj__Mkproofstate__item__main_goal : proofstate -> goal) =
+let __proj__Mkproofstate__item__main_goal: proofstate -> goal =
   fun projectee  ->
     match projectee with
     | { main_context = __fname__main_context; main_goal = __fname__main_goal;
@@ -85,9 +78,8 @@ let (__proj__Mkproofstate__item__main_goal : proofstate -> goal) =
         smt_goals = __fname__smt_goals; depth = __fname__depth;
         __dump = __fname____dump; psc = __fname__psc;
         entry_range = __fname__entry_range;_} -> __fname__main_goal
-  
-let (__proj__Mkproofstate__item__all_implicits :
-  proofstate -> FStar_TypeChecker_Env.implicits) =
+let __proj__Mkproofstate__item__all_implicits:
+  proofstate -> FStar_TypeChecker_Env.implicits =
   fun projectee  ->
     match projectee with
     | { main_context = __fname__main_context; main_goal = __fname__main_goal;
@@ -95,8 +87,7 @@ let (__proj__Mkproofstate__item__all_implicits :
         smt_goals = __fname__smt_goals; depth = __fname__depth;
         __dump = __fname____dump; psc = __fname__psc;
         entry_range = __fname__entry_range;_} -> __fname__all_implicits
-  
-let (__proj__Mkproofstate__item__goals : proofstate -> goal Prims.list) =
+let __proj__Mkproofstate__item__goals: proofstate -> goal Prims.list =
   fun projectee  ->
     match projectee with
     | { main_context = __fname__main_context; main_goal = __fname__main_goal;
@@ -104,8 +95,7 @@ let (__proj__Mkproofstate__item__goals : proofstate -> goal Prims.list) =
         smt_goals = __fname__smt_goals; depth = __fname__depth;
         __dump = __fname____dump; psc = __fname__psc;
         entry_range = __fname__entry_range;_} -> __fname__goals
-  
-let (__proj__Mkproofstate__item__smt_goals : proofstate -> goal Prims.list) =
+let __proj__Mkproofstate__item__smt_goals: proofstate -> goal Prims.list =
   fun projectee  ->
     match projectee with
     | { main_context = __fname__main_context; main_goal = __fname__main_goal;
@@ -113,8 +103,7 @@ let (__proj__Mkproofstate__item__smt_goals : proofstate -> goal Prims.list) =
         smt_goals = __fname__smt_goals; depth = __fname__depth;
         __dump = __fname____dump; psc = __fname__psc;
         entry_range = __fname__entry_range;_} -> __fname__smt_goals
-  
-let (__proj__Mkproofstate__item__depth : proofstate -> Prims.int) =
+let __proj__Mkproofstate__item__depth: proofstate -> Prims.int =
   fun projectee  ->
     match projectee with
     | { main_context = __fname__main_context; main_goal = __fname__main_goal;
@@ -122,9 +111,8 @@ let (__proj__Mkproofstate__item__depth : proofstate -> Prims.int) =
         smt_goals = __fname__smt_goals; depth = __fname__depth;
         __dump = __fname____dump; psc = __fname__psc;
         entry_range = __fname__entry_range;_} -> __fname__depth
-  
-let (__proj__Mkproofstate__item____dump :
-  proofstate -> proofstate -> Prims.string -> Prims.unit) =
+let __proj__Mkproofstate__item____dump:
+  proofstate -> proofstate -> Prims.string -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { main_context = __fname__main_context; main_goal = __fname__main_goal;
@@ -132,9 +120,8 @@ let (__proj__Mkproofstate__item____dump :
         smt_goals = __fname__smt_goals; depth = __fname__depth;
         __dump = __fname____dump; psc = __fname__psc;
         entry_range = __fname__entry_range;_} -> __fname____dump
-  
-let (__proj__Mkproofstate__item__psc :
-  proofstate -> FStar_TypeChecker_Normalize.psc) =
+let __proj__Mkproofstate__item__psc:
+  proofstate -> FStar_TypeChecker_Normalize.psc =
   fun projectee  ->
     match projectee with
     | { main_context = __fname__main_context; main_goal = __fname__main_goal;
@@ -142,9 +129,8 @@ let (__proj__Mkproofstate__item__psc :
         smt_goals = __fname__smt_goals; depth = __fname__depth;
         __dump = __fname____dump; psc = __fname__psc;
         entry_range = __fname__entry_range;_} -> __fname__psc
-  
-let (__proj__Mkproofstate__item__entry_range :
-  proofstate -> FStar_Range.range) =
+let __proj__Mkproofstate__item__entry_range: proofstate -> FStar_Range.range
+  =
   fun projectee  ->
     match projectee with
     | { main_context = __fname__main_context; main_goal = __fname__main_goal;
@@ -152,18 +138,17 @@ let (__proj__Mkproofstate__item__entry_range :
         smt_goals = __fname__smt_goals; depth = __fname__depth;
         __dump = __fname____dump; psc = __fname__psc;
         entry_range = __fname__entry_range;_} -> __fname__entry_range
-  
-let (subst_proof_state :
-  FStar_Syntax_Syntax.subst_t -> proofstate -> proofstate) =
+let subst_proof_state:
+  FStar_Syntax_Syntax.subst_t -> proofstate -> proofstate =
   fun subst1  ->
     fun ps  ->
-      let uu____321 = FStar_Options.tactic_raw_binders ()  in
+      let uu____321 = FStar_Options.tactic_raw_binders () in
       if uu____321
       then ps
       else
-        (let uu___52_323 = ps  in
-         let uu____324 = subst_goal subst1 ps.main_goal  in
-         let uu____325 = FStar_List.map (subst_goal subst1) ps.goals  in
+        (let uu___52_323 = ps in
+         let uu____324 = subst_goal subst1 ps.main_goal in
+         let uu____325 = FStar_List.map (subst_goal subst1) ps.goals in
          {
            main_context = (uu___52_323.main_context);
            main_goal = uu____324;
@@ -175,10 +160,9 @@ let (subst_proof_state :
            psc = (uu___52_323.psc);
            entry_range = (uu___52_323.entry_range)
          })
-  
-let (decr_depth : proofstate -> proofstate) =
+let decr_depth: proofstate -> proofstate =
   fun ps  ->
-    let uu___53_331 = ps  in
+    let uu___53_331 = ps in
     {
       main_context = (uu___53_331.main_context);
       main_goal = (uu___53_331.main_goal);
@@ -190,10 +174,9 @@ let (decr_depth : proofstate -> proofstate) =
       psc = (uu___53_331.psc);
       entry_range = (uu___53_331.entry_range)
     }
-  
-let (incr_depth : proofstate -> proofstate) =
+let incr_depth: proofstate -> proofstate =
   fun ps  ->
-    let uu___54_335 = ps  in
+    let uu___54_335 = ps in
     {
       main_context = (uu___54_335.main_context);
       main_goal = (uu___54_335.main_goal);
@@ -205,27 +188,23 @@ let (incr_depth : proofstate -> proofstate) =
       psc = (uu___54_335.psc);
       entry_range = (uu___54_335.entry_range)
     }
-  
-let (tracepoint : proofstate -> Prims.unit) =
+let tracepoint: proofstate -> Prims.unit =
   fun ps  ->
     let uu____339 =
       (FStar_Options.tactic_trace ()) ||
-        (let uu____341 = FStar_Options.tactic_trace_d ()  in
-         ps.depth <= uu____341)
-       in
+        (let uu____341 = FStar_Options.tactic_trace_d () in
+         ps.depth <= uu____341) in
     if uu____339
     then
       let uu____342 =
-        let uu____343 = FStar_TypeChecker_Normalize.psc_subst ps.psc  in
-        subst_proof_state uu____343 ps  in
+        let uu____343 = FStar_TypeChecker_Normalize.psc_subst ps.psc in
+        subst_proof_state uu____343 ps in
       ps.__dump uu____342 "TRACE"
     else ()
-  
-let (set_ps_psc :
-  FStar_TypeChecker_Normalize.psc -> proofstate -> proofstate) =
+let set_ps_psc: FStar_TypeChecker_Normalize.psc -> proofstate -> proofstate =
   fun psc  ->
     fun ps  ->
-      let uu___55_351 = ps  in
+      let uu___55_351 = ps in
       {
         main_context = (uu___55_351.main_context);
         main_goal = (uu___55_351.main_goal);
@@ -237,11 +216,10 @@ let (set_ps_psc :
         psc;
         entry_range = (uu___55_351.entry_range)
       }
-  
-let (set_proofstate_range : proofstate -> FStar_Range.range -> proofstate) =
+let set_proofstate_range: proofstate -> FStar_Range.range -> proofstate =
   fun ps  ->
     fun r  ->
-      let uu___56_358 = ps  in
+      let uu___56_358 = ps in
       {
         main_context = (uu___56_358.main_context);
         main_goal = (uu___56_358.main_goal);
@@ -253,15 +231,12 @@ let (set_proofstate_range : proofstate -> FStar_Range.range -> proofstate) =
         psc = (uu___56_358.psc);
         entry_range = r
       }
-  
 type direction =
-  | TopDown 
-  | BottomUp [@@deriving show]
-let (uu___is_TopDown : direction -> Prims.bool) =
+  | TopDown
+  | BottomUp[@@deriving show]
+let uu___is_TopDown: direction -> Prims.bool =
   fun projectee  ->
     match projectee with | TopDown  -> true | uu____362 -> false
-  
-let (uu___is_BottomUp : direction -> Prims.bool) =
+let uu___is_BottomUp: direction -> Prims.bool =
   fun projectee  ->
     match projectee with | BottomUp  -> true | uu____366 -> false
-  

--- a/src/ocaml-output/FStar_Tests_Norm.ml
+++ b/src/ocaml-output/FStar_Tests_Norm.ml
@@ -1,65 +1,59 @@
 open Prims
-let (b : FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.binder) =
-  FStar_Syntax_Syntax.mk_binder 
-let (id : FStar_Syntax_Syntax.term) = FStar_Tests_Pars.pars "fun x -> x" 
-let (apply : FStar_Syntax_Syntax.term) =
-  FStar_Tests_Pars.pars "fun f x -> f x" 
-let (twice : FStar_Syntax_Syntax.term) =
-  FStar_Tests_Pars.pars "fun f x -> f (f x)" 
-let (tt : FStar_Syntax_Syntax.term) = FStar_Tests_Pars.pars "fun x y -> x" 
-let (ff : FStar_Syntax_Syntax.term) = FStar_Tests_Pars.pars "fun x y -> y" 
-let (z : FStar_Syntax_Syntax.term) = FStar_Tests_Pars.pars "fun f x -> x" 
-let (one : FStar_Syntax_Syntax.term) = FStar_Tests_Pars.pars "fun f x -> f x" 
-let (two : FStar_Syntax_Syntax.term) =
-  FStar_Tests_Pars.pars "fun f x -> f (f x)" 
-let (succ : FStar_Syntax_Syntax.term) =
-  FStar_Tests_Pars.pars "fun n f x -> f (n f x)" 
-let (pred : FStar_Syntax_Syntax.term) =
+let b: FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.binder =
+  FStar_Syntax_Syntax.mk_binder
+let id: FStar_Syntax_Syntax.term = FStar_Tests_Pars.pars "fun x -> x"
+let apply: FStar_Syntax_Syntax.term = FStar_Tests_Pars.pars "fun f x -> f x"
+let twice: FStar_Syntax_Syntax.term =
+  FStar_Tests_Pars.pars "fun f x -> f (f x)"
+let tt: FStar_Syntax_Syntax.term = FStar_Tests_Pars.pars "fun x y -> x"
+let ff: FStar_Syntax_Syntax.term = FStar_Tests_Pars.pars "fun x y -> y"
+let z: FStar_Syntax_Syntax.term = FStar_Tests_Pars.pars "fun f x -> x"
+let one: FStar_Syntax_Syntax.term = FStar_Tests_Pars.pars "fun f x -> f x"
+let two: FStar_Syntax_Syntax.term =
+  FStar_Tests_Pars.pars "fun f x -> f (f x)"
+let succ: FStar_Syntax_Syntax.term =
+  FStar_Tests_Pars.pars "fun n f x -> f (n f x)"
+let pred: FStar_Syntax_Syntax.term =
   FStar_Tests_Pars.pars
     "fun n f x -> n (fun g h -> h (g f)) (fun y -> x) (fun y -> y)"
-  
-let (mul : FStar_Syntax_Syntax.term) =
-  FStar_Tests_Pars.pars "fun m n f -> m (n f)" 
-let rec (encode : Prims.int -> FStar_Syntax_Syntax.term) =
+let mul: FStar_Syntax_Syntax.term =
+  FStar_Tests_Pars.pars "fun m n f -> m (n f)"
+let rec encode: Prims.int -> FStar_Syntax_Syntax.term =
   fun n1  ->
     if n1 = (Prims.parse_int "0")
     then z
     else
       (let uu____7 =
-         let uu____10 = encode (n1 - (Prims.parse_int "1"))  in [uu____10]
-          in
+         let uu____10 = encode (n1 - (Prims.parse_int "1")) in [uu____10] in
        FStar_Tests_Util.app succ uu____7)
-  
-let (minus :
+let minus:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  = fun m1  -> fun n1  -> FStar_Tests_Util.app n1 [pred; m1] 
-let (let_ :
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
+  = fun m1  -> fun n1  -> FStar_Tests_Util.app n1 [pred; m1]
+let let_:
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun x1  ->
     fun e  ->
       fun e'  ->
         let uu____32 =
-          let uu____35 = let uu____36 = b x1  in [uu____36]  in
-          FStar_Syntax_Util.abs uu____35 e' FStar_Pervasives_Native.None  in
+          let uu____35 = let uu____36 = b x1 in [uu____36] in
+          FStar_Syntax_Util.abs uu____35 e' FStar_Pervasives_Native.None in
         FStar_Tests_Util.app uu____32 [e]
-  
-let (mk_let :
+let mk_let:
   FStar_Syntax_Syntax.bv ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun x1  ->
     fun e  ->
       fun e'  ->
         let e'1 =
           FStar_Syntax_Subst.subst
-            [FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))] e'
-           in
+            [FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))] e' in
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_let
              ((false,
@@ -73,70 +67,62 @@ let (mk_let :
                    FStar_Syntax_Syntax.lbattrs = []
                  }]), e'1)) FStar_Pervasives_Native.None
           FStar_Range.dummyRange
-  
-let (lid : Prims.string -> FStar_Ident.lident) =
-  fun x1  -> FStar_Ident.lid_of_path [x1] FStar_Range.dummyRange 
-let (znat_l : FStar_Syntax_Syntax.fv) =
-  let uu____64 = lid "Z"  in
+let lid: Prims.string -> FStar_Ident.lident =
+  fun x1  -> FStar_Ident.lid_of_path [x1] FStar_Range.dummyRange
+let znat_l: FStar_Syntax_Syntax.fv =
+  let uu____64 = lid "Z" in
   FStar_Syntax_Syntax.lid_as_fv uu____64 FStar_Syntax_Syntax.Delta_constant
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-  
-let (snat_l : FStar_Syntax_Syntax.fv) =
-  let uu____65 = lid "S"  in
+let snat_l: FStar_Syntax_Syntax.fv =
+  let uu____65 = lid "S" in
   FStar_Syntax_Syntax.lid_as_fv uu____65 FStar_Syntax_Syntax.Delta_constant
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-  
-let (tm_fv :
+let tm_fv:
   FStar_Syntax_Syntax.fv ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun fv  ->
     FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
       FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (znat : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
-  tm_fv znat_l 
-let (snat :
+let znat: FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax = tm_fv znat_l
+let snat:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun s  ->
     let uu____78 =
       let uu____81 =
         let uu____82 =
-          let uu____97 = tm_fv snat_l  in
+          let uu____97 = tm_fv snat_l in
           let uu____100 =
-            let uu____103 = FStar_Syntax_Syntax.as_arg s  in [uu____103]  in
-          (uu____97, uu____100)  in
-        FStar_Syntax_Syntax.Tm_app uu____82  in
-      FStar_Syntax_Syntax.mk uu____81  in
+            let uu____103 = FStar_Syntax_Syntax.as_arg s in [uu____103] in
+          (uu____97, uu____100) in
+        FStar_Syntax_Syntax.Tm_app uu____82 in
+      FStar_Syntax_Syntax.mk uu____81 in
     uu____78 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let pat :
+let pat:
   'Auu____113 . 'Auu____113 -> 'Auu____113 FStar_Syntax_Syntax.withinfo_t =
-  fun p  -> FStar_Syntax_Syntax.withinfo p FStar_Range.dummyRange 
-let (mk_match :
+  fun p  -> FStar_Syntax_Syntax.withinfo p FStar_Range.dummyRange
+let mk_match:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.branch Prims.list ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun h1  ->
     fun branches  ->
       let branches1 =
         FStar_All.pipe_right branches
-          (FStar_List.map FStar_Syntax_Util.branch)
-         in
+          (FStar_List.map FStar_Syntax_Util.branch) in
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (h1, branches1))
         FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (pred_nat :
+let pred_nat:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun s  ->
     let zbranch =
-      let uu____171 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, []))  in
-      (uu____171, FStar_Pervasives_Native.None, znat)  in
+      let uu____171 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, [])) in
+      (uu____171, FStar_Pervasives_Native.None, znat) in
     let sbranch =
       let uu____213 =
         let uu____216 =
@@ -144,39 +130,37 @@ let (pred_nat :
             let uu____230 =
               let uu____239 =
                 let uu____246 =
-                  pat (FStar_Syntax_Syntax.Pat_var FStar_Tests_Util.x)  in
-                (uu____246, false)  in
-              [uu____239]  in
-            (snat_l, uu____230)  in
-          FStar_Syntax_Syntax.Pat_cons uu____217  in
-        pat uu____216  in
+                  pat (FStar_Syntax_Syntax.Pat_var FStar_Tests_Util.x) in
+                (uu____246, false) in
+              [uu____239] in
+            (snat_l, uu____230) in
+          FStar_Syntax_Syntax.Pat_cons uu____217 in
+        pat uu____216 in
       let uu____271 =
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_bvar
-             (let uu___75_276 = FStar_Tests_Util.x  in
+             (let uu___75_276 = FStar_Tests_Util.x in
               {
                 FStar_Syntax_Syntax.ppname =
                   (uu___75_276.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index = (Prims.parse_int "0");
                 FStar_Syntax_Syntax.sort =
                   (uu___75_276.FStar_Syntax_Syntax.sort)
-              })) FStar_Pervasives_Native.None FStar_Range.dummyRange
-         in
-      (uu____213, FStar_Pervasives_Native.None, uu____271)  in
+              })) FStar_Pervasives_Native.None FStar_Range.dummyRange in
+      (uu____213, FStar_Pervasives_Native.None, uu____271) in
     mk_match s [zbranch; sbranch]
-  
-let (minus_nat :
+let minus_nat:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t1  ->
     fun t2  ->
-      let minus1 = FStar_Tests_Util.m  in
+      let minus1 = FStar_Tests_Util.m in
       let zbranch =
-        let uu____351 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, []))  in
-        let uu____368 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-        (uu____351, FStar_Pervasives_Native.None, uu____368)  in
+        let uu____351 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, [])) in
+        let uu____368 = FStar_Tests_Util.nm FStar_Tests_Util.x in
+        (uu____351, FStar_Pervasives_Native.None, uu____368) in
       let sbranch =
         let uu____392 =
           let uu____395 =
@@ -184,44 +168,42 @@ let (minus_nat :
               let uu____409 =
                 let uu____418 =
                   let uu____425 =
-                    pat (FStar_Syntax_Syntax.Pat_var FStar_Tests_Util.n)  in
-                  (uu____425, false)  in
-                [uu____418]  in
-              (snat_l, uu____409)  in
-            FStar_Syntax_Syntax.Pat_cons uu____396  in
-          pat uu____395  in
+                    pat (FStar_Syntax_Syntax.Pat_var FStar_Tests_Util.n) in
+                  (uu____425, false) in
+                [uu____418] in
+              (snat_l, uu____409) in
+            FStar_Syntax_Syntax.Pat_cons uu____396 in
+          pat uu____395 in
         let uu____450 =
-          let uu____453 = FStar_Tests_Util.nm minus1  in
+          let uu____453 = FStar_Tests_Util.nm minus1 in
           let uu____456 =
             let uu____459 =
-              let uu____462 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-              pred_nat uu____462  in
+              let uu____462 = FStar_Tests_Util.nm FStar_Tests_Util.x in
+              pred_nat uu____462 in
             let uu____465 =
-              let uu____470 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
-              [uu____470]  in
-            uu____459 :: uu____465  in
-          FStar_Tests_Util.app uu____453 uu____456  in
-        (uu____392, FStar_Pervasives_Native.None, uu____450)  in
+              let uu____470 = FStar_Tests_Util.nm FStar_Tests_Util.n in
+              [uu____470] in
+            uu____459 :: uu____465 in
+          FStar_Tests_Util.app uu____453 uu____456 in
+        (uu____392, FStar_Pervasives_Native.None, uu____450) in
       let lb =
         let uu____484 =
-          FStar_Ident.lid_of_path ["Pure"] FStar_Range.dummyRange  in
+          FStar_Ident.lid_of_path ["Pure"] FStar_Range.dummyRange in
         let uu____485 =
           let uu____488 =
             let uu____489 =
-              let uu____490 = b FStar_Tests_Util.x  in
+              let uu____490 = b FStar_Tests_Util.x in
               let uu____491 =
-                let uu____494 = b FStar_Tests_Util.y  in [uu____494]  in
-              uu____490 :: uu____491  in
+                let uu____494 = b FStar_Tests_Util.y in [uu____494] in
+              uu____490 :: uu____491 in
             let uu____495 =
-              let uu____496 = FStar_Tests_Util.nm FStar_Tests_Util.y  in
-              mk_match uu____496 [zbranch; sbranch]  in
+              let uu____496 = FStar_Tests_Util.nm FStar_Tests_Util.y in
+              mk_match uu____496 [zbranch; sbranch] in
             FStar_Syntax_Util.abs uu____489 uu____495
-              FStar_Pervasives_Native.None
-             in
+              FStar_Pervasives_Native.None in
           FStar_Syntax_Subst.subst
             [FStar_Syntax_Syntax.NM (minus1, (Prims.parse_int "0"))]
-            uu____488
-           in
+            uu____488 in
         {
           FStar_Syntax_Syntax.lbname = (FStar_Util.Inl minus1);
           FStar_Syntax_Syntax.lbunivs = [];
@@ -229,64 +211,58 @@ let (minus_nat :
           FStar_Syntax_Syntax.lbeff = uu____484;
           FStar_Syntax_Syntax.lbdef = uu____485;
           FStar_Syntax_Syntax.lbattrs = []
-        }  in
+        } in
       let uu____541 =
         let uu____544 =
           let uu____545 =
             let uu____558 =
               let uu____559 =
-                let uu____560 = FStar_Tests_Util.nm minus1  in
-                FStar_Tests_Util.app uu____560 [t1; t2]  in
+                let uu____560 = FStar_Tests_Util.nm minus1 in
+                FStar_Tests_Util.app uu____560 [t1; t2] in
               FStar_Syntax_Subst.subst
                 [FStar_Syntax_Syntax.NM (minus1, (Prims.parse_int "0"))]
-                uu____559
-               in
-            ((true, [lb]), uu____558)  in
-          FStar_Syntax_Syntax.Tm_let uu____545  in
-        FStar_Syntax_Syntax.mk uu____544  in
+                uu____559 in
+            ((true, [lb]), uu____558) in
+          FStar_Syntax_Syntax.Tm_let uu____545 in
+        FStar_Syntax_Syntax.mk uu____544 in
       uu____541 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let (encode_nat : Prims.int -> FStar_Syntax_Syntax.term) =
+let encode_nat: Prims.int -> FStar_Syntax_Syntax.term =
   fun n1  ->
     let rec aux out n2 =
       if n2 = (Prims.parse_int "0")
       then out
       else
-        (let uu____585 = snat out  in
-         aux uu____585 (n2 - (Prims.parse_int "1")))
-       in
+        (let uu____585 = snat out in
+         aux uu____585 (n2 - (Prims.parse_int "1"))) in
     aux znat n1
-  
-let (run :
+let run:
   Prims.int ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.unit)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.unit
   =
   fun i  ->
     fun r  ->
       fun expected  ->
-        (let uu____596 = FStar_Util.string_of_int i  in
+        (let uu____596 = FStar_Util.string_of_int i in
          FStar_Util.print1 "%s: ... \n" uu____596);
-        (let tcenv = FStar_Tests_Pars.init ()  in
-         (let uu____599 = FStar_Main.process_args ()  in
+        (let tcenv = FStar_Tests_Pars.init () in
+         (let uu____599 = FStar_Main.process_args () in
           FStar_All.pipe_right uu____599 FStar_Pervasives.ignore);
          (let x1 =
             FStar_TypeChecker_Normalize.normalize
               [FStar_TypeChecker_Normalize.Beta;
               FStar_TypeChecker_Normalize.UnfoldUntil
                 FStar_Syntax_Syntax.Delta_constant;
-              FStar_TypeChecker_Normalize.Primops] tcenv r
-             in
+              FStar_TypeChecker_Normalize.Primops] tcenv r in
           FStar_Options.init ();
           FStar_Options.set_option "print_universes"
             (FStar_Options.Bool true);
           FStar_Options.set_option "print_implicits"
             (FStar_Options.Bool true);
           (let uu____622 =
-             let uu____623 = FStar_Syntax_Util.unascribe x1  in
-             FStar_Tests_Util.term_eq uu____623 expected  in
+             let uu____623 = FStar_Syntax_Util.unascribe x1 in
+             FStar_Tests_Util.term_eq uu____623 expected in
            FStar_Tests_Util.always i uu____622)))
-  
-let (run_all : Prims.unit -> Prims.unit) =
+let run_all: Prims.unit -> Prims.unit =
   fun uu____626  ->
     FStar_Util.print_string "Testing the normalizer\n";
     FStar_Tests_Pars.pars_and_tc_fragment
@@ -302,36 +278,36 @@ let (run_all : Prims.unit -> Prims.unit) =
        let uu____635 =
          let uu____638 =
            let uu____641 =
-             let uu____644 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
-             [uu____644]  in
-           id :: uu____641  in
-         one :: uu____638  in
-       FStar_Tests_Util.app apply uu____635  in
-     let uu____645 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+             let uu____644 = FStar_Tests_Util.nm FStar_Tests_Util.n in
+             [uu____644] in
+           id :: uu____641 in
+         one :: uu____638 in
+       FStar_Tests_Util.app apply uu____635 in
+     let uu____645 = FStar_Tests_Util.nm FStar_Tests_Util.n in
      run (Prims.parse_int "0") uu____634 uu____645);
     (let uu____647 =
        let uu____648 =
          let uu____651 =
-           let uu____654 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+           let uu____654 = FStar_Tests_Util.nm FStar_Tests_Util.n in
            let uu____655 =
-             let uu____658 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
-             [uu____658]  in
-           uu____654 :: uu____655  in
-         tt :: uu____651  in
-       FStar_Tests_Util.app apply uu____648  in
-     let uu____659 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+             let uu____658 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+             [uu____658] in
+           uu____654 :: uu____655 in
+         tt :: uu____651 in
+       FStar_Tests_Util.app apply uu____648 in
+     let uu____659 = FStar_Tests_Util.nm FStar_Tests_Util.n in
      run (Prims.parse_int "1") uu____647 uu____659);
     (let uu____661 =
        let uu____662 =
          let uu____665 =
-           let uu____668 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+           let uu____668 = FStar_Tests_Util.nm FStar_Tests_Util.n in
            let uu____669 =
-             let uu____672 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
-             [uu____672]  in
-           uu____668 :: uu____669  in
-         ff :: uu____665  in
-       FStar_Tests_Util.app apply uu____662  in
-     let uu____673 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
+             let uu____672 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+             [uu____672] in
+           uu____668 :: uu____669 in
+         ff :: uu____665 in
+       FStar_Tests_Util.app apply uu____662 in
+     let uu____673 = FStar_Tests_Util.nm FStar_Tests_Util.m in
      run (Prims.parse_int "2") uu____661 uu____673);
     (let uu____675 =
        let uu____676 =
@@ -341,161 +317,157 @@ let (run_all : Prims.unit -> Prims.unit) =
                let uu____688 =
                  let uu____691 =
                    let uu____694 =
-                     let uu____697 = FStar_Tests_Util.nm FStar_Tests_Util.n
-                        in
+                     let uu____697 = FStar_Tests_Util.nm FStar_Tests_Util.n in
                      let uu____698 =
-                       let uu____701 = FStar_Tests_Util.nm FStar_Tests_Util.m
-                          in
-                       [uu____701]  in
-                     uu____697 :: uu____698  in
-                   ff :: uu____694  in
-                 apply :: uu____691  in
-               apply :: uu____688  in
-             apply :: uu____685  in
-           apply :: uu____682  in
-         apply :: uu____679  in
-       FStar_Tests_Util.app apply uu____676  in
-     let uu____702 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
+                       let uu____701 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+                       [uu____701] in
+                     uu____697 :: uu____698 in
+                   ff :: uu____694 in
+                 apply :: uu____691 in
+               apply :: uu____688 in
+             apply :: uu____685 in
+           apply :: uu____682 in
+         apply :: uu____679 in
+       FStar_Tests_Util.app apply uu____676 in
+     let uu____702 = FStar_Tests_Util.nm FStar_Tests_Util.m in
      run (Prims.parse_int "3") uu____675 uu____702);
     (let uu____704 =
        let uu____705 =
          let uu____708 =
            let uu____711 =
-             let uu____714 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+             let uu____714 = FStar_Tests_Util.nm FStar_Tests_Util.n in
              let uu____715 =
-               let uu____718 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
-               [uu____718]  in
-             uu____714 :: uu____715  in
-           ff :: uu____711  in
-         apply :: uu____708  in
-       FStar_Tests_Util.app twice uu____705  in
-     let uu____719 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
+               let uu____718 = FStar_Tests_Util.nm FStar_Tests_Util.m in
+               [uu____718] in
+             uu____714 :: uu____715 in
+           ff :: uu____711 in
+         apply :: uu____708 in
+       FStar_Tests_Util.app twice uu____705 in
+     let uu____719 = FStar_Tests_Util.nm FStar_Tests_Util.m in
      run (Prims.parse_int "4") uu____704 uu____719);
-    (let uu____721 = minus one z  in run (Prims.parse_int "5") uu____721 one);
-    (let uu____723 = FStar_Tests_Util.app pred [one]  in
+    (let uu____721 = minus one z in run (Prims.parse_int "5") uu____721 one);
+    (let uu____723 = FStar_Tests_Util.app pred [one] in
      run (Prims.parse_int "6") uu____723 z);
-    (let uu____725 = minus one one  in run (Prims.parse_int "7") uu____725 z);
-    (let uu____727 = FStar_Tests_Util.app mul [one; one]  in
+    (let uu____725 = minus one one in run (Prims.parse_int "7") uu____725 z);
+    (let uu____727 = FStar_Tests_Util.app mul [one; one] in
      run (Prims.parse_int "8") uu____727 one);
-    (let uu____729 = FStar_Tests_Util.app mul [two; one]  in
+    (let uu____729 = FStar_Tests_Util.app mul [two; one] in
      run (Prims.parse_int "9") uu____729 two);
     (let uu____731 =
        let uu____732 =
-         let uu____735 = FStar_Tests_Util.app succ [one]  in [uu____735; one]
-          in
-       FStar_Tests_Util.app mul uu____732  in
+         let uu____735 = FStar_Tests_Util.app succ [one] in [uu____735; one] in
+       FStar_Tests_Util.app mul uu____732 in
      run (Prims.parse_int "10") uu____731 two);
     (let uu____741 =
-       let uu____742 = encode (Prims.parse_int "10")  in
-       let uu____743 = encode (Prims.parse_int "10")  in
-       minus uu____742 uu____743  in
+       let uu____742 = encode (Prims.parse_int "10") in
+       let uu____743 = encode (Prims.parse_int "10") in
+       minus uu____742 uu____743 in
      run (Prims.parse_int "11") uu____741 z);
     (let uu____747 =
-       let uu____748 = encode (Prims.parse_int "100")  in
-       let uu____749 = encode (Prims.parse_int "100")  in
-       minus uu____748 uu____749  in
+       let uu____748 = encode (Prims.parse_int "100") in
+       let uu____749 = encode (Prims.parse_int "100") in
+       minus uu____748 uu____749 in
      run (Prims.parse_int "12") uu____747 z);
     (let uu____753 =
-       let uu____754 = encode (Prims.parse_int "100")  in
+       let uu____754 = encode (Prims.parse_int "100") in
        let uu____755 =
-         let uu____756 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-         let uu____757 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-         minus uu____756 uu____757  in
-       let_ FStar_Tests_Util.x uu____754 uu____755  in
+         let uu____756 = FStar_Tests_Util.nm FStar_Tests_Util.x in
+         let uu____757 = FStar_Tests_Util.nm FStar_Tests_Util.x in
+         minus uu____756 uu____757 in
+       let_ FStar_Tests_Util.x uu____754 uu____755 in
      run (Prims.parse_int "13") uu____753 z);
     (let uu____761 =
-       let uu____762 = FStar_Tests_Util.app succ [one]  in
+       let uu____762 = FStar_Tests_Util.app succ [one] in
        let uu____763 =
          let uu____764 =
            let uu____765 =
-             let uu____768 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
+             let uu____768 = FStar_Tests_Util.nm FStar_Tests_Util.x in
              let uu____769 =
-               let uu____772 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-               [uu____772]  in
-             uu____768 :: uu____769  in
-           FStar_Tests_Util.app mul uu____765  in
+               let uu____772 = FStar_Tests_Util.nm FStar_Tests_Util.x in
+               [uu____772] in
+             uu____768 :: uu____769 in
+           FStar_Tests_Util.app mul uu____765 in
          let uu____773 =
            let uu____774 =
              let uu____775 =
-               let uu____778 = FStar_Tests_Util.nm FStar_Tests_Util.y  in
+               let uu____778 = FStar_Tests_Util.nm FStar_Tests_Util.y in
                let uu____779 =
-                 let uu____782 = FStar_Tests_Util.nm FStar_Tests_Util.y  in
-                 [uu____782]  in
-               uu____778 :: uu____779  in
-             FStar_Tests_Util.app mul uu____775  in
+                 let uu____782 = FStar_Tests_Util.nm FStar_Tests_Util.y in
+                 [uu____782] in
+               uu____778 :: uu____779 in
+             FStar_Tests_Util.app mul uu____775 in
            let uu____783 =
-             let uu____784 = FStar_Tests_Util.nm FStar_Tests_Util.h  in
-             let uu____785 = FStar_Tests_Util.nm FStar_Tests_Util.h  in
-             minus uu____784 uu____785  in
-           let_ FStar_Tests_Util.h uu____774 uu____783  in
-         let_ FStar_Tests_Util.y uu____764 uu____773  in
-       let_ FStar_Tests_Util.x uu____762 uu____763  in
+             let uu____784 = FStar_Tests_Util.nm FStar_Tests_Util.h in
+             let uu____785 = FStar_Tests_Util.nm FStar_Tests_Util.h in
+             minus uu____784 uu____785 in
+           let_ FStar_Tests_Util.h uu____774 uu____783 in
+         let_ FStar_Tests_Util.y uu____764 uu____773 in
+       let_ FStar_Tests_Util.x uu____762 uu____763 in
      run (Prims.parse_int "14") uu____761 z);
     (let uu____789 =
-       let uu____790 = FStar_Tests_Util.app succ [one]  in
+       let uu____790 = FStar_Tests_Util.app succ [one] in
        let uu____793 =
          let uu____794 =
            let uu____797 =
-             let uu____800 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
+             let uu____800 = FStar_Tests_Util.nm FStar_Tests_Util.x in
              let uu____801 =
-               let uu____804 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-               [uu____804]  in
-             uu____800 :: uu____801  in
-           FStar_Tests_Util.app mul uu____797  in
+               let uu____804 = FStar_Tests_Util.nm FStar_Tests_Util.x in
+               [uu____804] in
+             uu____800 :: uu____801 in
+           FStar_Tests_Util.app mul uu____797 in
          let uu____805 =
            let uu____806 =
              let uu____809 =
-               let uu____812 = FStar_Tests_Util.nm FStar_Tests_Util.y  in
+               let uu____812 = FStar_Tests_Util.nm FStar_Tests_Util.y in
                let uu____813 =
-                 let uu____816 = FStar_Tests_Util.nm FStar_Tests_Util.y  in
-                 [uu____816]  in
-               uu____812 :: uu____813  in
-             FStar_Tests_Util.app mul uu____809  in
+                 let uu____816 = FStar_Tests_Util.nm FStar_Tests_Util.y in
+                 [uu____816] in
+               uu____812 :: uu____813 in
+             FStar_Tests_Util.app mul uu____809 in
            let uu____817 =
-             let uu____818 = FStar_Tests_Util.nm FStar_Tests_Util.h  in
-             let uu____819 = FStar_Tests_Util.nm FStar_Tests_Util.h  in
-             minus uu____818 uu____819  in
-           mk_let FStar_Tests_Util.h uu____806 uu____817  in
-         mk_let FStar_Tests_Util.y uu____794 uu____805  in
-       mk_let FStar_Tests_Util.x uu____790 uu____793  in
+             let uu____818 = FStar_Tests_Util.nm FStar_Tests_Util.h in
+             let uu____819 = FStar_Tests_Util.nm FStar_Tests_Util.h in
+             minus uu____818 uu____819 in
+           mk_let FStar_Tests_Util.h uu____806 uu____817 in
+         mk_let FStar_Tests_Util.y uu____794 uu____805 in
+       mk_let FStar_Tests_Util.x uu____790 uu____793 in
      run (Prims.parse_int "15") uu____789 z);
     (let uu____823 =
-       let uu____824 = let uu____827 = snat znat  in snat uu____827  in
-       pred_nat uu____824  in
-     let uu____828 = snat znat  in
+       let uu____824 = let uu____827 = snat znat in snat uu____827 in
+       pred_nat uu____824 in
+     let uu____828 = snat znat in
      run (Prims.parse_int "16") uu____823 uu____828);
     (let uu____830 =
-       let uu____831 = let uu____832 = snat znat  in snat uu____832  in
-       let uu____833 = snat znat  in minus_nat uu____831 uu____833  in
-     let uu____834 = snat znat  in
+       let uu____831 = let uu____832 = snat znat in snat uu____832 in
+       let uu____833 = snat znat in minus_nat uu____831 uu____833 in
+     let uu____834 = snat znat in
      run (Prims.parse_int "17") uu____830 uu____834);
     (let uu____836 =
-       let uu____837 = encode_nat (Prims.parse_int "100")  in
-       let uu____838 = encode_nat (Prims.parse_int "100")  in
-       minus_nat uu____837 uu____838  in
+       let uu____837 = encode_nat (Prims.parse_int "100") in
+       let uu____838 = encode_nat (Prims.parse_int "100") in
+       minus_nat uu____837 uu____838 in
      run (Prims.parse_int "18") uu____836 znat);
     (let uu____840 =
-       let uu____841 = encode_nat (Prims.parse_int "10000")  in
-       let uu____842 = encode_nat (Prims.parse_int "10000")  in
-       minus_nat uu____841 uu____842  in
+       let uu____841 = encode_nat (Prims.parse_int "10000") in
+       let uu____842 = encode_nat (Prims.parse_int "10000") in
+       minus_nat uu____841 uu____842 in
      run (Prims.parse_int "19") uu____840 znat);
     (let uu____844 =
-       let uu____845 = encode_nat (Prims.parse_int "10")  in
-       let uu____846 = encode_nat (Prims.parse_int "10")  in
-       minus_nat uu____845 uu____846  in
+       let uu____845 = encode_nat (Prims.parse_int "10") in
+       let uu____846 = encode_nat (Prims.parse_int "10") in
+       minus_nat uu____845 uu____846 in
      run (Prims.parse_int "20") uu____844 znat);
     FStar_Options.__clear_unit_tests ();
-    (let uu____849 = FStar_Tests_Pars.tc "recons [0;1]"  in
-     let uu____850 = FStar_Tests_Pars.tc "[0;1]"  in
+    (let uu____849 = FStar_Tests_Pars.tc "recons [0;1]" in
+     let uu____850 = FStar_Tests_Pars.tc "[0;1]" in
      run (Prims.parse_int "21") uu____849 uu____850);
-    (let uu____852 = FStar_Tests_Pars.tc "copy [0;1]"  in
-     let uu____853 = FStar_Tests_Pars.tc "[0;1]"  in
+    (let uu____852 = FStar_Tests_Pars.tc "copy [0;1]" in
+     let uu____853 = FStar_Tests_Pars.tc "[0;1]" in
      run (Prims.parse_int "22") uu____852 uu____853);
-    (let uu____855 = FStar_Tests_Pars.tc "rev [0;1;2;3;4;5;6;7;8;9;10]"  in
-     let uu____856 = FStar_Tests_Pars.tc "[10;9;8;7;6;5;4;3;2;1;0]"  in
+    (let uu____855 = FStar_Tests_Pars.tc "rev [0;1;2;3;4;5;6;7;8;9;10]" in
+     let uu____856 = FStar_Tests_Pars.tc "[10;9;8;7;6;5;4;3;2;1;0]" in
      run (Prims.parse_int "23") uu____855 uu____856);
-    (let uu____858 = FStar_Tests_Pars.tc "f (B 5 3)"  in
-     let uu____859 = FStar_Tests_Pars.tc "2"  in
+    (let uu____858 = FStar_Tests_Pars.tc "f (B 5 3)" in
+     let uu____859 = FStar_Tests_Pars.tc "2" in
      run (Prims.parse_int "1062") uu____858 uu____859);
     FStar_Util.print_string "Normalizer ok\n"
-  

--- a/src/ocaml-output/FStar_Tests_Pars.ml
+++ b/src/ocaml-output/FStar_Tests_Pars.ml
@@ -1,11 +1,11 @@
 open Prims
-let (test_lid : FStar_Ident.lident) =
-  FStar_Ident.lid_of_path ["Test"] FStar_Range.dummyRange 
-let (tcenv_ref :
-  FStar_TypeChecker_Env.env FStar_Pervasives_Native.option FStar_ST.ref) =
-  FStar_Util.mk_ref FStar_Pervasives_Native.None 
-let (test_mod_ref :
-  FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option FStar_ST.ref) =
+let test_lid: FStar_Ident.lident =
+  FStar_Ident.lid_of_path ["Test"] FStar_Range.dummyRange
+let tcenv_ref:
+  FStar_TypeChecker_Env.env FStar_Pervasives_Native.option FStar_ST.ref =
+  FStar_Util.mk_ref FStar_Pervasives_Native.None
+let test_mod_ref:
+  FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option FStar_ST.ref =
   FStar_Util.mk_ref
     (FStar_Pervasives_Native.Some
        {
@@ -14,51 +14,45 @@ let (test_mod_ref :
          FStar_Syntax_Syntax.exports = [];
          FStar_Syntax_Syntax.is_interface = false
        })
-  
-let (parse_mod :
+let parse_mod:
   FStar_Parser_ParseIt.filename ->
     FStar_ToSyntax_Env.env ->
       (FStar_ToSyntax_Env.env,FStar_Syntax_Syntax.modul)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun mod_name1  ->
     fun dsenv  ->
       let uu____45 =
-        FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Filename mod_name1)
-         in
+        FStar_Parser_ParseIt.parse (FStar_Parser_ParseIt.Filename mod_name1) in
       match uu____45 with
       | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inl m,uu____51) ->
           let uu____72 =
-            let uu____77 = FStar_ToSyntax_ToSyntax.ast_modul_to_modul m  in
-            uu____77 dsenv  in
+            let uu____77 = FStar_ToSyntax_ToSyntax.ast_modul_to_modul m in
+            uu____77 dsenv in
           (match uu____72 with
            | (m1,env') ->
                let uu____88 =
                  let uu____93 =
-                   FStar_Ident.lid_of_path ["Test"] FStar_Range.dummyRange
-                    in
+                   FStar_Ident.lid_of_path ["Test"] FStar_Range.dummyRange in
                  FStar_ToSyntax_Env.prepare_module_or_interface false false
-                   env' uu____93 FStar_ToSyntax_Env.default_mii
-                  in
+                   env' uu____93 FStar_ToSyntax_Env.default_mii in
                (match uu____88 with | (env'1,uu____99) -> (env'1, m1)))
       | FStar_Parser_ParseIt.ParseError (err,msg,r) ->
           FStar_Exn.raise (FStar_Errors.Error (err, msg, r))
       | FStar_Parser_ParseIt.ASTFragment (FStar_Util.Inr uu____107,uu____108)
           ->
-          let msg = FStar_Util.format1 "%s: expected a module\n" mod_name1
-             in
+          let msg = FStar_Util.format1 "%s: expected a module\n" mod_name1 in
           FStar_Errors.raise_error (FStar_Errors.Fatal_ModuleExpected, msg)
             FStar_Range.dummyRange
       | FStar_Parser_ParseIt.Term uu____136 ->
           failwith
             "Impossible: parsing a Filename always results in an ASTFragment"
-  
-let (add_mods :
+let add_mods:
   FStar_Parser_ParseIt.filename Prims.list ->
     FStar_ToSyntax_Env.env ->
       FStar_TypeChecker_Env.env ->
         (FStar_ToSyntax_Env.env,FStar_TypeChecker_Env.env)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun mod_names  ->
     fun dsenv  ->
@@ -68,35 +62,32 @@ let (add_mods :
              fun mod_name1  ->
                match uu____172 with
                | (dsenv1,env1) ->
-                   let uu____184 = parse_mod mod_name1 dsenv1  in
+                   let uu____184 = parse_mod mod_name1 dsenv1 in
                    (match uu____184 with
                     | (dsenv2,string_mod) ->
                         let uu____195 =
-                          FStar_TypeChecker_Tc.check_module env1 string_mod
-                           in
+                          FStar_TypeChecker_Tc.check_module env1 string_mod in
                         (match uu____195 with | (_mod,env2) -> (dsenv2, env2))))
           (dsenv, env) mod_names
-  
-let (init_once : Prims.unit -> Prims.unit) =
+let init_once: Prims.unit -> Prims.unit =
   fun uu____208  ->
-    let solver1 = FStar_SMTEncoding_Solver.dummy  in
+    let solver1 = FStar_SMTEncoding_Solver.dummy in
     let env =
       FStar_TypeChecker_Env.initial_env FStar_Parser_Dep.empty_deps
         FStar_TypeChecker_TcTerm.tc_term
         FStar_TypeChecker_TcTerm.type_of_tot_term
         FStar_TypeChecker_TcTerm.universe_of
         FStar_TypeChecker_TcTerm.check_type_of_well_typed_term solver1
-        FStar_Parser_Const.prims_lid
-       in
+        FStar_Parser_Const.prims_lid in
     (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.init env;
     (let uu____212 =
-       let uu____217 = FStar_Options.prims ()  in
-       let uu____218 = FStar_ToSyntax_Env.empty_env ()  in
-       parse_mod uu____217 uu____218  in
+       let uu____217 = FStar_Options.prims () in
+       let uu____218 = FStar_ToSyntax_Env.empty_env () in
+       parse_mod uu____217 uu____218 in
      match uu____212 with
      | (dsenv,prims_mod) ->
          let env1 =
-           let uu___51_222 = env  in
+           let uu___51_222 = env in
            {
              FStar_TypeChecker_Env.solver =
                (uu___51_222.FStar_TypeChecker_Env.solver);
@@ -167,41 +158,37 @@ let (init_once : Prims.unit -> Prims.unit) =
              FStar_TypeChecker_Env.dsenv = dsenv;
              FStar_TypeChecker_Env.dep_graph =
                (uu___51_222.FStar_TypeChecker_Env.dep_graph)
-           }  in
-         let uu____223 = FStar_TypeChecker_Tc.check_module env1 prims_mod  in
+           } in
+         let uu____223 = FStar_TypeChecker_Tc.check_module env1 prims_mod in
          (match uu____223 with
           | (_prims_mod,env2) ->
               let env3 =
-                FStar_TypeChecker_Env.set_current_module env2 test_lid  in
+                FStar_TypeChecker_Env.set_current_module env2 test_lid in
               FStar_ST.op_Colon_Equals tcenv_ref
                 (FStar_Pervasives_Native.Some env3)))
-  
-let rec (init : Prims.unit -> FStar_TypeChecker_Env.env) =
+let rec init: Prims.unit -> FStar_TypeChecker_Env.env =
   fun uu____256  ->
-    let uu____257 = FStar_ST.op_Bang tcenv_ref  in
+    let uu____257 = FStar_ST.op_Bang tcenv_ref in
     match uu____257 with
     | FStar_Pervasives_Native.Some f -> f
     | uu____284 -> (init_once (); init ())
-  
-let (frag_of_text : Prims.string -> FStar_Parser_ParseIt.input_frag) =
+let frag_of_text: Prims.string -> FStar_Parser_ParseIt.input_frag =
   fun s  ->
     {
       FStar_Parser_ParseIt.frag_text = s;
       FStar_Parser_ParseIt.frag_line = (Prims.parse_int "1");
       FStar_Parser_ParseIt.frag_col = (Prims.parse_int "0")
     }
-  
-let (pars : Prims.string -> FStar_Syntax_Syntax.term) =
+let pars: Prims.string -> FStar_Syntax_Syntax.term =
   fun s  ->
     try
-      let tcenv = init ()  in
+      let tcenv = init () in
       let uu____300 =
         let uu____301 =
           FStar_All.pipe_left
             (fun _0_40  -> FStar_Parser_ParseIt.Fragment _0_40)
-            (frag_of_text s)
-           in
-        FStar_Parser_ParseIt.parse uu____301  in
+            (frag_of_text s) in
+        FStar_Parser_ParseIt.parse uu____301 in
       match uu____300 with
       | FStar_Parser_ParseIt.Term t ->
           FStar_ToSyntax_ToSyntax.desugar_term
@@ -212,15 +199,14 @@ let (pars : Prims.string -> FStar_Syntax_Syntax.term) =
           failwith "Impossible: parsing a Fragment always results in a Term"
     with
     | e when
-        let uu____321 = FStar_Options.trace_error ()  in
+        let uu____321 = FStar_Options.trace_error () in
         Prims.op_Negation uu____321 -> FStar_Exn.raise e
-  
-let (tc : Prims.string -> FStar_Syntax_Syntax.term) =
+let tc: Prims.string -> FStar_Syntax_Syntax.term =
   fun s  ->
-    let tm = pars s  in
-    let tcenv = init ()  in
+    let tm = pars s in
+    let tcenv = init () in
     let tcenv1 =
-      let uu___54_328 = tcenv  in
+      let uu___54_328 = tcenv in
       {
         FStar_TypeChecker_Env.solver =
           (uu___54_328.FStar_TypeChecker_Env.solver);
@@ -290,39 +276,36 @@ let (tc : Prims.string -> FStar_Syntax_Syntax.term) =
           (uu___54_328.FStar_TypeChecker_Env.dsenv);
         FStar_TypeChecker_Env.dep_graph =
           (uu___54_328.FStar_TypeChecker_Env.dep_graph)
-      }  in
-    let uu____329 = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm
-       in
+      } in
+    let uu____329 = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm in
     match uu____329 with | (tm1,uu____337,uu____338) -> tm1
-  
-let (pars_and_tc_fragment : Prims.string -> Prims.unit) =
+let pars_and_tc_fragment: Prims.string -> Prims.unit =
   fun s  ->
     FStar_Options.set_option "trace_error" (FStar_Options.Bool true);
     (let report uu____346 =
-       let uu____347 = FStar_Errors.report_all ()  in
-       FStar_All.pipe_right uu____347 FStar_Pervasives.ignore  in
+       let uu____347 = FStar_Errors.report_all () in
+       FStar_All.pipe_right uu____347 FStar_Pervasives.ignore in
      try
-       let tcenv = init ()  in
-       let frag = frag_of_text s  in
+       let tcenv = init () in
+       let frag = frag_of_text s in
        try
          let uu____370 =
-           let uu____377 = FStar_ST.op_Bang test_mod_ref  in
-           FStar_Universal.tc_one_fragment uu____377 tcenv frag  in
+           let uu____377 = FStar_ST.op_Bang test_mod_ref in
+           FStar_Universal.tc_one_fragment uu____377 tcenv frag in
          match uu____370 with
          | (test_mod',tcenv') ->
              (FStar_ST.op_Colon_Equals test_mod_ref test_mod';
               FStar_ST.op_Colon_Equals tcenv_ref
                 (FStar_Pervasives_Native.Some tcenv');
-              (let n1 = FStar_Errors.get_err_count ()  in
+              (let n1 = FStar_Errors.get_err_count () in
                if n1 <> (Prims.parse_int "0")
                then
                  (report ();
                   (let uu____459 =
                      let uu____464 =
-                       let uu____465 = FStar_Util.string_of_int n1  in
-                       FStar_Util.format1 "%s errors were reported" uu____465
-                        in
-                     (FStar_Errors.Fatal_ErrorsReported, uu____464)  in
+                       let uu____465 = FStar_Util.string_of_int n1 in
+                       FStar_Util.format1 "%s errors were reported" uu____465 in
+                     (FStar_Errors.Fatal_ErrorsReported, uu____464) in
                    FStar_Errors.raise_err uu____459))
                else ()))
        with
@@ -333,6 +316,5 @@ let (pars_and_tc_fragment : Prims.string -> Prims.unit) =
                 (Prims.strcat "tc_one_fragment failed: " s)))
      with
      | e when
-         let uu____477 = FStar_Options.trace_error ()  in
+         let uu____477 = FStar_Options.trace_error () in
          Prims.op_Negation uu____477 -> FStar_Exn.raise e)
-  

--- a/src/ocaml-output/FStar_Tests_Test.ml
+++ b/src/ocaml-output/FStar_Tests_Test.ml
@@ -1,21 +1,20 @@
 open Prims
-let main : 'Auu____4 'Auu____5 . 'Auu____5 -> 'Auu____4 =
+let main: 'Auu____4 'Auu____5 . 'Auu____5 -> 'Auu____4 =
   fun argv  ->
     FStar_Util.print_string "Initializing ...\n";
     (try
-       (let uu____17 = FStar_Tests_Pars.init ()  in
+       (let uu____17 = FStar_Tests_Pars.init () in
         FStar_All.pipe_right uu____17 FStar_Pervasives.ignore);
        FStar_Tests_Norm.run_all ();
        FStar_Tests_Unif.run_all ();
        FStar_All.exit (Prims.parse_int "0")
      with
      | FStar_Errors.Error (err,msg,r) when
-         let uu____29 = FStar_Options.trace_error ()  in
+         let uu____29 = FStar_Options.trace_error () in
          FStar_All.pipe_left Prims.op_Negation uu____29 ->
          (if r = FStar_Range.dummyRange
           then FStar_Util.print_string msg
           else
-            (let uu____32 = FStar_Range.string_of_range r  in
+            (let uu____32 = FStar_Range.string_of_range r in
              FStar_Util.print2 "%s: %s\n" uu____32 msg);
           FStar_All.exit (Prims.parse_int "1")))
-  

--- a/src/ocaml-output/FStar_Tests_Unif.ml
+++ b/src/ocaml-output/FStar_Tests_Unif.ml
@@ -1,19 +1,17 @@
 open Prims
-let (tcenv : Prims.unit -> FStar_TypeChecker_Env.env) =
-  fun uu____3  -> FStar_Tests_Pars.init () 
-let (guard_to_string :
-  FStar_TypeChecker_Common.guard_formula -> Prims.string) =
+let tcenv: Prims.unit -> FStar_TypeChecker_Env.env =
+  fun uu____3  -> FStar_Tests_Pars.init ()
+let guard_to_string: FStar_TypeChecker_Common.guard_formula -> Prims.string =
   fun g  ->
     match g with
     | FStar_TypeChecker_Common.Trivial  -> "trivial"
     | FStar_TypeChecker_Common.NonTrivial f ->
-        let uu____8 = tcenv ()  in
+        let uu____8 = tcenv () in
         FStar_TypeChecker_Normalize.term_to_string uu____8 f
-  
-let (guard_eq :
+let guard_eq:
   Prims.int ->
     FStar_TypeChecker_Common.guard_formula ->
-      FStar_TypeChecker_Common.guard_formula -> Prims.unit)
+      FStar_TypeChecker_Common.guard_formula -> Prims.unit
   =
   fun i  ->
     fun g  ->
@@ -25,127 +23,117 @@ let (guard_eq :
           | (FStar_TypeChecker_Common.NonTrivial
              f,FStar_TypeChecker_Common.NonTrivial f') ->
               let f1 =
-                let uu____34 = tcenv ()  in
+                let uu____34 = tcenv () in
                 FStar_TypeChecker_Normalize.normalize
-                  [FStar_TypeChecker_Normalize.EraseUniverses] uu____34 f
-                 in
+                  [FStar_TypeChecker_Normalize.EraseUniverses] uu____34 f in
               let f'1 =
-                let uu____36 = tcenv ()  in
+                let uu____36 = tcenv () in
                 FStar_TypeChecker_Normalize.normalize
-                  [FStar_TypeChecker_Normalize.EraseUniverses] uu____36 f'
-                 in
-              let uu____37 = FStar_Tests_Util.term_eq f1 f'1  in
+                  [FStar_TypeChecker_Normalize.EraseUniverses] uu____36 f' in
+              let uu____37 = FStar_Tests_Util.term_eq f1 f'1 in
               (uu____37, (FStar_TypeChecker_Common.NonTrivial f1),
                 (FStar_TypeChecker_Common.NonTrivial f'1))
-          | uu____38 -> (false, g, g')  in
+          | uu____38 -> (false, g, g') in
         match uu____18 with
         | (b,g1,g'1) ->
             if Prims.op_Negation b
             then
               let msg =
-                let uu____47 = FStar_Util.string_of_int i  in
-                let uu____48 = guard_to_string g'1  in
-                let uu____49 = guard_to_string g1  in
+                let uu____47 = FStar_Util.string_of_int i in
+                let uu____48 = guard_to_string g'1 in
+                let uu____49 = guard_to_string g1 in
                 FStar_Util.format3
                   "Test %s failed:\n\tExpected guard %s;\n\tGot guard      %s\n"
-                  uu____47 uu____48 uu____49
-                 in
+                  uu____47 uu____48 uu____49 in
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnexpectedGuard, msg)
                 FStar_Range.dummyRange
             else ()
-  
-let (unify :
+let unify:
   Prims.int ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
         FStar_TypeChecker_Common.guard_formula ->
-          (Prims.unit -> Prims.unit) -> Prims.unit)
+          (Prims.unit -> Prims.unit) -> Prims.unit
   =
   fun i  ->
     fun x1  ->
       fun y1  ->
         fun g'  ->
           fun check  ->
-            (let uu____72 = FStar_Util.string_of_int i  in
+            (let uu____72 = FStar_Util.string_of_int i in
              FStar_Util.print1 "%s ..." uu____72);
-            (let uu____74 = FStar_Main.process_args ()  in
+            (let uu____74 = FStar_Main.process_args () in
              FStar_All.pipe_right uu____74 FStar_Pervasives.ignore);
-            (let uu____94 = FStar_Syntax_Print.term_to_string x1  in
-             let uu____95 = FStar_Syntax_Print.term_to_string y1  in
+            (let uu____94 = FStar_Syntax_Print.term_to_string x1 in
+             let uu____95 = FStar_Syntax_Print.term_to_string y1 in
              FStar_Util.print2 "Unify %s\nand %s\n" uu____94 uu____95);
             (let g =
                let uu____97 =
-                 let uu____98 = tcenv ()  in
-                 FStar_TypeChecker_Rel.teq uu____98 x1 y1  in
+                 let uu____98 = tcenv () in
+                 FStar_TypeChecker_Rel.teq uu____98 x1 y1 in
                let uu____99 =
-                 let uu____102 = tcenv ()  in
-                 FStar_TypeChecker_Rel.solve_deferred_constraints uu____102
-                  in
-               FStar_All.pipe_right uu____97 uu____99  in
+                 let uu____102 = tcenv () in
+                 FStar_TypeChecker_Rel.solve_deferred_constraints uu____102 in
+               FStar_All.pipe_right uu____97 uu____99 in
              guard_eq i g.FStar_TypeChecker_Env.guard_f g';
              check ();
              FStar_Options.init ())
-  
-let (should_fail :
-  FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.unit) =
+let should_fail:
+  FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.unit =
   fun x1  ->
     fun y1  ->
       try
         let g =
           let uu____116 =
-            let uu____117 = tcenv ()  in
-            FStar_TypeChecker_Rel.teq uu____117 x1 y1  in
+            let uu____117 = tcenv () in
+            FStar_TypeChecker_Rel.teq uu____117 x1 y1 in
           let uu____118 =
-            let uu____121 = tcenv ()  in
-            FStar_TypeChecker_Rel.solve_deferred_constraints uu____121  in
-          FStar_All.pipe_right uu____116 uu____118  in
+            let uu____121 = tcenv () in
+            FStar_TypeChecker_Rel.solve_deferred_constraints uu____121 in
+          FStar_All.pipe_right uu____116 uu____118 in
         match g.FStar_TypeChecker_Env.guard_f with
         | FStar_TypeChecker_Common.Trivial  ->
             let uu____122 =
-              let uu____123 = FStar_Syntax_Print.term_to_string x1  in
-              let uu____124 = FStar_Syntax_Print.term_to_string y1  in
+              let uu____123 = FStar_Syntax_Print.term_to_string x1 in
+              let uu____124 = FStar_Syntax_Print.term_to_string y1 in
               FStar_Util.format2 "%s and %s should not be unifiable\n"
-                uu____123 uu____124
-               in
+                uu____123 uu____124 in
             failwith uu____122
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu____126 = FStar_Syntax_Print.term_to_string x1  in
-            let uu____127 = FStar_Syntax_Print.term_to_string y1  in
-            let uu____128 = FStar_Syntax_Print.term_to_string f  in
+            let uu____126 = FStar_Syntax_Print.term_to_string x1 in
+            let uu____127 = FStar_Syntax_Print.term_to_string y1 in
+            let uu____128 = FStar_Syntax_Print.term_to_string f in
             FStar_Util.print3 "%s and %s are unifiable if %s\n" uu____126
               uu____127 uu____128
       with | FStar_Errors.Error (e,msg,r) -> FStar_Util.print1 "%s\n" msg
-  
-let (unify' : Prims.string -> Prims.string -> Prims.unit) =
+let unify': Prims.string -> Prims.string -> Prims.unit =
   fun x1  ->
     fun y1  ->
-      let x2 = FStar_Tests_Pars.pars x1  in
-      let y2 = FStar_Tests_Pars.pars y1  in
+      let x2 = FStar_Tests_Pars.pars x1 in
+      let y2 = FStar_Tests_Pars.pars y1 in
       let g =
         let uu____146 =
-          let uu____147 = tcenv ()  in
-          FStar_TypeChecker_Rel.teq uu____147 x2 y2  in
+          let uu____147 = tcenv () in
+          FStar_TypeChecker_Rel.teq uu____147 x2 y2 in
         let uu____148 =
-          let uu____151 = tcenv ()  in
-          FStar_TypeChecker_Rel.solve_deferred_constraints uu____151  in
-        FStar_All.pipe_right uu____146 uu____148  in
-      let uu____152 = FStar_Syntax_Print.term_to_string x2  in
-      let uu____153 = FStar_Syntax_Print.term_to_string y2  in
-      let uu____154 = guard_to_string g.FStar_TypeChecker_Env.guard_f  in
+          let uu____151 = tcenv () in
+          FStar_TypeChecker_Rel.solve_deferred_constraints uu____151 in
+        FStar_All.pipe_right uu____146 uu____148 in
+      let uu____152 = FStar_Syntax_Print.term_to_string x2 in
+      let uu____153 = FStar_Syntax_Print.term_to_string y2 in
+      let uu____154 = guard_to_string g.FStar_TypeChecker_Env.guard_f in
       FStar_Util.print3 "%s and %s are unifiable with guard %s\n" uu____152
         uu____153 uu____154
-  
-let (norm : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let norm: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun t  ->
-    let uu____158 = tcenv ()  in
+    let uu____158 = tcenv () in
     FStar_TypeChecker_Normalize.normalize [] uu____158 t
-  
-let (inst :
+let inst:
   Prims.int ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.typ Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun n1  ->
     fun tm1  ->
@@ -155,260 +143,227 @@ let (inst :
         else
           (let uu____191 =
              FStar_TypeChecker_Rel.new_uvar FStar_Range.dummyRange []
-               FStar_Syntax_Util.ktype0
-              in
+               FStar_Syntax_Util.ktype0 in
            match uu____191 with
            | (t,uu____203) ->
                let uu____204 =
-                 FStar_TypeChecker_Rel.new_uvar FStar_Range.dummyRange [] t
-                  in
+                 FStar_TypeChecker_Rel.new_uvar FStar_Range.dummyRange [] t in
                (match uu____204 with
                 | (u,uu____216) ->
-                    aux (u :: out) (n2 - (Prims.parse_int "1"))))
-         in
-      let us = aux [] n1  in
+                    aux (u :: out) (n2 - (Prims.parse_int "1")))) in
+      let us = aux [] n1 in
       let uu____220 =
-        let uu____221 = FStar_Tests_Util.app tm1 us  in norm uu____221  in
+        let uu____221 = FStar_Tests_Util.app tm1 us in norm uu____221 in
       (uu____220, us)
-  
-let (run_all : Prims.unit -> Prims.unit) =
+let run_all: Prims.unit -> Prims.unit =
   fun uu____226  ->
     FStar_Util.print_string "Testing the unifier\n";
     FStar_Options.__set_unit_tests ();
-    (let unify_check n1 x1 y1 g f = unify n1 x1 y1 g f  in
-     let unify1 n1 x1 y1 g = unify n1 x1 y1 g (fun uu____264  -> ())  in
-     let int_t = FStar_Tests_Pars.tc "Prims.int"  in
+    (let unify_check n1 x1 y1 g f = unify n1 x1 y1 g f in
+     let unify1 n1 x1 y1 g = unify n1 x1 y1 g (fun uu____264  -> ()) in
+     let int_t = FStar_Tests_Pars.tc "Prims.int" in
      let x1 =
        let uu____267 =
-         FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None int_t
-          in
-       FStar_All.pipe_right uu____267 FStar_Syntax_Syntax.bv_to_name  in
+         FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None int_t in
+       FStar_All.pipe_right uu____267 FStar_Syntax_Syntax.bv_to_name in
      let y1 =
        let uu____269 =
-         FStar_Syntax_Syntax.gen_bv "y" FStar_Pervasives_Native.None int_t
-          in
-       FStar_All.pipe_right uu____269 FStar_Syntax_Syntax.bv_to_name  in
+         FStar_Syntax_Syntax.gen_bv "y" FStar_Pervasives_Native.None int_t in
+       FStar_All.pipe_right uu____269 FStar_Syntax_Syntax.bv_to_name in
      unify1 (Prims.parse_int "0") x1 x1 FStar_TypeChecker_Common.Trivial;
      (let uu____272 =
         let uu____273 =
           FStar_Syntax_Util.mk_eq2 FStar_Syntax_Syntax.U_zero
-            FStar_Syntax_Util.t_bool x1 y1
-           in
-        FStar_TypeChecker_Common.NonTrivial uu____273  in
+            FStar_Syntax_Util.t_bool x1 y1 in
+        FStar_TypeChecker_Common.NonTrivial uu____273 in
       unify1 (Prims.parse_int "1") x1 y1 uu____272);
-     (let id1 = FStar_Tests_Pars.tc "fun x -> x"  in
-      (let uu____276 = FStar_Tests_Util.app id1 [x1]  in
+     (let id1 = FStar_Tests_Pars.tc "fun x -> x" in
+      (let uu____276 = FStar_Tests_Util.app id1 [x1] in
        unify1 (Prims.parse_int "2") x1 uu____276
          FStar_TypeChecker_Common.Trivial);
-      (let id2 = FStar_Tests_Pars.tc "fun x -> x"  in
+      (let id2 = FStar_Tests_Pars.tc "fun x -> x" in
        unify1 (Prims.parse_int "3") id2 id2 FStar_TypeChecker_Common.Trivial;
-       (let id3 = FStar_Tests_Pars.tc "fun x -> x"  in
-        let id' = FStar_Tests_Pars.tc "fun y -> y"  in
+       (let id3 = FStar_Tests_Pars.tc "fun x -> x" in
+        let id' = FStar_Tests_Pars.tc "fun y -> y" in
         unify1 (Prims.parse_int "4") id3 id' FStar_TypeChecker_Common.Trivial;
-        (let uu____283 = FStar_Tests_Pars.tc "fun x y -> x"  in
-         let uu____284 = FStar_Tests_Pars.tc "fun a b -> a"  in
+        (let uu____283 = FStar_Tests_Pars.tc "fun x y -> x" in
+         let uu____284 = FStar_Tests_Pars.tc "fun a b -> a" in
          unify1 (Prims.parse_int "5") uu____283 uu____284
            FStar_TypeChecker_Common.Trivial);
-        (let uu____286 = FStar_Tests_Pars.tc "fun x y z -> y"  in
-         let uu____287 = FStar_Tests_Pars.tc "fun a b c -> b"  in
+        (let uu____286 = FStar_Tests_Pars.tc "fun x y z -> y" in
+         let uu____287 = FStar_Tests_Pars.tc "fun a b c -> b" in
          unify1 (Prims.parse_int "6") uu____286 uu____287
            FStar_TypeChecker_Common.Trivial);
-        (let uu____289 = FStar_Tests_Pars.tc "fun (x:int) (y:int) -> y"  in
-         let uu____290 = FStar_Tests_Pars.tc "fun (x:int) (y:int) -> x"  in
+        (let uu____289 = FStar_Tests_Pars.tc "fun (x:int) (y:int) -> y" in
+         let uu____290 = FStar_Tests_Pars.tc "fun (x:int) (y:int) -> x" in
          let uu____291 =
            let uu____292 =
-             FStar_Tests_Pars.tc "(forall (x:int). (forall (y:int). y==x))"
-              in
-           FStar_TypeChecker_Common.NonTrivial uu____292  in
+             FStar_Tests_Pars.tc "(forall (x:int). (forall (y:int). y==x))" in
+           FStar_TypeChecker_Common.NonTrivial uu____292 in
          unify1 (Prims.parse_int "7") uu____289 uu____290 uu____291);
         (let uu____294 =
-           FStar_Tests_Pars.tc "fun (x:int) (y:int) (z:int) -> y"  in
+           FStar_Tests_Pars.tc "fun (x:int) (y:int) (z:int) -> y" in
          let uu____295 =
-           FStar_Tests_Pars.tc "fun (x:int) (y:int) (z:int) -> z"  in
+           FStar_Tests_Pars.tc "fun (x:int) (y:int) (z:int) -> z" in
          let uu____296 =
            let uu____297 =
              FStar_Tests_Pars.tc
-               "(forall (x:int). (forall (y:int). (forall (z:int). y==z)))"
-              in
-           FStar_TypeChecker_Common.NonTrivial uu____297  in
+               "(forall (x:int). (forall (y:int). (forall (z:int). y==z)))" in
+           FStar_TypeChecker_Common.NonTrivial uu____297 in
          unify1 (Prims.parse_int "8") uu____294 uu____295 uu____296);
-        (let uu____299 = FStar_Main.process_args ()  in
+        (let uu____299 = FStar_Main.process_args () in
          FStar_All.pipe_right uu____299 FStar_Pervasives.ignore);
         (let uu____318 =
-           let uu____325 = FStar_Tests_Pars.tc "fun u x -> u x"  in
-           inst (Prims.parse_int "1") uu____325  in
+           let uu____325 = FStar_Tests_Pars.tc "fun u x -> u x" in
+           inst (Prims.parse_int "1") uu____325 in
          match uu____318 with
          | (tm1,us) ->
-             let sol = FStar_Tests_Pars.tc "fun x -> c_and x x"  in
+             let sol = FStar_Tests_Pars.tc "fun x -> c_and x x" in
              (unify_check (Prims.parse_int "9") tm1 sol
                 FStar_TypeChecker_Common.Trivial
                 (fun uu____338  ->
                    let uu____339 =
                      let uu____340 =
-                       let uu____341 = FStar_List.hd us  in norm uu____341
-                        in
-                     let uu____342 = norm sol  in
-                     FStar_Tests_Util.term_eq uu____340 uu____342  in
+                       let uu____341 = FStar_List.hd us in norm uu____341 in
+                     let uu____342 = norm sol in
+                     FStar_Tests_Util.term_eq uu____340 uu____342 in
                    FStar_Tests_Util.always (Prims.parse_int "9") uu____339);
               (let uu____343 =
-                 let uu____350 = FStar_Tests_Pars.tc "fun u x -> u x"  in
-                 inst (Prims.parse_int "1") uu____350  in
+                 let uu____350 = FStar_Tests_Pars.tc "fun u x -> u x" in
+                 inst (Prims.parse_int "1") uu____350 in
                match uu____343 with
                | (tm2,us1) ->
-                   let sol1 = FStar_Tests_Pars.tc "fun x y -> x + y"  in
+                   let sol1 = FStar_Tests_Pars.tc "fun x y -> x + y" in
                    (unify_check (Prims.parse_int "10") tm2 sol1
                       FStar_TypeChecker_Common.Trivial
                       (fun uu____363  ->
                          let uu____364 =
                            let uu____365 =
-                             let uu____366 = FStar_List.hd us1  in
-                             norm uu____366  in
-                           let uu____367 = norm sol1  in
-                           FStar_Tests_Util.term_eq uu____365 uu____367  in
+                             let uu____366 = FStar_List.hd us1 in
+                             norm uu____366 in
+                           let uu____367 = norm sol1 in
+                           FStar_Tests_Util.term_eq uu____365 uu____367 in
                          FStar_Tests_Util.always (Prims.parse_int "10")
                            uu____364);
                     (let tm11 =
-                       FStar_Tests_Pars.tc "x:int -> y:int{eq2 y x} -> bool"
-                        in
-                     let tm21 = FStar_Tests_Pars.tc "x:int -> y:int -> bool"
-                        in
+                       FStar_Tests_Pars.tc "x:int -> y:int{eq2 y x} -> bool" in
+                     let tm21 = FStar_Tests_Pars.tc "x:int -> y:int -> bool" in
                      (let uu____371 =
                         let uu____372 =
                           FStar_Tests_Pars.tc
-                            "forall (x:int). (forall (y:int). y==x <==> True)"
-                           in
-                        FStar_TypeChecker_Common.NonTrivial uu____372  in
+                            "forall (x:int). (forall (y:int). y==x <==> True)" in
+                        FStar_TypeChecker_Common.NonTrivial uu____372 in
                       unify1 (Prims.parse_int "11") tm11 tm21 uu____371);
                      (let tm12 =
                         FStar_Tests_Pars.tc
-                          "a:Type0 -> b:(a -> Type0) -> x:a -> y:b x -> Tot Type0"
-                         in
+                          "a:Type0 -> b:(a -> Type0) -> x:a -> y:b x -> Tot Type0" in
                       let tm22 =
                         FStar_Tests_Pars.tc
-                          "a:Type0 -> b:(a -> Type0) -> x:a -> y:b x -> Tot Type0"
-                         in
+                          "a:Type0 -> b:(a -> Type0) -> x:a -> y:b x -> Tot Type0" in
                       unify1 (Prims.parse_int "12") tm12 tm22
                         FStar_TypeChecker_Common.Trivial;
                       (let uu____376 =
-                         let int_typ = FStar_Tests_Pars.tc "int"  in
+                         let int_typ = FStar_Tests_Pars.tc "int" in
                          let x2 =
                            FStar_Syntax_Syntax.new_bv
-                             FStar_Pervasives_Native.None int_typ
-                            in
-                         let typ = FStar_Tests_Pars.tc "unit -> Type0"  in
+                             FStar_Pervasives_Native.None int_typ in
+                         let typ = FStar_Tests_Pars.tc "unit -> Type0" in
                          let l =
                            FStar_Tests_Pars.tc
-                             "fun (q:(unit -> Type0)) -> q ()"
-                            in
+                             "fun (q:(unit -> Type0)) -> q ()" in
                          let q =
                            FStar_Syntax_Syntax.new_bv
-                             FStar_Pervasives_Native.None typ
-                            in
+                             FStar_Pervasives_Native.None typ in
                          let tm13 =
                            let uu____389 =
                              let uu____390 =
                                let uu____393 =
-                                 FStar_Syntax_Syntax.bv_to_name q  in
-                               [uu____393]  in
-                             FStar_Tests_Util.app l uu____390  in
-                           norm uu____389  in
+                                 FStar_Syntax_Syntax.bv_to_name q in
+                               [uu____393] in
+                             FStar_Tests_Util.app l uu____390 in
+                           norm uu____389 in
                          let l1 =
-                           FStar_Tests_Pars.tc "fun (p:unit -> Type0) -> p"
-                            in
-                         let unit = FStar_Tests_Pars.tc "()"  in
+                           FStar_Tests_Pars.tc "fun (p:unit -> Type0) -> p" in
+                         let unit = FStar_Tests_Pars.tc "()" in
                          let uu____396 =
                            let uu____401 =
-                             let uu____402 = FStar_Syntax_Syntax.mk_binder x2
-                                in
+                             let uu____402 = FStar_Syntax_Syntax.mk_binder x2 in
                              let uu____403 =
                                let uu____406 =
-                                 FStar_Syntax_Syntax.mk_binder q  in
-                               [uu____406]  in
-                             uu____402 :: uu____403  in
+                                 FStar_Syntax_Syntax.mk_binder q in
+                               [uu____406] in
+                             uu____402 :: uu____403 in
                            FStar_TypeChecker_Rel.new_uvar
-                             FStar_Range.dummyRange uu____401 typ
-                            in
+                             FStar_Range.dummyRange uu____401 typ in
                          match uu____396 with
                          | (u_p,uu____414) ->
                              let tm23 =
                                let uu____418 =
                                  let uu____421 =
-                                   FStar_Tests_Util.app l1 [u_p]  in
-                                 norm uu____421  in
-                               FStar_Tests_Util.app uu____418 [unit]  in
-                             (tm13, tm23)
-                          in
+                                   FStar_Tests_Util.app l1 [u_p] in
+                                 norm uu____421 in
+                               FStar_Tests_Util.app uu____418 [unit] in
+                             (tm13, tm23) in
                        match uu____376 with
                        | (tm13,tm23) ->
                            ((let uu____431 =
                                let uu____432 =
-                                 FStar_Tests_Pars.tc "Prims.l_True"  in
-                               FStar_TypeChecker_Common.NonTrivial uu____432
-                                in
+                                 FStar_Tests_Pars.tc "Prims.l_True" in
+                               FStar_TypeChecker_Common.NonTrivial uu____432 in
                              unify1 (Prims.parse_int "13") tm13 tm23
                                uu____431);
                             (let uu____433 =
-                               let int_typ = FStar_Tests_Pars.tc "int"  in
+                               let int_typ = FStar_Tests_Pars.tc "int" in
                                let x2 =
                                  FStar_Syntax_Syntax.new_bv
-                                   FStar_Pervasives_Native.None int_typ
-                                  in
-                               let typ = FStar_Tests_Pars.tc "pure_post unit"
-                                  in
+                                   FStar_Pervasives_Native.None int_typ in
+                               let typ = FStar_Tests_Pars.tc "pure_post unit" in
                                let l =
                                  FStar_Tests_Pars.tc
-                                   "fun (q:pure_post unit) -> q ()"
-                                  in
+                                   "fun (q:pure_post unit) -> q ()" in
                                let q =
                                  FStar_Syntax_Syntax.new_bv
-                                   FStar_Pervasives_Native.None typ
-                                  in
+                                   FStar_Pervasives_Native.None typ in
                                let tm14 =
                                  let uu____446 =
                                    let uu____447 =
                                      let uu____450 =
-                                       FStar_Syntax_Syntax.bv_to_name q  in
-                                     [uu____450]  in
-                                   FStar_Tests_Util.app l uu____447  in
-                                 norm uu____446  in
+                                       FStar_Syntax_Syntax.bv_to_name q in
+                                     [uu____450] in
+                                   FStar_Tests_Util.app l uu____447 in
+                                 norm uu____446 in
                                let l1 =
                                  FStar_Tests_Pars.tc
-                                   "fun (p:pure_post unit) -> p"
-                                  in
-                               let unit = FStar_Tests_Pars.tc "()"  in
+                                   "fun (p:pure_post unit) -> p" in
+                               let unit = FStar_Tests_Pars.tc "()" in
                                let uu____453 =
                                  let uu____458 =
                                    let uu____459 =
-                                     FStar_Syntax_Syntax.mk_binder x2  in
+                                     FStar_Syntax_Syntax.mk_binder x2 in
                                    let uu____460 =
                                      let uu____463 =
-                                       FStar_Syntax_Syntax.mk_binder q  in
-                                     [uu____463]  in
-                                   uu____459 :: uu____460  in
+                                       FStar_Syntax_Syntax.mk_binder q in
+                                     [uu____463] in
+                                   uu____459 :: uu____460 in
                                  FStar_TypeChecker_Rel.new_uvar
-                                   FStar_Range.dummyRange uu____458 typ
-                                  in
+                                   FStar_Range.dummyRange uu____458 typ in
                                match uu____453 with
                                | (u_p,uu____471) ->
                                    let tm24 =
                                      let uu____475 =
                                        let uu____478 =
-                                         FStar_Tests_Util.app l1 [u_p]  in
-                                       norm uu____478  in
-                                     FStar_Tests_Util.app uu____475 [unit]
-                                      in
-                                   (tm14, tm24)
-                                in
+                                         FStar_Tests_Util.app l1 [u_p] in
+                                       norm uu____478 in
+                                     FStar_Tests_Util.app uu____475 [unit] in
+                                   (tm14, tm24) in
                              match uu____433 with
                              | (tm14,tm24) ->
                                  ((let uu____488 =
                                      let uu____489 =
-                                       FStar_Tests_Pars.tc "Prims.l_True"  in
+                                       FStar_Tests_Pars.tc "Prims.l_True" in
                                      FStar_TypeChecker_Common.NonTrivial
-                                       uu____489
-                                      in
+                                       uu____489 in
                                    unify1 (Prims.parse_int "14") tm14 tm24
                                      uu____488);
                                   FStar_Options.__clear_unit_tests ();
                                   FStar_Util.print_string "Unifier ok\n"))))))))))))))
-  

--- a/src/ocaml-output/FStar_Tests_Util.ml
+++ b/src/ocaml-output/FStar_Tests_Util.ml
@@ -1,5 +1,5 @@
 open Prims
-let (always : Prims.int -> Prims.bool -> Prims.unit) =
+let always: Prims.int -> Prims.bool -> Prims.unit =
   fun id1  ->
     fun b  ->
       if b
@@ -7,60 +7,52 @@ let (always : Prims.int -> Prims.bool -> Prims.unit) =
       else
         (let uu____8 =
            let uu____13 =
-             let uu____14 = FStar_Util.string_of_int id1  in
-             FStar_Util.format1 "Assertion failed: test %s" uu____14  in
-           (FStar_Errors.Fatal_AssertionFailure, uu____13)  in
+             let uu____14 = FStar_Util.string_of_int id1 in
+             FStar_Util.format1 "Assertion failed: test %s" uu____14 in
+           (FStar_Errors.Fatal_AssertionFailure, uu____13) in
          FStar_Errors.raise_error uu____8 FStar_Range.dummyRange)
-  
-let (x : FStar_Syntax_Syntax.bv) =
+let x: FStar_Syntax_Syntax.bv =
   FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None
     FStar_Syntax_Syntax.tun
-  
-let (y : FStar_Syntax_Syntax.bv) =
+let y: FStar_Syntax_Syntax.bv =
   FStar_Syntax_Syntax.gen_bv "y" FStar_Pervasives_Native.None
     FStar_Syntax_Syntax.tun
-  
-let (n : FStar_Syntax_Syntax.bv) =
+let n: FStar_Syntax_Syntax.bv =
   FStar_Syntax_Syntax.gen_bv "n" FStar_Pervasives_Native.None
     FStar_Syntax_Syntax.tun
-  
-let (h : FStar_Syntax_Syntax.bv) =
+let h: FStar_Syntax_Syntax.bv =
   FStar_Syntax_Syntax.gen_bv "h" FStar_Pervasives_Native.None
     FStar_Syntax_Syntax.tun
-  
-let (m : FStar_Syntax_Syntax.bv) =
+let m: FStar_Syntax_Syntax.bv =
   FStar_Syntax_Syntax.gen_bv "m" FStar_Pervasives_Native.None
     FStar_Syntax_Syntax.tun
-  
-let tm : 'Auu____17 . 'Auu____17 -> 'Auu____17 FStar_Syntax_Syntax.syntax =
+let tm: 'Auu____17 . 'Auu____17 -> 'Auu____17 FStar_Syntax_Syntax.syntax =
   fun t  ->
     FStar_Syntax_Syntax.mk t FStar_Pervasives_Native.None
       FStar_Range.dummyRange
-  
-let (nm : FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term) =
-  fun x1  -> FStar_Syntax_Syntax.bv_to_name x1 
-let (app :
+let nm: FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term =
+  fun x1  -> FStar_Syntax_Syntax.bv_to_name x1
+let app:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term Prims.list ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun x1  ->
     fun ts  ->
       let uu____43 =
         let uu____46 =
           let uu____47 =
-            let uu____62 = FStar_List.map FStar_Syntax_Syntax.as_arg ts  in
-            (x1, uu____62)  in
-          FStar_Syntax_Syntax.Tm_app uu____47  in
-        FStar_Syntax_Syntax.mk uu____46  in
+            let uu____62 = FStar_List.map FStar_Syntax_Syntax.as_arg ts in
+            (x1, uu____62) in
+          FStar_Syntax_Syntax.Tm_app uu____47 in
+        FStar_Syntax_Syntax.mk uu____46 in
       uu____43 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let rec (term_eq' :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let rec term_eq':
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun t1  ->
     fun t2  ->
-      let t11 = FStar_Syntax_Subst.compress t1  in
-      let t21 = FStar_Syntax_Subst.compress t2  in
+      let t11 = FStar_Syntax_Subst.compress t1 in
+      let t21 = FStar_Syntax_Subst.compress t2 in
       let binders_eq xs ys =
         ((FStar_List.length xs) = (FStar_List.length ys)) &&
           (FStar_List.forall2
@@ -69,8 +61,7 @@ let rec (term_eq' :
                   match (uu____101, uu____102) with
                   | ((x1,uu____104),(y1,uu____106)) ->
                       term_eq' x1.FStar_Syntax_Syntax.sort
-                        y1.FStar_Syntax_Syntax.sort) xs ys)
-         in
+                        y1.FStar_Syntax_Syntax.sort) xs ys) in
       let args_eq xs ys =
         ((FStar_List.length xs) = (FStar_List.length ys)) &&
           (FStar_List.forall2
@@ -78,8 +69,7 @@ let rec (term_eq' :
                 fun uu____169  ->
                   match (uu____168, uu____169) with
                   | ((a,imp),(b,imp')) -> (term_eq' a b) && (imp = imp')) xs
-             ys)
-         in
+             ys) in
       let comp_eq1 c d =
         match ((c.FStar_Syntax_Syntax.n), (d.FStar_Syntax_Syntax.n)) with
         | (FStar_Syntax_Syntax.Total (t,uu____206),FStar_Syntax_Syntax.Total
@@ -93,7 +83,7 @@ let rec (term_eq' :
               &&
               (args_eq ct1.FStar_Syntax_Syntax.effect_args
                  ct2.FStar_Syntax_Syntax.effect_args)
-        | uu____227 -> false  in
+        | uu____227 -> false in
       match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
       | (FStar_Syntax_Syntax.Tm_bvar x1,FStar_Syntax_Syntax.Tm_bvar y1) ->
           x1.FStar_Syntax_Syntax.index = y1.FStar_Syntax_Syntax.index
@@ -116,7 +106,7 @@ let rec (term_eq' :
          (xs,t,uu____310),FStar_Syntax_Syntax.Tm_abs (ys,u,uu____313)) ->
           if (FStar_List.length xs) > (FStar_List.length ys)
           then
-            let uu____362 = FStar_Util.first_N (FStar_List.length ys) xs  in
+            let uu____362 = FStar_Util.first_N (FStar_List.length ys) xs in
             (match uu____362 with
              | (xs1,xs') ->
                  let t12 =
@@ -128,17 +118,15 @@ let rec (term_eq' :
                              (FStar_Syntax_Syntax.Tm_abs
                                 (xs', t, FStar_Pervasives_Native.None))
                              FStar_Pervasives_Native.None
-                             t11.FStar_Syntax_Syntax.pos
-                            in
-                         (xs1, uu____437, FStar_Pervasives_Native.None)  in
-                       FStar_Syntax_Syntax.Tm_abs uu____420  in
-                     FStar_Syntax_Syntax.mk uu____419  in
+                             t11.FStar_Syntax_Syntax.pos in
+                         (xs1, uu____437, FStar_Pervasives_Native.None) in
+                       FStar_Syntax_Syntax.Tm_abs uu____420 in
+                     FStar_Syntax_Syntax.mk uu____419 in
                    uu____416 FStar_Pervasives_Native.None
-                     t11.FStar_Syntax_Syntax.pos
-                    in
+                     t11.FStar_Syntax_Syntax.pos in
                  term_eq' t12 t21)
           else
-            (let uu____464 = FStar_Util.first_N (FStar_List.length xs) ys  in
+            (let uu____464 = FStar_Util.first_N (FStar_List.length xs) ys in
              match uu____464 with
              | (ys1,ys') ->
                  let t22 =
@@ -150,14 +138,12 @@ let rec (term_eq' :
                              (FStar_Syntax_Syntax.Tm_abs
                                 (ys', u, FStar_Pervasives_Native.None))
                              FStar_Pervasives_Native.None
-                             t21.FStar_Syntax_Syntax.pos
-                            in
-                         (ys1, uu____539, FStar_Pervasives_Native.None)  in
-                       FStar_Syntax_Syntax.Tm_abs uu____522  in
-                     FStar_Syntax_Syntax.mk uu____521  in
+                             t21.FStar_Syntax_Syntax.pos in
+                         (ys1, uu____539, FStar_Pervasives_Native.None) in
+                       FStar_Syntax_Syntax.Tm_abs uu____522 in
+                     FStar_Syntax_Syntax.mk uu____521 in
                    uu____518 FStar_Pervasives_Native.None
-                     t21.FStar_Syntax_Syntax.pos
-                    in
+                     t21.FStar_Syntax_Syntax.pos in
                  term_eq' t11 t22)
       | (FStar_Syntax_Syntax.Tm_arrow (xs,c),FStar_Syntax_Syntax.Tm_arrow
          (ys,d)) -> (binders_eq xs ys) && (comp_eq1 c d)
@@ -219,33 +205,29 @@ let rec (term_eq' :
           term_eq' t11 t22
       | (FStar_Syntax_Syntax.Tm_delayed uu____1299,uu____1300) ->
           let uu____1325 =
-            let uu____1326 = FStar_Syntax_Print.tag_of_term t11  in
-            let uu____1327 = FStar_Syntax_Print.tag_of_term t21  in
-            FStar_Util.format2 "Impossible: %s and %s" uu____1326 uu____1327
-             in
+            let uu____1326 = FStar_Syntax_Print.tag_of_term t11 in
+            let uu____1327 = FStar_Syntax_Print.tag_of_term t21 in
+            FStar_Util.format2 "Impossible: %s and %s" uu____1326 uu____1327 in
           failwith uu____1325
       | (uu____1328,FStar_Syntax_Syntax.Tm_delayed uu____1329) ->
           let uu____1354 =
-            let uu____1355 = FStar_Syntax_Print.tag_of_term t11  in
-            let uu____1356 = FStar_Syntax_Print.tag_of_term t21  in
-            FStar_Util.format2 "Impossible: %s and %s" uu____1355 uu____1356
-             in
+            let uu____1355 = FStar_Syntax_Print.tag_of_term t11 in
+            let uu____1356 = FStar_Syntax_Print.tag_of_term t21 in
+            FStar_Util.format2 "Impossible: %s and %s" uu____1355 uu____1356 in
           failwith uu____1354
       | (FStar_Syntax_Syntax.Tm_unknown ,FStar_Syntax_Syntax.Tm_unknown ) ->
           true
       | uu____1357 -> false
-  
-let (term_eq :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let term_eq:
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun t1  ->
     fun t2  ->
-      let b = term_eq' t1 t2  in
+      let b = term_eq' t1 t2 in
       if Prims.op_Negation b
       then
-        (let uu____1370 = FStar_Syntax_Print.term_to_string t1  in
-         let uu____1371 = FStar_Syntax_Print.term_to_string t2  in
+        (let uu____1370 = FStar_Syntax_Print.term_to_string t1 in
+         let uu____1371 = FStar_Syntax_Print.term_to_string t2 in
          FStar_Util.print2 ">>>>>>>>>>>Term %s is not equal to %s\n"
            uu____1370 uu____1371)
       else ();
       b
-  

--- a/src/ocaml-output/FStar_ToSyntax_Env.ml
+++ b/src/ocaml-output/FStar_ToSyntax_Env.ml
@@ -9,61 +9,55 @@ type module_abbrev =
   (FStar_Ident.ident,FStar_Ident.lident) FStar_Pervasives_Native.tuple2
 [@@deriving show]
 type open_kind =
-  | Open_module 
-  | Open_namespace [@@deriving show]
-let (uu___is_Open_module : open_kind -> Prims.bool) =
+  | Open_module
+  | Open_namespace[@@deriving show]
+let uu___is_Open_module: open_kind -> Prims.bool =
   fun projectee  ->
     match projectee with | Open_module  -> true | uu____20 -> false
-  
-let (uu___is_Open_namespace : open_kind -> Prims.bool) =
+let uu___is_Open_namespace: open_kind -> Prims.bool =
   fun projectee  ->
     match projectee with | Open_namespace  -> true | uu____24 -> false
-  
 type open_module_or_namespace =
   (FStar_Ident.lident,open_kind) FStar_Pervasives_Native.tuple2[@@deriving
                                                                  show]
 type record_or_dc =
   {
-  typename: FStar_Ident.lident ;
-  constrname: FStar_Ident.ident ;
-  parms: FStar_Syntax_Syntax.binders ;
+  typename: FStar_Ident.lident;
+  constrname: FStar_Ident.ident;
+  parms: FStar_Syntax_Syntax.binders;
   fields:
     (FStar_Ident.ident,FStar_Syntax_Syntax.typ)
-      FStar_Pervasives_Native.tuple2 Prims.list
-    ;
-  is_private_or_abstract: Prims.bool ;
-  is_record: Prims.bool }[@@deriving show]
-let (__proj__Mkrecord_or_dc__item__typename :
-  record_or_dc -> FStar_Ident.lident) =
+      FStar_Pervasives_Native.tuple2 Prims.list;
+  is_private_or_abstract: Prims.bool;
+  is_record: Prims.bool;}[@@deriving show]
+let __proj__Mkrecord_or_dc__item__typename:
+  record_or_dc -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { typename = __fname__typename; constrname = __fname__constrname;
         parms = __fname__parms; fields = __fname__fields;
         is_private_or_abstract = __fname__is_private_or_abstract;
         is_record = __fname__is_record;_} -> __fname__typename
-  
-let (__proj__Mkrecord_or_dc__item__constrname :
-  record_or_dc -> FStar_Ident.ident) =
+let __proj__Mkrecord_or_dc__item__constrname:
+  record_or_dc -> FStar_Ident.ident =
   fun projectee  ->
     match projectee with
     | { typename = __fname__typename; constrname = __fname__constrname;
         parms = __fname__parms; fields = __fname__fields;
         is_private_or_abstract = __fname__is_private_or_abstract;
         is_record = __fname__is_record;_} -> __fname__constrname
-  
-let (__proj__Mkrecord_or_dc__item__parms :
-  record_or_dc -> FStar_Syntax_Syntax.binders) =
+let __proj__Mkrecord_or_dc__item__parms:
+  record_or_dc -> FStar_Syntax_Syntax.binders =
   fun projectee  ->
     match projectee with
     | { typename = __fname__typename; constrname = __fname__constrname;
         parms = __fname__parms; fields = __fname__fields;
         is_private_or_abstract = __fname__is_private_or_abstract;
         is_record = __fname__is_record;_} -> __fname__parms
-  
-let (__proj__Mkrecord_or_dc__item__fields :
+let __proj__Mkrecord_or_dc__item__fields:
   record_or_dc ->
     (FStar_Ident.ident,FStar_Syntax_Syntax.typ)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
@@ -71,122 +65,108 @@ let (__proj__Mkrecord_or_dc__item__fields :
         parms = __fname__parms; fields = __fname__fields;
         is_private_or_abstract = __fname__is_private_or_abstract;
         is_record = __fname__is_record;_} -> __fname__fields
-  
-let (__proj__Mkrecord_or_dc__item__is_private_or_abstract :
-  record_or_dc -> Prims.bool) =
+let __proj__Mkrecord_or_dc__item__is_private_or_abstract:
+  record_or_dc -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { typename = __fname__typename; constrname = __fname__constrname;
         parms = __fname__parms; fields = __fname__fields;
         is_private_or_abstract = __fname__is_private_or_abstract;
         is_record = __fname__is_record;_} -> __fname__is_private_or_abstract
-  
-let (__proj__Mkrecord_or_dc__item__is_record : record_or_dc -> Prims.bool) =
+let __proj__Mkrecord_or_dc__item__is_record: record_or_dc -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { typename = __fname__typename; constrname = __fname__constrname;
         parms = __fname__parms; fields = __fname__fields;
         is_private_or_abstract = __fname__is_private_or_abstract;
         is_record = __fname__is_record;_} -> __fname__is_record
-  
 type scope_mod =
-  | Local_binding of local_binding 
-  | Rec_binding of rec_binding 
-  | Module_abbrev of module_abbrev 
-  | Open_module_or_namespace of open_module_or_namespace 
-  | Top_level_def of FStar_Ident.ident 
-  | Record_or_dc of record_or_dc [@@deriving show]
-let (uu___is_Local_binding : scope_mod -> Prims.bool) =
+  | Local_binding of local_binding
+  | Rec_binding of rec_binding
+  | Module_abbrev of module_abbrev
+  | Open_module_or_namespace of open_module_or_namespace
+  | Top_level_def of FStar_Ident.ident
+  | Record_or_dc of record_or_dc[@@deriving show]
+let uu___is_Local_binding: scope_mod -> Prims.bool =
   fun projectee  ->
     match projectee with | Local_binding _0 -> true | uu____189 -> false
-  
-let (__proj__Local_binding__item___0 : scope_mod -> local_binding) =
-  fun projectee  -> match projectee with | Local_binding _0 -> _0 
-let (uu___is_Rec_binding : scope_mod -> Prims.bool) =
+let __proj__Local_binding__item___0: scope_mod -> local_binding =
+  fun projectee  -> match projectee with | Local_binding _0 -> _0
+let uu___is_Rec_binding: scope_mod -> Prims.bool =
   fun projectee  ->
     match projectee with | Rec_binding _0 -> true | uu____201 -> false
-  
-let (__proj__Rec_binding__item___0 : scope_mod -> rec_binding) =
-  fun projectee  -> match projectee with | Rec_binding _0 -> _0 
-let (uu___is_Module_abbrev : scope_mod -> Prims.bool) =
+let __proj__Rec_binding__item___0: scope_mod -> rec_binding =
+  fun projectee  -> match projectee with | Rec_binding _0 -> _0
+let uu___is_Module_abbrev: scope_mod -> Prims.bool =
   fun projectee  ->
     match projectee with | Module_abbrev _0 -> true | uu____213 -> false
-  
-let (__proj__Module_abbrev__item___0 : scope_mod -> module_abbrev) =
-  fun projectee  -> match projectee with | Module_abbrev _0 -> _0 
-let (uu___is_Open_module_or_namespace : scope_mod -> Prims.bool) =
+let __proj__Module_abbrev__item___0: scope_mod -> module_abbrev =
+  fun projectee  -> match projectee with | Module_abbrev _0 -> _0
+let uu___is_Open_module_or_namespace: scope_mod -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Open_module_or_namespace _0 -> true
     | uu____225 -> false
-  
-let (__proj__Open_module_or_namespace__item___0 :
-  scope_mod -> open_module_or_namespace) =
-  fun projectee  -> match projectee with | Open_module_or_namespace _0 -> _0 
-let (uu___is_Top_level_def : scope_mod -> Prims.bool) =
+let __proj__Open_module_or_namespace__item___0:
+  scope_mod -> open_module_or_namespace =
+  fun projectee  -> match projectee with | Open_module_or_namespace _0 -> _0
+let uu___is_Top_level_def: scope_mod -> Prims.bool =
   fun projectee  ->
     match projectee with | Top_level_def _0 -> true | uu____237 -> false
-  
-let (__proj__Top_level_def__item___0 : scope_mod -> FStar_Ident.ident) =
-  fun projectee  -> match projectee with | Top_level_def _0 -> _0 
-let (uu___is_Record_or_dc : scope_mod -> Prims.bool) =
+let __proj__Top_level_def__item___0: scope_mod -> FStar_Ident.ident =
+  fun projectee  -> match projectee with | Top_level_def _0 -> _0
+let uu___is_Record_or_dc: scope_mod -> Prims.bool =
   fun projectee  ->
     match projectee with | Record_or_dc _0 -> true | uu____249 -> false
-  
-let (__proj__Record_or_dc__item___0 : scope_mod -> record_or_dc) =
-  fun projectee  -> match projectee with | Record_or_dc _0 -> _0 
+let __proj__Record_or_dc__item___0: scope_mod -> record_or_dc =
+  fun projectee  -> match projectee with | Record_or_dc _0 -> _0
 type string_set = Prims.string FStar_Util.set[@@deriving show]
 type exported_id_kind =
-  | Exported_id_term_type 
-  | Exported_id_field [@@deriving show]
-let (uu___is_Exported_id_term_type : exported_id_kind -> Prims.bool) =
+  | Exported_id_term_type
+  | Exported_id_field[@@deriving show]
+let uu___is_Exported_id_term_type: exported_id_kind -> Prims.bool =
   fun projectee  ->
     match projectee with
     | Exported_id_term_type  -> true
     | uu____262 -> false
-  
-let (uu___is_Exported_id_field : exported_id_kind -> Prims.bool) =
+let uu___is_Exported_id_field: exported_id_kind -> Prims.bool =
   fun projectee  ->
     match projectee with | Exported_id_field  -> true | uu____266 -> false
-  
 type exported_id_set = exported_id_kind -> string_set FStar_ST.ref[@@deriving
                                                                     show]
 type env =
   {
-  curmodule: FStar_Ident.lident FStar_Pervasives_Native.option ;
-  curmonad: FStar_Ident.ident FStar_Pervasives_Native.option ;
+  curmodule: FStar_Ident.lident FStar_Pervasives_Native.option;
+  curmonad: FStar_Ident.ident FStar_Pervasives_Native.option;
   modules:
     (FStar_Ident.lident,FStar_Syntax_Syntax.modul)
-      FStar_Pervasives_Native.tuple2 Prims.list
-    ;
-  scope_mods: scope_mod Prims.list ;
-  exported_ids: exported_id_set FStar_Util.smap ;
-  trans_exported_ids: exported_id_set FStar_Util.smap ;
-  includes: FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap ;
-  sigaccum: FStar_Syntax_Syntax.sigelts ;
+      FStar_Pervasives_Native.tuple2 Prims.list;
+  scope_mods: scope_mod Prims.list;
+  exported_ids: exported_id_set FStar_Util.smap;
+  trans_exported_ids: exported_id_set FStar_Util.smap;
+  includes: FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap;
+  sigaccum: FStar_Syntax_Syntax.sigelts;
   sigmap:
     (FStar_Syntax_Syntax.sigelt,Prims.bool) FStar_Pervasives_Native.tuple2
-      FStar_Util.smap
-    ;
-  iface: Prims.bool ;
-  admitted_iface: Prims.bool ;
-  expect_typ: Prims.bool ;
-  docs: FStar_Parser_AST.fsdoc FStar_Util.smap ;
+      FStar_Util.smap;
+  iface: Prims.bool;
+  admitted_iface: Prims.bool;
+  expect_typ: Prims.bool;
+  docs: FStar_Parser_AST.fsdoc FStar_Util.smap;
   remaining_iface_decls:
     (FStar_Ident.lident,FStar_Parser_AST.decl Prims.list)
-      FStar_Pervasives_Native.tuple2 Prims.list
-    ;
-  syntax_only: Prims.bool ;
-  ds_hooks: dsenv_hooks }[@@deriving show]
+      FStar_Pervasives_Native.tuple2 Prims.list;
+  syntax_only: Prims.bool;
+  ds_hooks: dsenv_hooks;}[@@deriving show]
 and dsenv_hooks =
   {
-  ds_push_open_hook: env -> open_module_or_namespace -> Prims.unit ;
-  ds_push_include_hook: env -> FStar_Ident.lident -> Prims.unit ;
+  ds_push_open_hook: env -> open_module_or_namespace -> Prims.unit;
+  ds_push_include_hook: env -> FStar_Ident.lident -> Prims.unit;
   ds_push_module_abbrev_hook:
-    env -> FStar_Ident.ident -> FStar_Ident.lident -> Prims.unit }[@@deriving
+    env -> FStar_Ident.ident -> FStar_Ident.lident -> Prims.unit;}[@@deriving
                                                                     show]
-let (__proj__Mkenv__item__curmodule :
-  env -> FStar_Ident.lident FStar_Pervasives_Native.option) =
+let __proj__Mkenv__item__curmodule:
+  env -> FStar_Ident.lident FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -200,9 +180,8 @@ let (__proj__Mkenv__item__curmodule :
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__curmodule
-  
-let (__proj__Mkenv__item__curmonad :
-  env -> FStar_Ident.ident FStar_Pervasives_Native.option) =
+let __proj__Mkenv__item__curmonad:
+  env -> FStar_Ident.ident FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -216,11 +195,10 @@ let (__proj__Mkenv__item__curmonad :
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__curmonad
-  
-let (__proj__Mkenv__item__modules :
+let __proj__Mkenv__item__modules:
   env ->
     (FStar_Ident.lident,FStar_Syntax_Syntax.modul)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
@@ -235,8 +213,7 @@ let (__proj__Mkenv__item__modules :
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__modules
-  
-let (__proj__Mkenv__item__scope_mods : env -> scope_mod Prims.list) =
+let __proj__Mkenv__item__scope_mods: env -> scope_mod Prims.list =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -250,9 +227,8 @@ let (__proj__Mkenv__item__scope_mods : env -> scope_mod Prims.list) =
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__scope_mods
-  
-let (__proj__Mkenv__item__exported_ids :
-  env -> exported_id_set FStar_Util.smap) =
+let __proj__Mkenv__item__exported_ids: env -> exported_id_set FStar_Util.smap
+  =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -266,9 +242,8 @@ let (__proj__Mkenv__item__exported_ids :
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__exported_ids
-  
-let (__proj__Mkenv__item__trans_exported_ids :
-  env -> exported_id_set FStar_Util.smap) =
+let __proj__Mkenv__item__trans_exported_ids:
+  env -> exported_id_set FStar_Util.smap =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -282,9 +257,8 @@ let (__proj__Mkenv__item__trans_exported_ids :
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__trans_exported_ids
-  
-let (__proj__Mkenv__item__includes :
-  env -> FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap) =
+let __proj__Mkenv__item__includes:
+  env -> FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -298,8 +272,7 @@ let (__proj__Mkenv__item__includes :
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__includes
-  
-let (__proj__Mkenv__item__sigaccum : env -> FStar_Syntax_Syntax.sigelts) =
+let __proj__Mkenv__item__sigaccum: env -> FStar_Syntax_Syntax.sigelts =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -313,11 +286,10 @@ let (__proj__Mkenv__item__sigaccum : env -> FStar_Syntax_Syntax.sigelts) =
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__sigaccum
-  
-let (__proj__Mkenv__item__sigmap :
+let __proj__Mkenv__item__sigmap:
   env ->
     (FStar_Syntax_Syntax.sigelt,Prims.bool) FStar_Pervasives_Native.tuple2
-      FStar_Util.smap)
+      FStar_Util.smap
   =
   fun projectee  ->
     match projectee with
@@ -332,8 +304,7 @@ let (__proj__Mkenv__item__sigmap :
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__sigmap
-  
-let (__proj__Mkenv__item__iface : env -> Prims.bool) =
+let __proj__Mkenv__item__iface: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -347,8 +318,7 @@ let (__proj__Mkenv__item__iface : env -> Prims.bool) =
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__iface
-  
-let (__proj__Mkenv__item__admitted_iface : env -> Prims.bool) =
+let __proj__Mkenv__item__admitted_iface: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -362,8 +332,7 @@ let (__proj__Mkenv__item__admitted_iface : env -> Prims.bool) =
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__admitted_iface
-  
-let (__proj__Mkenv__item__expect_typ : env -> Prims.bool) =
+let __proj__Mkenv__item__expect_typ: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -377,9 +346,8 @@ let (__proj__Mkenv__item__expect_typ : env -> Prims.bool) =
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__expect_typ
-  
-let (__proj__Mkenv__item__docs :
-  env -> FStar_Parser_AST.fsdoc FStar_Util.smap) =
+let __proj__Mkenv__item__docs: env -> FStar_Parser_AST.fsdoc FStar_Util.smap
+  =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -393,11 +361,10 @@ let (__proj__Mkenv__item__docs :
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__docs
-  
-let (__proj__Mkenv__item__remaining_iface_decls :
+let __proj__Mkenv__item__remaining_iface_decls:
   env ->
     (FStar_Ident.lident,FStar_Parser_AST.decl Prims.list)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
@@ -412,8 +379,7 @@ let (__proj__Mkenv__item__remaining_iface_decls :
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__remaining_iface_decls
-  
-let (__proj__Mkenv__item__syntax_only : env -> Prims.bool) =
+let __proj__Mkenv__item__syntax_only: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -427,8 +393,7 @@ let (__proj__Mkenv__item__syntax_only : env -> Prims.bool) =
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__syntax_only
-  
-let (__proj__Mkenv__item__ds_hooks : env -> dsenv_hooks) =
+let __proj__Mkenv__item__ds_hooks: env -> dsenv_hooks =
   fun projectee  ->
     match projectee with
     | { curmodule = __fname__curmodule; curmonad = __fname__curmonad;
@@ -442,27 +407,24 @@ let (__proj__Mkenv__item__ds_hooks : env -> dsenv_hooks) =
         remaining_iface_decls = __fname__remaining_iface_decls;
         syntax_only = __fname__syntax_only; ds_hooks = __fname__ds_hooks;_}
         -> __fname__ds_hooks
-  
-let (__proj__Mkdsenv_hooks__item__ds_push_open_hook :
-  dsenv_hooks -> env -> open_module_or_namespace -> Prims.unit) =
+let __proj__Mkdsenv_hooks__item__ds_push_open_hook:
+  dsenv_hooks -> env -> open_module_or_namespace -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { ds_push_open_hook = __fname__ds_push_open_hook;
         ds_push_include_hook = __fname__ds_push_include_hook;
         ds_push_module_abbrev_hook = __fname__ds_push_module_abbrev_hook;_}
         -> __fname__ds_push_open_hook
-  
-let (__proj__Mkdsenv_hooks__item__ds_push_include_hook :
-  dsenv_hooks -> env -> FStar_Ident.lident -> Prims.unit) =
+let __proj__Mkdsenv_hooks__item__ds_push_include_hook:
+  dsenv_hooks -> env -> FStar_Ident.lident -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { ds_push_open_hook = __fname__ds_push_open_hook;
         ds_push_include_hook = __fname__ds_push_include_hook;
         ds_push_module_abbrev_hook = __fname__ds_push_module_abbrev_hook;_}
         -> __fname__ds_push_include_hook
-  
-let (__proj__Mkdsenv_hooks__item__ds_push_module_abbrev_hook :
-  dsenv_hooks -> env -> FStar_Ident.ident -> FStar_Ident.lident -> Prims.unit)
+let __proj__Mkdsenv_hooks__item__ds_push_module_abbrev_hook:
+  dsenv_hooks -> env -> FStar_Ident.ident -> FStar_Ident.lident -> Prims.unit
   =
   fun projectee  ->
     match projectee with
@@ -470,46 +432,43 @@ let (__proj__Mkdsenv_hooks__item__ds_push_module_abbrev_hook :
         ds_push_include_hook = __fname__ds_push_include_hook;
         ds_push_module_abbrev_hook = __fname__ds_push_module_abbrev_hook;_}
         -> __fname__ds_push_module_abbrev_hook
-  
 type 'a withenv = env -> ('a,env) FStar_Pervasives_Native.tuple2[@@deriving
                                                                   show]
-let (default_ds_hooks : dsenv_hooks) =
+let default_ds_hooks: dsenv_hooks =
   {
     ds_push_open_hook = (fun uu____1535  -> fun uu____1536  -> ());
     ds_push_include_hook = (fun uu____1539  -> fun uu____1540  -> ());
     ds_push_module_abbrev_hook =
       (fun uu____1544  -> fun uu____1545  -> fun uu____1546  -> ())
-  } 
+  }
 type foundname =
   | Term_name of
   (FStar_Syntax_Syntax.typ,Prims.bool,FStar_Syntax_Syntax.attribute
                                         Prims.list)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | Eff_name of (FStar_Syntax_Syntax.sigelt,FStar_Ident.lident)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let (uu___is_Term_name : foundname -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_Term_name: foundname -> Prims.bool =
   fun projectee  ->
     match projectee with | Term_name _0 -> true | uu____1579 -> false
-  
-let (__proj__Term_name__item___0 :
+let __proj__Term_name__item___0:
   foundname ->
     (FStar_Syntax_Syntax.typ,Prims.bool,FStar_Syntax_Syntax.attribute
                                           Prims.list)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Term_name _0 -> _0 
-let (uu___is_Eff_name : foundname -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Term_name _0 -> _0
+let uu___is_Eff_name: foundname -> Prims.bool =
   fun projectee  ->
     match projectee with | Eff_name _0 -> true | uu____1619 -> false
-  
-let (__proj__Eff_name__item___0 :
+let __proj__Eff_name__item___0:
   foundname ->
     (FStar_Syntax_Syntax.sigelt,FStar_Ident.lident)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Eff_name _0 -> _0 
-let (set_iface : env -> Prims.bool -> env) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Eff_name _0 -> _0
+let set_iface: env -> Prims.bool -> env =
   fun env  ->
     fun b  ->
-      let uu___112_1645 = env  in
+      let uu___112_1645 = env in
       {
         curmodule = (uu___112_1645.curmodule);
         curmonad = (uu___112_1645.curmonad);
@@ -528,12 +487,11 @@ let (set_iface : env -> Prims.bool -> env) =
         syntax_only = (uu___112_1645.syntax_only);
         ds_hooks = (uu___112_1645.ds_hooks)
       }
-  
-let (iface : env -> Prims.bool) = fun e  -> e.iface 
-let (set_admitted_iface : env -> Prims.bool -> env) =
+let iface: env -> Prims.bool = fun e  -> e.iface
+let set_admitted_iface: env -> Prims.bool -> env =
   fun e  ->
     fun b  ->
-      let uu___113_1655 = e  in
+      let uu___113_1655 = e in
       {
         curmodule = (uu___113_1655.curmodule);
         curmonad = (uu___113_1655.curmonad);
@@ -552,12 +510,11 @@ let (set_admitted_iface : env -> Prims.bool -> env) =
         syntax_only = (uu___113_1655.syntax_only);
         ds_hooks = (uu___113_1655.ds_hooks)
       }
-  
-let (admitted_iface : env -> Prims.bool) = fun e  -> e.admitted_iface 
-let (set_expect_typ : env -> Prims.bool -> env) =
+let admitted_iface: env -> Prims.bool = fun e  -> e.admitted_iface
+let set_expect_typ: env -> Prims.bool -> env =
   fun e  ->
     fun b  ->
-      let uu___114_1665 = e  in
+      let uu___114_1665 = e in
       {
         curmodule = (uu___114_1665.curmodule);
         curmonad = (uu___114_1665.curmonad);
@@ -576,31 +533,29 @@ let (set_expect_typ : env -> Prims.bool -> env) =
         syntax_only = (uu___114_1665.syntax_only);
         ds_hooks = (uu___114_1665.ds_hooks)
       }
-  
-let (expect_typ : env -> Prims.bool) = fun e  -> e.expect_typ 
-let (all_exported_id_kinds : exported_id_kind Prims.list) =
-  [Exported_id_field; Exported_id_term_type] 
-let (transitive_exported_ids :
-  env -> FStar_Ident.lident -> Prims.string Prims.list) =
+let expect_typ: env -> Prims.bool = fun e  -> e.expect_typ
+let all_exported_id_kinds: exported_id_kind Prims.list =
+  [Exported_id_field; Exported_id_term_type]
+let transitive_exported_ids:
+  env -> FStar_Ident.lident -> Prims.string Prims.list =
   fun env  ->
     fun lid  ->
-      let module_name = FStar_Ident.string_of_lid lid  in
+      let module_name = FStar_Ident.string_of_lid lid in
       let uu____1680 =
-        FStar_Util.smap_try_find env.trans_exported_ids module_name  in
+        FStar_Util.smap_try_find env.trans_exported_ids module_name in
       match uu____1680 with
       | FStar_Pervasives_Native.None  -> []
       | FStar_Pervasives_Native.Some exported_id_set ->
           let uu____1686 =
-            let uu____1687 = exported_id_set Exported_id_term_type  in
-            FStar_ST.op_Bang uu____1687  in
+            let uu____1687 = exported_id_set Exported_id_term_type in
+            FStar_ST.op_Bang uu____1687 in
           FStar_All.pipe_right uu____1686 FStar_Util.set_elements
-  
-let (open_modules :
+let open_modules:
   env ->
     (FStar_Ident.lident,FStar_Syntax_Syntax.modul)
-      FStar_Pervasives_Native.tuple2 Prims.list)
-  = fun e  -> e.modules 
-let (open_modules_and_namespaces : env -> FStar_Ident.lident Prims.list) =
+      FStar_Pervasives_Native.tuple2 Prims.list
+  = fun e  -> e.modules
+let open_modules_and_namespaces: env -> FStar_Ident.lident Prims.list =
   fun env  ->
     FStar_List.filter_map
       (fun uu___80_1817  ->
@@ -608,11 +563,10 @@ let (open_modules_and_namespaces : env -> FStar_Ident.lident Prims.list) =
          | Open_module_or_namespace (lid,_info) ->
              FStar_Pervasives_Native.Some lid
          | uu____1822 -> FStar_Pervasives_Native.None) env.scope_mods
-  
-let (set_current_module : env -> FStar_Ident.lident -> env) =
+let set_current_module: env -> FStar_Ident.lident -> env =
   fun e  ->
     fun l  ->
-      let uu___115_1829 = e  in
+      let uu___115_1829 = e in
       {
         curmodule = (FStar_Pervasives_Native.Some l);
         curmonad = (uu___115_1829.curmonad);
@@ -631,17 +585,15 @@ let (set_current_module : env -> FStar_Ident.lident -> env) =
         syntax_only = (uu___115_1829.syntax_only);
         ds_hooks = (uu___115_1829.ds_hooks)
       }
-  
-let (current_module : env -> FStar_Ident.lident) =
+let current_module: env -> FStar_Ident.lident =
   fun env  ->
     match env.curmodule with
     | FStar_Pervasives_Native.None  -> failwith "Unset current module"
     | FStar_Pervasives_Native.Some m -> m
-  
-let (iface_decls :
+let iface_decls:
   env ->
     FStar_Ident.lident ->
-      FStar_Parser_AST.decl Prims.list FStar_Pervasives_Native.option)
+      FStar_Parser_AST.decl Prims.list FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
@@ -650,15 +602,13 @@ let (iface_decls :
           (FStar_List.tryFind
              (fun uu____1878  ->
                 match uu____1878 with
-                | (m,uu____1886) -> FStar_Ident.lid_equals l m))
-         in
+                | (m,uu____1886) -> FStar_Ident.lid_equals l m)) in
       match uu____1844 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (uu____1903,decls) ->
           FStar_Pervasives_Native.Some decls
-  
-let (set_iface_decls :
-  env -> FStar_Ident.lident -> FStar_Parser_AST.decl Prims.list -> env) =
+let set_iface_decls:
+  env -> FStar_Ident.lident -> FStar_Parser_AST.decl Prims.list -> env =
   fun env  ->
     fun l  ->
       fun ds  ->
@@ -667,11 +617,10 @@ let (set_iface_decls :
             (fun uu____1960  ->
                match uu____1960 with
                | (m,uu____1968) -> FStar_Ident.lid_equals l m)
-            env.remaining_iface_decls
-           in
+            env.remaining_iface_decls in
         match uu____1930 with
         | (uu____1973,rest) ->
-            let uu___116_2007 = env  in
+            let uu___116_2007 = env in
             {
               curmodule = (uu___116_2007.curmodule);
               curmonad = (uu___116_2007.curmonad);
@@ -690,25 +639,23 @@ let (set_iface_decls :
               syntax_only = (uu___116_2007.syntax_only);
               ds_hooks = (uu___116_2007.ds_hooks)
             }
-  
-let (qual : FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident) =
-  FStar_Syntax_Util.qual_id 
-let (qualify : env -> FStar_Ident.ident -> FStar_Ident.lident) =
+let qual: FStar_Ident.lident -> FStar_Ident.ident -> FStar_Ident.lident =
+  FStar_Syntax_Util.qual_id
+let qualify: env -> FStar_Ident.ident -> FStar_Ident.lident =
   fun env  ->
     fun id1  ->
       match env.curmonad with
       | FStar_Pervasives_Native.None  ->
-          let uu____2026 = current_module env  in qual uu____2026 id1
+          let uu____2026 = current_module env in qual uu____2026 id1
       | FStar_Pervasives_Native.Some monad ->
           let uu____2028 =
-            let uu____2029 = current_module env  in qual uu____2029 monad  in
+            let uu____2029 = current_module env in qual uu____2029 monad in
           FStar_Syntax_Util.mk_field_projector_name_from_ident uu____2028 id1
-  
-let (syntax_only : env -> Prims.bool) = fun env  -> env.syntax_only 
-let (set_syntax_only : env -> Prims.bool -> env) =
+let syntax_only: env -> Prims.bool = fun env  -> env.syntax_only
+let set_syntax_only: env -> Prims.bool -> env =
   fun env  ->
     fun b  ->
-      let uu___117_2039 = env  in
+      let uu___117_2039 = env in
       {
         curmodule = (uu___117_2039.curmodule);
         curmonad = (uu___117_2039.curmonad);
@@ -727,12 +674,11 @@ let (set_syntax_only : env -> Prims.bool -> env) =
         syntax_only = b;
         ds_hooks = (uu___117_2039.ds_hooks)
       }
-  
-let (ds_hooks : env -> dsenv_hooks) = fun env  -> env.ds_hooks 
-let (set_ds_hooks : env -> dsenv_hooks -> env) =
+let ds_hooks: env -> dsenv_hooks = fun env  -> env.ds_hooks
+let set_ds_hooks: env -> dsenv_hooks -> env =
   fun env  ->
     fun hooks  ->
-      let uu___118_2049 = env  in
+      let uu___118_2049 = env in
       {
         curmodule = (uu___118_2049.curmodule);
         curmonad = (uu___118_2049.curmonad);
@@ -751,16 +697,15 @@ let (set_ds_hooks : env -> dsenv_hooks -> env) =
         syntax_only = (uu___118_2049.syntax_only);
         ds_hooks = hooks
       }
-  
-let new_sigmap : 'Auu____2052 . Prims.unit -> 'Auu____2052 FStar_Util.smap =
-  fun uu____2058  -> FStar_Util.smap_create (Prims.parse_int "100") 
-let (empty_env : Prims.unit -> env) =
+let new_sigmap: 'Auu____2052 . Prims.unit -> 'Auu____2052 FStar_Util.smap =
+  fun uu____2058  -> FStar_Util.smap_create (Prims.parse_int "100")
+let empty_env: Prims.unit -> env =
   fun uu____2061  ->
-    let uu____2062 = new_sigmap ()  in
-    let uu____2065 = new_sigmap ()  in
-    let uu____2068 = new_sigmap ()  in
-    let uu____2079 = new_sigmap ()  in
-    let uu____2090 = new_sigmap ()  in
+    let uu____2062 = new_sigmap () in
+    let uu____2065 = new_sigmap () in
+    let uu____2068 = new_sigmap () in
+    let uu____2079 = new_sigmap () in
+    let uu____2090 = new_sigmap () in
     {
       curmodule = FStar_Pervasives_Native.None;
       curmonad = FStar_Pervasives_Native.None;
@@ -779,54 +724,50 @@ let (empty_env : Prims.unit -> env) =
       syntax_only = false;
       ds_hooks = default_ds_hooks
     }
-  
-let (sigmap :
+let sigmap:
   env ->
     (FStar_Syntax_Syntax.sigelt,Prims.bool) FStar_Pervasives_Native.tuple2
-      FStar_Util.smap)
-  = fun env  -> env.sigmap 
-let (has_all_in_scope : env -> Prims.bool) =
+      FStar_Util.smap
+  = fun env  -> env.sigmap
+let has_all_in_scope: env -> Prims.bool =
   fun env  ->
     FStar_List.existsb
       (fun uu____2122  ->
          match uu____2122 with
          | (m,uu____2128) ->
              FStar_Ident.lid_equals m FStar_Parser_Const.all_lid) env.modules
-  
-let (set_bv_range :
-  FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.bv) =
+let set_bv_range:
+  FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.bv =
   fun bv  ->
     fun r  ->
       let id1 =
-        let uu___119_2136 = bv.FStar_Syntax_Syntax.ppname  in
+        let uu___119_2136 = bv.FStar_Syntax_Syntax.ppname in
         {
           FStar_Ident.idText = (uu___119_2136.FStar_Ident.idText);
           FStar_Ident.idRange = r
-        }  in
-      let uu___120_2137 = bv  in
+        } in
+      let uu___120_2137 = bv in
       {
         FStar_Syntax_Syntax.ppname = id1;
         FStar_Syntax_Syntax.index = (uu___120_2137.FStar_Syntax_Syntax.index);
         FStar_Syntax_Syntax.sort = (uu___120_2137.FStar_Syntax_Syntax.sort)
       }
-  
-let (bv_to_name :
-  FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.term) =
-  fun bv  -> fun r  -> FStar_Syntax_Syntax.bv_to_name (set_bv_range bv r) 
-let (unmangleMap :
+let bv_to_name:
+  FStar_Syntax_Syntax.bv -> FStar_Range.range -> FStar_Syntax_Syntax.term =
+  fun bv  -> fun r  -> FStar_Syntax_Syntax.bv_to_name (set_bv_range bv r)
+let unmangleMap:
   (Prims.string,Prims.string,FStar_Syntax_Syntax.delta_depth,FStar_Syntax_Syntax.fv_qual
                                                                FStar_Pervasives_Native.option)
-    FStar_Pervasives_Native.tuple4 Prims.list)
+    FStar_Pervasives_Native.tuple4 Prims.list
   =
   [("op_ColonColon", "Cons", FStar_Syntax_Syntax.Delta_constant,
      (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor));
   ("not", "op_Negation", FStar_Syntax_Syntax.Delta_equational,
     FStar_Pervasives_Native.None)]
-  
-let (unmangleOpName :
+let unmangleOpName:
   FStar_Ident.ident ->
     (FStar_Syntax_Syntax.term,Prims.bool) FStar_Pervasives_Native.tuple2
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun id1  ->
     let t =
@@ -839,36 +780,30 @@ let (unmangleOpName :
                  let uu____2247 =
                    let uu____2248 =
                      FStar_Ident.lid_of_path ["Prims"; y]
-                       id1.FStar_Ident.idRange
-                      in
-                   FStar_Syntax_Syntax.fvar uu____2248 dd dq  in
+                       id1.FStar_Ident.idRange in
+                   FStar_Syntax_Syntax.fvar uu____2248 dd dq in
                  FStar_Pervasives_Native.Some uu____2247
-               else FStar_Pervasives_Native.None)
-       in
+               else FStar_Pervasives_Native.None) in
     match t with
     | FStar_Pervasives_Native.Some v1 ->
         FStar_Pervasives_Native.Some (v1, false)
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-  
 type 'a cont_t =
-  | Cont_ok of 'a 
-  | Cont_fail 
-  | Cont_ignore [@@deriving show]
-let uu___is_Cont_ok : 'a . 'a cont_t -> Prims.bool =
+  | Cont_ok of 'a
+  | Cont_fail
+  | Cont_ignore[@@deriving show]
+let uu___is_Cont_ok: 'a . 'a cont_t -> Prims.bool =
   fun projectee  ->
     match projectee with | Cont_ok _0 -> true | uu____2291 -> false
-  
-let __proj__Cont_ok__item___0 : 'a . 'a cont_t -> 'a =
-  fun projectee  -> match projectee with | Cont_ok _0 -> _0 
-let uu___is_Cont_fail : 'a . 'a cont_t -> Prims.bool =
+let __proj__Cont_ok__item___0: 'a . 'a cont_t -> 'a =
+  fun projectee  -> match projectee with | Cont_ok _0 -> _0
+let uu___is_Cont_fail: 'a . 'a cont_t -> Prims.bool =
   fun projectee  ->
     match projectee with | Cont_fail  -> true | uu____2320 -> false
-  
-let uu___is_Cont_ignore : 'a . 'a cont_t -> Prims.bool =
+let uu___is_Cont_ignore: 'a . 'a cont_t -> Prims.bool =
   fun projectee  ->
     match projectee with | Cont_ignore  -> true | uu____2334 -> false
-  
-let option_of_cont :
+let option_of_cont:
   'a .
     (Prims.unit -> 'a FStar_Pervasives_Native.option) ->
       'a cont_t -> 'a FStar_Pervasives_Native.option
@@ -879,8 +814,7 @@ let option_of_cont :
       | Cont_ok a -> FStar_Pervasives_Native.Some a
       | Cont_fail  -> FStar_Pervasives_Native.None
       | Cont_ignore  -> k_ignore ()
-  
-let find_in_record :
+let find_in_record:
   'Auu____2370 .
     FStar_Ident.ident Prims.list ->
       FStar_Ident.ident ->
@@ -893,14 +827,12 @@ let find_in_record :
         fun cont  ->
           let typename' =
             FStar_Ident.lid_of_ids
-              (FStar_List.append ns [(record.typename).FStar_Ident.ident])
-             in
+              (FStar_List.append ns [(record.typename).FStar_Ident.ident]) in
           if FStar_Ident.lid_equals typename' record.typename
           then
             let fname =
               FStar_Ident.lid_of_ids
-                (FStar_List.append (record.typename).FStar_Ident.ns [id1])
-               in
+                (FStar_List.append (record.typename).FStar_Ident.ns [id1]) in
             let find1 =
               FStar_Util.find_map record.fields
                 (fun uu____2416  ->
@@ -908,33 +840,30 @@ let find_in_record :
                    | (f,uu____2424) ->
                        if id1.FStar_Ident.idText = f.FStar_Ident.idText
                        then FStar_Pervasives_Native.Some record
-                       else FStar_Pervasives_Native.None)
-               in
+                       else FStar_Pervasives_Native.None) in
             match find1 with
             | FStar_Pervasives_Native.Some r -> cont r
             | FStar_Pervasives_Native.None  -> Cont_ignore
           else Cont_ignore
-  
-let (get_exported_id_set :
+let get_exported_id_set:
   env ->
     Prims.string ->
       (exported_id_kind -> string_set FStar_ST.ref)
-        FStar_Pervasives_Native.option)
-  = fun e  -> fun mname  -> FStar_Util.smap_try_find e.exported_ids mname 
-let (get_trans_exported_id_set :
+        FStar_Pervasives_Native.option
+  = fun e  -> fun mname  -> FStar_Util.smap_try_find e.exported_ids mname
+let get_trans_exported_id_set:
   env ->
     Prims.string ->
       (exported_id_kind -> string_set FStar_ST.ref)
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
-  fun e  -> fun mname  -> FStar_Util.smap_try_find e.trans_exported_ids mname 
-let (string_of_exported_id_kind : exported_id_kind -> Prims.string) =
+  fun e  -> fun mname  -> FStar_Util.smap_try_find e.trans_exported_ids mname
+let string_of_exported_id_kind: exported_id_kind -> Prims.string =
   fun uu___82_2470  ->
     match uu___82_2470 with
     | Exported_id_field  -> "field"
     | Exported_id_term_type  -> "term/type"
-  
-let find_in_module_with_includes :
+let find_in_module_with_includes:
   'a .
     exported_id_kind ->
       (FStar_Ident.lident -> 'a cont_t) ->
@@ -947,49 +876,44 @@ let find_in_module_with_includes :
         fun env  ->
           fun ns  ->
             fun id1  ->
-              let idstr = id1.FStar_Ident.idText  in
+              let idstr = id1.FStar_Ident.idText in
               let rec aux uu___83_2526 =
                 match uu___83_2526 with
                 | [] -> find_in_module_default
                 | modul::q ->
-                    let mname = modul.FStar_Ident.str  in
+                    let mname = modul.FStar_Ident.str in
                     let not_shadowed =
-                      let uu____2537 = get_exported_id_set env mname  in
+                      let uu____2537 = get_exported_id_set env mname in
                       match uu____2537 with
                       | FStar_Pervasives_Native.None  -> true
                       | FStar_Pervasives_Native.Some mex ->
                           let mexports =
-                            let uu____2558 = mex eikind  in
-                            FStar_ST.op_Bang uu____2558  in
-                          FStar_Util.set_mem idstr mexports
-                       in
+                            let uu____2558 = mex eikind in
+                            FStar_ST.op_Bang uu____2558 in
+                          FStar_Util.set_mem idstr mexports in
                     let mincludes =
                       let uu____2672 =
-                        FStar_Util.smap_try_find env.includes mname  in
+                        FStar_Util.smap_try_find env.includes mname in
                       match uu____2672 with
                       | FStar_Pervasives_Native.None  -> []
                       | FStar_Pervasives_Native.Some minc ->
-                          FStar_ST.op_Bang minc
-                       in
+                          FStar_ST.op_Bang minc in
                     let look_into =
                       if not_shadowed
                       then
-                        let uu____2748 = qual modul id1  in
+                        let uu____2748 = qual modul id1 in
                         find_in_module uu____2748
-                      else Cont_ignore  in
+                      else Cont_ignore in
                     (match look_into with
                      | Cont_ignore  -> aux (FStar_List.append mincludes q)
-                     | uu____2752 -> look_into)
-                 in
+                     | uu____2752 -> look_into) in
               aux [ns]
-  
-let (is_exported_id_field : exported_id_kind -> Prims.bool) =
+let is_exported_id_field: exported_id_kind -> Prims.bool =
   fun uu___84_2757  ->
     match uu___84_2757 with
     | Exported_id_field  -> true
     | uu____2758 -> false
-  
-let try_lookup_id'' :
+let try_lookup_id'':
   'a .
     env ->
       FStar_Ident.ident ->
@@ -1012,16 +936,14 @@ let try_lookup_id'' :
                   let check_local_binding_id uu___85_2860 =
                     match uu___85_2860 with
                     | (id',uu____2862,uu____2863) ->
-                        id'.FStar_Ident.idText = id1.FStar_Ident.idText
-                     in
+                        id'.FStar_Ident.idText = id1.FStar_Ident.idText in
                   let check_rec_binding_id uu___86_2867 =
                     match uu___86_2867 with
                     | (id',uu____2869,uu____2870) ->
-                        id'.FStar_Ident.idText = id1.FStar_Ident.idText
-                     in
+                        id'.FStar_Ident.idText = id1.FStar_Ident.idText in
                   let curmod_ns =
-                    let uu____2874 = current_module env  in
-                    FStar_Ident.ids_of_lid uu____2874  in
+                    let uu____2874 = current_module env in
+                    FStar_Ident.ids_of_lid uu____2874 in
                   let proc uu___87_2880 =
                     match uu___87_2880 with
                     | Local_binding l when check_local_binding_id l ->
@@ -1035,27 +957,25 @@ let try_lookup_id'' :
                         id'.FStar_Ident.idText = id1.FStar_Ident.idText ->
                         lookup_default_id Cont_ignore id1
                     | Record_or_dc r when is_exported_id_field eikind ->
-                        let uu____2888 = FStar_Ident.lid_of_ids curmod_ns  in
+                        let uu____2888 = FStar_Ident.lid_of_ids curmod_ns in
                         find_in_module_with_includes Exported_id_field
                           (fun lid  ->
-                             let id2 = lid.FStar_Ident.ident  in
+                             let id2 = lid.FStar_Ident.ident in
                              find_in_record lid.FStar_Ident.ns id2 r k_record)
                           Cont_ignore env uu____2888 id1
-                    | uu____2893 -> Cont_ignore  in
+                    | uu____2893 -> Cont_ignore in
                   let rec aux uu___88_2901 =
                     match uu___88_2901 with
                     | a::q ->
-                        let uu____2910 = proc a  in
+                        let uu____2910 = proc a in
                         option_of_cont (fun uu____2914  -> aux q) uu____2910
                     | [] ->
-                        let uu____2915 = lookup_default_id Cont_fail id1  in
+                        let uu____2915 = lookup_default_id Cont_fail id1 in
                         option_of_cont
                           (fun uu____2919  -> FStar_Pervasives_Native.None)
-                          uu____2915
-                     in
+                          uu____2915 in
                   aux env.scope_mods
-  
-let found_local_binding :
+let found_local_binding:
   'Auu____2924 'Auu____2925 .
     FStar_Range.range ->
       ('Auu____2925,FStar_Syntax_Syntax.bv,'Auu____2924)
@@ -1066,9 +986,8 @@ let found_local_binding :
   fun r  ->
     fun uu____2943  ->
       match uu____2943 with
-      | (id',x,mut) -> let uu____2953 = bv_to_name x r  in (uu____2953, mut)
-  
-let find_in_module :
+      | (id',x,mut) -> let uu____2953 = bv_to_name x r in (uu____2953, mut)
+let find_in_module:
   'Auu____2959 .
     env ->
       FStar_Ident.lident ->
@@ -1082,27 +1001,25 @@ let find_in_module :
       fun k_global_def  ->
         fun k_not_found  ->
           let uu____2994 =
-            FStar_Util.smap_try_find (sigmap env) lid.FStar_Ident.str  in
+            FStar_Util.smap_try_find (sigmap env) lid.FStar_Ident.str in
           match uu____2994 with
           | FStar_Pervasives_Native.Some sb -> k_global_def lid sb
           | FStar_Pervasives_Native.None  -> k_not_found
-  
-let (try_lookup_id :
+let try_lookup_id:
   env ->
     FStar_Ident.ident ->
       (FStar_Syntax_Syntax.term,Prims.bool) FStar_Pervasives_Native.tuple2
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
   fun env  ->
     fun id1  ->
-      let uu____3030 = unmangleOpName id1  in
+      let uu____3030 = unmangleOpName id1 in
       match uu____3030 with
       | FStar_Pervasives_Native.Some f -> FStar_Pervasives_Native.Some f
       | uu____3056 ->
           try_lookup_id'' env id1 Exported_id_term_type
             (fun r  ->
-               let uu____3070 = found_local_binding id1.FStar_Ident.idRange r
-                  in
+               let uu____3070 = found_local_binding id1.FStar_Ident.idRange r in
                Cont_ok uu____3070) (fun uu____3080  -> Cont_fail)
             (fun uu____3086  -> Cont_ignore)
             (fun i  ->
@@ -1110,8 +1027,7 @@ let (try_lookup_id :
                  (fun uu____3101  -> fun uu____3102  -> Cont_fail)
                  Cont_ignore)
             (fun uu____3117  -> fun uu____3118  -> Cont_fail)
-  
-let lookup_default_id :
+let lookup_default_id:
   'a .
     env ->
       FStar_Ident.ident ->
@@ -1127,53 +1043,48 @@ let lookup_default_id :
           let find_in_monad =
             match env.curmonad with
             | FStar_Pervasives_Native.Some uu____3188 ->
-                let lid = qualify env id1  in
+                let lid = qualify env id1 in
                 let uu____3190 =
-                  FStar_Util.smap_try_find (sigmap env) lid.FStar_Ident.str
-                   in
+                  FStar_Util.smap_try_find (sigmap env) lid.FStar_Ident.str in
                 (match uu____3190 with
                  | FStar_Pervasives_Native.Some r ->
-                     let uu____3214 = k_global_def lid r  in
+                     let uu____3214 = k_global_def lid r in
                      FStar_Pervasives_Native.Some uu____3214
                  | FStar_Pervasives_Native.None  ->
                      FStar_Pervasives_Native.None)
-            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-             in
+            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None in
           match find_in_monad with
           | FStar_Pervasives_Native.Some v1 -> v1
           | FStar_Pervasives_Native.None  ->
               let lid =
-                let uu____3237 = current_module env  in qual uu____3237 id1
-                 in
+                let uu____3237 = current_module env in qual uu____3237 id1 in
               find_in_module env lid k_global_def k_not_found
-  
-let (module_is_defined : env -> FStar_Ident.lident -> Prims.bool) =
+let module_is_defined: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun lid  ->
       (match env.curmodule with
        | FStar_Pervasives_Native.None  -> false
        | FStar_Pervasives_Native.Some m ->
-           let uu____3247 = current_module env  in
+           let uu____3247 = current_module env in
            FStar_Ident.lid_equals lid uu____3247)
         ||
         (FStar_List.existsb
            (fun x  ->
               FStar_Ident.lid_equals lid (FStar_Pervasives_Native.fst x))
            env.modules)
-  
-let (resolve_module_name :
+let resolve_module_name:
   env ->
     FStar_Ident.lident ->
-      Prims.bool -> FStar_Ident.lident FStar_Pervasives_Native.option)
+      Prims.bool -> FStar_Ident.lident FStar_Pervasives_Native.option
   =
   fun env  ->
     fun lid  ->
       fun honor_ns  ->
-        let nslen = FStar_List.length lid.FStar_Ident.ns  in
+        let nslen = FStar_List.length lid.FStar_Ident.ns in
         let rec aux uu___89_3279 =
           match uu___89_3279 with
           | [] ->
-              let uu____3284 = module_is_defined env lid  in
+              let uu____3284 = module_is_defined env lid in
               if uu____3284
               then FStar_Pervasives_Native.Some lid
               else FStar_Pervasives_Native.None
@@ -1181,13 +1092,12 @@ let (resolve_module_name :
               ->
               let new_lid =
                 let uu____3293 =
-                  let uu____3296 = FStar_Ident.path_of_lid ns  in
-                  let uu____3299 = FStar_Ident.path_of_lid lid  in
-                  FStar_List.append uu____3296 uu____3299  in
+                  let uu____3296 = FStar_Ident.path_of_lid ns in
+                  let uu____3299 = FStar_Ident.path_of_lid lid in
+                  FStar_List.append uu____3296 uu____3299 in
                 FStar_Ident.lid_of_path uu____3293
-                  (FStar_Ident.range_of_lid lid)
-                 in
-              let uu____3302 = module_is_defined env new_lid  in
+                  (FStar_Ident.range_of_lid lid) in
+              let uu____3302 = module_is_defined env new_lid in
               if uu____3302
               then FStar_Pervasives_Native.Some new_lid
               else aux q
@@ -1196,17 +1106,16 @@ let (resolve_module_name :
                 (name.FStar_Ident.idText =
                    (lid.FStar_Ident.ident).FStar_Ident.idText)
               -> FStar_Pervasives_Native.Some modul
-          | uu____3315::q -> aux q  in
+          | uu____3315::q -> aux q in
         aux env.scope_mods
-  
-let (fail_if_curmodule :
-  env -> FStar_Ident.lident -> FStar_Ident.lident -> Prims.unit) =
+let fail_if_curmodule:
+  env -> FStar_Ident.lident -> FStar_Ident.lident -> Prims.unit =
   fun env  ->
     fun ns_original  ->
       fun ns_resolved  ->
         let uu____3328 =
-          let uu____3329 = current_module env  in
-          FStar_Ident.lid_equals ns_resolved uu____3329  in
+          let uu____3329 = current_module env in
+          FStar_Ident.lid_equals ns_resolved uu____3329 in
         if uu____3328
         then
           (if FStar_Ident.lid_equals ns_resolved FStar_Parser_Const.prims_lid
@@ -1216,30 +1125,25 @@ let (fail_if_curmodule :
                 let uu____3336 =
                   FStar_Util.format1
                     "Reference %s to current module is forbidden (see GitHub issue #451)"
-                    ns_original.FStar_Ident.str
-                   in
+                    ns_original.FStar_Ident.str in
                 (FStar_Errors.Fatal_ForbiddenReferenceToCurrentModule,
-                  uu____3336)
-                 in
+                  uu____3336) in
               FStar_Errors.raise_error uu____3331
                 (FStar_Ident.range_of_lid ns_original)))
         else ()
-  
-let (fail_if_qualified_by_curmodule :
-  env -> FStar_Ident.lident -> Prims.unit) =
+let fail_if_qualified_by_curmodule: env -> FStar_Ident.lident -> Prims.unit =
   fun env  ->
     fun lid  ->
       match lid.FStar_Ident.ns with
       | [] -> ()
       | uu____3344 ->
-          let modul_orig = FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-          let uu____3348 = resolve_module_name env modul_orig true  in
+          let modul_orig = FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
+          let uu____3348 = resolve_module_name env modul_orig true in
           (match uu____3348 with
            | FStar_Pervasives_Native.Some modul_res ->
                fail_if_curmodule env modul_orig modul_res
            | uu____3352 -> ())
-  
-let (namespace_is_open : env -> FStar_Ident.lident -> Prims.bool) =
+let namespace_is_open: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun lid  ->
       FStar_List.existsb
@@ -1248,20 +1152,18 @@ let (namespace_is_open : env -> FStar_Ident.lident -> Prims.bool) =
            | Open_module_or_namespace (ns,Open_namespace ) ->
                FStar_Ident.lid_equals lid ns
            | uu____3365 -> false) env.scope_mods
-  
-let (shorten_module_path :
+let shorten_module_path:
   env ->
     FStar_Ident.ident Prims.list ->
       Prims.bool ->
         (FStar_Ident.ident Prims.list,FStar_Ident.ident Prims.list)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun ids  ->
       fun is_full_path  ->
         let rec aux revns id1 =
-          let lid = FStar_Ident.lid_of_ns_and_id (FStar_List.rev revns) id1
-             in
+          let lid = FStar_Ident.lid_of_ns_and_id (FStar_List.rev revns) id1 in
           if namespace_is_open env lid
           then
             FStar_Pervasives_Native.Some
@@ -1270,40 +1172,36 @@ let (shorten_module_path :
             (match revns with
              | [] -> FStar_Pervasives_Native.None
              | ns_last_id::rev_ns_prefix ->
-                 let uu____3454 = aux rev_ns_prefix ns_last_id  in
+                 let uu____3454 = aux rev_ns_prefix ns_last_id in
                  FStar_All.pipe_right uu____3454
                    (FStar_Util.map_option
                       (fun uu____3504  ->
                          match uu____3504 with
                          | (stripped_ids,rev_kept_ids) ->
-                             (stripped_ids, (id1 :: rev_kept_ids)))))
-           in
+                             (stripped_ids, (id1 :: rev_kept_ids))))) in
         let uu____3535 =
           is_full_path &&
-            (let uu____3537 = FStar_Ident.lid_of_ids ids  in
-             module_is_defined env uu____3537)
-           in
+            (let uu____3537 = FStar_Ident.lid_of_ids ids in
+             module_is_defined env uu____3537) in
         if uu____3535
         then (ids, [])
         else
           (match FStar_List.rev ids with
            | [] -> ([], [])
            | ns_last_id::ns_rev_prefix ->
-               let uu____3567 = aux ns_rev_prefix ns_last_id  in
+               let uu____3567 = aux ns_rev_prefix ns_last_id in
                (match uu____3567 with
                 | FStar_Pervasives_Native.None  -> ([], ids)
                 | FStar_Pervasives_Native.Some (stripped_ids,rev_kept_ids) ->
                     (stripped_ids, (FStar_List.rev rev_kept_ids))))
-  
-let (shorten_lid : env -> FStar_Ident.lid -> FStar_Ident.lid) =
+let shorten_lid: env -> FStar_Ident.lid -> FStar_Ident.lid =
   fun env  ->
     fun lid  ->
-      let uu____3626 = shorten_module_path env lid.FStar_Ident.ns true  in
+      let uu____3626 = shorten_module_path env lid.FStar_Ident.ns true in
       match uu____3626 with
       | (uu____3635,short) ->
           FStar_Ident.lid_of_ns_and_id short lid.FStar_Ident.ident
-  
-let resolve_in_open_namespaces'' :
+let resolve_in_open_namespaces'':
   'a .
     env ->
       FStar_Ident.lident ->
@@ -1328,19 +1226,17 @@ let resolve_in_open_namespaces'' :
                       let uu____3747 =
                         let uu____3750 =
                           let uu____3751 =
-                            FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
+                            FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
                           FStar_Ident.set_lid_range uu____3751
-                            (FStar_Ident.range_of_lid lid)
-                           in
-                        resolve_module_name env uu____3750 true  in
+                            (FStar_Ident.range_of_lid lid) in
+                        resolve_module_name env uu____3750 true in
                       (match uu____3747 with
                        | FStar_Pervasives_Native.None  ->
                            FStar_Pervasives_Native.None
                        | FStar_Pervasives_Native.Some modul ->
                            let uu____3755 =
                              find_in_module_with_includes eikind f_module
-                               Cont_fail env modul lid.FStar_Ident.ident
-                              in
+                               Cont_fail env modul lid.FStar_Ident.ident in
                            option_of_cont
                              (fun uu____3759  -> FStar_Pervasives_Native.None)
                              uu____3755)
@@ -1348,16 +1244,14 @@ let resolve_in_open_namespaces'' :
                       try_lookup_id'' env lid.FStar_Ident.ident eikind
                         k_local_binding k_rec_binding k_record f_module
                         l_default
-  
-let cont_of_option :
+let cont_of_option:
   'a . 'a cont_t -> 'a FStar_Pervasives_Native.option -> 'a cont_t =
   fun k_none  ->
     fun uu___91_3777  ->
       match uu___91_3777 with
       | FStar_Pervasives_Native.Some v1 -> Cont_ok v1
       | FStar_Pervasives_Native.None  -> k_none
-  
-let resolve_in_open_namespaces' :
+let resolve_in_open_namespaces':
   'a .
     env ->
       FStar_Ident.lident ->
@@ -1375,25 +1269,23 @@ let resolve_in_open_namespaces' :
         fun k_rec_binding  ->
           fun k_global_def  ->
             let k_global_def' k lid1 def =
-              let uu____3876 = k_global_def lid1 def  in
-              cont_of_option k uu____3876  in
+              let uu____3876 = k_global_def lid1 def in
+              cont_of_option k uu____3876 in
             let f_module lid' =
-              let k = Cont_ignore  in
-              find_in_module env lid' (k_global_def' k) k  in
-            let l_default k i = lookup_default_id env i (k_global_def' k) k
-               in
+              let k = Cont_ignore in
+              find_in_module env lid' (k_global_def' k) k in
+            let l_default k i = lookup_default_id env i (k_global_def' k) k in
             resolve_in_open_namespaces'' env lid Exported_id_term_type
               (fun l  ->
-                 let uu____3906 = k_local_binding l  in
+                 let uu____3906 = k_local_binding l in
                  cont_of_option Cont_fail uu____3906)
               (fun r  ->
-                 let uu____3912 = k_rec_binding r  in
+                 let uu____3912 = k_rec_binding r in
                  cont_of_option Cont_fail uu____3912)
               (fun uu____3916  -> Cont_ignore) f_module l_default
-  
-let (fv_qual_of_se :
+let fv_qual_of_se:
   FStar_Syntax_Syntax.sigelt ->
-    FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option
   =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
@@ -1406,8 +1298,7 @@ let (fv_qual_of_se :
                | FStar_Syntax_Syntax.RecordConstructor (uu____3943,fs) ->
                    FStar_Pervasives_Native.Some
                      (FStar_Syntax_Syntax.Record_ctor (l, fs))
-               | uu____3955 -> FStar_Pervasives_Native.None)
-           in
+               | uu____3955 -> FStar_Pervasives_Native.None) in
         (match qopt with
          | FStar_Pervasives_Native.None  ->
              FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor
@@ -1415,44 +1306,40 @@ let (fv_qual_of_se :
     | FStar_Syntax_Syntax.Sig_declare_typ (uu____3961,uu____3962,uu____3963)
         -> FStar_Pervasives_Native.None
     | uu____3964 -> FStar_Pervasives_Native.None
-  
-let (lb_fv :
+let lb_fv:
   FStar_Syntax_Syntax.letbinding Prims.list ->
-    FStar_Ident.lident -> FStar_Syntax_Syntax.fv)
+    FStar_Ident.lident -> FStar_Syntax_Syntax.fv
   =
   fun lbs  ->
     fun lid  ->
       let uu____3975 =
         FStar_Util.find_map lbs
           (fun lb  ->
-             let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-             let uu____3983 = FStar_Syntax_Syntax.fv_eq_lid fv lid  in
+             let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
+             let uu____3983 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
              if uu____3983
              then FStar_Pervasives_Native.Some fv
-             else FStar_Pervasives_Native.None)
-         in
+             else FStar_Pervasives_Native.None) in
       FStar_All.pipe_right uu____3975 FStar_Util.must
-  
-let (ns_of_lid_equals :
-  FStar_Ident.lident -> FStar_Ident.lident -> Prims.bool) =
+let ns_of_lid_equals: FStar_Ident.lident -> FStar_Ident.lident -> Prims.bool
+  =
   fun lid  ->
     fun ns  ->
       ((FStar_List.length lid.FStar_Ident.ns) =
          (FStar_List.length (FStar_Ident.ids_of_lid ns)))
         &&
-        (let uu____3996 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
+        (let uu____3996 = FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
          FStar_Ident.lid_equals uu____3996 ns)
-  
-let (try_lookup_name :
+let try_lookup_name:
   Prims.bool ->
     Prims.bool ->
-      env -> FStar_Ident.lident -> foundname FStar_Pervasives_Native.option)
+      env -> FStar_Ident.lident -> foundname FStar_Pervasives_Native.option
   =
   fun any_val  ->
     fun exclude_interf  ->
       fun env  ->
         fun lid  ->
-          let occurrence_range = FStar_Ident.range_of_lid lid  in
+          let occurrence_range = FStar_Ident.range_of_lid lid in
           let k_global_def source_lid uu___97_4026 =
             match uu___97_4026 with
             | (uu____4033,true ) when exclude_interf ->
@@ -1465,44 +1352,38 @@ let (try_lookup_name :
                          let uu____4065 =
                            FStar_Syntax_Syntax.fvar source_lid
                              FStar_Syntax_Syntax.Delta_constant
-                             FStar_Pervasives_Native.None
-                            in
+                             FStar_Pervasives_Native.None in
                          (uu____4065, false,
-                           (se.FStar_Syntax_Syntax.sigattrs))
-                          in
-                       Term_name uu____4056  in
+                           (se.FStar_Syntax_Syntax.sigattrs)) in
+                       Term_name uu____4056 in
                      FStar_Pervasives_Native.Some uu____4055
                  | FStar_Syntax_Syntax.Sig_datacon uu____4068 ->
                      let uu____4083 =
                        let uu____4084 =
                          let uu____4093 =
-                           let uu____4094 = fv_qual_of_se se  in
+                           let uu____4094 = fv_qual_of_se se in
                            FStar_Syntax_Syntax.fvar source_lid
-                             FStar_Syntax_Syntax.Delta_constant uu____4094
-                            in
+                             FStar_Syntax_Syntax.Delta_constant uu____4094 in
                          (uu____4093, false,
-                           (se.FStar_Syntax_Syntax.sigattrs))
-                          in
-                       Term_name uu____4084  in
+                           (se.FStar_Syntax_Syntax.sigattrs)) in
+                       Term_name uu____4084 in
                      FStar_Pervasives_Native.Some uu____4083
                  | FStar_Syntax_Syntax.Sig_let ((uu____4099,lbs),uu____4101)
                      ->
-                     let fv = lb_fv lbs source_lid  in
+                     let fv = lb_fv lbs source_lid in
                      let uu____4117 =
                        let uu____4118 =
                          let uu____4127 =
                            FStar_Syntax_Syntax.fvar source_lid
                              fv.FStar_Syntax_Syntax.fv_delta
-                             fv.FStar_Syntax_Syntax.fv_qual
-                            in
+                             fv.FStar_Syntax_Syntax.fv_qual in
                          (uu____4127, false,
-                           (se.FStar_Syntax_Syntax.sigattrs))
-                          in
-                       Term_name uu____4118  in
+                           (se.FStar_Syntax_Syntax.sigattrs)) in
+                       Term_name uu____4118 in
                      FStar_Pervasives_Native.Some uu____4117
                  | FStar_Syntax_Syntax.Sig_declare_typ
                      (lid1,uu____4131,uu____4132) ->
-                     let quals = se.FStar_Syntax_Syntax.sigquals  in
+                     let quals = se.FStar_Syntax_Syntax.sigquals in
                      let uu____4136 =
                        any_val ||
                          (FStar_All.pipe_right quals
@@ -1510,14 +1391,12 @@ let (try_lookup_name :
                                (fun uu___93_4140  ->
                                   match uu___93_4140 with
                                   | FStar_Syntax_Syntax.Assumption  -> true
-                                  | uu____4141 -> false)))
-                        in
+                                  | uu____4141 -> false))) in
                      if uu____4136
                      then
                        let lid2 =
                          FStar_Ident.set_lid_range lid1
-                           (FStar_Ident.range_of_lid source_lid)
-                          in
+                           (FStar_Ident.range_of_lid source_lid) in
                        let dd =
                          let uu____4146 =
                            (FStar_Syntax_Util.is_primop_lid lid2) ||
@@ -1529,11 +1408,10 @@ let (try_lookup_name :
                                           uu____4152 -> true
                                       | FStar_Syntax_Syntax.Discriminator
                                           uu____4157 -> true
-                                      | uu____4158 -> false)))
-                            in
+                                      | uu____4158 -> false))) in
                          if uu____4146
                          then FStar_Syntax_Syntax.Delta_equational
-                         else FStar_Syntax_Syntax.Delta_constant  in
+                         else FStar_Syntax_Syntax.Delta_constant in
                        let dd1 =
                          let uu____4161 =
                            FStar_All.pipe_right quals
@@ -1541,27 +1419,24 @@ let (try_lookup_name :
                                 (fun uu___95_4165  ->
                                    match uu___95_4165 with
                                    | FStar_Syntax_Syntax.Abstract  -> true
-                                   | uu____4166 -> false))
-                            in
+                                   | uu____4166 -> false)) in
                          if uu____4161
                          then FStar_Syntax_Syntax.Delta_abstract dd
-                         else dd  in
+                         else dd in
                        let uu____4168 =
                          FStar_Util.find_map quals
                            (fun uu___96_4173  ->
                               match uu___96_4173 with
                               | FStar_Syntax_Syntax.Reflectable refl_monad ->
                                   FStar_Pervasives_Native.Some refl_monad
-                              | uu____4177 -> FStar_Pervasives_Native.None)
-                          in
+                              | uu____4177 -> FStar_Pervasives_Native.None) in
                        (match uu____4168 with
                         | FStar_Pervasives_Native.Some refl_monad ->
                             let refl_const =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_constant
                                    (FStar_Const.Const_reflect refl_monad))
-                                FStar_Pervasives_Native.None occurrence_range
-                               in
+                                FStar_Pervasives_Native.None occurrence_range in
                             FStar_Pervasives_Native.Some
                               (Term_name
                                  (refl_const, false,
@@ -1570,14 +1445,12 @@ let (try_lookup_name :
                             let uu____4191 =
                               let uu____4192 =
                                 let uu____4201 =
-                                  let uu____4202 = fv_qual_of_se se  in
+                                  let uu____4202 = fv_qual_of_se se in
                                   FStar_Syntax_Syntax.fvar lid2 dd1
-                                    uu____4202
-                                   in
+                                    uu____4202 in
                                 (uu____4201, false,
-                                  (se.FStar_Syntax_Syntax.sigattrs))
-                                 in
-                              Term_name uu____4192  in
+                                  (se.FStar_Syntax_Syntax.sigattrs)) in
+                              Term_name uu____4192 in
                             FStar_Pervasives_Native.Some uu____4191)
                      else FStar_Pervasives_Native.None
                  | FStar_Syntax_Syntax.Sig_new_effect_for_free ne ->
@@ -1596,15 +1469,13 @@ let (try_lookup_name :
                                (FStar_Ident.range_of_lid source_lid))))
                  | FStar_Syntax_Syntax.Sig_effect_abbrev uu____4210 ->
                      FStar_Pervasives_Native.Some (Eff_name (se, source_lid))
-                 | uu____4223 -> FStar_Pervasives_Native.None)
-             in
+                 | uu____4223 -> FStar_Pervasives_Native.None) in
           let k_local_binding r =
             let uu____4242 =
-              found_local_binding (FStar_Ident.range_of_lid lid) r  in
+              found_local_binding (FStar_Ident.range_of_lid lid) r in
             match uu____4242 with
             | (t,mut) ->
-                FStar_Pervasives_Native.Some (Term_name (t, mut, []))
-             in
+                FStar_Pervasives_Native.Some (Term_name (t, mut, [])) in
           let k_rec_binding uu____4264 =
             match uu____4264 with
             | (id1,l,dd) ->
@@ -1614,66 +1485,61 @@ let (try_lookup_name :
                       FStar_Syntax_Syntax.fvar
                         (FStar_Ident.set_lid_range l
                            (FStar_Ident.range_of_lid lid)) dd
-                        FStar_Pervasives_Native.None
-                       in
-                    (uu____4286, false, [])  in
-                  Term_name uu____4277  in
-                FStar_Pervasives_Native.Some uu____4276
-             in
+                        FStar_Pervasives_Native.None in
+                    (uu____4286, false, []) in
+                  Term_name uu____4277 in
+                FStar_Pervasives_Native.Some uu____4276 in
           let found_unmangled =
             match lid.FStar_Ident.ns with
             | [] ->
-                let uu____4294 = unmangleOpName lid.FStar_Ident.ident  in
+                let uu____4294 = unmangleOpName lid.FStar_Ident.ident in
                 (match uu____4294 with
                  | FStar_Pervasives_Native.Some (t,mut) ->
                      FStar_Pervasives_Native.Some (Term_name (t, mut, []))
                  | uu____4311 -> FStar_Pervasives_Native.None)
-            | uu____4318 -> FStar_Pervasives_Native.None  in
+            | uu____4318 -> FStar_Pervasives_Native.None in
           match found_unmangled with
           | FStar_Pervasives_Native.None  ->
               resolve_in_open_namespaces' env lid k_local_binding
                 k_rec_binding k_global_def
           | x -> x
-  
-let (try_lookup_effect_name' :
+let try_lookup_effect_name':
   Prims.bool ->
     env ->
       FStar_Ident.lident ->
         (FStar_Syntax_Syntax.sigelt,FStar_Ident.lident)
-          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun exclude_interf  ->
     fun env  ->
       fun lid  ->
-        let uu____4347 = try_lookup_name true exclude_interf env lid  in
+        let uu____4347 = try_lookup_name true exclude_interf env lid in
         match uu____4347 with
         | FStar_Pervasives_Native.Some (Eff_name (o,l)) ->
             FStar_Pervasives_Native.Some (o, l)
         | uu____4362 -> FStar_Pervasives_Native.None
-  
-let (try_lookup_effect_name :
+let try_lookup_effect_name:
   env ->
-    FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option)
+    FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
       let uu____4377 =
-        try_lookup_effect_name' (Prims.op_Negation env.iface) env l  in
+        try_lookup_effect_name' (Prims.op_Negation env.iface) env l in
       match uu____4377 with
       | FStar_Pervasives_Native.Some (o,l1) ->
           FStar_Pervasives_Native.Some l1
       | uu____4392 -> FStar_Pervasives_Native.None
-  
-let (try_lookup_effect_name_and_attributes :
+let try_lookup_effect_name_and_attributes:
   env ->
     FStar_Ident.lident ->
       (FStar_Ident.lident,FStar_Syntax_Syntax.cflags Prims.list)
-        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
       let uu____4413 =
-        try_lookup_effect_name' (Prims.op_Negation env.iface) env l  in
+        try_lookup_effect_name' (Prims.op_Negation env.iface) env l in
       match uu____4413 with
       | FStar_Pervasives_Native.Some
           ({
@@ -1708,16 +1574,15 @@ let (try_lookup_effect_name_and_attributes :
              FStar_Syntax_Syntax.sigattrs = uu____4480;_},l1)
           -> FStar_Pervasives_Native.Some (l1, cattributes)
       | uu____4502 -> FStar_Pervasives_Native.None
-  
-let (try_lookup_effect_defn :
+let try_lookup_effect_defn:
   env ->
     FStar_Ident.lident ->
-      FStar_Syntax_Syntax.eff_decl FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.eff_decl FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
       let uu____4523 =
-        try_lookup_effect_name' (Prims.op_Negation env.iface) env l  in
+        try_lookup_effect_name' (Prims.op_Negation env.iface) env l in
       match uu____4523 with
       | FStar_Pervasives_Native.Some
           ({
@@ -1738,23 +1603,21 @@ let (try_lookup_effect_defn :
              FStar_Syntax_Syntax.sigattrs = uu____4550;_},uu____4551)
           -> FStar_Pervasives_Native.Some ne
       | uu____4560 -> FStar_Pervasives_Native.None
-  
-let (is_effect_name : env -> FStar_Ident.lident -> Prims.bool) =
+let is_effect_name: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun lid  ->
-      let uu____4573 = try_lookup_effect_name env lid  in
+      let uu____4573 = try_lookup_effect_name env lid in
       match uu____4573 with
       | FStar_Pervasives_Native.None  -> false
       | FStar_Pervasives_Native.Some uu____4576 -> true
-  
-let (try_lookup_root_effect_name :
+let try_lookup_root_effect_name:
   env ->
-    FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option)
+    FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
       let uu____4585 =
-        try_lookup_effect_name' (Prims.op_Negation env.iface) env l  in
+        try_lookup_effect_name' (Prims.op_Negation env.iface) env l in
       match uu____4585 with
       | FStar_Pervasives_Native.Some
           ({
@@ -1768,8 +1631,7 @@ let (try_lookup_root_effect_name :
           ->
           let rec aux new_name =
             let uu____4622 =
-              FStar_Util.smap_try_find (sigmap env) new_name.FStar_Ident.str
-               in
+              FStar_Util.smap_try_find (sigmap env) new_name.FStar_Ident.str in
             match uu____4622 with
             | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
             | FStar_Pervasives_Native.Some (s,uu____4640) ->
@@ -1786,17 +1648,15 @@ let (try_lookup_root_effect_name :
                           (FStar_Ident.range_of_lid l))
                  | FStar_Syntax_Syntax.Sig_effect_abbrev
                      (uu____4649,uu____4650,uu____4651,cmp,uu____4653) ->
-                     let l'' = FStar_Syntax_Util.comp_effect_name cmp  in
+                     let l'' = FStar_Syntax_Util.comp_effect_name cmp in
                      aux l''
-                 | uu____4659 -> FStar_Pervasives_Native.None)
-             in
+                 | uu____4659 -> FStar_Pervasives_Native.None) in
           aux l'
       | FStar_Pervasives_Native.Some (uu____4660,l') ->
           FStar_Pervasives_Native.Some l'
       | uu____4666 -> FStar_Pervasives_Native.None
-  
-let (lookup_letbinding_quals :
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list) =
+let lookup_letbinding_quals:
+  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list =
   fun env  ->
     fun lid  ->
       let k_global_def lid1 uu___98_4695 =
@@ -1809,20 +1669,18 @@ let (lookup_letbinding_quals :
              FStar_Syntax_Syntax.sigmeta = uu____4709;
              FStar_Syntax_Syntax.sigattrs = uu____4710;_},uu____4711)
             -> FStar_Pervasives_Native.Some quals
-        | uu____4718 -> FStar_Pervasives_Native.None  in
+        | uu____4718 -> FStar_Pervasives_Native.None in
       let uu____4725 =
         resolve_in_open_namespaces' env lid
           (fun uu____4733  -> FStar_Pervasives_Native.None)
-          (fun uu____4737  -> FStar_Pervasives_Native.None) k_global_def
-         in
+          (fun uu____4737  -> FStar_Pervasives_Native.None) k_global_def in
       match uu____4725 with
       | FStar_Pervasives_Native.Some quals -> quals
       | uu____4747 -> []
-  
-let (try_lookup_module :
+let try_lookup_module:
   env ->
     Prims.string Prims.list ->
-      FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option
   =
   fun env  ->
     fun path  ->
@@ -1831,18 +1689,16 @@ let (try_lookup_module :
           (fun uu____4779  ->
              match uu____4779 with
              | (mlid,modul) ->
-                 let uu____4786 = FStar_Ident.path_of_lid mlid  in
-                 uu____4786 = path) env.modules
-         in
+                 let uu____4786 = FStar_Ident.path_of_lid mlid in
+                 uu____4786 = path) env.modules in
       match uu____4764 with
       | FStar_Pervasives_Native.Some (uu____4793,modul) ->
           FStar_Pervasives_Native.Some modul
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-  
-let (try_lookup_let :
+let try_lookup_let:
   env ->
     FStar_Ident.lident ->
-      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun env  ->
     fun lid  ->
@@ -1856,21 +1712,19 @@ let (try_lookup_let :
              FStar_Syntax_Syntax.sigmeta = uu____4835;
              FStar_Syntax_Syntax.sigattrs = uu____4836;_},uu____4837)
             ->
-            let fv = lb_fv lbs lid1  in
+            let fv = lb_fv lbs lid1 in
             let uu____4857 =
               FStar_Syntax_Syntax.fvar lid1 fv.FStar_Syntax_Syntax.fv_delta
-                fv.FStar_Syntax_Syntax.fv_qual
-               in
+                fv.FStar_Syntax_Syntax.fv_qual in
             FStar_Pervasives_Native.Some uu____4857
-        | uu____4858 -> FStar_Pervasives_Native.None  in
+        | uu____4858 -> FStar_Pervasives_Native.None in
       resolve_in_open_namespaces' env lid
         (fun uu____4864  -> FStar_Pervasives_Native.None)
         (fun uu____4866  -> FStar_Pervasives_Native.None) k_global_def
-  
-let (try_lookup_definition :
+let try_lookup_definition:
   env ->
     FStar_Ident.lident ->
-      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun env  ->
     fun lid  ->
@@ -1892,96 +1746,89 @@ let (try_lookup_definition :
                      FStar_Pervasives_Native.Some
                        (lb.FStar_Syntax_Syntax.lbdef)
                  | uu____4927 -> FStar_Pervasives_Native.None)
-        | uu____4934 -> FStar_Pervasives_Native.None  in
+        | uu____4934 -> FStar_Pervasives_Native.None in
       resolve_in_open_namespaces' env lid
         (fun uu____4944  -> FStar_Pervasives_Native.None)
         (fun uu____4948  -> FStar_Pervasives_Native.None) k_global_def
-  
-let (empty_include_smap :
-  FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap) = new_sigmap () 
-let (empty_exported_id_smap : exported_id_set FStar_Util.smap) =
-  new_sigmap () 
-let (try_lookup_lid' :
+let empty_include_smap:
+  FStar_Ident.lident Prims.list FStar_ST.ref FStar_Util.smap = new_sigmap ()
+let empty_exported_id_smap: exported_id_set FStar_Util.smap = new_sigmap ()
+let try_lookup_lid':
   Prims.bool ->
     Prims.bool ->
       env ->
         FStar_Ident.lident ->
           (FStar_Syntax_Syntax.term,Prims.bool,FStar_Syntax_Syntax.attribute
                                                  Prims.list)
-            FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option)
+            FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option
   =
   fun any_val  ->
     fun exclude_interface  ->
       fun env  ->
         fun lid  ->
-          let uu____4995 = try_lookup_name any_val exclude_interface env lid
-             in
+          let uu____4995 = try_lookup_name any_val exclude_interface env lid in
           match uu____4995 with
           | FStar_Pervasives_Native.Some (Term_name (e,mut,attrs)) ->
               FStar_Pervasives_Native.Some (e, mut, attrs)
           | uu____5025 -> FStar_Pervasives_Native.None
-  
-let (drop_attributes :
+let drop_attributes:
   (FStar_Syntax_Syntax.term,Prims.bool,FStar_Syntax_Syntax.attribute
                                          Prims.list)
     FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option ->
     (FStar_Syntax_Syntax.term,Prims.bool) FStar_Pervasives_Native.tuple2
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun x  ->
     match x with
     | FStar_Pervasives_Native.Some (t,mut,uu____5079) ->
         FStar_Pervasives_Native.Some (t, mut)
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-  
-let (try_lookup_lid_with_attributes :
+let try_lookup_lid_with_attributes:
   env ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.term,Prims.bool,FStar_Syntax_Syntax.attribute
                                              Prims.list)
-        FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option)
-  = fun env  -> fun l  -> try_lookup_lid' env.iface false env l 
-let (try_lookup_lid :
+        FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option
+  = fun env  -> fun l  -> try_lookup_lid' env.iface false env l
+let try_lookup_lid:
   env ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.term,Prims.bool) FStar_Pervasives_Native.tuple2
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
-      let uu____5146 = try_lookup_lid_with_attributes env l  in
+      let uu____5146 = try_lookup_lid_with_attributes env l in
       FStar_All.pipe_right uu____5146 drop_attributes
-  
-let (resolve_to_fully_qualified_name :
+let resolve_to_fully_qualified_name:
   env ->
-    FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option)
+    FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
-      let uu____5181 = try_lookup_lid env l  in
+      let uu____5181 = try_lookup_lid env l in
       match uu____5181 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (e,uu____5195) ->
           let uu____5200 =
-            let uu____5201 = FStar_Syntax_Subst.compress e  in
-            uu____5201.FStar_Syntax_Syntax.n  in
+            let uu____5201 = FStar_Syntax_Subst.compress e in
+            uu____5201.FStar_Syntax_Syntax.n in
           (match uu____5200 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                FStar_Pervasives_Native.Some
                  ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
            | uu____5207 -> FStar_Pervasives_Native.None)
-  
-let (try_lookup_lid_with_attributes_no_resolve :
+let try_lookup_lid_with_attributes_no_resolve:
   env ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.term,Prims.bool,FStar_Syntax_Syntax.attribute
                                              Prims.list)
-        FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.tuple3 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
       let env' =
-        let uu___121_5235 = env  in
+        let uu___121_5235 = env in
         {
           curmodule = (uu___121_5235.curmodule);
           curmonad = (uu___121_5235.curmonad);
@@ -1999,28 +1846,26 @@ let (try_lookup_lid_with_attributes_no_resolve :
           remaining_iface_decls = (uu___121_5235.remaining_iface_decls);
           syntax_only = (uu___121_5235.syntax_only);
           ds_hooks = (uu___121_5235.ds_hooks)
-        }  in
+        } in
       try_lookup_lid_with_attributes env' l
-  
-let (try_lookup_lid_no_resolve :
+let try_lookup_lid_no_resolve:
   env ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.term,Prims.bool) FStar_Pervasives_Native.tuple2
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
-      let uu____5254 = try_lookup_lid_with_attributes_no_resolve env l  in
+      let uu____5254 = try_lookup_lid_with_attributes_no_resolve env l in
       FStar_All.pipe_right uu____5254 drop_attributes
-  
-let (try_lookup_doc :
+let try_lookup_doc:
   env ->
-    FStar_Ident.lid -> FStar_Parser_AST.fsdoc FStar_Pervasives_Native.option)
-  = fun env  -> fun l  -> FStar_Util.smap_try_find env.docs l.FStar_Ident.str 
-let (try_lookup_datacon :
+    FStar_Ident.lid -> FStar_Parser_AST.fsdoc FStar_Pervasives_Native.option
+  = fun env  -> fun l  -> FStar_Util.smap_try_find env.docs l.FStar_Ident.str
+let try_lookup_datacon:
   env ->
     FStar_Ident.lident ->
-      FStar_Syntax_Syntax.fv FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.fv FStar_Pervasives_Native.option
   =
   fun env  ->
     fun lid  ->
@@ -2040,15 +1885,13 @@ let (try_lookup_datacon :
                    (fun uu___101_5332  ->
                       match uu___101_5332 with
                       | FStar_Syntax_Syntax.Assumption  -> true
-                      | uu____5333 -> false))
-               in
+                      | uu____5333 -> false)) in
             if uu____5328
             then
               let uu____5336 =
                 FStar_Syntax_Syntax.lid_as_fv lid1
                   FStar_Syntax_Syntax.Delta_constant
-                  FStar_Pervasives_Native.None
-                 in
+                  FStar_Pervasives_Native.None in
               FStar_Pervasives_Native.Some uu____5336
             else FStar_Pervasives_Native.None
         | ({
@@ -2062,18 +1905,16 @@ let (try_lookup_datacon :
             let uu____5362 =
               FStar_Syntax_Syntax.lid_as_fv lid1
                 FStar_Syntax_Syntax.Delta_constant
-                (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-               in
+                (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
             FStar_Pervasives_Native.Some uu____5362
-        | uu____5363 -> FStar_Pervasives_Native.None  in
+        | uu____5363 -> FStar_Pervasives_Native.None in
       resolve_in_open_namespaces' env lid
         (fun uu____5369  -> FStar_Pervasives_Native.None)
         (fun uu____5371  -> FStar_Pervasives_Native.None) k_global_def
-  
-let (find_all_datacons :
+let find_all_datacons:
   env ->
     FStar_Ident.lident ->
-      FStar_Ident.lident Prims.list FStar_Pervasives_Native.option)
+      FStar_Ident.lident Prims.list FStar_Pervasives_Native.option
   =
   fun env  ->
     fun lid  ->
@@ -2088,87 +1929,84 @@ let (find_all_datacons :
              FStar_Syntax_Syntax.sigmeta = uu____5413;
              FStar_Syntax_Syntax.sigattrs = uu____5414;_},uu____5415)
             -> FStar_Pervasives_Native.Some datas
-        | uu____5430 -> FStar_Pervasives_Native.None  in
+        | uu____5430 -> FStar_Pervasives_Native.None in
       resolve_in_open_namespaces' env lid
         (fun uu____5440  -> FStar_Pervasives_Native.None)
         (fun uu____5444  -> FStar_Pervasives_Native.None) k_global_def
-  
-let (record_cache_aux_with_filter :
+let record_cache_aux_with_filter:
   ((Prims.unit -> Prims.unit,Prims.unit -> Prims.unit,Prims.unit ->
                                                         record_or_dc
                                                           Prims.list,
      record_or_dc -> Prims.unit) FStar_Pervasives_Native.tuple4,Prims.unit ->
                                                                   Prims.unit)
-    FStar_Pervasives_Native.tuple2)
+    FStar_Pervasives_Native.tuple2
   =
-  let record_cache = FStar_Util.mk_ref [[]]  in
+  let record_cache = FStar_Util.mk_ref [[]] in
   let push1 uu____5489 =
     let uu____5490 =
       let uu____5495 =
-        let uu____5498 = FStar_ST.op_Bang record_cache  in
-        FStar_List.hd uu____5498  in
-      let uu____5554 = FStar_ST.op_Bang record_cache  in uu____5495 ::
-        uu____5554
-       in
-    FStar_ST.op_Colon_Equals record_cache uu____5490  in
+        let uu____5498 = FStar_ST.op_Bang record_cache in
+        FStar_List.hd uu____5498 in
+      let uu____5554 = FStar_ST.op_Bang record_cache in uu____5495 ::
+        uu____5554 in
+    FStar_ST.op_Colon_Equals record_cache uu____5490 in
   let pop1 uu____5662 =
     let uu____5663 =
-      let uu____5668 = FStar_ST.op_Bang record_cache  in
-      FStar_List.tl uu____5668  in
-    FStar_ST.op_Colon_Equals record_cache uu____5663  in
+      let uu____5668 = FStar_ST.op_Bang record_cache in
+      FStar_List.tl uu____5668 in
+    FStar_ST.op_Colon_Equals record_cache uu____5663 in
   let peek1 uu____5778 =
-    let uu____5779 = FStar_ST.op_Bang record_cache  in
-    FStar_List.hd uu____5779  in
+    let uu____5779 = FStar_ST.op_Bang record_cache in
+    FStar_List.hd uu____5779 in
   let insert r =
     let uu____5839 =
-      let uu____5844 = let uu____5847 = peek1 ()  in r :: uu____5847  in
+      let uu____5844 = let uu____5847 = peek1 () in r :: uu____5847 in
       let uu____5850 =
-        let uu____5855 = FStar_ST.op_Bang record_cache  in
-        FStar_List.tl uu____5855  in
-      uu____5844 :: uu____5850  in
-    FStar_ST.op_Colon_Equals record_cache uu____5839  in
+        let uu____5855 = FStar_ST.op_Bang record_cache in
+        FStar_List.tl uu____5855 in
+      uu____5844 :: uu____5850 in
+    FStar_ST.op_Colon_Equals record_cache uu____5839 in
   let filter1 uu____5965 =
-    let rc = peek1 ()  in
+    let rc = peek1 () in
     let filtered =
       FStar_List.filter
-        (fun r  -> Prims.op_Negation r.is_private_or_abstract) rc
-       in
+        (fun r  -> Prims.op_Negation r.is_private_or_abstract) rc in
     let uu____5974 =
       let uu____5979 =
-        let uu____5984 = FStar_ST.op_Bang record_cache  in
-        FStar_List.tl uu____5984  in
-      filtered :: uu____5979  in
-    FStar_ST.op_Colon_Equals record_cache uu____5974  in
-  let aux = (push1, pop1, peek1, insert)  in (aux, filter1) 
-let (record_cache_aux :
+        let uu____5984 = FStar_ST.op_Bang record_cache in
+        FStar_List.tl uu____5984 in
+      filtered :: uu____5979 in
+    FStar_ST.op_Colon_Equals record_cache uu____5974 in
+  let aux = (push1, pop1, peek1, insert) in (aux, filter1)
+let record_cache_aux:
   (Prims.unit -> Prims.unit,Prims.unit -> Prims.unit,Prims.unit ->
                                                        record_or_dc
                                                          Prims.list,record_or_dc
                                                                     ->
                                                                     Prims.unit)
-    FStar_Pervasives_Native.tuple4)
+    FStar_Pervasives_Native.tuple4
   =
-  let uu____6158 = record_cache_aux_with_filter  in
-  match uu____6158 with | (aux,uu____6202) -> aux 
-let (filter_record_cache : Prims.unit -> Prims.unit) =
-  let uu____6245 = record_cache_aux_with_filter  in
-  match uu____6245 with | (uu____6272,filter1) -> filter1 
-let (push_record_cache : Prims.unit -> Prims.unit) =
-  let uu____6316 = record_cache_aux  in
-  match uu____6316 with | (push1,uu____6338,uu____6339,uu____6340) -> push1 
-let (pop_record_cache : Prims.unit -> Prims.unit) =
-  let uu____6363 = record_cache_aux  in
-  match uu____6363 with | (uu____6384,pop1,uu____6386,uu____6387) -> pop1 
-let (peek_record_cache : Prims.unit -> record_or_dc Prims.list) =
-  let uu____6412 = record_cache_aux  in
-  match uu____6412 with | (uu____6435,uu____6436,peek1,uu____6438) -> peek1 
-let (insert_record_cache : record_or_dc -> Prims.unit) =
-  let uu____6461 = record_cache_aux  in
-  match uu____6461 with | (uu____6482,uu____6483,uu____6484,insert) -> insert 
-let (extract_record :
+  let uu____6158 = record_cache_aux_with_filter in
+  match uu____6158 with | (aux,uu____6202) -> aux
+let filter_record_cache: Prims.unit -> Prims.unit =
+  let uu____6245 = record_cache_aux_with_filter in
+  match uu____6245 with | (uu____6272,filter1) -> filter1
+let push_record_cache: Prims.unit -> Prims.unit =
+  let uu____6316 = record_cache_aux in
+  match uu____6316 with | (push1,uu____6338,uu____6339,uu____6340) -> push1
+let pop_record_cache: Prims.unit -> Prims.unit =
+  let uu____6363 = record_cache_aux in
+  match uu____6363 with | (uu____6384,pop1,uu____6386,uu____6387) -> pop1
+let peek_record_cache: Prims.unit -> record_or_dc Prims.list =
+  let uu____6412 = record_cache_aux in
+  match uu____6412 with | (uu____6435,uu____6436,peek1,uu____6438) -> peek1
+let insert_record_cache: record_or_dc -> Prims.unit =
+  let uu____6461 = record_cache_aux in
+  match uu____6461 with | (uu____6482,uu____6483,uu____6484,insert) -> insert
+let extract_record:
   env ->
     scope_mod Prims.list FStar_ST.ref ->
-      FStar_Syntax_Syntax.sigelt -> Prims.unit)
+      FStar_Syntax_Syntax.sigelt -> Prims.unit
   =
   fun e  ->
     fun new_globs  ->
@@ -2181,8 +2019,7 @@ let (extract_record :
                    match uu___104_6562 with
                    | FStar_Syntax_Syntax.RecordType uu____6563 -> true
                    | FStar_Syntax_Syntax.RecordConstructor uu____6572 -> true
-                   | uu____6581 -> false)
-               in
+                   | uu____6581 -> false) in
             let find_dc dc =
               FStar_All.pipe_right sigs
                 (FStar_Util.find_opt
@@ -2197,8 +2034,7 @@ let (extract_record :
                           FStar_Syntax_Syntax.sigmeta = uu____6612;
                           FStar_Syntax_Syntax.sigattrs = uu____6613;_} ->
                           FStar_Ident.lid_equals dc lid
-                      | uu____6622 -> false))
-               in
+                      | uu____6622 -> false)) in
             FStar_All.pipe_right sigs
               (FStar_List.iter
                  (fun uu___106_6657  ->
@@ -2212,8 +2048,8 @@ let (extract_record :
                         FStar_Syntax_Syntax.sigmeta = uu____6666;
                         FStar_Syntax_Syntax.sigattrs = uu____6667;_} ->
                         let uu____6678 =
-                          let uu____6679 = find_dc dc  in
-                          FStar_All.pipe_left FStar_Util.must uu____6679  in
+                          let uu____6679 = find_dc dc in
+                          FStar_All.pipe_left FStar_Util.must uu____6679 in
                         (match uu____6678 with
                          | {
                              FStar_Syntax_Syntax.sigel =
@@ -2224,10 +2060,10 @@ let (extract_record :
                              FStar_Syntax_Syntax.sigmeta = uu____6692;
                              FStar_Syntax_Syntax.sigattrs = uu____6693;_} ->
                              let uu____6702 =
-                               FStar_Syntax_Util.arrow_formals t  in
+                               FStar_Syntax_Util.arrow_formals t in
                              (match uu____6702 with
                               | (formals,uu____6716) ->
-                                  let is_rec = is_record typename_quals  in
+                                  let is_rec = is_record typename_quals in
                                   let formals' =
                                     FStar_All.pipe_right formals
                                       (FStar_List.collect
@@ -2240,12 +2076,10 @@ let (extract_record :
                                                     ||
                                                     (is_rec &&
                                                        (FStar_Syntax_Syntax.is_implicit
-                                                          q))
-                                                   in
+                                                          q)) in
                                                 if uu____6778
                                                 then []
-                                                else [(x, q)]))
-                                     in
+                                                else [(x, q)])) in
                                   let fields' =
                                     FStar_All.pipe_right formals'
                                       (FStar_List.map
@@ -2258,12 +2092,10 @@ let (extract_record :
                                                     FStar_Syntax_Util.unmangle_field_name
                                                       x.FStar_Syntax_Syntax.ppname
                                                   else
-                                                    x.FStar_Syntax_Syntax.ppname
-                                                   in
+                                                    x.FStar_Syntax_Syntax.ppname in
                                                 (uu____6848,
-                                                  (x.FStar_Syntax_Syntax.sort))))
-                                     in
-                                  let fields = fields'  in
+                                                  (x.FStar_Syntax_Syntax.sort)))) in
+                                  let fields = fields' in
                                   let record =
                                     {
                                       typename;
@@ -2280,11 +2112,11 @@ let (extract_record :
                                               FStar_Syntax_Syntax.Abstract
                                               typename_quals));
                                       is_record = is_rec
-                                    }  in
+                                    } in
                                   ((let uu____6863 =
                                       let uu____6866 =
-                                        FStar_ST.op_Bang new_globs  in
-                                      (Record_or_dc record) :: uu____6866  in
+                                        FStar_ST.op_Bang new_globs in
+                                      (Record_or_dc record) :: uu____6866 in
                                     FStar_ST.op_Colon_Equals new_globs
                                       uu____6863);
                                    (match () with
@@ -2295,29 +2127,23 @@ let (extract_record :
                                                 let modul =
                                                   let uu____6983 =
                                                     FStar_Ident.lid_of_ids
-                                                      constrname.FStar_Ident.ns
-                                                     in
-                                                  uu____6983.FStar_Ident.str
-                                                   in
+                                                      constrname.FStar_Ident.ns in
+                                                  uu____6983.FStar_Ident.str in
                                                 let uu____6984 =
-                                                  get_exported_id_set e modul
-                                                   in
+                                                  get_exported_id_set e modul in
                                                 (match uu____6984 with
                                                  | FStar_Pervasives_Native.Some
                                                      my_ex ->
                                                      let my_exported_ids =
                                                        my_ex
-                                                         Exported_id_field
-                                                        in
+                                                         Exported_id_field in
                                                      ((let uu____7015 =
                                                          let uu____7016 =
                                                            FStar_ST.op_Bang
-                                                             my_exported_ids
-                                                            in
+                                                             my_exported_ids in
                                                          FStar_Util.set_add
                                                            id1.FStar_Ident.idText
-                                                           uu____7016
-                                                          in
+                                                           uu____7016 in
                                                        FStar_ST.op_Colon_Equals
                                                          my_exported_ids
                                                          uu____7015);
@@ -2329,107 +2155,93 @@ let (extract_record :
                                                                  =
                                                                  FStar_Syntax_Util.mk_field_projector_name_from_ident
                                                                    constrname
-                                                                   id1
-                                                                  in
-                                                               uu____7103.FStar_Ident.ident
-                                                                in
-                                                             uu____7102.FStar_Ident.idText
-                                                              in
+                                                                   id1 in
+                                                               uu____7103.FStar_Ident.ident in
+                                                             uu____7102.FStar_Ident.idText in
                                                            let uu____7105 =
                                                              let uu____7106 =
                                                                FStar_ST.op_Bang
-                                                                 my_exported_ids
-                                                                in
+                                                                 my_exported_ids in
                                                              FStar_Util.set_add
                                                                projname
-                                                               uu____7106
-                                                              in
+                                                               uu____7106 in
                                                            FStar_ST.op_Colon_Equals
                                                              my_exported_ids
                                                              uu____7105))
                                                  | FStar_Pervasives_Native.None
-                                                      -> ())
-                                             in
+                                                      -> ()) in
                                           FStar_List.iter add_field fields');
                                          (match () with
                                           | () -> insert_record_cache record)))))
                          | uu____7201 -> ())
                     | uu____7202 -> ()))
         | uu____7203 -> ()
-  
-let (try_lookup_record_or_dc_by_field_name :
-  env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
+let try_lookup_record_or_dc_by_field_name:
+  env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option =
   fun env  ->
     fun fieldname  ->
       let find_in_cache fieldname1 =
         let uu____7218 =
-          ((fieldname1.FStar_Ident.ns), (fieldname1.FStar_Ident.ident))  in
+          ((fieldname1.FStar_Ident.ns), (fieldname1.FStar_Ident.ident)) in
         match uu____7218 with
         | (ns,id1) ->
-            let uu____7235 = peek_record_cache ()  in
+            let uu____7235 = peek_record_cache () in
             FStar_Util.find_map uu____7235
               (fun record  ->
                  let uu____7241 =
-                   find_in_record ns id1 record (fun r  -> Cont_ok r)  in
+                   find_in_record ns id1 record (fun r  -> Cont_ok r) in
                  option_of_cont
                    (fun uu____7247  -> FStar_Pervasives_Native.None)
-                   uu____7241)
-         in
+                   uu____7241) in
       resolve_in_open_namespaces'' env fieldname Exported_id_field
         (fun uu____7249  -> Cont_ignore) (fun uu____7251  -> Cont_ignore)
         (fun r  -> Cont_ok r)
         (fun fn  ->
-           let uu____7257 = find_in_cache fn  in
+           let uu____7257 = find_in_cache fn in
            cont_of_option Cont_ignore uu____7257)
         (fun k  -> fun uu____7263  -> k)
-  
-let (try_lookup_record_by_field_name :
-  env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
+let try_lookup_record_by_field_name:
+  env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option =
   fun env  ->
     fun fieldname  ->
-      let uu____7274 = try_lookup_record_or_dc_by_field_name env fieldname
-         in
+      let uu____7274 = try_lookup_record_or_dc_by_field_name env fieldname in
       match uu____7274 with
       | FStar_Pervasives_Native.Some r when r.is_record ->
           FStar_Pervasives_Native.Some r
       | uu____7280 -> FStar_Pervasives_Native.None
-  
-let (belongs_to_record :
-  env -> FStar_Ident.lident -> record_or_dc -> Prims.bool) =
+let belongs_to_record:
+  env -> FStar_Ident.lident -> record_or_dc -> Prims.bool =
   fun env  ->
     fun lid  ->
       fun record  ->
-        let uu____7292 = try_lookup_record_by_field_name env lid  in
+        let uu____7292 = try_lookup_record_by_field_name env lid in
         match uu____7292 with
         | FStar_Pervasives_Native.Some record' when
             let uu____7296 =
               let uu____7297 =
-                FStar_Ident.path_of_ns (record.typename).FStar_Ident.ns  in
-              FStar_Ident.text_of_path uu____7297  in
+                FStar_Ident.path_of_ns (record.typename).FStar_Ident.ns in
+              FStar_Ident.text_of_path uu____7297 in
             let uu____7300 =
               let uu____7301 =
-                FStar_Ident.path_of_ns (record'.typename).FStar_Ident.ns  in
-              FStar_Ident.text_of_path uu____7301  in
+                FStar_Ident.path_of_ns (record'.typename).FStar_Ident.ns in
+              FStar_Ident.text_of_path uu____7301 in
             uu____7296 = uu____7300 ->
             let uu____7304 =
               find_in_record (record.typename).FStar_Ident.ns
-                lid.FStar_Ident.ident record (fun uu____7308  -> Cont_ok ())
-               in
+                lid.FStar_Ident.ident record (fun uu____7308  -> Cont_ok ()) in
             (match uu____7304 with
              | Cont_ok uu____7309 -> true
              | uu____7310 -> false)
         | uu____7313 -> false
-  
-let (try_lookup_dc_by_field_name :
+let try_lookup_dc_by_field_name:
   env ->
     FStar_Ident.lident ->
       (FStar_Ident.lident,Prims.bool) FStar_Pervasives_Native.tuple2
-        FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option
   =
   fun env  ->
     fun fieldname  ->
-      let uu____7328 = try_lookup_record_or_dc_by_field_name env fieldname
-         in
+      let uu____7328 = try_lookup_record_or_dc_by_field_name env fieldname in
       match uu____7328 with
       | FStar_Pervasives_Native.Some r ->
           let uu____7338 =
@@ -2437,34 +2249,29 @@ let (try_lookup_dc_by_field_name :
               let uu____7344 =
                 FStar_Ident.lid_of_ids
                   (FStar_List.append (r.typename).FStar_Ident.ns
-                     [r.constrname])
-                 in
+                     [r.constrname]) in
               FStar_Ident.set_lid_range uu____7344
-                (FStar_Ident.range_of_lid fieldname)
-               in
-            (uu____7343, (r.is_record))  in
+                (FStar_Ident.range_of_lid fieldname) in
+            (uu____7343, (r.is_record)) in
           FStar_Pervasives_Native.Some uu____7338
       | uu____7349 -> FStar_Pervasives_Native.None
-  
-let (string_set_ref_new :
-  Prims.unit -> Prims.string FStar_Util.set FStar_ST.ref) =
+let string_set_ref_new:
+  Prims.unit -> Prims.string FStar_Util.set FStar_ST.ref =
   fun uu____7373  ->
-    let uu____7374 = FStar_Util.new_set FStar_Util.compare  in
+    let uu____7374 = FStar_Util.new_set FStar_Util.compare in
     FStar_Util.mk_ref uu____7374
-  
-let (exported_id_set_new :
-  Prims.unit -> exported_id_kind -> Prims.string FStar_Util.set FStar_ST.ref)
+let exported_id_set_new:
+  Prims.unit -> exported_id_kind -> Prims.string FStar_Util.set FStar_ST.ref
   =
   fun uu____7398  ->
-    let term_type_set = string_set_ref_new ()  in
-    let field_set = string_set_ref_new ()  in
+    let term_type_set = string_set_ref_new () in
+    let field_set = string_set_ref_new () in
     fun uu___107_7409  ->
       match uu___107_7409 with
       | Exported_id_term_type  -> term_type_set
       | Exported_id_field  -> field_set
-  
-let (unique :
-  Prims.bool -> Prims.bool -> env -> FStar_Ident.lident -> Prims.bool) =
+let unique:
+  Prims.bool -> Prims.bool -> env -> FStar_Ident.lident -> Prims.bool =
   fun any_val  ->
     fun exclude_interface  ->
       fun env  ->
@@ -2472,11 +2279,11 @@ let (unique :
           let filter_scope_mods uu___108_7451 =
             match uu___108_7451 with
             | Rec_binding uu____7452 -> true
-            | uu____7453 -> false  in
+            | uu____7453 -> false in
           let this_env =
-            let uu___122_7455 = env  in
+            let uu___122_7455 = env in
             let uu____7456 =
-              FStar_List.filter filter_scope_mods env.scope_mods  in
+              FStar_List.filter filter_scope_mods env.scope_mods in
             {
               curmodule = (uu___122_7455.curmodule);
               curmonad = (uu___122_7455.curmonad);
@@ -2494,17 +2301,16 @@ let (unique :
               remaining_iface_decls = (uu___122_7455.remaining_iface_decls);
               syntax_only = (uu___122_7455.syntax_only);
               ds_hooks = (uu___122_7455.ds_hooks)
-            }  in
+            } in
           let uu____7459 =
-            try_lookup_lid' any_val exclude_interface this_env lid  in
+            try_lookup_lid' any_val exclude_interface this_env lid in
           match uu____7459 with
           | FStar_Pervasives_Native.None  -> true
           | FStar_Pervasives_Native.Some uu____7478 -> false
-  
-let (push_scope_mod : env -> scope_mod -> env) =
+let push_scope_mod: env -> scope_mod -> env =
   fun env  ->
     fun scope_mod  ->
-      let uu___123_7501 = env  in
+      let uu___123_7501 = env in
       {
         curmodule = (uu___123_7501.curmodule);
         curmonad = (uu___123_7501.curmonad);
@@ -2523,12 +2329,11 @@ let (push_scope_mod : env -> scope_mod -> env) =
         syntax_only = (uu___123_7501.syntax_only);
         ds_hooks = (uu___123_7501.ds_hooks)
       }
-  
-let (push_bv' :
+let push_bv':
   env ->
     FStar_Ident.ident ->
       Prims.bool ->
-        (env,FStar_Syntax_Syntax.bv) FStar_Pervasives_Native.tuple2)
+        (env,FStar_Syntax_Syntax.bv) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun x  ->
@@ -2536,28 +2341,26 @@ let (push_bv' :
         let bv =
           FStar_Syntax_Syntax.gen_bv x.FStar_Ident.idText
             (FStar_Pervasives_Native.Some (x.FStar_Ident.idRange))
-            FStar_Syntax_Syntax.tun
-           in
+            FStar_Syntax_Syntax.tun in
         ((push_scope_mod env (Local_binding (x, bv, is_mutable))), bv)
-  
-let (push_bv_mutable :
+let push_bv_mutable:
   env ->
     FStar_Ident.ident ->
-      (env,FStar_Syntax_Syntax.bv) FStar_Pervasives_Native.tuple2)
-  = fun env  -> fun x  -> push_bv' env x true 
-let (push_bv :
+      (env,FStar_Syntax_Syntax.bv) FStar_Pervasives_Native.tuple2
+  = fun env  -> fun x  -> push_bv' env x true
+let push_bv:
   env ->
     FStar_Ident.ident ->
-      (env,FStar_Syntax_Syntax.bv) FStar_Pervasives_Native.tuple2)
-  = fun env  -> fun x  -> push_bv' env x false 
-let (push_top_level_rec_binding :
-  env -> FStar_Ident.ident -> FStar_Syntax_Syntax.delta_depth -> env) =
+      (env,FStar_Syntax_Syntax.bv) FStar_Pervasives_Native.tuple2
+  = fun env  -> fun x  -> push_bv' env x false
+let push_top_level_rec_binding:
+  env -> FStar_Ident.ident -> FStar_Syntax_Syntax.delta_depth -> env =
   fun env  ->
     fun x  ->
       fun dd  ->
-        let l = qualify env x  in
+        let l = qualify env x in
         let uu____7546 =
-          (unique false true env l) || (FStar_Options.interactive ())  in
+          (unique false true env l) || (FStar_Options.interactive ()) in
         if uu____7546
         then push_scope_mod env (Rec_binding (x, l, dd))
         else
@@ -2565,60 +2368,54 @@ let (push_top_level_rec_binding :
             (FStar_Errors.Fatal_DuplicateTopLevelNames,
               (Prims.strcat "Duplicate top-level names " l.FStar_Ident.str))
             (FStar_Ident.range_of_lid l)
-  
-let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
+let push_sigelt: env -> FStar_Syntax_Syntax.sigelt -> env =
   fun env  ->
     fun s  ->
       let err l =
-        let sopt = FStar_Util.smap_try_find (sigmap env) l.FStar_Ident.str
-           in
+        let sopt = FStar_Util.smap_try_find (sigmap env) l.FStar_Ident.str in
         let r =
           match sopt with
           | FStar_Pervasives_Native.Some (se,uu____7571) ->
               let uu____7576 =
                 FStar_Util.find_opt (FStar_Ident.lid_equals l)
-                  (FStar_Syntax_Util.lids_of_sigelt se)
-                 in
+                  (FStar_Syntax_Util.lids_of_sigelt se) in
               (match uu____7576 with
                | FStar_Pervasives_Native.Some l1 ->
                    FStar_All.pipe_left FStar_Range.string_of_range
                      (FStar_Ident.range_of_lid l1)
                | FStar_Pervasives_Native.None  -> "<unknown>")
-          | FStar_Pervasives_Native.None  -> "<unknown>"  in
+          | FStar_Pervasives_Native.None  -> "<unknown>" in
         let uu____7584 =
           let uu____7589 =
             FStar_Util.format2
               "Duplicate top-level names [%s]; previously declared at %s"
-              (FStar_Ident.text_of_lid l) r
-             in
-          (FStar_Errors.Fatal_DuplicateTopLevelNames, uu____7589)  in
-        FStar_Errors.raise_error uu____7584 (FStar_Ident.range_of_lid l)  in
-      let globals = FStar_Util.mk_ref env.scope_mods  in
+              (FStar_Ident.text_of_lid l) r in
+          (FStar_Errors.Fatal_DuplicateTopLevelNames, uu____7589) in
+        FStar_Errors.raise_error uu____7584 (FStar_Ident.range_of_lid l) in
+      let globals = FStar_Util.mk_ref env.scope_mods in
       let env1 =
         let uu____7598 =
           match s.FStar_Syntax_Syntax.sigel with
           | FStar_Syntax_Syntax.Sig_let uu____7607 -> (false, true)
           | FStar_Syntax_Syntax.Sig_bundle uu____7614 -> (false, true)
-          | uu____7623 -> (false, false)  in
+          | uu____7623 -> (false, false) in
         match uu____7598 with
         | (any_val,exclude_interface) ->
-            let lids = FStar_Syntax_Util.lids_of_sigelt s  in
+            let lids = FStar_Syntax_Util.lids_of_sigelt s in
             let uu____7629 =
               FStar_Util.find_map lids
                 (fun l  ->
                    let uu____7635 =
-                     let uu____7636 = unique any_val exclude_interface env l
-                        in
-                     Prims.op_Negation uu____7636  in
+                     let uu____7636 = unique any_val exclude_interface env l in
+                     Prims.op_Negation uu____7636 in
                    if uu____7635
                    then FStar_Pervasives_Native.Some l
-                   else FStar_Pervasives_Native.None)
-               in
+                   else FStar_Pervasives_Native.None) in
             (match uu____7629 with
              | FStar_Pervasives_Native.Some l -> err l
              | uu____7641 ->
                  (extract_record env globals s;
-                  (let uu___124_7667 = env  in
+                  (let uu___124_7667 = env in
                    {
                      curmodule = (uu___124_7667.curmodule);
                      curmonad = (uu___124_7667.curmonad);
@@ -2637,11 +2434,10 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
                        (uu___124_7667.remaining_iface_decls);
                      syntax_only = (uu___124_7667.syntax_only);
                      ds_hooks = (uu___124_7667.ds_hooks)
-                   })))
-         in
+                   }))) in
       let env2 =
-        let uu___125_7669 = env1  in
-        let uu____7670 = FStar_ST.op_Bang globals  in
+        let uu___125_7669 = env1 in
+        let uu____7670 = FStar_ST.op_Bang globals in
         {
           curmodule = (uu___125_7669.curmodule);
           curmonad = (uu___125_7669.curmonad);
@@ -2659,17 +2455,15 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
           remaining_iface_decls = (uu___125_7669.remaining_iface_decls);
           syntax_only = (uu___125_7669.syntax_only);
           ds_hooks = (uu___125_7669.ds_hooks)
-        }  in
+        } in
       let uu____7718 =
         match s.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_bundle (ses,uu____7744) ->
             let uu____7753 =
               FStar_List.map
-                (fun se  -> ((FStar_Syntax_Util.lids_of_sigelt se), se)) ses
-               in
+                (fun se  -> ((FStar_Syntax_Util.lids_of_sigelt se), se)) ses in
             (env2, uu____7753)
-        | uu____7780 -> (env2, [((FStar_Syntax_Util.lids_of_sigelt s), s)])
-         in
+        | uu____7780 -> (env2, [((FStar_Syntax_Util.lids_of_sigelt s), s)]) in
       match uu____7718 with
       | (env3,lss) ->
           (FStar_All.pipe_right lss
@@ -2681,35 +2475,30 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
                          (FStar_List.iter
                             (fun lid  ->
                                (let uu____7861 =
-                                  let uu____7864 = FStar_ST.op_Bang globals
-                                     in
+                                  let uu____7864 = FStar_ST.op_Bang globals in
                                   (Top_level_def (lid.FStar_Ident.ident)) ::
-                                    uu____7864
-                                   in
+                                    uu____7864 in
                                 FStar_ST.op_Colon_Equals globals uu____7861);
                                (match () with
                                 | () ->
                                     let modul =
                                       let uu____7958 =
                                         FStar_Ident.lid_of_ids
-                                          lid.FStar_Ident.ns
-                                         in
-                                      uu____7958.FStar_Ident.str  in
+                                          lid.FStar_Ident.ns in
+                                      uu____7958.FStar_Ident.str in
                                     ((let uu____7960 =
-                                        get_exported_id_set env3 modul  in
+                                        get_exported_id_set env3 modul in
                                       match uu____7960 with
                                       | FStar_Pervasives_Native.Some f ->
                                           let my_exported_ids =
-                                            f Exported_id_term_type  in
+                                            f Exported_id_term_type in
                                           let uu____7990 =
                                             let uu____7991 =
                                               FStar_ST.op_Bang
-                                                my_exported_ids
-                                               in
+                                                my_exported_ids in
                                             FStar_Util.set_add
                                               (lid.FStar_Ident.ident).FStar_Ident.idText
-                                              uu____7991
-                                             in
+                                              uu____7991 in
                                           FStar_ST.op_Colon_Equals
                                             my_exported_ids uu____7990
                                       | FStar_Pervasives_Native.None  -> ());
@@ -2718,8 +2507,7 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
                                           let is_iface =
                                             env3.iface &&
                                               (Prims.op_Negation
-                                                 env3.admitted_iface)
-                                             in
+                                                 env3.admitted_iface) in
                                           FStar_Util.smap_add (sigmap env3)
                                             lid.FStar_Ident.str
                                             (se,
@@ -2727,8 +2515,8 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
                                                  (Prims.op_Negation
                                                     env3.admitted_iface))))))))));
            (let env4 =
-              let uu___126_8086 = env3  in
-              let uu____8087 = FStar_ST.op_Bang globals  in
+              let uu___126_8086 = env3 in
+              let uu____8087 = FStar_ST.op_Bang globals in
               {
                 curmodule = (uu___126_8086.curmodule);
                 curmonad = (uu___126_8086.curmonad);
@@ -2746,17 +2534,16 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
                 remaining_iface_decls = (uu___126_8086.remaining_iface_decls);
                 syntax_only = (uu___126_8086.syntax_only);
                 ds_hooks = (uu___126_8086.ds_hooks)
-              }  in
+              } in
             env4))
-  
-let (push_namespace : env -> FStar_Ident.lident -> env) =
+let push_namespace: env -> FStar_Ident.lident -> env =
   fun env  ->
     fun ns  ->
       let uu____8141 =
-        let uu____8146 = resolve_module_name env ns false  in
+        let uu____8146 = resolve_module_name env ns false in
         match uu____8146 with
         | FStar_Pervasives_Native.None  ->
-            let modules = env.modules  in
+            let modules = env.modules in
             let uu____8160 =
               FStar_All.pipe_right modules
                 (FStar_Util.for_some
@@ -2765,90 +2552,79 @@ let (push_namespace : env -> FStar_Ident.lident -> env) =
                       | (m,uu____8180) ->
                           FStar_Util.starts_with
                             (Prims.strcat (FStar_Ident.text_of_lid m) ".")
-                            (Prims.strcat (FStar_Ident.text_of_lid ns) ".")))
-               in
+                            (Prims.strcat (FStar_Ident.text_of_lid ns) "."))) in
             if uu____8160
             then (ns, Open_namespace)
             else
               (let uu____8186 =
                  let uu____8191 =
                    FStar_Util.format1 "Namespace %s cannot be found"
-                     (FStar_Ident.text_of_lid ns)
-                    in
-                 (FStar_Errors.Fatal_NameSpaceNotFound, uu____8191)  in
+                     (FStar_Ident.text_of_lid ns) in
+                 (FStar_Errors.Fatal_NameSpaceNotFound, uu____8191) in
                FStar_Errors.raise_error uu____8186
                  (FStar_Ident.range_of_lid ns))
         | FStar_Pervasives_Native.Some ns' ->
-            (fail_if_curmodule env ns ns'; (ns', Open_module))
-         in
+            (fail_if_curmodule env ns ns'; (ns', Open_module)) in
       match uu____8141 with
       | (ns',kd) ->
           ((env.ds_hooks).ds_push_open_hook env (ns', kd);
            push_scope_mod env (Open_module_or_namespace (ns', kd)))
-  
-let (push_include : env -> FStar_Ident.lident -> env) =
+let push_include: env -> FStar_Ident.lident -> env =
   fun env  ->
     fun ns  ->
-      let ns0 = ns  in
-      let uu____8208 = resolve_module_name env ns false  in
+      let ns0 = ns in
+      let uu____8208 = resolve_module_name env ns false in
       match uu____8208 with
       | FStar_Pervasives_Native.Some ns1 ->
           ((env.ds_hooks).ds_push_include_hook env ns1;
            fail_if_curmodule env ns0 ns1;
            (let env1 =
               push_scope_mod env
-                (Open_module_or_namespace (ns1, Open_module))
-               in
+                (Open_module_or_namespace (ns1, Open_module)) in
             let curmod =
-              let uu____8216 = current_module env1  in
-              uu____8216.FStar_Ident.str  in
-            (let uu____8218 = FStar_Util.smap_try_find env1.includes curmod
-                in
+              let uu____8216 = current_module env1 in
+              uu____8216.FStar_Ident.str in
+            (let uu____8218 = FStar_Util.smap_try_find env1.includes curmod in
              match uu____8218 with
              | FStar_Pervasives_Native.None  -> ()
              | FStar_Pervasives_Native.Some incl ->
                  let uu____8242 =
-                   let uu____8245 = FStar_ST.op_Bang incl  in ns1 ::
-                     uu____8245
-                    in
+                   let uu____8245 = FStar_ST.op_Bang incl in ns1 ::
+                     uu____8245 in
                  FStar_ST.op_Colon_Equals incl uu____8242);
             (match () with
              | () ->
                  let uu____8338 =
-                   get_trans_exported_id_set env1 ns1.FStar_Ident.str  in
+                   get_trans_exported_id_set env1 ns1.FStar_Ident.str in
                  (match uu____8338 with
                   | FStar_Pervasives_Native.Some ns_trans_exports ->
                       ((let uu____8355 =
-                          let uu____8372 = get_exported_id_set env1 curmod
-                             in
+                          let uu____8372 = get_exported_id_set env1 curmod in
                           let uu____8379 =
-                            get_trans_exported_id_set env1 curmod  in
-                          (uu____8372, uu____8379)  in
+                            get_trans_exported_id_set env1 curmod in
+                          (uu____8372, uu____8379) in
                         match uu____8355 with
                         | (FStar_Pervasives_Native.Some
                            cur_exports,FStar_Pervasives_Native.Some
                            cur_trans_exports) ->
                             let update_exports k =
                               let ns_ex =
-                                let uu____8433 = ns_trans_exports k  in
-                                FStar_ST.op_Bang uu____8433  in
-                              let ex = cur_exports k  in
+                                let uu____8433 = ns_trans_exports k in
+                                FStar_ST.op_Bang uu____8433 in
+                              let ex = cur_exports k in
                               (let uu____8559 =
-                                 let uu____8560 = FStar_ST.op_Bang ex  in
-                                 FStar_Util.set_difference uu____8560 ns_ex
-                                  in
+                                 let uu____8560 = FStar_ST.op_Bang ex in
+                                 FStar_Util.set_difference uu____8560 ns_ex in
                                FStar_ST.op_Colon_Equals ex uu____8559);
                               (match () with
                                | () ->
-                                   let trans_ex = cur_trans_exports k  in
+                                   let trans_ex = cur_trans_exports k in
                                    let uu____8660 =
                                      let uu____8661 =
-                                       FStar_ST.op_Bang trans_ex  in
-                                     FStar_Util.set_union uu____8661 ns_ex
-                                      in
+                                       FStar_ST.op_Bang trans_ex in
+                                     FStar_Util.set_union uu____8661 ns_ex in
                                    FStar_ST.op_Colon_Equals trans_ex
-                                     uu____8660)
-                               in
+                                     uu____8660) in
                             FStar_List.iter update_exports
                               all_exported_id_kinds
                         | uu____8746 -> ());
@@ -2858,28 +2634,24 @@ let (push_include : env -> FStar_Ident.lident -> env) =
                         let uu____8772 =
                           FStar_Util.format1
                             "include: Module %s was not prepared"
-                            ns1.FStar_Ident.str
-                           in
+                            ns1.FStar_Ident.str in
                         (FStar_Errors.Fatal_IncludeModuleNotPrepared,
-                          uu____8772)
-                         in
+                          uu____8772) in
                       FStar_Errors.raise_error uu____8767
                         (FStar_Ident.range_of_lid ns1)))))
       | uu____8773 ->
           let uu____8776 =
             let uu____8781 =
               FStar_Util.format1 "include: Module %s cannot be found"
-                ns.FStar_Ident.str
-               in
-            (FStar_Errors.Fatal_ModuleNotFound, uu____8781)  in
+                ns.FStar_Ident.str in
+            (FStar_Errors.Fatal_ModuleNotFound, uu____8781) in
           FStar_Errors.raise_error uu____8776 (FStar_Ident.range_of_lid ns)
-  
-let (push_module_abbrev :
-  env -> FStar_Ident.ident -> FStar_Ident.lident -> env) =
+let push_module_abbrev: env -> FStar_Ident.ident -> FStar_Ident.lident -> env
+  =
   fun env  ->
     fun x  ->
       fun l  ->
-        let uu____8791 = module_is_defined env l  in
+        let uu____8791 = module_is_defined env l in
         if uu____8791
         then
           (fail_if_curmodule env l l;
@@ -2889,15 +2661,13 @@ let (push_module_abbrev :
           (let uu____8795 =
              let uu____8800 =
                FStar_Util.format1 "Module %s cannot be found"
-                 (FStar_Ident.text_of_lid l)
-                in
-             (FStar_Errors.Fatal_ModuleNotFound, uu____8800)  in
+                 (FStar_Ident.text_of_lid l) in
+             (FStar_Errors.Fatal_ModuleNotFound, uu____8800) in
            FStar_Errors.raise_error uu____8795 (FStar_Ident.range_of_lid l))
-  
-let (push_doc :
+let push_doc:
   env ->
     FStar_Ident.lident ->
-      FStar_Parser_AST.fsdoc FStar_Pervasives_Native.option -> env)
+      FStar_Parser_AST.fsdoc FStar_Pervasives_Native.option -> env
   =
   fun env  ->
     fun l  ->
@@ -2906,29 +2676,26 @@ let (push_doc :
         | FStar_Pervasives_Native.None  -> env
         | FStar_Pervasives_Native.Some doc1 ->
             ((let uu____8816 =
-                FStar_Util.smap_try_find env.docs l.FStar_Ident.str  in
+                FStar_Util.smap_try_find env.docs l.FStar_Ident.str in
               match uu____8816 with
               | FStar_Pervasives_Native.None  -> ()
               | FStar_Pervasives_Native.Some old_doc ->
                   let uu____8820 =
                     let uu____8825 =
-                      let uu____8826 = FStar_Ident.string_of_lid l  in
+                      let uu____8826 = FStar_Ident.string_of_lid l in
                       let uu____8827 =
-                        FStar_Parser_AST.string_of_fsdoc old_doc  in
-                      let uu____8828 = FStar_Parser_AST.string_of_fsdoc doc1
-                         in
+                        FStar_Parser_AST.string_of_fsdoc old_doc in
+                      let uu____8828 = FStar_Parser_AST.string_of_fsdoc doc1 in
                       FStar_Util.format3
                         "Overwriting doc of %s; old doc was [%s]; new doc are [%s]"
-                        uu____8826 uu____8827 uu____8828
-                       in
-                    (FStar_Errors.Warning_DocOverwrite, uu____8825)  in
+                        uu____8826 uu____8827 uu____8828 in
+                    (FStar_Errors.Warning_DocOverwrite, uu____8825) in
                   FStar_Errors.log_issue (FStar_Ident.range_of_lid l)
                     uu____8820);
              FStar_Util.smap_add env.docs l.FStar_Ident.str doc1;
              env)
-  
-let (check_admits :
-  env -> FStar_Syntax_Syntax.modul -> FStar_Syntax_Syntax.modul) =
+let check_admits:
+  env -> FStar_Syntax_Syntax.modul -> FStar_Syntax_Syntax.modul =
   fun env  ->
     fun m  ->
       let admitted_sig_lids =
@@ -2938,97 +2705,93 @@ let (check_admits :
                 fun se  ->
                   match se.FStar_Syntax_Syntax.sigel with
                   | FStar_Syntax_Syntax.Sig_declare_typ (l,u,t) ->
-                      let uu____8861 = try_lookup_lid env l  in
+                      let uu____8861 =
+                        FStar_Util.smap_try_find (sigmap env)
+                          l.FStar_Ident.str in
                       (match uu____8861 with
                        | FStar_Pervasives_Native.None  ->
-                           ((let uu____8875 =
-                               let uu____8876 = FStar_Options.interactive ()
-                                  in
-                               Prims.op_Negation uu____8876  in
-                             if uu____8875
+                           ((let uu____8879 =
+                               let uu____8880 = FStar_Options.interactive () in
+                               Prims.op_Negation uu____8880 in
+                             if uu____8879
                              then
-                               let uu____8877 =
-                                 let uu____8882 =
-                                   let uu____8883 =
-                                     FStar_Syntax_Print.lid_to_string l  in
+                               let uu____8881 =
+                                 let uu____8886 =
+                                   let uu____8887 =
+                                     FStar_Syntax_Print.lid_to_string l in
                                    FStar_Util.format1
                                      "Admitting %s without a definition"
-                                     uu____8883
-                                    in
+                                     uu____8887 in
                                  (FStar_Errors.Warning_AdmitWithoutDefinition,
-                                   uu____8882)
-                                  in
+                                   uu____8886) in
                                FStar_Errors.log_issue
-                                 (FStar_Ident.range_of_lid l) uu____8877
+                                 (FStar_Ident.range_of_lid l) uu____8881
                              else ());
                             (let quals = FStar_Syntax_Syntax.Assumption ::
-                               (se.FStar_Syntax_Syntax.sigquals)  in
+                               (se.FStar_Syntax_Syntax.sigquals) in
                              FStar_Util.smap_add (sigmap env)
                                l.FStar_Ident.str
-                               ((let uu___127_8894 = se  in
+                               ((let uu___127_8898 = se in
                                  {
                                    FStar_Syntax_Syntax.sigel =
-                                     (uu___127_8894.FStar_Syntax_Syntax.sigel);
+                                     (uu___127_8898.FStar_Syntax_Syntax.sigel);
                                    FStar_Syntax_Syntax.sigrng =
-                                     (uu___127_8894.FStar_Syntax_Syntax.sigrng);
+                                     (uu___127_8898.FStar_Syntax_Syntax.sigrng);
                                    FStar_Syntax_Syntax.sigquals = quals;
                                    FStar_Syntax_Syntax.sigmeta =
-                                     (uu___127_8894.FStar_Syntax_Syntax.sigmeta);
+                                     (uu___127_8898.FStar_Syntax_Syntax.sigmeta);
                                    FStar_Syntax_Syntax.sigattrs =
-                                     (uu___127_8894.FStar_Syntax_Syntax.sigattrs)
+                                     (uu___127_8898.FStar_Syntax_Syntax.sigattrs)
                                  }), false);
                              l
                              ::
                              lids))
-                       | FStar_Pervasives_Native.Some uu____8895 -> lids)
-                  | uu____8904 -> lids) [])
-         in
-      let uu___128_8905 = m  in
-      let uu____8906 =
+                       | FStar_Pervasives_Native.Some uu____8899 -> lids)
+                  | uu____8908 -> lids) []) in
+      let uu___128_8909 = m in
+      let uu____8910 =
         FStar_All.pipe_right m.FStar_Syntax_Syntax.declarations
           (FStar_List.map
              (fun s  ->
                 match s.FStar_Syntax_Syntax.sigel with
                 | FStar_Syntax_Syntax.Sig_declare_typ
-                    (lid,uu____8916,uu____8917) when
+                    (lid,uu____8920,uu____8921) when
                     FStar_List.existsb
                       (fun l  -> FStar_Ident.lid_equals l lid)
                       admitted_sig_lids
                     ->
-                    let uu___129_8920 = s  in
+                    let uu___129_8924 = s in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___129_8920.FStar_Syntax_Syntax.sigel);
+                        (uu___129_8924.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___129_8920.FStar_Syntax_Syntax.sigrng);
+                        (uu___129_8924.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
                         (FStar_Syntax_Syntax.Assumption ::
                         (s.FStar_Syntax_Syntax.sigquals));
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___129_8920.FStar_Syntax_Syntax.sigmeta);
+                        (uu___129_8924.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___129_8920.FStar_Syntax_Syntax.sigattrs)
+                        (uu___129_8924.FStar_Syntax_Syntax.sigattrs)
                     }
-                | uu____8921 -> s))
-         in
+                | uu____8925 -> s)) in
       {
-        FStar_Syntax_Syntax.name = (uu___128_8905.FStar_Syntax_Syntax.name);
-        FStar_Syntax_Syntax.declarations = uu____8906;
+        FStar_Syntax_Syntax.name = (uu___128_8909.FStar_Syntax_Syntax.name);
+        FStar_Syntax_Syntax.declarations = uu____8910;
         FStar_Syntax_Syntax.exports =
-          (uu___128_8905.FStar_Syntax_Syntax.exports);
+          (uu___128_8909.FStar_Syntax_Syntax.exports);
         FStar_Syntax_Syntax.is_interface =
-          (uu___128_8905.FStar_Syntax_Syntax.is_interface)
+          (uu___128_8909.FStar_Syntax_Syntax.is_interface)
       }
-  
-let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
+let finish: env -> FStar_Syntax_Syntax.modul -> env =
   fun env  ->
     fun modul  ->
       FStar_All.pipe_right modul.FStar_Syntax_Syntax.declarations
         (FStar_List.iter
            (fun se  ->
-              let quals = se.FStar_Syntax_Syntax.sigquals  in
+              let quals = se.FStar_Syntax_Syntax.sigquals in
               match se.FStar_Syntax_Syntax.sigel with
-              | FStar_Syntax_Syntax.Sig_bundle (ses,uu____8938) ->
+              | FStar_Syntax_Syntax.Sig_bundle (ses,uu____8942) ->
                   if
                     (FStar_List.contains FStar_Syntax_Syntax.Private quals)
                       ||
@@ -3039,12 +2802,12 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                          (fun se1  ->
                             match se1.FStar_Syntax_Syntax.sigel with
                             | FStar_Syntax_Syntax.Sig_datacon
-                                (lid,uu____8958,uu____8959,uu____8960,uu____8961,uu____8962)
+                                (lid,uu____8962,uu____8963,uu____8964,uu____8965,uu____8966)
                                 ->
                                 FStar_Util.smap_remove (sigmap env)
                                   lid.FStar_Ident.str
                             | FStar_Syntax_Syntax.Sig_inductive_typ
-                                (lid,univ_names,binders,typ,uu____8975,uu____8976)
+                                (lid,univ_names,binders,typ,uu____8979,uu____8980)
                                 ->
                                 (FStar_Util.smap_remove (sigmap env)
                                    lid.FStar_Ident.str;
@@ -3054,55 +2817,50 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                                         FStar_Syntax_Syntax.Private quals)
                                  then
                                    (let sigel =
-                                      let uu____8991 =
-                                        let uu____8998 =
-                                          let uu____9001 =
-                                            let uu____9004 =
-                                              let uu____9005 =
-                                                let uu____9018 =
+                                      let uu____8995 =
+                                        let uu____9002 =
+                                          let uu____9005 =
+                                            let uu____9008 =
+                                              let uu____9009 =
+                                                let uu____9022 =
                                                   FStar_Syntax_Syntax.mk_Total
-                                                    typ
-                                                   in
-                                                (binders, uu____9018)  in
+                                                    typ in
+                                                (binders, uu____9022) in
                                               FStar_Syntax_Syntax.Tm_arrow
-                                                uu____9005
-                                               in
-                                            FStar_Syntax_Syntax.mk uu____9004
-                                             in
-                                          uu____9001
+                                                uu____9009 in
+                                            FStar_Syntax_Syntax.mk uu____9008 in
+                                          uu____9005
                                             FStar_Pervasives_Native.None
-                                            (FStar_Ident.range_of_lid lid)
-                                           in
-                                        (lid, univ_names, uu____8998)  in
+                                            (FStar_Ident.range_of_lid lid) in
+                                        (lid, univ_names, uu____9002) in
                                       FStar_Syntax_Syntax.Sig_declare_typ
-                                        uu____8991
-                                       in
+                                        uu____8995 in
                                     let se2 =
-                                      let uu___130_9025 = se1  in
+                                      let uu___130_9029 = se1 in
                                       {
                                         FStar_Syntax_Syntax.sigel = sigel;
                                         FStar_Syntax_Syntax.sigrng =
-                                          (uu___130_9025.FStar_Syntax_Syntax.sigrng);
+                                          (uu___130_9029.FStar_Syntax_Syntax.sigrng);
                                         FStar_Syntax_Syntax.sigquals =
                                           (FStar_Syntax_Syntax.Assumption ::
                                           quals);
                                         FStar_Syntax_Syntax.sigmeta =
-                                          (uu___130_9025.FStar_Syntax_Syntax.sigmeta);
+                                          (uu___130_9029.FStar_Syntax_Syntax.sigmeta);
                                         FStar_Syntax_Syntax.sigattrs =
-                                          (uu___130_9025.FStar_Syntax_Syntax.sigattrs)
-                                      }  in
+                                          (uu___130_9029.FStar_Syntax_Syntax.sigattrs)
+                                      } in
                                     FStar_Util.smap_add (sigmap env)
                                       lid.FStar_Ident.str (se2, false))
                                  else ())
-                            | uu____9031 -> ()))
+                            | uu____9035 -> ()))
                   else ()
               | FStar_Syntax_Syntax.Sig_declare_typ
-                  (lid,uu____9034,uu____9035) ->
+                  (lid,uu____9038,uu____9039) ->
                   if FStar_List.contains FStar_Syntax_Syntax.Private quals
                   then
                     FStar_Util.smap_remove (sigmap env) lid.FStar_Ident.str
                   else ()
-              | FStar_Syntax_Syntax.Sig_let ((uu____9041,lbs),uu____9043) ->
+              | FStar_Syntax_Syntax.Sig_let ((uu____9045,lbs),uu____9047) ->
                   (if
                      (FStar_List.contains FStar_Syntax_Syntax.Private quals)
                        ||
@@ -3112,17 +2870,16 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                      FStar_All.pipe_right lbs
                        (FStar_List.iter
                           (fun lb  ->
-                             let uu____9064 =
-                               let uu____9065 =
-                                 let uu____9066 =
-                                   let uu____9069 =
+                             let uu____9068 =
+                               let uu____9069 =
+                                 let uu____9070 =
+                                   let uu____9073 =
                                      FStar_Util.right
-                                       lb.FStar_Syntax_Syntax.lbname
-                                      in
-                                   uu____9069.FStar_Syntax_Syntax.fv_name  in
-                                 uu____9066.FStar_Syntax_Syntax.v  in
-                               uu____9065.FStar_Ident.str  in
-                             FStar_Util.smap_remove (sigmap env) uu____9064))
+                                       lb.FStar_Syntax_Syntax.lbname in
+                                   uu____9073.FStar_Syntax_Syntax.fv_name in
+                                 uu____9070.FStar_Syntax_Syntax.v in
+                               uu____9069.FStar_Ident.str in
+                             FStar_Util.smap_remove (sigmap env) uu____9068))
                    else ();
                    if
                      (FStar_List.contains FStar_Syntax_Syntax.Abstract quals)
@@ -3135,302 +2892,284 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                        (FStar_List.iter
                           (fun lb  ->
                              let lid =
-                               let uu____9083 =
-                                 let uu____9086 =
+                               let uu____9087 =
+                                 let uu____9090 =
                                    FStar_Util.right
-                                     lb.FStar_Syntax_Syntax.lbname
-                                    in
-                                 uu____9086.FStar_Syntax_Syntax.fv_name  in
-                               uu____9083.FStar_Syntax_Syntax.v  in
+                                     lb.FStar_Syntax_Syntax.lbname in
+                                 uu____9090.FStar_Syntax_Syntax.fv_name in
+                               uu____9087.FStar_Syntax_Syntax.v in
                              let quals1 = FStar_Syntax_Syntax.Assumption ::
-                               quals  in
+                               quals in
                              let decl =
-                               let uu___131_9091 = se  in
+                               let uu___131_9095 = se in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_declare_typ
                                       (lid, (lb.FStar_Syntax_Syntax.lbunivs),
                                         (lb.FStar_Syntax_Syntax.lbtyp)));
                                  FStar_Syntax_Syntax.sigrng =
-                                   (uu___131_9091.FStar_Syntax_Syntax.sigrng);
+                                   (uu___131_9095.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals = quals1;
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (uu___131_9091.FStar_Syntax_Syntax.sigmeta);
+                                   (uu___131_9095.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (uu___131_9091.FStar_Syntax_Syntax.sigattrs)
-                               }  in
+                                   (uu___131_9095.FStar_Syntax_Syntax.sigattrs)
+                               } in
                              FStar_Util.smap_add (sigmap env)
                                lid.FStar_Ident.str (decl, false)))
                    else ())
-              | uu____9101 -> ()));
+              | uu____9105 -> ()));
       (let curmod =
-         let uu____9103 = current_module env  in uu____9103.FStar_Ident.str
-          in
-       (let uu____9105 =
-          let uu____9122 = get_exported_id_set env curmod  in
-          let uu____9129 = get_trans_exported_id_set env curmod  in
-          (uu____9122, uu____9129)  in
-        match uu____9105 with
+         let uu____9107 = current_module env in uu____9107.FStar_Ident.str in
+       (let uu____9109 =
+          let uu____9126 = get_exported_id_set env curmod in
+          let uu____9133 = get_trans_exported_id_set env curmod in
+          (uu____9126, uu____9133) in
+        match uu____9109 with
         | (FStar_Pervasives_Native.Some cur_ex,FStar_Pervasives_Native.Some
            cur_trans_ex) ->
             let update_exports eikind =
               let cur_ex_set =
-                let uu____9183 = cur_ex eikind  in
-                FStar_ST.op_Bang uu____9183  in
-              let cur_trans_ex_set_ref = cur_trans_ex eikind  in
-              let uu____9308 =
-                let uu____9309 = FStar_ST.op_Bang cur_trans_ex_set_ref  in
-                FStar_Util.set_union cur_ex_set uu____9309  in
-              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu____9308  in
+                let uu____9187 = cur_ex eikind in FStar_ST.op_Bang uu____9187 in
+              let cur_trans_ex_set_ref = cur_trans_ex eikind in
+              let uu____9312 =
+                let uu____9313 = FStar_ST.op_Bang cur_trans_ex_set_ref in
+                FStar_Util.set_union cur_ex_set uu____9313 in
+              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu____9312 in
             FStar_List.iter update_exports all_exported_id_kinds
-        | uu____9394 -> ());
+        | uu____9398 -> ());
        (match () with
         | () ->
             (filter_record_cache ();
              (match () with
               | () ->
-                  let uu___132_9412 = env  in
+                  let uu___132_9416 = env in
                   {
                     curmodule = FStar_Pervasives_Native.None;
-                    curmonad = (uu___132_9412.curmonad);
+                    curmonad = (uu___132_9416.curmonad);
                     modules = (((modul.FStar_Syntax_Syntax.name), modul) ::
                       (env.modules));
                     scope_mods = [];
-                    exported_ids = (uu___132_9412.exported_ids);
-                    trans_exported_ids = (uu___132_9412.trans_exported_ids);
-                    includes = (uu___132_9412.includes);
+                    exported_ids = (uu___132_9416.exported_ids);
+                    trans_exported_ids = (uu___132_9416.trans_exported_ids);
+                    includes = (uu___132_9416.includes);
                     sigaccum = [];
-                    sigmap = (uu___132_9412.sigmap);
-                    iface = (uu___132_9412.iface);
-                    admitted_iface = (uu___132_9412.admitted_iface);
-                    expect_typ = (uu___132_9412.expect_typ);
-                    docs = (uu___132_9412.docs);
+                    sigmap = (uu___132_9416.sigmap);
+                    iface = (uu___132_9416.iface);
+                    admitted_iface = (uu___132_9416.admitted_iface);
+                    expect_typ = (uu___132_9416.expect_typ);
+                    docs = (uu___132_9416.docs);
                     remaining_iface_decls =
-                      (uu___132_9412.remaining_iface_decls);
-                    syntax_only = (uu___132_9412.syntax_only);
-                    ds_hooks = (uu___132_9412.ds_hooks)
+                      (uu___132_9416.remaining_iface_decls);
+                    syntax_only = (uu___132_9416.syntax_only);
+                    ds_hooks = (uu___132_9416.ds_hooks)
                   }))))
-  
-let (stack : env Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
-let (push : env -> env) =
+let stack: env Prims.list FStar_ST.ref = FStar_Util.mk_ref []
+let push: env -> env =
   fun env  ->
     push_record_cache ();
-    (let uu____9439 =
-       let uu____9442 = FStar_ST.op_Bang stack  in env :: uu____9442  in
-     FStar_ST.op_Colon_Equals stack uu____9439);
-    (let uu___133_9491 = env  in
-     let uu____9492 = FStar_Util.smap_copy (sigmap env)  in
-     let uu____9503 = FStar_Util.smap_copy env.docs  in
+    (let uu____9443 =
+       let uu____9446 = FStar_ST.op_Bang stack in env :: uu____9446 in
+     FStar_ST.op_Colon_Equals stack uu____9443);
+    (let uu___133_9495 = env in
+     let uu____9496 = FStar_Util.smap_copy (sigmap env) in
+     let uu____9507 = FStar_Util.smap_copy env.docs in
      {
-       curmodule = (uu___133_9491.curmodule);
-       curmonad = (uu___133_9491.curmonad);
-       modules = (uu___133_9491.modules);
-       scope_mods = (uu___133_9491.scope_mods);
-       exported_ids = (uu___133_9491.exported_ids);
-       trans_exported_ids = (uu___133_9491.trans_exported_ids);
-       includes = (uu___133_9491.includes);
-       sigaccum = (uu___133_9491.sigaccum);
-       sigmap = uu____9492;
-       iface = (uu___133_9491.iface);
-       admitted_iface = (uu___133_9491.admitted_iface);
-       expect_typ = (uu___133_9491.expect_typ);
-       docs = uu____9503;
-       remaining_iface_decls = (uu___133_9491.remaining_iface_decls);
-       syntax_only = (uu___133_9491.syntax_only);
-       ds_hooks = (uu___133_9491.ds_hooks)
+       curmodule = (uu___133_9495.curmodule);
+       curmonad = (uu___133_9495.curmonad);
+       modules = (uu___133_9495.modules);
+       scope_mods = (uu___133_9495.scope_mods);
+       exported_ids = (uu___133_9495.exported_ids);
+       trans_exported_ids = (uu___133_9495.trans_exported_ids);
+       includes = (uu___133_9495.includes);
+       sigaccum = (uu___133_9495.sigaccum);
+       sigmap = uu____9496;
+       iface = (uu___133_9495.iface);
+       admitted_iface = (uu___133_9495.admitted_iface);
+       expect_typ = (uu___133_9495.expect_typ);
+       docs = uu____9507;
+       remaining_iface_decls = (uu___133_9495.remaining_iface_decls);
+       syntax_only = (uu___133_9495.syntax_only);
+       ds_hooks = (uu___133_9495.ds_hooks)
      })
-  
-let (pop : Prims.unit -> env) =
-  fun uu____9508  ->
-    let uu____9509 = FStar_ST.op_Bang stack  in
-    match uu____9509 with
+let pop: Prims.unit -> env =
+  fun uu____9512  ->
+    let uu____9513 = FStar_ST.op_Bang stack in
+    match uu____9513 with
     | env::tl1 ->
         (pop_record_cache (); FStar_ST.op_Colon_Equals stack tl1; env)
-    | uu____9564 -> failwith "Impossible: Too many pops"
-  
-let (export_interface : FStar_Ident.lident -> env -> env) =
+    | uu____9568 -> failwith "Impossible: Too many pops"
+let export_interface: FStar_Ident.lident -> env -> env =
   fun m  ->
     fun env  ->
       let sigelt_in_m se =
         match FStar_Syntax_Util.lids_of_sigelt se with
-        | l::uu____9578 -> l.FStar_Ident.nsstr = m.FStar_Ident.str
-        | uu____9581 -> false  in
-      let sm = sigmap env  in
-      let env1 = pop ()  in
-      let keys = FStar_Util.smap_keys sm  in
-      let sm' = sigmap env1  in
+        | l::uu____9582 -> l.FStar_Ident.nsstr = m.FStar_Ident.str
+        | uu____9585 -> false in
+      let sm = sigmap env in
+      let env1 = pop () in
+      let keys = FStar_Util.smap_keys sm in
+      let sm' = sigmap env1 in
       FStar_All.pipe_right keys
         (FStar_List.iter
            (fun k  ->
-              let uu____9615 = FStar_Util.smap_try_find sm' k  in
-              match uu____9615 with
+              let uu____9619 = FStar_Util.smap_try_find sm' k in
+              match uu____9619 with
               | FStar_Pervasives_Native.Some (se,true ) when sigelt_in_m se
                   ->
                   (FStar_Util.smap_remove sm' k;
                    (let se1 =
                       match se.FStar_Syntax_Syntax.sigel with
                       | FStar_Syntax_Syntax.Sig_declare_typ (l,u,t) ->
-                          let uu___134_9640 = se  in
+                          let uu___134_9644 = se in
                           {
                             FStar_Syntax_Syntax.sigel =
-                              (uu___134_9640.FStar_Syntax_Syntax.sigel);
+                              (uu___134_9644.FStar_Syntax_Syntax.sigel);
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___134_9640.FStar_Syntax_Syntax.sigrng);
+                              (uu___134_9644.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
                               (FStar_Syntax_Syntax.Assumption ::
                               (se.FStar_Syntax_Syntax.sigquals));
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___134_9640.FStar_Syntax_Syntax.sigmeta);
+                              (uu___134_9644.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___134_9640.FStar_Syntax_Syntax.sigattrs)
+                              (uu___134_9644.FStar_Syntax_Syntax.sigattrs)
                           }
-                      | uu____9641 -> se  in
+                      | uu____9645 -> se in
                     FStar_Util.smap_add sm' k (se1, false)))
-              | uu____9646 -> ()));
+              | uu____9650 -> ()));
       env1
-  
-let (finish_module_or_interface :
+let finish_module_or_interface:
   env ->
     FStar_Syntax_Syntax.modul ->
-      (env,FStar_Syntax_Syntax.modul) FStar_Pervasives_Native.tuple2)
+      (env,FStar_Syntax_Syntax.modul) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun modul  ->
       let modul1 =
         if Prims.op_Negation modul.FStar_Syntax_Syntax.is_interface
         then check_admits env modul
-        else modul  in
-      let uu____9665 = finish env modul1  in (uu____9665, modul1)
-  
+        else modul in
+      let uu____9669 = finish env modul1 in (uu____9669, modul1)
 type exported_ids =
   {
-  exported_id_terms: Prims.string Prims.list ;
-  exported_id_fields: Prims.string Prims.list }[@@deriving show]
-let (__proj__Mkexported_ids__item__exported_id_terms :
-  exported_ids -> Prims.string Prims.list) =
+  exported_id_terms: Prims.string Prims.list;
+  exported_id_fields: Prims.string Prims.list;}[@@deriving show]
+let __proj__Mkexported_ids__item__exported_id_terms:
+  exported_ids -> Prims.string Prims.list =
   fun projectee  ->
     match projectee with
     | { exported_id_terms = __fname__exported_id_terms;
         exported_id_fields = __fname__exported_id_fields;_} ->
         __fname__exported_id_terms
-  
-let (__proj__Mkexported_ids__item__exported_id_fields :
-  exported_ids -> Prims.string Prims.list) =
+let __proj__Mkexported_ids__item__exported_id_fields:
+  exported_ids -> Prims.string Prims.list =
   fun projectee  ->
     match projectee with
     | { exported_id_terms = __fname__exported_id_terms;
         exported_id_fields = __fname__exported_id_fields;_} ->
         __fname__exported_id_fields
-  
-let (as_exported_ids : exported_id_set -> exported_ids) =
+let as_exported_ids: exported_id_set -> exported_ids =
   fun e  ->
     let terms =
-      let uu____9743 =
-        let uu____9746 = e Exported_id_term_type  in
-        FStar_ST.op_Bang uu____9746  in
-      FStar_Util.set_elements uu____9743  in
+      let uu____9747 =
+        let uu____9750 = e Exported_id_term_type in
+        FStar_ST.op_Bang uu____9750 in
+      FStar_Util.set_elements uu____9747 in
     let fields =
-      let uu____9860 =
-        let uu____9863 = e Exported_id_field  in FStar_ST.op_Bang uu____9863
-         in
-      FStar_Util.set_elements uu____9860  in
+      let uu____9864 =
+        let uu____9867 = e Exported_id_field in FStar_ST.op_Bang uu____9867 in
+      FStar_Util.set_elements uu____9864 in
     { exported_id_terms = terms; exported_id_fields = fields }
-  
-let (as_exported_id_set :
+let as_exported_id_set:
   exported_ids FStar_Pervasives_Native.option ->
-    exported_id_kind -> Prims.string FStar_Util.set FStar_ST.ref)
+    exported_id_kind -> Prims.string FStar_Util.set FStar_ST.ref
   =
   fun e  ->
     match e with
     | FStar_Pervasives_Native.None  -> exported_id_set_new ()
     | FStar_Pervasives_Native.Some e1 ->
         let terms =
-          let uu____10010 =
-            FStar_Util.as_set e1.exported_id_terms FStar_Util.compare  in
-          FStar_Util.mk_ref uu____10010  in
+          let uu____10014 =
+            FStar_Util.as_set e1.exported_id_terms FStar_Util.compare in
+          FStar_Util.mk_ref uu____10014 in
         let fields =
-          let uu____10020 =
-            FStar_Util.as_set e1.exported_id_fields FStar_Util.compare  in
-          FStar_Util.mk_ref uu____10020  in
-        (fun uu___109_10025  ->
-           match uu___109_10025 with
+          let uu____10024 =
+            FStar_Util.as_set e1.exported_id_fields FStar_Util.compare in
+          FStar_Util.mk_ref uu____10024 in
+        (fun uu___109_10029  ->
+           match uu___109_10029 with
            | Exported_id_term_type  -> terms
            | Exported_id_field  -> fields)
-  
 type module_inclusion_info =
   {
-  mii_exported_ids: exported_ids FStar_Pervasives_Native.option ;
-  mii_trans_exported_ids: exported_ids FStar_Pervasives_Native.option ;
-  mii_includes: FStar_Ident.lident Prims.list FStar_Pervasives_Native.option }
+  mii_exported_ids: exported_ids FStar_Pervasives_Native.option;
+  mii_trans_exported_ids: exported_ids FStar_Pervasives_Native.option;
+  mii_includes: FStar_Ident.lident Prims.list FStar_Pervasives_Native.option;}
 [@@deriving show]
-let (__proj__Mkmodule_inclusion_info__item__mii_exported_ids :
-  module_inclusion_info -> exported_ids FStar_Pervasives_Native.option) =
+let __proj__Mkmodule_inclusion_info__item__mii_exported_ids:
+  module_inclusion_info -> exported_ids FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { mii_exported_ids = __fname__mii_exported_ids;
         mii_trans_exported_ids = __fname__mii_trans_exported_ids;
         mii_includes = __fname__mii_includes;_} -> __fname__mii_exported_ids
-  
-let (__proj__Mkmodule_inclusion_info__item__mii_trans_exported_ids :
-  module_inclusion_info -> exported_ids FStar_Pervasives_Native.option) =
+let __proj__Mkmodule_inclusion_info__item__mii_trans_exported_ids:
+  module_inclusion_info -> exported_ids FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { mii_exported_ids = __fname__mii_exported_ids;
         mii_trans_exported_ids = __fname__mii_trans_exported_ids;
         mii_includes = __fname__mii_includes;_} ->
         __fname__mii_trans_exported_ids
-  
-let (__proj__Mkmodule_inclusion_info__item__mii_includes :
+let __proj__Mkmodule_inclusion_info__item__mii_includes:
   module_inclusion_info ->
-    FStar_Ident.lident Prims.list FStar_Pervasives_Native.option)
+    FStar_Ident.lident Prims.list FStar_Pervasives_Native.option
   =
   fun projectee  ->
     match projectee with
     | { mii_exported_ids = __fname__mii_exported_ids;
         mii_trans_exported_ids = __fname__mii_trans_exported_ids;
         mii_includes = __fname__mii_includes;_} -> __fname__mii_includes
-  
-let (default_mii : module_inclusion_info) =
+let default_mii: module_inclusion_info =
   {
     mii_exported_ids = FStar_Pervasives_Native.None;
     mii_trans_exported_ids = FStar_Pervasives_Native.None;
     mii_includes = FStar_Pervasives_Native.None
-  } 
-let as_includes :
-  'Auu____10145 .
-    'Auu____10145 Prims.list FStar_Pervasives_Native.option ->
-      'Auu____10145 Prims.list FStar_ST.ref
+  }
+let as_includes:
+  'Auu____10149 .
+    'Auu____10149 Prims.list FStar_Pervasives_Native.option ->
+      'Auu____10149 Prims.list FStar_ST.ref
   =
-  fun uu___110_10157  ->
-    match uu___110_10157 with
+  fun uu___110_10161  ->
+    match uu___110_10161 with
     | FStar_Pervasives_Native.None  -> FStar_Util.mk_ref []
     | FStar_Pervasives_Native.Some l -> FStar_Util.mk_ref l
-  
-let (inclusion_info : env -> FStar_Ident.lident -> module_inclusion_info) =
+let inclusion_info: env -> FStar_Ident.lident -> module_inclusion_info =
   fun env  ->
     fun l  ->
-      let mname = FStar_Ident.string_of_lid l  in
+      let mname = FStar_Ident.string_of_lid l in
       let as_ids_opt m =
-        let uu____10190 = FStar_Util.smap_try_find m mname  in
-        FStar_Util.map_opt uu____10190 as_exported_ids  in
-      let uu____10193 = as_ids_opt env.exported_ids  in
-      let uu____10196 = as_ids_opt env.trans_exported_ids  in
-      let uu____10199 =
-        let uu____10204 = FStar_Util.smap_try_find env.includes mname  in
-        FStar_Util.map_opt uu____10204 (fun r  -> FStar_ST.op_Bang r)  in
+        let uu____10194 = FStar_Util.smap_try_find m mname in
+        FStar_Util.map_opt uu____10194 as_exported_ids in
+      let uu____10197 = as_ids_opt env.exported_ids in
+      let uu____10200 = as_ids_opt env.trans_exported_ids in
+      let uu____10203 =
+        let uu____10208 = FStar_Util.smap_try_find env.includes mname in
+        FStar_Util.map_opt uu____10208 (fun r  -> FStar_ST.op_Bang r) in
       {
-        mii_exported_ids = uu____10193;
-        mii_trans_exported_ids = uu____10196;
-        mii_includes = uu____10199
+        mii_exported_ids = uu____10197;
+        mii_trans_exported_ids = uu____10200;
+        mii_includes = uu____10203
       }
-  
-let (prepare_module_or_interface :
+let prepare_module_or_interface:
   Prims.bool ->
     Prims.bool ->
       env ->
         FStar_Ident.lident ->
           module_inclusion_info ->
-            (env,Prims.bool) FStar_Pervasives_Native.tuple2)
+            (env,Prims.bool) FStar_Pervasives_Native.tuple2
   =
   fun intf  ->
     fun admitted  ->
@@ -3439,121 +3178,112 @@ let (prepare_module_or_interface :
           fun mii  ->
             let prep env1 =
               let filename =
-                FStar_Util.strcat (FStar_Ident.text_of_lid mname) ".fst"  in
+                FStar_Util.strcat (FStar_Ident.text_of_lid mname) ".fst" in
               let auto_open =
-                FStar_Parser_Dep.hard_coded_dependencies filename  in
+                FStar_Parser_Dep.hard_coded_dependencies filename in
               let auto_open1 =
-                let convert_kind uu___111_10324 =
-                  match uu___111_10324 with
+                let convert_kind uu___111_10328 =
+                  match uu___111_10328 with
                   | FStar_Parser_Dep.Open_namespace  -> Open_namespace
-                  | FStar_Parser_Dep.Open_module  -> Open_module  in
+                  | FStar_Parser_Dep.Open_module  -> Open_module in
                 FStar_List.map
-                  (fun uu____10336  ->
-                     match uu____10336 with
-                     | (lid,kind) -> (lid, (convert_kind kind))) auto_open
-                 in
+                  (fun uu____10340  ->
+                     match uu____10340 with
+                     | (lid,kind) -> (lid, (convert_kind kind))) auto_open in
               let namespace_of_module =
                 if
                   (FStar_List.length mname.FStar_Ident.ns) >
                     (Prims.parse_int "0")
                 then
-                  let uu____10360 =
-                    let uu____10365 =
-                      FStar_Ident.lid_of_ids mname.FStar_Ident.ns  in
-                    (uu____10365, Open_namespace)  in
-                  [uu____10360]
-                else []  in
+                  let uu____10364 =
+                    let uu____10369 =
+                      FStar_Ident.lid_of_ids mname.FStar_Ident.ns in
+                    (uu____10369, Open_namespace) in
+                  [uu____10364]
+                else [] in
               let auto_open2 =
                 FStar_List.append namespace_of_module
-                  (FStar_List.rev auto_open1)
-                 in
-              (let uu____10395 = as_exported_id_set mii.mii_exported_ids  in
+                  (FStar_List.rev auto_open1) in
+              (let uu____10399 = as_exported_id_set mii.mii_exported_ids in
                FStar_Util.smap_add env1.exported_ids mname.FStar_Ident.str
-                 uu____10395);
+                 uu____10399);
               (match () with
                | () ->
-                   ((let uu____10419 =
-                       as_exported_id_set mii.mii_trans_exported_ids  in
+                   ((let uu____10423 =
+                       as_exported_id_set mii.mii_trans_exported_ids in
                      FStar_Util.smap_add env1.trans_exported_ids
-                       mname.FStar_Ident.str uu____10419);
+                       mname.FStar_Ident.str uu____10423);
                     (match () with
                      | () ->
-                         ((let uu____10443 = as_includes mii.mii_includes  in
+                         ((let uu____10447 = as_includes mii.mii_includes in
                            FStar_Util.smap_add env1.includes
-                             mname.FStar_Ident.str uu____10443);
+                             mname.FStar_Ident.str uu____10447);
                           (match () with
                            | () ->
                                let env' =
-                                 let uu___135_10475 = env1  in
-                                 let uu____10476 =
+                                 let uu___135_10479 = env1 in
+                                 let uu____10480 =
                                    FStar_List.map
                                      (fun x  -> Open_module_or_namespace x)
-                                     auto_open2
-                                    in
+                                     auto_open2 in
                                  {
                                    curmodule =
                                      (FStar_Pervasives_Native.Some mname);
-                                   curmonad = (uu___135_10475.curmonad);
-                                   modules = (uu___135_10475.modules);
-                                   scope_mods = uu____10476;
+                                   curmonad = (uu___135_10479.curmonad);
+                                   modules = (uu___135_10479.modules);
+                                   scope_mods = uu____10480;
                                    exported_ids =
-                                     (uu___135_10475.exported_ids);
+                                     (uu___135_10479.exported_ids);
                                    trans_exported_ids =
-                                     (uu___135_10475.trans_exported_ids);
-                                   includes = (uu___135_10475.includes);
-                                   sigaccum = (uu___135_10475.sigaccum);
+                                     (uu___135_10479.trans_exported_ids);
+                                   includes = (uu___135_10479.includes);
+                                   sigaccum = (uu___135_10479.sigaccum);
                                    sigmap = (env1.sigmap);
                                    iface = intf;
                                    admitted_iface = admitted;
-                                   expect_typ = (uu___135_10475.expect_typ);
-                                   docs = (uu___135_10475.docs);
+                                   expect_typ = (uu___135_10479.expect_typ);
+                                   docs = (uu___135_10479.docs);
                                    remaining_iface_decls =
-                                     (uu___135_10475.remaining_iface_decls);
-                                   syntax_only = (uu___135_10475.syntax_only);
-                                   ds_hooks = (uu___135_10475.ds_hooks)
-                                 }  in
+                                     (uu___135_10479.remaining_iface_decls);
+                                   syntax_only = (uu___135_10479.syntax_only);
+                                   ds_hooks = (uu___135_10479.ds_hooks)
+                                 } in
                                (FStar_List.iter
                                   (fun op  ->
                                      (env1.ds_hooks).ds_push_open_hook env'
                                        op) (FStar_List.rev auto_open2);
-                                env'))))))
-               in
-            let uu____10488 =
+                                env')))))) in
+            let uu____10492 =
               FStar_All.pipe_right env.modules
                 (FStar_Util.find_opt
-                   (fun uu____10514  ->
-                      match uu____10514 with
-                      | (l,uu____10520) -> FStar_Ident.lid_equals l mname))
-               in
-            match uu____10488 with
+                   (fun uu____10518  ->
+                      match uu____10518 with
+                      | (l,uu____10524) -> FStar_Ident.lid_equals l mname)) in
+            match uu____10492 with
             | FStar_Pervasives_Native.None  ->
-                let uu____10529 = prep env  in (uu____10529, false)
-            | FStar_Pervasives_Native.Some (uu____10530,m) ->
-                ((let uu____10537 =
-                    (let uu____10540 = FStar_Options.interactive ()  in
-                     Prims.op_Negation uu____10540) &&
+                let uu____10533 = prep env in (uu____10533, false)
+            | FStar_Pervasives_Native.Some (uu____10534,m) ->
+                ((let uu____10541 =
+                    (let uu____10544 = FStar_Options.interactive () in
+                     Prims.op_Negation uu____10544) &&
                       ((Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)
-                         || intf)
-                     in
-                  if uu____10537
+                         || intf) in
+                  if uu____10541
                   then
-                    let uu____10541 =
-                      let uu____10546 =
+                    let uu____10545 =
+                      let uu____10550 =
                         FStar_Util.format1
                           "Duplicate module or interface name: %s"
-                          mname.FStar_Ident.str
-                         in
+                          mname.FStar_Ident.str in
                       (FStar_Errors.Fatal_DuplicateModuleOrInterface,
-                        uu____10546)
-                       in
-                    FStar_Errors.raise_error uu____10541
+                        uu____10550) in
+                    FStar_Errors.raise_error uu____10545
                       (FStar_Ident.range_of_lid mname)
                   else ());
-                 (let uu____10548 =
-                    let uu____10549 = push env  in prep uu____10549  in
-                  (uu____10548, true)))
-  
-let (enter_monad_scope : env -> FStar_Ident.ident -> env) =
+                 (let uu____10552 =
+                    let uu____10553 = push env in prep uu____10553 in
+                  (uu____10552, true)))
+let enter_monad_scope: env -> FStar_Ident.ident -> env =
   fun env  ->
     fun mname  ->
       match env.curmonad with
@@ -3566,27 +3296,26 @@ let (enter_monad_scope : env -> FStar_Ident.ident -> env) =
                        mname'.FStar_Ident.idText))))
             mname.FStar_Ident.idRange
       | FStar_Pervasives_Native.None  ->
-          let uu___136_10557 = env  in
+          let uu___136_10561 = env in
           {
-            curmodule = (uu___136_10557.curmodule);
+            curmodule = (uu___136_10561.curmodule);
             curmonad = (FStar_Pervasives_Native.Some mname);
-            modules = (uu___136_10557.modules);
-            scope_mods = (uu___136_10557.scope_mods);
-            exported_ids = (uu___136_10557.exported_ids);
-            trans_exported_ids = (uu___136_10557.trans_exported_ids);
-            includes = (uu___136_10557.includes);
-            sigaccum = (uu___136_10557.sigaccum);
-            sigmap = (uu___136_10557.sigmap);
-            iface = (uu___136_10557.iface);
-            admitted_iface = (uu___136_10557.admitted_iface);
-            expect_typ = (uu___136_10557.expect_typ);
-            docs = (uu___136_10557.docs);
-            remaining_iface_decls = (uu___136_10557.remaining_iface_decls);
-            syntax_only = (uu___136_10557.syntax_only);
-            ds_hooks = (uu___136_10557.ds_hooks)
+            modules = (uu___136_10561.modules);
+            scope_mods = (uu___136_10561.scope_mods);
+            exported_ids = (uu___136_10561.exported_ids);
+            trans_exported_ids = (uu___136_10561.trans_exported_ids);
+            includes = (uu___136_10561.includes);
+            sigaccum = (uu___136_10561.sigaccum);
+            sigmap = (uu___136_10561.sigmap);
+            iface = (uu___136_10561.iface);
+            admitted_iface = (uu___136_10561.admitted_iface);
+            expect_typ = (uu___136_10561.expect_typ);
+            docs = (uu___136_10561.docs);
+            remaining_iface_decls = (uu___136_10561.remaining_iface_decls);
+            syntax_only = (uu___136_10561.syntax_only);
+            ds_hooks = (uu___136_10561.ds_hooks)
           }
-  
-let fail_or :
+let fail_or:
   'a .
     env ->
       (FStar_Ident.lident -> 'a FStar_Pervasives_Native.option) ->
@@ -3595,20 +3324,18 @@ let fail_or :
   fun env  ->
     fun lookup  ->
       fun lid  ->
-        let uu____10584 = lookup lid  in
-        match uu____10584 with
+        let uu____10588 = lookup lid in
+        match uu____10588 with
         | FStar_Pervasives_Native.None  ->
             let opened_modules =
               FStar_List.map
-                (fun uu____10597  ->
-                   match uu____10597 with
-                   | (lid1,uu____10603) -> FStar_Ident.text_of_lid lid1)
-                env.modules
-               in
+                (fun uu____10601  ->
+                   match uu____10601 with
+                   | (lid1,uu____10607) -> FStar_Ident.text_of_lid lid1)
+                env.modules in
             let msg =
               FStar_Util.format1 "Identifier not found: [%s]"
-                (FStar_Ident.text_of_lid lid)
-               in
+                (FStar_Ident.text_of_lid lid) in
             let msg1 =
               if
                 (FStar_List.length lid.FStar_Ident.ns) =
@@ -3616,16 +3343,15 @@ let fail_or :
               then msg
               else
                 (let modul =
-                   let uu____10608 =
-                     FStar_Ident.lid_of_ids lid.FStar_Ident.ns  in
-                   FStar_Ident.set_lid_range uu____10608
-                     (FStar_Ident.range_of_lid lid)
-                    in
-                 let uu____10609 = resolve_module_name env modul true  in
-                 match uu____10609 with
+                   let uu____10612 =
+                     FStar_Ident.lid_of_ids lid.FStar_Ident.ns in
+                   FStar_Ident.set_lid_range uu____10612
+                     (FStar_Ident.range_of_lid lid) in
+                 let uu____10613 = resolve_module_name env modul true in
+                 match uu____10613 with
                  | FStar_Pervasives_Native.None  ->
                      let opened_modules1 =
-                       FStar_String.concat ", " opened_modules  in
+                       FStar_String.concat ", " opened_modules in
                      FStar_Util.format3
                        "%s\nModule %s does not belong to the list of modules in scope, namely %s"
                        msg modul.FStar_Ident.str opened_modules1
@@ -3636,7 +3362,7 @@ let fail_or :
                           opened_modules)
                      ->
                      let opened_modules1 =
-                       FStar_String.concat ", " opened_modules  in
+                       FStar_String.concat ", " opened_modules in
                      FStar_Util.format4
                        "%s\nModule %s resolved into %s, which does not belong to the list of modules in scope, namely %s"
                        msg modul.FStar_Ident.str modul'.FStar_Ident.str
@@ -3645,22 +3371,20 @@ let fail_or :
                      FStar_Util.format4
                        "%s\nModule %s resolved into %s, definition %s not found"
                        msg modul.FStar_Ident.str modul'.FStar_Ident.str
-                       (lid.FStar_Ident.ident).FStar_Ident.idText)
-               in
+                       (lid.FStar_Ident.ident).FStar_Ident.idText) in
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_IdentifierNotFound, msg1)
               (FStar_Ident.range_of_lid lid)
         | FStar_Pervasives_Native.Some r -> r
-  
-let fail_or2 :
+let fail_or2:
   'a .
     (FStar_Ident.ident -> 'a FStar_Pervasives_Native.option) ->
       FStar_Ident.ident -> 'a
   =
   fun lookup  ->
     fun id1  ->
-      let uu____10640 = lookup id1  in
-      match uu____10640 with
+      let uu____10644 = lookup id1 in
+      match uu____10644 with
       | FStar_Pervasives_Native.None  ->
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_IdentifierNotFound,
@@ -3668,4 +3392,3 @@ let fail_or2 :
                  (Prims.strcat id1.FStar_Ident.idText "]")))
             id1.FStar_Ident.idRange
       | FStar_Pervasives_Native.Some r -> r
-  

--- a/src/ocaml-output/FStar_ToSyntax_Interleave.ml
+++ b/src/ocaml-output/FStar_ToSyntax_Interleave.ml
@@ -1,17 +1,15 @@
 open Prims
-let (id_eq_lid : FStar_Ident.ident -> FStar_Ident.lident -> Prims.bool) =
+let id_eq_lid: FStar_Ident.ident -> FStar_Ident.lident -> Prims.bool =
   fun i  ->
     fun l  -> i.FStar_Ident.idText = (l.FStar_Ident.ident).FStar_Ident.idText
-  
-let (is_val : FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
+let is_val: FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool =
   fun x  ->
     fun d  ->
       match d.FStar_Parser_AST.d with
       | FStar_Parser_AST.Val (y,uu____14) ->
           x.FStar_Ident.idText = y.FStar_Ident.idText
       | uu____15 -> false
-  
-let (is_type : FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
+let is_type: FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool =
   fun x  ->
     fun d  ->
       match d.FStar_Parser_AST.d with
@@ -23,8 +21,7 @@ let (is_type : FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
                   | (t,uu____65) ->
                       (FStar_Parser_AST.id_of_tycon t) = x.FStar_Ident.idText))
       | uu____70 -> false
-  
-let (definition_lids : FStar_Parser_AST.decl -> FStar_Ident.lid Prims.list) =
+let definition_lids: FStar_Parser_AST.decl -> FStar_Ident.lid Prims.list =
   fun d  ->
     match d.FStar_Parser_AST.d with
     | FStar_Parser_AST.TopLevelLet (uu____78,defs) ->
@@ -36,31 +33,29 @@ let (definition_lids : FStar_Parser_AST.decl -> FStar_Ident.lid Prims.list) =
                 match uu___57_133 with
                 | (FStar_Parser_AST.TyconAbbrev
                    (id1,uu____143,uu____144,uu____145),uu____146) ->
-                    let uu____159 = FStar_Ident.lid_of_ids [id1]  in
+                    let uu____159 = FStar_Ident.lid_of_ids [id1] in
                     [uu____159]
                 | (FStar_Parser_AST.TyconRecord
                    (id1,uu____161,uu____162,uu____163),uu____164) ->
-                    let uu____197 = FStar_Ident.lid_of_ids [id1]  in
+                    let uu____197 = FStar_Ident.lid_of_ids [id1] in
                     [uu____197]
                 | (FStar_Parser_AST.TyconVariant
                    (id1,uu____199,uu____200,uu____201),uu____202) ->
-                    let uu____243 = FStar_Ident.lid_of_ids [id1]  in
+                    let uu____243 = FStar_Ident.lid_of_ids [id1] in
                     [uu____243]
                 | uu____244 -> []))
     | uu____251 -> []
-  
-let (is_definition_of :
-  FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
+let is_definition_of:
+  FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool =
   fun x  ->
     fun d  ->
-      let uu____258 = definition_lids d  in
+      let uu____258 = definition_lids d in
       FStar_Util.for_some (id_eq_lid x) uu____258
-  
-let rec (prefix_with_iface_decls :
+let rec prefix_with_iface_decls:
   FStar_Parser_AST.decl Prims.list ->
     FStar_Parser_AST.decl ->
       (FStar_Parser_AST.decl Prims.list,FStar_Parser_AST.decl Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun iface1  ->
     fun impl  ->
@@ -70,9 +65,8 @@ let rec (prefix_with_iface_decls :
             (FStar_Parser_AST.Const
                (FStar_Const.Const_string
                   ("KremlinPrivate", (impl1.FStar_Parser_AST.drange))))
-            impl1.FStar_Parser_AST.drange FStar_Parser_AST.Expr
-           in
-        let uu___61_292 = impl1  in
+            impl1.FStar_Parser_AST.drange FStar_Parser_AST.Expr in
+        let uu___61_292 = impl1 in
         {
           FStar_Parser_AST.d = (uu___61_292.FStar_Parser_AST.d);
           FStar_Parser_AST.drange = (uu___61_292.FStar_Parser_AST.drange);
@@ -80,7 +74,7 @@ let rec (prefix_with_iface_decls :
           FStar_Parser_AST.quals = (uu___61_292.FStar_Parser_AST.quals);
           FStar_Parser_AST.attrs = (krem_private ::
             (impl1.FStar_Parser_AST.attrs))
-        }  in
+        } in
       match iface1 with
       | [] -> ([], [qualify_kremlin_private impl])
       | iface_hd::iface_tl ->
@@ -99,8 +93,8 @@ let rec (prefix_with_iface_decls :
                    "Interface contains an abstract 'type' declaration; use 'val' instead")
                  impl.FStar_Parser_AST.drange
            | FStar_Parser_AST.Val (x,t) ->
-               let def_ids = definition_lids impl  in
-               let defines_x = FStar_Util.for_some (id_eq_lid x) def_ids  in
+               let def_ids = definition_lids impl in
+               let defines_x = FStar_Util.for_some (id_eq_lid x) def_ids in
                if Prims.op_Negation defines_x
                then
                  let uu____404 =
@@ -109,8 +103,7 @@ let rec (prefix_with_iface_decls :
                         (fun y  ->
                            FStar_All.pipe_right iface_tl
                              (FStar_Util.for_some
-                                (is_val y.FStar_Ident.ident))))
-                    in
+                                (is_val y.FStar_Ident.ident)))) in
                  (if uu____404
                   then
                     let uu____419 =
@@ -118,17 +111,13 @@ let rec (prefix_with_iface_decls :
                         let uu____425 =
                           let uu____426 =
                             FStar_All.pipe_right def_ids
-                              (FStar_List.map FStar_Ident.string_of_lid)
-                             in
+                              (FStar_List.map FStar_Ident.string_of_lid) in
                           FStar_All.pipe_right uu____426
-                            (FStar_String.concat ", ")
-                           in
+                            (FStar_String.concat ", ") in
                         FStar_Util.format2
                           "Expected the definition of %s to precede %s"
-                          x.FStar_Ident.idText uu____425
-                         in
-                      (FStar_Errors.Fatal_WrongDefinitionOrder, uu____424)
-                       in
+                          x.FStar_Ident.idText uu____425 in
+                      (FStar_Errors.Fatal_WrongDefinitionOrder, uu____424) in
                     FStar_Errors.raise_error uu____419
                       impl.FStar_Parser_AST.drange
                   else (iface1, [qualify_kremlin_private impl]))
@@ -136,8 +125,7 @@ let rec (prefix_with_iface_decls :
                  (let mutually_defined_with_x =
                     FStar_All.pipe_right def_ids
                       (FStar_List.filter
-                         (fun y  -> Prims.op_Negation (id_eq_lid x y)))
-                     in
+                         (fun y  -> Prims.op_Negation (id_eq_lid x y))) in
                   let rec aux mutuals iface2 =
                     match (mutuals, iface2) with
                     | ([],uu____493) -> ([], iface2)
@@ -145,7 +133,7 @@ let rec (prefix_with_iface_decls :
                     | (y::ys,iface_hd1::iface_tl1) ->
                         if is_val y.FStar_Ident.ident iface_hd1
                         then
-                          let uu____536 = aux ys iface_tl1  in
+                          let uu____536 = aux ys iface_tl1 in
                           (match uu____536 with
                            | (val_ys,iface3) ->
                                ((iface_hd1 :: val_ys), iface3))
@@ -153,43 +141,35 @@ let rec (prefix_with_iface_decls :
                           (let uu____568 =
                              let uu____569 =
                                FStar_List.tryFind
-                                 (is_val y.FStar_Ident.ident) iface_tl1
-                                in
+                                 (is_val y.FStar_Ident.ident) iface_tl1 in
                              FStar_All.pipe_left FStar_Option.isSome
-                               uu____569
-                              in
+                               uu____569 in
                            if uu____568
                            then
                              let uu____582 =
                                let uu____587 =
                                  let uu____588 =
-                                   FStar_Parser_AST.decl_to_string iface_hd1
-                                    in
-                                 let uu____589 = FStar_Ident.string_of_lid y
-                                    in
+                                   FStar_Parser_AST.decl_to_string iface_hd1 in
+                                 let uu____589 = FStar_Ident.string_of_lid y in
                                  FStar_Util.format2
                                    "%s is out of order with the definition of %s"
-                                   uu____588 uu____589
-                                  in
+                                   uu____588 uu____589 in
                                (FStar_Errors.Fatal_WrongDefinitionOrder,
-                                 uu____587)
-                                in
+                                 uu____587) in
                              FStar_Errors.raise_error uu____582
                                iface_hd1.FStar_Parser_AST.drange
-                           else aux ys iface2)
-                     in
-                  let uu____599 = aux mutually_defined_with_x iface_tl  in
+                           else aux ys iface2) in
+                  let uu____599 = aux mutually_defined_with_x iface_tl in
                   match uu____599 with
                   | (take_iface,rest_iface) ->
                       (rest_iface,
                         (FStar_List.append (iface_hd :: take_iface) [impl])))
            | uu____630 ->
-               let uu____631 = prefix_with_iface_decls iface_tl impl  in
+               let uu____631 = prefix_with_iface_decls iface_tl impl in
                (match uu____631 with
                 | (iface2,ds) -> (iface2, (iface_hd :: ds))))
-  
-let (check_initial_interface :
-  FStar_Parser_AST.decl Prims.list -> FStar_Parser_AST.decl Prims.list) =
+let check_initial_interface:
+  FStar_Parser_AST.decl Prims.list -> FStar_Parser_AST.decl Prims.list =
   fun iface1  ->
     let rec aux iface2 =
       match iface2 with
@@ -210,25 +190,21 @@ let (check_initial_interface :
                    "Interface contains an abstract 'type' declaration; use 'val' instead")
                  hd1.FStar_Parser_AST.drange
            | FStar_Parser_AST.Val (x,t) ->
-               let uu____750 = FStar_Util.for_some (is_definition_of x) tl1
-                  in
+               let uu____750 = FStar_Util.for_some (is_definition_of x) tl1 in
                if uu____750
                then
                  let uu____751 =
                    let uu____756 =
                      FStar_Util.format2
                        "'val %s' and 'let %s' cannot both be provided in an interface"
-                       x.FStar_Ident.idText x.FStar_Ident.idText
-                      in
-                   (FStar_Errors.Fatal_BothValAndLetInInterface, uu____756)
-                    in
+                       x.FStar_Ident.idText x.FStar_Ident.idText in
+                   (FStar_Errors.Fatal_BothValAndLetInInterface, uu____756) in
                  FStar_Errors.raise_error uu____751
                    hd1.FStar_Parser_AST.drange
                else
                  (let uu____758 =
                     FStar_All.pipe_right hd1.FStar_Parser_AST.quals
-                      (FStar_List.contains FStar_Parser_AST.Assumption)
-                     in
+                      (FStar_List.contains FStar_Parser_AST.Assumption) in
                   if uu____758
                   then
                     FStar_Errors.raise_error
@@ -236,8 +212,7 @@ let (check_initial_interface :
                         "Interfaces cannot use `assume val x : t`; just write `val x : t` instead")
                       hd1.FStar_Parser_AST.drange
                   else ())
-           | uu____760 -> ())
-       in
+           | uu____760 -> ()) in
     aux iface1;
     FStar_All.pipe_right iface1
       (FStar_List.filter
@@ -245,32 +220,29 @@ let (check_initial_interface :
             match d.FStar_Parser_AST.d with
             | FStar_Parser_AST.TopLevelModule uu____769 -> false
             | uu____770 -> true))
-  
-let rec (ml_mode_prefix_with_iface_decls :
+let rec ml_mode_prefix_with_iface_decls:
   FStar_Parser_AST.decl Prims.list ->
     FStar_Parser_AST.decl ->
       (FStar_Parser_AST.decl Prims.list,FStar_Parser_AST.decl Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun iface1  ->
     fun impl  ->
       match impl.FStar_Parser_AST.d with
       | FStar_Parser_AST.TopLevelLet (uu____797,defs) ->
-          let xs = FStar_Parser_AST.lids_of_let defs  in
+          let xs = FStar_Parser_AST.lids_of_let defs in
           let uu____814 =
             FStar_List.partition
               (fun d  ->
                  FStar_All.pipe_right xs
                    (FStar_Util.for_some
-                      (fun x  -> is_val x.FStar_Ident.ident d))) iface1
-             in
+                      (fun x  -> is_val x.FStar_Ident.ident d))) iface1 in
           (match uu____814 with
            | (val_xs,rest_iface) ->
                (rest_iface, (FStar_List.append val_xs [impl])))
       | uu____851 -> (iface1, [impl])
-  
-let (ml_mode_check_initial_interface :
-  FStar_Parser_AST.decl Prims.list -> FStar_Parser_AST.decl Prims.list) =
+let ml_mode_check_initial_interface:
+  FStar_Parser_AST.decl Prims.list -> FStar_Parser_AST.decl Prims.list =
   fun iface1  ->
     FStar_All.pipe_right iface1
       (FStar_List.filter
@@ -278,75 +250,70 @@ let (ml_mode_check_initial_interface :
             match d.FStar_Parser_AST.d with
             | FStar_Parser_AST.Val uu____872 -> true
             | uu____877 -> false))
-  
-let (prefix_one_decl :
+let prefix_one_decl:
   FStar_Parser_AST.decl Prims.list ->
     FStar_Parser_AST.decl ->
       (FStar_Parser_AST.decl Prims.list,FStar_Parser_AST.decl Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun iface1  ->
     fun impl  ->
       match impl.FStar_Parser_AST.d with
       | FStar_Parser_AST.TopLevelModule uu____904 -> (iface1, [impl])
       | uu____909 ->
-          let uu____910 = FStar_Options.ml_ish ()  in
+          let uu____910 = FStar_Options.ml_ish () in
           if uu____910
           then ml_mode_prefix_with_iface_decls iface1 impl
           else prefix_with_iface_decls iface1 impl
-  
-let (initialize_interface :
+let initialize_interface:
   FStar_Ident.lident ->
-    FStar_Parser_AST.decl Prims.list -> Prims.unit FStar_ToSyntax_Env.withenv)
+    FStar_Parser_AST.decl Prims.list -> Prims.unit FStar_ToSyntax_Env.withenv
   =
   fun mname  ->
     fun l  ->
       fun env  ->
         let decls =
-          let uu____942 = FStar_Options.ml_ish ()  in
+          let uu____942 = FStar_Options.ml_ish () in
           if uu____942
           then ml_mode_check_initial_interface l
-          else check_initial_interface l  in
-        let uu____946 = FStar_ToSyntax_Env.iface_decls env mname  in
+          else check_initial_interface l in
+        let uu____946 = FStar_ToSyntax_Env.iface_decls env mname in
         match uu____946 with
         | FStar_Pervasives_Native.Some uu____955 ->
             let uu____960 =
               let uu____965 =
-                let uu____966 = FStar_Ident.string_of_lid mname  in
+                let uu____966 = FStar_Ident.string_of_lid mname in
                 FStar_Util.format1 "Interface %s has already been processed"
-                  uu____966
-                 in
-              (FStar_Errors.Fatal_InterfaceAlreadyProcessed, uu____965)  in
+                  uu____966 in
+              (FStar_Errors.Fatal_InterfaceAlreadyProcessed, uu____965) in
             FStar_Errors.raise_error uu____960
               (FStar_Ident.range_of_lid mname)
         | FStar_Pervasives_Native.None  ->
             let uu____973 =
-              FStar_ToSyntax_Env.set_iface_decls env mname decls  in
+              FStar_ToSyntax_Env.set_iface_decls env mname decls in
             ((), uu____973)
-  
-let (prefix_with_interface_decls :
+let prefix_with_interface_decls:
   FStar_Parser_AST.decl ->
-    FStar_Parser_AST.decl Prims.list FStar_ToSyntax_Env.withenv)
+    FStar_Parser_AST.decl Prims.list FStar_ToSyntax_Env.withenv
   =
   fun impl  ->
     fun env  ->
       let uu____990 =
-        let uu____995 = FStar_ToSyntax_Env.current_module env  in
-        FStar_ToSyntax_Env.iface_decls env uu____995  in
+        let uu____995 = FStar_ToSyntax_Env.current_module env in
+        FStar_ToSyntax_Env.iface_decls env uu____995 in
       match uu____990 with
       | FStar_Pervasives_Native.None  -> ([impl], env)
       | FStar_Pervasives_Native.Some iface1 ->
-          let uu____1011 = prefix_one_decl iface1 impl  in
+          let uu____1011 = prefix_one_decl iface1 impl in
           (match uu____1011 with
            | (iface2,impl1) ->
                let env1 =
-                 let uu____1037 = FStar_ToSyntax_Env.current_module env  in
-                 FStar_ToSyntax_Env.set_iface_decls env uu____1037 iface2  in
+                 let uu____1037 = FStar_ToSyntax_Env.current_module env in
+                 FStar_ToSyntax_Env.set_iface_decls env uu____1037 iface2 in
                (impl1, env1))
-  
-let (interleave_module :
+let interleave_module:
   FStar_Parser_AST.modul ->
-    Prims.bool -> FStar_Parser_AST.modul FStar_ToSyntax_Env.withenv)
+    Prims.bool -> FStar_Parser_AST.modul FStar_ToSyntax_Env.withenv
   =
   fun a  ->
     fun expect_complete_modul  ->
@@ -354,7 +321,7 @@ let (interleave_module :
         match a with
         | FStar_Parser_AST.Interface uu____1059 -> (a, env)
         | FStar_Parser_AST.Module (l,impls) ->
-            let uu____1074 = FStar_ToSyntax_Env.iface_decls env l  in
+            let uu____1074 = FStar_ToSyntax_Env.iface_decls env l in
             (match uu____1074 with
              | FStar_Pervasives_Native.None  -> (a, env)
              | FStar_Pervasives_Native.Some iface1 ->
@@ -364,14 +331,12 @@ let (interleave_module :
                         fun impl  ->
                           match uu____1114 with
                           | (iface2,impls1) ->
-                              let uu____1142 = prefix_one_decl iface2 impl
-                                 in
+                              let uu____1142 = prefix_one_decl iface2 impl in
                               (match uu____1142 with
                                | (iface3,impls') ->
                                    (iface3,
                                      (FStar_List.append impls1 impls'))))
-                     (iface1, []) impls
-                    in
+                     (iface1, []) impls in
                  (match uu____1090 with
                   | (iface2,impls1) ->
                       let uu____1191 =
@@ -387,22 +352,18 @@ let (interleave_module :
                                    FStar_Parser_AST.quals = uu____1223;
                                    FStar_Parser_AST.attrs = uu____1224;_} ->
                                    true
-                               | uu____1231 -> false) iface2
-                           in
+                               | uu____1231 -> false) iface2 in
                         match uu____1200 with
                         | FStar_Pervasives_Native.None  -> (iface2, [])
                         | FStar_Pervasives_Native.Some (lets,one_val,rest) ->
-                            (lets, (one_val :: rest))
-                         in
+                            (lets, (one_val :: rest)) in
                       (match uu____1191 with
                        | (iface_lets,remaining_iface_vals) ->
-                           let impls2 = FStar_List.append impls1 iface_lets
-                              in
+                           let impls2 = FStar_List.append impls1 iface_lets in
                            let env1 =
                              FStar_ToSyntax_Env.set_iface_decls env l
-                               remaining_iface_vals
-                              in
-                           let a1 = FStar_Parser_AST.Module (l, impls2)  in
+                               remaining_iface_vals in
+                           let a1 = FStar_Parser_AST.Module (l, impls2) in
                            (match remaining_iface_vals with
                             | uu____1304::uu____1305 when
                                 expect_complete_modul ->
@@ -410,23 +371,18 @@ let (interleave_module :
                                   let uu____1309 =
                                     FStar_List.map
                                       FStar_Parser_AST.decl_to_string
-                                      remaining_iface_vals
-                                     in
+                                      remaining_iface_vals in
                                   FStar_All.pipe_right uu____1309
-                                    (FStar_String.concat "\n\t")
-                                   in
+                                    (FStar_String.concat "\n\t") in
                                 let uu____1314 =
                                   let uu____1319 =
                                     let uu____1320 =
-                                      FStar_Ident.string_of_lid l  in
+                                      FStar_Ident.string_of_lid l in
                                     FStar_Util.format2
                                       "Some interface elements were not implemented by module %s:\n\t%s"
-                                      uu____1320 err
-                                     in
+                                      uu____1320 err in
                                   (FStar_Errors.Fatal_InterfaceNotImplementedByModule,
-                                    uu____1319)
-                                   in
+                                    uu____1319) in
                                 FStar_Errors.raise_error uu____1314
                                   (FStar_Ident.range_of_lid l)
                             | uu____1325 -> (a1, env1)))))
-  

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -1,10 +1,10 @@
 open Prims
-let (desugar_disjunctive_pattern :
+let desugar_disjunctive_pattern:
   FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t Prims.list ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
       FStar_Pervasives_Native.option ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.branch Prims.list)
+        FStar_Syntax_Syntax.branch Prims.list
   =
   fun pats  ->
     fun when_opt  ->
@@ -12,10 +12,9 @@ let (desugar_disjunctive_pattern :
         FStar_All.pipe_right pats
           (FStar_List.map
              (fun pat  -> FStar_Syntax_Util.branch (pat, when_opt, branch1)))
-  
-let (trans_aqual :
+let trans_aqual:
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
-    FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option
   =
   fun uu___82_58  ->
     match uu___82_58 with
@@ -24,11 +23,10 @@ let (trans_aqual :
     | FStar_Pervasives_Native.Some (FStar_Parser_AST.Equality ) ->
         FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Equality
     | uu____63 -> FStar_Pervasives_Native.None
-  
-let (trans_qual :
+let trans_qual:
   FStar_Range.range ->
     FStar_Ident.lident FStar_Pervasives_Native.option ->
-      FStar_Parser_AST.qualifier -> FStar_Syntax_Syntax.qualifier)
+      FStar_Parser_AST.qualifier -> FStar_Syntax_Syntax.qualifier
   =
   fun r  ->
     fun maybe_effect_id  ->
@@ -76,34 +74,31 @@ let (trans_qual :
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnsupportedQualifier,
                 "Unsupported qualifier") r
-  
-let (trans_pragma : FStar_Parser_AST.pragma -> FStar_Syntax_Syntax.pragma) =
+let trans_pragma: FStar_Parser_AST.pragma -> FStar_Syntax_Syntax.pragma =
   fun uu___84_83  ->
     match uu___84_83 with
     | FStar_Parser_AST.SetOptions s -> FStar_Syntax_Syntax.SetOptions s
     | FStar_Parser_AST.ResetOptions sopt ->
         FStar_Syntax_Syntax.ResetOptions sopt
     | FStar_Parser_AST.LightOff  -> FStar_Syntax_Syntax.LightOff
-  
-let (as_imp :
+let as_imp:
   FStar_Parser_AST.imp ->
-    FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option
   =
   fun uu___85_92  ->
     match uu___85_92 with
     | FStar_Parser_AST.Hash  ->
         FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag
     | uu____95 -> FStar_Pervasives_Native.None
-  
-let arg_withimp_e :
+let arg_withimp_e:
   'Auu____99 .
     FStar_Parser_AST.imp ->
       'Auu____99 ->
         ('Auu____99,FStar_Syntax_Syntax.arg_qualifier
                       FStar_Pervasives_Native.option)
           FStar_Pervasives_Native.tuple2
-  = fun imp  -> fun t  -> (t, (as_imp imp)) 
-let arg_withimp_t :
+  = fun imp  -> fun t  -> (t, (as_imp imp))
+let arg_withimp_t:
   'Auu____119 .
     FStar_Parser_AST.imp ->
       'Auu____119 ->
@@ -117,8 +112,7 @@ let arg_withimp_t :
       | FStar_Parser_AST.Hash  ->
           (t, (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag))
       | uu____136 -> (t, FStar_Pervasives_Native.None)
-  
-let (contains_binder : FStar_Parser_AST.binder Prims.list -> Prims.bool) =
+let contains_binder: FStar_Parser_AST.binder Prims.list -> Prims.bool =
   fun binders  ->
     FStar_All.pipe_right binders
       (FStar_Util.for_some
@@ -126,39 +120,35 @@ let (contains_binder : FStar_Parser_AST.binder Prims.list -> Prims.bool) =
             match b.FStar_Parser_AST.b with
             | FStar_Parser_AST.Annotated uu____151 -> true
             | uu____156 -> false))
-  
-let rec (unparen : FStar_Parser_AST.term -> FStar_Parser_AST.term) =
+let rec unparen: FStar_Parser_AST.term -> FStar_Parser_AST.term =
   fun t  ->
     match t.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Paren t1 -> unparen t1
     | uu____161 -> t
-  
-let (tm_type_z : FStar_Range.range -> FStar_Parser_AST.term) =
+let tm_type_z: FStar_Range.range -> FStar_Parser_AST.term =
   fun r  ->
     let uu____165 =
-      let uu____166 = FStar_Ident.lid_of_path ["Type0"] r  in
-      FStar_Parser_AST.Name uu____166  in
+      let uu____166 = FStar_Ident.lid_of_path ["Type0"] r in
+      FStar_Parser_AST.Name uu____166 in
     FStar_Parser_AST.mk_term uu____165 r FStar_Parser_AST.Kind
-  
-let (tm_type : FStar_Range.range -> FStar_Parser_AST.term) =
+let tm_type: FStar_Range.range -> FStar_Parser_AST.term =
   fun r  ->
     let uu____170 =
-      let uu____171 = FStar_Ident.lid_of_path ["Type"] r  in
-      FStar_Parser_AST.Name uu____171  in
+      let uu____171 = FStar_Ident.lid_of_path ["Type"] r in
+      FStar_Parser_AST.Name uu____171 in
     FStar_Parser_AST.mk_term uu____170 r FStar_Parser_AST.Kind
-  
-let rec (is_comp_type :
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> Prims.bool) =
+let rec is_comp_type:
+  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> Prims.bool =
   fun env  ->
     fun t  ->
       let uu____178 =
-        let uu____179 = unparen t  in uu____179.FStar_Parser_AST.tm  in
+        let uu____179 = unparen t in uu____179.FStar_Parser_AST.tm in
       match uu____178 with
       | FStar_Parser_AST.Name l ->
-          let uu____181 = FStar_ToSyntax_Env.try_lookup_effect_name env l  in
+          let uu____181 = FStar_ToSyntax_Env.try_lookup_effect_name env l in
           FStar_All.pipe_right uu____181 FStar_Option.isSome
       | FStar_Parser_AST.Construct (l,uu____187) ->
-          let uu____200 = FStar_ToSyntax_Env.try_lookup_effect_name env l  in
+          let uu____200 = FStar_ToSyntax_Env.try_lookup_effect_name env l in
           FStar_All.pipe_right uu____200 FStar_Option.isSome
       | FStar_Parser_AST.App (head1,uu____206,uu____207) ->
           is_comp_type env head1
@@ -167,27 +157,24 @@ let rec (is_comp_type :
           is_comp_type env t1
       | FStar_Parser_AST.LetOpen (uu____216,t1) -> is_comp_type env t1
       | uu____218 -> false
-  
-let (unit_ty : FStar_Parser_AST.term) =
+let unit_ty: FStar_Parser_AST.term =
   FStar_Parser_AST.mk_term
     (FStar_Parser_AST.Name FStar_Parser_Const.unit_lid)
     FStar_Range.dummyRange FStar_Parser_AST.Type_level
-  
-let (compile_op_lid :
-  Prims.int -> Prims.string -> FStar_Range.range -> FStar_Ident.lident) =
+let compile_op_lid:
+  Prims.int -> Prims.string -> FStar_Range.range -> FStar_Ident.lident =
   fun n1  ->
     fun s  ->
       fun r  ->
         let uu____228 =
           let uu____231 =
             let uu____232 =
-              let uu____237 = FStar_Parser_AST.compile_op n1 s r  in
-              (uu____237, r)  in
-            FStar_Ident.mk_ident uu____232  in
-          [uu____231]  in
+              let uu____237 = FStar_Parser_AST.compile_op n1 s r in
+              (uu____237, r) in
+            FStar_Ident.mk_ident uu____232 in
+          [uu____231] in
         FStar_All.pipe_right uu____228 FStar_Ident.lid_of_ids
-  
-let op_as_term :
+let op_as_term:
   'Auu____245 .
     FStar_ToSyntax_Env.env ->
       Prims.int ->
@@ -204,10 +191,9 @@ let op_as_term :
               let uu____274 =
                 FStar_Syntax_Syntax.lid_as_fv
                   (FStar_Ident.set_lid_range l op.FStar_Ident.idRange) dd
-                  FStar_Pervasives_Native.None
-                 in
-              FStar_All.pipe_right uu____274 FStar_Syntax_Syntax.fv_to_tm  in
-            FStar_Pervasives_Native.Some uu____273  in
+                  FStar_Pervasives_Native.None in
+              FStar_All.pipe_right uu____274 FStar_Syntax_Syntax.fv_to_tm in
+            FStar_Pervasives_Native.Some uu____273 in
           let fallback uu____280 =
             match FStar_Ident.text_of_id op with
             | "=" ->
@@ -253,7 +239,7 @@ let op_as_term :
                 r FStar_Parser_Const.read_lid
                   FStar_Syntax_Syntax.Delta_equational
             | "@" ->
-                let uu____283 = FStar_Options.ml_ish ()  in
+                let uu____283 = FStar_Options.ml_ish () in
                 if uu____283
                 then
                   r FStar_Parser_Const.list_append_lid
@@ -300,66 +286,60 @@ let op_as_term :
                 r FStar_Parser_Const.iff_lid
                   (FStar_Syntax_Syntax.Delta_defined_at_level
                      (Prims.parse_int "2"))
-            | uu____287 -> FStar_Pervasives_Native.None  in
+            | uu____287 -> FStar_Pervasives_Native.None in
           let uu____288 =
             let uu____295 =
               compile_op_lid arity op.FStar_Ident.idText
-                op.FStar_Ident.idRange
-               in
-            FStar_ToSyntax_Env.try_lookup_lid env uu____295  in
+                op.FStar_Ident.idRange in
+            FStar_ToSyntax_Env.try_lookup_lid env uu____295 in
           match uu____288 with
           | FStar_Pervasives_Native.Some t ->
               FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst t)
           | uu____307 -> fallback ()
-  
-let (sort_ftv : FStar_Ident.ident Prims.list -> FStar_Ident.ident Prims.list)
-  =
+let sort_ftv: FStar_Ident.ident Prims.list -> FStar_Ident.ident Prims.list =
   fun ftv  ->
     let uu____323 =
       FStar_Util.remove_dups
-        (fun x  -> fun y  -> x.FStar_Ident.idText = y.FStar_Ident.idText) ftv
-       in
+        (fun x  -> fun y  -> x.FStar_Ident.idText = y.FStar_Ident.idText) ftv in
     FStar_All.pipe_left
       (FStar_Util.sort_with
          (fun x  ->
             fun y  ->
               FStar_String.compare x.FStar_Ident.idText y.FStar_Ident.idText))
       uu____323
-  
-let rec (free_type_vars_b :
+let rec free_type_vars_b:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.binder ->
       (FStar_ToSyntax_Env.env,FStar_Ident.ident Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun binder  ->
       match binder.FStar_Parser_AST.b with
       | FStar_Parser_AST.Variable uu____362 -> (env, [])
       | FStar_Parser_AST.TVariable x ->
-          let uu____366 = FStar_ToSyntax_Env.push_bv env x  in
+          let uu____366 = FStar_ToSyntax_Env.push_bv env x in
           (match uu____366 with | (env1,uu____378) -> (env1, [x]))
       | FStar_Parser_AST.Annotated (uu____381,term) ->
-          let uu____383 = free_type_vars env term  in (env, uu____383)
+          let uu____383 = free_type_vars env term in (env, uu____383)
       | FStar_Parser_AST.TAnnotated (id1,uu____389) ->
-          let uu____390 = FStar_ToSyntax_Env.push_bv env id1  in
+          let uu____390 = FStar_ToSyntax_Env.push_bv env id1 in
           (match uu____390 with | (env1,uu____402) -> (env1, []))
       | FStar_Parser_AST.NoName t ->
-          let uu____406 = free_type_vars env t  in (env, uu____406)
-
-and (free_type_vars :
+          let uu____406 = free_type_vars env t in (env, uu____406)
+and free_type_vars:
   FStar_ToSyntax_Env.env ->
-    FStar_Parser_AST.term -> FStar_Ident.ident Prims.list)
+    FStar_Parser_AST.term -> FStar_Ident.ident Prims.list
   =
   fun env  ->
     fun t  ->
       let uu____413 =
-        let uu____414 = unparen t  in uu____414.FStar_Parser_AST.tm  in
+        let uu____414 = unparen t in uu____414.FStar_Parser_AST.tm in
       match uu____413 with
       | FStar_Parser_AST.Labeled uu____417 ->
           failwith "Impossible --- labeled source term"
       | FStar_Parser_AST.Tvar a ->
-          let uu____427 = FStar_ToSyntax_Env.try_lookup_id env a  in
+          let uu____427 = FStar_ToSyntax_Env.try_lookup_id env a in
           (match uu____427 with
            | FStar_Pervasives_Native.None  -> [a]
            | uu____440 -> [])
@@ -378,8 +358,7 @@ and (free_type_vars :
           let ts = t1 :: t' ::
             (match tacopt with
              | FStar_Pervasives_Native.None  -> []
-             | FStar_Pervasives_Native.Some t2 -> [t2])
-             in
+             | FStar_Pervasives_Native.Some t2 -> [t2]) in
           FStar_List.collect (free_type_vars env) ts
       | FStar_Parser_AST.Construct (uu____487,ts) ->
           FStar_List.collect
@@ -389,14 +368,14 @@ and (free_type_vars :
       | FStar_Parser_AST.Op (uu____517,ts) ->
           FStar_List.collect (free_type_vars env) ts
       | FStar_Parser_AST.App (t1,t2,uu____525) ->
-          let uu____526 = free_type_vars env t1  in
-          let uu____529 = free_type_vars env t2  in
+          let uu____526 = free_type_vars env t1 in
+          let uu____529 = free_type_vars env t2 in
           FStar_List.append uu____526 uu____529
       | FStar_Parser_AST.Refine (b,t1) ->
-          let uu____534 = free_type_vars_b env b  in
+          let uu____534 = free_type_vars_b env b in
           (match uu____534 with
            | (env1,f) ->
-               let uu____549 = free_type_vars env1 t1  in
+               let uu____549 = free_type_vars env1 t1 in
                FStar_List.append f uu____549)
       | FStar_Parser_AST.Product (binders,body) ->
           let uu____558 =
@@ -405,14 +384,13 @@ and (free_type_vars :
                  fun binder  ->
                    match uu____578 with
                    | (env1,free) ->
-                       let uu____598 = free_type_vars_b env1 binder  in
+                       let uu____598 = free_type_vars_b env1 binder in
                        (match uu____598 with
                         | (env2,f) -> (env2, (FStar_List.append f free))))
-              (env, []) binders
-             in
+              (env, []) binders in
           (match uu____558 with
            | (env1,free) ->
-               let uu____629 = free_type_vars env1 body  in
+               let uu____629 = free_type_vars env1 body in
                FStar_List.append free uu____629)
       | FStar_Parser_AST.Sum (binders,body) ->
           let uu____638 =
@@ -421,14 +399,13 @@ and (free_type_vars :
                  fun binder  ->
                    match uu____658 with
                    | (env1,free) ->
-                       let uu____678 = free_type_vars_b env1 binder  in
+                       let uu____678 = free_type_vars_b env1 binder in
                        (match uu____678 with
                         | (env2,f) -> (env2, (FStar_List.append f free))))
-              (env, []) binders
-             in
+              (env, []) binders in
           (match uu____638 with
            | (env1,free) ->
-               let uu____709 = free_type_vars env1 body  in
+               let uu____709 = free_type_vars env1 body in
                FStar_List.append free uu____709)
       | FStar_Parser_AST.Project (t1,uu____713) -> free_type_vars env t1
       | FStar_Parser_AST.Attributes cattributes ->
@@ -444,17 +421,16 @@ and (free_type_vars :
       | FStar_Parser_AST.TryWith uu____811 -> []
       | FStar_Parser_AST.Bind uu____826 -> []
       | FStar_Parser_AST.Seq uu____833 -> []
-
-let (head_and_args :
+let head_and_args:
   FStar_Parser_AST.term ->
     (FStar_Parser_AST.term,(FStar_Parser_AST.term,FStar_Parser_AST.imp)
                              FStar_Pervasives_Native.tuple2 Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     let rec aux args t1 =
       let uu____880 =
-        let uu____881 = unparen t1  in uu____881.FStar_Parser_AST.tm  in
+        let uu____881 = unparen t1 in uu____881.FStar_Parser_AST.tm in
       match uu____880 with
       | FStar_Parser_AST.App (t2,arg,imp) -> aux ((arg, imp) :: args) t2
       | FStar_Parser_AST.Construct (l,args') ->
@@ -463,16 +439,15 @@ let (head_and_args :
              FStar_Parser_AST.range = (t1.FStar_Parser_AST.range);
              FStar_Parser_AST.level = (t1.FStar_Parser_AST.level)
            }, (FStar_List.append args' args))
-      | uu____923 -> (t1, args)  in
+      | uu____923 -> (t1, args) in
     aux [] t
-  
-let (close :
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Parser_AST.term) =
+let close:
+  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Parser_AST.term =
   fun env  ->
     fun t  ->
       let ftv =
-        let uu____943 = free_type_vars env t  in
-        FStar_All.pipe_left sort_ftv uu____943  in
+        let uu____943 = free_type_vars env t in
+        FStar_All.pipe_left sort_ftv uu____943 in
       if (FStar_List.length ftv) = (Prims.parse_int "0")
       then t
       else
@@ -482,26 +457,23 @@ let (close :
                 (fun x  ->
                    let uu____961 =
                      let uu____962 =
-                       let uu____967 = tm_type x.FStar_Ident.idRange  in
-                       (x, uu____967)  in
-                     FStar_Parser_AST.TAnnotated uu____962  in
+                       let uu____967 = tm_type x.FStar_Ident.idRange in
+                       (x, uu____967) in
+                     FStar_Parser_AST.TAnnotated uu____962 in
                    FStar_Parser_AST.mk_binder uu____961 x.FStar_Ident.idRange
                      FStar_Parser_AST.Type_level
-                     (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)))
-            in
+                     (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit))) in
          let result =
            FStar_Parser_AST.mk_term (FStar_Parser_AST.Product (binders, t))
-             t.FStar_Parser_AST.range t.FStar_Parser_AST.level
-            in
+             t.FStar_Parser_AST.range t.FStar_Parser_AST.level in
          result)
-  
-let (close_fun :
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Parser_AST.term) =
+let close_fun:
+  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Parser_AST.term =
   fun env  ->
     fun t  ->
       let ftv =
-        let uu____980 = free_type_vars env t  in
-        FStar_All.pipe_left sort_ftv uu____980  in
+        let uu____980 = free_type_vars env t in
+        FStar_All.pipe_left sort_ftv uu____980 in
       if (FStar_List.length ftv) = (Prims.parse_int "0")
       then t
       else
@@ -511,17 +483,15 @@ let (close_fun :
                 (fun x  ->
                    let uu____998 =
                      let uu____999 =
-                       let uu____1004 = tm_type x.FStar_Ident.idRange  in
-                       (x, uu____1004)  in
-                     FStar_Parser_AST.TAnnotated uu____999  in
+                       let uu____1004 = tm_type x.FStar_Ident.idRange in
+                       (x, uu____1004) in
+                     FStar_Parser_AST.TAnnotated uu____999 in
                    FStar_Parser_AST.mk_binder uu____998 x.FStar_Ident.idRange
                      FStar_Parser_AST.Type_level
-                     (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)))
-            in
+                     (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit))) in
          let t1 =
            let uu____1006 =
-             let uu____1007 = unparen t  in uu____1007.FStar_Parser_AST.tm
-              in
+             let uu____1007 = unparen t in uu____1007.FStar_Parser_AST.tm in
            match uu____1006 with
            | FStar_Parser_AST.Product uu____1008 -> t
            | uu____1015 ->
@@ -532,19 +502,16 @@ let (close_fun :
                            FStar_Parser_Const.effect_Tot_lid)
                         t.FStar_Parser_AST.range t.FStar_Parser_AST.level),
                       t, FStar_Parser_AST.Nothing)) t.FStar_Parser_AST.range
-                 t.FStar_Parser_AST.level
-            in
+                 t.FStar_Parser_AST.level in
          let result =
            FStar_Parser_AST.mk_term (FStar_Parser_AST.Product (binders, t1))
-             t1.FStar_Parser_AST.range t1.FStar_Parser_AST.level
-            in
+             t1.FStar_Parser_AST.range t1.FStar_Parser_AST.level in
          result)
-  
-let rec (uncurry :
+let rec uncurry:
   FStar_Parser_AST.binder Prims.list ->
     FStar_Parser_AST.term ->
       (FStar_Parser_AST.binder Prims.list,FStar_Parser_AST.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun bs  ->
     fun t  ->
@@ -552,8 +519,7 @@ let rec (uncurry :
       | FStar_Parser_AST.Product (binders,t1) ->
           uncurry (FStar_List.append bs binders) t1
       | uu____1047 -> (bs, t)
-  
-let rec (is_var_pattern : FStar_Parser_AST.pattern -> Prims.bool) =
+let rec is_var_pattern: FStar_Parser_AST.pattern -> Prims.bool =
   fun p  ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatWild  -> true
@@ -561,8 +527,7 @@ let rec (is_var_pattern : FStar_Parser_AST.pattern -> Prims.bool) =
     | FStar_Parser_AST.PatVar (uu____1059,uu____1060) -> true
     | FStar_Parser_AST.PatAscribed (p1,uu____1066) -> is_var_pattern p1
     | uu____1067 -> false
-  
-let rec (is_app_pattern : FStar_Parser_AST.pattern -> Prims.bool) =
+let rec is_app_pattern: FStar_Parser_AST.pattern -> Prims.bool =
   fun p  ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatAscribed (p1,uu____1072) -> is_app_pattern p1
@@ -571,9 +536,8 @@ let rec (is_app_pattern : FStar_Parser_AST.pattern -> Prims.bool) =
            FStar_Parser_AST.prange = uu____1074;_},uu____1075)
         -> true
     | uu____1086 -> false
-  
-let (replace_unit_pattern :
-  FStar_Parser_AST.pattern -> FStar_Parser_AST.pattern) =
+let replace_unit_pattern:
+  FStar_Parser_AST.pattern -> FStar_Parser_AST.pattern =
   fun p  ->
     match p.FStar_Parser_AST.pat with
     | FStar_Parser_AST.PatConst (FStar_Const.Const_unit ) ->
@@ -583,22 +547,21 @@ let (replace_unit_pattern :
                  p.FStar_Parser_AST.prange), unit_ty))
           p.FStar_Parser_AST.prange
     | uu____1090 -> p
-  
-let rec (destruct_app_pattern :
+let rec destruct_app_pattern:
   FStar_ToSyntax_Env.env ->
     Prims.bool ->
       FStar_Parser_AST.pattern ->
         ((FStar_Ident.ident,FStar_Ident.lident) FStar_Util.either,FStar_Parser_AST.pattern
                                                                     Prims.list,
           FStar_Parser_AST.term FStar_Pervasives_Native.option)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun is_top_level1  ->
       fun p  ->
         match p.FStar_Parser_AST.pat with
         | FStar_Parser_AST.PatAscribed (p1,t) ->
-            let uu____1130 = destruct_app_pattern env is_top_level1 p1  in
+            let uu____1130 = destruct_app_pattern env is_top_level1 p1 in
             (match uu____1130 with
              | (name,args,uu____1161) ->
                  (name, args, (FStar_Pervasives_Native.Some t)))
@@ -609,8 +572,8 @@ let rec (destruct_app_pattern :
                FStar_Parser_AST.prange = uu____1188;_},args)
             when is_top_level1 ->
             let uu____1198 =
-              let uu____1203 = FStar_ToSyntax_Env.qualify env id1  in
-              FStar_Util.Inr uu____1203  in
+              let uu____1203 = FStar_ToSyntax_Env.qualify env id1 in
+              FStar_Util.Inr uu____1203 in
             (uu____1198, args, FStar_Pervasives_Native.None)
         | FStar_Parser_AST.PatApp
             ({
@@ -619,15 +582,14 @@ let rec (destruct_app_pattern :
                FStar_Parser_AST.prange = uu____1214;_},args)
             -> ((FStar_Util.Inl id1), args, FStar_Pervasives_Native.None)
         | uu____1232 -> failwith "Not an app pattern"
-  
-let rec (gather_pattern_bound_vars_maybe_top :
+let rec gather_pattern_bound_vars_maybe_top:
   FStar_Ident.ident FStar_Util.set ->
-    FStar_Parser_AST.pattern -> FStar_Ident.ident FStar_Util.set)
+    FStar_Parser_AST.pattern -> FStar_Ident.ident FStar_Util.set
   =
   fun acc  ->
     fun p  ->
       let gather_pattern_bound_vars_from_list =
-        FStar_List.fold_left gather_pattern_bound_vars_maybe_top acc  in
+        FStar_List.fold_left gather_pattern_bound_vars_maybe_top acc in
       match p.FStar_Parser_AST.pat with
       | FStar_Parser_AST.PatWild  -> acc
       | FStar_Parser_AST.PatConst uu____1270 -> acc
@@ -649,75 +611,70 @@ let rec (gather_pattern_bound_vars_maybe_top :
           gather_pattern_bound_vars_from_list pats
       | FStar_Parser_AST.PatRecord guarded_pats ->
           let uu____1314 =
-            FStar_List.map FStar_Pervasives_Native.snd guarded_pats  in
+            FStar_List.map FStar_Pervasives_Native.snd guarded_pats in
           gather_pattern_bound_vars_from_list uu____1314
       | FStar_Parser_AST.PatAscribed (pat,uu____1322) ->
           gather_pattern_bound_vars_maybe_top acc pat
-  
-let (gather_pattern_bound_vars :
-  FStar_Parser_AST.pattern -> FStar_Ident.ident FStar_Util.set) =
+let gather_pattern_bound_vars:
+  FStar_Parser_AST.pattern -> FStar_Ident.ident FStar_Util.set =
   let acc =
     FStar_Util.new_set
       (fun id1  ->
          fun id2  ->
            if id1.FStar_Ident.idText = id2.FStar_Ident.idText
-           then (Prims.parse_int "0")
-           else (Prims.parse_int "1"))
-     in
-  fun p  -> gather_pattern_bound_vars_maybe_top acc p 
+           then Prims.parse_int "0"
+           else Prims.parse_int "1") in
+  fun p  -> gather_pattern_bound_vars_maybe_top acc p
 type bnd =
   | LocalBinder of (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | LetBinder of (FStar_Ident.lident,FStar_Syntax_Syntax.term)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let (uu___is_LocalBinder : bnd -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_LocalBinder: bnd -> Prims.bool =
   fun projectee  ->
     match projectee with | LocalBinder _0 -> true | uu____1360 -> false
-  
-let (__proj__LocalBinder__item___0 :
+let __proj__LocalBinder__item___0:
   bnd ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | LocalBinder _0 -> _0 
-let (uu___is_LetBinder : bnd -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | LocalBinder _0 -> _0
+let uu___is_LetBinder: bnd -> Prims.bool =
   fun projectee  ->
     match projectee with | LetBinder _0 -> true | uu____1388 -> false
-  
-let (__proj__LetBinder__item___0 :
+let __proj__LetBinder__item___0:
   bnd ->
     (FStar_Ident.lident,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | LetBinder _0 -> _0 
-let (binder_of_bnd :
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | LetBinder _0 -> _0
+let binder_of_bnd:
   bnd ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun uu___86_1414  ->
     match uu___86_1414 with
     | LocalBinder (a,aq) -> (a, aq)
     | uu____1421 -> failwith "Impossible"
-  
-let (as_binder :
+let as_binder:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
       (FStar_Ident.ident FStar_Pervasives_Native.option,FStar_Syntax_Syntax.term)
         FStar_Pervasives_Native.tuple2 ->
         (FStar_Syntax_Syntax.binder,FStar_ToSyntax_Env.env)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun imp  ->
       fun uu___87_1446  ->
         match uu___87_1446 with
         | (FStar_Pervasives_Native.None ,k) ->
-            let uu____1462 = FStar_Syntax_Syntax.null_binder k  in
+            let uu____1462 = FStar_Syntax_Syntax.null_binder k in
             (uu____1462, env)
         | (FStar_Pervasives_Native.Some a,k) ->
-            let uu____1467 = FStar_ToSyntax_Env.push_bv env a  in
+            let uu____1467 = FStar_ToSyntax_Env.push_bv env a in
             (match uu____1467 with
              | (env1,a1) ->
-                 (((let uu___111_1487 = a1  in
+                 (((let uu___111_1487 = a1 in
                     {
                       FStar_Syntax_Syntax.ppname =
                         (uu___111_1487.FStar_Syntax_Syntax.ppname);
@@ -725,16 +682,15 @@ let (as_binder :
                         (uu___111_1487.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort = k
                     }), (trans_aqual imp)), env1))
-  
 type env_t = FStar_ToSyntax_Env.env[@@deriving show]
 type lenv_t = FStar_Syntax_Syntax.bv Prims.list[@@deriving show]
-let (mk_lb :
+let mk_lb:
   (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list,(FStar_Syntax_Syntax.bv,
                                                                     FStar_Syntax_Syntax.fv)
                                                                     FStar_Util.either,
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.term'
                                                            FStar_Syntax_Syntax.syntax)
-    FStar_Pervasives_Native.tuple4 -> FStar_Syntax_Syntax.letbinding)
+    FStar_Pervasives_Native.tuple4 -> FStar_Syntax_Syntax.letbinding
   =
   fun uu____1512  ->
     match uu____1512 with
@@ -747,17 +703,15 @@ let (mk_lb :
           FStar_Syntax_Syntax.lbdef = e;
           FStar_Syntax_Syntax.lbattrs = attrs
         }
-  
-let (no_annot_abs :
+let no_annot_abs:
   FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun bs  ->
     fun t  -> FStar_Syntax_Util.abs bs t FStar_Pervasives_Native.None
-  
-let (mk_ref_read :
+let mk_ref_read:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun tm  ->
     let tm' =
@@ -765,22 +719,20 @@ let (mk_ref_read :
         let uu____1592 =
           let uu____1593 =
             FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.sread_lid
-              FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None
-             in
-          FStar_Syntax_Syntax.fv_to_tm uu____1593  in
+              FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.fv_to_tm uu____1593 in
         let uu____1594 =
           let uu____1603 =
-            let uu____1610 = FStar_Syntax_Syntax.as_implicit false  in
-            (tm, uu____1610)  in
-          [uu____1603]  in
-        (uu____1592, uu____1594)  in
-      FStar_Syntax_Syntax.Tm_app uu____1577  in
+            let uu____1610 = FStar_Syntax_Syntax.as_implicit false in
+            (tm, uu____1610) in
+          [uu____1603] in
+        (uu____1592, uu____1594) in
+      FStar_Syntax_Syntax.Tm_app uu____1577 in
     FStar_Syntax_Syntax.mk tm' FStar_Pervasives_Native.None
       tm.FStar_Syntax_Syntax.pos
-  
-let (mk_ref_alloc :
+let mk_ref_alloc:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun tm  ->
     let tm' =
@@ -788,24 +740,22 @@ let (mk_ref_alloc :
         let uu____1658 =
           let uu____1659 =
             FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.salloc_lid
-              FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None
-             in
-          FStar_Syntax_Syntax.fv_to_tm uu____1659  in
+              FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.fv_to_tm uu____1659 in
         let uu____1660 =
           let uu____1669 =
-            let uu____1676 = FStar_Syntax_Syntax.as_implicit false  in
-            (tm, uu____1676)  in
-          [uu____1669]  in
-        (uu____1658, uu____1660)  in
-      FStar_Syntax_Syntax.Tm_app uu____1643  in
+            let uu____1676 = FStar_Syntax_Syntax.as_implicit false in
+            (tm, uu____1676) in
+          [uu____1669] in
+        (uu____1658, uu____1660) in
+      FStar_Syntax_Syntax.Tm_app uu____1643 in
     FStar_Syntax_Syntax.mk tm' FStar_Pervasives_Native.None
       tm.FStar_Syntax_Syntax.pos
-  
-let (mk_ref_assign :
+let mk_ref_assign:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       FStar_Range.range ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun t1  ->
     fun t2  ->
@@ -816,24 +766,22 @@ let (mk_ref_assign :
               let uu____1735 =
                 FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.swrite_lid
                   FStar_Syntax_Syntax.Delta_constant
-                  FStar_Pervasives_Native.None
-                 in
-              FStar_Syntax_Syntax.fv_to_tm uu____1735  in
+                  FStar_Pervasives_Native.None in
+              FStar_Syntax_Syntax.fv_to_tm uu____1735 in
             let uu____1736 =
               let uu____1745 =
-                let uu____1752 = FStar_Syntax_Syntax.as_implicit false  in
-                (t1, uu____1752)  in
+                let uu____1752 = FStar_Syntax_Syntax.as_implicit false in
+                (t1, uu____1752) in
               let uu____1755 =
                 let uu____1764 =
-                  let uu____1771 = FStar_Syntax_Syntax.as_implicit false  in
-                  (t2, uu____1771)  in
-                [uu____1764]  in
-              uu____1745 :: uu____1755  in
-            (uu____1734, uu____1736)  in
-          FStar_Syntax_Syntax.Tm_app uu____1719  in
+                  let uu____1771 = FStar_Syntax_Syntax.as_implicit false in
+                  (t2, uu____1771) in
+                [uu____1764] in
+              uu____1745 :: uu____1755 in
+            (uu____1734, uu____1736) in
+          FStar_Syntax_Syntax.Tm_app uu____1719 in
         FStar_Syntax_Syntax.mk tm FStar_Pervasives_Native.None pos
-  
-let (is_special_effect_combinator : Prims.string -> Prims.bool) =
+let is_special_effect_combinator: Prims.string -> Prims.bool =
   fun uu___88_1802  ->
     match uu___88_1802 with
     | "repr" -> true
@@ -841,37 +789,34 @@ let (is_special_effect_combinator : Prims.string -> Prims.bool) =
     | "pre" -> true
     | "wp" -> true
     | uu____1803 -> false
-  
-let rec (sum_to_universe :
-  FStar_Syntax_Syntax.universe -> Prims.int -> FStar_Syntax_Syntax.universe)
-  =
+let rec sum_to_universe:
+  FStar_Syntax_Syntax.universe -> Prims.int -> FStar_Syntax_Syntax.universe =
   fun u  ->
     fun n1  ->
       if n1 = (Prims.parse_int "0")
       then u
       else
-        (let uu____1811 = sum_to_universe u (n1 - (Prims.parse_int "1"))  in
+        (let uu____1811 = sum_to_universe u (n1 - (Prims.parse_int "1")) in
          FStar_Syntax_Syntax.U_succ uu____1811)
-  
-let (int_to_universe : Prims.int -> FStar_Syntax_Syntax.universe) =
-  fun n1  -> sum_to_universe FStar_Syntax_Syntax.U_zero n1 
-let rec (desugar_maybe_non_constant_universe :
+let int_to_universe: Prims.int -> FStar_Syntax_Syntax.universe =
+  fun n1  -> sum_to_universe FStar_Syntax_Syntax.U_zero n1
+let rec desugar_maybe_non_constant_universe:
   FStar_Parser_AST.term ->
-    (Prims.int,FStar_Syntax_Syntax.universe) FStar_Util.either)
+    (Prims.int,FStar_Syntax_Syntax.universe) FStar_Util.either
   =
   fun t  ->
     let uu____1826 =
-      let uu____1827 = unparen t  in uu____1827.FStar_Parser_AST.tm  in
+      let uu____1827 = unparen t in uu____1827.FStar_Parser_AST.tm in
     match uu____1826 with
     | FStar_Parser_AST.Wild  ->
         let uu____1832 =
-          let uu____1833 = FStar_Syntax_Unionfind.univ_fresh ()  in
-          FStar_Syntax_Syntax.U_unif uu____1833  in
+          let uu____1833 = FStar_Syntax_Unionfind.univ_fresh () in
+          FStar_Syntax_Syntax.U_unif uu____1833 in
         FStar_Util.Inr uu____1832
     | FStar_Parser_AST.Uvar u ->
         FStar_Util.Inr (FStar_Syntax_Syntax.U_name u)
     | FStar_Parser_AST.Const (FStar_Const.Const_int (repr,uu____1844)) ->
-        let n1 = FStar_Util.int_of_string repr  in
+        let n1 = FStar_Util.int_of_string repr in
         (if n1 < (Prims.parse_int "0")
          then
            FStar_Errors.raise_error
@@ -882,36 +827,33 @@ let rec (desugar_maybe_non_constant_universe :
          else ();
          FStar_Util.Inl n1)
     | FStar_Parser_AST.Op (op_plus,t1::t2::[]) ->
-        let u1 = desugar_maybe_non_constant_universe t1  in
-        let u2 = desugar_maybe_non_constant_universe t2  in
+        let u1 = desugar_maybe_non_constant_universe t1 in
+        let u2 = desugar_maybe_non_constant_universe t2 in
         (match (u1, u2) with
          | (FStar_Util.Inl n1,FStar_Util.Inl n2) -> FStar_Util.Inl (n1 + n2)
          | (FStar_Util.Inl n1,FStar_Util.Inr u) ->
-             let uu____1910 = sum_to_universe u n1  in
+             let uu____1910 = sum_to_universe u n1 in
              FStar_Util.Inr uu____1910
          | (FStar_Util.Inr u,FStar_Util.Inl n1) ->
-             let uu____1921 = sum_to_universe u n1  in
+             let uu____1921 = sum_to_universe u n1 in
              FStar_Util.Inr uu____1921
          | (FStar_Util.Inr u11,FStar_Util.Inr u21) ->
              let uu____1932 =
                let uu____1937 =
-                 let uu____1938 = FStar_Parser_AST.term_to_string t  in
+                 let uu____1938 = FStar_Parser_AST.term_to_string t in
                  Prims.strcat
                    "This universe might contain a sum of two universe variables "
-                   uu____1938
-                  in
+                   uu____1938 in
                (FStar_Errors.Fatal_UniverseMightContainSumOfTwoUnivVars,
-                 uu____1937)
-                in
+                 uu____1937) in
              FStar_Errors.raise_error uu____1932 t.FStar_Parser_AST.range)
     | FStar_Parser_AST.App uu____1943 ->
         let rec aux t1 univargs =
           let uu____1973 =
-            let uu____1974 = unparen t1  in uu____1974.FStar_Parser_AST.tm
-             in
+            let uu____1974 = unparen t1 in uu____1974.FStar_Parser_AST.tm in
           match uu____1973 with
           | FStar_Parser_AST.App (t2,targ,uu____1981) ->
-              let uarg = desugar_maybe_non_constant_universe targ  in
+              let uarg = desugar_maybe_non_constant_universe targ in
               aux t2 (uarg :: univargs)
           | FStar_Parser_AST.Var max_lid1 ->
               if
@@ -927,9 +869,8 @@ let rec (desugar_maybe_non_constant_universe :
                       (fun uu___90_2026  ->
                          match uu___90_2026 with
                          | FStar_Util.Inl n1 -> int_to_universe n1
-                         | FStar_Util.Inr u -> u) univargs
-                     in
-                  FStar_Syntax_Syntax.U_max uu____2017  in
+                         | FStar_Util.Inr u -> u) univargs in
+                  FStar_Syntax_Syntax.U_max uu____2017 in
                 FStar_Util.Inr uu____2016
               else
                 (let nargs =
@@ -938,44 +879,39 @@ let rec (desugar_maybe_non_constant_universe :
                         match uu___91_2043 with
                         | FStar_Util.Inl n1 -> n1
                         | FStar_Util.Inr uu____2049 -> failwith "impossible")
-                     univargs
-                    in
+                     univargs in
                  let uu____2050 =
                    FStar_List.fold_left
                      (fun m  -> fun n1  -> if m > n1 then m else n1)
-                     (Prims.parse_int "0") nargs
-                    in
+                     (Prims.parse_int "0") nargs in
                  FStar_Util.Inl uu____2050)
           | uu____2056 ->
               let uu____2057 =
                 let uu____2062 =
                   let uu____2063 =
-                    let uu____2064 = FStar_Parser_AST.term_to_string t1  in
-                    Prims.strcat uu____2064 " in universe context"  in
-                  Prims.strcat "Unexpected term " uu____2063  in
-                (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____2062)  in
-              FStar_Errors.raise_error uu____2057 t1.FStar_Parser_AST.range
-           in
+                    let uu____2064 = FStar_Parser_AST.term_to_string t1 in
+                    Prims.strcat uu____2064 " in universe context" in
+                  Prims.strcat "Unexpected term " uu____2063 in
+                (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____2062) in
+              FStar_Errors.raise_error uu____2057 t1.FStar_Parser_AST.range in
         aux t []
     | uu____2073 ->
         let uu____2074 =
           let uu____2079 =
             let uu____2080 =
-              let uu____2081 = FStar_Parser_AST.term_to_string t  in
-              Prims.strcat uu____2081 " in universe context"  in
-            Prims.strcat "Unexpected term " uu____2080  in
-          (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____2079)  in
+              let uu____2081 = FStar_Parser_AST.term_to_string t in
+              Prims.strcat uu____2081 " in universe context" in
+            Prims.strcat "Unexpected term " uu____2080 in
+          (FStar_Errors.Fatal_UnexpectedTermInUniverse, uu____2079) in
         FStar_Errors.raise_error uu____2074 t.FStar_Parser_AST.range
-  
-let rec (desugar_universe :
-  FStar_Parser_AST.term -> FStar_Syntax_Syntax.universe) =
+let rec desugar_universe:
+  FStar_Parser_AST.term -> FStar_Syntax_Syntax.universe =
   fun t  ->
-    let u = desugar_maybe_non_constant_universe t  in
+    let u = desugar_maybe_non_constant_universe t in
     match u with
     | FStar_Util.Inl n1 -> int_to_universe n1
     | FStar_Util.Inr u1 -> u1
-  
-let check_fields :
+let check_fields:
   'Auu____2100 .
     FStar_ToSyntax_Env.env ->
       (FStar_Ident.lident,'Auu____2100) FStar_Pervasives_Native.tuple2
@@ -984,21 +920,19 @@ let check_fields :
   fun env  ->
     fun fields  ->
       fun rg  ->
-        let uu____2125 = FStar_List.hd fields  in
+        let uu____2125 = FStar_List.hd fields in
         match uu____2125 with
         | (f,uu____2135) ->
             (FStar_ToSyntax_Env.fail_if_qualified_by_curmodule env f;
              (let record =
                 FStar_ToSyntax_Env.fail_or env
-                  (FStar_ToSyntax_Env.try_lookup_record_by_field_name env) f
-                 in
+                  (FStar_ToSyntax_Env.try_lookup_record_by_field_name env) f in
               let check_field uu____2145 =
                 match uu____2145 with
                 | (f',uu____2151) ->
                     (FStar_ToSyntax_Env.fail_if_qualified_by_curmodule env f';
                      (let uu____2153 =
-                        FStar_ToSyntax_Env.belongs_to_record env f' record
-                         in
+                        FStar_ToSyntax_Env.belongs_to_record env f' record in
                       if uu____2153
                       then ()
                       else
@@ -1007,22 +941,19 @@ let check_fields :
                              "Field %s belongs to record type %s, whereas field %s does not"
                              f.FStar_Ident.str
                              (record.FStar_ToSyntax_Env.typename).FStar_Ident.str
-                             f'.FStar_Ident.str
-                            in
+                             f'.FStar_Ident.str in
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_FieldsNotBelongToSameRecordType,
-                             msg) rg)))
-                 in
-              (let uu____2157 = FStar_List.tl fields  in
+                             msg) rg))) in
+              (let uu____2157 = FStar_List.tl fields in
                FStar_List.iter check_field uu____2157);
               (match () with | () -> record)))
-  
-let rec (desugar_data_pat :
+let rec desugar_data_pat:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.pattern ->
       Prims.bool ->
         (env_t,bnd,FStar_Syntax_Syntax.pat Prims.list)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun p  ->
@@ -1047,20 +978,19 @@ let rec (desugar_data_pat :
                           | (p3,uu____2435) ->
                               let uu____2436 =
                                 let uu____2437 =
-                                  let uu____2440 = pat_vars p3  in
-                                  FStar_Util.set_intersect uu____2440 out  in
-                                FStar_Util.set_is_empty uu____2437  in
+                                  let uu____2440 = pat_vars p3 in
+                                  FStar_Util.set_intersect uu____2440 out in
+                                FStar_Util.set_is_empty uu____2437 in
                               if uu____2436
                               then
-                                let uu____2445 = pat_vars p3  in
+                                let uu____2445 = pat_vars p3 in
                                 FStar_Util.set_union out uu____2445
                               else
                                 FStar_Errors.raise_error
                                   (FStar_Errors.Fatal_NonLinearPatternNotPermitted,
                                     "Non-linear patterns are not permitted.")
-                                  r) FStar_Syntax_Syntax.no_names)
-             in
-          pat_vars p1  in
+                                  r) FStar_Syntax_Syntax.no_names) in
+          pat_vars p1 in
         (match (is_mut, (p.FStar_Parser_AST.pat)) with
          | (false ,uu____2452) -> ()
          | (true ,FStar_Parser_AST.PatVar uu____2453) -> ()
@@ -1072,26 +1002,24 @@ let rec (desugar_data_pat :
         (let push_bv_maybe_mut =
            if is_mut
            then FStar_ToSyntax_Env.push_bv_mutable
-           else FStar_ToSyntax_Env.push_bv  in
+           else FStar_ToSyntax_Env.push_bv in
          let resolvex l e x =
            let uu____2495 =
              FStar_All.pipe_right l
                (FStar_Util.find_opt
                   (fun y  ->
                      (y.FStar_Syntax_Syntax.ppname).FStar_Ident.idText =
-                       x.FStar_Ident.idText))
-              in
+                       x.FStar_Ident.idText)) in
            match uu____2495 with
            | FStar_Pervasives_Native.Some y -> (l, e, y)
            | uu____2509 ->
-               let uu____2512 = push_bv_maybe_mut e x  in
-               (match uu____2512 with | (e1,x1) -> ((x1 :: l), e1, x1))
-            in
+               let uu____2512 = push_bv_maybe_mut e x in
+               (match uu____2512 with | (e1,x1) -> ((x1 :: l), e1, x1)) in
          let rec aux' top loc env1 p1 =
            let pos q =
-             FStar_Syntax_Syntax.withinfo q p1.FStar_Parser_AST.prange  in
-           let pos_r r q = FStar_Syntax_Syntax.withinfo q r  in
-           let orig = p1  in
+             FStar_Syntax_Syntax.withinfo q p1.FStar_Parser_AST.prange in
+           let pos_r r q = FStar_Syntax_Syntax.withinfo q r in
+           let orig = p1 in
            match p1.FStar_Parser_AST.pat with
            | FStar_Parser_AST.PatOr uu____2599 -> failwith "impossible"
            | FStar_Parser_AST.PatOp op ->
@@ -1102,29 +1030,28 @@ let rec (desugar_data_pat :
                        let uu____2625 =
                          let uu____2630 =
                            FStar_Parser_AST.compile_op (Prims.parse_int "0")
-                             op.FStar_Ident.idText op.FStar_Ident.idRange
-                            in
-                         (uu____2630, (op.FStar_Ident.idRange))  in
-                       FStar_Ident.mk_ident uu____2625  in
-                     (uu____2624, FStar_Pervasives_Native.None)  in
-                   FStar_Parser_AST.PatVar uu____2617  in
+                             op.FStar_Ident.idText op.FStar_Ident.idRange in
+                         (uu____2630, (op.FStar_Ident.idRange)) in
+                       FStar_Ident.mk_ident uu____2625 in
+                     (uu____2624, FStar_Pervasives_Native.None) in
+                   FStar_Parser_AST.PatVar uu____2617 in
                  {
                    FStar_Parser_AST.pat = uu____2616;
                    FStar_Parser_AST.prange = (p1.FStar_Parser_AST.prange)
-                 }  in
+                 } in
                aux loc env1 uu____2615
            | FStar_Parser_AST.PatAscribed (p2,t) ->
-               let uu____2635 = aux loc env1 p2  in
+               let uu____2635 = aux loc env1 p2 in
                (match uu____2635 with
                 | (loc1,env',binder,p3,imp) ->
                     let annot_pat_var p4 t1 =
                       match p4.FStar_Syntax_Syntax.v with
                       | FStar_Syntax_Syntax.Pat_var x ->
-                          let uu___112_2689 = p4  in
+                          let uu___112_2689 = p4 in
                           {
                             FStar_Syntax_Syntax.v =
                               (FStar_Syntax_Syntax.Pat_var
-                                 (let uu___113_2694 = x  in
+                                 (let uu___113_2694 = x in
                                   {
                                     FStar_Syntax_Syntax.ppname =
                                       (uu___113_2694.FStar_Syntax_Syntax.ppname);
@@ -1136,11 +1063,11 @@ let rec (desugar_data_pat :
                               (uu___112_2689.FStar_Syntax_Syntax.p)
                           }
                       | FStar_Syntax_Syntax.Pat_wild x ->
-                          let uu___114_2696 = p4  in
+                          let uu___114_2696 = p4 in
                           {
                             FStar_Syntax_Syntax.v =
                               (FStar_Syntax_Syntax.Pat_wild
-                                 (let uu___115_2701 = x  in
+                                 (let uu___115_2701 = x in
                                   {
                                     FStar_Syntax_Syntax.ppname =
                                       (uu___115_2701.FStar_Syntax_Syntax.ppname);
@@ -1156,15 +1083,14 @@ let rec (desugar_data_pat :
                           FStar_Errors.raise_error
                             (FStar_Errors.Fatal_TypeWithinPatternsAllowedOnVariablesOnly,
                               "Type ascriptions within patterns are only allowed on variables")
-                            orig.FStar_Parser_AST.prange
-                       in
+                            orig.FStar_Parser_AST.prange in
                     let uu____2706 =
                       match binder with
                       | LetBinder uu____2719 -> failwith "impossible"
                       | LocalBinder (x,aq) ->
                           let t1 =
-                            let uu____2733 = close_fun env1 t  in
-                            desugar_term env1 uu____2733  in
+                            let uu____2733 = close_fun env1 t in
+                            desugar_term env1 uu____2733 in
                           (if
                              (match (x.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.n
                               with
@@ -1174,100 +1100,86 @@ let rec (desugar_data_pat :
                              (let uu____2736 =
                                 let uu____2741 =
                                   let uu____2742 =
-                                    FStar_Syntax_Print.bv_to_string x  in
+                                    FStar_Syntax_Print.bv_to_string x in
                                   let uu____2743 =
                                     FStar_Syntax_Print.term_to_string
-                                      x.FStar_Syntax_Syntax.sort
-                                     in
+                                      x.FStar_Syntax_Syntax.sort in
                                   let uu____2744 =
-                                    FStar_Syntax_Print.term_to_string t1  in
+                                    FStar_Syntax_Print.term_to_string t1 in
                                   FStar_Util.format3
                                     "Multiple ascriptions for %s in pattern, type %s was shadowed by %s\n"
-                                    uu____2742 uu____2743 uu____2744
-                                   in
+                                    uu____2742 uu____2743 uu____2744 in
                                 (FStar_Errors.Warning_MultipleAscriptions,
-                                  uu____2741)
-                                 in
+                                  uu____2741) in
                               FStar_Errors.log_issue
                                 orig.FStar_Parser_AST.prange uu____2736)
                            else ();
-                           (let uu____2746 = annot_pat_var p3 t1  in
+                           (let uu____2746 = annot_pat_var p3 t1 in
                             (uu____2746,
                               (LocalBinder
-                                 ((let uu___116_2752 = x  in
+                                 ((let uu___116_2752 = x in
                                    {
                                      FStar_Syntax_Syntax.ppname =
                                        (uu___116_2752.FStar_Syntax_Syntax.ppname);
                                      FStar_Syntax_Syntax.index =
                                        (uu___116_2752.FStar_Syntax_Syntax.index);
                                      FStar_Syntax_Syntax.sort = t1
-                                   }), aq)))))
-                       in
+                                   }), aq))))) in
                     (match uu____2706 with
                      | (p4,binder1) -> (loc1, env', binder1, p4, imp)))
            | FStar_Parser_AST.PatWild  ->
                let x =
                  FStar_Syntax_Syntax.new_bv
                    (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
-                   FStar_Syntax_Syntax.tun
-                  in
+                   FStar_Syntax_Syntax.tun in
                let uu____2774 =
-                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_wild x)  in
+                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_wild x) in
                (loc, env1, (LocalBinder (x, FStar_Pervasives_Native.None)),
                  uu____2774, false)
            | FStar_Parser_AST.PatConst c ->
                let x =
                  FStar_Syntax_Syntax.new_bv
                    (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
-                   FStar_Syntax_Syntax.tun
-                  in
+                   FStar_Syntax_Syntax.tun in
                let uu____2785 =
-                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_constant c)
-                  in
+                 FStar_All.pipe_left pos (FStar_Syntax_Syntax.Pat_constant c) in
                (loc, env1, (LocalBinder (x, FStar_Pervasives_Native.None)),
                  uu____2785, false)
            | FStar_Parser_AST.PatTvar (x,aq) ->
                let imp =
                  aq =
-                   (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)
-                  in
-               let aq1 = trans_aqual aq  in
-               let uu____2806 = resolvex loc env1 x  in
+                   (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit) in
+               let aq1 = trans_aqual aq in
+               let uu____2806 = resolvex loc env1 x in
                (match uu____2806 with
                 | (loc1,env2,xbv) ->
                     let uu____2828 =
                       FStar_All.pipe_left pos
-                        (FStar_Syntax_Syntax.Pat_var xbv)
-                       in
+                        (FStar_Syntax_Syntax.Pat_var xbv) in
                     (loc1, env2, (LocalBinder (xbv, aq1)), uu____2828, imp))
            | FStar_Parser_AST.PatVar (x,aq) ->
                let imp =
                  aq =
-                   (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)
-                  in
-               let aq1 = trans_aqual aq  in
-               let uu____2849 = resolvex loc env1 x  in
+                   (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit) in
+               let aq1 = trans_aqual aq in
+               let uu____2849 = resolvex loc env1 x in
                (match uu____2849 with
                 | (loc1,env2,xbv) ->
                     let uu____2871 =
                       FStar_All.pipe_left pos
-                        (FStar_Syntax_Syntax.Pat_var xbv)
-                       in
+                        (FStar_Syntax_Syntax.Pat_var xbv) in
                     (loc1, env2, (LocalBinder (xbv, aq1)), uu____2871, imp))
            | FStar_Parser_AST.PatName l ->
                let l1 =
                  FStar_ToSyntax_Env.fail_or env1
-                   (FStar_ToSyntax_Env.try_lookup_datacon env1) l
-                  in
+                   (FStar_ToSyntax_Env.try_lookup_datacon env1) l in
                let x =
                  FStar_Syntax_Syntax.new_bv
                    (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
-                   FStar_Syntax_Syntax.tun
-                  in
+                   FStar_Syntax_Syntax.tun in
                let uu____2883 =
                  FStar_All.pipe_left pos
-                   (FStar_Syntax_Syntax.Pat_cons (l1, []))
-                  in
+                   (FStar_Syntax_Syntax.Pat_cons (l1, [])) in
                (loc, env1, (LocalBinder (x, FStar_Pervasives_Native.None)),
                  uu____2883, false)
            | FStar_Parser_AST.PatApp
@@ -1280,28 +1192,24 @@ let rec (desugar_data_pat :
                       fun uu____2954  ->
                         match uu____2954 with
                         | (loc1,env2,args1) ->
-                            let uu____3002 = aux loc1 env2 arg  in
+                            let uu____3002 = aux loc1 env2 arg in
                             (match uu____3002 with
                              | (loc2,env3,uu____3031,arg1,imp) ->
                                  (loc2, env3, ((arg1, imp) :: args1)))) args
-                   (loc, env1, [])
-                  in
+                   (loc, env1, []) in
                (match uu____2913 with
                 | (loc1,env2,args1) ->
                     let l1 =
                       FStar_ToSyntax_Env.fail_or env2
-                        (FStar_ToSyntax_Env.try_lookup_datacon env2) l
-                       in
+                        (FStar_ToSyntax_Env.try_lookup_datacon env2) l in
                     let x =
                       FStar_Syntax_Syntax.new_bv
                         (FStar_Pervasives_Native.Some
                            (p1.FStar_Parser_AST.prange))
-                        FStar_Syntax_Syntax.tun
-                       in
+                        FStar_Syntax_Syntax.tun in
                     let uu____3101 =
                       FStar_All.pipe_left pos
-                        (FStar_Syntax_Syntax.Pat_cons (l1, args1))
-                       in
+                        (FStar_Syntax_Syntax.Pat_cons (l1, args1)) in
                     (loc1, env2,
                       (LocalBinder (x, FStar_Pervasives_Native.None)),
                       uu____3101, false))
@@ -1316,21 +1224,19 @@ let rec (desugar_data_pat :
                       fun uu____3173  ->
                         match uu____3173 with
                         | (loc1,env2,pats1) ->
-                            let uu____3205 = aux loc1 env2 pat  in
+                            let uu____3205 = aux loc1 env2 pat in
                             (match uu____3205 with
                              | (loc2,env3,uu____3230,pat1,uu____3232) ->
                                  (loc2, env3, (pat1 :: pats1)))) pats
-                   (loc, env1, [])
-                  in
+                   (loc, env1, []) in
                (match uu____3140 with
                 | (loc1,env2,pats1) ->
                     let pat =
                       let uu____3275 =
                         let uu____3278 =
                           let uu____3283 =
-                            FStar_Range.end_range p1.FStar_Parser_AST.prange
-                             in
-                          pos_r uu____3283  in
+                            FStar_Range.end_range p1.FStar_Parser_AST.prange in
+                          pos_r uu____3283 in
                         let uu____3284 =
                           let uu____3285 =
                             let uu____3298 =
@@ -1338,19 +1244,17 @@ let rec (desugar_data_pat :
                                 FStar_Parser_Const.nil_lid
                                 FStar_Syntax_Syntax.Delta_constant
                                 (FStar_Pervasives_Native.Some
-                                   FStar_Syntax_Syntax.Data_ctor)
-                               in
-                            (uu____3298, [])  in
-                          FStar_Syntax_Syntax.Pat_cons uu____3285  in
-                        FStar_All.pipe_left uu____3278 uu____3284  in
+                                   FStar_Syntax_Syntax.Data_ctor) in
+                            (uu____3298, []) in
+                          FStar_Syntax_Syntax.Pat_cons uu____3285 in
+                        FStar_All.pipe_left uu____3278 uu____3284 in
                       FStar_List.fold_right
                         (fun hd1  ->
                            fun tl1  ->
                              let r =
                                FStar_Range.union_ranges
                                  hd1.FStar_Syntax_Syntax.p
-                                 tl1.FStar_Syntax_Syntax.p
-                                in
+                                 tl1.FStar_Syntax_Syntax.p in
                              let uu____3330 =
                                let uu____3331 =
                                  let uu____3344 =
@@ -1358,20 +1262,16 @@ let rec (desugar_data_pat :
                                      FStar_Parser_Const.cons_lid
                                      FStar_Syntax_Syntax.Delta_constant
                                      (FStar_Pervasives_Native.Some
-                                        FStar_Syntax_Syntax.Data_ctor)
-                                    in
-                                 (uu____3344, [(hd1, false); (tl1, false)])
-                                  in
-                               FStar_Syntax_Syntax.Pat_cons uu____3331  in
+                                        FStar_Syntax_Syntax.Data_ctor) in
+                                 (uu____3344, [(hd1, false); (tl1, false)]) in
+                               FStar_Syntax_Syntax.Pat_cons uu____3331 in
                              FStar_All.pipe_left (pos_r r) uu____3330) pats1
-                        uu____3275
-                       in
+                        uu____3275 in
                     let x =
                       FStar_Syntax_Syntax.new_bv
                         (FStar_Pervasives_Native.Some
                            (p1.FStar_Parser_AST.prange))
-                        FStar_Syntax_Syntax.tun
-                       in
+                        FStar_Syntax_Syntax.tun in
                     (loc1, env2,
                       (LocalBinder (x, FStar_Pervasives_Native.None)), pat,
                       false))
@@ -1382,15 +1282,14 @@ let rec (desugar_data_pat :
                       fun p2  ->
                         match uu____3428 with
                         | (loc1,env2,pats) ->
-                            let uu____3477 = aux loc1 env2 p2  in
+                            let uu____3477 = aux loc1 env2 p2 in
                             (match uu____3477 with
                              | (loc2,env3,uu____3506,pat,uu____3508) ->
                                  (loc2, env3, ((pat, false) :: pats))))
-                   (loc, env1, []) args
-                  in
+                   (loc, env1, []) args in
                (match uu____3388 with
                 | (loc1,env2,args1) ->
-                    let args2 = FStar_List.rev args1  in
+                    let args2 = FStar_List.rev args1 in
                     let l =
                       if dep1
                       then
@@ -1400,28 +1299,24 @@ let rec (desugar_data_pat :
                       else
                         FStar_Parser_Const.mk_tuple_data_lid
                           (FStar_List.length args2)
-                          p1.FStar_Parser_AST.prange
-                       in
+                          p1.FStar_Parser_AST.prange in
                     let uu____3603 =
                       FStar_ToSyntax_Env.fail_or env2
-                        (FStar_ToSyntax_Env.try_lookup_lid env2) l
-                       in
+                        (FStar_ToSyntax_Env.try_lookup_lid env2) l in
                     (match uu____3603 with
                      | (constr,uu____3625) ->
                          let l1 =
                            match constr.FStar_Syntax_Syntax.n with
                            | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-                           | uu____3628 -> failwith "impossible"  in
+                           | uu____3628 -> failwith "impossible" in
                          let x =
                            FStar_Syntax_Syntax.new_bv
                              (FStar_Pervasives_Native.Some
                                 (p1.FStar_Parser_AST.prange))
-                             FStar_Syntax_Syntax.tun
-                            in
+                             FStar_Syntax_Syntax.tun in
                          let uu____3630 =
                            FStar_All.pipe_left pos
-                             (FStar_Syntax_Syntax.Pat_cons (l1, args2))
-                            in
+                             (FStar_Syntax_Syntax.Pat_cons (l1, args2)) in
                          (loc1, env2,
                            (LocalBinder (x, FStar_Pervasives_Native.None)),
                            uu____3630, false)))
@@ -1431,14 +1326,13 @@ let rec (desugar_data_pat :
                  p1.FStar_Parser_AST.prange
            | FStar_Parser_AST.PatRecord fields ->
                let record =
-                 check_fields env1 fields p1.FStar_Parser_AST.prange  in
+                 check_fields env1 fields p1.FStar_Parser_AST.prange in
                let fields1 =
                  FStar_All.pipe_right fields
                    (FStar_List.map
                       (fun uu____3701  ->
                          match uu____3701 with
-                         | (f,p2) -> ((f.FStar_Ident.ident), p2)))
-                  in
+                         | (f,p2) -> ((f.FStar_Ident.ident), p2))) in
                let args =
                  FStar_All.pipe_right record.FStar_ToSyntax_Env.fields
                    (FStar_List.map
@@ -1452,16 +1346,14 @@ let rec (desugar_data_pat :
                                        match uu____3764 with
                                        | (g,uu____3770) ->
                                            f.FStar_Ident.idText =
-                                             g.FStar_Ident.idText))
-                                in
+                                             g.FStar_Ident.idText)) in
                              (match uu____3738 with
                               | FStar_Pervasives_Native.None  ->
                                   FStar_Parser_AST.mk_pattern
                                     FStar_Parser_AST.PatWild
                                     p1.FStar_Parser_AST.prange
                               | FStar_Pervasives_Native.Some (uu____3775,p2)
-                                  -> p2)))
-                  in
+                                  -> p2))) in
                let app =
                  let uu____3782 =
                    let uu____3783 =
@@ -1471,18 +1363,15 @@ let rec (desugar_data_pat :
                            FStar_Ident.lid_of_ids
                              (FStar_List.append
                                 (record.FStar_ToSyntax_Env.typename).FStar_Ident.ns
-                                [record.FStar_ToSyntax_Env.constrname])
-                            in
-                         FStar_Parser_AST.PatName uu____3792  in
+                                [record.FStar_ToSyntax_Env.constrname]) in
+                         FStar_Parser_AST.PatName uu____3792 in
                        FStar_Parser_AST.mk_pattern uu____3791
-                         p1.FStar_Parser_AST.prange
-                        in
-                     (uu____3790, args)  in
-                   FStar_Parser_AST.PatApp uu____3783  in
+                         p1.FStar_Parser_AST.prange in
+                     (uu____3790, args) in
+                   FStar_Parser_AST.PatApp uu____3783 in
                  FStar_Parser_AST.mk_pattern uu____3782
-                   p1.FStar_Parser_AST.prange
-                  in
-               let uu____3795 = aux loc env1 app  in
+                   p1.FStar_Parser_AST.prange in
+               let uu____3795 = aux loc env1 app in
                (match uu____3795 with
                 | (env2,e,b,p2,uu____3824) ->
                     let p3 =
@@ -1491,7 +1380,7 @@ let rec (desugar_data_pat :
                           let uu____3852 =
                             let uu____3853 =
                               let uu____3866 =
-                                let uu___117_3867 = fv  in
+                                let uu___117_3867 = fv in
                                 let uu____3868 =
                                   let uu____3871 =
                                     let uu____3872 =
@@ -1499,36 +1388,31 @@ let rec (desugar_data_pat :
                                         FStar_All.pipe_right
                                           record.FStar_ToSyntax_Env.fields
                                           (FStar_List.map
-                                             FStar_Pervasives_Native.fst)
-                                         in
+                                             FStar_Pervasives_Native.fst) in
                                       ((record.FStar_ToSyntax_Env.typename),
-                                        uu____3879)
-                                       in
+                                        uu____3879) in
                                     FStar_Syntax_Syntax.Record_ctor
-                                      uu____3872
-                                     in
-                                  FStar_Pervasives_Native.Some uu____3871  in
+                                      uu____3872 in
+                                  FStar_Pervasives_Native.Some uu____3871 in
                                 {
                                   FStar_Syntax_Syntax.fv_name =
                                     (uu___117_3867.FStar_Syntax_Syntax.fv_name);
                                   FStar_Syntax_Syntax.fv_delta =
                                     (uu___117_3867.FStar_Syntax_Syntax.fv_delta);
                                   FStar_Syntax_Syntax.fv_qual = uu____3868
-                                }  in
-                              (uu____3866, args1)  in
-                            FStar_Syntax_Syntax.Pat_cons uu____3853  in
+                                } in
+                              (uu____3866, args1) in
+                            FStar_Syntax_Syntax.Pat_cons uu____3853 in
                           FStar_All.pipe_left pos uu____3852
-                      | uu____3906 -> p2  in
+                      | uu____3906 -> p2 in
                     (env2, e, b, p3, false))
-         
-         and aux loc env1 p1 = aux' false loc env1 p1
-          in
+         and aux loc env1 p1 = aux' false loc env1 p1 in
          let aux_maybe_or env1 p1 =
-           let loc = []  in
+           let loc = [] in
            match p1.FStar_Parser_AST.pat with
            | FStar_Parser_AST.PatOr [] -> failwith "impossible"
            | FStar_Parser_AST.PatOr (p2::ps) ->
-               let uu____3956 = aux' true loc env1 p2  in
+               let uu____3956 = aux' true loc env1 p2 in
                (match uu____3956 with
                 | (loc1,env2,var,p3,uu____3983) ->
                     let uu____3988 =
@@ -1537,40 +1421,36 @@ let rec (desugar_data_pat :
                            fun p4  ->
                              match uu____4020 with
                              | (loc2,env3,ps1) ->
-                                 let uu____4053 = aux' true loc2 env3 p4  in
+                                 let uu____4053 = aux' true loc2 env3 p4 in
                                  (match uu____4053 with
                                   | (loc3,env4,uu____4078,p5,uu____4080) ->
                                       (loc3, env4, (p5 :: ps1))))
-                        (loc1, env2, []) ps
-                       in
+                        (loc1, env2, []) ps in
                     (match uu____3988 with
                      | (loc2,env3,ps1) ->
-                         let pats = p3 :: (FStar_List.rev ps1)  in
+                         let pats = p3 :: (FStar_List.rev ps1) in
                          (env3, var, pats)))
            | uu____4131 ->
-               let uu____4132 = aux' true loc env1 p1  in
+               let uu____4132 = aux' true loc env1 p1 in
                (match uu____4132 with
-                | (loc1,env2,vars,pat,b) -> (env2, vars, [pat]))
-            in
-         let uu____4172 = aux_maybe_or env p  in
+                | (loc1,env2,vars,pat,b) -> (env2, vars, [pat])) in
+         let uu____4172 = aux_maybe_or env p in
          match uu____4172 with
          | (env1,b,pats) ->
              ((let uu____4203 =
                  FStar_List.map
                    (fun pats1  ->
                       check_linear_pattern_variables pats1
-                        p.FStar_Parser_AST.prange) pats
-                  in
+                        p.FStar_Parser_AST.prange) pats in
                FStar_All.pipe_left FStar_Pervasives.ignore uu____4203);
               (env1, b, pats)))
-
-and (desugar_binding_pat_maybe_top :
+and desugar_binding_pat_maybe_top:
   Prims.bool ->
     FStar_ToSyntax_Env.env ->
       FStar_Parser_AST.pattern ->
         Prims.bool ->
           (env_t,bnd,FStar_Syntax_Syntax.pat Prims.list)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun top  ->
     fun env  ->
@@ -1579,10 +1459,10 @@ and (desugar_binding_pat_maybe_top :
           let mklet x =
             let uu____4240 =
               let uu____4241 =
-                let uu____4246 = FStar_ToSyntax_Env.qualify env x  in
-                (uu____4246, FStar_Syntax_Syntax.tun)  in
-              LetBinder uu____4241  in
-            (env, uu____4240, [])  in
+                let uu____4246 = FStar_ToSyntax_Env.qualify env x in
+                (uu____4246, FStar_Syntax_Syntax.tun) in
+              LetBinder uu____4241 in
+            (env, uu____4240, []) in
           if top
           then
             match p.FStar_Parser_AST.pat with
@@ -1591,10 +1471,9 @@ and (desugar_binding_pat_maybe_top :
                   let uu____4267 =
                     let uu____4272 =
                       FStar_Parser_AST.compile_op (Prims.parse_int "0")
-                        x.FStar_Ident.idText x.FStar_Ident.idRange
-                       in
-                    (uu____4272, (x.FStar_Ident.idRange))  in
-                  FStar_Ident.mk_ident uu____4267  in
+                        x.FStar_Ident.idText x.FStar_Ident.idRange in
+                    (uu____4272, (x.FStar_Ident.idRange)) in
+                  FStar_Ident.mk_ident uu____4267 in
                 mklet uu____4266
             | FStar_Parser_AST.PatVar (x,uu____4274) -> mklet x
             | FStar_Parser_AST.PatAscribed
@@ -1605,10 +1484,10 @@ and (desugar_binding_pat_maybe_top :
                 ->
                 let uu____4287 =
                   let uu____4288 =
-                    let uu____4293 = FStar_ToSyntax_Env.qualify env x  in
-                    let uu____4294 = desugar_term env t  in
-                    (uu____4293, uu____4294)  in
-                  LetBinder uu____4288  in
+                    let uu____4293 = FStar_ToSyntax_Env.qualify env x in
+                    let uu____4294 = desugar_term env t in
+                    (uu____4293, uu____4294) in
+                  LetBinder uu____4288 in
                 (env, uu____4287, [])
             | uu____4297 ->
                 FStar_Errors.raise_error
@@ -1616,7 +1495,7 @@ and (desugar_binding_pat_maybe_top :
                     "Unexpected pattern at the top-level")
                   p.FStar_Parser_AST.prange
           else
-            (let uu____4307 = desugar_data_pat env p is_mut  in
+            (let uu____4307 = desugar_data_pat env p is_mut in
              match uu____4307 with
              | (env1,binder,p1) ->
                  let p2 =
@@ -1629,58 +1508,52 @@ and (desugar_binding_pat_maybe_top :
                        FStar_Syntax_Syntax.v = FStar_Syntax_Syntax.Pat_wild
                          uu____4342;
                        FStar_Syntax_Syntax.p = uu____4343;_}::[] -> []
-                   | uu____4348 -> p1  in
+                   | uu____4348 -> p1 in
                  (env1, binder, p2))
-
-and (desugar_binding_pat :
+and desugar_binding_pat:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.pattern ->
       (env_t,bnd,FStar_Syntax_Syntax.pat Prims.list)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   = fun env  -> fun p  -> desugar_binding_pat_maybe_top false env p false
-
-and (desugar_match_pat_maybe_top :
+and desugar_match_pat_maybe_top:
   Prims.bool ->
     FStar_ToSyntax_Env.env ->
       FStar_Parser_AST.pattern ->
         (env_t,FStar_Syntax_Syntax.pat Prims.list)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun uu____4355  ->
     fun env  ->
       fun pat  ->
-        let uu____4358 = desugar_data_pat env pat false  in
+        let uu____4358 = desugar_data_pat env pat false in
         match uu____4358 with | (env1,uu____4374,pat1) -> (env1, pat1)
-
-and (desugar_match_pat :
+and desugar_match_pat:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.pattern ->
       (env_t,FStar_Syntax_Syntax.pat Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   = fun env  -> fun p  -> desugar_match_pat_maybe_top false env p
-
-and (desugar_term :
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term)
+and desugar_term:
+  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun e  ->
-      let env1 = FStar_ToSyntax_Env.set_expect_typ env false  in
+      let env1 = FStar_ToSyntax_Env.set_expect_typ env false in
       desugar_term_maybe_top false env1 e
-
-and (desugar_typ :
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term)
+and desugar_typ:
+  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun e  ->
-      let env1 = FStar_ToSyntax_Env.set_expect_typ env true  in
+      let env1 = FStar_ToSyntax_Env.set_expect_typ env true in
       desugar_term_maybe_top false env1 e
-
-and (desugar_machine_integer :
+and desugar_machine_integer:
   FStar_ToSyntax_Env.env ->
     Prims.string ->
       (FStar_Const.signedness,FStar_Const.width)
         FStar_Pervasives_Native.tuple2 ->
-        FStar_Range.range -> FStar_Syntax_Syntax.term)
+        FStar_Range.range -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun repr  ->
@@ -1699,20 +1572,18 @@ and (desugar_machine_integer :
                          | FStar_Const.Int8  -> "8"
                          | FStar_Const.Int16  -> "16"
                          | FStar_Const.Int32  -> "32"
-                         | FStar_Const.Int64  -> "64")))
-                 in
+                         | FStar_Const.Int64  -> "64"))) in
               ((let uu____4402 =
                   let uu____4403 =
-                    FStar_Const.within_bounds repr signedness width  in
-                  Prims.op_Negation uu____4403  in
+                    FStar_Const.within_bounds repr signedness width in
+                  Prims.op_Negation uu____4403 in
                 if uu____4402
                 then
                   let uu____4404 =
                     let uu____4409 =
                       FStar_Util.format2
-                        "%s is not in the expected range for %s" repr tnm
-                       in
-                    (FStar_Errors.Error_OutOfRange, uu____4409)  in
+                        "%s is not in the expected range for %s" repr tnm in
+                    (FStar_Errors.Error_OutOfRange, uu____4409) in
                   FStar_Errors.log_issue range uu____4404
                 else ());
                (let private_intro_nm =
@@ -1721,23 +1592,19 @@ and (desugar_machine_integer :
                        (Prims.strcat
                           (match signedness with
                            | FStar_Const.Unsigned  -> "u"
-                           | FStar_Const.Signed  -> "") "int_to_t"))
-                   in
+                           | FStar_Const.Signed  -> "") "int_to_t")) in
                 let intro_nm =
                   Prims.strcat tnm
                     (Prims.strcat "."
                        (Prims.strcat
                           (match signedness with
                            | FStar_Const.Unsigned  -> "u"
-                           | FStar_Const.Signed  -> "") "int_to_t"))
-                   in
+                           | FStar_Const.Signed  -> "") "int_to_t")) in
                 let lid =
                   FStar_Ident.lid_of_path (FStar_Ident.path_of_text intro_nm)
-                    range
-                   in
+                    range in
                 let lid1 =
-                  let uu____4417 = FStar_ToSyntax_Env.try_lookup_lid env lid
-                     in
+                  let uu____4417 = FStar_ToSyntax_Env.try_lookup_lid env lid in
                   match uu____4417 with
                   | FStar_Pervasives_Native.Some (intro_term,uu____4427) ->
                       (match intro_term.FStar_Syntax_Syntax.n with
@@ -1745,17 +1612,14 @@ and (desugar_machine_integer :
                            let private_lid =
                              FStar_Ident.lid_of_path
                                (FStar_Ident.path_of_text private_intro_nm)
-                               range
-                              in
+                               range in
                            let private_fv =
                              let uu____4437 =
                                FStar_Syntax_Util.incr_delta_depth
-                                 fv.FStar_Syntax_Syntax.fv_delta
-                                in
+                                 fv.FStar_Syntax_Syntax.fv_delta in
                              FStar_Syntax_Syntax.lid_as_fv private_lid
-                               uu____4437 fv.FStar_Syntax_Syntax.fv_qual
-                              in
-                           let uu___118_4438 = intro_term  in
+                               uu____4437 fv.FStar_Syntax_Syntax.fv_qual in
+                           let uu___118_4438 = intro_term in
                            {
                              FStar_Syntax_Syntax.n =
                                (FStar_Syntax_Syntax.Tm_fvar private_fv);
@@ -1773,39 +1637,34 @@ and (desugar_machine_integer :
                         let uu____4451 =
                           FStar_Util.format1
                             "Unexpected numeric literal.  Restart F* to load %s."
-                            tnm
-                           in
+                            tnm in
                         (FStar_Errors.Fatal_UnexpectedNumericLiteral,
-                          uu____4451)
-                         in
-                      FStar_Errors.raise_error uu____4446 range
-                   in
+                          uu____4451) in
+                      FStar_Errors.raise_error uu____4446 range in
                 let repr1 =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_constant
                        (FStar_Const.Const_int
                           (repr, FStar_Pervasives_Native.None)))
-                    FStar_Pervasives_Native.None range
-                   in
+                    FStar_Pervasives_Native.None range in
                 let uu____4467 =
                   let uu____4470 =
                     let uu____4471 =
                       let uu____4486 =
                         let uu____4495 =
                           let uu____4502 =
-                            FStar_Syntax_Syntax.as_implicit false  in
-                          (repr1, uu____4502)  in
-                        [uu____4495]  in
-                      (lid1, uu____4486)  in
-                    FStar_Syntax_Syntax.Tm_app uu____4471  in
-                  FStar_Syntax_Syntax.mk uu____4470  in
+                            FStar_Syntax_Syntax.as_implicit false in
+                          (repr1, uu____4502) in
+                        [uu____4495] in
+                      (lid1, uu____4486) in
+                    FStar_Syntax_Syntax.Tm_app uu____4471 in
+                  FStar_Syntax_Syntax.mk uu____4470 in
                 uu____4467 FStar_Pervasives_Native.None range))
-
-and (desugar_name :
+and desugar_name:
   (FStar_Syntax_Syntax.term' -> FStar_Syntax_Syntax.term) ->
     (FStar_Syntax_Syntax.term ->
        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-      -> env_t -> Prims.bool -> FStar_Ident.lid -> FStar_Syntax_Syntax.term)
+      -> env_t -> Prims.bool -> FStar_Ident.lid -> FStar_Syntax_Syntax.term
   =
   fun mk1  ->
     fun setpos  ->
@@ -1818,8 +1677,7 @@ and (desugar_name :
                   then FStar_ToSyntax_Env.try_lookup_lid_with_attributes
                   else
                     FStar_ToSyntax_Env.try_lookup_lid_with_attributes_no_resolve)
-                   env) l
-               in
+                   env) l in
             match uu____4541 with
             | (tm,mut,attrs) ->
                 let warn_if_deprecated attrs1 =
@@ -1839,8 +1697,8 @@ and (desugar_name :
                            ->
                            let msg =
                              let uu____4611 =
-                               FStar_Syntax_Print.term_to_string tm  in
-                             Prims.strcat uu____4611 " is deprecated"  in
+                               FStar_Syntax_Print.term_to_string tm in
+                             Prims.strcat uu____4611 " is deprecated" in
                            let msg1 =
                              if
                                (FStar_List.length args) >
@@ -1848,9 +1706,9 @@ and (desugar_name :
                              then
                                let uu____4619 =
                                  let uu____4620 =
-                                   let uu____4623 = FStar_List.hd args  in
-                                   FStar_Pervasives_Native.fst uu____4623  in
-                                 uu____4620.FStar_Syntax_Syntax.n  in
+                                   let uu____4623 = FStar_List.hd args in
+                                   FStar_Pervasives_Native.fst uu____4623 in
+                                 uu____4620.FStar_Syntax_Syntax.n in
                                match uu____4619 with
                                | FStar_Syntax_Syntax.Tm_constant
                                    (FStar_Const.Const_string (s,uu____4639))
@@ -1862,7 +1720,7 @@ and (desugar_name :
                                      (Prims.strcat ", use "
                                         (Prims.strcat s " instead"))
                                | uu____4640 -> msg
-                             else msg  in
+                             else msg in
                            FStar_Errors.log_issue
                              (FStar_Ident.range_of_lid l)
                              (FStar_Errors.Warning_DeprecatedDefinition,
@@ -1874,37 +1732,34 @@ and (desugar_name :
                            ->
                            let msg =
                              let uu____4644 =
-                               FStar_Syntax_Print.term_to_string tm  in
-                             Prims.strcat uu____4644 " is deprecated"  in
+                               FStar_Syntax_Print.term_to_string tm in
+                             Prims.strcat uu____4644 " is deprecated" in
                            FStar_Errors.log_issue
                              (FStar_Ident.range_of_lid l)
                              (FStar_Errors.Warning_DeprecatedDefinition, msg)
-                       | uu____4645 -> ()) attrs1
-                   in
+                       | uu____4645 -> ()) attrs1 in
                 (warn_if_deprecated attrs;
-                 (let tm1 = setpos tm  in
+                 (let tm1 = setpos tm in
                   if mut
                   then
                     let uu____4650 =
                       let uu____4651 =
-                        let uu____4658 = mk_ref_read tm1  in
+                        let uu____4658 = mk_ref_read tm1 in
                         (uu____4658,
                           (FStar_Syntax_Syntax.Meta_desugared
-                             FStar_Syntax_Syntax.Mutable_rval))
-                         in
-                      FStar_Syntax_Syntax.Tm_meta uu____4651  in
+                             FStar_Syntax_Syntax.Mutable_rval)) in
+                      FStar_Syntax_Syntax.Tm_meta uu____4651 in
                     FStar_All.pipe_left mk1 uu____4650
                   else tm1))
-
-and (desugar_attributes :
+and desugar_attributes:
   env_t ->
-    FStar_Parser_AST.term Prims.list -> FStar_Syntax_Syntax.cflags Prims.list)
+    FStar_Parser_AST.term Prims.list -> FStar_Syntax_Syntax.cflags Prims.list
   =
   fun env  ->
     fun cattributes  ->
       let desugar_attribute t =
         let uu____4674 =
-          let uu____4675 = unparen t  in uu____4675.FStar_Parser_AST.tm  in
+          let uu____4675 = unparen t in uu____4675.FStar_Parser_AST.tm in
         match uu____4674 with
         | FStar_Parser_AST.Var
             { FStar_Ident.ns = uu____4676; FStar_Ident.ident = uu____4677;
@@ -1913,32 +1768,29 @@ and (desugar_attributes :
         | uu____4681 ->
             let uu____4682 =
               let uu____4687 =
-                let uu____4688 = FStar_Parser_AST.term_to_string t  in
-                Prims.strcat "Unknown attribute " uu____4688  in
-              (FStar_Errors.Fatal_UnknownAttribute, uu____4687)  in
-            FStar_Errors.raise_error uu____4682 t.FStar_Parser_AST.range
-         in
+                let uu____4688 = FStar_Parser_AST.term_to_string t in
+                Prims.strcat "Unknown attribute " uu____4688 in
+              (FStar_Errors.Fatal_UnknownAttribute, uu____4687) in
+            FStar_Errors.raise_error uu____4682 t.FStar_Parser_AST.range in
       FStar_List.map desugar_attribute cattributes
-
-and (desugar_term_maybe_top :
-  Prims.bool -> env_t -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term) =
+and desugar_term_maybe_top:
+  Prims.bool -> env_t -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term =
   fun top_level  ->
     fun env  ->
       fun top  ->
         let mk1 e =
           FStar_Syntax_Syntax.mk e FStar_Pervasives_Native.None
-            top.FStar_Parser_AST.range
-           in
+            top.FStar_Parser_AST.range in
         let setpos e =
-          let uu___119_4708 = e  in
+          let uu___119_4708 = e in
           {
             FStar_Syntax_Syntax.n = (uu___119_4708.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = (top.FStar_Parser_AST.range);
             FStar_Syntax_Syntax.vars =
               (uu___119_4708.FStar_Syntax_Syntax.vars)
-          }  in
+          } in
         let uu____4711 =
-          let uu____4712 = unparen top  in uu____4712.FStar_Parser_AST.tm  in
+          let uu____4712 = unparen top in uu____4712.FStar_Parser_AST.tm in
         match uu____4711 with
         | FStar_Parser_AST.Wild  -> setpos FStar_Syntax_Syntax.tun
         | FStar_Parser_AST.Labeled uu____4713 -> desugar_formula env top
@@ -1957,8 +1809,7 @@ and (desugar_term_maybe_top :
             let e =
               FStar_Parser_AST.mk_term
                 (FStar_Parser_AST.Op ((FStar_Ident.mk_ident ("==", r)), args))
-                top.FStar_Parser_AST.range top.FStar_Parser_AST.level
-               in
+                top.FStar_Parser_AST.range top.FStar_Parser_AST.level in
             desugar_term env
               (FStar_Parser_AST.mk_term
                  (FStar_Parser_AST.Op ((FStar_Ident.mk_ident ("~", r)), [e]))
@@ -1967,8 +1818,7 @@ and (desugar_term_maybe_top :
             ((FStar_Ident.text_of_id op_star) = "*") &&
               (let uu____4769 =
                  op_as_term env (Prims.parse_int "2")
-                   top.FStar_Parser_AST.range op_star
-                  in
+                   top.FStar_Parser_AST.range op_star in
                FStar_All.pipe_right uu____4769 FStar_Option.isNone)
             ->
             let rec flatten1 t =
@@ -1977,26 +1827,23 @@ and (desugar_term_maybe_top :
                   ({ FStar_Ident.idText = "*";
                      FStar_Ident.idRange = uu____4782;_},t1::t2::[])
                   ->
-                  let uu____4787 = flatten1 t1  in
+                  let uu____4787 = flatten1 t1 in
                   FStar_List.append uu____4787 [t2]
-              | uu____4790 -> [t]  in
+              | uu____4790 -> [t] in
             let targs =
               let uu____4794 =
-                let uu____4797 = unparen top  in flatten1 uu____4797  in
+                let uu____4797 = unparen top in flatten1 uu____4797 in
               FStar_All.pipe_right uu____4794
                 (FStar_List.map
                    (fun t  ->
-                      let uu____4805 = desugar_typ env t  in
-                      FStar_Syntax_Syntax.as_arg uu____4805))
-               in
+                      let uu____4805 = desugar_typ env t in
+                      FStar_Syntax_Syntax.as_arg uu____4805)) in
             let uu____4806 =
               let uu____4811 =
                 FStar_Parser_Const.mk_tuple_lid (FStar_List.length targs)
-                  top.FStar_Parser_AST.range
-                 in
+                  top.FStar_Parser_AST.range in
               FStar_ToSyntax_Env.fail_or env
-                (FStar_ToSyntax_Env.try_lookup_lid env) uu____4811
-               in
+                (FStar_ToSyntax_Env.try_lookup_lid env) uu____4811 in
             (match uu____4806 with
              | (tup,uu____4817) ->
                  mk1 (FStar_Syntax_Syntax.Tm_app (tup, targs)))
@@ -2004,9 +1851,8 @@ and (desugar_term_maybe_top :
             let uu____4821 =
               let uu____4824 =
                 FStar_ToSyntax_Env.fail_or2
-                  (FStar_ToSyntax_Env.try_lookup_id env) a
-                 in
-              FStar_Pervasives_Native.fst uu____4824  in
+                  (FStar_ToSyntax_Env.try_lookup_id env) a in
+              FStar_Pervasives_Native.fst uu____4824 in
             FStar_All.pipe_left setpos uu____4821
         | FStar_Parser_AST.Uvar u ->
             FStar_Errors.raise_error
@@ -2018,8 +1864,7 @@ and (desugar_term_maybe_top :
         | FStar_Parser_AST.Op (s,args) ->
             let uu____4844 =
               op_as_term env (FStar_List.length args)
-                top.FStar_Parser_AST.range s
-               in
+                top.FStar_Parser_AST.range s in
             (match uu____4844 with
              | FStar_Pervasives_Native.None  ->
                  FStar_Errors.raise_error
@@ -2034,41 +1879,39 @@ and (desugar_term_maybe_top :
                      FStar_All.pipe_right args
                        (FStar_List.map
                           (fun t  ->
-                             let uu____4876 = desugar_term env t  in
-                             (uu____4876, FStar_Pervasives_Native.None)))
-                      in
+                             let uu____4876 = desugar_term env t in
+                             (uu____4876, FStar_Pervasives_Native.None))) in
                    mk1 (FStar_Syntax_Syntax.Tm_app (op, args1))
                  else op)
         | FStar_Parser_AST.Construct (n1,(a,uu____4890)::[]) when
             n1.FStar_Ident.str = "SMTPat" ->
             let uu____4905 =
-              let uu___120_4906 = top  in
+              let uu___120_4906 = top in
               let uu____4907 =
                 let uu____4908 =
                   let uu____4915 =
-                    let uu___121_4916 = top  in
+                    let uu___121_4916 = top in
                     let uu____4917 =
                       let uu____4918 =
                         FStar_Ident.lid_of_path ["Prims"; "smt_pat"]
-                          top.FStar_Parser_AST.range
-                         in
-                      FStar_Parser_AST.Var uu____4918  in
+                          top.FStar_Parser_AST.range in
+                      FStar_Parser_AST.Var uu____4918 in
                     {
                       FStar_Parser_AST.tm = uu____4917;
                       FStar_Parser_AST.range =
                         (uu___121_4916.FStar_Parser_AST.range);
                       FStar_Parser_AST.level =
                         (uu___121_4916.FStar_Parser_AST.level)
-                    }  in
-                  (uu____4915, a, FStar_Parser_AST.Nothing)  in
-                FStar_Parser_AST.App uu____4908  in
+                    } in
+                  (uu____4915, a, FStar_Parser_AST.Nothing) in
+                FStar_Parser_AST.App uu____4908 in
               {
                 FStar_Parser_AST.tm = uu____4907;
                 FStar_Parser_AST.range =
                   (uu___120_4906.FStar_Parser_AST.range);
                 FStar_Parser_AST.level =
                   (uu___120_4906.FStar_Parser_AST.level)
-              }  in
+              } in
             desugar_term_maybe_top top_level env uu____4905
         | FStar_Parser_AST.Construct (n1,(a,uu____4921)::[]) when
             n1.FStar_Ident.str = "SMTPatT" ->
@@ -2076,64 +1919,62 @@ and (desugar_term_maybe_top :
                (FStar_Errors.Warning_SMTPatTDeprecated,
                  "SMTPatT is deprecated; please just use SMTPat");
              (let uu____4937 =
-                let uu___122_4938 = top  in
+                let uu___122_4938 = top in
                 let uu____4939 =
                   let uu____4940 =
                     let uu____4947 =
-                      let uu___123_4948 = top  in
+                      let uu___123_4948 = top in
                       let uu____4949 =
                         let uu____4950 =
                           FStar_Ident.lid_of_path ["Prims"; "smt_pat"]
-                            top.FStar_Parser_AST.range
-                           in
-                        FStar_Parser_AST.Var uu____4950  in
+                            top.FStar_Parser_AST.range in
+                        FStar_Parser_AST.Var uu____4950 in
                       {
                         FStar_Parser_AST.tm = uu____4949;
                         FStar_Parser_AST.range =
                           (uu___123_4948.FStar_Parser_AST.range);
                         FStar_Parser_AST.level =
                           (uu___123_4948.FStar_Parser_AST.level)
-                      }  in
-                    (uu____4947, a, FStar_Parser_AST.Nothing)  in
-                  FStar_Parser_AST.App uu____4940  in
+                      } in
+                    (uu____4947, a, FStar_Parser_AST.Nothing) in
+                  FStar_Parser_AST.App uu____4940 in
                 {
                   FStar_Parser_AST.tm = uu____4939;
                   FStar_Parser_AST.range =
                     (uu___122_4938.FStar_Parser_AST.range);
                   FStar_Parser_AST.level =
                     (uu___122_4938.FStar_Parser_AST.level)
-                }  in
+                } in
               desugar_term_maybe_top top_level env uu____4937))
         | FStar_Parser_AST.Construct (n1,(a,uu____4953)::[]) when
             n1.FStar_Ident.str = "SMTPatOr" ->
             let uu____4968 =
-              let uu___124_4969 = top  in
+              let uu___124_4969 = top in
               let uu____4970 =
                 let uu____4971 =
                   let uu____4978 =
-                    let uu___125_4979 = top  in
+                    let uu___125_4979 = top in
                     let uu____4980 =
                       let uu____4981 =
                         FStar_Ident.lid_of_path ["Prims"; "smt_pat_or"]
-                          top.FStar_Parser_AST.range
-                         in
-                      FStar_Parser_AST.Var uu____4981  in
+                          top.FStar_Parser_AST.range in
+                      FStar_Parser_AST.Var uu____4981 in
                     {
                       FStar_Parser_AST.tm = uu____4980;
                       FStar_Parser_AST.range =
                         (uu___125_4979.FStar_Parser_AST.range);
                       FStar_Parser_AST.level =
                         (uu___125_4979.FStar_Parser_AST.level)
-                    }  in
-                  (uu____4978, a, FStar_Parser_AST.Nothing)  in
-                FStar_Parser_AST.App uu____4971  in
+                    } in
+                  (uu____4978, a, FStar_Parser_AST.Nothing) in
+                FStar_Parser_AST.App uu____4971 in
               {
                 FStar_Parser_AST.tm = uu____4970;
                 FStar_Parser_AST.range =
                   (uu___124_4969.FStar_Parser_AST.range);
                 FStar_Parser_AST.level =
                   (uu___124_4969.FStar_Parser_AST.level)
-              }  in
+              } in
             desugar_term_maybe_top top_level env uu____4968
         | FStar_Parser_AST.Name
             { FStar_Ident.ns = uu____4982; FStar_Ident.ident = uu____4983;
@@ -2150,8 +1991,8 @@ and (desugar_term_maybe_top :
              (t,FStar_Parser_AST.UnivApp )::[])
             ->
             let uu____5012 =
-              let uu____5013 = desugar_universe t  in
-              FStar_Syntax_Syntax.Tm_type uu____5013  in
+              let uu____5013 = desugar_universe t in
+              FStar_Syntax_Syntax.Tm_type uu____5013 in
             mk1 uu____5012
         | FStar_Parser_AST.Name
             { FStar_Ident.ns = uu____5014; FStar_Ident.ident = uu____5015;
@@ -2182,10 +2023,10 @@ and (desugar_term_maybe_top :
             ->
             (FStar_ToSyntax_Env.fail_if_qualified_by_curmodule env eff_name;
              (let uu____5033 =
-                FStar_ToSyntax_Env.try_lookup_effect_defn env eff_name  in
+                FStar_ToSyntax_Env.try_lookup_effect_defn env eff_name in
               match uu____5033 with
               | FStar_Pervasives_Native.Some ed ->
-                  let lid = FStar_Syntax_Util.dm4f_lid ed txt  in
+                  let lid = FStar_Syntax_Util.dm4f_lid ed txt in
                   FStar_Syntax_Syntax.fvar lid
                     (FStar_Syntax_Syntax.Delta_defined_at_level
                        (Prims.parse_int "1")) FStar_Pervasives_Native.None
@@ -2193,8 +2034,7 @@ and (desugar_term_maybe_top :
                   let uu____5038 =
                     FStar_Util.format2
                       "Member %s of effect %s is not accessible (using an effect abbreviation instead of the original effect ?)"
-                      (FStar_Ident.text_of_lid eff_name) txt
-                     in
+                      (FStar_Ident.text_of_lid eff_name) txt in
                   failwith uu____5038))
         | FStar_Parser_AST.Var l ->
             (FStar_ToSyntax_Env.fail_if_qualified_by_curmodule env l;
@@ -2205,65 +2045,55 @@ and (desugar_term_maybe_top :
         | FStar_Parser_AST.Projector (l,i) ->
             (FStar_ToSyntax_Env.fail_if_qualified_by_curmodule env l;
              (let name =
-                let uu____5053 = FStar_ToSyntax_Env.try_lookup_datacon env l
-                   in
+                let uu____5053 = FStar_ToSyntax_Env.try_lookup_datacon env l in
                 match uu____5053 with
                 | FStar_Pervasives_Native.Some uu____5062 ->
                     FStar_Pervasives_Native.Some (true, l)
                 | FStar_Pervasives_Native.None  ->
                     let uu____5067 =
-                      FStar_ToSyntax_Env.try_lookup_root_effect_name env l
-                       in
+                      FStar_ToSyntax_Env.try_lookup_root_effect_name env l in
                     (match uu____5067 with
                      | FStar_Pervasives_Native.Some new_name ->
                          FStar_Pervasives_Native.Some (false, new_name)
-                     | uu____5081 -> FStar_Pervasives_Native.None)
-                 in
+                     | uu____5081 -> FStar_Pervasives_Native.None) in
               match name with
               | FStar_Pervasives_Native.Some (resolve,new_name) ->
                   let uu____5094 =
                     FStar_Syntax_Util.mk_field_projector_name_from_ident
-                      new_name i
-                     in
+                      new_name i in
                   desugar_name mk1 setpos env resolve uu____5094
               | uu____5095 ->
                   let uu____5102 =
                     let uu____5107 =
                       FStar_Util.format1
                         "Data constructor or effect %s not found"
-                        l.FStar_Ident.str
-                       in
-                    (FStar_Errors.Fatal_EffectNotFound, uu____5107)  in
+                        l.FStar_Ident.str in
+                    (FStar_Errors.Fatal_EffectNotFound, uu____5107) in
                   FStar_Errors.raise_error uu____5102
                     top.FStar_Parser_AST.range))
         | FStar_Parser_AST.Discrim lid ->
             (FStar_ToSyntax_Env.fail_if_qualified_by_curmodule env lid;
-             (let uu____5110 = FStar_ToSyntax_Env.try_lookup_datacon env lid
-                 in
+             (let uu____5110 = FStar_ToSyntax_Env.try_lookup_datacon env lid in
               match uu____5110 with
               | FStar_Pervasives_Native.None  ->
                   let uu____5113 =
                     let uu____5118 =
                       FStar_Util.format1 "Data constructor %s not found"
-                        lid.FStar_Ident.str
-                       in
-                    (FStar_Errors.Fatal_DataContructorNotFound, uu____5118)
-                     in
+                        lid.FStar_Ident.str in
+                    (FStar_Errors.Fatal_DataContructorNotFound, uu____5118) in
                   FStar_Errors.raise_error uu____5113
                     top.FStar_Parser_AST.range
               | uu____5119 ->
-                  let lid' = FStar_Syntax_Util.mk_discriminator lid  in
+                  let lid' = FStar_Syntax_Util.mk_discriminator lid in
                   desugar_name mk1 setpos env true lid'))
         | FStar_Parser_AST.Construct (l,args) ->
             (FStar_ToSyntax_Env.fail_if_qualified_by_curmodule env l;
-             (let uu____5138 = FStar_ToSyntax_Env.try_lookup_datacon env l
-                 in
+             (let uu____5138 = FStar_ToSyntax_Env.try_lookup_datacon env l in
               match uu____5138 with
               | FStar_Pervasives_Native.Some head1 ->
                   let uu____5142 =
-                    let uu____5149 = mk1 (FStar_Syntax_Syntax.Tm_fvar head1)
-                       in
-                    (uu____5149, true)  in
+                    let uu____5149 = mk1 (FStar_Syntax_Syntax.Tm_fvar head1) in
+                    (uu____5149, true) in
                   (match uu____5142 with
                    | (head2,is_data) ->
                        (match args with
@@ -2274,8 +2104,7 @@ and (desugar_term_maybe_top :
                                 (fun uu____5195  ->
                                    match uu____5195 with
                                    | (uu____5200,imp) ->
-                                       imp = FStar_Parser_AST.UnivApp) args
-                               in
+                                       imp = FStar_Parser_AST.UnivApp) args in
                             (match uu____5171 with
                              | (universes,args1) ->
                                  let universes1 =
@@ -2283,29 +2112,25 @@ and (desugar_term_maybe_top :
                                      (fun x  ->
                                         desugar_universe
                                           (FStar_Pervasives_Native.fst x))
-                                     universes
-                                    in
+                                     universes in
                                  let args2 =
                                    FStar_List.map
                                      (fun uu____5264  ->
                                         match uu____5264 with
                                         | (t,imp) ->
-                                            let te = desugar_term env t  in
-                                            arg_withimp_e imp te) args1
-                                    in
+                                            let te = desugar_term env t in
+                                            arg_withimp_e imp te) args1 in
                                  let head3 =
                                    if universes1 = []
                                    then head2
                                    else
                                      mk1
                                        (FStar_Syntax_Syntax.Tm_uinst
-                                          (head2, universes1))
-                                    in
+                                          (head2, universes1)) in
                                  let app =
                                    mk1
                                      (FStar_Syntax_Syntax.Tm_app
-                                        (head3, args2))
-                                    in
+                                        (head3, args2)) in
                                  if is_data
                                  then
                                    mk1
@@ -2317,7 +2142,7 @@ and (desugar_term_maybe_top :
               | FStar_Pervasives_Native.None  ->
                   let err =
                     let uu____5311 =
-                      FStar_ToSyntax_Env.try_lookup_effect_name env l  in
+                      FStar_ToSyntax_Env.try_lookup_effect_name env l in
                     match uu____5311 with
                     | FStar_Pervasives_Native.None  ->
                         (FStar_Errors.Fatal_ConstructorNotFound,
@@ -2327,8 +2152,7 @@ and (desugar_term_maybe_top :
                         (FStar_Errors.Fatal_UnexpectedEffect,
                           (Prims.strcat "Effect "
                              (Prims.strcat l.FStar_Ident.str
-                                " used at an unexpected position")))
-                     in
+                                " used at an unexpected position"))) in
                   FStar_Errors.raise_error err top.FStar_Parser_AST.range))
         | FStar_Parser_AST.Sum (binders,t) ->
             let uu____5325 =
@@ -2337,7 +2161,7 @@ and (desugar_term_maybe_top :
                    fun b  ->
                      match uu____5370 with
                      | (env1,tparams,typs) ->
-                         let uu____5427 = desugar_binder env1 b  in
+                         let uu____5427 = desugar_binder env1 b in
                          (match uu____5427 with
                           | (xopt,t1) ->
                               let uu____5456 =
@@ -2347,28 +2171,25 @@ and (desugar_term_maybe_top :
                                       FStar_Syntax_Syntax.new_bv
                                         (FStar_Pervasives_Native.Some
                                            (top.FStar_Parser_AST.range))
-                                        FStar_Syntax_Syntax.tun
-                                       in
+                                        FStar_Syntax_Syntax.tun in
                                     (env1, uu____5465)
                                 | FStar_Pervasives_Native.Some x ->
-                                    FStar_ToSyntax_Env.push_bv env1 x
-                                 in
+                                    FStar_ToSyntax_Env.push_bv env1 x in
                               (match uu____5456 with
                                | (env2,x) ->
                                    let uu____5485 =
                                      let uu____5488 =
                                        let uu____5491 =
                                          let uu____5492 =
-                                           no_annot_abs tparams t1  in
+                                           no_annot_abs tparams t1 in
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
-                                           uu____5492
-                                          in
-                                       [uu____5491]  in
-                                     FStar_List.append typs uu____5488  in
+                                           uu____5492 in
+                                       [uu____5491] in
+                                     FStar_List.append typs uu____5488 in
                                    (env2,
                                      (FStar_List.append tparams
-                                        [(((let uu___126_5518 = x  in
+                                        [(((let uu___126_5518 = x in
                                             {
                                               FStar_Syntax_Syntax.ppname =
                                                 (uu___126_5518.FStar_Syntax_Syntax.ppname);
@@ -2381,60 +2202,55 @@ and (desugar_term_maybe_top :
                 (FStar_List.append binders
                    [FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName t)
                       t.FStar_Parser_AST.range FStar_Parser_AST.Type_level
-                      FStar_Pervasives_Native.None])
-               in
+                      FStar_Pervasives_Native.None]) in
             (match uu____5325 with
              | (env1,uu____5542,targs) ->
                  let uu____5564 =
                    let uu____5569 =
                      FStar_Parser_Const.mk_dtuple_lid
-                       (FStar_List.length targs) top.FStar_Parser_AST.range
-                      in
+                       (FStar_List.length targs) top.FStar_Parser_AST.range in
                    FStar_ToSyntax_Env.fail_or env1
-                     (FStar_ToSyntax_Env.try_lookup_lid env1) uu____5569
-                    in
+                     (FStar_ToSyntax_Env.try_lookup_lid env1) uu____5569 in
                  (match uu____5564 with
                   | (tup,uu____5575) ->
                       FStar_All.pipe_left mk1
                         (FStar_Syntax_Syntax.Tm_app (tup, targs))))
         | FStar_Parser_AST.Product (binders,t) ->
-            let uu____5586 = uncurry binders t  in
+            let uu____5586 = uncurry binders t in
             (match uu____5586 with
              | (bs,t1) ->
                  let rec aux env1 bs1 uu___92_5618 =
                    match uu___92_5618 with
                    | [] ->
                        let cod =
-                         desugar_comp top.FStar_Parser_AST.range env1 t1  in
+                         desugar_comp top.FStar_Parser_AST.range env1 t1 in
                        let uu____5632 =
-                         FStar_Syntax_Util.arrow (FStar_List.rev bs1) cod  in
+                         FStar_Syntax_Util.arrow (FStar_List.rev bs1) cod in
                        FStar_All.pipe_left setpos uu____5632
                    | hd1::tl1 ->
-                       let bb = desugar_binder env1 hd1  in
+                       let bb = desugar_binder env1 hd1 in
                        let uu____5654 =
-                         as_binder env1 hd1.FStar_Parser_AST.aqual bb  in
+                         as_binder env1 hd1.FStar_Parser_AST.aqual bb in
                        (match uu____5654 with
-                        | (b,env2) -> aux env2 (b :: bs1) tl1)
-                    in
+                        | (b,env2) -> aux env2 (b :: bs1) tl1) in
                  aux env [] bs)
         | FStar_Parser_AST.Refine (b,f) ->
-            let uu____5669 = desugar_binder env b  in
+            let uu____5669 = desugar_binder env b in
             (match uu____5669 with
              | (FStar_Pervasives_Native.None ,uu____5676) ->
                  failwith "Missing binder in refinement"
              | b1 ->
                  let uu____5686 =
-                   as_binder env FStar_Pervasives_Native.None b1  in
+                   as_binder env FStar_Pervasives_Native.None b1 in
                  (match uu____5686 with
                   | ((x,uu____5692),env1) ->
-                      let f1 = desugar_formula env1 f  in
-                      let uu____5699 = FStar_Syntax_Util.refine x f1  in
+                      let f1 = desugar_formula env1 f in
+                      let uu____5699 = FStar_Syntax_Util.refine x f1 in
                       FStar_All.pipe_left setpos uu____5699))
         | FStar_Parser_AST.Abs (binders,body) ->
             let binders1 =
               FStar_All.pipe_right binders
-                (FStar_List.map replace_unit_pattern)
-               in
+                (FStar_List.map replace_unit_pattern) in
             let uu____5719 =
               FStar_List.fold_left
                 (fun uu____5739  ->
@@ -2444,14 +2260,13 @@ and (desugar_term_maybe_top :
                          (match pat.FStar_Parser_AST.pat with
                           | FStar_Parser_AST.PatAscribed (uu____5765,t) ->
                               let uu____5767 =
-                                let uu____5770 = free_type_vars env1 t  in
-                                FStar_List.append uu____5770 ftvs  in
+                                let uu____5770 = free_type_vars env1 t in
+                                FStar_List.append uu____5770 ftvs in
                               (env1, uu____5767)
-                          | uu____5775 -> (env1, ftvs))) (env, []) binders1
-               in
+                          | uu____5775 -> (env1, ftvs))) (env, []) binders1 in
             (match uu____5719 with
              | (uu____5780,ftv) ->
-                 let ftv1 = sort_ftv ftv  in
+                 let ftv1 = sort_ftv ftv in
                  let binders2 =
                    let uu____5792 =
                      FStar_All.pipe_right ftv1
@@ -2462,37 +2277,35 @@ and (desugar_term_maybe_top :
                                   (a,
                                     (FStar_Pervasives_Native.Some
                                        FStar_Parser_AST.Implicit)))
-                               top.FStar_Parser_AST.range))
-                      in
-                   FStar_List.append uu____5792 binders1  in
+                               top.FStar_Parser_AST.range)) in
+                   FStar_List.append uu____5792 binders1 in
                  let rec aux env1 bs sc_pat_opt uu___93_5833 =
                    match uu___93_5833 with
                    | [] ->
-                       let body1 = desugar_term env1 body  in
+                       let body1 = desugar_term env1 body in
                        let body2 =
                          match sc_pat_opt with
                          | FStar_Pervasives_Native.Some (sc,pat) ->
                              let body2 =
                                let uu____5871 =
                                  let uu____5872 =
-                                   FStar_Syntax_Syntax.pat_bvs pat  in
+                                   FStar_Syntax_Syntax.pat_bvs pat in
                                  FStar_All.pipe_right uu____5872
                                    (FStar_List.map
-                                      FStar_Syntax_Syntax.mk_binder)
-                                  in
-                               FStar_Syntax_Subst.close uu____5871 body1  in
+                                      FStar_Syntax_Syntax.mk_binder) in
+                               FStar_Syntax_Subst.close uu____5871 body1 in
                              FStar_Syntax_Syntax.mk
                                (FStar_Syntax_Syntax.Tm_match
                                   (sc,
                                     [(pat, FStar_Pervasives_Native.None,
                                        body2)])) FStar_Pervasives_Native.None
                                body2.FStar_Syntax_Syntax.pos
-                         | FStar_Pervasives_Native.None  -> body1  in
+                         | FStar_Pervasives_Native.None  -> body1 in
                        let uu____5925 =
-                         no_annot_abs (FStar_List.rev bs) body2  in
+                         no_annot_abs (FStar_List.rev bs) body2 in
                        setpos uu____5925
                    | p::rest ->
-                       let uu____5936 = desugar_binding_pat env1 p  in
+                       let uu____5936 = desugar_binding_pat env1 p in
                        (match uu____5936 with
                         | (env2,b,pat) ->
                             let pat1 =
@@ -2503,8 +2316,7 @@ and (desugar_term_maybe_top :
                                   FStar_Errors.raise_error
                                     (FStar_Errors.Fatal_UnsupportedDisjuctivePatterns,
                                       "Disjunctive patterns are not supported in abstractions")
-                                    p.FStar_Parser_AST.prange
-                               in
+                                    p.FStar_Parser_AST.prange in
                             let uu____5965 =
                               match b with
                               | LetBinder uu____5998 -> failwith "Impossible"
@@ -2517,9 +2329,8 @@ and (desugar_term_maybe_top :
                                        p1,FStar_Pervasives_Native.None ) ->
                                         let uu____6084 =
                                           let uu____6089 =
-                                            FStar_Syntax_Syntax.bv_to_name x
-                                             in
-                                          (uu____6089, p1)  in
+                                            FStar_Syntax_Syntax.bv_to_name x in
+                                          (uu____6089, p1) in
                                         FStar_Pervasives_Native.Some
                                           uu____6084
                                     | (FStar_Pervasives_Native.Some
@@ -2534,14 +2345,12 @@ and (desugar_term_maybe_top :
                                                let uu____6128 =
                                                  FStar_Parser_Const.mk_tuple_data_lid
                                                    (Prims.parse_int "2")
-                                                   top.FStar_Parser_AST.range
-                                                  in
+                                                   top.FStar_Parser_AST.range in
                                                FStar_Syntax_Syntax.lid_as_fv
                                                  uu____6128
                                                  FStar_Syntax_Syntax.Delta_constant
                                                  (FStar_Pervasives_Native.Some
-                                                    FStar_Syntax_Syntax.Data_ctor)
-                                                in
+                                                    FStar_Syntax_Syntax.Data_ctor) in
                                              let sc1 =
                                                let uu____6132 =
                                                  let uu____6135 =
@@ -2549,52 +2358,41 @@ and (desugar_term_maybe_top :
                                                      let uu____6151 =
                                                        mk1
                                                          (FStar_Syntax_Syntax.Tm_fvar
-                                                            tup2)
-                                                        in
+                                                            tup2) in
                                                      let uu____6154 =
                                                        let uu____6157 =
                                                          FStar_Syntax_Syntax.as_arg
-                                                           sc
-                                                          in
+                                                           sc in
                                                        let uu____6158 =
                                                          let uu____6161 =
                                                            let uu____6162 =
                                                              FStar_Syntax_Syntax.bv_to_name
-                                                               x
-                                                              in
+                                                               x in
                                                            FStar_All.pipe_left
                                                              FStar_Syntax_Syntax.as_arg
-                                                             uu____6162
-                                                            in
-                                                         [uu____6161]  in
+                                                             uu____6162 in
+                                                         [uu____6161] in
                                                        uu____6157 ::
-                                                         uu____6158
-                                                        in
-                                                     (uu____6151, uu____6154)
-                                                      in
+                                                         uu____6158 in
+                                                     (uu____6151, uu____6154) in
                                                    FStar_Syntax_Syntax.Tm_app
-                                                     uu____6136
-                                                    in
+                                                     uu____6136 in
                                                  FStar_Syntax_Syntax.mk
-                                                   uu____6135
-                                                  in
+                                                   uu____6135 in
                                                uu____6132
                                                  FStar_Pervasives_Native.None
-                                                 top.FStar_Parser_AST.range
-                                                in
+                                                 top.FStar_Parser_AST.range in
                                              let p2 =
                                                let uu____6173 =
                                                  FStar_Range.union_ranges
                                                    p'.FStar_Syntax_Syntax.p
-                                                   p1.FStar_Syntax_Syntax.p
-                                                  in
+                                                   p1.FStar_Syntax_Syntax.p in
                                                FStar_Syntax_Syntax.withinfo
                                                  (FStar_Syntax_Syntax.Pat_cons
                                                     (tup2,
                                                       [(p', false);
                                                       (p1, false)]))
-                                                 uu____6173
-                                                in
+                                                 uu____6173 in
                                              FStar_Pervasives_Native.Some
                                                (sc1, p2)
                                          | (FStar_Syntax_Syntax.Tm_app
@@ -2605,123 +2403,101 @@ and (desugar_term_maybe_top :
                                                  FStar_Parser_Const.mk_tuple_data_lid
                                                    ((Prims.parse_int "1") +
                                                       (FStar_List.length args))
-                                                   top.FStar_Parser_AST.range
-                                                  in
+                                                   top.FStar_Parser_AST.range in
                                                FStar_Syntax_Syntax.lid_as_fv
                                                  uu____6245
                                                  FStar_Syntax_Syntax.Delta_constant
                                                  (FStar_Pervasives_Native.Some
-                                                    FStar_Syntax_Syntax.Data_ctor)
-                                                in
+                                                    FStar_Syntax_Syntax.Data_ctor) in
                                              let sc1 =
                                                let uu____6255 =
                                                  let uu____6256 =
                                                    let uu____6271 =
                                                      mk1
                                                        (FStar_Syntax_Syntax.Tm_fvar
-                                                          tupn)
-                                                      in
+                                                          tupn) in
                                                    let uu____6274 =
                                                      let uu____6283 =
                                                        let uu____6292 =
                                                          let uu____6293 =
                                                            FStar_Syntax_Syntax.bv_to_name
-                                                             x
-                                                            in
+                                                             x in
                                                          FStar_All.pipe_left
                                                            FStar_Syntax_Syntax.as_arg
-                                                           uu____6293
-                                                          in
-                                                       [uu____6292]  in
+                                                           uu____6293 in
+                                                       [uu____6292] in
                                                      FStar_List.append args
-                                                       uu____6283
-                                                      in
-                                                   (uu____6271, uu____6274)
-                                                    in
+                                                       uu____6283 in
+                                                   (uu____6271, uu____6274) in
                                                  FStar_Syntax_Syntax.Tm_app
-                                                   uu____6256
-                                                  in
-                                               mk1 uu____6255  in
+                                                   uu____6256 in
+                                               mk1 uu____6255 in
                                              let p2 =
                                                let uu____6313 =
                                                  FStar_Range.union_ranges
                                                    p'.FStar_Syntax_Syntax.p
-                                                   p1.FStar_Syntax_Syntax.p
-                                                  in
+                                                   p1.FStar_Syntax_Syntax.p in
                                                FStar_Syntax_Syntax.withinfo
                                                  (FStar_Syntax_Syntax.Pat_cons
                                                     (tupn,
                                                       (FStar_List.append pats
                                                          [(p1, false)])))
-                                                 uu____6313
-                                                in
+                                                 uu____6313 in
                                              FStar_Pervasives_Native.Some
                                                (sc1, p2)
                                          | uu____6348 ->
-                                             failwith "Impossible")
-                                     in
-                                  ((x, aq), sc_pat_opt1)
-                               in
+                                             failwith "Impossible") in
+                                  ((x, aq), sc_pat_opt1) in
                             (match uu____5965 with
                              | (b1,sc_pat_opt1) ->
-                                 aux env2 (b1 :: bs) sc_pat_opt1 rest))
-                    in
+                                 aux env2 (b1 :: bs) sc_pat_opt1 rest)) in
                  aux env [] FStar_Pervasives_Native.None binders2)
         | FStar_Parser_AST.App
             (uu____6415,uu____6416,FStar_Parser_AST.UnivApp ) ->
             let rec aux universes e =
               let uu____6430 =
-                let uu____6431 = unparen e  in uu____6431.FStar_Parser_AST.tm
-                 in
+                let uu____6431 = unparen e in uu____6431.FStar_Parser_AST.tm in
               match uu____6430 with
               | FStar_Parser_AST.App (e1,t,FStar_Parser_AST.UnivApp ) ->
-                  let univ_arg = desugar_universe t  in
+                  let univ_arg = desugar_universe t in
                   aux (univ_arg :: universes) e1
               | uu____6437 ->
-                  let head1 = desugar_term env e  in
-                  mk1 (FStar_Syntax_Syntax.Tm_uinst (head1, universes))
-               in
+                  let head1 = desugar_term env e in
+                  mk1 (FStar_Syntax_Syntax.Tm_uinst (head1, universes)) in
             aux [] top
         | FStar_Parser_AST.App uu____6441 ->
             let rec aux args e =
               let uu____6473 =
-                let uu____6474 = unparen e  in uu____6474.FStar_Parser_AST.tm
-                 in
+                let uu____6474 = unparen e in uu____6474.FStar_Parser_AST.tm in
               match uu____6473 with
               | FStar_Parser_AST.App (e1,t,imp) when
                   imp <> FStar_Parser_AST.UnivApp ->
                   let arg =
-                    let uu____6487 = desugar_term env t  in
-                    FStar_All.pipe_left (arg_withimp_e imp) uu____6487  in
+                    let uu____6487 = desugar_term env t in
+                    FStar_All.pipe_left (arg_withimp_e imp) uu____6487 in
                   aux (arg :: args) e1
               | uu____6500 ->
-                  let head1 = desugar_term env e  in
-                  mk1 (FStar_Syntax_Syntax.Tm_app (head1, args))
-               in
+                  let head1 = desugar_term env e in
+                  mk1 (FStar_Syntax_Syntax.Tm_app (head1, args)) in
             aux [] top
         | FStar_Parser_AST.Bind (x,t1,t2) ->
             let tac_bind_lid =
               FStar_Ident.lid_of_path ["FStar"; "Tactics"; "Effect"; "bind"]
-                x.FStar_Ident.idRange
-               in
+                x.FStar_Ident.idRange in
             let xpat =
               FStar_Parser_AST.mk_pattern
                 (FStar_Parser_AST.PatVar (x, FStar_Pervasives_Native.None))
-                x.FStar_Ident.idRange
-               in
+                x.FStar_Ident.idRange in
             let k =
               FStar_Parser_AST.mk_term (FStar_Parser_AST.Abs ([xpat], t2))
-                t2.FStar_Parser_AST.range t2.FStar_Parser_AST.level
-               in
+                t2.FStar_Parser_AST.range t2.FStar_Parser_AST.level in
             let bind_lid =
-              FStar_Ident.lid_of_path ["bind"] x.FStar_Ident.idRange  in
+              FStar_Ident.lid_of_path ["bind"] x.FStar_Ident.idRange in
             let bind1 =
               FStar_Parser_AST.mk_term (FStar_Parser_AST.Var bind_lid)
-                x.FStar_Ident.idRange FStar_Parser_AST.Expr
-               in
+                x.FStar_Ident.idRange FStar_Parser_AST.Expr in
             let uu____6528 =
-              FStar_ToSyntax_Env.resolve_to_fully_qualified_name env bind_lid
-               in
+              FStar_ToSyntax_Env.resolve_to_fully_qualified_name env bind_lid in
             (match uu____6528 with
              | FStar_Pervasives_Native.Some flid when
                  FStar_Ident.lid_equals flid tac_bind_lid ->
@@ -2729,18 +2505,15 @@ and (desugar_term_maybe_top :
                    FStar_Parser_AST.mk_term
                      (FStar_Parser_AST.Const
                         (FStar_Const.Const_range (t2.FStar_Parser_AST.range)))
-                     t2.FStar_Parser_AST.range FStar_Parser_AST.Expr
-                    in
+                     t2.FStar_Parser_AST.range FStar_Parser_AST.Expr in
                  let uu____6533 =
                    FStar_Parser_AST.mkExplicitApp bind1 [r; t1; k]
-                     top.FStar_Parser_AST.range
-                    in
+                     top.FStar_Parser_AST.range in
                  desugar_term env uu____6533
              | uu____6534 ->
                  let uu____6537 =
                    FStar_Parser_AST.mkExplicitApp bind1 [t1; k]
-                     top.FStar_Parser_AST.range
-                    in
+                     top.FStar_Parser_AST.range in
                  desugar_term env uu____6537)
         | FStar_Parser_AST.Seq (t1,t2) ->
             let uu____6540 =
@@ -2754,42 +2527,39 @@ and (desugar_term_maybe_top :
                                ((FStar_Parser_AST.mk_pattern
                                    FStar_Parser_AST.PatWild
                                    t1.FStar_Parser_AST.range), t1))], t2))
-                       top.FStar_Parser_AST.range FStar_Parser_AST.Expr)
-                   in
+                       top.FStar_Parser_AST.range FStar_Parser_AST.Expr) in
                 (uu____6548,
                   (FStar_Syntax_Syntax.Meta_desugared
-                     FStar_Syntax_Syntax.Sequence))
-                 in
-              FStar_Syntax_Syntax.Tm_meta uu____6541  in
+                     FStar_Syntax_Syntax.Sequence)) in
+              FStar_Syntax_Syntax.Tm_meta uu____6541 in
             mk1 uu____6540
         | FStar_Parser_AST.LetOpen (lid,e) ->
-            let env1 = FStar_ToSyntax_Env.push_namespace env lid  in
+            let env1 = FStar_ToSyntax_Env.push_namespace env lid in
             let uu____6600 =
-              let uu____6605 = FStar_ToSyntax_Env.expect_typ env1  in
-              if uu____6605 then desugar_typ else desugar_term  in
+              let uu____6605 = FStar_ToSyntax_Env.expect_typ env1 in
+              if uu____6605 then desugar_typ else desugar_term in
             uu____6600 env1 e
         | FStar_Parser_AST.Let (qual,lbs,body) ->
-            let is_rec = qual = FStar_Parser_AST.Rec  in
+            let is_rec = qual = FStar_Parser_AST.Rec in
             let ds_let_rec_or_app uu____6648 =
-              let bindings = lbs  in
+              let bindings = lbs in
               let funs =
                 FStar_All.pipe_right bindings
                   (FStar_List.map
                      (fun uu____6773  ->
                         match uu____6773 with
                         | (attr_opt,(p,def)) ->
-                            let uu____6825 = is_app_pattern p  in
+                            let uu____6825 = is_app_pattern p in
                             if uu____6825
                             then
                               let uu____6850 =
-                                destruct_app_pattern env top_level p  in
+                                destruct_app_pattern env top_level p in
                               (attr_opt, uu____6850, def)
                             else
                               (match FStar_Parser_AST.un_function p def with
                                | FStar_Pervasives_Native.Some (p1,def1) ->
                                    let uu____6914 =
-                                     destruct_app_pattern env top_level p1
-                                      in
+                                     destruct_app_pattern env top_level p1 in
                                    (attr_opt, uu____6914, def1)
                                | uu____6947 ->
                                    (match p.FStar_Parser_AST.pat with
@@ -2807,12 +2577,10 @@ and (desugar_term_maybe_top :
                                             let uu____7025 =
                                               let uu____7030 =
                                                 FStar_ToSyntax_Env.qualify
-                                                  env id1
-                                                 in
-                                              FStar_Util.Inr uu____7030  in
+                                                  env id1 in
+                                              FStar_Util.Inr uu____7030 in
                                             (uu____7025, [],
-                                              (FStar_Pervasives_Native.Some t))
-                                             in
+                                              (FStar_Pervasives_Native.Some t)) in
                                           (attr_opt, uu____7010, def)
                                         else
                                           (attr_opt,
@@ -2827,12 +2595,10 @@ and (desugar_term_maybe_top :
                                             let uu____7129 =
                                               let uu____7134 =
                                                 FStar_ToSyntax_Env.qualify
-                                                  env id1
-                                                 in
-                                              FStar_Util.Inr uu____7134  in
+                                                  env id1 in
+                                              FStar_Util.Inr uu____7134 in
                                             (uu____7129, [],
-                                              FStar_Pervasives_Native.None)
-                                             in
+                                              FStar_Pervasives_Native.None) in
                                           (attr_opt, uu____7114, def)
                                         else
                                           (attr_opt,
@@ -2843,8 +2609,7 @@ and (desugar_term_maybe_top :
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_UnexpectedLetBinding,
                                             "Unexpected let binding")
-                                          p.FStar_Parser_AST.prange))))
-                 in
+                                          p.FStar_Parser_AST.prange)))) in
               let uu____7213 =
                 FStar_List.fold_left
                   (fun uu____7280  ->
@@ -2856,46 +2621,41 @@ and (desugar_term_maybe_top :
                              match f with
                              | FStar_Util.Inl x ->
                                  let uu____7498 =
-                                   FStar_ToSyntax_Env.push_bv env1 x  in
+                                   FStar_ToSyntax_Env.push_bv env1 x in
                                  (match uu____7498 with
                                   | (env2,xx) ->
                                       let uu____7517 =
                                         let uu____7520 =
-                                          FStar_Syntax_Syntax.mk_binder xx
-                                           in
-                                        uu____7520 :: rec_bindings  in
+                                          FStar_Syntax_Syntax.mk_binder xx in
+                                        uu____7520 :: rec_bindings in
                                       (env2, (FStar_Util.Inl xx), uu____7517))
                              | FStar_Util.Inr l ->
                                  let uu____7528 =
                                    FStar_ToSyntax_Env.push_top_level_rec_binding
                                      env1 l.FStar_Ident.ident
-                                     FStar_Syntax_Syntax.Delta_equational
-                                    in
+                                     FStar_Syntax_Syntax.Delta_equational in
                                  (uu____7528, (FStar_Util.Inr l),
-                                   rec_bindings)
-                              in
+                                   rec_bindings) in
                            (match uu____7472 with
                             | (env2,lbname,rec_bindings1) ->
                                 (env2, (lbname :: fnames), rec_bindings1)))
-                  (env, [], []) funs
-                 in
+                  (env, [], []) funs in
               match uu____7213 with
               | (env',fnames,rec_bindings) ->
-                  let fnames1 = FStar_List.rev fnames  in
-                  let rec_bindings1 = FStar_List.rev rec_bindings  in
+                  let fnames1 = FStar_List.rev fnames in
+                  let rec_bindings1 = FStar_List.rev rec_bindings in
                   let desugar_one_def env1 lbname uu____7660 =
                     match uu____7660 with
                     | (attrs_opt,(uu____7690,args,result_t),def) ->
                         let args1 =
                           FStar_All.pipe_right args
-                            (FStar_List.map replace_unit_pattern)
-                           in
+                            (FStar_List.map replace_unit_pattern) in
                         let def1 =
                           match result_t with
                           | FStar_Pervasives_Native.None  -> def
                           | FStar_Pervasives_Native.Some t ->
                               let t1 =
-                                let uu____7742 = is_comp_type env1 t  in
+                                let uu____7742 = is_comp_type env1 t in
                                 if uu____7742
                                 then
                                   ((let uu____7744 =
@@ -2903,9 +2663,8 @@ and (desugar_term_maybe_top :
                                         (FStar_List.tryFind
                                            (fun x  ->
                                               let uu____7754 =
-                                                is_var_pattern x  in
-                                              Prims.op_Negation uu____7754))
-                                       in
+                                                is_var_pattern x in
+                                              Prims.op_Negation uu____7754)) in
                                     match uu____7744 with
                                     | FStar_Pervasives_Native.None  -> ()
                                     | FStar_Pervasives_Native.Some p ->
@@ -2920,28 +2679,23 @@ and (desugar_term_maybe_top :
                                         (let uu____7759 =
                                            FStar_ToSyntax_Env.try_lookup_effect_name
                                              env1
-                                             FStar_Parser_Const.effect_ML_lid
-                                            in
+                                             FStar_Parser_Const.effect_ML_lid in
                                          FStar_Option.isSome uu____7759))
                                        &&
                                        ((Prims.op_Negation is_rec) ||
                                           ((FStar_List.length args1) <>
-                                             (Prims.parse_int "0")))
-                                      in
+                                             (Prims.parse_int "0"))) in
                                    if uu____7757
                                    then FStar_Parser_AST.ml_comp t
-                                   else FStar_Parser_AST.tot_comp t)
-                                 in
+                                   else FStar_Parser_AST.tot_comp t) in
                               let uu____7763 =
                                 FStar_Range.union_ranges
                                   t1.FStar_Parser_AST.range
-                                  def.FStar_Parser_AST.range
-                                 in
+                                  def.FStar_Parser_AST.range in
                               FStar_Parser_AST.mk_term
                                 (FStar_Parser_AST.Ascribed
                                    (def, t1, FStar_Pervasives_Native.None))
-                                uu____7763 FStar_Parser_AST.Expr
-                           in
+                                uu____7763 FStar_Parser_AST.Expr in
                         let def2 =
                           match args1 with
                           | [] -> def1
@@ -2949,9 +2703,8 @@ and (desugar_term_maybe_top :
                               FStar_Parser_AST.mk_term
                                 (FStar_Parser_AST.un_curry_abs args1 def1)
                                 top.FStar_Parser_AST.range
-                                top.FStar_Parser_AST.level
-                           in
-                        let body1 = desugar_term env1 def2  in
+                                top.FStar_Parser_AST.level in
+                        let body1 = desugar_term env1 def2 in
                         let lbname1 =
                           match lbname with
                           | FStar_Util.Inl x -> FStar_Util.Inl x
@@ -2959,72 +2712,62 @@ and (desugar_term_maybe_top :
                               let uu____7782 =
                                 let uu____7783 =
                                   FStar_Syntax_Util.incr_delta_qualifier
-                                    body1
-                                   in
+                                    body1 in
                                 FStar_Syntax_Syntax.lid_as_fv l uu____7783
-                                  FStar_Pervasives_Native.None
-                                 in
-                              FStar_Util.Inr uu____7782
-                           in
+                                  FStar_Pervasives_Native.None in
+                              FStar_Util.Inr uu____7782 in
                         let body2 =
                           if is_rec
                           then FStar_Syntax_Subst.close rec_bindings1 body1
-                          else body1  in
+                          else body1 in
                         let attrs =
                           match attrs_opt with
                           | FStar_Pervasives_Native.None  -> []
                           | FStar_Pervasives_Native.Some l ->
-                              FStar_List.map (desugar_term env1) l
-                           in
+                              FStar_List.map (desugar_term env1) l in
                         mk_lb
-                          (attrs, lbname1, FStar_Syntax_Syntax.tun, body2)
-                     in
+                          (attrs, lbname1, FStar_Syntax_Syntax.tun, body2) in
                   let lbs1 =
                     FStar_List.map2
                       (desugar_one_def (if is_rec then env' else env))
-                      fnames1 funs
-                     in
-                  let body1 = desugar_term env' body  in
+                      fnames1 funs in
+                  let body1 = desugar_term env' body in
                   let uu____7837 =
                     let uu____7838 =
                       let uu____7851 =
-                        FStar_Syntax_Subst.close rec_bindings1 body1  in
-                      ((is_rec, lbs1), uu____7851)  in
-                    FStar_Syntax_Syntax.Tm_let uu____7838  in
-                  FStar_All.pipe_left mk1 uu____7837
-               in
+                        FStar_Syntax_Subst.close rec_bindings1 body1 in
+                      ((is_rec, lbs1), uu____7851) in
+                    FStar_Syntax_Syntax.Tm_let uu____7838 in
+                  FStar_All.pipe_left mk1 uu____7837 in
             let ds_non_rec attrs_opt pat t1 t2 =
               let attrs =
                 match attrs_opt with
                 | FStar_Pervasives_Native.None  -> []
                 | FStar_Pervasives_Native.Some l ->
-                    FStar_List.map (desugar_term env) l
-                 in
-              let t11 = desugar_term env t1  in
-              let is_mutable = qual = FStar_Parser_AST.Mutable  in
-              let t12 = if is_mutable then mk_ref_alloc t11 else t11  in
+                    FStar_List.map (desugar_term env) l in
+              let t11 = desugar_term env t1 in
+              let is_mutable = qual = FStar_Parser_AST.Mutable in
+              let t12 = if is_mutable then mk_ref_alloc t11 else t11 in
               let uu____7905 =
-                desugar_binding_pat_maybe_top top_level env pat is_mutable
-                 in
+                desugar_binding_pat_maybe_top top_level env pat is_mutable in
               match uu____7905 with
               | (env1,binder,pat1) ->
                   let tm =
                     match binder with
                     | LetBinder (l,t) ->
-                        let body1 = desugar_term env1 t2  in
+                        let body1 = desugar_term env1 t2 in
                         let fv =
                           let uu____7932 =
-                            FStar_Syntax_Util.incr_delta_qualifier t12  in
+                            FStar_Syntax_Util.incr_delta_qualifier t12 in
                           FStar_Syntax_Syntax.lid_as_fv l uu____7932
-                            FStar_Pervasives_Native.None
-                           in
+                            FStar_Pervasives_Native.None in
                         FStar_All.pipe_left mk1
                           (FStar_Syntax_Syntax.Tm_let
                              ((false,
                                 [mk_lb (attrs, (FStar_Util.Inr fv), t, t12)]),
                                body1))
                     | LocalBinder (x,uu____7952) ->
-                        let body1 = desugar_term env1 t2  in
+                        let body1 = desugar_term env1 t2 in
                         let body2 =
                           match pat1 with
                           | [] -> body1
@@ -3038,34 +2781,30 @@ and (desugar_term_maybe_top :
                                 let uu____7967 =
                                   let uu____7968 =
                                     let uu____7991 =
-                                      FStar_Syntax_Syntax.bv_to_name x  in
+                                      FStar_Syntax_Syntax.bv_to_name x in
                                     let uu____7992 =
                                       desugar_disjunctive_pattern pat1
-                                        FStar_Pervasives_Native.None body1
-                                       in
-                                    (uu____7991, uu____7992)  in
-                                  FStar_Syntax_Syntax.Tm_match uu____7968  in
-                                FStar_Syntax_Syntax.mk uu____7967  in
+                                        FStar_Pervasives_Native.None body1 in
+                                    (uu____7991, uu____7992) in
+                                  FStar_Syntax_Syntax.Tm_match uu____7968 in
+                                FStar_Syntax_Syntax.mk uu____7967 in
                               uu____7964 FStar_Pervasives_Native.None
-                                top.FStar_Parser_AST.range
-                           in
+                                top.FStar_Parser_AST.range in
                         let uu____8002 =
                           let uu____8003 =
                             let uu____8016 =
                               let uu____8017 =
                                 let uu____8018 =
-                                  FStar_Syntax_Syntax.mk_binder x  in
-                                [uu____8018]  in
-                              FStar_Syntax_Subst.close uu____8017 body2  in
+                                  FStar_Syntax_Syntax.mk_binder x in
+                                [uu____8018] in
+                              FStar_Syntax_Subst.close uu____8017 body2 in
                             ((false,
                                [mk_lb
                                   (attrs, (FStar_Util.Inl x),
                                     (x.FStar_Syntax_Syntax.sort), t12)]),
-                              uu____8016)
-                             in
-                          FStar_Syntax_Syntax.Tm_let uu____8003  in
-                        FStar_All.pipe_left mk1 uu____8002
-                     in
+                              uu____8016) in
+                          FStar_Syntax_Syntax.Tm_let uu____8003 in
+                        FStar_All.pipe_left mk1 uu____8002 in
                   if is_mutable
                   then
                     FStar_All.pipe_left mk1
@@ -3073,12 +2812,11 @@ and (desugar_term_maybe_top :
                          (tm,
                            (FStar_Syntax_Syntax.Meta_desugared
                               FStar_Syntax_Syntax.Mutable_alloc)))
-                  else tm
-               in
-            let uu____8046 = FStar_List.hd lbs  in
+                  else tm in
+            let uu____8046 = FStar_List.hd lbs in
             (match uu____8046 with
              | (attrs,(head_pat,defn)) ->
-                 let uu____8086 = is_rec || (is_app_pattern head_pat)  in
+                 let uu____8086 = is_rec || (is_app_pattern head_pat) in
                  if uu____8086
                  then ds_let_rec_or_app ()
                  else ds_non_rec attrs head_pat defn body)
@@ -3086,78 +2824,68 @@ and (desugar_term_maybe_top :
             let x =
               FStar_Syntax_Syntax.new_bv
                 (FStar_Pervasives_Native.Some (t3.FStar_Parser_AST.range))
-                FStar_Syntax_Syntax.tun
-               in
+                FStar_Syntax_Syntax.tun in
             let t_bool1 =
               let uu____8095 =
                 let uu____8096 =
                   FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.bool_lid
                     FStar_Syntax_Syntax.Delta_constant
-                    FStar_Pervasives_Native.None
-                   in
-                FStar_Syntax_Syntax.Tm_fvar uu____8096  in
-              mk1 uu____8095  in
+                    FStar_Pervasives_Native.None in
+                FStar_Syntax_Syntax.Tm_fvar uu____8096 in
+              mk1 uu____8095 in
             let uu____8097 =
               let uu____8098 =
                 let uu____8121 =
-                  let uu____8124 = desugar_term env t1  in
+                  let uu____8124 = desugar_term env t1 in
                   FStar_Syntax_Util.ascribe uu____8124
-                    ((FStar_Util.Inl t_bool1), FStar_Pervasives_Native.None)
-                   in
+                    ((FStar_Util.Inl t_bool1), FStar_Pervasives_Native.None) in
                 let uu____8145 =
                   let uu____8160 =
                     let uu____8173 =
                       FStar_Syntax_Syntax.withinfo
                         (FStar_Syntax_Syntax.Pat_constant
                            (FStar_Const.Const_bool true))
-                        t2.FStar_Parser_AST.range
-                       in
-                    let uu____8176 = desugar_term env t2  in
-                    (uu____8173, FStar_Pervasives_Native.None, uu____8176)
-                     in
+                        t2.FStar_Parser_AST.range in
+                    let uu____8176 = desugar_term env t2 in
+                    (uu____8173, FStar_Pervasives_Native.None, uu____8176) in
                   let uu____8185 =
                     let uu____8200 =
                       let uu____8213 =
                         FStar_Syntax_Syntax.withinfo
                           (FStar_Syntax_Syntax.Pat_wild x)
-                          t3.FStar_Parser_AST.range
-                         in
-                      let uu____8216 = desugar_term env t3  in
-                      (uu____8213, FStar_Pervasives_Native.None, uu____8216)
-                       in
-                    [uu____8200]  in
-                  uu____8160 :: uu____8185  in
-                (uu____8121, uu____8145)  in
-              FStar_Syntax_Syntax.Tm_match uu____8098  in
+                          t3.FStar_Parser_AST.range in
+                      let uu____8216 = desugar_term env t3 in
+                      (uu____8213, FStar_Pervasives_Native.None, uu____8216) in
+                    [uu____8200] in
+                  uu____8160 :: uu____8185 in
+                (uu____8121, uu____8145) in
+              FStar_Syntax_Syntax.Tm_match uu____8098 in
             mk1 uu____8097
         | FStar_Parser_AST.TryWith (e,branches) ->
-            let r = top.FStar_Parser_AST.range  in
-            let handler = FStar_Parser_AST.mk_function branches r r  in
+            let r = top.FStar_Parser_AST.range in
+            let handler = FStar_Parser_AST.mk_function branches r r in
             let body =
               FStar_Parser_AST.mk_function
                 [((FStar_Parser_AST.mk_pattern
                      (FStar_Parser_AST.PatConst FStar_Const.Const_unit) r),
-                   FStar_Pervasives_Native.None, e)] r r
-               in
+                   FStar_Pervasives_Native.None, e)] r r in
             let a1 =
               FStar_Parser_AST.mk_term
                 (FStar_Parser_AST.App
                    ((FStar_Parser_AST.mk_term
                        (FStar_Parser_AST.Var FStar_Parser_Const.try_with_lid)
                        r top.FStar_Parser_AST.level), body,
-                     FStar_Parser_AST.Nothing)) r top.FStar_Parser_AST.level
-               in
+                     FStar_Parser_AST.Nothing)) r top.FStar_Parser_AST.level in
             let a2 =
               FStar_Parser_AST.mk_term
                 (FStar_Parser_AST.App (a1, handler, FStar_Parser_AST.Nothing))
-                r top.FStar_Parser_AST.level
-               in
+                r top.FStar_Parser_AST.level in
             desugar_term env a2
         | FStar_Parser_AST.Match (e,branches) ->
             let desugar_branch uu____8357 =
               match uu____8357 with
               | (pat,wopt,b) ->
-                  let uu____8375 = desugar_match_pat env pat  in
+                  let uu____8375 = desugar_match_pat env pat in
                   (match uu____8375 with
                    | (env1,pat1) ->
                        let wopt1 =
@@ -3165,50 +2893,43 @@ and (desugar_term_maybe_top :
                          | FStar_Pervasives_Native.None  ->
                              FStar_Pervasives_Native.None
                          | FStar_Pervasives_Native.Some e1 ->
-                             let uu____8396 = desugar_term env1 e1  in
-                             FStar_Pervasives_Native.Some uu____8396
-                          in
-                       let b1 = desugar_term env1 b  in
-                       desugar_disjunctive_pattern pat1 wopt1 b1)
-               in
+                             let uu____8396 = desugar_term env1 e1 in
+                             FStar_Pervasives_Native.Some uu____8396 in
+                       let b1 = desugar_term env1 b in
+                       desugar_disjunctive_pattern pat1 wopt1 b1) in
             let uu____8398 =
               let uu____8399 =
-                let uu____8422 = desugar_term env e  in
-                let uu____8423 = FStar_List.collect desugar_branch branches
-                   in
-                (uu____8422, uu____8423)  in
-              FStar_Syntax_Syntax.Tm_match uu____8399  in
+                let uu____8422 = desugar_term env e in
+                let uu____8423 = FStar_List.collect desugar_branch branches in
+                (uu____8422, uu____8423) in
+              FStar_Syntax_Syntax.Tm_match uu____8399 in
             FStar_All.pipe_left mk1 uu____8398
         | FStar_Parser_AST.Ascribed (e,t,tac_opt) ->
             let annot =
-              let uu____8452 = is_comp_type env t  in
+              let uu____8452 = is_comp_type env t in
               if uu____8452
               then
-                let uu____8459 = desugar_comp t.FStar_Parser_AST.range env t
-                   in
+                let uu____8459 = desugar_comp t.FStar_Parser_AST.range env t in
                 FStar_Util.Inr uu____8459
               else
-                (let uu____8465 = desugar_term env t  in
-                 FStar_Util.Inl uu____8465)
-               in
-            let tac_opt1 = FStar_Util.map_opt tac_opt (desugar_term env)  in
+                (let uu____8465 = desugar_term env t in
+                 FStar_Util.Inl uu____8465) in
+            let tac_opt1 = FStar_Util.map_opt tac_opt (desugar_term env) in
             let uu____8471 =
               let uu____8472 =
-                let uu____8499 = desugar_term env e  in
-                (uu____8499, (annot, tac_opt1), FStar_Pervasives_Native.None)
-                 in
-              FStar_Syntax_Syntax.Tm_ascribed uu____8472  in
+                let uu____8499 = desugar_term env e in
+                (uu____8499, (annot, tac_opt1), FStar_Pervasives_Native.None) in
+              FStar_Syntax_Syntax.Tm_ascribed uu____8472 in
             FStar_All.pipe_left mk1 uu____8471
         | FStar_Parser_AST.Record (uu____8524,[]) ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnexpectedEmptyRecord,
                 "Unexpected empty record") top.FStar_Parser_AST.range
         | FStar_Parser_AST.Record (eopt,fields) ->
-            let record = check_fields env fields top.FStar_Parser_AST.range
-               in
+            let record = check_fields env fields top.FStar_Parser_AST.range in
             let user_ns =
-              let uu____8561 = FStar_List.hd fields  in
-              match uu____8561 with | (f,uu____8573) -> f.FStar_Ident.ns  in
+              let uu____8561 = FStar_List.hd fields in
+              match uu____8561 with | (f,uu____8573) -> f.FStar_Ident.ns in
             let get_field xopt f =
               let found =
                 FStar_All.pipe_right fields
@@ -3217,10 +2938,8 @@ and (desugar_term_maybe_top :
                         match uu____8615 with
                         | (g,uu____8621) ->
                             f.FStar_Ident.idText =
-                              (g.FStar_Ident.ident).FStar_Ident.idText))
-                 in
-              let fn = FStar_Ident.lid_of_ids (FStar_List.append user_ns [f])
-                 in
+                              (g.FStar_Ident.ident).FStar_Ident.idText)) in
+              let fn = FStar_Ident.lid_of_ids (FStar_List.append user_ns [f]) in
               match found with
               | FStar_Pervasives_Native.Some (uu____8627,e) -> (fn, e)
               | FStar_Pervasives_Native.None  ->
@@ -3231,24 +2950,20 @@ and (desugar_term_maybe_top :
                            FStar_Util.format2
                              "Field %s of record type %s is missing"
                              f.FStar_Ident.idText
-                             (record.FStar_ToSyntax_Env.typename).FStar_Ident.str
-                            in
+                             (record.FStar_ToSyntax_Env.typename).FStar_Ident.str in
                          (FStar_Errors.Fatal_MissingFieldInRecord,
-                           uu____8646)
-                          in
+                           uu____8646) in
                        FStar_Errors.raise_error uu____8641
                          top.FStar_Parser_AST.range
                    | FStar_Pervasives_Native.Some x ->
                        (fn,
                          (FStar_Parser_AST.mk_term
                             (FStar_Parser_AST.Project (x, fn))
-                            x.FStar_Parser_AST.range x.FStar_Parser_AST.level)))
-               in
+                            x.FStar_Parser_AST.range x.FStar_Parser_AST.level))) in
             let user_constrname =
               FStar_Ident.lid_of_ids
                 (FStar_List.append user_ns
-                   [record.FStar_ToSyntax_Env.constrname])
-               in
+                   [record.FStar_ToSyntax_Env.constrname]) in
             let recterm =
               match eopt with
               | FStar_Pervasives_Native.None  ->
@@ -3262,24 +2977,20 @@ and (desugar_term_maybe_top :
                                   let uu____8707 =
                                     let uu____8708 =
                                       get_field FStar_Pervasives_Native.None
-                                        f
-                                       in
+                                        f in
                                     FStar_All.pipe_left
-                                      FStar_Pervasives_Native.snd uu____8708
-                                     in
-                                  (uu____8707, FStar_Parser_AST.Nothing)))
-                       in
-                    (user_constrname, uu____8665)  in
+                                      FStar_Pervasives_Native.snd uu____8708 in
+                                  (uu____8707, FStar_Parser_AST.Nothing))) in
+                    (user_constrname, uu____8665) in
                   FStar_Parser_AST.Construct uu____8654
               | FStar_Pervasives_Native.Some e ->
-                  let x = FStar_Ident.gen e.FStar_Parser_AST.range  in
+                  let x = FStar_Ident.gen e.FStar_Parser_AST.range in
                   let xterm =
                     let uu____8726 =
-                      let uu____8727 = FStar_Ident.lid_of_ids [x]  in
-                      FStar_Parser_AST.Var uu____8727  in
+                      let uu____8727 = FStar_Ident.lid_of_ids [x] in
+                      FStar_Parser_AST.Var uu____8727 in
                     FStar_Parser_AST.mk_term uu____8726 x.FStar_Ident.idRange
-                      FStar_Parser_AST.Expr
-                     in
+                      FStar_Parser_AST.Expr in
                   let record1 =
                     let uu____8729 =
                       let uu____8742 =
@@ -3289,10 +3000,9 @@ and (desugar_term_maybe_top :
                                 match uu____8772 with
                                 | (f,uu____8782) ->
                                     get_field
-                                      (FStar_Pervasives_Native.Some xterm) f))
-                         in
-                      (FStar_Pervasives_Native.None, uu____8742)  in
-                    FStar_Parser_AST.Record uu____8729  in
+                                      (FStar_Pervasives_Native.Some xterm) f)) in
+                      (FStar_Pervasives_Native.None, uu____8742) in
+                    FStar_Parser_AST.Record uu____8729 in
                   FStar_Parser_AST.Let
                     (FStar_Parser_AST.NoLetQualifier,
                       [(FStar_Pervasives_Native.None,
@@ -3302,13 +3012,11 @@ and (desugar_term_maybe_top :
                              x.FStar_Ident.idRange), e))],
                       (FStar_Parser_AST.mk_term record1
                          top.FStar_Parser_AST.range
-                         top.FStar_Parser_AST.level))
-               in
+                         top.FStar_Parser_AST.level)) in
             let recterm1 =
               FStar_Parser_AST.mk_term recterm top.FStar_Parser_AST.range
-                top.FStar_Parser_AST.level
-               in
-            let e = desugar_term env recterm1  in
+                top.FStar_Parser_AST.level in
+            let e = desugar_term env recterm1 in
             (match e.FStar_Syntax_Syntax.n with
              | FStar_Syntax_Syntax.Tm_meta
                  ({
@@ -3333,22 +3041,19 @@ and (desugar_term_maybe_top :
                                  FStar_All.pipe_right
                                    record.FStar_ToSyntax_Env.fields
                                    (FStar_List.map
-                                      FStar_Pervasives_Native.fst)
-                                  in
+                                      FStar_Pervasives_Native.fst) in
                                ((record.FStar_ToSyntax_Env.typename),
-                                 uu____8904)
-                                in
-                             FStar_Syntax_Syntax.Record_ctor uu____8897  in
-                           FStar_Pervasives_Native.Some uu____8896  in
+                                 uu____8904) in
+                             FStar_Syntax_Syntax.Record_ctor uu____8897 in
+                           FStar_Pervasives_Native.Some uu____8896 in
                          FStar_Syntax_Syntax.fvar
                            (FStar_Ident.set_lid_range
                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                               e.FStar_Syntax_Syntax.pos)
-                           FStar_Syntax_Syntax.Delta_constant uu____8893
-                          in
-                       (uu____8892, args)  in
-                     FStar_Syntax_Syntax.Tm_app uu____8877  in
-                   FStar_All.pipe_left mk1 uu____8876  in
+                           FStar_Syntax_Syntax.Delta_constant uu____8893 in
+                       (uu____8892, args) in
+                     FStar_Syntax_Syntax.Tm_app uu____8877 in
+                   FStar_All.pipe_left mk1 uu____8876 in
                  FStar_All.pipe_left mk1
                    (FStar_Syntax_Syntax.Tm_meta
                       (e1,
@@ -3359,35 +3064,32 @@ and (desugar_term_maybe_top :
             (FStar_ToSyntax_Env.fail_if_qualified_by_curmodule env f;
              (let uu____8939 =
                 FStar_ToSyntax_Env.fail_or env
-                  (FStar_ToSyntax_Env.try_lookup_dc_by_field_name env) f
-                 in
+                  (FStar_ToSyntax_Env.try_lookup_dc_by_field_name env) f in
               match uu____8939 with
               | (constrname,is_rec) ->
-                  let e1 = desugar_term env e  in
+                  let e1 = desugar_term env e in
                   let projname =
                     FStar_Syntax_Util.mk_field_projector_name_from_ident
-                      constrname f.FStar_Ident.ident
-                     in
+                      constrname f.FStar_Ident.ident in
                   let qual =
                     if is_rec
                     then
                       FStar_Pervasives_Native.Some
                         (FStar_Syntax_Syntax.Record_projector
                            (constrname, (f.FStar_Ident.ident)))
-                    else FStar_Pervasives_Native.None  in
+                    else FStar_Pervasives_Native.None in
                   let uu____8958 =
                     let uu____8959 =
                       let uu____8974 =
                         FStar_Syntax_Syntax.fvar
                           (FStar_Ident.set_lid_range projname
                              (FStar_Ident.range_of_lid f))
-                          FStar_Syntax_Syntax.Delta_equational qual
-                         in
+                          FStar_Syntax_Syntax.Delta_equational qual in
                       let uu____8975 =
-                        let uu____8978 = FStar_Syntax_Syntax.as_arg e1  in
-                        [uu____8978]  in
-                      (uu____8974, uu____8975)  in
-                    FStar_Syntax_Syntax.Tm_app uu____8959  in
+                        let uu____8978 = FStar_Syntax_Syntax.as_arg e1 in
+                        [uu____8978] in
+                      (uu____8974, uu____8975) in
+                    FStar_Syntax_Syntax.Tm_app uu____8959 in
                   FStar_All.pipe_left mk1 uu____8958))
         | FStar_Parser_AST.NamedTyp (uu____8983,e) -> desugar_term env e
         | FStar_Parser_AST.Paren e -> failwith "impossible"
@@ -3397,19 +3099,17 @@ and (desugar_term_maybe_top :
         | uu____8987 ->
             let uu____8988 =
               let uu____8993 =
-                let uu____8994 = FStar_Parser_AST.term_to_string top  in
-                Prims.strcat "Unexpected term" uu____8994  in
-              (FStar_Errors.Fatal_UnexpectedTerm, uu____8993)  in
+                let uu____8994 = FStar_Parser_AST.term_to_string top in
+                Prims.strcat "Unexpected term" uu____8994 in
+              (FStar_Errors.Fatal_UnexpectedTerm, uu____8993) in
             FStar_Errors.raise_error uu____8988 top.FStar_Parser_AST.range
-
-and (not_ascribed : FStar_Parser_AST.term -> Prims.bool) =
+and not_ascribed: FStar_Parser_AST.term -> Prims.bool =
   fun t  ->
     match t.FStar_Parser_AST.tm with
     | FStar_Parser_AST.Ascribed uu____8996 -> false
     | uu____9005 -> true
-
-and (is_synth_by_tactic :
-  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> Prims.bool) =
+and is_synth_by_tactic:
+  FStar_ToSyntax_Env.env -> FStar_Parser_AST.term -> Prims.bool =
   fun e  ->
     fun t  ->
       match t.FStar_Parser_AST.tm with
@@ -3417,20 +3117,19 @@ and (is_synth_by_tactic :
           is_synth_by_tactic e l
       | FStar_Parser_AST.Var lid ->
           let uu____9011 =
-            FStar_ToSyntax_Env.resolve_to_fully_qualified_name e lid  in
+            FStar_ToSyntax_Env.resolve_to_fully_qualified_name e lid in
           (match uu____9011 with
            | FStar_Pervasives_Native.Some lid1 ->
                FStar_Ident.lid_equals lid1 FStar_Parser_Const.synth_lid
            | FStar_Pervasives_Native.None  -> false)
       | uu____9015 -> false
-
-and (desugar_args :
+and desugar_args:
   FStar_ToSyntax_Env.env ->
     (FStar_Parser_AST.term,FStar_Parser_AST.imp)
       FStar_Pervasives_Native.tuple2 Prims.list ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.arg_qualifier
                                   FStar_Pervasives_Native.option)
-        FStar_Pervasives_Native.tuple2 Prims.list)
+        FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun env  ->
     fun args  ->
@@ -3439,59 +3138,51 @@ and (desugar_args :
            (fun uu____9052  ->
               match uu____9052 with
               | (a,imp) ->
-                  let uu____9065 = desugar_term env a  in
+                  let uu____9065 = desugar_term env a in
                   arg_withimp_e imp uu____9065))
-
-and (desugar_comp :
+and desugar_comp:
   FStar_Range.range ->
     FStar_ToSyntax_Env.env ->
       FStar_Parser_AST.term ->
-        FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax
   =
   fun r  ->
     fun env  ->
       fun t  ->
-        let fail a err = FStar_Errors.raise_error err r  in
+        let fail a err = FStar_Errors.raise_error err r in
         let is_requires uu____9091 =
           match uu____9091 with
           | (t1,uu____9097) ->
               let uu____9098 =
-                let uu____9099 = unparen t1  in
-                uu____9099.FStar_Parser_AST.tm  in
+                let uu____9099 = unparen t1 in uu____9099.FStar_Parser_AST.tm in
               (match uu____9098 with
                | FStar_Parser_AST.Requires uu____9100 -> true
-               | uu____9107 -> false)
-           in
+               | uu____9107 -> false) in
         let is_ensures uu____9115 =
           match uu____9115 with
           | (t1,uu____9121) ->
               let uu____9122 =
-                let uu____9123 = unparen t1  in
-                uu____9123.FStar_Parser_AST.tm  in
+                let uu____9123 = unparen t1 in uu____9123.FStar_Parser_AST.tm in
               (match uu____9122 with
                | FStar_Parser_AST.Ensures uu____9124 -> true
-               | uu____9131 -> false)
-           in
+               | uu____9131 -> false) in
         let is_app head1 uu____9142 =
           match uu____9142 with
           | (t1,uu____9148) ->
               let uu____9149 =
-                let uu____9150 = unparen t1  in
-                uu____9150.FStar_Parser_AST.tm  in
+                let uu____9150 = unparen t1 in uu____9150.FStar_Parser_AST.tm in
               (match uu____9149 with
                | FStar_Parser_AST.App
                    ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var d;
                       FStar_Parser_AST.range = uu____9152;
                       FStar_Parser_AST.level = uu____9153;_},uu____9154,uu____9155)
                    -> (d.FStar_Ident.ident).FStar_Ident.idText = head1
-               | uu____9156 -> false)
-           in
+               | uu____9156 -> false) in
         let is_smt_pat uu____9164 =
           match uu____9164 with
           | (t1,uu____9170) ->
               let uu____9171 =
-                let uu____9172 = unparen t1  in
-                uu____9172.FStar_Parser_AST.tm  in
+                let uu____9172 = unparen t1 in uu____9172.FStar_Parser_AST.tm in
               (match uu____9171 with
                | FStar_Parser_AST.Construct
                    (cons1,({
@@ -3517,11 +3208,10 @@ and (desugar_comp :
                      (FStar_Util.for_some
                         (fun s  -> smtpat.FStar_Ident.str = s)
                         ["smt_pat"; "smt_pat_or"])
-               | uu____9246 -> false)
-           in
-        let is_decreases = is_app "decreases"  in
+               | uu____9246 -> false) in
+        let is_decreases = is_app "decreases" in
         let pre_process_comp_typ t1 =
-          let uu____9274 = head_and_args t1  in
+          let uu____9274 = head_and_args t1 in
           match uu____9274 with
           | (head1,args) ->
               (match head1.FStar_Parser_AST.tm with
@@ -3532,14 +3222,12 @@ and (desugar_comp :
                          (FStar_Parser_AST.Name FStar_Parser_Const.unit_lid)
                          t1.FStar_Parser_AST.range
                          FStar_Parser_AST.Type_level),
-                       FStar_Parser_AST.Nothing)
-                      in
+                       FStar_Parser_AST.Nothing) in
                    let nil_pat =
                      ((FStar_Parser_AST.mk_term
                          (FStar_Parser_AST.Name FStar_Parser_Const.nil_lid)
                          t1.FStar_Parser_AST.range FStar_Parser_AST.Expr),
-                       FStar_Parser_AST.Nothing)
-                      in
+                       FStar_Parser_AST.Nothing) in
                    let req_true =
                      let req =
                        FStar_Parser_AST.Requires
@@ -3548,26 +3236,21 @@ and (desugar_comp :
                                 FStar_Parser_Const.true_lid)
                              t1.FStar_Parser_AST.range
                              FStar_Parser_AST.Formula),
-                           FStar_Pervasives_Native.None)
-                        in
+                           FStar_Pervasives_Native.None) in
                      ((FStar_Parser_AST.mk_term req t1.FStar_Parser_AST.range
                          FStar_Parser_AST.Type_level),
-                       FStar_Parser_AST.Nothing)
-                      in
+                       FStar_Parser_AST.Nothing) in
                    let thunk_ens_ ens =
                      let wildpat =
                        FStar_Parser_AST.mk_pattern FStar_Parser_AST.PatWild
-                         ens.FStar_Parser_AST.range
-                        in
+                         ens.FStar_Parser_AST.range in
                      FStar_Parser_AST.mk_term
                        (FStar_Parser_AST.Abs ([wildpat], ens))
-                       ens.FStar_Parser_AST.range FStar_Parser_AST.Expr
-                      in
+                       ens.FStar_Parser_AST.range FStar_Parser_AST.Expr in
                    let thunk_ens uu____9368 =
                      match uu____9368 with
                      | (e,i) ->
-                         let uu____9379 = thunk_ens_ e  in (uu____9379, i)
-                      in
+                         let uu____9379 = thunk_ens_ e in (uu____9379, i) in
                    let fail_lemma uu____9389 =
                      let expected_one_of =
                        ["Lemma post";
@@ -3579,15 +3262,13 @@ and (desugar_comp :
                        "Lemma (ensures post) (decreases d) [SMTPat ...]";
                        "Lemma (requires pre) (ensures post) (decreases d)";
                        "Lemma (requires pre) (ensures post) [SMTPat ...]";
-                       "Lemma (requires pre) (ensures post) (decreases d) [SMTPat ...]"]
-                        in
-                     let msg = FStar_String.concat "\n\t" expected_one_of  in
+                       "Lemma (requires pre) (ensures post) (decreases d) [SMTPat ...]"] in
+                     let msg = FStar_String.concat "\n\t" expected_one_of in
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_InvalidLemmaArgument,
                          (Prims.strcat
                             "Invalid arguments to 'Lemma'; expected one of the following:\n\t"
-                            msg)) t1.FStar_Parser_AST.range
-                      in
+                            msg)) t1.FStar_Parser_AST.range in
                    let args1 =
                      match args with
                      | [] -> fail_lemma ()
@@ -3597,41 +3278,41 @@ and (desugar_comp :
                      | ens::[] ->
                          let uu____9469 =
                            let uu____9476 =
-                             let uu____9483 = thunk_ens ens  in
-                             [uu____9483; nil_pat]  in
-                           req_true :: uu____9476  in
+                             let uu____9483 = thunk_ens ens in
+                             [uu____9483; nil_pat] in
+                           req_true :: uu____9476 in
                          unit_tm :: uu____9469
                      | req::ens::[] when
                          (is_requires req) && (is_ensures ens) ->
                          let uu____9530 =
                            let uu____9537 =
-                             let uu____9544 = thunk_ens ens  in
-                             [uu____9544; nil_pat]  in
-                           req :: uu____9537  in
+                             let uu____9544 = thunk_ens ens in
+                             [uu____9544; nil_pat] in
+                           req :: uu____9537 in
                          unit_tm :: uu____9530
                      | ens::smtpat::[] when
-                         (((let uu____9593 = is_requires ens  in
+                         (((let uu____9593 = is_requires ens in
                             Prims.op_Negation uu____9593) &&
-                             (let uu____9595 = is_smt_pat ens  in
+                             (let uu____9595 = is_smt_pat ens in
                               Prims.op_Negation uu____9595))
                             &&
-                            (let uu____9597 = is_decreases ens  in
+                            (let uu____9597 = is_decreases ens in
                              Prims.op_Negation uu____9597))
                            && (is_smt_pat smtpat)
                          ->
                          let uu____9598 =
                            let uu____9605 =
-                             let uu____9612 = thunk_ens ens  in
-                             [uu____9612; smtpat]  in
-                           req_true :: uu____9605  in
+                             let uu____9612 = thunk_ens ens in
+                             [uu____9612; smtpat] in
+                           req_true :: uu____9605 in
                          unit_tm :: uu____9598
                      | ens::dec::[] when
                          (is_ensures ens) && (is_decreases dec) ->
                          let uu____9659 =
                            let uu____9666 =
-                             let uu____9673 = thunk_ens ens  in
-                             [uu____9673; nil_pat; dec]  in
-                           req_true :: uu____9666  in
+                             let uu____9673 = thunk_ens ens in
+                             [uu____9673; nil_pat; dec] in
+                           req_true :: uu____9666 in
                          unit_tm :: uu____9659
                      | ens::dec::smtpat::[] when
                          ((is_ensures ens) && (is_decreases dec)) &&
@@ -3639,9 +3320,9 @@ and (desugar_comp :
                          ->
                          let uu____9733 =
                            let uu____9740 =
-                             let uu____9747 = thunk_ens ens  in
-                             [uu____9747; smtpat; dec]  in
-                           req_true :: uu____9740  in
+                             let uu____9747 = thunk_ens ens in
+                             [uu____9747; smtpat; dec] in
+                           req_true :: uu____9740 in
                          unit_tm :: uu____9733
                      | req::ens::dec::[] when
                          ((is_requires req) && (is_ensures ens)) &&
@@ -3649,9 +3330,9 @@ and (desugar_comp :
                          ->
                          let uu____9807 =
                            let uu____9814 =
-                             let uu____9821 = thunk_ens ens  in
-                             [uu____9821; nil_pat; dec]  in
-                           req :: uu____9814  in
+                             let uu____9821 = thunk_ens ens in
+                             [uu____9821; nil_pat; dec] in
+                           req :: uu____9814 in
                          unit_tm :: uu____9807
                      | req::ens::smtpat::[] when
                          ((is_requires req) && (is_ensures ens)) &&
@@ -3659,9 +3340,9 @@ and (desugar_comp :
                          ->
                          let uu____9881 =
                            let uu____9888 =
-                             let uu____9895 = thunk_ens ens  in
-                             [uu____9895; smtpat]  in
-                           req :: uu____9888  in
+                             let uu____9895 = thunk_ens ens in
+                             [uu____9895; smtpat] in
+                           req :: uu____9888 in
                          unit_tm :: uu____9881
                      | req::ens::dec::smtpat::[] when
                          (((is_requires req) && (is_ensures ens)) &&
@@ -3670,28 +3351,25 @@ and (desugar_comp :
                          ->
                          let uu____9960 =
                            let uu____9967 =
-                             let uu____9974 = thunk_ens ens  in
-                             [uu____9974; dec; smtpat]  in
-                           req :: uu____9967  in
+                             let uu____9974 = thunk_ens ens in
+                             [uu____9974; dec; smtpat] in
+                           req :: uu____9967 in
                          unit_tm :: uu____9960
-                     | _other -> fail_lemma ()  in
+                     | _other -> fail_lemma () in
                    let head_and_attributes =
                      FStar_ToSyntax_Env.fail_or env
                        (FStar_ToSyntax_Env.try_lookup_effect_name_and_attributes
-                          env) lemma
-                      in
+                          env) lemma in
                    (head_and_attributes, args1)
                | FStar_Parser_AST.Name l when
                    FStar_ToSyntax_Env.is_effect_name env l ->
                    let uu____10036 =
                      FStar_ToSyntax_Env.fail_or env
                        (FStar_ToSyntax_Env.try_lookup_effect_name_and_attributes
-                          env) l
-                      in
+                          env) l in
                    (uu____10036, args)
                | FStar_Parser_AST.Name l when
-                   (let uu____10064 = FStar_ToSyntax_Env.current_module env
-                       in
+                   (let uu____10064 = FStar_ToSyntax_Env.current_module env in
                     FStar_Ident.lid_equals uu____10064
                       FStar_Parser_Const.prims_lid)
                      && ((l.FStar_Ident.ident).FStar_Ident.idText = "Tot")
@@ -3700,8 +3378,7 @@ and (desugar_comp :
                         FStar_Parser_Const.effect_Tot_lid
                         head1.FStar_Parser_AST.range), []), args)
                | FStar_Parser_AST.Name l when
-                   (let uu____10082 = FStar_ToSyntax_Env.current_module env
-                       in
+                   (let uu____10082 = FStar_ToSyntax_Env.current_module env in
                     FStar_Ident.lid_equals uu____10082
                       FStar_Parser_Const.prims_lid)
                      && ((l.FStar_Ident.ident).FStar_Ident.idText = "GTot")
@@ -3720,12 +3397,12 @@ and (desugar_comp :
                      [(t1, FStar_Parser_AST.Nothing)])
                | uu____10120 ->
                    let default_effect =
-                     let uu____10122 = FStar_Options.ml_ish ()  in
+                     let uu____10122 = FStar_Options.ml_ish () in
                      if uu____10122
                      then FStar_Parser_Const.effect_ML_lid
                      else
                        ((let uu____10125 =
-                           FStar_Options.warn_default_effects ()  in
+                           FStar_Options.warn_default_effects () in
                          if uu____10125
                          then
                            FStar_Errors.log_issue
@@ -3733,13 +3410,11 @@ and (desugar_comp :
                              (FStar_Errors.Warning_UseDefaultEffect,
                                "Using default effect Tot")
                          else ());
-                        FStar_Parser_Const.effect_Tot_lid)
-                      in
+                        FStar_Parser_Const.effect_Tot_lid) in
                    (((FStar_Ident.set_lid_range default_effect
                         head1.FStar_Parser_AST.range), []),
-                     [(t1, FStar_Parser_AST.Nothing)]))
-           in
-        let uu____10149 = pre_process_comp_typ t  in
+                     [(t1, FStar_Parser_AST.Nothing)])) in
+        let uu____10149 = pre_process_comp_typ t in
         match uu____10149 with
         | ((eff,cattributes),args) ->
             (Obj.magic
@@ -3749,38 +3424,34 @@ and (desugar_comp :
                     (let uu____10198 =
                        let uu____10203 =
                          let uu____10204 =
-                           FStar_Syntax_Print.lid_to_string eff  in
+                           FStar_Syntax_Print.lid_to_string eff in
                          FStar_Util.format1 "Not enough args to effect %s"
-                           uu____10204
-                          in
+                           uu____10204 in
                        (FStar_Errors.Fatal_NotEnoughArgsToEffect,
-                         uu____10203)
-                        in
+                         uu____10203) in
                      fail () uu____10198)
                 else Obj.repr ());
              (let is_universe uu____10213 =
                 match uu____10213 with
-                | (uu____10218,imp) -> imp = FStar_Parser_AST.UnivApp  in
-              let uu____10220 = FStar_Util.take is_universe args  in
+                | (uu____10218,imp) -> imp = FStar_Parser_AST.UnivApp in
+              let uu____10220 = FStar_Util.take is_universe args in
               match uu____10220 with
               | (universes,args1) ->
                   let universes1 =
                     FStar_List.map
                       (fun uu____10279  ->
                          match uu____10279 with
-                         | (u,imp) -> desugar_universe u) universes
-                     in
+                         | (u,imp) -> desugar_universe u) universes in
                   let uu____10286 =
-                    let uu____10301 = FStar_List.hd args1  in
-                    let uu____10310 = FStar_List.tl args1  in
-                    (uu____10301, uu____10310)  in
+                    let uu____10301 = FStar_List.hd args1 in
+                    let uu____10310 = FStar_List.tl args1 in
+                    (uu____10301, uu____10310) in
                   (match uu____10286 with
                    | (result_arg,rest) ->
                        let result_typ =
                          desugar_typ env
-                           (FStar_Pervasives_Native.fst result_arg)
-                          in
-                       let rest1 = desugar_args env rest  in
+                           (FStar_Pervasives_Native.fst result_arg) in
+                       let rest1 = desugar_args env rest in
                        let uu____10365 =
                          let is_decrease uu____10401 =
                            match uu____10401 with
@@ -3795,11 +3466,9 @@ and (desugar_comp :
                                     ->
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.decreases_lid
-                                | uu____10454 -> false)
-                            in
+                                | uu____10454 -> false) in
                          FStar_All.pipe_right rest1
-                           (FStar_List.partition is_decrease)
-                          in
+                           (FStar_List.partition is_decrease) in
                        (match uu____10365 with
                         | (dec,rest2) ->
                             let decreases_clause =
@@ -3815,18 +3484,16 @@ and (desugar_comp :
                                                ->
                                                FStar_Syntax_Syntax.DECREASES
                                                  arg
-                                           | uu____10618 -> failwith "impos")))
-                               in
+                                           | uu____10618 -> failwith "impos"))) in
                             let no_additional_args =
                               let is_empty a l =
                                 match l with
                                 | [] -> true
-                                | uu____10631 -> false  in
+                                | uu____10631 -> false in
                               (((is_empty () (Obj.magic decreases_clause)) &&
                                   (is_empty () (Obj.magic rest2)))
                                  && (is_empty () (Obj.magic cattributes)))
-                                && (is_empty () (Obj.magic universes1))
-                               in
+                                && (is_empty () (Obj.magic universes1)) in
                             if
                               no_additional_args &&
                                 (FStar_Ident.lid_equals eff
@@ -3860,10 +3527,9 @@ and (desugar_comp :
                                              FStar_Parser_Const.effect_GTot_lid
                                          then
                                            [FStar_Syntax_Syntax.SOMETRIVIAL]
-                                         else []
-                                    in
+                                         else [] in
                                  let flags2 =
-                                   FStar_List.append flags1 cattributes  in
+                                   FStar_List.append flags1 cattributes in
                                  let rest3 =
                                    if
                                      FStar_Ident.lid_equals eff
@@ -3883,16 +3549,14 @@ and (desugar_comp :
                                                let nil =
                                                  FStar_Syntax_Syntax.mk_Tm_uinst
                                                    pat
-                                                   [FStar_Syntax_Syntax.U_zero]
-                                                  in
+                                                   [FStar_Syntax_Syntax.U_zero] in
                                                let pattern =
                                                  FStar_Syntax_Syntax.fvar
                                                    (FStar_Ident.set_lid_range
                                                       FStar_Parser_Const.pattern_lid
                                                       pat.FStar_Syntax_Syntax.pos)
                                                    FStar_Syntax_Syntax.Delta_constant
-                                                   FStar_Pervasives_Native.None
-                                                  in
+                                                   FStar_Pervasives_Native.None in
                                                FStar_Syntax_Syntax.mk_Tm_app
                                                  nil
                                                  [(pattern,
@@ -3900,7 +3564,7 @@ and (desugar_comp :
                                                        FStar_Syntax_Syntax.imp_tag))]
                                                  FStar_Pervasives_Native.None
                                                  pat.FStar_Syntax_Syntax.pos
-                                           | uu____10771 -> pat  in
+                                           | uu____10771 -> pat in
                                          let uu____10772 =
                                            let uu____10783 =
                                              let uu____10794 =
@@ -3911,14 +3575,13 @@ and (desugar_comp :
                                                         (FStar_Syntax_Syntax.Meta_desugared
                                                            FStar_Syntax_Syntax.Meta_smt_pat)))
                                                    FStar_Pervasives_Native.None
-                                                   pat1.FStar_Syntax_Syntax.pos
-                                                  in
-                                               (uu____10803, aq)  in
-                                             [uu____10794]  in
-                                           ens :: uu____10783  in
+                                                   pat1.FStar_Syntax_Syntax.pos in
+                                               (uu____10803, aq) in
+                                             [uu____10794] in
+                                           ens :: uu____10783 in
                                          req :: uu____10772
                                      | uu____10844 -> rest2
-                                   else rest2  in
+                                   else rest2 in
                                  FStar_Syntax_Syntax.mk_Comp
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
@@ -3931,9 +3594,8 @@ and (desugar_comp :
                                        (FStar_List.append flags2
                                           decreases_clause)
                                    })))))
-
-and (desugar_formula :
-  env_t -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term) =
+and desugar_formula:
+  env_t -> FStar_Parser_AST.term -> FStar_Syntax_Syntax.term =
   fun env  ->
     fun f  ->
       let connective s =
@@ -3943,23 +3605,22 @@ and (desugar_formula :
         | "==>" -> FStar_Pervasives_Native.Some FStar_Parser_Const.imp_lid
         | "<==>" -> FStar_Pervasives_Native.Some FStar_Parser_Const.iff_lid
         | "~" -> FStar_Pervasives_Native.Some FStar_Parser_Const.not_lid
-        | uu____10866 -> FStar_Pervasives_Native.None  in
+        | uu____10866 -> FStar_Pervasives_Native.None in
       let mk1 t =
         FStar_Syntax_Syntax.mk t FStar_Pervasives_Native.None
-          f.FStar_Parser_AST.range
-         in
+          f.FStar_Parser_AST.range in
       let setpos t =
-        let uu___127_10883 = t  in
+        let uu___127_10883 = t in
         {
           FStar_Syntax_Syntax.n = (uu___127_10883.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (f.FStar_Parser_AST.range);
           FStar_Syntax_Syntax.vars =
             (uu___127_10883.FStar_Syntax_Syntax.vars)
-        }  in
+        } in
       let desugar_quant q b pats body =
         let tk =
           desugar_binder env
-            (let uu___128_10917 = b  in
+            (let uu___128_10917 = b in
              {
                FStar_Parser_AST.b = (uu___128_10917.FStar_Parser_AST.b);
                FStar_Parser_AST.brange =
@@ -3967,50 +3628,47 @@ and (desugar_formula :
                FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                FStar_Parser_AST.aqual =
                  (uu___128_10917.FStar_Parser_AST.aqual)
-             })
-           in
+             }) in
         let desugar_pats env1 pats1 =
           FStar_List.map
             (fun es  ->
                FStar_All.pipe_right es
                  (FStar_List.map
                     (fun e  ->
-                       let uu____10976 = desugar_term env1 e  in
+                       let uu____10976 = desugar_term env1 e in
                        FStar_All.pipe_left
                          (arg_withimp_t FStar_Parser_AST.Nothing) uu____10976)))
-            pats1
-           in
+            pats1 in
         match tk with
         | (FStar_Pervasives_Native.Some a,k) ->
-            let uu____10989 = FStar_ToSyntax_Env.push_bv env a  in
+            let uu____10989 = FStar_ToSyntax_Env.push_bv env a in
             (match uu____10989 with
              | (env1,a1) ->
                  let a2 =
-                   let uu___129_10999 = a1  in
+                   let uu___129_10999 = a1 in
                    {
                      FStar_Syntax_Syntax.ppname =
                        (uu___129_10999.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
                        (uu___129_10999.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort = k
-                   }  in
-                 let pats1 = desugar_pats env1 pats  in
-                 let body1 = desugar_formula env1 body  in
+                   } in
+                 let pats1 = desugar_pats env1 pats in
+                 let body1 = desugar_formula env1 body in
                  let body2 =
                    match pats1 with
                    | [] -> body1
                    | uu____11021 ->
                        mk1
                          (FStar_Syntax_Syntax.Tm_meta
-                            (body1, (FStar_Syntax_Syntax.Meta_pattern pats1)))
-                    in
+                            (body1, (FStar_Syntax_Syntax.Meta_pattern pats1))) in
                  let body3 =
                    let uu____11035 =
                      let uu____11038 =
-                       let uu____11039 = FStar_Syntax_Syntax.mk_binder a2  in
-                       [uu____11039]  in
-                     no_annot_abs uu____11038 body2  in
-                   FStar_All.pipe_left setpos uu____11035  in
+                       let uu____11039 = FStar_Syntax_Syntax.mk_binder a2 in
+                       [uu____11039] in
+                     no_annot_abs uu____11038 body2 in
+                   FStar_All.pipe_left setpos uu____11035 in
                  let uu____11044 =
                    let uu____11045 =
                      let uu____11060 =
@@ -4019,37 +3677,34 @@ and (desugar_formula :
                             b.FStar_Parser_AST.brange)
                          (FStar_Syntax_Syntax.Delta_defined_at_level
                             (Prims.parse_int "1"))
-                         FStar_Pervasives_Native.None
-                        in
+                         FStar_Pervasives_Native.None in
                      let uu____11061 =
-                       let uu____11064 = FStar_Syntax_Syntax.as_arg body3  in
-                       [uu____11064]  in
-                     (uu____11060, uu____11061)  in
-                   FStar_Syntax_Syntax.Tm_app uu____11045  in
+                       let uu____11064 = FStar_Syntax_Syntax.as_arg body3 in
+                       [uu____11064] in
+                     (uu____11060, uu____11061) in
+                   FStar_Syntax_Syntax.Tm_app uu____11045 in
                  FStar_All.pipe_left mk1 uu____11044)
-        | uu____11069 -> failwith "impossible"  in
+        | uu____11069 -> failwith "impossible" in
       let push_quant q binders pats body =
         match binders with
         | b::b'::_rest ->
-            let rest = b' :: _rest  in
+            let rest = b' :: _rest in
             let body1 =
-              let uu____11141 = q (rest, pats, body)  in
+              let uu____11141 = q (rest, pats, body) in
               let uu____11148 =
                 FStar_Range.union_ranges b'.FStar_Parser_AST.brange
-                  body.FStar_Parser_AST.range
-                 in
+                  body.FStar_Parser_AST.range in
               FStar_Parser_AST.mk_term uu____11141 uu____11148
-                FStar_Parser_AST.Formula
-               in
-            let uu____11149 = q ([b], [], body1)  in
+                FStar_Parser_AST.Formula in
+            let uu____11149 = q ([b], [], body1) in
             FStar_Parser_AST.mk_term uu____11149 f.FStar_Parser_AST.range
               FStar_Parser_AST.Formula
-        | uu____11158 -> failwith "impossible"  in
+        | uu____11158 -> failwith "impossible" in
       let uu____11161 =
-        let uu____11162 = unparen f  in uu____11162.FStar_Parser_AST.tm  in
+        let uu____11162 = unparen f in uu____11162.FStar_Parser_AST.tm in
       match uu____11161 with
       | FStar_Parser_AST.Labeled (f1,l,p) ->
-          let f2 = desugar_formula env f1  in
+          let f2 = desugar_formula env f1 in
           FStar_All.pipe_left mk1
             (FStar_Syntax_Syntax.Tm_meta
                (f2,
@@ -4060,18 +3715,16 @@ and (desugar_formula :
       | FStar_Parser_AST.QExists ([],uu____11181,uu____11182) ->
           failwith "Impossible: Quantifier without binders"
       | FStar_Parser_AST.QForall (_1::_2::_3,pats,body) ->
-          let binders = _1 :: _2 :: _3  in
+          let binders = _1 :: _2 :: _3 in
           let uu____11213 =
             push_quant (fun x  -> FStar_Parser_AST.QForall x) binders pats
-              body
-             in
+              body in
           desugar_formula env uu____11213
       | FStar_Parser_AST.QExists (_1::_2::_3,pats,body) ->
-          let binders = _1 :: _2 :: _3  in
+          let binders = _1 :: _2 :: _3 in
           let uu____11249 =
             push_quant (fun x  -> FStar_Parser_AST.QExists x) binders pats
-              body
-             in
+              body in
           desugar_formula env uu____11249
       | FStar_Parser_AST.QForall (b::[],pats,body) ->
           desugar_quant FStar_Parser_Const.forall_lid b pats body
@@ -4079,14 +3732,13 @@ and (desugar_formula :
           desugar_quant FStar_Parser_Const.exists_lid b pats body
       | FStar_Parser_AST.Paren f1 -> failwith "impossible"
       | uu____11292 -> desugar_term env f
-
-and (typars_of_binders :
+and typars_of_binders:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.binder Prims.list ->
       (FStar_ToSyntax_Env.env,(FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.arg_qualifier
                                                         FStar_Pervasives_Native.option)
                                 FStar_Pervasives_Native.tuple2 Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun bs  ->
@@ -4098,7 +3750,7 @@ and (typars_of_binders :
                | (env1,out) ->
                    let tk =
                      desugar_binder env1
-                       (let uu___130_11385 = b  in
+                       (let uu___130_11385 = b in
                         {
                           FStar_Parser_AST.b =
                             (uu___130_11385.FStar_Parser_AST.b);
@@ -4107,23 +3759,21 @@ and (typars_of_binders :
                           FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                           FStar_Parser_AST.aqual =
                             (uu___130_11385.FStar_Parser_AST.aqual)
-                        })
-                      in
+                        }) in
                    (match tk with
                     | (FStar_Pervasives_Native.Some a,k) ->
-                        let uu____11402 = FStar_ToSyntax_Env.push_bv env1 a
-                           in
+                        let uu____11402 = FStar_ToSyntax_Env.push_bv env1 a in
                         (match uu____11402 with
                          | (env2,a1) ->
                              let a2 =
-                               let uu___131_11422 = a1  in
+                               let uu___131_11422 = a1 in
                                {
                                  FStar_Syntax_Syntax.ppname =
                                    (uu___131_11422.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
                                    (uu___131_11422.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = k
-                               }  in
+                               } in
                              (env2,
                                ((a2, (trans_aqual b.FStar_Parser_AST.aqual))
                                :: out)))
@@ -4131,42 +3781,38 @@ and (typars_of_binders :
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_UnexpectedBinder,
                             "Unexpected binder") b.FStar_Parser_AST.brange))
-          (env, []) bs
-         in
+          (env, []) bs in
       match uu____11297 with | (env1,tpars) -> (env1, (FStar_List.rev tpars))
-
-and (desugar_binder :
+and desugar_binder:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.binder ->
       (FStar_Ident.ident FStar_Pervasives_Native.option,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun b  ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.TAnnotated (x,t) ->
-          let uu____11526 = desugar_typ env t  in
+          let uu____11526 = desugar_typ env t in
           ((FStar_Pervasives_Native.Some x), uu____11526)
       | FStar_Parser_AST.Annotated (x,t) ->
-          let uu____11531 = desugar_typ env t  in
+          let uu____11531 = desugar_typ env t in
           ((FStar_Pervasives_Native.Some x), uu____11531)
       | FStar_Parser_AST.TVariable x ->
           let uu____11535 =
             FStar_Syntax_Syntax.mk
               (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
-              FStar_Pervasives_Native.None x.FStar_Ident.idRange
-             in
+              FStar_Pervasives_Native.None x.FStar_Ident.idRange in
           ((FStar_Pervasives_Native.Some x), uu____11535)
       | FStar_Parser_AST.NoName t ->
-          let uu____11543 = desugar_typ env t  in
+          let uu____11543 = desugar_typ env t in
           (FStar_Pervasives_Native.None, uu____11543)
       | FStar_Parser_AST.Variable x ->
           ((FStar_Pervasives_Native.Some x), FStar_Syntax_Syntax.tun)
-
-let (mk_data_discriminators :
+let mk_data_discriminators:
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_ToSyntax_Env.env ->
-      FStar_Ident.lident Prims.list -> FStar_Syntax_Syntax.sigelt Prims.list)
+      FStar_Ident.lident Prims.list -> FStar_Syntax_Syntax.sigelt Prims.list
   =
   fun quals  ->
     fun env  ->
@@ -4178,26 +3824,23 @@ let (mk_data_discriminators :
                   match uu___94_11576 with
                   | FStar_Syntax_Syntax.Abstract  -> true
                   | FStar_Syntax_Syntax.Private  -> true
-                  | uu____11577 -> false))
-           in
+                  | uu____11577 -> false)) in
         let quals2 q =
           let uu____11588 =
-            (let uu____11591 = FStar_ToSyntax_Env.iface env  in
+            (let uu____11591 = FStar_ToSyntax_Env.iface env in
              Prims.op_Negation uu____11591) ||
-              (FStar_ToSyntax_Env.admitted_iface env)
-             in
+              (FStar_ToSyntax_Env.admitted_iface env) in
           if uu____11588
           then FStar_List.append (FStar_Syntax_Syntax.Assumption :: q) quals1
-          else FStar_List.append q quals1  in
+          else FStar_List.append q quals1 in
         FStar_All.pipe_right datas
           (FStar_List.map
              (fun d  ->
-                let disc_name = FStar_Syntax_Util.mk_discriminator d  in
+                let disc_name = FStar_Syntax_Util.mk_discriminator d in
                 let uu____11604 =
                   quals2
                     [FStar_Syntax_Syntax.OnlyName;
-                    FStar_Syntax_Syntax.Discriminator d]
-                   in
+                    FStar_Syntax_Syntax.Discriminator d] in
                 {
                   FStar_Syntax_Syntax.sigel =
                     (FStar_Syntax_Syntax.Sig_declare_typ
@@ -4209,21 +3852,20 @@ let (mk_data_discriminators :
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = []
                 }))
-  
-let (mk_indexed_projector_names :
+let mk_indexed_projector_names:
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_Syntax_Syntax.fv_qual ->
       FStar_ToSyntax_Env.env ->
         FStar_Ident.lid ->
           FStar_Syntax_Syntax.binder Prims.list ->
-            FStar_Syntax_Syntax.sigelt Prims.list)
+            FStar_Syntax_Syntax.sigelt Prims.list
   =
   fun iquals  ->
     fun fvq  ->
       fun env  ->
         fun lid  ->
           fun fields  ->
-            let p = FStar_Ident.range_of_lid lid  in
+            let p = FStar_Ident.range_of_lid lid in
             let uu____11635 =
               FStar_All.pipe_right fields
                 (FStar_List.mapi
@@ -4233,14 +3875,12 @@ let (mk_indexed_projector_names :
                         | (x,uu____11673) ->
                             let uu____11674 =
                               FStar_Syntax_Util.mk_field_projector_name lid x
-                                i
-                               in
+                                i in
                             (match uu____11674 with
                              | (field_name,uu____11682) ->
                                  let only_decl =
                                    ((let uu____11686 =
-                                       FStar_ToSyntax_Env.current_module env
-                                        in
+                                       FStar_ToSyntax_Env.current_module env in
                                      FStar_Ident.lid_equals
                                        FStar_Parser_Const.prims_lid
                                        uu____11686)
@@ -4250,16 +3890,13 @@ let (mk_indexed_projector_names :
                                      (let uu____11688 =
                                         let uu____11689 =
                                           FStar_ToSyntax_Env.current_module
-                                            env
-                                           in
-                                        uu____11689.FStar_Ident.str  in
+                                            env in
+                                        uu____11689.FStar_Ident.str in
                                       FStar_Options.dont_gen_projectors
-                                        uu____11688)
-                                    in
+                                        uu____11688) in
                                  let no_decl =
                                    FStar_Syntax_Syntax.is_type
-                                     x.FStar_Syntax_Syntax.sort
-                                    in
+                                     x.FStar_Syntax_Syntax.sort in
                                  let quals q =
                                    if only_decl
                                    then
@@ -4269,11 +3906,10 @@ let (mk_indexed_projector_names :
                                             match uu___95_11707 with
                                             | FStar_Syntax_Syntax.Abstract 
                                                 -> false
-                                            | uu____11708 -> true) q
-                                        in
+                                            | uu____11708 -> true) q in
                                      FStar_Syntax_Syntax.Assumption ::
                                        uu____11703
-                                   else q  in
+                                   else q in
                                  let quals1 =
                                    let iquals1 =
                                      FStar_All.pipe_right iquals
@@ -4284,13 +3920,11 @@ let (mk_indexed_projector_names :
                                                  -> true
                                              | FStar_Syntax_Syntax.Private 
                                                  -> true
-                                             | uu____11722 -> false))
-                                      in
+                                             | uu____11722 -> false)) in
                                    quals (FStar_Syntax_Syntax.OnlyName ::
                                      (FStar_Syntax_Syntax.Projector
                                         (lid, (x.FStar_Syntax_Syntax.ppname)))
-                                     :: iquals1)
-                                    in
+                                     :: iquals1) in
                                  let decl =
                                    {
                                      FStar_Syntax_Syntax.sigel =
@@ -4303,7 +3937,7 @@ let (mk_indexed_projector_names :
                                      FStar_Syntax_Syntax.sigmeta =
                                        FStar_Syntax_Syntax.default_sigmeta;
                                      FStar_Syntax_Syntax.sigattrs = []
-                                   }  in
+                                   } in
                                  if only_decl
                                  then [decl]
                                  else
@@ -4311,23 +3945,20 @@ let (mk_indexed_projector_names :
                                       let uu____11730 =
                                         FStar_All.pipe_right quals1
                                           (FStar_List.contains
-                                             FStar_Syntax_Syntax.Abstract)
-                                         in
+                                             FStar_Syntax_Syntax.Abstract) in
                                       if uu____11730
                                       then
                                         FStar_Syntax_Syntax.Delta_abstract
                                           FStar_Syntax_Syntax.Delta_equational
                                       else
-                                        FStar_Syntax_Syntax.Delta_equational
-                                       in
+                                        FStar_Syntax_Syntax.Delta_equational in
                                     let lb =
                                       let uu____11735 =
                                         let uu____11740 =
                                           FStar_Syntax_Syntax.lid_as_fv
                                             field_name dd
-                                            FStar_Pervasives_Native.None
-                                           in
-                                        FStar_Util.Inr uu____11740  in
+                                            FStar_Pervasives_Native.None in
+                                        FStar_Util.Inr uu____11740 in
                                       {
                                         FStar_Syntax_Syntax.lbname =
                                           uu____11735;
@@ -4339,7 +3970,7 @@ let (mk_indexed_projector_names :
                                         FStar_Syntax_Syntax.lbdef =
                                           FStar_Syntax_Syntax.tun;
                                         FStar_Syntax_Syntax.lbattrs = []
-                                      }  in
+                                      } in
                                     let impl =
                                       let uu____11744 =
                                         let uu____11745 =
@@ -4348,18 +3979,15 @@ let (mk_indexed_projector_names :
                                               let uu____11756 =
                                                 FStar_All.pipe_right
                                                   lb.FStar_Syntax_Syntax.lbname
-                                                  FStar_Util.right
-                                                 in
+                                                  FStar_Util.right in
                                               FStar_All.pipe_right
                                                 uu____11756
                                                 (fun fv  ->
-                                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                                               in
-                                            [uu____11755]  in
-                                          ((false, [lb]), uu____11752)  in
+                                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
+                                            [uu____11755] in
+                                          ((false, [lb]), uu____11752) in
                                         FStar_Syntax_Syntax.Sig_let
-                                          uu____11745
-                                         in
+                                          uu____11745 in
                                       {
                                         FStar_Syntax_Syntax.sigel =
                                           uu____11744;
@@ -4368,15 +3996,13 @@ let (mk_indexed_projector_names :
                                         FStar_Syntax_Syntax.sigmeta =
                                           FStar_Syntax_Syntax.default_sigmeta;
                                         FStar_Syntax_Syntax.sigattrs = []
-                                      }  in
-                                    if no_decl then [impl] else [decl; impl]))))
-               in
+                                      } in
+                                    if no_decl then [impl] else [decl; impl])))) in
             FStar_All.pipe_right uu____11635 FStar_List.flatten
-  
-let (mk_data_projector_names :
+let mk_data_projector_names:
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_ToSyntax_Env.env ->
-      FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt Prims.list)
+      FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt Prims.list
   =
   fun iquals  ->
     fun env  ->
@@ -4387,7 +4013,7 @@ let (mk_data_projector_names :
             Prims.op_Negation
               (FStar_Ident.lid_equals lid FStar_Parser_Const.lexcons_lid)
             ->
-            let uu____11809 = FStar_Syntax_Util.arrow_formals t  in
+            let uu____11809 = FStar_Syntax_Util.arrow_formals t in
             (match uu____11809 with
              | (formals,uu____11825) ->
                  (match formals with
@@ -4399,30 +4025,28 @@ let (mk_data_projector_names :
                             (uu____11863,fns) ->
                             FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Record_ctor (lid, fns))
-                        | uu____11875 -> FStar_Pervasives_Native.None  in
+                        | uu____11875 -> FStar_Pervasives_Native.None in
                       let fv_qual =
                         let uu____11877 =
                           FStar_Util.find_map se.FStar_Syntax_Syntax.sigquals
-                            filter_records
-                           in
+                            filter_records in
                         match uu____11877 with
                         | FStar_Pervasives_Native.None  ->
                             FStar_Syntax_Syntax.Data_ctor
-                        | FStar_Pervasives_Native.Some q -> q  in
+                        | FStar_Pervasives_Native.Some q -> q in
                       let iquals1 =
                         if
                           FStar_List.contains FStar_Syntax_Syntax.Abstract
                             iquals
                         then FStar_Syntax_Syntax.Private :: iquals
-                        else iquals  in
-                      let uu____11887 = FStar_Util.first_N n1 formals  in
+                        else iquals in
+                      let uu____11887 = FStar_Util.first_N n1 formals in
                       (match uu____11887 with
                        | (uu____11910,rest) ->
                            mk_indexed_projector_names iquals1 fv_qual env lid
                              rest)))
         | uu____11936 -> []
-  
-let (mk_typ_abbrev :
+let mk_typ_abbrev:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.univ_name Prims.list ->
       (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
@@ -4431,7 +4055,7 @@ let (mk_typ_abbrev :
           FStar_Syntax_Syntax.term ->
             FStar_Ident.lident Prims.list ->
               FStar_Syntax_Syntax.qualifier Prims.list ->
-                FStar_Range.range -> FStar_Syntax_Syntax.sigelt)
+                FStar_Range.range -> FStar_Syntax_Syntax.sigelt
   =
   fun lid  ->
     fun uvs  ->
@@ -4444,25 +4068,23 @@ let (mk_typ_abbrev :
                   let dd =
                     let uu____11986 =
                       FStar_All.pipe_right quals
-                        (FStar_List.contains FStar_Syntax_Syntax.Abstract)
-                       in
+                        (FStar_List.contains FStar_Syntax_Syntax.Abstract) in
                     if uu____11986
                     then
                       let uu____11989 =
-                        FStar_Syntax_Util.incr_delta_qualifier t  in
+                        FStar_Syntax_Util.incr_delta_qualifier t in
                       FStar_Syntax_Syntax.Delta_abstract uu____11989
-                    else FStar_Syntax_Util.incr_delta_qualifier t  in
+                    else FStar_Syntax_Util.incr_delta_qualifier t in
                   let lb =
                     let uu____11992 =
                       let uu____11997 =
                         FStar_Syntax_Syntax.lid_as_fv lid dd
-                          FStar_Pervasives_Native.None
-                         in
-                      FStar_Util.Inr uu____11997  in
+                          FStar_Pervasives_Native.None in
+                      FStar_Util.Inr uu____11997 in
                     let uu____11998 =
-                      let uu____12001 = FStar_Syntax_Syntax.mk_Total k  in
-                      FStar_Syntax_Util.arrow typars uu____12001  in
-                    let uu____12004 = no_annot_abs typars t  in
+                      let uu____12001 = FStar_Syntax_Syntax.mk_Total k in
+                      FStar_Syntax_Util.arrow typars uu____12001 in
+                    let uu____12004 = no_annot_abs typars t in
                     {
                       FStar_Syntax_Syntax.lbname = uu____11992;
                       FStar_Syntax_Syntax.lbunivs = uvs;
@@ -4471,7 +4093,7 @@ let (mk_typ_abbrev :
                         FStar_Parser_Const.effect_Tot_lid;
                       FStar_Syntax_Syntax.lbdef = uu____12004;
                       FStar_Syntax_Syntax.lbattrs = []
-                    }  in
+                    } in
                   {
                     FStar_Syntax_Syntax.sigel =
                       (FStar_Syntax_Syntax.Sig_let ((false, [lb]), lids));
@@ -4481,19 +4103,18 @@ let (mk_typ_abbrev :
                       FStar_Syntax_Syntax.default_sigmeta;
                     FStar_Syntax_Syntax.sigattrs = []
                   }
-  
-let rec (desugar_tycon :
+let rec desugar_tycon:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.decl ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
         FStar_Parser_AST.tycon Prims.list ->
-          (env_t,FStar_Syntax_Syntax.sigelts) FStar_Pervasives_Native.tuple2)
+          (env_t,FStar_Syntax_Syntax.sigelts) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun d  ->
       fun quals  ->
         fun tcs  ->
-          let rng = d.FStar_Parser_AST.drange  in
+          let rng = d.FStar_Parser_AST.drange in
           let tycon_id uu___98_12051 =
             match uu___98_12051 with
             | FStar_Parser_AST.TyconAbstract (id1,uu____12053,uu____12054) ->
@@ -4503,20 +4124,19 @@ let rec (desugar_tycon :
             | FStar_Parser_AST.TyconRecord
                 (id1,uu____12076,uu____12077,uu____12078) -> id1
             | FStar_Parser_AST.TyconVariant
-                (id1,uu____12108,uu____12109,uu____12110) -> id1
-             in
+                (id1,uu____12108,uu____12109,uu____12110) -> id1 in
           let binder_to_term b =
             match b.FStar_Parser_AST.b with
             | FStar_Parser_AST.Annotated (x,uu____12152) ->
                 let uu____12153 =
-                  let uu____12154 = FStar_Ident.lid_of_ids [x]  in
-                  FStar_Parser_AST.Var uu____12154  in
+                  let uu____12154 = FStar_Ident.lid_of_ids [x] in
+                  FStar_Parser_AST.Var uu____12154 in
                 FStar_Parser_AST.mk_term uu____12153 x.FStar_Ident.idRange
                   FStar_Parser_AST.Expr
             | FStar_Parser_AST.Variable x ->
                 let uu____12156 =
-                  let uu____12157 = FStar_Ident.lid_of_ids [x]  in
-                  FStar_Parser_AST.Var uu____12157  in
+                  let uu____12157 = FStar_Ident.lid_of_ids [x] in
+                  FStar_Parser_AST.Var uu____12157 in
                 FStar_Parser_AST.mk_term uu____12156 x.FStar_Ident.idRange
                   FStar_Parser_AST.Expr
             | FStar_Parser_AST.TAnnotated (a,uu____12159) ->
@@ -4525,43 +4145,39 @@ let rec (desugar_tycon :
             | FStar_Parser_AST.TVariable a ->
                 FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
                   a.FStar_Ident.idRange FStar_Parser_AST.Type_level
-            | FStar_Parser_AST.NoName t -> t  in
+            | FStar_Parser_AST.NoName t -> t in
           let tot =
             FStar_Parser_AST.mk_term
               (FStar_Parser_AST.Name FStar_Parser_Const.effect_Tot_lid) rng
-              FStar_Parser_AST.Expr
-             in
+              FStar_Parser_AST.Expr in
           let with_constructor_effect t =
             FStar_Parser_AST.mk_term
               (FStar_Parser_AST.App (tot, t, FStar_Parser_AST.Nothing))
-              t.FStar_Parser_AST.range t.FStar_Parser_AST.level
-             in
+              t.FStar_Parser_AST.range t.FStar_Parser_AST.level in
           let apply_binders t binders =
             let imp_of_aqual b =
               match b.FStar_Parser_AST.aqual with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit ) ->
                   FStar_Parser_AST.Hash
-              | uu____12182 -> FStar_Parser_AST.Nothing  in
+              | uu____12182 -> FStar_Parser_AST.Nothing in
             FStar_List.fold_left
               (fun out  ->
                  fun b  ->
                    let uu____12188 =
                      let uu____12189 =
-                       let uu____12196 = binder_to_term b  in
-                       (out, uu____12196, (imp_of_aqual b))  in
-                     FStar_Parser_AST.App uu____12189  in
+                       let uu____12196 = binder_to_term b in
+                       (out, uu____12196, (imp_of_aqual b)) in
+                     FStar_Parser_AST.App uu____12189 in
                    FStar_Parser_AST.mk_term uu____12188
                      out.FStar_Parser_AST.range out.FStar_Parser_AST.level) t
-              binders
-             in
+              binders in
           let tycon_record_as_variant uu___99_12206 =
             match uu___99_12206 with
             | FStar_Parser_AST.TyconRecord (id1,parms,kopt,fields) ->
                 let constrName =
                   FStar_Ident.mk_ident
                     ((Prims.strcat "Mk" id1.FStar_Ident.idText),
-                      (id1.FStar_Ident.idRange))
-                   in
+                      (id1.FStar_Ident.idRange)) in
                 let mfields =
                   FStar_List.map
                     (fun uu____12261  ->
@@ -4571,41 +4187,37 @@ let rec (desugar_tycon :
                              (FStar_Parser_AST.Annotated
                                 ((FStar_Syntax_Util.mangle_field_name x), t))
                              x.FStar_Ident.idRange FStar_Parser_AST.Expr
-                             FStar_Pervasives_Native.None) fields
-                   in
+                             FStar_Pervasives_Native.None) fields in
                 let result =
                   let uu____12278 =
                     let uu____12279 =
-                      let uu____12280 = FStar_Ident.lid_of_ids [id1]  in
-                      FStar_Parser_AST.Var uu____12280  in
+                      let uu____12280 = FStar_Ident.lid_of_ids [id1] in
+                      FStar_Parser_AST.Var uu____12280 in
                     FStar_Parser_AST.mk_term uu____12279
-                      id1.FStar_Ident.idRange FStar_Parser_AST.Type_level
-                     in
-                  apply_binders uu____12278 parms  in
+                      id1.FStar_Ident.idRange FStar_Parser_AST.Type_level in
+                  apply_binders uu____12278 parms in
                 let constrTyp =
                   FStar_Parser_AST.mk_term
                     (FStar_Parser_AST.Product
                        (mfields, (with_constructor_effect result)))
-                    id1.FStar_Ident.idRange FStar_Parser_AST.Type_level
-                   in
+                    id1.FStar_Ident.idRange FStar_Parser_AST.Type_level in
                 let uu____12284 =
                   FStar_All.pipe_right fields
                     (FStar_List.map
                        (fun uu____12311  ->
                           match uu____12311 with
                           | (x,uu____12321,uu____12322) ->
-                              FStar_Syntax_Util.unmangle_field_name x))
-                   in
+                              FStar_Syntax_Util.unmangle_field_name x)) in
                 ((FStar_Parser_AST.TyconVariant
                     (id1, parms, kopt,
                       [(constrName, (FStar_Pervasives_Native.Some constrTyp),
                          FStar_Pervasives_Native.None, false)])),
                   uu____12284)
-            | uu____12375 -> failwith "impossible"  in
+            | uu____12375 -> failwith "impossible" in
           let desugar_abstract_tc quals1 _env mutuals uu___100_12406 =
             match uu___100_12406 with
             | FStar_Parser_AST.TyconAbstract (id1,binders,kopt) ->
-                let uu____12430 = typars_of_binders _env binders  in
+                let uu____12430 = typars_of_binders _env binders in
                 (match uu____12430 with
                  | (_env',typars) ->
                      let k =
@@ -4613,22 +4225,19 @@ let rec (desugar_tycon :
                        | FStar_Pervasives_Native.None  ->
                            FStar_Syntax_Util.ktype
                        | FStar_Pervasives_Native.Some k ->
-                           desugar_term _env' k
-                        in
+                           desugar_term _env' k in
                      let tconstr =
                        let uu____12476 =
                          let uu____12477 =
-                           let uu____12478 = FStar_Ident.lid_of_ids [id1]  in
-                           FStar_Parser_AST.Var uu____12478  in
+                           let uu____12478 = FStar_Ident.lid_of_ids [id1] in
+                           FStar_Parser_AST.Var uu____12478 in
                          FStar_Parser_AST.mk_term uu____12477
                            id1.FStar_Ident.idRange
-                           FStar_Parser_AST.Type_level
-                          in
-                       apply_binders uu____12476 binders  in
-                     let qlid = FStar_ToSyntax_Env.qualify _env id1  in
-                     let typars1 = FStar_Syntax_Subst.close_binders typars
-                        in
-                     let k1 = FStar_Syntax_Subst.close typars1 k  in
+                           FStar_Parser_AST.Type_level in
+                       apply_binders uu____12476 binders in
+                     let qlid = FStar_ToSyntax_Env.qualify _env id1 in
+                     let typars1 = FStar_Syntax_Subst.close_binders typars in
+                     let k1 = FStar_Syntax_Subst.close typars1 k in
                      let se =
                        {
                          FStar_Syntax_Syntax.sigel =
@@ -4639,17 +4248,15 @@ let rec (desugar_tycon :
                          FStar_Syntax_Syntax.sigmeta =
                            FStar_Syntax_Syntax.default_sigmeta;
                          FStar_Syntax_Syntax.sigattrs = []
-                       }  in
+                       } in
                      let _env1 =
                        FStar_ToSyntax_Env.push_top_level_rec_binding _env id1
-                         FStar_Syntax_Syntax.Delta_constant
-                        in
+                         FStar_Syntax_Syntax.Delta_constant in
                      let _env2 =
                        FStar_ToSyntax_Env.push_top_level_rec_binding _env'
-                         id1 FStar_Syntax_Syntax.Delta_constant
-                        in
+                         id1 FStar_Syntax_Syntax.Delta_constant in
                      (_env1, _env2, se, tconstr))
-            | uu____12491 -> failwith "Unexpected tycon"  in
+            | uu____12491 -> failwith "Unexpected tycon" in
           let push_tparams env1 bs =
             let uu____12535 =
               FStar_List.fold_left
@@ -4659,31 +4266,29 @@ let rec (desugar_tycon :
                      | ((env2,tps),(x,imp)) ->
                          let uu____12667 =
                            FStar_ToSyntax_Env.push_bv env2
-                             x.FStar_Syntax_Syntax.ppname
-                            in
+                             x.FStar_Syntax_Syntax.ppname in
                          (match uu____12667 with
                           | (env3,y) -> (env3, ((y, imp) :: tps))))
-                (env1, []) bs
-               in
+                (env1, []) bs in
             match uu____12535 with
-            | (env2,bs1) -> (env2, (FStar_List.rev bs1))  in
+            | (env2,bs1) -> (env2, (FStar_List.rev bs1)) in
           match tcs with
           | (FStar_Parser_AST.TyconAbstract (id1,bs,kopt))::[] ->
               let kopt1 =
                 match kopt with
                 | FStar_Pervasives_Native.None  ->
-                    let uu____12780 = tm_type_z id1.FStar_Ident.idRange  in
+                    let uu____12780 = tm_type_z id1.FStar_Ident.idRange in
                     FStar_Pervasives_Native.Some uu____12780
-                | uu____12781 -> kopt  in
-              let tc = FStar_Parser_AST.TyconAbstract (id1, bs, kopt1)  in
-              let uu____12789 = desugar_abstract_tc quals env [] tc  in
+                | uu____12781 -> kopt in
+              let tc = FStar_Parser_AST.TyconAbstract (id1, bs, kopt1) in
+              let uu____12789 = desugar_abstract_tc quals env [] tc in
               (match uu____12789 with
                | (uu____12802,uu____12803,se,uu____12805) ->
                    let se1 =
                      match se.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
                          (l,uu____12808,typars,k,[],[]) ->
-                         let quals1 = se.FStar_Syntax_Syntax.sigquals  in
+                         let quals1 = se.FStar_Syntax_Syntax.sigquals in
                          let quals2 =
                            if
                              FStar_List.contains
@@ -4691,22 +4296,19 @@ let rec (desugar_tycon :
                            then quals1
                            else
                              ((let uu____12825 =
-                                 let uu____12826 = FStar_Options.ml_ish ()
-                                    in
-                                 Prims.op_Negation uu____12826  in
+                                 let uu____12826 = FStar_Options.ml_ish () in
+                                 Prims.op_Negation uu____12826 in
                                if uu____12825
                                then
                                  let uu____12827 =
                                    let uu____12832 =
                                      let uu____12833 =
-                                       FStar_Syntax_Print.lid_to_string l  in
+                                       FStar_Syntax_Print.lid_to_string l in
                                      FStar_Util.format1
                                        "Adding an implicit 'assume new' qualifier on %s"
-                                       uu____12833
-                                      in
+                                       uu____12833 in
                                    (FStar_Errors.Warning_AddImplicitAssumeNewQualifier,
-                                     uu____12832)
-                                    in
+                                     uu____12832) in
                                  FStar_Errors.log_issue
                                    se.FStar_Syntax_Syntax.sigrng uu____12827
                                else ());
@@ -4714,8 +4316,7 @@ let rec (desugar_tycon :
                               ::
                               FStar_Syntax_Syntax.New
                               ::
-                              quals1)
-                            in
+                              quals1) in
                          let t =
                            match typars with
                            | [] -> k
@@ -4724,15 +4325,13 @@ let rec (desugar_tycon :
                                  let uu____12844 =
                                    let uu____12845 =
                                      let uu____12858 =
-                                       FStar_Syntax_Syntax.mk_Total k  in
-                                     (typars, uu____12858)  in
-                                   FStar_Syntax_Syntax.Tm_arrow uu____12845
-                                    in
-                                 FStar_Syntax_Syntax.mk uu____12844  in
+                                       FStar_Syntax_Syntax.mk_Total k in
+                                     (typars, uu____12858) in
+                                   FStar_Syntax_Syntax.Tm_arrow uu____12845 in
+                                 FStar_Syntax_Syntax.mk uu____12844 in
                                uu____12841 FStar_Pervasives_Native.None
-                                 se.FStar_Syntax_Syntax.sigrng
-                            in
-                         let uu___132_12862 = se  in
+                                 se.FStar_Syntax_Syntax.sigrng in
+                         let uu___132_12862 = se in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_declare_typ (l, [], t));
@@ -4744,17 +4343,15 @@ let rec (desugar_tycon :
                            FStar_Syntax_Syntax.sigattrs =
                              (uu___132_12862.FStar_Syntax_Syntax.sigattrs)
                          }
-                     | uu____12865 -> failwith "Impossible"  in
-                   let env1 = FStar_ToSyntax_Env.push_sigelt env se1  in
+                     | uu____12865 -> failwith "Impossible" in
+                   let env1 = FStar_ToSyntax_Env.push_sigelt env se1 in
                    let env2 =
-                     let uu____12868 = FStar_ToSyntax_Env.qualify env1 id1
-                        in
+                     let uu____12868 = FStar_ToSyntax_Env.qualify env1 id1 in
                      FStar_ToSyntax_Env.push_doc env1 uu____12868
-                       d.FStar_Parser_AST.doc
-                      in
+                       d.FStar_Parser_AST.doc in
                    (env2, [se1]))
           | (FStar_Parser_AST.TyconAbbrev (id1,binders,kopt,t))::[] ->
-              let uu____12883 = typars_of_binders env binders  in
+              let uu____12883 = typars_of_binders env binders in
               (match uu____12883 with
                | (env',typars) ->
                    let k =
@@ -4765,14 +4362,12 @@ let rec (desugar_tycon :
                              (fun uu___101_12921  ->
                                 match uu___101_12921 with
                                 | FStar_Syntax_Syntax.Effect  -> true
-                                | uu____12922 -> false) quals
-                            in
+                                | uu____12922 -> false) quals in
                          if uu____12919
                          then FStar_Syntax_Syntax.teff
                          else FStar_Syntax_Util.ktype
-                     | FStar_Pervasives_Native.Some k -> desugar_term env' k
-                      in
-                   let t0 = t  in
+                     | FStar_Pervasives_Native.Some k -> desugar_term env' k in
+                   let t0 = t in
                    let quals1 =
                      let uu____12929 =
                        FStar_All.pipe_right quals
@@ -4780,68 +4375,62 @@ let rec (desugar_tycon :
                             (fun uu___102_12933  ->
                                match uu___102_12933 with
                                | FStar_Syntax_Syntax.Logic  -> true
-                               | uu____12934 -> false))
-                        in
+                               | uu____12934 -> false)) in
                      if uu____12929
                      then quals
                      else
                        if
                          t0.FStar_Parser_AST.level = FStar_Parser_AST.Formula
                        then FStar_Syntax_Syntax.Logic :: quals
-                       else quals
-                      in
-                   let qlid = FStar_ToSyntax_Env.qualify env id1  in
+                       else quals in
+                   let qlid = FStar_ToSyntax_Env.qualify env id1 in
                    let se =
                      let uu____12943 =
                        FStar_All.pipe_right quals1
-                         (FStar_List.contains FStar_Syntax_Syntax.Effect)
-                        in
+                         (FStar_List.contains FStar_Syntax_Syntax.Effect) in
                      if uu____12943
                      then
                        let uu____12946 =
                          let uu____12953 =
-                           let uu____12954 = unparen t  in
-                           uu____12954.FStar_Parser_AST.tm  in
+                           let uu____12954 = unparen t in
+                           uu____12954.FStar_Parser_AST.tm in
                          match uu____12953 with
                          | FStar_Parser_AST.Construct (head1,args) ->
                              let uu____12975 =
                                match FStar_List.rev args with
                                | (last_arg,uu____13005)::args_rev ->
                                    let uu____13017 =
-                                     let uu____13018 = unparen last_arg  in
-                                     uu____13018.FStar_Parser_AST.tm  in
+                                     let uu____13018 = unparen last_arg in
+                                     uu____13018.FStar_Parser_AST.tm in
                                    (match uu____13017 with
                                     | FStar_Parser_AST.Attributes ts ->
                                         (ts, (FStar_List.rev args_rev))
                                     | uu____13046 -> ([], args))
-                               | uu____13055 -> ([], args)  in
+                               | uu____13055 -> ([], args) in
                              (match uu____12975 with
                               | (cattributes,args1) ->
                                   let uu____13094 =
-                                    desugar_attributes env cattributes  in
+                                    desugar_attributes env cattributes in
                                   ((FStar_Parser_AST.mk_term
                                       (FStar_Parser_AST.Construct
                                          (head1, args1))
                                       t.FStar_Parser_AST.range
                                       t.FStar_Parser_AST.level), uu____13094))
-                         | uu____13105 -> (t, [])  in
+                         | uu____13105 -> (t, []) in
                        match uu____12946 with
                        | (t1,cattributes) ->
                            let c =
-                             desugar_comp t1.FStar_Parser_AST.range env' t1
-                              in
+                             desugar_comp t1.FStar_Parser_AST.range env' t1 in
                            let typars1 =
-                             FStar_Syntax_Subst.close_binders typars  in
-                           let c1 = FStar_Syntax_Subst.close_comp typars1 c
-                              in
+                             FStar_Syntax_Subst.close_binders typars in
+                           let c1 = FStar_Syntax_Subst.close_comp typars1 c in
                            let quals2 =
                              FStar_All.pipe_right quals1
                                (FStar_List.filter
                                   (fun uu___103_13127  ->
                                      match uu___103_13127 with
                                      | FStar_Syntax_Syntax.Effect  -> false
-                                     | uu____13128 -> true))
-                              in
+                                     | uu____13128 -> true)) in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_effect_abbrev
@@ -4855,18 +4444,16 @@ let rec (desugar_tycon :
                              FStar_Syntax_Syntax.sigattrs = []
                            }
                      else
-                       (let t1 = desugar_typ env' t  in
-                        mk_typ_abbrev qlid [] typars k t1 [qlid] quals1 rng)
-                      in
-                   let env1 = FStar_ToSyntax_Env.push_sigelt env se  in
+                       (let t1 = desugar_typ env' t in
+                        mk_typ_abbrev qlid [] typars k t1 [qlid] quals1 rng) in
+                   let env1 = FStar_ToSyntax_Env.push_sigelt env se in
                    let env2 =
                      FStar_ToSyntax_Env.push_doc env1 qlid
-                       d.FStar_Parser_AST.doc
-                      in
+                       d.FStar_Parser_AST.doc in
                    (env2, [se]))
           | (FStar_Parser_AST.TyconRecord uu____13139)::[] ->
-              let trec = FStar_List.hd tcs  in
-              let uu____13163 = tycon_record_as_variant trec  in
+              let trec = FStar_List.hd tcs in
+              let uu____13163 = tycon_record_as_variant trec in
               (match uu____13163 with
                | (t,fs) ->
                    let uu____13180 =
@@ -4874,28 +4461,27 @@ let rec (desugar_tycon :
                        let uu____13184 =
                          let uu____13193 =
                            let uu____13196 =
-                             FStar_ToSyntax_Env.current_module env  in
-                           FStar_Ident.ids_of_lid uu____13196  in
-                         (uu____13193, fs)  in
-                       FStar_Syntax_Syntax.RecordType uu____13184  in
-                     uu____13183 :: quals  in
+                             FStar_ToSyntax_Env.current_module env in
+                           FStar_Ident.ids_of_lid uu____13196 in
+                         (uu____13193, fs) in
+                       FStar_Syntax_Syntax.RecordType uu____13184 in
+                     uu____13183 :: quals in
                    desugar_tycon env d uu____13180 [t])
           | uu____13201::uu____13202 ->
-              let env0 = env  in
+              let env0 = env in
               let mutuals =
                 FStar_List.map
                   (fun x  ->
                      FStar_All.pipe_left (FStar_ToSyntax_Env.qualify env)
-                       (tycon_id x)) tcs
-                 in
+                       (tycon_id x)) tcs in
               let rec collect_tcs quals1 et tc =
-                let uu____13363 = et  in
+                let uu____13363 = et in
                 match uu____13363 with
                 | (env1,tcs1) ->
                     (match tc with
                      | FStar_Parser_AST.TyconRecord uu____13588 ->
-                         let trec = tc  in
-                         let uu____13612 = tycon_record_as_variant trec  in
+                         let trec = tc in
+                         let uu____13612 = tycon_record_as_variant trec in
                          (match uu____13612 with
                           | (t,fs) ->
                               let uu____13671 =
@@ -4904,21 +4490,18 @@ let rec (desugar_tycon :
                                     let uu____13684 =
                                       let uu____13687 =
                                         FStar_ToSyntax_Env.current_module
-                                          env1
-                                         in
-                                      FStar_Ident.ids_of_lid uu____13687  in
-                                    (uu____13684, fs)  in
-                                  FStar_Syntax_Syntax.RecordType uu____13675
-                                   in
-                                uu____13674 :: quals1  in
+                                          env1 in
+                                      FStar_Ident.ids_of_lid uu____13687 in
+                                    (uu____13684, fs) in
+                                  FStar_Syntax_Syntax.RecordType uu____13675 in
+                                uu____13674 :: quals1 in
                               collect_tcs uu____13671 (env1, tcs1) t)
                      | FStar_Parser_AST.TyconVariant
                          (id1,binders,kopt,constructors) ->
                          let uu____13774 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
-                                (id1, binders, kopt))
-                            in
+                                (id1, binders, kopt)) in
                          (match uu____13774 with
                           | (env2,uu____13834,se,tconstr) ->
                               (env2,
@@ -4929,21 +4512,19 @@ let rec (desugar_tycon :
                          let uu____13983 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
-                                (id1, binders, kopt))
-                            in
+                                (id1, binders, kopt)) in
                          (match uu____13983 with
                           | (env2,uu____14043,se,tconstr) ->
                               (env2,
                                 ((FStar_Util.Inr (se, binders, t, quals1)) ::
                                 tcs1)))
                      | uu____14168 ->
-                         failwith "Unrecognized mutual type definition")
-                 in
+                         failwith "Unrecognized mutual type definition") in
               let uu____14215 =
-                FStar_List.fold_left (collect_tcs quals) (env, []) tcs  in
+                FStar_List.fold_left (collect_tcs quals) (env, []) tcs in
               (match uu____14215 with
                | (env1,tcs1) ->
-                   let tcs2 = FStar_List.rev tcs1  in
+                   let tcs2 = FStar_List.rev tcs1 in
                    let docs_tps_sigelts =
                      FStar_All.pipe_right tcs2
                        (FStar_List.collect
@@ -4963,30 +4544,25 @@ let rec (desugar_tycon :
                                  ->
                                  let t1 =
                                    let uu____14859 =
-                                     typars_of_binders env1 binders  in
+                                     typars_of_binders env1 binders in
                                    match uu____14859 with
                                    | (env2,tpars1) ->
                                        let uu____14890 =
-                                         push_tparams env2 tpars1  in
+                                         push_tparams env2 tpars1 in
                                        (match uu____14890 with
                                         | (env_tps,tpars2) ->
-                                            let t1 = desugar_typ env_tps t
-                                               in
+                                            let t1 = desugar_typ env_tps t in
                                             let tpars3 =
                                               FStar_Syntax_Subst.close_binders
-                                                tpars2
-                                               in
+                                                tpars2 in
                                             FStar_Syntax_Subst.close tpars3
-                                              t1)
-                                    in
+                                              t1) in
                                  let uu____14923 =
                                    let uu____14944 =
                                      mk_typ_abbrev id1 uvs tpars k t1 
-                                       [id1] quals1 rng
-                                      in
+                                       [id1] quals1 rng in
                                    ((id1, (d.FStar_Parser_AST.doc)), [],
-                                     uu____14944)
-                                    in
+                                     uu____14944) in
                                  [uu____14923]
                              | FStar_Util.Inl
                                  ({
@@ -5006,17 +4582,14 @@ let rec (desugar_tycon :
                                        (FStar_Parser_AST.Name
                                           FStar_Parser_Const.effect_Tot_lid)
                                        t.FStar_Parser_AST.range
-                                       t.FStar_Parser_AST.level
-                                      in
+                                       t.FStar_Parser_AST.level in
                                    FStar_Parser_AST.mk_term
                                      (FStar_Parser_AST.App
                                         (tot1, t, FStar_Parser_AST.Nothing))
                                      t.FStar_Parser_AST.range
-                                     t.FStar_Parser_AST.level
-                                    in
-                                 let tycon = (tname, tpars, k)  in
-                                 let uu____15112 = push_tparams env1 tpars
-                                    in
+                                     t.FStar_Parser_AST.level in
+                                 let tycon = (tname, tpars, k) in
+                                 let uu____15112 = push_tparams env1 tpars in
                                  (match uu____15112 with
                                   | (env_tps,tps) ->
                                       let data_tpars =
@@ -5027,9 +4600,8 @@ let rec (desugar_tycon :
                                                  (x,
                                                    (FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Syntax.Implicit
-                                                         true)))) tps
-                                         in
-                                      let tot_tconstr = mk_tot tconstr  in
+                                                         true)))) tps in
+                                      let tot_tconstr = mk_tot tconstr in
                                       let uu____15211 =
                                         let uu____15240 =
                                           FStar_All.pipe_right constrs
@@ -5065,18 +4637,15 @@ let rec (desugar_tycon :
                                                                failwith
                                                                  "Impossible"
                                                            | FStar_Pervasives_Native.Some
-                                                               t -> t)
-                                                         in
+                                                               t -> t) in
                                                       let t1 =
                                                         let uu____15410 =
-                                                          close env_tps t  in
+                                                          close env_tps t in
                                                         desugar_term env_tps
-                                                          uu____15410
-                                                         in
+                                                          uu____15410 in
                                                       let name =
                                                         FStar_ToSyntax_Env.qualify
-                                                          env1 id1
-                                                         in
+                                                          env1 id1 in
                                                       let quals2 =
                                                         FStar_All.pipe_right
                                                           tname_quals
@@ -5092,12 +4661,10 @@ let rec (desugar_tycon :
                                                                     FStar_Syntax_Syntax.RecordConstructor
                                                                     fns]
                                                                 | uu____15433
-                                                                    -> []))
-                                                         in
+                                                                    -> [])) in
                                                       let ntps =
                                                         FStar_List.length
-                                                          data_tpars
-                                                         in
+                                                          data_tpars in
                                                       let uu____15441 =
                                                         let uu____15462 =
                                                           let uu____15463 =
@@ -5110,23 +4677,18 @@ let rec (desugar_tycon :
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     t1
-                                                                    FStar_Syntax_Util.name_function_binders
-                                                                     in
+                                                                    FStar_Syntax_Util.name_function_binders in
                                                                   FStar_Syntax_Syntax.mk_Total
-                                                                    uu____15485
-                                                                   in
+                                                                    uu____15485 in
                                                                 FStar_Syntax_Util.arrow
                                                                   data_tpars
-                                                                  uu____15482
-                                                                 in
+                                                                  uu____15482 in
                                                               (name, univs1,
                                                                 uu____15479,
                                                                 tname, ntps,
-                                                                mutuals1)
-                                                               in
+                                                                mutuals1) in
                                                             FStar_Syntax_Syntax.Sig_datacon
-                                                              uu____15464
-                                                             in
+                                                              uu____15464 in
                                                           {
                                                             FStar_Syntax_Syntax.sigel
                                                               = uu____15463;
@@ -5139,15 +4701,12 @@ let rec (desugar_tycon :
                                                               FStar_Syntax_Syntax.default_sigmeta;
                                                             FStar_Syntax_Syntax.sigattrs
                                                               = []
-                                                          }  in
+                                                          } in
                                                         ((name, doc1), tps,
-                                                          uu____15462)
-                                                         in
-                                                      (name, uu____15441)))
-                                           in
+                                                          uu____15462) in
+                                                      (name, uu____15441))) in
                                         FStar_All.pipe_left FStar_List.split
-                                          uu____15240
-                                         in
+                                          uu____15240 in
                                       (match uu____15211 with
                                        | (constrNames,constrs1) ->
                                            ((tname, (d.FStar_Parser_AST.doc)),
@@ -5167,46 +4726,38 @@ let rec (desugar_tycon :
                                                  []
                                              })
                                            :: constrs1))
-                             | uu____15724 -> failwith "impossible"))
-                      in
+                             | uu____15724 -> failwith "impossible")) in
                    let name_docs =
                      FStar_All.pipe_right docs_tps_sigelts
                        (FStar_List.map
                           (fun uu____15856  ->
                              match uu____15856 with
-                             | (name_doc,uu____15884,uu____15885) -> name_doc))
-                      in
+                             | (name_doc,uu____15884,uu____15885) -> name_doc)) in
                    let sigelts =
                      FStar_All.pipe_right docs_tps_sigelts
                        (FStar_List.map
                           (fun uu____15965  ->
                              match uu____15965 with
-                             | (uu____15986,uu____15987,se) -> se))
-                      in
+                             | (uu____15986,uu____15987,se) -> se)) in
                    let uu____16017 =
                      let uu____16024 =
                        FStar_List.collect FStar_Syntax_Util.lids_of_sigelt
-                         sigelts
-                        in
+                         sigelts in
                      FStar_Syntax_MutRecTy.disentangle_abbrevs_from_bundle
-                       sigelts quals uu____16024 rng
-                      in
+                       sigelts quals uu____16024 rng in
                    (match uu____16017 with
                     | (bundle,abbrevs) ->
-                        let env2 = FStar_ToSyntax_Env.push_sigelt env0 bundle
-                           in
+                        let env2 = FStar_ToSyntax_Env.push_sigelt env0 bundle in
                         let env3 =
                           FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt
-                            env2 abbrevs
-                           in
+                            env2 abbrevs in
                         let data_ops =
                           FStar_All.pipe_right docs_tps_sigelts
                             (FStar_List.collect
                                (fun uu____16090  ->
                                   match uu____16090 with
                                   | (uu____16113,tps,se) ->
-                                      mk_data_projector_names quals env3 se))
-                           in
+                                      mk_data_projector_names quals env3 se)) in
                         let discs =
                           FStar_All.pipe_right sigelts
                             (FStar_List.collect
@@ -5219,7 +4770,7 @@ let rec (desugar_tycon :
                                         (Prims.parse_int "1")
                                       ->
                                       let quals1 =
-                                        se.FStar_Syntax_Syntax.sigquals  in
+                                        se.FStar_Syntax_Syntax.sigquals in
                                       let quals2 =
                                         if
                                           FStar_List.contains
@@ -5227,16 +4778,14 @@ let rec (desugar_tycon :
                                             quals1
                                         then FStar_Syntax_Syntax.Private ::
                                           quals1
-                                        else quals1  in
+                                        else quals1 in
                                       mk_data_discriminators quals2 env3
                                         constrs
-                                  | uu____16186 -> []))
-                           in
-                        let ops = FStar_List.append discs data_ops  in
+                                  | uu____16186 -> [])) in
+                        let ops = FStar_List.append discs data_ops in
                         let env4 =
                           FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt
-                            env3 ops
-                           in
+                            env3 ops in
                         let env5 =
                           FStar_List.fold_left
                             (fun acc  ->
@@ -5244,18 +4793,16 @@ let rec (desugar_tycon :
                                  match uu____16203 with
                                  | (lid,doc1) ->
                                      FStar_ToSyntax_Env.push_doc env4 lid
-                                       doc1) env4 name_docs
-                           in
+                                       doc1) env4 name_docs in
                         (env5,
                           (FStar_List.append [bundle]
                              (FStar_List.append abbrevs ops)))))
           | [] -> failwith "impossible"
-  
-let (desugar_binders :
+let desugar_binders:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.binder Prims.list ->
       (FStar_ToSyntax_Env.env,FStar_Syntax_Syntax.binder Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun binders  ->
@@ -5265,28 +4812,25 @@ let (desugar_binders :
              fun b  ->
                match uu____16261 with
                | (env1,binders1) ->
-                   let uu____16281 = desugar_binder env1 b  in
+                   let uu____16281 = desugar_binder env1 b in
                    (match uu____16281 with
                     | (FStar_Pervasives_Native.Some a,k) ->
                         let uu____16298 =
                           as_binder env1 b.FStar_Parser_AST.aqual
-                            ((FStar_Pervasives_Native.Some a), k)
-                           in
+                            ((FStar_Pervasives_Native.Some a), k) in
                         (match uu____16298 with
                          | (binder,env2) -> (env2, (binder :: binders1)))
                     | uu____16315 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_MissingNameInBinder,
                             "Missing name in binder")
-                          b.FStar_Parser_AST.brange)) (env, []) binders
-         in
+                          b.FStar_Parser_AST.brange)) (env, []) binders in
       match uu____16238 with
       | (env1,binders1) -> (env1, (FStar_List.rev binders1))
-  
-let (push_reflect_effect :
+let push_reflect_effect:
   FStar_ToSyntax_Env.env ->
     FStar_Syntax_Syntax.qualifier Prims.list ->
-      FStar_Ident.lid -> FStar_Range.range -> FStar_ToSyntax_Env.env)
+      FStar_Ident.lid -> FStar_Range.range -> FStar_ToSyntax_Env.env
   =
   fun env  ->
     fun quals  ->
@@ -5298,21 +4842,18 @@ let (push_reflect_effect :
                  (fun uu___106_16365  ->
                     match uu___106_16365 with
                     | FStar_Syntax_Syntax.Reflectable uu____16366 -> true
-                    | uu____16367 -> false))
-             in
+                    | uu____16367 -> false)) in
           if uu____16360
           then
             let monad_env =
               FStar_ToSyntax_Env.enter_monad_scope env
-                effect_name.FStar_Ident.ident
-               in
+                effect_name.FStar_Ident.ident in
             let reflect_lid =
               FStar_All.pipe_right (FStar_Ident.id_of_text "reflect")
-                (FStar_ToSyntax_Env.qualify monad_env)
-               in
+                (FStar_ToSyntax_Env.qualify monad_env) in
             let quals1 =
               [FStar_Syntax_Syntax.Assumption;
-              FStar_Syntax_Syntax.Reflectable effect_name]  in
+              FStar_Syntax_Syntax.Reflectable effect_name] in
             let refl_decl =
               {
                 FStar_Syntax_Syntax.sigel =
@@ -5323,11 +4864,10 @@ let (push_reflect_effect :
                 FStar_Syntax_Syntax.sigmeta =
                   FStar_Syntax_Syntax.default_sigmeta;
                 FStar_Syntax_Syntax.sigattrs = []
-              }  in
+              } in
             FStar_ToSyntax_Env.push_sigelt env refl_decl
           else env
-  
-let rec (desugar_effect :
+let rec desugar_effect:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.decl ->
       FStar_Parser_AST.qualifiers ->
@@ -5336,7 +4876,7 @@ let rec (desugar_effect :
             FStar_Parser_AST.term ->
               FStar_Parser_AST.decl Prims.list ->
                 (FStar_ToSyntax_Env.env,FStar_Syntax_Syntax.sigelt Prims.list)
-                  FStar_Pervasives_Native.tuple2)
+                  FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun d  ->
@@ -5345,23 +4885,23 @@ let rec (desugar_effect :
           fun eff_binders  ->
             fun eff_typ  ->
               fun eff_decls  ->
-                let env0 = env  in
+                let env0 = env in
                 let monad_env =
-                  FStar_ToSyntax_Env.enter_monad_scope env eff_name  in
-                let uu____16466 = desugar_binders monad_env eff_binders  in
+                  FStar_ToSyntax_Env.enter_monad_scope env eff_name in
+                let uu____16466 = desugar_binders monad_env eff_binders in
                 match uu____16466 with
                 | (env1,binders) ->
-                    let eff_t = desugar_term env1 eff_typ  in
+                    let eff_t = desugar_term env1 eff_typ in
                     let for_free =
                       let uu____16487 =
                         let uu____16488 =
                           let uu____16495 =
-                            FStar_Syntax_Util.arrow_formals eff_t  in
-                          FStar_Pervasives_Native.fst uu____16495  in
-                        FStar_List.length uu____16488  in
-                      uu____16487 = (Prims.parse_int "1")  in
+                            FStar_Syntax_Util.arrow_formals eff_t in
+                          FStar_Pervasives_Native.fst uu____16495 in
+                        FStar_List.length uu____16488 in
+                      uu____16487 = (Prims.parse_int "1") in
                     let mandatory_members =
-                      let rr_members = ["repr"; "return"; "bind"]  in
+                      let rr_members = ["repr"; "return"; "bind"] in
                       if for_free
                       then rr_members
                       else
@@ -5375,8 +4915,7 @@ let rec (desugar_effect :
                           "assert_p";
                           "assume_p";
                           "null_wp";
-                          "trivial"]
-                       in
+                          "trivial"] in
                     let name_of_eff_decl decl =
                       match decl.FStar_Parser_AST.d with
                       | FStar_Parser_AST.Tycon
@@ -5384,15 +4923,13 @@ let rec (desugar_effect :
                                         (name,uu____16539,uu____16540,uu____16541),uu____16542)::[])
                           -> FStar_Ident.text_of_id name
                       | uu____16575 ->
-                          failwith "Malformed effect member declaration."
-                       in
+                          failwith "Malformed effect member declaration." in
                     let uu____16576 =
                       FStar_List.partition
                         (fun decl  ->
-                           let uu____16588 = name_of_eff_decl decl  in
+                           let uu____16588 = name_of_eff_decl decl in
                            FStar_List.mem uu____16588 mandatory_members)
-                        eff_decls
-                       in
+                        eff_decls in
                     (match uu____16576 with
                      | (mandatory_members_decls,actions) ->
                          let uu____16605 =
@@ -5403,20 +4940,19 @@ let rec (desugar_effect :
                                      match uu____16634 with
                                      | (env2,out) ->
                                          let uu____16654 =
-                                           desugar_decl env2 decl  in
+                                           desugar_decl env2 decl in
                                          (match uu____16654 with
                                           | (env3,ses) ->
                                               let uu____16667 =
                                                 let uu____16670 =
-                                                  FStar_List.hd ses  in
-                                                uu____16670 :: out  in
+                                                  FStar_List.hd ses in
+                                                uu____16670 :: out in
                                               (env3, uu____16667)))
-                                (env1, []))
-                            in
+                                (env1, [])) in
                          (match uu____16605 with
                           | (env2,decls) ->
                               let binders1 =
-                                FStar_Syntax_Subst.close_binders binders  in
+                                FStar_Syntax_Subst.close_binders binders in
                               let actions_docs =
                                 FStar_All.pipe_right actions
                                   (FStar_List.map
@@ -5440,40 +4976,33 @@ let rec (desugar_effect :
                                             ->
                                             let uu____16800 =
                                               desugar_binders env2
-                                                action_params
-                                               in
+                                                action_params in
                                             (match uu____16800 with
                                              | (env3,action_params1) ->
                                                  let action_params2 =
                                                    FStar_Syntax_Subst.close_binders
-                                                     action_params1
-                                                    in
+                                                     action_params1 in
                                                  let uu____16820 =
                                                    let uu____16821 =
                                                      FStar_ToSyntax_Env.qualify
-                                                       env3 name
-                                                      in
+                                                       env3 name in
                                                    let uu____16822 =
                                                      let uu____16823 =
-                                                       desugar_term env3 def
-                                                        in
+                                                       desugar_term env3 def in
                                                      FStar_Syntax_Subst.close
                                                        (FStar_List.append
                                                           binders1
                                                           action_params2)
-                                                       uu____16823
-                                                      in
+                                                       uu____16823 in
                                                    let uu____16828 =
                                                      let uu____16829 =
                                                        desugar_typ env3
-                                                         cps_type
-                                                        in
+                                                         cps_type in
                                                      FStar_Syntax_Subst.close
                                                        (FStar_List.append
                                                           binders1
                                                           action_params2)
-                                                       uu____16829
-                                                      in
+                                                       uu____16829 in
                                                    {
                                                      FStar_Syntax_Syntax.action_name
                                                        = uu____16821;
@@ -5487,7 +5016,7 @@ let rec (desugar_effect :
                                                        = uu____16822;
                                                      FStar_Syntax_Syntax.action_typ
                                                        = uu____16828
-                                                   }  in
+                                                   } in
                                                  (uu____16820, doc1))
                                         | FStar_Parser_AST.Tycon
                                             (uu____16836,(FStar_Parser_AST.TyconAbbrev
@@ -5495,29 +5024,24 @@ let rec (desugar_effect :
                                             when for_free ->
                                             let uu____16874 =
                                               desugar_binders env2
-                                                action_params
-                                               in
+                                                action_params in
                                             (match uu____16874 with
                                              | (env3,action_params1) ->
                                                  let action_params2 =
                                                    FStar_Syntax_Subst.close_binders
-                                                     action_params1
-                                                    in
+                                                     action_params1 in
                                                  let uu____16894 =
                                                    let uu____16895 =
                                                      FStar_ToSyntax_Env.qualify
-                                                       env3 name
-                                                      in
+                                                       env3 name in
                                                    let uu____16896 =
                                                      let uu____16897 =
-                                                       desugar_term env3 defn
-                                                        in
+                                                       desugar_term env3 defn in
                                                      FStar_Syntax_Subst.close
                                                        (FStar_List.append
                                                           binders1
                                                           action_params2)
-                                                       uu____16897
-                                                      in
+                                                       uu____16897 in
                                                    {
                                                      FStar_Syntax_Syntax.action_name
                                                        = uu____16895;
@@ -5532,45 +5056,39 @@ let rec (desugar_effect :
                                                      FStar_Syntax_Syntax.action_typ
                                                        =
                                                        FStar_Syntax_Syntax.tun
-                                                   }  in
+                                                   } in
                                                  (uu____16894, doc1))
                                         | uu____16904 ->
                                             FStar_Errors.raise_error
                                               (FStar_Errors.Fatal_MalformedActionDeclaration,
                                                 "Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).")
-                                              d1.FStar_Parser_AST.drange))
-                                 in
+                                              d1.FStar_Parser_AST.drange)) in
                               let actions1 =
                                 FStar_List.map FStar_Pervasives_Native.fst
-                                  actions_docs
-                                 in
+                                  actions_docs in
                               let eff_t1 =
-                                FStar_Syntax_Subst.close binders1 eff_t  in
+                                FStar_Syntax_Subst.close binders1 eff_t in
                               let lookup s =
                                 let l =
                                   FStar_ToSyntax_Env.qualify env2
                                     (FStar_Ident.mk_ident
-                                       (s, (d.FStar_Parser_AST.drange)))
-                                   in
+                                       (s, (d.FStar_Parser_AST.drange))) in
                                 let uu____16934 =
                                   let uu____16935 =
                                     FStar_ToSyntax_Env.fail_or env2
                                       (FStar_ToSyntax_Env.try_lookup_definition
-                                         env2) l
-                                     in
+                                         env2) l in
                                   FStar_All.pipe_left
                                     (FStar_Syntax_Subst.close binders1)
-                                    uu____16935
-                                   in
-                                ([], uu____16934)  in
+                                    uu____16935 in
+                                ([], uu____16934) in
                               let mname =
-                                FStar_ToSyntax_Env.qualify env0 eff_name  in
+                                FStar_ToSyntax_Env.qualify env0 eff_name in
                               let qualifiers =
                                 FStar_List.map
                                   (trans_qual d.FStar_Parser_AST.drange
                                      (FStar_Pervasives_Native.Some mname))
-                                  quals
-                                 in
+                                  quals in
                               let se =
                                 if for_free
                                 then
@@ -5579,18 +5097,16 @@ let rec (desugar_effect :
                                       FStar_Syntax_Syntax.mk
                                         FStar_Syntax_Syntax.Tm_unknown
                                         FStar_Pervasives_Native.None
-                                        FStar_Range.dummyRange
-                                       in
-                                    ([], uu____16952)  in
+                                        FStar_Range.dummyRange in
+                                    ([], uu____16952) in
                                   let uu____16959 =
                                     let uu____16960 =
                                       let uu____16961 =
-                                        let uu____16962 = lookup "repr"  in
+                                        let uu____16962 = lookup "repr" in
                                         FStar_Pervasives_Native.snd
-                                          uu____16962
-                                         in
-                                      let uu____16971 = lookup "return"  in
-                                      let uu____16972 = lookup "bind"  in
+                                          uu____16962 in
+                                      let uu____16971 = lookup "return" in
+                                      let uu____16972 = lookup "bind" in
                                       {
                                         FStar_Syntax_Syntax.cattributes = [];
                                         FStar_Syntax_Syntax.mname = mname;
@@ -5627,10 +5143,9 @@ let rec (desugar_effect :
                                           uu____16972;
                                         FStar_Syntax_Syntax.actions =
                                           actions1
-                                      }  in
+                                      } in
                                     FStar_Syntax_Syntax.Sig_new_effect_for_free
-                                      uu____16960
-                                     in
+                                      uu____16960 in
                                   {
                                     FStar_Syntax_Syntax.sigel = uu____16959;
                                     FStar_Syntax_Syntax.sigrng =
@@ -5649,44 +5164,35 @@ let rec (desugar_effect :
                                               true
                                           | FStar_Syntax_Syntax.Reflectable
                                               uu____16977 -> true
-                                          | uu____16978 -> false) qualifiers
-                                      in
-                                   let un_ts = ([], FStar_Syntax_Syntax.tun)
-                                      in
+                                          | uu____16978 -> false) qualifiers in
+                                   let un_ts = ([], FStar_Syntax_Syntax.tun) in
                                    let uu____16988 =
                                      let uu____16989 =
-                                       let uu____16990 = lookup "return_wp"
-                                          in
-                                       let uu____16991 = lookup "bind_wp"  in
+                                       let uu____16990 = lookup "return_wp" in
+                                       let uu____16991 = lookup "bind_wp" in
                                        let uu____16992 =
-                                         lookup "if_then_else"  in
-                                       let uu____16993 = lookup "ite_wp"  in
-                                       let uu____16994 = lookup "stronger"
-                                          in
-                                       let uu____16995 = lookup "close_wp"
-                                          in
-                                       let uu____16996 = lookup "assert_p"
-                                          in
-                                       let uu____16997 = lookup "assume_p"
-                                          in
-                                       let uu____16998 = lookup "null_wp"  in
-                                       let uu____16999 = lookup "trivial"  in
+                                         lookup "if_then_else" in
+                                       let uu____16993 = lookup "ite_wp" in
+                                       let uu____16994 = lookup "stronger" in
+                                       let uu____16995 = lookup "close_wp" in
+                                       let uu____16996 = lookup "assert_p" in
+                                       let uu____16997 = lookup "assume_p" in
+                                       let uu____16998 = lookup "null_wp" in
+                                       let uu____16999 = lookup "trivial" in
                                        let uu____17000 =
                                          if rr
                                          then
-                                           let uu____17001 = lookup "repr"
-                                              in
+                                           let uu____17001 = lookup "repr" in
                                            FStar_All.pipe_left
                                              FStar_Pervasives_Native.snd
                                              uu____17001
-                                         else FStar_Syntax_Syntax.tun  in
+                                         else FStar_Syntax_Syntax.tun in
                                        let uu____17017 =
                                          if rr
                                          then lookup "return"
-                                         else un_ts  in
+                                         else un_ts in
                                        let uu____17019 =
-                                         if rr then lookup "bind" else un_ts
-                                          in
+                                         if rr then lookup "bind" else un_ts in
                                        {
                                          FStar_Syntax_Syntax.cattributes = [];
                                          FStar_Syntax_Syntax.mname = mname;
@@ -5723,10 +5229,9 @@ let rec (desugar_effect :
                                            uu____17019;
                                          FStar_Syntax_Syntax.actions =
                                            actions1
-                                       }  in
+                                       } in
                                      FStar_Syntax_Syntax.Sig_new_effect
-                                       uu____16989
-                                      in
+                                       uu____16989 in
                                    {
                                      FStar_Syntax_Syntax.sigel = uu____16988;
                                      FStar_Syntax_Syntax.sigrng =
@@ -5736,14 +5241,12 @@ let rec (desugar_effect :
                                      FStar_Syntax_Syntax.sigmeta =
                                        FStar_Syntax_Syntax.default_sigmeta;
                                      FStar_Syntax_Syntax.sigattrs = []
-                                   })
-                                 in
+                                   }) in
                               let env3 =
-                                FStar_ToSyntax_Env.push_sigelt env0 se  in
+                                FStar_ToSyntax_Env.push_sigelt env0 se in
                               let env4 =
                                 FStar_ToSyntax_Env.push_doc env3 mname
-                                  d.FStar_Parser_AST.doc
-                                 in
+                                  d.FStar_Parser_AST.doc in
                               let env5 =
                                 FStar_All.pipe_right actions_docs
                                   (FStar_List.fold_left
@@ -5754,27 +5257,21 @@ let rec (desugar_effect :
                                               let env6 =
                                                 let uu____17058 =
                                                   FStar_Syntax_Util.action_as_lb
-                                                    mname a
-                                                   in
+                                                    mname a in
                                                 FStar_ToSyntax_Env.push_sigelt
-                                                  env5 uu____17058
-                                                 in
+                                                  env5 uu____17058 in
                                               FStar_ToSyntax_Env.push_doc
                                                 env6
                                                 a.FStar_Syntax_Syntax.action_name
-                                                doc1) env4)
-                                 in
+                                                doc1) env4) in
                               let env6 =
                                 push_reflect_effect env5 qualifiers mname
-                                  d.FStar_Parser_AST.drange
-                                 in
+                                  d.FStar_Parser_AST.drange in
                               let env7 =
                                 FStar_ToSyntax_Env.push_doc env6 mname
-                                  d.FStar_Parser_AST.doc
-                                 in
+                                  d.FStar_Parser_AST.doc in
                               (env7, [se])))
-
-and (desugar_redefine_effect :
+and desugar_redefine_effect:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.decl ->
       (FStar_Ident.lident FStar_Pervasives_Native.option ->
@@ -5785,7 +5282,7 @@ and (desugar_redefine_effect :
             FStar_Parser_AST.binder Prims.list ->
               FStar_Parser_AST.term ->
                 (FStar_ToSyntax_Env.env,FStar_Syntax_Syntax.sigelt Prims.list)
-                  FStar_Pervasives_Native.tuple2)
+                  FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun d  ->
@@ -5794,14 +5291,13 @@ and (desugar_redefine_effect :
           fun eff_name  ->
             fun eff_binders  ->
               fun defn  ->
-                let env0 = env  in
-                let env1 = FStar_ToSyntax_Env.enter_monad_scope env eff_name
-                   in
-                let uu____17082 = desugar_binders env1 eff_binders  in
+                let env0 = env in
+                let env1 = FStar_ToSyntax_Env.enter_monad_scope env eff_name in
+                let uu____17082 = desugar_binders env1 eff_binders in
                 match uu____17082 with
                 | (env2,binders) ->
                     let uu____17101 =
-                      let uu____17120 = head_and_args defn  in
+                      let uu____17120 = head_and_args defn in
                       match uu____17120 with
                       | (head1,args) ->
                           let lid =
@@ -5812,44 +5308,38 @@ and (desugar_redefine_effect :
                                   let uu____17171 =
                                     let uu____17172 =
                                       let uu____17173 =
-                                        FStar_Parser_AST.term_to_string head1
-                                         in
-                                      Prims.strcat uu____17173 " not found"
-                                       in
-                                    Prims.strcat "Effect " uu____17172  in
+                                        FStar_Parser_AST.term_to_string head1 in
+                                      Prims.strcat uu____17173 " not found" in
+                                    Prims.strcat "Effect " uu____17172 in
                                   (FStar_Errors.Fatal_EffectNotFound,
-                                    uu____17171)
-                                   in
+                                    uu____17171) in
                                 FStar_Errors.raise_error uu____17166
-                                  d.FStar_Parser_AST.drange
-                             in
+                                  d.FStar_Parser_AST.drange in
                           let ed =
                             FStar_ToSyntax_Env.fail_or env2
                               (FStar_ToSyntax_Env.try_lookup_effect_defn env2)
-                              lid
-                             in
+                              lid in
                           let uu____17175 =
                             match FStar_List.rev args with
                             | (last_arg,uu____17205)::args_rev ->
                                 let uu____17217 =
-                                  let uu____17218 = unparen last_arg  in
-                                  uu____17218.FStar_Parser_AST.tm  in
+                                  let uu____17218 = unparen last_arg in
+                                  uu____17218.FStar_Parser_AST.tm in
                                 (match uu____17217 with
                                  | FStar_Parser_AST.Attributes ts ->
                                      (ts, (FStar_List.rev args_rev))
                                  | uu____17246 -> ([], args))
-                            | uu____17255 -> ([], args)  in
+                            | uu____17255 -> ([], args) in
                           (match uu____17175 with
                            | (cattributes,args1) ->
-                               let uu____17306 = desugar_args env2 args1  in
+                               let uu____17306 = desugar_args env2 args1 in
                                let uu____17315 =
-                                 desugar_attributes env2 cattributes  in
-                               (lid, ed, uu____17306, uu____17315))
-                       in
+                                 desugar_attributes env2 cattributes in
+                               (lid, ed, uu____17306, uu____17315)) in
                     (match uu____17101 with
                      | (ed_lid,ed,args,cattributes) ->
                          let binders1 =
-                           FStar_Syntax_Subst.close_binders binders  in
+                           FStar_Syntax_Subst.close_binders binders in
                          (if
                             (FStar_List.length args) <>
                               (FStar_List.length
@@ -5863,8 +5353,7 @@ and (desugar_redefine_effect :
                           (let uu____17371 =
                              FStar_Syntax_Subst.open_term'
                                ed.FStar_Syntax_Syntax.binders
-                               FStar_Syntax_Syntax.t_unit
-                              in
+                               FStar_Syntax_Syntax.t_unit in
                            match uu____17371 with
                            | (ed_binders,uu____17385,ed_binders_opening) ->
                                let sub1 uu____17396 =
@@ -5874,89 +5363,74 @@ and (desugar_redefine_effect :
                                        let uu____17410 =
                                          FStar_Syntax_Subst.shift_subst
                                            (FStar_List.length us)
-                                           ed_binders_opening
-                                          in
-                                       FStar_Syntax_Subst.subst uu____17410 x
-                                        in
+                                           ed_binders_opening in
+                                       FStar_Syntax_Subst.subst uu____17410 x in
                                      let s =
                                        FStar_Syntax_Util.subst_of_list
-                                         ed_binders args
-                                        in
+                                         ed_binders args in
                                      let uu____17414 =
                                        let uu____17415 =
-                                         FStar_Syntax_Subst.subst s x1  in
-                                       (us, uu____17415)  in
+                                         FStar_Syntax_Subst.subst s x1 in
+                                       (us, uu____17415) in
                                      FStar_Syntax_Subst.close_tscheme
-                                       binders1 uu____17414
-                                  in
+                                       binders1 uu____17414 in
                                let mname =
-                                 FStar_ToSyntax_Env.qualify env0 eff_name  in
+                                 FStar_ToSyntax_Env.qualify env0 eff_name in
                                let ed1 =
                                  let uu____17420 =
                                    let uu____17421 =
                                      sub1
                                        ([],
-                                         (ed.FStar_Syntax_Syntax.signature))
-                                      in
-                                   FStar_Pervasives_Native.snd uu____17421
-                                    in
+                                         (ed.FStar_Syntax_Syntax.signature)) in
+                                   FStar_Pervasives_Native.snd uu____17421 in
                                  let uu____17432 =
-                                   sub1 ed.FStar_Syntax_Syntax.ret_wp  in
+                                   sub1 ed.FStar_Syntax_Syntax.ret_wp in
                                  let uu____17433 =
-                                   sub1 ed.FStar_Syntax_Syntax.bind_wp  in
+                                   sub1 ed.FStar_Syntax_Syntax.bind_wp in
                                  let uu____17434 =
-                                   sub1 ed.FStar_Syntax_Syntax.if_then_else
-                                    in
+                                   sub1 ed.FStar_Syntax_Syntax.if_then_else in
                                  let uu____17435 =
-                                   sub1 ed.FStar_Syntax_Syntax.ite_wp  in
+                                   sub1 ed.FStar_Syntax_Syntax.ite_wp in
                                  let uu____17436 =
-                                   sub1 ed.FStar_Syntax_Syntax.stronger  in
+                                   sub1 ed.FStar_Syntax_Syntax.stronger in
                                  let uu____17437 =
-                                   sub1 ed.FStar_Syntax_Syntax.close_wp  in
+                                   sub1 ed.FStar_Syntax_Syntax.close_wp in
                                  let uu____17438 =
-                                   sub1 ed.FStar_Syntax_Syntax.assert_p  in
+                                   sub1 ed.FStar_Syntax_Syntax.assert_p in
                                  let uu____17439 =
-                                   sub1 ed.FStar_Syntax_Syntax.assume_p  in
+                                   sub1 ed.FStar_Syntax_Syntax.assume_p in
                                  let uu____17440 =
-                                   sub1 ed.FStar_Syntax_Syntax.null_wp  in
+                                   sub1 ed.FStar_Syntax_Syntax.null_wp in
                                  let uu____17441 =
-                                   sub1 ed.FStar_Syntax_Syntax.trivial  in
+                                   sub1 ed.FStar_Syntax_Syntax.trivial in
                                  let uu____17442 =
                                    let uu____17443 =
-                                     sub1 ([], (ed.FStar_Syntax_Syntax.repr))
-                                      in
-                                   FStar_Pervasives_Native.snd uu____17443
-                                    in
+                                     sub1 ([], (ed.FStar_Syntax_Syntax.repr)) in
+                                   FStar_Pervasives_Native.snd uu____17443 in
                                  let uu____17454 =
-                                   sub1 ed.FStar_Syntax_Syntax.return_repr
-                                    in
+                                   sub1 ed.FStar_Syntax_Syntax.return_repr in
                                  let uu____17455 =
-                                   sub1 ed.FStar_Syntax_Syntax.bind_repr  in
+                                   sub1 ed.FStar_Syntax_Syntax.bind_repr in
                                  let uu____17456 =
                                    FStar_List.map
                                      (fun action  ->
                                         let uu____17464 =
                                           FStar_ToSyntax_Env.qualify env2
-                                            action.FStar_Syntax_Syntax.action_unqualified_name
-                                           in
+                                            action.FStar_Syntax_Syntax.action_unqualified_name in
                                         let uu____17465 =
                                           let uu____17466 =
                                             sub1
                                               ([],
-                                                (action.FStar_Syntax_Syntax.action_defn))
-                                             in
+                                                (action.FStar_Syntax_Syntax.action_defn)) in
                                           FStar_Pervasives_Native.snd
-                                            uu____17466
-                                           in
+                                            uu____17466 in
                                         let uu____17477 =
                                           let uu____17478 =
                                             sub1
                                               ([],
-                                                (action.FStar_Syntax_Syntax.action_typ))
-                                             in
+                                                (action.FStar_Syntax_Syntax.action_typ)) in
                                           FStar_Pervasives_Native.snd
-                                            uu____17478
-                                           in
+                                            uu____17478 in
                                         {
                                           FStar_Syntax_Syntax.action_name =
                                             uu____17464;
@@ -5971,8 +5445,7 @@ and (desugar_redefine_effect :
                                             uu____17465;
                                           FStar_Syntax_Syntax.action_typ =
                                             uu____17477
-                                        }) ed.FStar_Syntax_Syntax.actions
-                                    in
+                                        }) ed.FStar_Syntax_Syntax.actions in
                                  {
                                    FStar_Syntax_Syntax.cattributes =
                                      cattributes;
@@ -5999,26 +5472,23 @@ and (desugar_redefine_effect :
                                    FStar_Syntax_Syntax.bind_repr =
                                      uu____17455;
                                    FStar_Syntax_Syntax.actions = uu____17456
-                                 }  in
+                                 } in
                                let se =
                                  let for_free =
                                    let uu____17491 =
                                      let uu____17492 =
                                        let uu____17499 =
                                          FStar_Syntax_Util.arrow_formals
-                                           ed1.FStar_Syntax_Syntax.signature
-                                          in
+                                           ed1.FStar_Syntax_Syntax.signature in
                                        FStar_Pervasives_Native.fst
-                                         uu____17499
-                                        in
-                                     FStar_List.length uu____17492  in
-                                   uu____17491 = (Prims.parse_int "1")  in
+                                         uu____17499 in
+                                     FStar_List.length uu____17492 in
+                                   uu____17491 = (Prims.parse_int "1") in
                                  let uu____17528 =
                                    let uu____17531 =
                                      trans_qual1
-                                       (FStar_Pervasives_Native.Some mname)
-                                      in
-                                   FStar_List.map uu____17531 quals  in
+                                       (FStar_Pervasives_Native.Some mname) in
+                                   FStar_List.map uu____17531 quals in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (if for_free
@@ -6034,14 +5504,13 @@ and (desugar_redefine_effect :
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
                                    FStar_Syntax_Syntax.sigattrs = []
-                                 }  in
-                               let monad_env = env2  in
+                                 } in
+                               let monad_env = env2 in
                                let env3 =
-                                 FStar_ToSyntax_Env.push_sigelt env0 se  in
+                                 FStar_ToSyntax_Env.push_sigelt env0 se in
                                let env4 =
                                  FStar_ToSyntax_Env.push_doc env3 ed_lid
-                                   d.FStar_Parser_AST.doc
-                                  in
+                                   d.FStar_Parser_AST.doc in
                                let env5 =
                                  FStar_All.pipe_right
                                    ed1.FStar_Syntax_Syntax.actions
@@ -6051,37 +5520,30 @@ and (desugar_redefine_effect :
                                            let doc1 =
                                              FStar_ToSyntax_Env.try_lookup_doc
                                                env5
-                                               a.FStar_Syntax_Syntax.action_name
-                                              in
+                                               a.FStar_Syntax_Syntax.action_name in
                                            let env6 =
                                              let uu____17551 =
                                                FStar_Syntax_Util.action_as_lb
-                                                 mname a
-                                                in
+                                                 mname a in
                                              FStar_ToSyntax_Env.push_sigelt
-                                               env5 uu____17551
-                                              in
+                                               env5 uu____17551 in
                                            FStar_ToSyntax_Env.push_doc env6
                                              a.FStar_Syntax_Syntax.action_name
-                                             doc1) env4)
-                                  in
+                                             doc1) env4) in
                                let env6 =
                                  let uu____17553 =
                                    FStar_All.pipe_right quals
                                      (FStar_List.contains
-                                        FStar_Parser_AST.Reflectable)
-                                    in
+                                        FStar_Parser_AST.Reflectable) in
                                  if uu____17553
                                  then
                                    let reflect_lid =
                                      FStar_All.pipe_right
                                        (FStar_Ident.id_of_text "reflect")
-                                       (FStar_ToSyntax_Env.qualify monad_env)
-                                      in
+                                       (FStar_ToSyntax_Env.qualify monad_env) in
                                    let quals1 =
                                      [FStar_Syntax_Syntax.Assumption;
-                                     FStar_Syntax_Syntax.Reflectable mname]
-                                      in
+                                     FStar_Syntax_Syntax.Reflectable mname] in
                                    let refl_decl =
                                      {
                                        FStar_Syntax_Syntax.sigel =
@@ -6094,44 +5556,40 @@ and (desugar_redefine_effect :
                                        FStar_Syntax_Syntax.sigmeta =
                                          FStar_Syntax_Syntax.default_sigmeta;
                                        FStar_Syntax_Syntax.sigattrs = []
-                                     }  in
+                                     } in
                                    FStar_ToSyntax_Env.push_sigelt env5
                                      refl_decl
-                                 else env5  in
+                                 else env5 in
                                let env7 =
                                  FStar_ToSyntax_Env.push_doc env6 mname
-                                   d.FStar_Parser_AST.doc
-                                  in
+                                   d.FStar_Parser_AST.doc in
                                (env7, [se]))))
-
-and (mk_comment_attr :
+and mk_comment_attr:
   FStar_Parser_AST.decl ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun d  ->
     let uu____17568 =
       match d.FStar_Parser_AST.doc with
       | FStar_Pervasives_Native.None  -> ("", [])
-      | FStar_Pervasives_Native.Some fsdoc -> fsdoc  in
+      | FStar_Pervasives_Native.Some fsdoc -> fsdoc in
     match uu____17568 with
     | (text,kv) ->
         let summary =
           match FStar_List.assoc "summary" kv with
           | FStar_Pervasives_Native.None  -> ""
           | FStar_Pervasives_Native.Some s ->
-              Prims.strcat "  " (Prims.strcat s "\n")
-           in
+              Prims.strcat "  " (Prims.strcat s "\n") in
         let pp =
           match FStar_List.assoc "type" kv with
           | FStar_Pervasives_Native.Some uu____17619 ->
               let uu____17620 =
                 let uu____17621 =
-                  FStar_Parser_ToDocument.signature_to_document d  in
+                  FStar_Parser_ToDocument.signature_to_document d in
                 FStar_Pprint.pretty_string 0.95 (Prims.parse_int "80")
-                  uu____17621
-                 in
+                  uu____17621 in
               Prims.strcat "\n  " uu____17620
-          | uu____17622 -> ""  in
+          | uu____17622 -> "" in
         let other =
           FStar_List.filter_map
             (fun uu____17635  ->
@@ -6141,55 +5599,47 @@ and (mk_comment_attr :
                    then
                      FStar_Pervasives_Native.Some
                        (Prims.strcat k (Prims.strcat ": " v1))
-                   else FStar_Pervasives_Native.None) kv
-           in
+                   else FStar_Pervasives_Native.None) kv in
         let other1 =
           if other <> []
           then Prims.strcat (FStar_String.concat "\n" other) "\n"
-          else ""  in
+          else "" in
         let str =
-          Prims.strcat summary (Prims.strcat pp (Prims.strcat other1 text))
-           in
+          Prims.strcat summary (Prims.strcat pp (Prims.strcat other1 text)) in
         let fv =
-          let uu____17653 = FStar_Ident.lid_of_str "FStar.Pervasives.Comment"
-             in
+          let uu____17653 = FStar_Ident.lid_of_str "FStar.Pervasives.Comment" in
           FStar_Syntax_Syntax.fvar uu____17653
-            FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None
-           in
-        let arg = FStar_Syntax_Util.exp_string str  in
+            FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None in
+        let arg = FStar_Syntax_Util.exp_string str in
         let uu____17655 =
-          let uu____17664 = FStar_Syntax_Syntax.as_arg arg  in [uu____17664]
-           in
+          let uu____17664 = FStar_Syntax_Syntax.as_arg arg in [uu____17664] in
         FStar_Syntax_Util.mk_app fv uu____17655
-
-and (desugar_decl :
+and desugar_decl:
   env_t ->
     FStar_Parser_AST.decl ->
-      (env_t,FStar_Syntax_Syntax.sigelts) FStar_Pervasives_Native.tuple2)
+      (env_t,FStar_Syntax_Syntax.sigelts) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun d  ->
-      let uu____17671 = desugar_decl_noattrs env d  in
+      let uu____17671 = desugar_decl_noattrs env d in
       match uu____17671 with
       | (env1,sigelts) ->
-          let attrs = d.FStar_Parser_AST.attrs  in
-          let attrs1 = FStar_List.map (desugar_term env1) attrs  in
+          let attrs = d.FStar_Parser_AST.attrs in
+          let attrs1 = FStar_List.map (desugar_term env1) attrs in
           let attrs2 =
-            let uu____17691 = mk_comment_attr d  in uu____17691 :: attrs1  in
+            let uu____17691 = mk_comment_attr d in uu____17691 :: attrs1 in
           let s =
             FStar_List.fold_left
               (fun s  ->
                  fun a  ->
                    let uu____17702 =
-                     let uu____17703 = FStar_Syntax_Print.term_to_string a
-                        in
-                     Prims.strcat "; " uu____17703  in
-                   Prims.strcat s uu____17702) "" attrs2
-             in
+                     let uu____17703 = FStar_Syntax_Print.term_to_string a in
+                     Prims.strcat "; " uu____17703 in
+                   Prims.strcat s uu____17702) "" attrs2 in
           let uu____17704 =
             FStar_List.map
               (fun sigelt  ->
-                 let uu___133_17710 = sigelt  in
+                 let uu___133_17710 = sigelt in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (uu___133_17710.FStar_Syntax_Syntax.sigel);
@@ -6200,18 +5650,16 @@ and (desugar_decl :
                    FStar_Syntax_Syntax.sigmeta =
                      (uu___133_17710.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs = attrs2
-                 }) sigelts
-             in
+                 }) sigelts in
           (env1, uu____17704)
-
-and (desugar_decl_noattrs :
+and desugar_decl_noattrs:
   env_t ->
     FStar_Parser_AST.decl ->
-      (env_t,FStar_Syntax_Syntax.sigelts) FStar_Pervasives_Native.tuple2)
+      (env_t,FStar_Syntax_Syntax.sigelts) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun d  ->
-      let trans_qual1 = trans_qual d.FStar_Parser_AST.drange  in
+      let trans_qual1 = trans_qual d.FStar_Parser_AST.drange in
       match d.FStar_Parser_AST.d with
       | FStar_Parser_AST.Pragma p ->
           let se =
@@ -6223,7 +5671,7 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = []
-            }  in
+            } in
           (if p = FStar_Parser_AST.LightOff
            then FStar_Options.set_ml_ish ()
            else ();
@@ -6231,28 +5679,26 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Fsdoc uu____17736 -> (env, [])
       | FStar_Parser_AST.TopLevelModule id1 -> (env, [])
       | FStar_Parser_AST.Open lid ->
-          let env1 = FStar_ToSyntax_Env.push_namespace env lid  in (env1, [])
+          let env1 = FStar_ToSyntax_Env.push_namespace env lid in (env1, [])
       | FStar_Parser_AST.Include lid ->
-          let env1 = FStar_ToSyntax_Env.push_include env lid  in (env1, [])
+          let env1 = FStar_ToSyntax_Env.push_include env lid in (env1, [])
       | FStar_Parser_AST.ModuleAbbrev (x,l) ->
-          let uu____17752 = FStar_ToSyntax_Env.push_module_abbrev env x l  in
+          let uu____17752 = FStar_ToSyntax_Env.push_module_abbrev env x l in
           (uu____17752, [])
       | FStar_Parser_AST.Tycon (is_effect,tcs) ->
           let quals =
             if is_effect
             then FStar_Parser_AST.Effect_qual :: (d.FStar_Parser_AST.quals)
-            else d.FStar_Parser_AST.quals  in
+            else d.FStar_Parser_AST.quals in
           let tcs1 =
             FStar_List.map
               (fun uu____17791  ->
-                 match uu____17791 with | (x,uu____17799) -> x) tcs
-             in
+                 match uu____17791 with | (x,uu____17799) -> x) tcs in
           let uu____17804 =
-            FStar_List.map (trans_qual1 FStar_Pervasives_Native.None) quals
-             in
+            FStar_List.map (trans_qual1 FStar_Pervasives_Native.None) quals in
           desugar_tycon env d uu____17804 tcs1
       | FStar_Parser_AST.TopLevelLet (isrec,lets) ->
-          let quals = d.FStar_Parser_AST.quals  in
+          let quals = d.FStar_Parser_AST.quals in
           let expand_toplevel_pattern =
             (isrec = FStar_Parser_AST.NoLetQualifier) &&
               (match lets with
@@ -6274,16 +5720,14 @@ and (desugar_decl_noattrs :
                     FStar_Parser_AST.prange = uu____17857;_},uu____17858)::[]
                    -> false
                | (p,uu____17874)::[] ->
-                   let uu____17883 = is_app_pattern p  in
+                   let uu____17883 = is_app_pattern p in
                    Prims.op_Negation uu____17883
-               | uu____17884 -> false)
-             in
+               | uu____17884 -> false) in
           if Prims.op_Negation expand_toplevel_pattern
           then
             let lets1 =
               FStar_List.map (fun x  -> (FStar_Pervasives_Native.None, x))
-                lets
-               in
+                lets in
             let as_inner_let =
               FStar_Parser_AST.mk_term
                 (FStar_Parser_AST.Let
@@ -6291,21 +5735,19 @@ and (desugar_decl_noattrs :
                      (FStar_Parser_AST.mk_term
                         (FStar_Parser_AST.Const FStar_Const.Const_unit)
                         d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)))
-                d.FStar_Parser_AST.drange FStar_Parser_AST.Expr
-               in
-            let ds_lets = desugar_term_maybe_top true env as_inner_let  in
+                d.FStar_Parser_AST.drange FStar_Parser_AST.Expr in
+            let ds_lets = desugar_term_maybe_top true env as_inner_let in
             let uu____17958 =
               let uu____17959 =
-                FStar_All.pipe_left FStar_Syntax_Subst.compress ds_lets  in
-              uu____17959.FStar_Syntax_Syntax.n  in
+                FStar_All.pipe_left FStar_Syntax_Subst.compress ds_lets in
+              uu____17959.FStar_Syntax_Syntax.n in
             (match uu____17958 with
              | FStar_Syntax_Syntax.Tm_let (lbs,uu____17967) ->
                  let fvs =
                    FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                      (FStar_List.map
                         (fun lb  ->
-                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname))
-                    in
+                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname)) in
                  let quals1 =
                    match quals with
                    | uu____18000::uu____18001 ->
@@ -6336,8 +5778,7 @@ and (desugar_decl_noattrs :
                                    ->
                                    FStar_ToSyntax_Env.lookup_letbinding_quals
                                      env
-                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v))
-                    in
+                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)) in
                  let quals2 =
                    let uu____18056 =
                      FStar_All.pipe_right lets1
@@ -6346,16 +5787,14 @@ and (desugar_decl_noattrs :
                              match uu____18087 with
                              | (uu____18100,(uu____18101,t)) ->
                                  t.FStar_Parser_AST.level =
-                                   FStar_Parser_AST.Formula))
-                      in
+                                   FStar_Parser_AST.Formula)) in
                    if uu____18056
                    then FStar_Syntax_Syntax.Logic :: quals1
-                   else quals1  in
+                   else quals1 in
                  let lbs1 =
                    let uu____18125 =
                      FStar_All.pipe_right quals2
-                       (FStar_List.contains FStar_Syntax_Syntax.Abstract)
-                      in
+                       (FStar_List.contains FStar_Syntax_Syntax.Abstract) in
                    if uu____18125
                    then
                      let uu____18134 =
@@ -6364,13 +5803,12 @@ and (desugar_decl_noattrs :
                             (fun lb  ->
                                let fv =
                                  FStar_Util.right
-                                   lb.FStar_Syntax_Syntax.lbname
-                                  in
-                               let uu___134_18148 = lb  in
+                                   lb.FStar_Syntax_Syntax.lbname in
+                               let uu___134_18148 = lb in
                                {
                                  FStar_Syntax_Syntax.lbname =
                                    (FStar_Util.Inr
-                                      (let uu___135_18150 = fv  in
+                                      (let uu___135_18150 = fv in
                                        {
                                          FStar_Syntax_Syntax.fv_name =
                                            (uu___135_18150.FStar_Syntax_Syntax.fv_name);
@@ -6390,19 +5828,16 @@ and (desugar_decl_noattrs :
                                    (uu___134_18148.FStar_Syntax_Syntax.lbdef);
                                  FStar_Syntax_Syntax.lbattrs =
                                    (uu___134_18148.FStar_Syntax_Syntax.lbattrs)
-                               }))
-                        in
+                               })) in
                      ((FStar_Pervasives_Native.fst lbs), uu____18134)
-                   else lbs  in
+                   else lbs in
                  let names1 =
                    FStar_All.pipe_right fvs
                      (FStar_List.map
                         (fun fv  ->
-                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v))
-                    in
+                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)) in
                  let attrs =
-                   FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs
-                    in
+                   FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs in
                  let s =
                    {
                      FStar_Syntax_Syntax.sigel =
@@ -6412,15 +5847,14 @@ and (desugar_decl_noattrs :
                      FStar_Syntax_Syntax.sigmeta =
                        FStar_Syntax_Syntax.default_sigmeta;
                      FStar_Syntax_Syntax.sigattrs = attrs
-                   }  in
-                 let env1 = FStar_ToSyntax_Env.push_sigelt env s  in
+                   } in
+                 let env1 = FStar_ToSyntax_Env.push_sigelt env s in
                  let env2 =
                    FStar_List.fold_left
                      (fun env2  ->
                         fun id1  ->
                           FStar_ToSyntax_Env.push_doc env2 id1
-                            d.FStar_Parser_AST.doc) env1 names1
-                    in
+                            d.FStar_Parser_AST.doc) env1 names1 in
                  (env2, [s])
              | uu____18185 ->
                  failwith "Desugaring a let did not produce a let")
@@ -6430,32 +5864,30 @@ and (desugar_decl_noattrs :
                | (pat,body)::[] -> (pat, body)
                | uu____18210 ->
                    failwith
-                     "expand_toplevel_pattern should only allow single definition lets"
-                in
+                     "expand_toplevel_pattern should only allow single definition lets" in
              match uu____18191 with
              | (pat,body) ->
                  let fresh_toplevel_name =
-                   FStar_Ident.gen FStar_Range.dummyRange  in
+                   FStar_Ident.gen FStar_Range.dummyRange in
                  let fresh_pat =
                    let var_pat =
                      FStar_Parser_AST.mk_pattern
                        (FStar_Parser_AST.PatVar
                           (fresh_toplevel_name, FStar_Pervasives_Native.None))
-                       FStar_Range.dummyRange
-                      in
+                       FStar_Range.dummyRange in
                    match pat.FStar_Parser_AST.pat with
                    | FStar_Parser_AST.PatAscribed (pat1,ty) ->
-                       let uu___136_18234 = pat1  in
+                       let uu___136_18234 = pat1 in
                        {
                          FStar_Parser_AST.pat =
                            (FStar_Parser_AST.PatAscribed (var_pat, ty));
                          FStar_Parser_AST.prange =
                            (uu___136_18234.FStar_Parser_AST.prange)
                        }
-                   | uu____18235 -> var_pat  in
+                   | uu____18235 -> var_pat in
                  let main_let =
                    desugar_decl env
-                     (let uu___137_18242 = d  in
+                     (let uu___137_18242 = d in
                       {
                         FStar_Parser_AST.d =
                           (FStar_Parser_AST.TopLevelLet
@@ -6468,55 +5900,47 @@ and (desugar_decl_noattrs :
                           (d.FStar_Parser_AST.quals));
                         FStar_Parser_AST.attrs =
                           (uu___137_18242.FStar_Parser_AST.attrs)
-                      })
-                    in
+                      }) in
                  let build_projection uu____18274 id1 =
                    match uu____18274 with
                    | (env1,ses) ->
                        let main =
                          let uu____18295 =
                            let uu____18296 =
-                             FStar_Ident.lid_of_ids [fresh_toplevel_name]  in
-                           FStar_Parser_AST.Var uu____18296  in
+                             FStar_Ident.lid_of_ids [fresh_toplevel_name] in
+                           FStar_Parser_AST.Var uu____18296 in
                          FStar_Parser_AST.mk_term uu____18295
-                           FStar_Range.dummyRange FStar_Parser_AST.Expr
-                          in
-                       let lid = FStar_Ident.lid_of_ids [id1]  in
+                           FStar_Range.dummyRange FStar_Parser_AST.Expr in
+                       let lid = FStar_Ident.lid_of_ids [id1] in
                        let projectee =
                          FStar_Parser_AST.mk_term (FStar_Parser_AST.Var lid)
-                           FStar_Range.dummyRange FStar_Parser_AST.Expr
-                          in
+                           FStar_Range.dummyRange FStar_Parser_AST.Expr in
                        let body1 =
                          FStar_Parser_AST.mk_term
                            (FStar_Parser_AST.Match
                               (main,
                                 [(pat, FStar_Pervasives_Native.None,
                                    projectee)])) FStar_Range.dummyRange
-                           FStar_Parser_AST.Expr
-                          in
+                           FStar_Parser_AST.Expr in
                        let bv_pat =
                          FStar_Parser_AST.mk_pattern
                            (FStar_Parser_AST.PatVar
                               (id1, FStar_Pervasives_Native.None))
-                           FStar_Range.dummyRange
-                          in
+                           FStar_Range.dummyRange in
                        let id_decl =
                          FStar_Parser_AST.mk_decl
                            (FStar_Parser_AST.TopLevelLet
                               (FStar_Parser_AST.NoLetQualifier,
-                                [(bv_pat, body1)])) FStar_Range.dummyRange []
-                          in
-                       let uu____18346 = desugar_decl env1 id_decl  in
+                                [(bv_pat, body1)])) FStar_Range.dummyRange [] in
+                       let uu____18346 = desugar_decl env1 id_decl in
                        (match uu____18346 with
-                        | (env2,ses') -> (env2, (FStar_List.append ses ses')))
-                    in
+                        | (env2,ses') -> (env2, (FStar_List.append ses ses'))) in
                  let bvs =
-                   let uu____18364 = gather_pattern_bound_vars pat  in
-                   FStar_All.pipe_right uu____18364 FStar_Util.set_elements
-                    in
+                   let uu____18364 = gather_pattern_bound_vars pat in
+                   FStar_All.pipe_right uu____18364 FStar_Util.set_elements in
                  FStar_List.fold_left build_projection main_let bvs)
       | FStar_Parser_AST.Main t ->
-          let e = desugar_term env t  in
+          let e = desugar_term env t in
           let se =
             {
               FStar_Syntax_Syntax.sigel = (FStar_Syntax_Syntax.Sig_main e);
@@ -6525,13 +5949,13 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = []
-            }  in
+            } in
           (env, [se])
       | FStar_Parser_AST.Assume (id1,t) ->
-          let f = desugar_formula env t  in
-          let lid = FStar_ToSyntax_Env.qualify env id1  in
+          let f = desugar_formula env t in
+          let lid = FStar_ToSyntax_Env.qualify env id1 in
           let env1 =
-            FStar_ToSyntax_Env.push_doc env lid d.FStar_Parser_AST.doc  in
+            FStar_ToSyntax_Env.push_doc env lid d.FStar_Parser_AST.doc in
           (env1,
             [{
                FStar_Syntax_Syntax.sigel =
@@ -6544,24 +5968,21 @@ and (desugar_decl_noattrs :
                FStar_Syntax_Syntax.sigattrs = []
              }])
       | FStar_Parser_AST.Val (id1,t) ->
-          let quals = d.FStar_Parser_AST.quals  in
+          let quals = d.FStar_Parser_AST.quals in
           let t1 =
-            let uu____18395 = close_fun env t  in
-            desugar_term env uu____18395  in
+            let uu____18395 = close_fun env t in desugar_term env uu____18395 in
           let quals1 =
             let uu____18399 =
               (FStar_ToSyntax_Env.iface env) &&
-                (FStar_ToSyntax_Env.admitted_iface env)
-               in
+                (FStar_ToSyntax_Env.admitted_iface env) in
             if uu____18399
             then FStar_Parser_AST.Assumption :: quals
-            else quals  in
-          let lid = FStar_ToSyntax_Env.qualify env id1  in
+            else quals in
+          let lid = FStar_ToSyntax_Env.qualify env id1 in
           let se =
             let uu____18405 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
-                quals1
-               in
+                quals1 in
             {
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, [], t1));
@@ -6570,21 +5991,20 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = []
-            }  in
-          let env1 = FStar_ToSyntax_Env.push_sigelt env se  in
+            } in
+          let env1 = FStar_ToSyntax_Env.push_sigelt env se in
           let env2 =
-            FStar_ToSyntax_Env.push_doc env1 lid d.FStar_Parser_AST.doc  in
+            FStar_ToSyntax_Env.push_doc env1 lid d.FStar_Parser_AST.doc in
           (env2, [se])
       | FStar_Parser_AST.Exception (id1,FStar_Pervasives_Native.None ) ->
           let uu____18417 =
             FStar_ToSyntax_Env.fail_or env
               (FStar_ToSyntax_Env.try_lookup_lid env)
-              FStar_Parser_Const.exn_lid
-             in
+              FStar_Parser_Const.exn_lid in
           (match uu____18417 with
            | (t,uu____18431) ->
-               let l = FStar_ToSyntax_Env.qualify env id1  in
-               let qual = [FStar_Syntax_Syntax.ExceptionConstructor]  in
+               let l = FStar_ToSyntax_Env.qualify env id1 in
+               let qual = [FStar_Syntax_Syntax.ExceptionConstructor] in
                let se =
                  {
                    FStar_Syntax_Syntax.sigel =
@@ -6597,7 +6017,7 @@ and (desugar_decl_noattrs :
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
                    FStar_Syntax_Syntax.sigattrs = []
-                 }  in
+                 } in
                let se' =
                  {
                    FStar_Syntax_Syntax.sigel =
@@ -6607,37 +6027,33 @@ and (desugar_decl_noattrs :
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
                    FStar_Syntax_Syntax.sigattrs = []
-                 }  in
-               let env1 = FStar_ToSyntax_Env.push_sigelt env se'  in
+                 } in
+               let env1 = FStar_ToSyntax_Env.push_sigelt env se' in
                let env2 =
-                 FStar_ToSyntax_Env.push_doc env1 l d.FStar_Parser_AST.doc
-                  in
-               let data_ops = mk_data_projector_names [] env2 se  in
-               let discs = mk_data_discriminators [] env2 [l]  in
+                 FStar_ToSyntax_Env.push_doc env1 l d.FStar_Parser_AST.doc in
+               let data_ops = mk_data_projector_names [] env2 se in
+               let discs = mk_data_discriminators [] env2 [l] in
                let env3 =
                  FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt env2
-                   (FStar_List.append discs data_ops)
-                  in
+                   (FStar_List.append discs data_ops) in
                (env3, (FStar_List.append (se' :: discs) data_ops)))
       | FStar_Parser_AST.Exception (id1,FStar_Pervasives_Native.Some term) ->
-          let t = desugar_term env term  in
+          let t = desugar_term env term in
           let t1 =
             let uu____18465 =
-              let uu____18472 = FStar_Syntax_Syntax.null_binder t  in
-              [uu____18472]  in
+              let uu____18472 = FStar_Syntax_Syntax.null_binder t in
+              [uu____18472] in
             let uu____18473 =
               let uu____18476 =
                 let uu____18477 =
                   FStar_ToSyntax_Env.fail_or env
                     (FStar_ToSyntax_Env.try_lookup_lid env)
-                    FStar_Parser_Const.exn_lid
-                   in
-                FStar_Pervasives_Native.fst uu____18477  in
-              FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total uu____18476
-               in
-            FStar_Syntax_Util.arrow uu____18465 uu____18473  in
-          let l = FStar_ToSyntax_Env.qualify env id1  in
-          let qual = [FStar_Syntax_Syntax.ExceptionConstructor]  in
+                    FStar_Parser_Const.exn_lid in
+                FStar_Pervasives_Native.fst uu____18477 in
+              FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total uu____18476 in
+            FStar_Syntax_Util.arrow uu____18465 uu____18473 in
+          let l = FStar_ToSyntax_Env.qualify env id1 in
+          let qual = [FStar_Syntax_Syntax.ExceptionConstructor] in
           let se =
             {
               FStar_Syntax_Syntax.sigel =
@@ -6649,7 +6065,7 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = []
-            }  in
+            } in
           let se' =
             {
               FStar_Syntax_Syntax.sigel =
@@ -6659,74 +6075,68 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = []
-            }  in
-          let env1 = FStar_ToSyntax_Env.push_sigelt env se'  in
+            } in
+          let env1 = FStar_ToSyntax_Env.push_sigelt env se' in
           let env2 =
-            FStar_ToSyntax_Env.push_doc env1 l d.FStar_Parser_AST.doc  in
-          let data_ops = mk_data_projector_names [] env2 se  in
-          let discs = mk_data_discriminators [] env2 [l]  in
+            FStar_ToSyntax_Env.push_doc env1 l d.FStar_Parser_AST.doc in
+          let data_ops = mk_data_projector_names [] env2 se in
+          let discs = mk_data_discriminators [] env2 [l] in
           let env3 =
             FStar_List.fold_left FStar_ToSyntax_Env.push_sigelt env2
-              (FStar_List.append discs data_ops)
-             in
+              (FStar_List.append discs data_ops) in
           (env3, (FStar_List.append (se' :: discs) data_ops))
       | FStar_Parser_AST.NewEffect (FStar_Parser_AST.RedefineEffect
           (eff_name,eff_binders,defn)) ->
-          let quals = d.FStar_Parser_AST.quals  in
+          let quals = d.FStar_Parser_AST.quals in
           desugar_redefine_effect env d trans_qual1 quals eff_name
             eff_binders defn
       | FStar_Parser_AST.NewEffect (FStar_Parser_AST.DefineEffect
           (eff_name,eff_binders,eff_typ,eff_decls)) ->
-          let quals = d.FStar_Parser_AST.quals  in
+          let quals = d.FStar_Parser_AST.quals in
           desugar_effect env d quals eff_name eff_binders eff_typ eff_decls
       | FStar_Parser_AST.SubEffect l ->
           let lookup l1 =
             let uu____18539 =
-              FStar_ToSyntax_Env.try_lookup_effect_name env l1  in
+              FStar_ToSyntax_Env.try_lookup_effect_name env l1 in
             match uu____18539 with
             | FStar_Pervasives_Native.None  ->
                 let uu____18542 =
                   let uu____18547 =
                     let uu____18548 =
-                      let uu____18549 = FStar_Syntax_Print.lid_to_string l1
-                         in
-                      Prims.strcat uu____18549 " not found"  in
-                    Prims.strcat "Effect name " uu____18548  in
-                  (FStar_Errors.Fatal_EffectNotFound, uu____18547)  in
+                      let uu____18549 = FStar_Syntax_Print.lid_to_string l1 in
+                      Prims.strcat uu____18549 " not found" in
+                    Prims.strcat "Effect name " uu____18548 in
+                  (FStar_Errors.Fatal_EffectNotFound, uu____18547) in
                 FStar_Errors.raise_error uu____18542
                   d.FStar_Parser_AST.drange
-            | FStar_Pervasives_Native.Some l2 -> l2  in
-          let src = lookup l.FStar_Parser_AST.msource  in
-          let dst = lookup l.FStar_Parser_AST.mdest  in
+            | FStar_Pervasives_Native.Some l2 -> l2 in
+          let src = lookup l.FStar_Parser_AST.msource in
+          let dst = lookup l.FStar_Parser_AST.mdest in
           let uu____18553 =
             match l.FStar_Parser_AST.lift_op with
             | FStar_Parser_AST.NonReifiableLift t ->
                 let uu____18595 =
                   let uu____18604 =
-                    let uu____18611 = desugar_term env t  in
-                    ([], uu____18611)  in
-                  FStar_Pervasives_Native.Some uu____18604  in
+                    let uu____18611 = desugar_term env t in ([], uu____18611) in
+                  FStar_Pervasives_Native.Some uu____18604 in
                 (uu____18595, FStar_Pervasives_Native.None)
             | FStar_Parser_AST.ReifiableLift (wp,t) ->
                 let uu____18644 =
                   let uu____18653 =
-                    let uu____18660 = desugar_term env wp  in
-                    ([], uu____18660)  in
-                  FStar_Pervasives_Native.Some uu____18653  in
+                    let uu____18660 = desugar_term env wp in
+                    ([], uu____18660) in
+                  FStar_Pervasives_Native.Some uu____18653 in
                 let uu____18669 =
                   let uu____18678 =
-                    let uu____18685 = desugar_term env t  in
-                    ([], uu____18685)  in
-                  FStar_Pervasives_Native.Some uu____18678  in
+                    let uu____18685 = desugar_term env t in ([], uu____18685) in
+                  FStar_Pervasives_Native.Some uu____18678 in
                 (uu____18644, uu____18669)
             | FStar_Parser_AST.LiftForFree t ->
                 let uu____18711 =
                   let uu____18720 =
-                    let uu____18727 = desugar_term env t  in
-                    ([], uu____18727)  in
-                  FStar_Pervasives_Native.Some uu____18720  in
-                (FStar_Pervasives_Native.None, uu____18711)
-             in
+                    let uu____18727 = desugar_term env t in ([], uu____18727) in
+                  FStar_Pervasives_Native.Some uu____18720 in
+                (FStar_Pervasives_Native.None, uu____18711) in
           (match uu____18553 with
            | (lift_wp,lift) ->
                let se =
@@ -6744,14 +6154,13 @@ and (desugar_decl_noattrs :
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
                    FStar_Syntax_Syntax.sigattrs = []
-                 }  in
+                 } in
                (env, [se]))
-
-let (desugar_decls :
+let desugar_decls:
   env_t ->
     FStar_Parser_AST.decl Prims.list ->
       (env_t,FStar_Syntax_Syntax.sigelt Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun decls  ->
@@ -6761,11 +6170,10 @@ let (desugar_decls :
              fun d  ->
                match uu____18835 with
                | (env1,sigelts) ->
-                   let uu____18855 = desugar_decl env1 d  in
+                   let uu____18855 = desugar_decl env1 d in
                    (match uu____18855 with
                     | (env2,se) -> (env2, (FStar_List.append sigelts se))))
-          (env, []) decls
-         in
+          (env, []) decls in
       match uu____18815 with
       | (env1,sigelts) ->
           let rec forward acc uu___110_18896 =
@@ -6778,7 +6186,7 @@ let (desugar_decls :
                     uu____18910,FStar_Syntax_Syntax.Sig_let uu____18911) ->
                      let uu____18924 =
                        let uu____18927 =
-                         let uu___138_18928 = se2  in
+                         let uu___138_18928 = se2 in
                          let uu____18929 =
                            let uu____18932 =
                              FStar_List.filter
@@ -6799,19 +6207,15 @@ let (desugar_decls :
                                       when
                                       let uu____18977 =
                                         let uu____18978 =
-                                          FStar_Syntax_Syntax.lid_of_fv fv
-                                           in
-                                        FStar_Ident.string_of_lid uu____18978
-                                         in
+                                          FStar_Syntax_Syntax.lid_of_fv fv in
+                                        FStar_Ident.string_of_lid uu____18978 in
                                       uu____18977 =
                                         "FStar.Pervasives.Comment"
                                       -> true
                                   | uu____18979 -> false)
-                               se1.FStar_Syntax_Syntax.sigattrs
-                              in
+                               se1.FStar_Syntax_Syntax.sigattrs in
                            FStar_List.append uu____18932
-                             se2.FStar_Syntax_Syntax.sigattrs
-                            in
+                             se2.FStar_Syntax_Syntax.sigattrs in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (uu___138_18928.FStar_Syntax_Syntax.sigel);
@@ -6822,29 +6226,27 @@ let (desugar_decls :
                            FStar_Syntax_Syntax.sigmeta =
                              (uu___138_18928.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs = uu____18929
-                         }  in
-                       uu____18927 :: se1 :: acc  in
+                         } in
+                       uu____18927 :: se1 :: acc in
                      forward uu____18924 sigelts1
                  | uu____18984 -> forward (se1 :: acc) (se2 :: sigelts1))
-            | sigelts1 -> FStar_List.rev_append acc sigelts1  in
-          let uu____18992 = forward [] sigelts  in (env1, uu____18992)
-  
-let (open_prims_all :
+            | sigelts1 -> FStar_List.rev_append acc sigelts1 in
+          let uu____18992 = forward [] sigelts in (env1, uu____18992)
+let open_prims_all:
   (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
-    Prims.list)
+    Prims.list
   =
   [FStar_Parser_AST.mk_decl
      (FStar_Parser_AST.Open FStar_Parser_Const.prims_lid)
      FStar_Range.dummyRange;
   FStar_Parser_AST.mk_decl (FStar_Parser_AST.Open FStar_Parser_Const.all_lid)
     FStar_Range.dummyRange]
-  
-let (desugar_modul_common :
+let desugar_modul_common:
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     FStar_ToSyntax_Env.env ->
       FStar_Parser_AST.modul ->
         (env_t,FStar_Syntax_Syntax.modul,Prims.bool)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun curmod  ->
     fun env  ->
@@ -6863,28 +6265,23 @@ let (desugar_modul_common :
               -> env
           | (FStar_Pervasives_Native.Some prev_mod,uu____19059) ->
               let uu____19062 =
-                FStar_ToSyntax_Env.finish_module_or_interface env prev_mod
-                 in
-              FStar_Pervasives_Native.fst uu____19062
-           in
+                FStar_ToSyntax_Env.finish_module_or_interface env prev_mod in
+              FStar_Pervasives_Native.fst uu____19062 in
         let uu____19067 =
           match m with
           | FStar_Parser_AST.Interface (mname,decls,admitted) ->
               let uu____19103 =
                 FStar_ToSyntax_Env.prepare_module_or_interface true admitted
-                  env1 mname FStar_ToSyntax_Env.default_mii
-                 in
+                  env1 mname FStar_ToSyntax_Env.default_mii in
               (uu____19103, mname, decls, true)
           | FStar_Parser_AST.Module (mname,decls) ->
               let uu____19120 =
                 FStar_ToSyntax_Env.prepare_module_or_interface false false
-                  env1 mname FStar_ToSyntax_Env.default_mii
-                 in
-              (uu____19120, mname, decls, false)
-           in
+                  env1 mname FStar_ToSyntax_Env.default_mii in
+              (uu____19120, mname, decls, false) in
         match uu____19067 with
         | ((env2,pop_when_done),mname,decls,intf) ->
-            let uu____19150 = desugar_decls env2 decls  in
+            let uu____19150 = desugar_decls env2 decls in
             (match uu____19150 with
              | (env3,sigelts) ->
                  let modul =
@@ -6893,21 +6290,19 @@ let (desugar_modul_common :
                      FStar_Syntax_Syntax.declarations = sigelts;
                      FStar_Syntax_Syntax.exports = [];
                      FStar_Syntax_Syntax.is_interface = intf
-                   }  in
+                   } in
                  (env3, modul, pop_when_done))
-  
-let (as_interface : FStar_Parser_AST.modul -> FStar_Parser_AST.modul) =
+let as_interface: FStar_Parser_AST.modul -> FStar_Parser_AST.modul =
   fun m  ->
     match m with
     | FStar_Parser_AST.Module (mname,decls) ->
         FStar_Parser_AST.Interface (mname, decls, true)
     | i -> i
-  
-let (desugar_partial_modul :
+let desugar_partial_modul:
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     env_t ->
       FStar_Parser_AST.modul ->
-        (env_t,FStar_Syntax_Syntax.modul) FStar_Pervasives_Native.tuple2)
+        (env_t,FStar_Syntax_Syntax.modul) FStar_Pervasives_Native.tuple2
   =
   fun curmod  ->
     fun env  ->
@@ -6917,43 +6312,40 @@ let (desugar_partial_modul :
             (FStar_Options.interactive ()) &&
               (let uu____19206 =
                  let uu____19207 =
-                   let uu____19208 = FStar_Options.file_list ()  in
-                   FStar_List.hd uu____19208  in
-                 FStar_Util.get_file_extension uu____19207  in
-               FStar_List.mem uu____19206 ["fsti"; "fsi"])
-             in
-          if uu____19204 then as_interface m else m  in
-        let uu____19212 = desugar_modul_common curmod env m1  in
+                   let uu____19208 = FStar_Options.file_list () in
+                   FStar_List.hd uu____19208 in
+                 FStar_Util.get_file_extension uu____19207 in
+               FStar_List.mem uu____19206 ["fsti"; "fsi"]) in
+          if uu____19204 then as_interface m else m in
+        let uu____19212 = desugar_modul_common curmod env m1 in
         match uu____19212 with
         | (x,y,pop_when_done) ->
             (if pop_when_done
-             then (let uu____19227 = FStar_ToSyntax_Env.pop ()  in ())
+             then (let uu____19227 = FStar_ToSyntax_Env.pop () in ())
              else ();
              (x, y))
-  
-let (desugar_modul :
+let desugar_modul:
   FStar_ToSyntax_Env.env ->
     FStar_Parser_AST.modul ->
-      (env_t,FStar_Syntax_Syntax.modul) FStar_Pervasives_Native.tuple2)
+      (env_t,FStar_Syntax_Syntax.modul) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun m  ->
       let uu____19243 =
-        desugar_modul_common FStar_Pervasives_Native.None env m  in
+        desugar_modul_common FStar_Pervasives_Native.None env m in
       match uu____19243 with
       | (env1,modul,pop_when_done) ->
           let uu____19257 =
-            FStar_ToSyntax_Env.finish_module_or_interface env1 modul  in
+            FStar_ToSyntax_Env.finish_module_or_interface env1 modul in
           (match uu____19257 with
            | (env2,modul1) ->
                ((let uu____19269 =
                    FStar_Options.dump_module
-                     (modul1.FStar_Syntax_Syntax.name).FStar_Ident.str
-                    in
+                     (modul1.FStar_Syntax_Syntax.name).FStar_Ident.str in
                  if uu____19269
                  then
                    let uu____19270 =
-                     FStar_Syntax_Print.modul_to_string modul1  in
+                     FStar_Syntax_Print.modul_to_string modul1 in
                    FStar_Util.print1 "Module after desugaring:\n%s\n"
                      uu____19270
                  else ());
@@ -6962,43 +6354,39 @@ let (desugar_modul :
                    then
                      FStar_ToSyntax_Env.export_interface
                        modul1.FStar_Syntax_Syntax.name env2
-                   else env2  in
+                   else env2 in
                  (uu____19272, modul1))))
-  
-let (ast_modul_to_modul :
+let ast_modul_to_modul:
   FStar_Parser_AST.modul ->
-    FStar_Syntax_Syntax.modul FStar_ToSyntax_Env.withenv)
+    FStar_Syntax_Syntax.modul FStar_ToSyntax_Env.withenv
   =
   fun modul  ->
     fun env  ->
-      let uu____19286 = desugar_modul env modul  in
+      let uu____19286 = desugar_modul env modul in
       match uu____19286 with | (env1,modul1) -> (modul1, env1)
-  
-let (decls_to_sigelts :
+let decls_to_sigelts:
   FStar_Parser_AST.decl Prims.list ->
-    FStar_Syntax_Syntax.sigelts FStar_ToSyntax_Env.withenv)
+    FStar_Syntax_Syntax.sigelts FStar_ToSyntax_Env.withenv
   =
   fun decls  ->
     fun env  ->
-      let uu____19313 = desugar_decls env decls  in
+      let uu____19313 = desugar_decls env decls in
       match uu____19313 with | (env1,sigelts) -> (sigelts, env1)
-  
-let (partial_ast_modul_to_modul :
+let partial_ast_modul_to_modul:
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     FStar_Parser_AST.modul ->
-      FStar_Syntax_Syntax.modul FStar_ToSyntax_Env.withenv)
+      FStar_Syntax_Syntax.modul FStar_ToSyntax_Env.withenv
   =
   fun modul  ->
     fun a_modul  ->
       fun env  ->
-        let uu____19351 = desugar_partial_modul modul env a_modul  in
+        let uu____19351 = desugar_partial_modul modul env a_modul in
         match uu____19351 with | (env1,modul1) -> (modul1, env1)
-  
-let (add_modul_to_env :
+let add_modul_to_env:
   FStar_Syntax_Syntax.modul ->
     FStar_ToSyntax_Env.module_inclusion_info ->
       (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
-        Prims.unit FStar_ToSyntax_Env.withenv)
+        Prims.unit FStar_ToSyntax_Env.withenv
   =
   fun m  ->
     fun mii  ->
@@ -7015,52 +6403,45 @@ let (add_modul_to_env :
                         (FStar_Syntax_Syntax.Tm_abs
                            (bs, FStar_Syntax_Syntax.t_unit,
                              FStar_Pervasives_Native.None))
-                        FStar_Pervasives_Native.None FStar_Range.dummyRange
-                       in
-                    erase_univs uu____19433  in
+                        FStar_Pervasives_Native.None FStar_Range.dummyRange in
+                    erase_univs uu____19433 in
                   let uu____19442 =
-                    let uu____19443 = FStar_Syntax_Subst.compress t  in
-                    uu____19443.FStar_Syntax_Syntax.n  in
+                    let uu____19443 = FStar_Syntax_Subst.compress t in
+                    uu____19443.FStar_Syntax_Syntax.n in
                   (match uu____19442 with
                    | FStar_Syntax_Syntax.Tm_abs (bs1,uu____19453,uu____19454)
                        -> bs1
-                   | uu____19475 -> failwith "Impossible")
-               in
+                   | uu____19475 -> failwith "Impossible") in
             let uu____19482 =
-              let uu____19489 = erase_binders ed.FStar_Syntax_Syntax.binders
-                 in
+              let uu____19489 = erase_binders ed.FStar_Syntax_Syntax.binders in
               FStar_Syntax_Subst.open_term' uu____19489
-                FStar_Syntax_Syntax.t_unit
-               in
+                FStar_Syntax_Syntax.t_unit in
             match uu____19482 with
             | (binders,uu____19491,binders_opening) ->
                 let erase_term t =
                   let uu____19497 =
                     let uu____19498 =
-                      FStar_Syntax_Subst.subst binders_opening t  in
-                    erase_univs uu____19498  in
-                  FStar_Syntax_Subst.close binders uu____19497  in
+                      FStar_Syntax_Subst.subst binders_opening t in
+                    erase_univs uu____19498 in
+                  FStar_Syntax_Subst.close binders uu____19497 in
                 let erase_tscheme uu____19514 =
                   match uu____19514 with
                   | (us,t) ->
                       let t1 =
                         let uu____19534 =
                           FStar_Syntax_Subst.shift_subst
-                            (FStar_List.length us) binders_opening
-                           in
-                        FStar_Syntax_Subst.subst uu____19534 t  in
+                            (FStar_List.length us) binders_opening in
+                        FStar_Syntax_Subst.subst uu____19534 t in
                       let uu____19537 =
-                        let uu____19538 = erase_univs t1  in
-                        FStar_Syntax_Subst.close binders uu____19538  in
-                      ([], uu____19537)
-                   in
+                        let uu____19538 = erase_univs t1 in
+                        FStar_Syntax_Subst.close binders uu____19538 in
+                      ([], uu____19537) in
                 let erase_action action =
                   let opening =
                     FStar_Syntax_Subst.shift_subst
                       (FStar_List.length
                          action.FStar_Syntax_Syntax.action_univs)
-                      binders_opening
-                     in
+                      binders_opening in
                   let erased_action_params =
                     match action.FStar_Syntax_Syntax.action_params with
                     | [] -> []
@@ -7068,39 +6449,35 @@ let (add_modul_to_env :
                         let bs =
                           let uu____19575 =
                             FStar_Syntax_Subst.subst_binders opening
-                              action.FStar_Syntax_Syntax.action_params
-                             in
-                          FStar_All.pipe_left erase_binders uu____19575  in
+                              action.FStar_Syntax_Syntax.action_params in
+                          FStar_All.pipe_left erase_binders uu____19575 in
                         let t =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_abs
                                (bs, FStar_Syntax_Syntax.t_unit,
                                  FStar_Pervasives_Native.None))
                             FStar_Pervasives_Native.None
-                            FStar_Range.dummyRange
-                           in
+                            FStar_Range.dummyRange in
                         let uu____19605 =
                           let uu____19606 =
                             let uu____19609 =
-                              FStar_Syntax_Subst.close binders t  in
-                            FStar_Syntax_Subst.compress uu____19609  in
-                          uu____19606.FStar_Syntax_Syntax.n  in
+                              FStar_Syntax_Subst.close binders t in
+                            FStar_Syntax_Subst.compress uu____19609 in
+                          uu____19606.FStar_Syntax_Syntax.n in
                         (match uu____19605 with
                          | FStar_Syntax_Syntax.Tm_abs
                              (bs1,uu____19617,uu____19618) -> bs1
-                         | uu____19639 -> failwith "Impossible")
-                     in
+                         | uu____19639 -> failwith "Impossible") in
                   let erase_term1 t =
                     let uu____19650 =
-                      let uu____19651 = FStar_Syntax_Subst.subst opening t
-                         in
-                      erase_univs uu____19651  in
-                    FStar_Syntax_Subst.close binders uu____19650  in
-                  let uu___139_19652 = action  in
+                      let uu____19651 = FStar_Syntax_Subst.subst opening t in
+                      erase_univs uu____19651 in
+                    FStar_Syntax_Subst.close binders uu____19650 in
+                  let uu___139_19652 = action in
                   let uu____19653 =
-                    erase_term1 action.FStar_Syntax_Syntax.action_defn  in
+                    erase_term1 action.FStar_Syntax_Syntax.action_defn in
                   let uu____19654 =
-                    erase_term1 action.FStar_Syntax_Syntax.action_typ  in
+                    erase_term1 action.FStar_Syntax_Syntax.action_typ in
                   {
                     FStar_Syntax_Syntax.action_name =
                       (uu___139_19652.FStar_Syntax_Syntax.action_name);
@@ -7110,40 +6487,35 @@ let (add_modul_to_env :
                     FStar_Syntax_Syntax.action_params = erased_action_params;
                     FStar_Syntax_Syntax.action_defn = uu____19653;
                     FStar_Syntax_Syntax.action_typ = uu____19654
-                  }  in
-                let uu___140_19655 = ed  in
-                let uu____19656 = FStar_Syntax_Subst.close_binders binders
-                   in
-                let uu____19657 = erase_term ed.FStar_Syntax_Syntax.signature
-                   in
-                let uu____19658 = erase_tscheme ed.FStar_Syntax_Syntax.ret_wp
-                   in
+                  } in
+                let uu___140_19655 = ed in
+                let uu____19656 = FStar_Syntax_Subst.close_binders binders in
+                let uu____19657 = erase_term ed.FStar_Syntax_Syntax.signature in
+                let uu____19658 = erase_tscheme ed.FStar_Syntax_Syntax.ret_wp in
                 let uu____19659 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.bind_wp  in
+                  erase_tscheme ed.FStar_Syntax_Syntax.bind_wp in
                 let uu____19660 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.if_then_else  in
-                let uu____19661 = erase_tscheme ed.FStar_Syntax_Syntax.ite_wp
-                   in
+                  erase_tscheme ed.FStar_Syntax_Syntax.if_then_else in
+                let uu____19661 = erase_tscheme ed.FStar_Syntax_Syntax.ite_wp in
                 let uu____19662 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.stronger  in
+                  erase_tscheme ed.FStar_Syntax_Syntax.stronger in
                 let uu____19663 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.close_wp  in
+                  erase_tscheme ed.FStar_Syntax_Syntax.close_wp in
                 let uu____19664 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.assert_p  in
+                  erase_tscheme ed.FStar_Syntax_Syntax.assert_p in
                 let uu____19665 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.assume_p  in
+                  erase_tscheme ed.FStar_Syntax_Syntax.assume_p in
                 let uu____19666 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.null_wp  in
+                  erase_tscheme ed.FStar_Syntax_Syntax.null_wp in
                 let uu____19667 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.trivial  in
-                let uu____19668 = erase_term ed.FStar_Syntax_Syntax.repr  in
+                  erase_tscheme ed.FStar_Syntax_Syntax.trivial in
+                let uu____19668 = erase_term ed.FStar_Syntax_Syntax.repr in
                 let uu____19669 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.return_repr  in
+                  erase_tscheme ed.FStar_Syntax_Syntax.return_repr in
                 let uu____19670 =
-                  erase_tscheme ed.FStar_Syntax_Syntax.bind_repr  in
+                  erase_tscheme ed.FStar_Syntax_Syntax.bind_repr in
                 let uu____19671 =
-                  FStar_List.map erase_action ed.FStar_Syntax_Syntax.actions
-                   in
+                  FStar_List.map erase_action ed.FStar_Syntax_Syntax.actions in
                 {
                   FStar_Syntax_Syntax.cattributes =
                     (uu___140_19655.FStar_Syntax_Syntax.cattributes);
@@ -7166,16 +6538,15 @@ let (add_modul_to_env :
                   FStar_Syntax_Syntax.return_repr = uu____19669;
                   FStar_Syntax_Syntax.bind_repr = uu____19670;
                   FStar_Syntax_Syntax.actions = uu____19671
-                }
-             in
+                } in
           let push_sigelt1 env se =
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_new_effect ed ->
                 let se' =
-                  let uu___141_19683 = se  in
+                  let uu___141_19683 = se in
                   let uu____19684 =
-                    let uu____19685 = erase_univs_ed ed  in
-                    FStar_Syntax_Syntax.Sig_new_effect uu____19685  in
+                    let uu____19685 = erase_univs_ed ed in
+                    FStar_Syntax_Syntax.Sig_new_effect uu____19685 in
                   {
                     FStar_Syntax_Syntax.sigel = uu____19684;
                     FStar_Syntax_Syntax.sigrng =
@@ -7186,17 +6557,16 @@ let (add_modul_to_env :
                       (uu___141_19683.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
                       (uu___141_19683.FStar_Syntax_Syntax.sigattrs)
-                  }  in
-                let env1 = FStar_ToSyntax_Env.push_sigelt env se'  in
+                  } in
+                let env1 = FStar_ToSyntax_Env.push_sigelt env se' in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
             | FStar_Syntax_Syntax.Sig_new_effect_for_free ed ->
                 let se' =
-                  let uu___142_19689 = se  in
+                  let uu___142_19689 = se in
                   let uu____19690 =
-                    let uu____19691 = erase_univs_ed ed  in
-                    FStar_Syntax_Syntax.Sig_new_effect_for_free uu____19691
-                     in
+                    let uu____19691 = erase_univs_ed ed in
+                    FStar_Syntax_Syntax.Sig_new_effect_for_free uu____19691 in
                   {
                     FStar_Syntax_Syntax.sigel = uu____19690;
                     FStar_Syntax_Syntax.sigrng =
@@ -7207,31 +6577,27 @@ let (add_modul_to_env :
                       (uu___142_19689.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
                       (uu___142_19689.FStar_Syntax_Syntax.sigattrs)
-                  }  in
-                let env1 = FStar_ToSyntax_Env.push_sigelt env se'  in
+                  } in
+                let env1 = FStar_ToSyntax_Env.push_sigelt env se' in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
-            | uu____19693 -> FStar_ToSyntax_Env.push_sigelt env se  in
+            | uu____19693 -> FStar_ToSyntax_Env.push_sigelt env se in
           let uu____19694 =
             FStar_ToSyntax_Env.prepare_module_or_interface false false en
-              m.FStar_Syntax_Syntax.name mii
-             in
+              m.FStar_Syntax_Syntax.name mii in
           match uu____19694 with
           | (en1,pop_when_done) ->
               let en2 =
                 let uu____19706 =
                   FStar_ToSyntax_Env.set_current_module en1
-                    m.FStar_Syntax_Syntax.name
-                   in
+                    m.FStar_Syntax_Syntax.name in
                 FStar_List.fold_left push_sigelt1 uu____19706
-                  m.FStar_Syntax_Syntax.exports
-                 in
-              let env = FStar_ToSyntax_Env.finish en2 m  in
+                  m.FStar_Syntax_Syntax.exports in
+              let env = FStar_ToSyntax_Env.finish en2 m in
               let uu____19708 =
                 if pop_when_done
                 then
                   FStar_ToSyntax_Env.export_interface
                     m.FStar_Syntax_Syntax.name env
-                else env  in
+                else env in
               ((), uu____19708)
-  

--- a/src/ocaml-output/FStar_TypeChecker_Common.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Common.ml
@@ -1,32 +1,30 @@
 open Prims
 type rel =
-  | EQ 
-  | SUB 
-  | SUBINV [@@deriving show]
-let (uu___is_EQ : rel -> Prims.bool) =
-  fun projectee  -> match projectee with | EQ  -> true | uu____4 -> false 
-let (uu___is_SUB : rel -> Prims.bool) =
-  fun projectee  -> match projectee with | SUB  -> true | uu____8 -> false 
-let (uu___is_SUBINV : rel -> Prims.bool) =
+  | EQ
+  | SUB
+  | SUBINV[@@deriving show]
+let uu___is_EQ: rel -> Prims.bool =
+  fun projectee  -> match projectee with | EQ  -> true | uu____4 -> false
+let uu___is_SUB: rel -> Prims.bool =
+  fun projectee  -> match projectee with | SUB  -> true | uu____8 -> false
+let uu___is_SUBINV: rel -> Prims.bool =
   fun projectee  ->
     match projectee with | SUBINV  -> true | uu____12 -> false
-  
 type ('a,'b) problem =
   {
-  pid: Prims.int ;
-  lhs: 'a ;
-  relation: rel ;
-  rhs: 'a ;
-  element: 'b FStar_Pervasives_Native.option ;
+  pid: Prims.int;
+  lhs: 'a;
+  relation: rel;
+  rhs: 'a;
+  element: 'b FStar_Pervasives_Native.option;
   logical_guard:
     (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2
-    ;
-  scope: FStar_Syntax_Syntax.binders ;
-  reason: Prims.string Prims.list ;
-  loc: FStar_Range.range ;
-  rank: Prims.int FStar_Pervasives_Native.option }[@@deriving show]
-let __proj__Mkproblem__item__pid : 'a 'b . ('a,'b) problem -> Prims.int =
+      FStar_Pervasives_Native.tuple2;
+  scope: FStar_Syntax_Syntax.binders;
+  reason: Prims.string Prims.list;
+  loc: FStar_Range.range;
+  rank: Prims.int FStar_Pervasives_Native.option;}[@@deriving show]
+let __proj__Mkproblem__item__pid: 'a 'b . ('a,'b) problem -> Prims.int =
   fun projectee  ->
     match projectee with
     | { pid = __fname__pid; lhs = __fname__lhs; relation = __fname__relation;
@@ -34,8 +32,7 @@ let __proj__Mkproblem__item__pid : 'a 'b . ('a,'b) problem -> Prims.int =
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__pid
-  
-let __proj__Mkproblem__item__lhs : 'a 'b . ('a,'b) problem -> 'a =
+let __proj__Mkproblem__item__lhs: 'a 'b . ('a,'b) problem -> 'a =
   fun projectee  ->
     match projectee with
     | { pid = __fname__pid; lhs = __fname__lhs; relation = __fname__relation;
@@ -43,8 +40,7 @@ let __proj__Mkproblem__item__lhs : 'a 'b . ('a,'b) problem -> 'a =
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__lhs
-  
-let __proj__Mkproblem__item__relation : 'a 'b . ('a,'b) problem -> rel =
+let __proj__Mkproblem__item__relation: 'a 'b . ('a,'b) problem -> rel =
   fun projectee  ->
     match projectee with
     | { pid = __fname__pid; lhs = __fname__lhs; relation = __fname__relation;
@@ -52,8 +48,7 @@ let __proj__Mkproblem__item__relation : 'a 'b . ('a,'b) problem -> rel =
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__relation
-  
-let __proj__Mkproblem__item__rhs : 'a 'b . ('a,'b) problem -> 'a =
+let __proj__Mkproblem__item__rhs: 'a 'b . ('a,'b) problem -> 'a =
   fun projectee  ->
     match projectee with
     | { pid = __fname__pid; lhs = __fname__lhs; relation = __fname__relation;
@@ -61,8 +56,7 @@ let __proj__Mkproblem__item__rhs : 'a 'b . ('a,'b) problem -> 'a =
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__rhs
-  
-let __proj__Mkproblem__item__element :
+let __proj__Mkproblem__item__element:
   'a 'b . ('a,'b) problem -> 'b FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
@@ -71,8 +65,7 @@ let __proj__Mkproblem__item__element :
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__element
-  
-let __proj__Mkproblem__item__logical_guard :
+let __proj__Mkproblem__item__logical_guard:
   'a 'b .
     ('a,'b) problem ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
@@ -85,8 +78,7 @@ let __proj__Mkproblem__item__logical_guard :
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__logical_guard
-  
-let __proj__Mkproblem__item__scope :
+let __proj__Mkproblem__item__scope:
   'a 'b . ('a,'b) problem -> FStar_Syntax_Syntax.binders =
   fun projectee  ->
     match projectee with
@@ -95,8 +87,7 @@ let __proj__Mkproblem__item__scope :
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__scope
-  
-let __proj__Mkproblem__item__reason :
+let __proj__Mkproblem__item__reason:
   'a 'b . ('a,'b) problem -> Prims.string Prims.list =
   fun projectee  ->
     match projectee with
@@ -105,8 +96,7 @@ let __proj__Mkproblem__item__reason :
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__reason
-  
-let __proj__Mkproblem__item__loc :
+let __proj__Mkproblem__item__loc:
   'a 'b . ('a,'b) problem -> FStar_Range.range =
   fun projectee  ->
     match projectee with
@@ -115,8 +105,7 @@ let __proj__Mkproblem__item__loc :
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__loc
-  
-let __proj__Mkproblem__item__rank :
+let __proj__Mkproblem__item__rank:
   'a 'b . ('a,'b) problem -> Prims.int FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
@@ -125,98 +114,86 @@ let __proj__Mkproblem__item__rank :
         logical_guard = __fname__logical_guard; scope = __fname__scope;
         reason = __fname__reason; loc = __fname__loc; rank = __fname__rank;_}
         -> __fname__rank
-  
 type prob =
-  | TProb of (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term) problem 
-  | CProb of (FStar_Syntax_Syntax.comp,Prims.unit) problem [@@deriving show]
-let (uu___is_TProb : prob -> Prims.bool) =
+  | TProb of (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term) problem
+  | CProb of (FStar_Syntax_Syntax.comp,Prims.unit) problem[@@deriving show]
+let uu___is_TProb: prob -> Prims.bool =
   fun projectee  ->
     match projectee with | TProb _0 -> true | uu____475 -> false
-  
-let (__proj__TProb__item___0 :
-  prob -> (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term) problem) =
-  fun projectee  -> match projectee with | TProb _0 -> _0 
-let (uu___is_CProb : prob -> Prims.bool) =
+let __proj__TProb__item___0:
+  prob -> (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term) problem =
+  fun projectee  -> match projectee with | TProb _0 -> _0
+let uu___is_CProb: prob -> Prims.bool =
   fun projectee  ->
     match projectee with | CProb _0 -> true | uu____503 -> false
-  
-let (__proj__CProb__item___0 :
-  prob -> (FStar_Syntax_Syntax.comp,Prims.unit) problem) =
-  fun projectee  -> match projectee with | CProb _0 -> _0 
-let (as_tprob :
-  prob -> (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term) problem) =
+let __proj__CProb__item___0:
+  prob -> (FStar_Syntax_Syntax.comp,Prims.unit) problem =
+  fun projectee  -> match projectee with | CProb _0 -> _0
+let as_tprob:
+  prob -> (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term) problem =
   fun uu___26_529  ->
     match uu___26_529 with
     | TProb p -> p
     | uu____539 -> failwith "Expected a TProb"
-  
 type probs = prob Prims.list[@@deriving show]
 type guard_formula =
-  | Trivial 
-  | NonTrivial of FStar_Syntax_Syntax.formula [@@deriving show]
-let (uu___is_Trivial : guard_formula -> Prims.bool) =
+  | Trivial
+  | NonTrivial of FStar_Syntax_Syntax.formula[@@deriving show]
+let uu___is_Trivial: guard_formula -> Prims.bool =
   fun projectee  ->
     match projectee with | Trivial  -> true | uu____553 -> false
-  
-let (uu___is_NonTrivial : guard_formula -> Prims.bool) =
+let uu___is_NonTrivial: guard_formula -> Prims.bool =
   fun projectee  ->
     match projectee with | NonTrivial _0 -> true | uu____558 -> false
-  
-let (__proj__NonTrivial__item___0 :
-  guard_formula -> FStar_Syntax_Syntax.formula) =
-  fun projectee  -> match projectee with | NonTrivial _0 -> _0 
+let __proj__NonTrivial__item___0:
+  guard_formula -> FStar_Syntax_Syntax.formula =
+  fun projectee  -> match projectee with | NonTrivial _0 -> _0
 type deferred = (Prims.string,prob) FStar_Pervasives_Native.tuple2 Prims.list
 [@@deriving show]
 type univ_ineq =
   (FStar_Syntax_Syntax.universe,FStar_Syntax_Syntax.universe)
     FStar_Pervasives_Native.tuple2[@@deriving show]
-let (mk_by_tactic :
+let mk_by_tactic:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun tac  ->
     fun f  ->
       let t_by_tactic =
         let uu____585 =
-          FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.by_tactic_lid  in
+          FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.by_tactic_lid in
         FStar_Syntax_Syntax.mk_Tm_uinst uu____585
-          [FStar_Syntax_Syntax.U_zero]
-         in
+          [FStar_Syntax_Syntax.U_zero] in
       let t_reify_tactic =
         let uu____587 =
-          FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.reify_tactic_lid  in
+          FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.reify_tactic_lid in
         FStar_Syntax_Syntax.mk_Tm_uinst uu____587
-          [FStar_Syntax_Syntax.U_zero]
-         in
+          [FStar_Syntax_Syntax.U_zero] in
       let tac1 =
         let uu____591 =
           let uu____592 =
             let uu____593 =
-              FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_unit  in
+              FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_unit in
             let uu____594 =
-              let uu____597 = FStar_Syntax_Syntax.as_arg tac  in [uu____597]
-               in
-            uu____593 :: uu____594  in
-          FStar_Syntax_Syntax.mk_Tm_app t_reify_tactic uu____592  in
-        uu____591 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+              let uu____597 = FStar_Syntax_Syntax.as_arg tac in [uu____597] in
+            uu____593 :: uu____594 in
+          FStar_Syntax_Syntax.mk_Tm_app t_reify_tactic uu____592 in
+        uu____591 FStar_Pervasives_Native.None FStar_Range.dummyRange in
       let uu____600 =
         let uu____601 =
-          let uu____602 = FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_unit
-             in
+          let uu____602 = FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_unit in
           let uu____603 =
-            let uu____606 = FStar_Syntax_Syntax.as_arg tac1  in
+            let uu____606 = FStar_Syntax_Syntax.as_arg tac1 in
             let uu____607 =
-              let uu____610 = FStar_Syntax_Syntax.as_arg f  in [uu____610]
-               in
-            uu____606 :: uu____607  in
-          uu____602 :: uu____603  in
-        FStar_Syntax_Syntax.mk_Tm_app t_by_tactic uu____601  in
+              let uu____610 = FStar_Syntax_Syntax.as_arg f in [uu____610] in
+            uu____606 :: uu____607 in
+          uu____602 :: uu____603 in
+        FStar_Syntax_Syntax.mk_Tm_app t_by_tactic uu____601 in
       uu____600 FStar_Pervasives_Native.None FStar_Range.dummyRange
-  
-let rec (delta_depth_greater_than :
+let rec delta_depth_greater_than:
   FStar_Syntax_Syntax.delta_depth ->
-    FStar_Syntax_Syntax.delta_depth -> Prims.bool)
+    FStar_Syntax_Syntax.delta_depth -> Prims.bool
   =
   fun l  ->
     fun m  ->
@@ -232,10 +209,9 @@ let rec (delta_depth_greater_than :
           delta_depth_greater_than d m
       | (uu____627,FStar_Syntax_Syntax.Delta_abstract d) ->
           delta_depth_greater_than l d
-  
-let rec (decr_delta_depth :
+let rec decr_delta_depth:
   FStar_Syntax_Syntax.delta_depth ->
-    FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option
   =
   fun uu___27_633  ->
     match uu___27_633 with
@@ -249,16 +225,15 @@ let rec (decr_delta_depth :
           (FStar_Syntax_Syntax.Delta_defined_at_level
              (i - (Prims.parse_int "1")))
     | FStar_Syntax_Syntax.Delta_abstract d -> decr_delta_depth d
-  
 type identifier_info =
   {
   identifier:
-    (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ;
-  identifier_ty: FStar_Syntax_Syntax.typ ;
-  identifier_range: FStar_Range.range }[@@deriving show]
-let (__proj__Mkidentifier_info__item__identifier :
+    (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either;
+  identifier_ty: FStar_Syntax_Syntax.typ;
+  identifier_range: FStar_Range.range;}[@@deriving show]
+let __proj__Mkidentifier_info__item__identifier:
   identifier_info ->
-    (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either)
+    (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either
   =
   fun projectee  ->
     match projectee with
@@ -266,26 +241,23 @@ let (__proj__Mkidentifier_info__item__identifier :
         identifier_ty = __fname__identifier_ty;
         identifier_range = __fname__identifier_range;_} ->
         __fname__identifier
-  
-let (__proj__Mkidentifier_info__item__identifier_ty :
-  identifier_info -> FStar_Syntax_Syntax.typ) =
+let __proj__Mkidentifier_info__item__identifier_ty:
+  identifier_info -> FStar_Syntax_Syntax.typ =
   fun projectee  ->
     match projectee with
     | { identifier = __fname__identifier;
         identifier_ty = __fname__identifier_ty;
         identifier_range = __fname__identifier_range;_} ->
         __fname__identifier_ty
-  
-let (__proj__Mkidentifier_info__item__identifier_range :
-  identifier_info -> FStar_Range.range) =
+let __proj__Mkidentifier_info__item__identifier_range:
+  identifier_info -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { identifier = __fname__identifier;
         identifier_ty = __fname__identifier_ty;
         identifier_range = __fname__identifier_range;_} ->
         __fname__identifier_range
-  
-let insert_col_info :
+let insert_col_info:
   'Auu____696 .
     Prims.int ->
       'Auu____696 ->
@@ -301,13 +273,11 @@ let insert_col_info :
           | (c,i)::rest' ->
               if col < c
               then (aux, ((col, info) :: rest))
-              else __insert ((c, i) :: aux) rest'
-           in
-        let uu____864 = __insert [] col_infos  in
+              else __insert ((c, i) :: aux) rest' in
+        let uu____864 = __insert [] col_infos in
         match uu____864 with
         | (l,r) -> FStar_List.append (FStar_List.rev l) r
-  
-let find_nearest_preceding_col_info :
+let find_nearest_preceding_col_info:
   'Auu____928 .
     Prims.int ->
       (Prims.int,'Auu____928) FStar_Pervasives_Native.tuple2 Prims.list ->
@@ -321,10 +291,8 @@ let find_nearest_preceding_col_info :
         | (c,i)::rest ->
             if c > col
             then out
-            else aux (FStar_Pervasives_Native.Some i) rest
-         in
+            else aux (FStar_Pervasives_Native.Some i) rest in
       aux FStar_Pervasives_Native.None col_infos
-  
 type id_info_by_col =
   (Prims.int,identifier_info) FStar_Pervasives_Native.tuple2 Prims.list
 [@@deriving show]
@@ -332,83 +300,78 @@ type col_info_by_row = id_info_by_col FStar_Util.pimap[@@deriving show]
 type row_info_by_file = col_info_by_row FStar_Util.psmap[@@deriving show]
 type id_info_table =
   {
-  id_info_enabled: Prims.bool ;
-  id_info_db: row_info_by_file ;
-  id_info_buffer: identifier_info Prims.list }[@@deriving show]
-let (__proj__Mkid_info_table__item__id_info_enabled :
-  id_info_table -> Prims.bool) =
+  id_info_enabled: Prims.bool;
+  id_info_db: row_info_by_file;
+  id_info_buffer: identifier_info Prims.list;}[@@deriving show]
+let __proj__Mkid_info_table__item__id_info_enabled:
+  id_info_table -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { id_info_enabled = __fname__id_info_enabled;
         id_info_db = __fname__id_info_db;
         id_info_buffer = __fname__id_info_buffer;_} ->
         __fname__id_info_enabled
-  
-let (__proj__Mkid_info_table__item__id_info_db :
-  id_info_table -> row_info_by_file) =
+let __proj__Mkid_info_table__item__id_info_db:
+  id_info_table -> row_info_by_file =
   fun projectee  ->
     match projectee with
     | { id_info_enabled = __fname__id_info_enabled;
         id_info_db = __fname__id_info_db;
         id_info_buffer = __fname__id_info_buffer;_} -> __fname__id_info_db
-  
-let (__proj__Mkid_info_table__item__id_info_buffer :
-  id_info_table -> identifier_info Prims.list) =
+let __proj__Mkid_info_table__item__id_info_buffer:
+  id_info_table -> identifier_info Prims.list =
   fun projectee  ->
     match projectee with
     | { id_info_enabled = __fname__id_info_enabled;
         id_info_db = __fname__id_info_db;
         id_info_buffer = __fname__id_info_buffer;_} ->
         __fname__id_info_buffer
-  
-let (id_info_table_empty : id_info_table) =
-  let uu____1050 = FStar_Util.psmap_empty ()  in
-  { id_info_enabled = false; id_info_db = uu____1050; id_info_buffer = [] } 
-let (id_info__insert :
+let id_info_table_empty: id_info_table =
+  let uu____1050 = FStar_Util.psmap_empty () in
+  { id_info_enabled = false; id_info_db = uu____1050; id_info_buffer = [] }
+let id_info__insert:
   (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) ->
     (Prims.int,identifier_info) FStar_Pervasives_Native.tuple2 Prims.list
       FStar_Util.pimap FStar_Util.psmap ->
       identifier_info ->
         (Prims.int,identifier_info) FStar_Pervasives_Native.tuple2 Prims.list
-          FStar_Util.pimap FStar_Util.psmap)
+          FStar_Util.pimap FStar_Util.psmap
   =
   fun ty_map  ->
     fun db  ->
       fun info  ->
-        let range = info.identifier_range  in
+        let range = info.identifier_range in
         let use_range1 =
-          let uu____1097 = FStar_Range.use_range range  in
-          FStar_Range.set_def_range range uu____1097  in
+          let uu____1097 = FStar_Range.use_range range in
+          FStar_Range.set_def_range range uu____1097 in
         let info1 =
-          let uu___29_1099 = info  in
-          let uu____1100 = ty_map info.identifier_ty  in
+          let uu___29_1099 = info in
+          let uu____1100 = ty_map info.identifier_ty in
           {
             identifier = (uu___29_1099.identifier);
             identifier_ty = uu____1100;
             identifier_range = use_range1
-          }  in
-        let fn = FStar_Range.file_of_range use_range1  in
-        let start = FStar_Range.start_of_range use_range1  in
+          } in
+        let fn = FStar_Range.file_of_range use_range1 in
+        let start = FStar_Range.start_of_range use_range1 in
         let uu____1103 =
-          let uu____1108 = FStar_Range.line_of_pos start  in
-          let uu____1109 = FStar_Range.col_of_pos start  in
-          (uu____1108, uu____1109)  in
+          let uu____1108 = FStar_Range.line_of_pos start in
+          let uu____1109 = FStar_Range.col_of_pos start in
+          (uu____1108, uu____1109) in
         match uu____1103 with
         | (row,col) ->
             let rows =
-              let uu____1131 = FStar_Util.pimap_empty ()  in
-              FStar_Util.psmap_find_default db fn uu____1131  in
-            let cols = FStar_Util.pimap_find_default rows row []  in
+              let uu____1131 = FStar_Util.pimap_empty () in
+              FStar_Util.psmap_find_default db fn uu____1131 in
+            let cols = FStar_Util.pimap_find_default rows row [] in
             let uu____1171 =
-              let uu____1180 = insert_col_info col info1 cols  in
-              FStar_All.pipe_right uu____1180 (FStar_Util.pimap_add rows row)
-               in
+              let uu____1180 = insert_col_info col info1 cols in
+              FStar_All.pipe_right uu____1180 (FStar_Util.pimap_add rows row) in
             FStar_All.pipe_right uu____1171 (FStar_Util.psmap_add db fn)
-  
-let (id_info_insert :
+let id_info_insert:
   id_info_table ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
-      FStar_Syntax_Syntax.typ -> FStar_Range.range -> id_info_table)
+      FStar_Syntax_Syntax.typ -> FStar_Range.range -> id_info_table
   =
   fun table  ->
     fun id1  ->
@@ -416,91 +379,84 @@ let (id_info_insert :
         fun range  ->
           let info =
             { identifier = id1; identifier_ty = ty; identifier_range = range
-            }  in
-          let uu___30_1254 = table  in
+            } in
+          let uu___30_1254 = table in
           {
             id_info_enabled = (uu___30_1254.id_info_enabled);
             id_info_db = (uu___30_1254.id_info_db);
             id_info_buffer = (info :: (table.id_info_buffer))
           }
-  
-let (id_info_insert_bv :
+let id_info_insert_bv:
   id_info_table ->
-    FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.typ -> id_info_table)
+    FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.typ -> id_info_table
   =
   fun table  ->
     fun bv  ->
       fun ty  ->
         if table.id_info_enabled
         then
-          let uu____1264 = FStar_Syntax_Syntax.range_of_bv bv  in
+          let uu____1264 = FStar_Syntax_Syntax.range_of_bv bv in
           id_info_insert table (FStar_Util.Inl bv) ty uu____1264
         else table
-  
-let (id_info_insert_fv :
+let id_info_insert_fv:
   id_info_table ->
-    FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.typ -> id_info_table)
+    FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.typ -> id_info_table
   =
   fun table  ->
     fun fv  ->
       fun ty  ->
         if table.id_info_enabled
         then
-          let uu____1275 = FStar_Syntax_Syntax.range_of_fv fv  in
+          let uu____1275 = FStar_Syntax_Syntax.range_of_fv fv in
           id_info_insert table (FStar_Util.Inr fv) ty uu____1275
         else table
-  
-let (id_info_toggle : id_info_table -> Prims.bool -> id_info_table) =
+let id_info_toggle: id_info_table -> Prims.bool -> id_info_table =
   fun table  ->
     fun enabled  ->
-      let uu___31_1283 = table  in
-      let uu____1284 = enabled && (FStar_Options.ide ())  in
+      let uu___31_1283 = table in
+      let uu____1284 = enabled && (FStar_Options.ide ()) in
       {
         id_info_enabled = uu____1284;
         id_info_db = (uu___31_1283.id_info_db);
         id_info_buffer = (uu___31_1283.id_info_buffer)
       }
-  
-let (id_info_promote :
+let id_info_promote:
   id_info_table ->
-    (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) -> id_info_table)
+    (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) -> id_info_table
   =
   fun table  ->
     fun ty_map  ->
-      let uu___32_1296 = table  in
+      let uu___32_1296 = table in
       let uu____1297 =
         FStar_List.fold_left (id_info__insert ty_map) table.id_info_db
-          table.id_info_buffer
-         in
+          table.id_info_buffer in
       {
         id_info_enabled = (uu___32_1296.id_info_enabled);
         id_info_db = uu____1297;
         id_info_buffer = []
       }
-  
-let (id_info_at_pos :
+let id_info_at_pos:
   id_info_table ->
     Prims.string ->
       Prims.int ->
-        Prims.int -> identifier_info FStar_Pervasives_Native.option)
+        Prims.int -> identifier_info FStar_Pervasives_Native.option
   =
   fun table  ->
     fun fn  ->
       fun row  ->
         fun col  ->
           let rows =
-            let uu____1325 = FStar_Util.pimap_empty ()  in
-            FStar_Util.psmap_find_default table.id_info_db fn uu____1325  in
-          let cols = FStar_Util.pimap_find_default rows row []  in
-          let uu____1331 = find_nearest_preceding_col_info col cols  in
+            let uu____1325 = FStar_Util.pimap_empty () in
+            FStar_Util.psmap_find_default table.id_info_db fn uu____1325 in
+          let cols = FStar_Util.pimap_find_default rows row [] in
+          let uu____1331 = find_nearest_preceding_col_info col cols in
           match uu____1331 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some info ->
               let last_col =
                 let uu____1338 =
-                  FStar_Range.end_of_range info.identifier_range  in
-                FStar_Range.col_of_pos uu____1338  in
+                  FStar_Range.end_of_range info.identifier_range in
+                FStar_Range.col_of_pos uu____1338 in
               if col <= last_col
               then FStar_Pervasives_Native.Some info
               else FStar_Pervasives_Native.None
-  

--- a/src/ocaml-output/FStar_TypeChecker_DMFF.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DMFF.ml
@@ -1,41 +1,38 @@
 open Prims
 type env =
   {
-  env: FStar_TypeChecker_Env.env ;
-  subst: FStar_Syntax_Syntax.subst_elt Prims.list ;
-  tc_const: FStar_Const.sconst -> FStar_Syntax_Syntax.typ }[@@deriving show]
-let (__proj__Mkenv__item__env : env -> FStar_TypeChecker_Env.env) =
+  env: FStar_TypeChecker_Env.env;
+  subst: FStar_Syntax_Syntax.subst_elt Prims.list;
+  tc_const: FStar_Const.sconst -> FStar_Syntax_Syntax.typ;}[@@deriving show]
+let __proj__Mkenv__item__env: env -> FStar_TypeChecker_Env.env =
   fun projectee  ->
     match projectee with
     | { env = __fname__env; subst = __fname__subst;
         tc_const = __fname__tc_const;_} -> __fname__env
-  
-let (__proj__Mkenv__item__subst :
-  env -> FStar_Syntax_Syntax.subst_elt Prims.list) =
+let __proj__Mkenv__item__subst:
+  env -> FStar_Syntax_Syntax.subst_elt Prims.list =
   fun projectee  ->
     match projectee with
     | { env = __fname__env; subst = __fname__subst;
         tc_const = __fname__tc_const;_} -> __fname__subst
-  
-let (__proj__Mkenv__item__tc_const :
-  env -> FStar_Const.sconst -> FStar_Syntax_Syntax.typ) =
+let __proj__Mkenv__item__tc_const:
+  env -> FStar_Const.sconst -> FStar_Syntax_Syntax.typ =
   fun projectee  ->
     match projectee with
     | { env = __fname__env; subst = __fname__subst;
         tc_const = __fname__tc_const;_} -> __fname__tc_const
-  
-let (empty :
+let empty:
   FStar_TypeChecker_Env.env ->
-    (FStar_Const.sconst -> FStar_Syntax_Syntax.typ) -> env)
-  = fun env  -> fun tc_const  -> { env; subst = []; tc_const } 
-let (gen_wps_for_free :
+    (FStar_Const.sconst -> FStar_Syntax_Syntax.typ) -> env
+  = fun env  -> fun tc_const  -> { env; subst = []; tc_const }
+let gen_wps_for_free:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
       FStar_Syntax_Syntax.bv ->
         FStar_Syntax_Syntax.term ->
           FStar_Syntax_Syntax.eff_decl ->
             (FStar_Syntax_Syntax.sigelts,FStar_Syntax_Syntax.eff_decl)
-              FStar_Pervasives_Native.tuple2)
+              FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun binders  ->
@@ -45,140 +42,122 @@ let (gen_wps_for_free :
             let wp_a1 =
               FStar_TypeChecker_Normalize.normalize
                 [FStar_TypeChecker_Normalize.Beta;
-                FStar_TypeChecker_Normalize.EraseUniverses] env wp_a
-               in
+                FStar_TypeChecker_Normalize.EraseUniverses] env wp_a in
             let a1 =
-              let uu___75_93 = a  in
+              let uu___75_93 = a in
               let uu____94 =
                 FStar_TypeChecker_Normalize.normalize
                   [FStar_TypeChecker_Normalize.EraseUniverses] env
-                  a.FStar_Syntax_Syntax.sort
-                 in
+                  a.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
                   (uu___75_93.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
                   (uu___75_93.FStar_Syntax_Syntax.index);
                 FStar_Syntax_Syntax.sort = uu____94
-              }  in
-            let d s = FStar_Util.print1 "\027[01;36m%s\027[00m\n" s  in
+              } in
+            let d s = FStar_Util.print1 "\027[01;36m%s\027[00m\n" s in
             (let uu____102 =
-               FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED")  in
+               FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
              if uu____102
              then
                (d "Elaborating extra WP combinators";
-                (let uu____104 = FStar_Syntax_Print.term_to_string wp_a1  in
+                (let uu____104 = FStar_Syntax_Print.term_to_string wp_a1 in
                  FStar_Util.print1 "wp_a is: %s\n" uu____104))
              else ());
             (let rec collect_binders t =
                let uu____116 =
                  let uu____117 =
-                   let uu____120 = FStar_Syntax_Subst.compress t  in
-                   FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____120
-                    in
-                 uu____117.FStar_Syntax_Syntax.n  in
+                   let uu____120 = FStar_Syntax_Subst.compress t in
+                   FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____120 in
+                 uu____117.FStar_Syntax_Syntax.n in
                match uu____116 with
                | FStar_Syntax_Syntax.Tm_arrow (bs,comp) ->
                    let rest =
                      match comp.FStar_Syntax_Syntax.n with
                      | FStar_Syntax_Syntax.Total (t1,uu____151) -> t1
-                     | uu____160 -> failwith "wp_a contains non-Tot arrow"
-                      in
-                   let uu____163 = collect_binders rest  in
+                     | uu____160 -> failwith "wp_a contains non-Tot arrow" in
+                   let uu____163 = collect_binders rest in
                    FStar_List.append bs uu____163
                | FStar_Syntax_Syntax.Tm_type uu____174 -> []
-               | uu____179 -> failwith "wp_a doesn't end in Type0"  in
-             let mk_lid name = FStar_Syntax_Util.dm4f_lid ed name  in
+               | uu____179 -> failwith "wp_a doesn't end in Type0" in
+             let mk_lid name = FStar_Syntax_Util.dm4f_lid ed name in
              let gamma =
-               let uu____197 = collect_binders wp_a1  in
-               FStar_All.pipe_right uu____197 FStar_Syntax_Util.name_binders
-                in
+               let uu____197 = collect_binders wp_a1 in
+               FStar_All.pipe_right uu____197 FStar_Syntax_Util.name_binders in
              (let uu____217 =
-                FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED")
-                 in
+                FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
               if uu____217
               then
                 let uu____218 =
                   let uu____219 =
-                    FStar_Syntax_Print.binders_to_string ", " gamma  in
-                  FStar_Util.format1 "Gamma is %s\n" uu____219  in
+                    FStar_Syntax_Print.binders_to_string ", " gamma in
+                  FStar_Util.format1 "Gamma is %s\n" uu____219 in
                 d uu____218
               else ());
-             (let unknown = FStar_Syntax_Syntax.tun  in
+             (let unknown = FStar_Syntax_Syntax.tun in
               let mk1 x =
                 FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-                  FStar_Range.dummyRange
-                 in
-              let sigelts = FStar_Util.mk_ref []  in
+                  FStar_Range.dummyRange in
+              let sigelts = FStar_Util.mk_ref [] in
               let register env1 lident def =
                 let uu____245 =
                   FStar_TypeChecker_Util.mk_toplevel_definition env1 lident
-                    def
-                   in
+                    def in
                 match uu____245 with
                 | (sigelt,fv) ->
                     ((let uu____253 =
-                        let uu____256 = FStar_ST.op_Bang sigelts  in sigelt
-                          :: uu____256
-                         in
+                        let uu____256 = FStar_ST.op_Bang sigelts in sigelt ::
+                          uu____256 in
                       FStar_ST.op_Colon_Equals sigelts uu____253);
-                     fv)
-                 in
+                     fv) in
               let binders_of_list1 =
                 FStar_List.map
                   (fun uu____376  ->
                      match uu____376 with
                      | (t,b) ->
-                         let uu____387 = FStar_Syntax_Syntax.as_implicit b
-                            in
-                         (t, uu____387))
-                 in
+                         let uu____387 = FStar_Syntax_Syntax.as_implicit b in
+                         (t, uu____387)) in
               let mk_all_implicit =
                 FStar_List.map
                   (fun t  ->
-                     let uu____418 = FStar_Syntax_Syntax.as_implicit true  in
-                     ((FStar_Pervasives_Native.fst t), uu____418))
-                 in
+                     let uu____418 = FStar_Syntax_Syntax.as_implicit true in
+                     ((FStar_Pervasives_Native.fst t), uu____418)) in
               let args_of_binders1 =
                 FStar_List.map
                   (fun bv  ->
                      let uu____441 =
                        FStar_Syntax_Syntax.bv_to_name
-                         (FStar_Pervasives_Native.fst bv)
-                        in
-                     FStar_Syntax_Syntax.as_arg uu____441)
-                 in
+                         (FStar_Pervasives_Native.fst bv) in
+                     FStar_Syntax_Syntax.as_arg uu____441) in
               let uu____442 =
                 let uu____457 =
                   let mk2 f =
                     let t =
                       FStar_Syntax_Syntax.gen_bv "t"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let body =
-                      let uu____479 = f (FStar_Syntax_Syntax.bv_to_name t)
-                         in
-                      FStar_Syntax_Util.arrow gamma uu____479  in
+                      let uu____479 = f (FStar_Syntax_Syntax.bv_to_name t) in
+                      FStar_Syntax_Util.arrow gamma uu____479 in
                     let uu____482 =
                       let uu____483 =
-                        let uu____490 = FStar_Syntax_Syntax.mk_binder a1  in
+                        let uu____490 = FStar_Syntax_Syntax.mk_binder a1 in
                         let uu____491 =
-                          let uu____494 = FStar_Syntax_Syntax.mk_binder t  in
-                          [uu____494]  in
-                        uu____490 :: uu____491  in
-                      FStar_List.append binders uu____483  in
+                          let uu____494 = FStar_Syntax_Syntax.mk_binder t in
+                          [uu____494] in
+                        uu____490 :: uu____491 in
+                      FStar_List.append binders uu____483 in
                     FStar_Syntax_Util.abs uu____482 body
-                      FStar_Pervasives_Native.None
-                     in
-                  let uu____499 = mk2 FStar_Syntax_Syntax.mk_Total  in
-                  let uu____500 = mk2 FStar_Syntax_Syntax.mk_GTotal  in
-                  (uu____499, uu____500)  in
+                      FStar_Pervasives_Native.None in
+                  let uu____499 = mk2 FStar_Syntax_Syntax.mk_Total in
+                  let uu____500 = mk2 FStar_Syntax_Syntax.mk_GTotal in
+                  (uu____499, uu____500) in
                 match uu____457 with
                 | (ctx_def,gctx_def) ->
-                    let ctx_lid = mk_lid "ctx"  in
-                    let ctx_fv = register env ctx_lid ctx_def  in
-                    let gctx_lid = mk_lid "gctx"  in
-                    let gctx_fv = register env gctx_lid gctx_def  in
+                    let ctx_lid = mk_lid "ctx" in
+                    let ctx_fv = register env ctx_lid ctx_def in
+                    let gctx_lid = mk_lid "gctx" in
+                    let gctx_fv = register env gctx_lid gctx_def in
                     let mk_app1 fv t =
                       let uu____534 =
                         let uu____535 =
@@ -189,76 +168,66 @@ let (gen_wps_for_free :
                                    match uu____577 with
                                    | (bv,uu____587) ->
                                        let uu____588 =
-                                         FStar_Syntax_Syntax.bv_to_name bv
-                                          in
+                                         FStar_Syntax_Syntax.bv_to_name bv in
                                        let uu____589 =
                                          FStar_Syntax_Syntax.as_implicit
-                                           false
-                                          in
-                                       (uu____588, uu____589)) binders
-                               in
+                                           false in
+                                       (uu____588, uu____589)) binders in
                             let uu____590 =
                               let uu____597 =
                                 let uu____602 =
-                                  FStar_Syntax_Syntax.bv_to_name a1  in
+                                  FStar_Syntax_Syntax.bv_to_name a1 in
                                 let uu____603 =
-                                  FStar_Syntax_Syntax.as_implicit false  in
-                                (uu____602, uu____603)  in
+                                  FStar_Syntax_Syntax.as_implicit false in
+                                (uu____602, uu____603) in
                               let uu____604 =
                                 let uu____611 =
                                   let uu____616 =
-                                    FStar_Syntax_Syntax.as_implicit false  in
-                                  (t, uu____616)  in
-                                [uu____611]  in
-                              uu____597 :: uu____604  in
-                            FStar_List.append uu____557 uu____590  in
-                          (fv, uu____550)  in
-                        FStar_Syntax_Syntax.Tm_app uu____535  in
-                      mk1 uu____534  in
-                    (env, (mk_app1 ctx_fv), (mk_app1 gctx_fv))
-                 in
+                                    FStar_Syntax_Syntax.as_implicit false in
+                                  (t, uu____616) in
+                                [uu____611] in
+                              uu____597 :: uu____604 in
+                            FStar_List.append uu____557 uu____590 in
+                          (fv, uu____550) in
+                        FStar_Syntax_Syntax.Tm_app uu____535 in
+                      mk1 uu____534 in
+                    (env, (mk_app1 ctx_fv), (mk_app1 gctx_fv)) in
               match uu____442 with
               | (env1,mk_ctx,mk_gctx) ->
                   let c_pure =
                     let t =
                       FStar_Syntax_Syntax.gen_bv "t"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let x =
-                      let uu____675 = FStar_Syntax_Syntax.bv_to_name t  in
+                      let uu____675 = FStar_Syntax_Syntax.bv_to_name t in
                       FStar_Syntax_Syntax.gen_bv "x"
-                        FStar_Pervasives_Native.None uu____675
-                       in
+                        FStar_Pervasives_Native.None uu____675 in
                     let ret1 =
                       let uu____679 =
                         let uu____680 =
-                          let uu____683 = FStar_Syntax_Syntax.bv_to_name t
-                             in
-                          mk_ctx uu____683  in
-                        FStar_Syntax_Util.residual_tot uu____680  in
-                      FStar_Pervasives_Native.Some uu____679  in
+                          let uu____683 = FStar_Syntax_Syntax.bv_to_name t in
+                          mk_ctx uu____683 in
+                        FStar_Syntax_Util.residual_tot uu____680 in
+                      FStar_Pervasives_Native.Some uu____679 in
                     let body =
-                      let uu____685 = FStar_Syntax_Syntax.bv_to_name x  in
-                      FStar_Syntax_Util.abs gamma uu____685 ret1  in
+                      let uu____685 = FStar_Syntax_Syntax.bv_to_name x in
+                      FStar_Syntax_Util.abs gamma uu____685 ret1 in
                     let uu____686 =
-                      let uu____687 = mk_all_implicit binders  in
+                      let uu____687 = mk_all_implicit binders in
                       let uu____694 =
-                        binders_of_list1 [(a1, true); (t, true); (x, false)]
-                         in
-                      FStar_List.append uu____687 uu____694  in
-                    FStar_Syntax_Util.abs uu____686 body ret1  in
+                        binders_of_list1 [(a1, true); (t, true); (x, false)] in
+                      FStar_List.append uu____687 uu____694 in
+                    FStar_Syntax_Util.abs uu____686 body ret1 in
                   let c_pure1 =
-                    let uu____722 = mk_lid "pure"  in
-                    register env1 uu____722 c_pure  in
+                    let uu____722 = mk_lid "pure" in
+                    register env1 uu____722 c_pure in
                   let c_app =
                     let t1 =
                       FStar_Syntax_Syntax.gen_bv "t1"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t2 =
                       FStar_Syntax_Syntax.gen_bv "t2"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let l =
                       let uu____727 =
                         let uu____728 =
@@ -266,119 +235,105 @@ let (gen_wps_for_free :
                             let uu____736 =
                               let uu____737 =
                                 let uu____738 =
-                                  FStar_Syntax_Syntax.bv_to_name t1  in
+                                  FStar_Syntax_Syntax.bv_to_name t1 in
                                 FStar_Syntax_Syntax.new_bv
-                                  FStar_Pervasives_Native.None uu____738
-                                 in
-                              FStar_Syntax_Syntax.mk_binder uu____737  in
-                            [uu____736]  in
+                                  FStar_Pervasives_Native.None uu____738 in
+                              FStar_Syntax_Syntax.mk_binder uu____737 in
+                            [uu____736] in
                           let uu____739 =
-                            let uu____742 = FStar_Syntax_Syntax.bv_to_name t2
-                               in
-                            FStar_Syntax_Syntax.mk_GTotal uu____742  in
-                          FStar_Syntax_Util.arrow uu____729 uu____739  in
-                        mk_gctx uu____728  in
+                            let uu____742 = FStar_Syntax_Syntax.bv_to_name t2 in
+                            FStar_Syntax_Syntax.mk_GTotal uu____742 in
+                          FStar_Syntax_Util.arrow uu____729 uu____739 in
+                        mk_gctx uu____728 in
                       FStar_Syntax_Syntax.gen_bv "l"
-                        FStar_Pervasives_Native.None uu____727
-                       in
+                        FStar_Pervasives_Native.None uu____727 in
                     let r =
                       let uu____744 =
-                        let uu____745 = FStar_Syntax_Syntax.bv_to_name t1  in
-                        mk_gctx uu____745  in
+                        let uu____745 = FStar_Syntax_Syntax.bv_to_name t1 in
+                        mk_gctx uu____745 in
                       FStar_Syntax_Syntax.gen_bv "r"
-                        FStar_Pervasives_Native.None uu____744
-                       in
+                        FStar_Pervasives_Native.None uu____744 in
                     let ret1 =
                       let uu____749 =
                         let uu____750 =
-                          let uu____753 = FStar_Syntax_Syntax.bv_to_name t2
-                             in
-                          mk_gctx uu____753  in
-                        FStar_Syntax_Util.residual_tot uu____750  in
-                      FStar_Pervasives_Native.Some uu____749  in
+                          let uu____753 = FStar_Syntax_Syntax.bv_to_name t2 in
+                          mk_gctx uu____753 in
+                        FStar_Syntax_Util.residual_tot uu____750 in
+                      FStar_Pervasives_Native.Some uu____749 in
                     let outer_body =
-                      let gamma_as_args = args_of_binders1 gamma  in
+                      let gamma_as_args = args_of_binders1 gamma in
                       let inner_body =
-                        let uu____761 = FStar_Syntax_Syntax.bv_to_name l  in
+                        let uu____761 = FStar_Syntax_Syntax.bv_to_name l in
                         let uu____764 =
                           let uu____773 =
                             let uu____776 =
                               let uu____777 =
                                 let uu____778 =
-                                  FStar_Syntax_Syntax.bv_to_name r  in
+                                  FStar_Syntax_Syntax.bv_to_name r in
                                 FStar_Syntax_Util.mk_app uu____778
-                                  gamma_as_args
-                                 in
-                              FStar_Syntax_Syntax.as_arg uu____777  in
-                            [uu____776]  in
-                          FStar_List.append gamma_as_args uu____773  in
-                        FStar_Syntax_Util.mk_app uu____761 uu____764  in
-                      FStar_Syntax_Util.abs gamma inner_body ret1  in
+                                  gamma_as_args in
+                              FStar_Syntax_Syntax.as_arg uu____777 in
+                            [uu____776] in
+                          FStar_List.append gamma_as_args uu____773 in
+                        FStar_Syntax_Util.mk_app uu____761 uu____764 in
+                      FStar_Syntax_Util.abs gamma inner_body ret1 in
                     let uu____781 =
-                      let uu____782 = mk_all_implicit binders  in
+                      let uu____782 = mk_all_implicit binders in
                       let uu____789 =
                         binders_of_list1
                           [(a1, true);
                           (t1, true);
                           (t2, true);
                           (l, false);
-                          (r, false)]
-                         in
-                      FStar_List.append uu____782 uu____789  in
-                    FStar_Syntax_Util.abs uu____781 outer_body ret1  in
+                          (r, false)] in
+                      FStar_List.append uu____782 uu____789 in
+                    FStar_Syntax_Util.abs uu____781 outer_body ret1 in
                   let c_app1 =
-                    let uu____825 = mk_lid "app"  in
-                    register env1 uu____825 c_app  in
+                    let uu____825 = mk_lid "app" in
+                    register env1 uu____825 c_app in
                   let c_lift1 =
                     let t1 =
                       FStar_Syntax_Syntax.gen_bv "t1"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t2 =
                       FStar_Syntax_Syntax.gen_bv "t2"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t_f =
                       let uu____832 =
                         let uu____839 =
-                          let uu____840 = FStar_Syntax_Syntax.bv_to_name t1
-                             in
-                          FStar_Syntax_Syntax.null_binder uu____840  in
-                        [uu____839]  in
+                          let uu____840 = FStar_Syntax_Syntax.bv_to_name t1 in
+                          FStar_Syntax_Syntax.null_binder uu____840 in
+                        [uu____839] in
                       let uu____841 =
-                        let uu____844 = FStar_Syntax_Syntax.bv_to_name t2  in
-                        FStar_Syntax_Syntax.mk_GTotal uu____844  in
-                      FStar_Syntax_Util.arrow uu____832 uu____841  in
+                        let uu____844 = FStar_Syntax_Syntax.bv_to_name t2 in
+                        FStar_Syntax_Syntax.mk_GTotal uu____844 in
+                      FStar_Syntax_Util.arrow uu____832 uu____841 in
                     let f =
                       FStar_Syntax_Syntax.gen_bv "f"
-                        FStar_Pervasives_Native.None t_f
-                       in
+                        FStar_Pervasives_Native.None t_f in
                     let a11 =
                       let uu____847 =
-                        let uu____848 = FStar_Syntax_Syntax.bv_to_name t1  in
-                        mk_gctx uu____848  in
+                        let uu____848 = FStar_Syntax_Syntax.bv_to_name t1 in
+                        mk_gctx uu____848 in
                       FStar_Syntax_Syntax.gen_bv "a1"
-                        FStar_Pervasives_Native.None uu____847
-                       in
+                        FStar_Pervasives_Native.None uu____847 in
                     let ret1 =
                       let uu____852 =
                         let uu____853 =
-                          let uu____856 = FStar_Syntax_Syntax.bv_to_name t2
-                             in
-                          mk_gctx uu____856  in
-                        FStar_Syntax_Util.residual_tot uu____853  in
-                      FStar_Pervasives_Native.Some uu____852  in
+                          let uu____856 = FStar_Syntax_Syntax.bv_to_name t2 in
+                          mk_gctx uu____856 in
+                        FStar_Syntax_Util.residual_tot uu____853 in
+                      FStar_Pervasives_Native.Some uu____852 in
                     let uu____857 =
-                      let uu____858 = mk_all_implicit binders  in
+                      let uu____858 = mk_all_implicit binders in
                       let uu____865 =
                         binders_of_list1
                           [(a1, true);
                           (t1, true);
                           (t2, true);
                           (f, false);
-                          (a11, false)]
-                         in
-                      FStar_List.append uu____858 uu____865  in
+                          (a11, false)] in
+                      FStar_List.append uu____858 uu____865 in
                     let uu____900 =
                       let uu____901 =
                         let uu____910 =
@@ -386,82 +341,71 @@ let (gen_wps_for_free :
                             let uu____916 =
                               let uu____925 =
                                 let uu____928 =
-                                  FStar_Syntax_Syntax.bv_to_name f  in
-                                [uu____928]  in
+                                  FStar_Syntax_Syntax.bv_to_name f in
+                                [uu____928] in
                               FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____925
-                               in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____916  in
+                                uu____925 in
+                            FStar_Syntax_Util.mk_app c_pure1 uu____916 in
                           let uu____929 =
                             let uu____934 =
-                              FStar_Syntax_Syntax.bv_to_name a11  in
-                            [uu____934]  in
-                          uu____913 :: uu____929  in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____910
-                         in
-                      FStar_Syntax_Util.mk_app c_app1 uu____901  in
-                    FStar_Syntax_Util.abs uu____857 uu____900 ret1  in
+                              FStar_Syntax_Syntax.bv_to_name a11 in
+                            [uu____934] in
+                          uu____913 :: uu____929 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____910 in
+                      FStar_Syntax_Util.mk_app c_app1 uu____901 in
+                    FStar_Syntax_Util.abs uu____857 uu____900 ret1 in
                   let c_lift11 =
-                    let uu____938 = mk_lid "lift1"  in
-                    register env1 uu____938 c_lift1  in
+                    let uu____938 = mk_lid "lift1" in
+                    register env1 uu____938 c_lift1 in
                   let c_lift2 =
                     let t1 =
                       FStar_Syntax_Syntax.gen_bv "t1"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t2 =
                       FStar_Syntax_Syntax.gen_bv "t2"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t3 =
                       FStar_Syntax_Syntax.gen_bv "t3"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t_f =
                       let uu____946 =
                         let uu____953 =
-                          let uu____954 = FStar_Syntax_Syntax.bv_to_name t1
-                             in
-                          FStar_Syntax_Syntax.null_binder uu____954  in
+                          let uu____954 = FStar_Syntax_Syntax.bv_to_name t1 in
+                          FStar_Syntax_Syntax.null_binder uu____954 in
                         let uu____955 =
                           let uu____958 =
-                            let uu____959 = FStar_Syntax_Syntax.bv_to_name t2
-                               in
-                            FStar_Syntax_Syntax.null_binder uu____959  in
-                          [uu____958]  in
-                        uu____953 :: uu____955  in
+                            let uu____959 = FStar_Syntax_Syntax.bv_to_name t2 in
+                            FStar_Syntax_Syntax.null_binder uu____959 in
+                          [uu____958] in
+                        uu____953 :: uu____955 in
                       let uu____960 =
-                        let uu____963 = FStar_Syntax_Syntax.bv_to_name t3  in
-                        FStar_Syntax_Syntax.mk_GTotal uu____963  in
-                      FStar_Syntax_Util.arrow uu____946 uu____960  in
+                        let uu____963 = FStar_Syntax_Syntax.bv_to_name t3 in
+                        FStar_Syntax_Syntax.mk_GTotal uu____963 in
+                      FStar_Syntax_Util.arrow uu____946 uu____960 in
                     let f =
                       FStar_Syntax_Syntax.gen_bv "f"
-                        FStar_Pervasives_Native.None t_f
-                       in
+                        FStar_Pervasives_Native.None t_f in
                     let a11 =
                       let uu____966 =
-                        let uu____967 = FStar_Syntax_Syntax.bv_to_name t1  in
-                        mk_gctx uu____967  in
+                        let uu____967 = FStar_Syntax_Syntax.bv_to_name t1 in
+                        mk_gctx uu____967 in
                       FStar_Syntax_Syntax.gen_bv "a1"
-                        FStar_Pervasives_Native.None uu____966
-                       in
+                        FStar_Pervasives_Native.None uu____966 in
                     let a2 =
                       let uu____969 =
-                        let uu____970 = FStar_Syntax_Syntax.bv_to_name t2  in
-                        mk_gctx uu____970  in
+                        let uu____970 = FStar_Syntax_Syntax.bv_to_name t2 in
+                        mk_gctx uu____970 in
                       FStar_Syntax_Syntax.gen_bv "a2"
-                        FStar_Pervasives_Native.None uu____969
-                       in
+                        FStar_Pervasives_Native.None uu____969 in
                     let ret1 =
                       let uu____974 =
                         let uu____975 =
-                          let uu____978 = FStar_Syntax_Syntax.bv_to_name t3
-                             in
-                          mk_gctx uu____978  in
-                        FStar_Syntax_Util.residual_tot uu____975  in
-                      FStar_Pervasives_Native.Some uu____974  in
+                          let uu____978 = FStar_Syntax_Syntax.bv_to_name t3 in
+                          mk_gctx uu____978 in
+                        FStar_Syntax_Util.residual_tot uu____975 in
+                      FStar_Pervasives_Native.Some uu____974 in
                     let uu____979 =
-                      let uu____980 = mk_all_implicit binders  in
+                      let uu____980 = mk_all_implicit binders in
                       let uu____987 =
                         binders_of_list1
                           [(a1, true);
@@ -470,9 +414,8 @@ let (gen_wps_for_free :
                           (t3, true);
                           (f, false);
                           (a11, false);
-                          (a2, false)]
-                         in
-                      FStar_List.append uu____980 uu____987  in
+                          (a2, false)] in
+                      FStar_List.append uu____980 uu____987 in
                     let uu____1030 =
                       let uu____1031 =
                         let uu____1040 =
@@ -483,61 +426,52 @@ let (gen_wps_for_free :
                                   let uu____1061 =
                                     let uu____1070 =
                                       let uu____1073 =
-                                        FStar_Syntax_Syntax.bv_to_name f  in
-                                      [uu____1073]  in
+                                        FStar_Syntax_Syntax.bv_to_name f in
+                                      [uu____1073] in
                                     FStar_List.map FStar_Syntax_Syntax.as_arg
-                                      uu____1070
-                                     in
-                                  FStar_Syntax_Util.mk_app c_pure1 uu____1061
-                                   in
+                                      uu____1070 in
+                                  FStar_Syntax_Util.mk_app c_pure1 uu____1061 in
                                 let uu____1074 =
                                   let uu____1079 =
-                                    FStar_Syntax_Syntax.bv_to_name a11  in
-                                  [uu____1079]  in
-                                uu____1058 :: uu____1074  in
+                                    FStar_Syntax_Syntax.bv_to_name a11 in
+                                  [uu____1079] in
+                                uu____1058 :: uu____1074 in
                               FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____1055
-                               in
-                            FStar_Syntax_Util.mk_app c_app1 uu____1046  in
+                                uu____1055 in
+                            FStar_Syntax_Util.mk_app c_app1 uu____1046 in
                           let uu____1082 =
                             let uu____1087 =
-                              FStar_Syntax_Syntax.bv_to_name a2  in
-                            [uu____1087]  in
-                          uu____1043 :: uu____1082  in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1040
-                         in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1031  in
-                    FStar_Syntax_Util.abs uu____979 uu____1030 ret1  in
+                              FStar_Syntax_Syntax.bv_to_name a2 in
+                            [uu____1087] in
+                          uu____1043 :: uu____1082 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1040 in
+                      FStar_Syntax_Util.mk_app c_app1 uu____1031 in
+                    FStar_Syntax_Util.abs uu____979 uu____1030 ret1 in
                   let c_lift21 =
-                    let uu____1091 = mk_lid "lift2"  in
-                    register env1 uu____1091 c_lift2  in
+                    let uu____1091 = mk_lid "lift2" in
+                    register env1 uu____1091 c_lift2 in
                   let c_push =
                     let t1 =
                       FStar_Syntax_Syntax.gen_bv "t1"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t2 =
                       FStar_Syntax_Syntax.gen_bv "t2"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t_f =
                       let uu____1098 =
                         let uu____1105 =
-                          let uu____1106 = FStar_Syntax_Syntax.bv_to_name t1
-                             in
-                          FStar_Syntax_Syntax.null_binder uu____1106  in
-                        [uu____1105]  in
+                          let uu____1106 = FStar_Syntax_Syntax.bv_to_name t1 in
+                          FStar_Syntax_Syntax.null_binder uu____1106 in
+                        [uu____1105] in
                       let uu____1107 =
                         let uu____1110 =
-                          let uu____1111 = FStar_Syntax_Syntax.bv_to_name t2
-                             in
-                          mk_gctx uu____1111  in
-                        FStar_Syntax_Syntax.mk_Total uu____1110  in
-                      FStar_Syntax_Util.arrow uu____1098 uu____1107  in
+                          let uu____1111 = FStar_Syntax_Syntax.bv_to_name t2 in
+                          mk_gctx uu____1111 in
+                        FStar_Syntax_Syntax.mk_Total uu____1110 in
+                      FStar_Syntax_Util.arrow uu____1098 uu____1107 in
                     let f =
                       FStar_Syntax_Syntax.gen_bv "f"
-                        FStar_Pervasives_Native.None t_f
-                       in
+                        FStar_Pervasives_Native.None t_f in
                     let ret1 =
                       let uu____1116 =
                         let uu____1117 =
@@ -545,96 +479,88 @@ let (gen_wps_for_free :
                             let uu____1121 =
                               let uu____1128 =
                                 let uu____1129 =
-                                  FStar_Syntax_Syntax.bv_to_name t1  in
-                                FStar_Syntax_Syntax.null_binder uu____1129
-                                 in
-                              [uu____1128]  in
+                                  FStar_Syntax_Syntax.bv_to_name t1 in
+                                FStar_Syntax_Syntax.null_binder uu____1129 in
+                              [uu____1128] in
                             let uu____1130 =
                               let uu____1133 =
-                                FStar_Syntax_Syntax.bv_to_name t2  in
-                              FStar_Syntax_Syntax.mk_GTotal uu____1133  in
-                            FStar_Syntax_Util.arrow uu____1121 uu____1130  in
-                          mk_ctx uu____1120  in
-                        FStar_Syntax_Util.residual_tot uu____1117  in
-                      FStar_Pervasives_Native.Some uu____1116  in
+                                FStar_Syntax_Syntax.bv_to_name t2 in
+                              FStar_Syntax_Syntax.mk_GTotal uu____1133 in
+                            FStar_Syntax_Util.arrow uu____1121 uu____1130 in
+                          mk_ctx uu____1120 in
+                        FStar_Syntax_Util.residual_tot uu____1117 in
+                      FStar_Pervasives_Native.Some uu____1116 in
                     let e1 =
-                      let uu____1135 = FStar_Syntax_Syntax.bv_to_name t1  in
+                      let uu____1135 = FStar_Syntax_Syntax.bv_to_name t1 in
                       FStar_Syntax_Syntax.gen_bv "e1"
-                        FStar_Pervasives_Native.None uu____1135
-                       in
+                        FStar_Pervasives_Native.None uu____1135 in
                     let body =
                       let uu____1137 =
                         let uu____1138 =
-                          let uu____1145 = FStar_Syntax_Syntax.mk_binder e1
-                             in
-                          [uu____1145]  in
-                        FStar_List.append gamma uu____1138  in
+                          let uu____1145 = FStar_Syntax_Syntax.mk_binder e1 in
+                          [uu____1145] in
+                        FStar_List.append gamma uu____1138 in
                       let uu____1150 =
-                        let uu____1151 = FStar_Syntax_Syntax.bv_to_name f  in
+                        let uu____1151 = FStar_Syntax_Syntax.bv_to_name f in
                         let uu____1154 =
                           let uu____1163 =
                             let uu____1164 =
-                              FStar_Syntax_Syntax.bv_to_name e1  in
-                            FStar_Syntax_Syntax.as_arg uu____1164  in
-                          let uu____1165 = args_of_binders1 gamma  in
-                          uu____1163 :: uu____1165  in
-                        FStar_Syntax_Util.mk_app uu____1151 uu____1154  in
-                      FStar_Syntax_Util.abs uu____1137 uu____1150 ret1  in
+                              FStar_Syntax_Syntax.bv_to_name e1 in
+                            FStar_Syntax_Syntax.as_arg uu____1164 in
+                          let uu____1165 = args_of_binders1 gamma in
+                          uu____1163 :: uu____1165 in
+                        FStar_Syntax_Util.mk_app uu____1151 uu____1154 in
+                      FStar_Syntax_Util.abs uu____1137 uu____1150 ret1 in
                     let uu____1168 =
-                      let uu____1169 = mk_all_implicit binders  in
+                      let uu____1169 = mk_all_implicit binders in
                       let uu____1176 =
                         binders_of_list1
-                          [(a1, true); (t1, true); (t2, true); (f, false)]
-                         in
-                      FStar_List.append uu____1169 uu____1176  in
-                    FStar_Syntax_Util.abs uu____1168 body ret1  in
+                          [(a1, true); (t1, true); (t2, true); (f, false)] in
+                      FStar_List.append uu____1169 uu____1176 in
+                    FStar_Syntax_Util.abs uu____1168 body ret1 in
                   let c_push1 =
-                    let uu____1208 = mk_lid "push"  in
-                    register env1 uu____1208 c_push  in
+                    let uu____1208 = mk_lid "push" in
+                    register env1 uu____1208 c_push in
                   let ret_tot_wp_a =
                     FStar_Pervasives_Native.Some
-                      (FStar_Syntax_Util.residual_tot wp_a1)
-                     in
+                      (FStar_Syntax_Util.residual_tot wp_a1) in
                   let mk_generic_app c =
                     if (FStar_List.length binders) > (Prims.parse_int "0")
                     then
                       let uu____1228 =
                         let uu____1229 =
-                          let uu____1244 = args_of_binders1 binders  in
-                          (c, uu____1244)  in
-                        FStar_Syntax_Syntax.Tm_app uu____1229  in
+                          let uu____1244 = args_of_binders1 binders in
+                          (c, uu____1244) in
+                        FStar_Syntax_Syntax.Tm_app uu____1229 in
                       mk1 uu____1228
-                    else c  in
+                    else c in
                   let wp_if_then_else =
                     let result_comp =
                       let uu____1254 =
                         let uu____1255 =
                           let uu____1262 =
-                            FStar_Syntax_Syntax.null_binder wp_a1  in
+                            FStar_Syntax_Syntax.null_binder wp_a1 in
                           let uu____1263 =
                             let uu____1266 =
-                              FStar_Syntax_Syntax.null_binder wp_a1  in
-                            [uu____1266]  in
-                          uu____1262 :: uu____1263  in
-                        let uu____1267 = FStar_Syntax_Syntax.mk_Total wp_a1
-                           in
-                        FStar_Syntax_Util.arrow uu____1255 uu____1267  in
-                      FStar_Syntax_Syntax.mk_Total uu____1254  in
+                              FStar_Syntax_Syntax.null_binder wp_a1 in
+                            [uu____1266] in
+                          uu____1262 :: uu____1263 in
+                        let uu____1267 = FStar_Syntax_Syntax.mk_Total wp_a1 in
+                        FStar_Syntax_Util.arrow uu____1255 uu____1267 in
+                      FStar_Syntax_Syntax.mk_Total uu____1254 in
                     let c =
                       FStar_Syntax_Syntax.gen_bv "c"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let uu____1271 =
                       let uu____1272 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; c]  in
-                      FStar_List.append binders uu____1272  in
+                        FStar_Syntax_Syntax.binders_of_list [a1; c] in
+                      FStar_List.append binders uu____1272 in
                     let uu____1283 =
                       let l_ite =
                         FStar_Syntax_Syntax.fvar FStar_Parser_Const.ite_lid
                           (FStar_Syntax_Syntax.Delta_defined_at_level
                              (Prims.parse_int "2"))
-                          FStar_Pervasives_Native.None
-                         in
+                          FStar_Pervasives_Native.None in
                       let uu____1285 =
                         let uu____1288 =
                           let uu____1297 =
@@ -642,42 +568,36 @@ let (gen_wps_for_free :
                               let uu____1303 =
                                 let uu____1312 =
                                   let uu____1313 =
-                                    FStar_Syntax_Syntax.bv_to_name c  in
-                                  FStar_Syntax_Syntax.as_arg uu____1313  in
-                                [uu____1312]  in
-                              FStar_Syntax_Util.mk_app l_ite uu____1303  in
-                            [uu____1300]  in
+                                    FStar_Syntax_Syntax.bv_to_name c in
+                                  FStar_Syntax_Syntax.as_arg uu____1313 in
+                                [uu____1312] in
+                              FStar_Syntax_Util.mk_app l_ite uu____1303 in
+                            [uu____1300] in
                           FStar_List.map FStar_Syntax_Syntax.as_arg
-                            uu____1297
-                           in
-                        FStar_Syntax_Util.mk_app c_lift21 uu____1288  in
+                            uu____1297 in
+                        FStar_Syntax_Util.mk_app c_lift21 uu____1288 in
                       FStar_Syntax_Util.ascribe uu____1285
                         ((FStar_Util.Inr result_comp),
-                          FStar_Pervasives_Native.None)
-                       in
+                          FStar_Pervasives_Native.None) in
                     FStar_Syntax_Util.abs uu____1271 uu____1283
                       (FStar_Pervasives_Native.Some
-                         (FStar_Syntax_Util.residual_comp_of_comp result_comp))
-                     in
+                         (FStar_Syntax_Util.residual_comp_of_comp result_comp)) in
                   let wp_if_then_else1 =
-                    let uu____1333 = mk_lid "wp_if_then_else"  in
-                    register env1 uu____1333 wp_if_then_else  in
-                  let wp_if_then_else2 = mk_generic_app wp_if_then_else1  in
+                    let uu____1333 = mk_lid "wp_if_then_else" in
+                    register env1 uu____1333 wp_if_then_else in
+                  let wp_if_then_else2 = mk_generic_app wp_if_then_else1 in
                   let wp_assert =
                     let q =
                       FStar_Syntax_Syntax.gen_bv "q"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
-                        FStar_Pervasives_Native.None wp_a1
-                       in
+                        FStar_Pervasives_Native.None wp_a1 in
                     let l_and =
                       FStar_Syntax_Syntax.fvar FStar_Parser_Const.and_lid
                         (FStar_Syntax_Syntax.Delta_defined_at_level
                            (Prims.parse_int "1"))
-                        FStar_Pervasives_Native.None
-                       in
+                        FStar_Pervasives_Native.None in
                     let body =
                       let uu____1344 =
                         let uu____1353 =
@@ -688,49 +608,42 @@ let (gen_wps_for_free :
                                   let uu____1374 =
                                     let uu____1383 =
                                       let uu____1384 =
-                                        FStar_Syntax_Syntax.bv_to_name q  in
-                                      FStar_Syntax_Syntax.as_arg uu____1384
-                                       in
-                                    [uu____1383]  in
-                                  FStar_Syntax_Util.mk_app l_and uu____1374
-                                   in
-                                [uu____1371]  in
+                                        FStar_Syntax_Syntax.bv_to_name q in
+                                      FStar_Syntax_Syntax.as_arg uu____1384 in
+                                    [uu____1383] in
+                                  FStar_Syntax_Util.mk_app l_and uu____1374 in
+                                [uu____1371] in
                               FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____1368
-                               in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____1359  in
+                                uu____1368 in
+                            FStar_Syntax_Util.mk_app c_pure1 uu____1359 in
                           let uu____1389 =
                             let uu____1394 =
-                              FStar_Syntax_Syntax.bv_to_name wp  in
-                            [uu____1394]  in
-                          uu____1356 :: uu____1389  in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1353
-                         in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1344  in
+                              FStar_Syntax_Syntax.bv_to_name wp in
+                            [uu____1394] in
+                          uu____1356 :: uu____1389 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1353 in
+                      FStar_Syntax_Util.mk_app c_app1 uu____1344 in
                     let uu____1397 =
                       let uu____1398 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; q; wp]  in
-                      FStar_List.append binders uu____1398  in
-                    FStar_Syntax_Util.abs uu____1397 body ret_tot_wp_a  in
+                        FStar_Syntax_Syntax.binders_of_list [a1; q; wp] in
+                      FStar_List.append binders uu____1398 in
+                    FStar_Syntax_Util.abs uu____1397 body ret_tot_wp_a in
                   let wp_assert1 =
-                    let uu____1410 = mk_lid "wp_assert"  in
-                    register env1 uu____1410 wp_assert  in
-                  let wp_assert2 = mk_generic_app wp_assert1  in
+                    let uu____1410 = mk_lid "wp_assert" in
+                    register env1 uu____1410 wp_assert in
+                  let wp_assert2 = mk_generic_app wp_assert1 in
                   let wp_assume =
                     let q =
                       FStar_Syntax_Syntax.gen_bv "q"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
-                        FStar_Pervasives_Native.None wp_a1
-                       in
+                        FStar_Pervasives_Native.None wp_a1 in
                     let l_imp =
                       FStar_Syntax_Syntax.fvar FStar_Parser_Const.imp_lid
                         (FStar_Syntax_Syntax.Delta_defined_at_level
                            (Prims.parse_int "1"))
-                        FStar_Pervasives_Native.None
-                       in
+                        FStar_Pervasives_Native.None in
                     let body =
                       let uu____1421 =
                         let uu____1430 =
@@ -741,102 +654,89 @@ let (gen_wps_for_free :
                                   let uu____1451 =
                                     let uu____1460 =
                                       let uu____1461 =
-                                        FStar_Syntax_Syntax.bv_to_name q  in
-                                      FStar_Syntax_Syntax.as_arg uu____1461
-                                       in
-                                    [uu____1460]  in
-                                  FStar_Syntax_Util.mk_app l_imp uu____1451
-                                   in
-                                [uu____1448]  in
+                                        FStar_Syntax_Syntax.bv_to_name q in
+                                      FStar_Syntax_Syntax.as_arg uu____1461 in
+                                    [uu____1460] in
+                                  FStar_Syntax_Util.mk_app l_imp uu____1451 in
+                                [uu____1448] in
                               FStar_List.map FStar_Syntax_Syntax.as_arg
-                                uu____1445
-                               in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____1436  in
+                                uu____1445 in
+                            FStar_Syntax_Util.mk_app c_pure1 uu____1436 in
                           let uu____1466 =
                             let uu____1471 =
-                              FStar_Syntax_Syntax.bv_to_name wp  in
-                            [uu____1471]  in
-                          uu____1433 :: uu____1466  in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1430
-                         in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1421  in
+                              FStar_Syntax_Syntax.bv_to_name wp in
+                            [uu____1471] in
+                          uu____1433 :: uu____1466 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1430 in
+                      FStar_Syntax_Util.mk_app c_app1 uu____1421 in
                     let uu____1474 =
                       let uu____1475 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; q; wp]  in
-                      FStar_List.append binders uu____1475  in
-                    FStar_Syntax_Util.abs uu____1474 body ret_tot_wp_a  in
+                        FStar_Syntax_Syntax.binders_of_list [a1; q; wp] in
+                      FStar_List.append binders uu____1475 in
+                    FStar_Syntax_Util.abs uu____1474 body ret_tot_wp_a in
                   let wp_assume1 =
-                    let uu____1487 = mk_lid "wp_assume"  in
-                    register env1 uu____1487 wp_assume  in
-                  let wp_assume2 = mk_generic_app wp_assume1  in
+                    let uu____1487 = mk_lid "wp_assume" in
+                    register env1 uu____1487 wp_assume in
+                  let wp_assume2 = mk_generic_app wp_assume1 in
                   let wp_close =
                     let b =
                       FStar_Syntax_Syntax.gen_bv "b"
-                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype
-                       in
+                        FStar_Pervasives_Native.None FStar_Syntax_Util.ktype in
                     let t_f =
                       let uu____1496 =
                         let uu____1503 =
-                          let uu____1504 = FStar_Syntax_Syntax.bv_to_name b
-                             in
-                          FStar_Syntax_Syntax.null_binder uu____1504  in
-                        [uu____1503]  in
-                      let uu____1505 = FStar_Syntax_Syntax.mk_Total wp_a1  in
-                      FStar_Syntax_Util.arrow uu____1496 uu____1505  in
+                          let uu____1504 = FStar_Syntax_Syntax.bv_to_name b in
+                          FStar_Syntax_Syntax.null_binder uu____1504 in
+                        [uu____1503] in
+                      let uu____1505 = FStar_Syntax_Syntax.mk_Total wp_a1 in
+                      FStar_Syntax_Util.arrow uu____1496 uu____1505 in
                     let f =
                       FStar_Syntax_Syntax.gen_bv "f"
-                        FStar_Pervasives_Native.None t_f
-                       in
+                        FStar_Pervasives_Native.None t_f in
                     let body =
                       let uu____1512 =
                         let uu____1521 =
                           let uu____1524 =
                             let uu____1527 =
                               FStar_List.map FStar_Syntax_Syntax.as_arg
-                                [FStar_Syntax_Util.tforall]
-                               in
-                            FStar_Syntax_Util.mk_app c_pure1 uu____1527  in
+                                [FStar_Syntax_Util.tforall] in
+                            FStar_Syntax_Util.mk_app c_pure1 uu____1527 in
                           let uu____1536 =
                             let uu____1541 =
                               let uu____1544 =
                                 let uu____1553 =
                                   let uu____1556 =
-                                    FStar_Syntax_Syntax.bv_to_name f  in
-                                  [uu____1556]  in
+                                    FStar_Syntax_Syntax.bv_to_name f in
+                                  [uu____1556] in
                                 FStar_List.map FStar_Syntax_Syntax.as_arg
-                                  uu____1553
-                                 in
-                              FStar_Syntax_Util.mk_app c_push1 uu____1544  in
-                            [uu____1541]  in
-                          uu____1524 :: uu____1536  in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1521
-                         in
-                      FStar_Syntax_Util.mk_app c_app1 uu____1512  in
+                                  uu____1553 in
+                              FStar_Syntax_Util.mk_app c_push1 uu____1544 in
+                            [uu____1541] in
+                          uu____1524 :: uu____1536 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____1521 in
+                      FStar_Syntax_Util.mk_app c_app1 uu____1512 in
                     let uu____1563 =
                       let uu____1564 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; b; f]  in
-                      FStar_List.append binders uu____1564  in
-                    FStar_Syntax_Util.abs uu____1563 body ret_tot_wp_a  in
+                        FStar_Syntax_Syntax.binders_of_list [a1; b; f] in
+                      FStar_List.append binders uu____1564 in
+                    FStar_Syntax_Util.abs uu____1563 body ret_tot_wp_a in
                   let wp_close1 =
-                    let uu____1576 = mk_lid "wp_close"  in
-                    register env1 uu____1576 wp_close  in
-                  let wp_close2 = mk_generic_app wp_close1  in
+                    let uu____1576 = mk_lid "wp_close" in
+                    register env1 uu____1576 wp_close in
+                  let wp_close2 = mk_generic_app wp_close1 in
                   let ret_tot_type =
                     FStar_Pervasives_Native.Some
-                      (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype)
-                     in
+                      (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype) in
                   let ret_gtot_type =
                     let uu____1586 =
                       let uu____1587 =
                         let uu____1588 =
                           FStar_Syntax_Syntax.mk_GTotal
-                            FStar_Syntax_Util.ktype
-                           in
+                            FStar_Syntax_Util.ktype in
                         FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                          uu____1588
-                         in
-                      FStar_Syntax_Util.residual_comp_of_lcomp uu____1587  in
-                    FStar_Pervasives_Native.Some uu____1586  in
+                          uu____1588 in
+                      FStar_Syntax_Util.residual_comp_of_lcomp uu____1587 in
+                    FStar_Pervasives_Native.Some uu____1586 in
                   let mk_forall1 x body =
                     let uu____1600 =
                       let uu____1603 =
@@ -846,23 +746,21 @@ let (gen_wps_for_free :
                               let uu____1623 =
                                 let uu____1624 =
                                   let uu____1625 =
-                                    FStar_Syntax_Syntax.mk_binder x  in
-                                  [uu____1625]  in
+                                    FStar_Syntax_Syntax.mk_binder x in
+                                  [uu____1625] in
                                 FStar_Syntax_Util.abs uu____1624 body
-                                  ret_tot_type
-                                 in
-                              FStar_Syntax_Syntax.as_arg uu____1623  in
-                            [uu____1622]  in
-                          (FStar_Syntax_Util.tforall, uu____1619)  in
-                        FStar_Syntax_Syntax.Tm_app uu____1604  in
-                      FStar_Syntax_Syntax.mk uu____1603  in
+                                  ret_tot_type in
+                              FStar_Syntax_Syntax.as_arg uu____1623 in
+                            [uu____1622] in
+                          (FStar_Syntax_Util.tforall, uu____1619) in
+                        FStar_Syntax_Syntax.Tm_app uu____1604 in
+                      FStar_Syntax_Syntax.mk uu____1603 in
                     uu____1600 FStar_Pervasives_Native.None
-                      FStar_Range.dummyRange
-                     in
+                      FStar_Range.dummyRange in
                   let rec is_discrete t =
                     let uu____1635 =
-                      let uu____1636 = FStar_Syntax_Subst.compress t  in
-                      uu____1636.FStar_Syntax_Syntax.n  in
+                      let uu____1636 = FStar_Syntax_Subst.compress t in
+                      uu____1636.FStar_Syntax_Syntax.n in
                     match uu____1635 with
                     | FStar_Syntax_Syntax.Tm_type uu____1639 -> false
                     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
@@ -872,11 +770,11 @@ let (gen_wps_for_free :
                               | (b,uu____1671) ->
                                   is_discrete b.FStar_Syntax_Syntax.sort) bs)
                           && (is_discrete (FStar_Syntax_Util.comp_result c))
-                    | uu____1672 -> true  in
+                    | uu____1672 -> true in
                   let rec is_monotonic t =
                     let uu____1677 =
-                      let uu____1678 = FStar_Syntax_Subst.compress t  in
-                      uu____1678.FStar_Syntax_Syntax.n  in
+                      let uu____1678 = FStar_Syntax_Subst.compress t in
+                      uu____1678.FStar_Syntax_Syntax.n in
                     match uu____1677 with
                     | FStar_Syntax_Syntax.Tm_type uu____1681 -> true
                     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
@@ -886,19 +784,18 @@ let (gen_wps_for_free :
                               | (b,uu____1713) ->
                                   is_discrete b.FStar_Syntax_Syntax.sort) bs)
                           && (is_monotonic (FStar_Syntax_Util.comp_result c))
-                    | uu____1714 -> is_discrete t  in
+                    | uu____1714 -> is_discrete t in
                   let rec mk_rel rel t x y =
-                    let mk_rel1 = mk_rel rel  in
+                    let mk_rel1 = mk_rel rel in
                     let t1 =
                       FStar_TypeChecker_Normalize.normalize
                         [FStar_TypeChecker_Normalize.Beta;
                         FStar_TypeChecker_Normalize.Eager_unfolding;
                         FStar_TypeChecker_Normalize.UnfoldUntil
-                          FStar_Syntax_Syntax.Delta_constant] env1 t
-                       in
+                          FStar_Syntax_Syntax.Delta_constant] env1 t in
                     let uu____1766 =
-                      let uu____1767 = FStar_Syntax_Subst.compress t1  in
-                      uu____1767.FStar_Syntax_Syntax.n  in
+                      let uu____1767 = FStar_Syntax_Subst.compress t1 in
+                      uu____1767.FStar_Syntax_Syntax.n in
                     match uu____1766 with
                     | FStar_Syntax_Syntax.Tm_type uu____1770 -> rel x y
                     | FStar_Syntax_Syntax.Tm_arrow
@@ -910,74 +807,67 @@ let (gen_wps_for_free :
                                       FStar_Syntax_Syntax.vars = uu____1775;_})
                         ->
                         let a2 =
-                          (FStar_Pervasives_Native.fst binder).FStar_Syntax_Syntax.sort
-                           in
+                          (FStar_Pervasives_Native.fst binder).FStar_Syntax_Syntax.sort in
                         let uu____1809 =
-                          (is_monotonic a2) || (is_monotonic b)  in
+                          (is_monotonic a2) || (is_monotonic b) in
                         if uu____1809
                         then
                           let a11 =
                             FStar_Syntax_Syntax.gen_bv "a1"
-                              FStar_Pervasives_Native.None a2
-                             in
+                              FStar_Pervasives_Native.None a2 in
                           let body =
                             let uu____1812 =
                               let uu____1815 =
                                 let uu____1824 =
                                   let uu____1825 =
-                                    FStar_Syntax_Syntax.bv_to_name a11  in
-                                  FStar_Syntax_Syntax.as_arg uu____1825  in
-                                [uu____1824]  in
-                              FStar_Syntax_Util.mk_app x uu____1815  in
+                                    FStar_Syntax_Syntax.bv_to_name a11 in
+                                  FStar_Syntax_Syntax.as_arg uu____1825 in
+                                [uu____1824] in
+                              FStar_Syntax_Util.mk_app x uu____1815 in
                             let uu____1826 =
                               let uu____1829 =
                                 let uu____1838 =
                                   let uu____1839 =
-                                    FStar_Syntax_Syntax.bv_to_name a11  in
-                                  FStar_Syntax_Syntax.as_arg uu____1839  in
-                                [uu____1838]  in
-                              FStar_Syntax_Util.mk_app y uu____1829  in
-                            mk_rel1 b uu____1812 uu____1826  in
+                                    FStar_Syntax_Syntax.bv_to_name a11 in
+                                  FStar_Syntax_Syntax.as_arg uu____1839 in
+                                [uu____1838] in
+                              FStar_Syntax_Util.mk_app y uu____1829 in
+                            mk_rel1 b uu____1812 uu____1826 in
                           mk_forall1 a11 body
                         else
                           (let a11 =
                              FStar_Syntax_Syntax.gen_bv "a1"
-                               FStar_Pervasives_Native.None a2
-                              in
+                               FStar_Pervasives_Native.None a2 in
                            let a21 =
                              FStar_Syntax_Syntax.gen_bv "a2"
-                               FStar_Pervasives_Native.None a2
-                              in
+                               FStar_Pervasives_Native.None a2 in
                            let body =
                              let uu____1844 =
                                let uu____1845 =
-                                 FStar_Syntax_Syntax.bv_to_name a11  in
+                                 FStar_Syntax_Syntax.bv_to_name a11 in
                                let uu____1848 =
-                                 FStar_Syntax_Syntax.bv_to_name a21  in
-                               mk_rel1 a2 uu____1845 uu____1848  in
+                                 FStar_Syntax_Syntax.bv_to_name a21 in
+                               mk_rel1 a2 uu____1845 uu____1848 in
                              let uu____1851 =
                                let uu____1852 =
                                  let uu____1855 =
                                    let uu____1864 =
                                      let uu____1865 =
-                                       FStar_Syntax_Syntax.bv_to_name a11  in
-                                     FStar_Syntax_Syntax.as_arg uu____1865
-                                      in
-                                   [uu____1864]  in
-                                 FStar_Syntax_Util.mk_app x uu____1855  in
+                                       FStar_Syntax_Syntax.bv_to_name a11 in
+                                     FStar_Syntax_Syntax.as_arg uu____1865 in
+                                   [uu____1864] in
+                                 FStar_Syntax_Util.mk_app x uu____1855 in
                                let uu____1866 =
                                  let uu____1869 =
                                    let uu____1878 =
                                      let uu____1879 =
-                                       FStar_Syntax_Syntax.bv_to_name a21  in
-                                     FStar_Syntax_Syntax.as_arg uu____1879
-                                      in
-                                   [uu____1878]  in
-                                 FStar_Syntax_Util.mk_app y uu____1869  in
-                               mk_rel1 b uu____1852 uu____1866  in
-                             FStar_Syntax_Util.mk_imp uu____1844 uu____1851
-                              in
-                           let uu____1880 = mk_forall1 a21 body  in
+                                       FStar_Syntax_Syntax.bv_to_name a21 in
+                                     FStar_Syntax_Syntax.as_arg uu____1879 in
+                                   [uu____1878] in
+                                 FStar_Syntax_Util.mk_app y uu____1869 in
+                               mk_rel1 b uu____1852 uu____1866 in
+                             FStar_Syntax_Util.mk_imp uu____1844 uu____1851 in
+                           let uu____1880 = mk_forall1 a21 body in
                            mk_forall1 a11 uu____1880)
                     | FStar_Syntax_Syntax.Tm_arrow
                         (binder::[],{
@@ -988,123 +878,112 @@ let (gen_wps_for_free :
                                       FStar_Syntax_Syntax.vars = uu____1885;_})
                         ->
                         let a2 =
-                          (FStar_Pervasives_Native.fst binder).FStar_Syntax_Syntax.sort
-                           in
+                          (FStar_Pervasives_Native.fst binder).FStar_Syntax_Syntax.sort in
                         let uu____1919 =
-                          (is_monotonic a2) || (is_monotonic b)  in
+                          (is_monotonic a2) || (is_monotonic b) in
                         if uu____1919
                         then
                           let a11 =
                             FStar_Syntax_Syntax.gen_bv "a1"
-                              FStar_Pervasives_Native.None a2
-                             in
+                              FStar_Pervasives_Native.None a2 in
                           let body =
                             let uu____1922 =
                               let uu____1925 =
                                 let uu____1934 =
                                   let uu____1935 =
-                                    FStar_Syntax_Syntax.bv_to_name a11  in
-                                  FStar_Syntax_Syntax.as_arg uu____1935  in
-                                [uu____1934]  in
-                              FStar_Syntax_Util.mk_app x uu____1925  in
+                                    FStar_Syntax_Syntax.bv_to_name a11 in
+                                  FStar_Syntax_Syntax.as_arg uu____1935 in
+                                [uu____1934] in
+                              FStar_Syntax_Util.mk_app x uu____1925 in
                             let uu____1936 =
                               let uu____1939 =
                                 let uu____1948 =
                                   let uu____1949 =
-                                    FStar_Syntax_Syntax.bv_to_name a11  in
-                                  FStar_Syntax_Syntax.as_arg uu____1949  in
-                                [uu____1948]  in
-                              FStar_Syntax_Util.mk_app y uu____1939  in
-                            mk_rel1 b uu____1922 uu____1936  in
+                                    FStar_Syntax_Syntax.bv_to_name a11 in
+                                  FStar_Syntax_Syntax.as_arg uu____1949 in
+                                [uu____1948] in
+                              FStar_Syntax_Util.mk_app y uu____1939 in
+                            mk_rel1 b uu____1922 uu____1936 in
                           mk_forall1 a11 body
                         else
                           (let a11 =
                              FStar_Syntax_Syntax.gen_bv "a1"
-                               FStar_Pervasives_Native.None a2
-                              in
+                               FStar_Pervasives_Native.None a2 in
                            let a21 =
                              FStar_Syntax_Syntax.gen_bv "a2"
-                               FStar_Pervasives_Native.None a2
-                              in
+                               FStar_Pervasives_Native.None a2 in
                            let body =
                              let uu____1954 =
                                let uu____1955 =
-                                 FStar_Syntax_Syntax.bv_to_name a11  in
+                                 FStar_Syntax_Syntax.bv_to_name a11 in
                                let uu____1958 =
-                                 FStar_Syntax_Syntax.bv_to_name a21  in
-                               mk_rel1 a2 uu____1955 uu____1958  in
+                                 FStar_Syntax_Syntax.bv_to_name a21 in
+                               mk_rel1 a2 uu____1955 uu____1958 in
                              let uu____1961 =
                                let uu____1962 =
                                  let uu____1965 =
                                    let uu____1974 =
                                      let uu____1975 =
-                                       FStar_Syntax_Syntax.bv_to_name a11  in
-                                     FStar_Syntax_Syntax.as_arg uu____1975
-                                      in
-                                   [uu____1974]  in
-                                 FStar_Syntax_Util.mk_app x uu____1965  in
+                                       FStar_Syntax_Syntax.bv_to_name a11 in
+                                     FStar_Syntax_Syntax.as_arg uu____1975 in
+                                   [uu____1974] in
+                                 FStar_Syntax_Util.mk_app x uu____1965 in
                                let uu____1976 =
                                  let uu____1979 =
                                    let uu____1988 =
                                      let uu____1989 =
-                                       FStar_Syntax_Syntax.bv_to_name a21  in
-                                     FStar_Syntax_Syntax.as_arg uu____1989
-                                      in
-                                   [uu____1988]  in
-                                 FStar_Syntax_Util.mk_app y uu____1979  in
-                               mk_rel1 b uu____1962 uu____1976  in
-                             FStar_Syntax_Util.mk_imp uu____1954 uu____1961
-                              in
-                           let uu____1990 = mk_forall1 a21 body  in
+                                       FStar_Syntax_Syntax.bv_to_name a21 in
+                                     FStar_Syntax_Syntax.as_arg uu____1989 in
+                                   [uu____1988] in
+                                 FStar_Syntax_Util.mk_app y uu____1979 in
+                               mk_rel1 b uu____1962 uu____1976 in
+                             FStar_Syntax_Util.mk_imp uu____1954 uu____1961 in
+                           let uu____1990 = mk_forall1 a21 body in
                            mk_forall1 a11 uu____1990)
                     | FStar_Syntax_Syntax.Tm_arrow (binder::binders1,comp) ->
                         let t2 =
-                          let uu___76_2021 = t1  in
+                          let uu___76_2021 = t1 in
                           let uu____2022 =
                             let uu____2023 =
                               let uu____2036 =
                                 let uu____2037 =
-                                  FStar_Syntax_Util.arrow binders1 comp  in
-                                FStar_Syntax_Syntax.mk_Total uu____2037  in
-                              ([binder], uu____2036)  in
-                            FStar_Syntax_Syntax.Tm_arrow uu____2023  in
+                                  FStar_Syntax_Util.arrow binders1 comp in
+                                FStar_Syntax_Syntax.mk_Total uu____2037 in
+                              ([binder], uu____2036) in
+                            FStar_Syntax_Syntax.Tm_arrow uu____2023 in
                           {
                             FStar_Syntax_Syntax.n = uu____2022;
                             FStar_Syntax_Syntax.pos =
                               (uu___76_2021.FStar_Syntax_Syntax.pos);
                             FStar_Syntax_Syntax.vars =
                               (uu___76_2021.FStar_Syntax_Syntax.vars)
-                          }  in
+                          } in
                         mk_rel1 t2 x y
                     | FStar_Syntax_Syntax.Tm_arrow uu____2052 ->
                         failwith "unhandled arrow"
-                    | uu____2065 -> FStar_Syntax_Util.mk_untyped_eq2 x y  in
+                    | uu____2065 -> FStar_Syntax_Util.mk_untyped_eq2 x y in
                   let stronger =
                     let wp1 =
                       FStar_Syntax_Syntax.gen_bv "wp1"
-                        FStar_Pervasives_Native.None wp_a1
-                       in
+                        FStar_Pervasives_Native.None wp_a1 in
                     let wp2 =
                       FStar_Syntax_Syntax.gen_bv "wp2"
-                        FStar_Pervasives_Native.None wp_a1
-                       in
+                        FStar_Pervasives_Native.None wp_a1 in
                     let rec mk_stronger t x y =
                       let t1 =
                         FStar_TypeChecker_Normalize.normalize
                           [FStar_TypeChecker_Normalize.Beta;
                           FStar_TypeChecker_Normalize.Eager_unfolding;
                           FStar_TypeChecker_Normalize.UnfoldUntil
-                            FStar_Syntax_Syntax.Delta_constant] env1 t
-                         in
+                            FStar_Syntax_Syntax.Delta_constant] env1 t in
                       let uu____2080 =
-                        let uu____2081 = FStar_Syntax_Subst.compress t1  in
-                        uu____2081.FStar_Syntax_Syntax.n  in
+                        let uu____2081 = FStar_Syntax_Subst.compress t1 in
+                        uu____2081.FStar_Syntax_Syntax.n in
                       match uu____2080 with
                       | FStar_Syntax_Syntax.Tm_type uu____2084 ->
                           FStar_Syntax_Util.mk_imp x y
                       | FStar_Syntax_Syntax.Tm_app (head1,args) when
-                          let uu____2107 = FStar_Syntax_Subst.compress head1
-                             in
+                          let uu____2107 = FStar_Syntax_Subst.compress head1 in
                           FStar_Syntax_Util.is_tuple_constructor uu____2107
                           ->
                           let project i tuple =
@@ -1113,19 +992,15 @@ let (gen_wps_for_free :
                                 let uu____2123 =
                                   FStar_Parser_Const.mk_tuple_data_lid
                                     (FStar_List.length args)
-                                    FStar_Range.dummyRange
-                                   in
+                                    FStar_Range.dummyRange in
                                 FStar_TypeChecker_Env.lookup_projector env1
-                                  uu____2123 i
-                                 in
+                                  uu____2123 i in
                               FStar_Syntax_Syntax.fvar uu____2122
                                 (FStar_Syntax_Syntax.Delta_defined_at_level
                                    (Prims.parse_int "1"))
-                                FStar_Pervasives_Native.None
-                               in
+                                FStar_Pervasives_Native.None in
                             FStar_Syntax_Util.mk_app projector
-                              [(tuple, FStar_Pervasives_Native.None)]
-                             in
+                              [(tuple, FStar_Pervasives_Native.None)] in
                           let uu____2150 =
                             let uu____2157 =
                               FStar_List.mapi
@@ -1133,16 +1008,15 @@ let (gen_wps_for_free :
                                    fun uu____2171  ->
                                      match uu____2171 with
                                      | (t2,q) ->
-                                         let uu____2178 = project i x  in
-                                         let uu____2179 = project i y  in
+                                         let uu____2178 = project i x in
+                                         let uu____2179 = project i y in
                                          mk_stronger t2 uu____2178 uu____2179)
-                                args
-                               in
+                                args in
                             match uu____2157 with
                             | [] ->
                                 failwith
                                   "Impossible : Empty application when creating stronger relation in DM4F"
-                            | rel0::rels -> (rel0, rels)  in
+                            | rel0::rels -> (rel0, rels) in
                           (match uu____2150 with
                            | (rel0,rels) ->
                                FStar_List.fold_left FStar_Syntax_Util.mk_conj
@@ -1163,26 +1037,22 @@ let (gen_wps_for_free :
                                    | (bv,q) ->
                                        let uu____2253 =
                                          let uu____2254 =
-                                           FStar_Util.string_of_int i  in
-                                         Prims.strcat "a" uu____2254  in
+                                           FStar_Util.string_of_int i in
+                                         Prims.strcat "a" uu____2254 in
                                        FStar_Syntax_Syntax.gen_bv uu____2253
                                          FStar_Pervasives_Native.None
                                          bv.FStar_Syntax_Syntax.sort)
-                              binders1
-                             in
+                              binders1 in
                           let args =
                             FStar_List.map
                               (fun ai  ->
                                  let uu____2261 =
-                                   FStar_Syntax_Syntax.bv_to_name ai  in
-                                 FStar_Syntax_Syntax.as_arg uu____2261) bvs
-                             in
+                                   FStar_Syntax_Syntax.bv_to_name ai in
+                                 FStar_Syntax_Syntax.as_arg uu____2261) bvs in
                           let body =
-                            let uu____2263 = FStar_Syntax_Util.mk_app x args
-                               in
-                            let uu____2264 = FStar_Syntax_Util.mk_app y args
-                               in
-                            mk_stronger b uu____2263 uu____2264  in
+                            let uu____2263 = FStar_Syntax_Util.mk_app x args in
+                            let uu____2264 = FStar_Syntax_Util.mk_app y args in
+                            mk_stronger b uu____2263 uu____2264 in
                           FStar_List.fold_right
                             (fun bv  -> fun body1  -> mk_forall1 bv body1)
                             bvs body
@@ -1202,94 +1072,82 @@ let (gen_wps_for_free :
                                    | (bv,q) ->
                                        let uu____2318 =
                                          let uu____2319 =
-                                           FStar_Util.string_of_int i  in
-                                         Prims.strcat "a" uu____2319  in
+                                           FStar_Util.string_of_int i in
+                                         Prims.strcat "a" uu____2319 in
                                        FStar_Syntax_Syntax.gen_bv uu____2318
                                          FStar_Pervasives_Native.None
                                          bv.FStar_Syntax_Syntax.sort)
-                              binders1
-                             in
+                              binders1 in
                           let args =
                             FStar_List.map
                               (fun ai  ->
                                  let uu____2326 =
-                                   FStar_Syntax_Syntax.bv_to_name ai  in
-                                 FStar_Syntax_Syntax.as_arg uu____2326) bvs
-                             in
+                                   FStar_Syntax_Syntax.bv_to_name ai in
+                                 FStar_Syntax_Syntax.as_arg uu____2326) bvs in
                           let body =
-                            let uu____2328 = FStar_Syntax_Util.mk_app x args
-                               in
-                            let uu____2329 = FStar_Syntax_Util.mk_app y args
-                               in
-                            mk_stronger b uu____2328 uu____2329  in
+                            let uu____2328 = FStar_Syntax_Util.mk_app x args in
+                            let uu____2329 = FStar_Syntax_Util.mk_app y args in
+                            mk_stronger b uu____2328 uu____2329 in
                           FStar_List.fold_right
                             (fun bv  -> fun body1  -> mk_forall1 bv body1)
                             bvs body
-                      | uu____2334 -> failwith "Not a DM elaborated type"  in
+                      | uu____2334 -> failwith "Not a DM elaborated type" in
                     let body =
-                      let uu____2336 = FStar_Syntax_Util.unascribe wp_a1  in
-                      let uu____2337 = FStar_Syntax_Syntax.bv_to_name wp1  in
-                      let uu____2338 = FStar_Syntax_Syntax.bv_to_name wp2  in
-                      mk_stronger uu____2336 uu____2337 uu____2338  in
+                      let uu____2336 = FStar_Syntax_Util.unascribe wp_a1 in
+                      let uu____2337 = FStar_Syntax_Syntax.bv_to_name wp1 in
+                      let uu____2338 = FStar_Syntax_Syntax.bv_to_name wp2 in
+                      mk_stronger uu____2336 uu____2337 uu____2338 in
                     let uu____2339 =
                       let uu____2340 =
                         binders_of_list1
-                          [(a1, false); (wp1, false); (wp2, false)]
-                         in
-                      FStar_List.append binders uu____2340  in
-                    FStar_Syntax_Util.abs uu____2339 body ret_tot_type  in
+                          [(a1, false); (wp1, false); (wp2, false)] in
+                      FStar_List.append binders uu____2340 in
+                    FStar_Syntax_Util.abs uu____2339 body ret_tot_type in
                   let stronger1 =
-                    let uu____2368 = mk_lid "stronger"  in
-                    register env1 uu____2368 stronger  in
-                  let stronger2 = mk_generic_app stronger1  in
+                    let uu____2368 = mk_lid "stronger" in
+                    register env1 uu____2368 stronger in
+                  let stronger2 = mk_generic_app stronger1 in
                   let wp_ite =
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
-                        FStar_Pervasives_Native.None wp_a1
-                       in
-                    let uu____2374 = FStar_Util.prefix gamma  in
+                        FStar_Pervasives_Native.None wp_a1 in
+                    let uu____2374 = FStar_Util.prefix gamma in
                     match uu____2374 with
                     | (wp_args,post) ->
                         let k =
                           FStar_Syntax_Syntax.gen_bv "k"
                             FStar_Pervasives_Native.None
-                            (FStar_Pervasives_Native.fst post).FStar_Syntax_Syntax.sort
-                           in
+                            (FStar_Pervasives_Native.fst post).FStar_Syntax_Syntax.sort in
                         let equiv1 =
-                          let k_tm = FStar_Syntax_Syntax.bv_to_name k  in
+                          let k_tm = FStar_Syntax_Syntax.bv_to_name k in
                           let eq1 =
                             let uu____2419 =
                               FStar_Syntax_Syntax.bv_to_name
-                                (FStar_Pervasives_Native.fst post)
-                               in
+                                (FStar_Pervasives_Native.fst post) in
                             mk_rel FStar_Syntax_Util.mk_iff
-                              k.FStar_Syntax_Syntax.sort k_tm uu____2419
-                             in
+                              k.FStar_Syntax_Syntax.sort k_tm uu____2419 in
                           let uu____2422 =
-                            FStar_Syntax_Util.destruct_typ_as_formula eq1  in
+                            FStar_Syntax_Util.destruct_typ_as_formula eq1 in
                           match uu____2422 with
                           | FStar_Pervasives_Native.Some
                               (FStar_Syntax_Util.QAll (binders1,[],body)) ->
                               let k_app =
-                                let uu____2432 = args_of_binders1 binders1
-                                   in
-                                FStar_Syntax_Util.mk_app k_tm uu____2432  in
+                                let uu____2432 = args_of_binders1 binders1 in
+                                FStar_Syntax_Util.mk_app k_tm uu____2432 in
                               let guard_free1 =
                                 let uu____2442 =
                                   FStar_Syntax_Syntax.lid_as_fv
                                     FStar_Parser_Const.guard_free
                                     FStar_Syntax_Syntax.Delta_constant
-                                    FStar_Pervasives_Native.None
-                                   in
-                                FStar_Syntax_Syntax.fv_to_tm uu____2442  in
+                                    FStar_Pervasives_Native.None in
+                                FStar_Syntax_Syntax.fv_to_tm uu____2442 in
                               let pat =
                                 let uu____2446 =
                                   let uu____2455 =
-                                    FStar_Syntax_Syntax.as_arg k_app  in
-                                  [uu____2455]  in
+                                    FStar_Syntax_Syntax.as_arg k_app in
+                                  [uu____2455] in
                                 FStar_Syntax_Util.mk_app guard_free1
-                                  uu____2446
-                                 in
+                                  uu____2446 in
                               let pattern_guarded_body =
                                 let uu____2459 =
                                   let uu____2460 =
@@ -1297,171 +1155,148 @@ let (gen_wps_for_free :
                                       let uu____2468 =
                                         let uu____2479 =
                                           let uu____2482 =
-                                            FStar_Syntax_Syntax.as_arg pat
-                                             in
-                                          [uu____2482]  in
-                                        [uu____2479]  in
+                                            FStar_Syntax_Syntax.as_arg pat in
+                                          [uu____2482] in
+                                        [uu____2479] in
                                       FStar_Syntax_Syntax.Meta_pattern
-                                        uu____2468
-                                       in
-                                    (body, uu____2467)  in
-                                  FStar_Syntax_Syntax.Tm_meta uu____2460  in
-                                mk1 uu____2459  in
+                                        uu____2468 in
+                                    (body, uu____2467) in
+                                  FStar_Syntax_Syntax.Tm_meta uu____2460 in
+                                mk1 uu____2459 in
                               FStar_Syntax_Util.close_forall_no_univs
                                 binders1 pattern_guarded_body
                           | uu____2487 ->
                               failwith
-                                "Impossible: Expected the equivalence to be a quantified formula"
-                           in
+                                "Impossible: Expected the equivalence to be a quantified formula" in
                         let body =
                           let uu____2491 =
                             let uu____2492 =
                               let uu____2493 =
                                 let uu____2494 =
-                                  FStar_Syntax_Syntax.bv_to_name wp  in
+                                  FStar_Syntax_Syntax.bv_to_name wp in
                                 let uu____2497 =
-                                  let uu____2506 = args_of_binders1 wp_args
-                                     in
+                                  let uu____2506 = args_of_binders1 wp_args in
                                   let uu____2509 =
                                     let uu____2512 =
                                       let uu____2513 =
-                                        FStar_Syntax_Syntax.bv_to_name k  in
-                                      FStar_Syntax_Syntax.as_arg uu____2513
-                                       in
-                                    [uu____2512]  in
-                                  FStar_List.append uu____2506 uu____2509  in
+                                        FStar_Syntax_Syntax.bv_to_name k in
+                                      FStar_Syntax_Syntax.as_arg uu____2513 in
+                                    [uu____2512] in
+                                  FStar_List.append uu____2506 uu____2509 in
                                 FStar_Syntax_Util.mk_app uu____2494
-                                  uu____2497
-                                 in
-                              FStar_Syntax_Util.mk_imp equiv1 uu____2493  in
-                            FStar_Syntax_Util.mk_forall_no_univ k uu____2492
-                             in
+                                  uu____2497 in
+                              FStar_Syntax_Util.mk_imp equiv1 uu____2493 in
+                            FStar_Syntax_Util.mk_forall_no_univ k uu____2492 in
                           FStar_Syntax_Util.abs gamma uu____2491
-                            ret_gtot_type
-                           in
+                            ret_gtot_type in
                         let uu____2514 =
                           let uu____2515 =
-                            FStar_Syntax_Syntax.binders_of_list [a1; wp]  in
-                          FStar_List.append binders uu____2515  in
-                        FStar_Syntax_Util.abs uu____2514 body ret_gtot_type
-                     in
+                            FStar_Syntax_Syntax.binders_of_list [a1; wp] in
+                          FStar_List.append binders uu____2515 in
+                        FStar_Syntax_Util.abs uu____2514 body ret_gtot_type in
                   let wp_ite1 =
-                    let uu____2527 = mk_lid "wp_ite"  in
-                    register env1 uu____2527 wp_ite  in
-                  let wp_ite2 = mk_generic_app wp_ite1  in
+                    let uu____2527 = mk_lid "wp_ite" in
+                    register env1 uu____2527 wp_ite in
+                  let wp_ite2 = mk_generic_app wp_ite1 in
                   let null_wp =
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
-                        FStar_Pervasives_Native.None wp_a1
-                       in
-                    let uu____2533 = FStar_Util.prefix gamma  in
+                        FStar_Pervasives_Native.None wp_a1 in
+                    let uu____2533 = FStar_Util.prefix gamma in
                     match uu____2533 with
                     | (wp_args,post) ->
                         let x =
                           FStar_Syntax_Syntax.gen_bv "x"
                             FStar_Pervasives_Native.None
-                            FStar_Syntax_Syntax.tun
-                           in
+                            FStar_Syntax_Syntax.tun in
                         let body =
                           let uu____2576 =
                             let uu____2577 =
                               FStar_All.pipe_left
                                 FStar_Syntax_Syntax.bv_to_name
-                                (FStar_Pervasives_Native.fst post)
-                               in
+                                (FStar_Pervasives_Native.fst post) in
                             let uu____2580 =
                               let uu____2589 =
                                 let uu____2590 =
-                                  FStar_Syntax_Syntax.bv_to_name x  in
-                                FStar_Syntax_Syntax.as_arg uu____2590  in
-                              [uu____2589]  in
-                            FStar_Syntax_Util.mk_app uu____2577 uu____2580
-                             in
-                          FStar_Syntax_Util.mk_forall_no_univ x uu____2576
-                           in
+                                  FStar_Syntax_Syntax.bv_to_name x in
+                                FStar_Syntax_Syntax.as_arg uu____2590 in
+                              [uu____2589] in
+                            FStar_Syntax_Util.mk_app uu____2577 uu____2580 in
+                          FStar_Syntax_Util.mk_forall_no_univ x uu____2576 in
                         let uu____2591 =
                           let uu____2592 =
                             let uu____2599 =
-                              FStar_Syntax_Syntax.binders_of_list [a1]  in
-                            FStar_List.append uu____2599 gamma  in
-                          FStar_List.append binders uu____2592  in
-                        FStar_Syntax_Util.abs uu____2591 body ret_gtot_type
-                     in
+                              FStar_Syntax_Syntax.binders_of_list [a1] in
+                            FStar_List.append uu____2599 gamma in
+                          FStar_List.append binders uu____2592 in
+                        FStar_Syntax_Util.abs uu____2591 body ret_gtot_type in
                   let null_wp1 =
-                    let uu____2615 = mk_lid "null_wp"  in
-                    register env1 uu____2615 null_wp  in
-                  let null_wp2 = mk_generic_app null_wp1  in
+                    let uu____2615 = mk_lid "null_wp" in
+                    register env1 uu____2615 null_wp in
+                  let null_wp2 = mk_generic_app null_wp1 in
                   let wp_trivial =
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
-                        FStar_Pervasives_Native.None wp_a1
-                       in
+                        FStar_Pervasives_Native.None wp_a1 in
                     let body =
                       let uu____2624 =
                         let uu____2633 =
-                          let uu____2636 = FStar_Syntax_Syntax.bv_to_name a1
-                             in
+                          let uu____2636 = FStar_Syntax_Syntax.bv_to_name a1 in
                           let uu____2637 =
                             let uu____2640 =
                               let uu____2643 =
                                 let uu____2652 =
                                   let uu____2653 =
-                                    FStar_Syntax_Syntax.bv_to_name a1  in
-                                  FStar_Syntax_Syntax.as_arg uu____2653  in
-                                [uu____2652]  in
-                              FStar_Syntax_Util.mk_app null_wp2 uu____2643
-                               in
+                                    FStar_Syntax_Syntax.bv_to_name a1 in
+                                  FStar_Syntax_Syntax.as_arg uu____2653 in
+                                [uu____2652] in
+                              FStar_Syntax_Util.mk_app null_wp2 uu____2643 in
                             let uu____2654 =
                               let uu____2659 =
-                                FStar_Syntax_Syntax.bv_to_name wp  in
-                              [uu____2659]  in
-                            uu____2640 :: uu____2654  in
-                          uu____2636 :: uu____2637  in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____2633
-                         in
-                      FStar_Syntax_Util.mk_app stronger2 uu____2624  in
+                                FStar_Syntax_Syntax.bv_to_name wp in
+                              [uu____2659] in
+                            uu____2640 :: uu____2654 in
+                          uu____2636 :: uu____2637 in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____2633 in
+                      FStar_Syntax_Util.mk_app stronger2 uu____2624 in
                     let uu____2662 =
                       let uu____2663 =
-                        FStar_Syntax_Syntax.binders_of_list [a1; wp]  in
-                      FStar_List.append binders uu____2663  in
-                    FStar_Syntax_Util.abs uu____2662 body ret_tot_type  in
+                        FStar_Syntax_Syntax.binders_of_list [a1; wp] in
+                      FStar_List.append binders uu____2663 in
+                    FStar_Syntax_Util.abs uu____2662 body ret_tot_type in
                   let wp_trivial1 =
-                    let uu____2675 = mk_lid "wp_trivial"  in
-                    register env1 uu____2675 wp_trivial  in
-                  let wp_trivial2 = mk_generic_app wp_trivial1  in
+                    let uu____2675 = mk_lid "wp_trivial" in
+                    register env1 uu____2675 wp_trivial in
+                  let wp_trivial2 = mk_generic_app wp_trivial1 in
                   ((let uu____2680 =
                       FStar_TypeChecker_Env.debug env1
-                        (FStar_Options.Other "ED")
-                       in
+                        (FStar_Options.Other "ED") in
                     if uu____2680
                     then d "End Dijkstra monads for free"
                     else ());
-                   (let c = FStar_Syntax_Subst.close binders  in
+                   (let c = FStar_Syntax_Subst.close binders in
                     let uu____2685 =
-                      let uu____2688 = FStar_ST.op_Bang sigelts  in
-                      FStar_List.rev uu____2688  in
+                      let uu____2688 = FStar_ST.op_Bang sigelts in
+                      FStar_List.rev uu____2688 in
                     let uu____2736 =
-                      let uu___77_2737 = ed  in
+                      let uu___77_2737 = ed in
                       let uu____2738 =
-                        let uu____2739 = c wp_if_then_else2  in
-                        ([], uu____2739)  in
+                        let uu____2739 = c wp_if_then_else2 in
+                        ([], uu____2739) in
                       let uu____2742 =
-                        let uu____2743 = c wp_ite2  in ([], uu____2743)  in
+                        let uu____2743 = c wp_ite2 in ([], uu____2743) in
                       let uu____2746 =
-                        let uu____2747 = c stronger2  in ([], uu____2747)  in
+                        let uu____2747 = c stronger2 in ([], uu____2747) in
                       let uu____2750 =
-                        let uu____2751 = c wp_close2  in ([], uu____2751)  in
+                        let uu____2751 = c wp_close2 in ([], uu____2751) in
                       let uu____2754 =
-                        let uu____2755 = c wp_assert2  in ([], uu____2755)
-                         in
+                        let uu____2755 = c wp_assert2 in ([], uu____2755) in
                       let uu____2758 =
-                        let uu____2759 = c wp_assume2  in ([], uu____2759)
-                         in
+                        let uu____2759 = c wp_assume2 in ([], uu____2759) in
                       let uu____2762 =
-                        let uu____2763 = c null_wp2  in ([], uu____2763)  in
+                        let uu____2763 = c null_wp2 in ([], uu____2763) in
                       let uu____2766 =
-                        let uu____2767 = c wp_trivial2  in ([], uu____2767)
-                         in
+                        let uu____2767 = c wp_trivial2 in ([], uu____2767) in
                       {
                         FStar_Syntax_Syntax.cattributes =
                           (uu___77_2737.FStar_Syntax_Syntax.cattributes);
@@ -1493,34 +1328,32 @@ let (gen_wps_for_free :
                           (uu___77_2737.FStar_Syntax_Syntax.bind_repr);
                         FStar_Syntax_Syntax.actions =
                           (uu___77_2737.FStar_Syntax_Syntax.actions)
-                      }  in
+                      } in
                     (uu____2685, uu____2736)))))
-  
 type env_ = env[@@deriving show]
-let (get_env : env -> FStar_TypeChecker_Env.env) = fun env  -> env.env 
-let (set_env : env -> FStar_TypeChecker_Env.env -> env) =
+let get_env: env -> FStar_TypeChecker_Env.env = fun env  -> env.env
+let set_env: env -> FStar_TypeChecker_Env.env -> env =
   fun dmff_env  ->
     fun env'  ->
-      let uu___78_2781 = dmff_env  in
+      let uu___78_2781 = dmff_env in
       {
         env = env';
         subst = (uu___78_2781.subst);
         tc_const = (uu___78_2781.tc_const)
       }
-  
 type nm =
-  | N of FStar_Syntax_Syntax.typ 
-  | M of FStar_Syntax_Syntax.typ [@@deriving show]
-let (uu___is_N : nm -> Prims.bool) =
-  fun projectee  -> match projectee with | N _0 -> true | uu____2794 -> false 
-let (__proj__N__item___0 : nm -> FStar_Syntax_Syntax.typ) =
-  fun projectee  -> match projectee with | N _0 -> _0 
-let (uu___is_M : nm -> Prims.bool) =
-  fun projectee  -> match projectee with | M _0 -> true | uu____2806 -> false 
-let (__proj__M__item___0 : nm -> FStar_Syntax_Syntax.typ) =
-  fun projectee  -> match projectee with | M _0 -> _0 
+  | N of FStar_Syntax_Syntax.typ
+  | M of FStar_Syntax_Syntax.typ[@@deriving show]
+let uu___is_N: nm -> Prims.bool =
+  fun projectee  -> match projectee with | N _0 -> true | uu____2794 -> false
+let __proj__N__item___0: nm -> FStar_Syntax_Syntax.typ =
+  fun projectee  -> match projectee with | N _0 -> _0
+let uu___is_M: nm -> Prims.bool =
+  fun projectee  -> match projectee with | M _0 -> true | uu____2806 -> false
+let __proj__M__item___0: nm -> FStar_Syntax_Syntax.typ =
+  fun projectee  -> match projectee with | M _0 -> _0
 type nm_ = nm[@@deriving show]
-let (nm_of_comp : FStar_Syntax_Syntax.comp' -> nm) =
+let nm_of_comp: FStar_Syntax_Syntax.comp' -> nm =
   fun uu___64_2816  ->
     match uu___64_2816 with
     | FStar_Syntax_Syntax.Total (t,uu____2818) -> N t
@@ -1535,25 +1368,22 @@ let (nm_of_comp : FStar_Syntax_Syntax.comp' -> nm) =
     | FStar_Syntax_Syntax.Comp c ->
         let uu____2834 =
           let uu____2835 =
-            let uu____2836 = FStar_Syntax_Syntax.mk_Comp c  in
-            FStar_All.pipe_left FStar_Syntax_Print.comp_to_string uu____2836
-             in
-          FStar_Util.format1 "[nm_of_comp]: impossible (%s)" uu____2835  in
+            let uu____2836 = FStar_Syntax_Syntax.mk_Comp c in
+            FStar_All.pipe_left FStar_Syntax_Print.comp_to_string uu____2836 in
+          FStar_Util.format1 "[nm_of_comp]: impossible (%s)" uu____2835 in
         failwith uu____2834
     | FStar_Syntax_Syntax.GTotal uu____2837 ->
         failwith "[nm_of_comp]: impossible (GTot)"
-  
-let (string_of_nm : nm -> Prims.string) =
+let string_of_nm: nm -> Prims.string =
   fun uu___65_2848  ->
     match uu___65_2848 with
     | N t ->
-        let uu____2850 = FStar_Syntax_Print.term_to_string t  in
+        let uu____2850 = FStar_Syntax_Print.term_to_string t in
         FStar_Util.format1 "N[%s]" uu____2850
     | M t ->
-        let uu____2852 = FStar_Syntax_Print.term_to_string t  in
+        let uu____2852 = FStar_Syntax_Print.term_to_string t in
         FStar_Util.format1 "M[%s]" uu____2852
-  
-let (is_monadic_arrow : FStar_Syntax_Syntax.term' -> nm) =
+let is_monadic_arrow: FStar_Syntax_Syntax.term' -> nm =
   fun n1  ->
     match n1 with
     | FStar_Syntax_Syntax.Tm_arrow
@@ -1562,40 +1392,35 @@ let (is_monadic_arrow : FStar_Syntax_Syntax.term' -> nm) =
                       FStar_Syntax_Syntax.vars = uu____2859;_})
         -> nm_of_comp n2
     | uu____2876 -> failwith "unexpected_argument: [is_monadic_arrow]"
-  
-let (is_monadic_comp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let is_monadic_comp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
-    let uu____2884 = nm_of_comp c.FStar_Syntax_Syntax.n  in
+    let uu____2884 = nm_of_comp c.FStar_Syntax_Syntax.n in
     match uu____2884 with | M uu____2885 -> true | N uu____2886 -> false
-  
-exception Not_found 
-let (uu___is_Not_found : Prims.exn -> Prims.bool) =
+exception Not_found
+let uu___is_Not_found: Prims.exn -> Prims.bool =
   fun projectee  ->
     match projectee with | Not_found  -> true | uu____2890 -> false
-  
-let (double_star : FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
+let double_star: FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ =
   fun typ  ->
     let star_once typ1 =
       let uu____2900 =
         let uu____2907 =
           let uu____2908 =
-            FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None typ1  in
-          FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____2908  in
-        [uu____2907]  in
-      let uu____2909 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0
-         in
-      FStar_Syntax_Util.arrow uu____2900 uu____2909  in
-    let uu____2912 = FStar_All.pipe_right typ star_once  in
+            FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None typ1 in
+          FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____2908 in
+        [uu____2907] in
+      let uu____2909 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
+      FStar_Syntax_Util.arrow uu____2900 uu____2909 in
+    let uu____2912 = FStar_All.pipe_right typ star_once in
     FStar_All.pipe_left star_once uu____2912
-  
-let rec (mk_star_to_type :
+let rec mk_star_to_type:
   (FStar_Syntax_Syntax.term' ->
      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
     ->
     env ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun mk1  ->
     fun env  ->
@@ -1605,29 +1430,27 @@ let rec (mk_star_to_type :
              let uu____2962 =
                let uu____2969 =
                  let uu____2974 =
-                   let uu____2975 = star_type' env a  in
-                   FStar_Syntax_Syntax.null_bv uu____2975  in
-                 let uu____2976 = FStar_Syntax_Syntax.as_implicit false  in
-                 (uu____2974, uu____2976)  in
-               [uu____2969]  in
+                   let uu____2975 = star_type' env a in
+                   FStar_Syntax_Syntax.null_bv uu____2975 in
+                 let uu____2976 = FStar_Syntax_Syntax.as_implicit false in
+                 (uu____2974, uu____2976) in
+               [uu____2969] in
              let uu____2985 =
-               FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0  in
-             (uu____2962, uu____2985)  in
+               FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
+             (uu____2962, uu____2985) in
            FStar_Syntax_Syntax.Tm_arrow uu____2949)
-
-and (star_type' :
+and star_type':
   env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  ->
       let mk1 x =
         FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-          t.FStar_Syntax_Syntax.pos
-         in
-      let mk_star_to_type1 = mk_star_to_type mk1  in
-      let t1 = FStar_Syntax_Subst.compress t  in
+          t.FStar_Syntax_Syntax.pos in
+      let mk_star_to_type1 = mk_star_to_type mk1 in
+      let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_arrow (binders,uu____3013) ->
           let binders1 =
@@ -1636,18 +1459,17 @@ and (star_type' :
                  match uu____3049 with
                  | (bv,aqual) ->
                      let uu____3060 =
-                       let uu___79_3061 = bv  in
+                       let uu___79_3061 = bv in
                        let uu____3062 =
-                         star_type' env bv.FStar_Syntax_Syntax.sort  in
+                         star_type' env bv.FStar_Syntax_Syntax.sort in
                        {
                          FStar_Syntax_Syntax.ppname =
                            (uu___79_3061.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
                            (uu___79_3061.FStar_Syntax_Syntax.index);
                          FStar_Syntax_Syntax.sort = uu____3062
-                       }  in
-                     (uu____3060, aqual)) binders
-             in
+                       } in
+                     (uu____3060, aqual)) binders in
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_arrow
                (uu____3065,{
@@ -1659,22 +1481,22 @@ and (star_type' :
                let uu____3094 =
                  let uu____3095 =
                    let uu____3108 =
-                     let uu____3109 = star_type' env hn  in
-                     FStar_Syntax_Syntax.mk_GTotal uu____3109  in
-                   (binders1, uu____3108)  in
-                 FStar_Syntax_Syntax.Tm_arrow uu____3095  in
+                     let uu____3109 = star_type' env hn in
+                     FStar_Syntax_Syntax.mk_GTotal uu____3109 in
+                   (binders1, uu____3108) in
+                 FStar_Syntax_Syntax.Tm_arrow uu____3095 in
                mk1 uu____3094
            | uu____3116 ->
-               let uu____3117 = is_monadic_arrow t1.FStar_Syntax_Syntax.n  in
+               let uu____3117 = is_monadic_arrow t1.FStar_Syntax_Syntax.n in
                (match uu____3117 with
                 | N hn ->
                     let uu____3119 =
                       let uu____3120 =
                         let uu____3133 =
-                          let uu____3134 = star_type' env hn  in
-                          FStar_Syntax_Syntax.mk_Total uu____3134  in
-                        (binders1, uu____3133)  in
-                      FStar_Syntax_Syntax.Tm_arrow uu____3120  in
+                          let uu____3134 = star_type' env hn in
+                          FStar_Syntax_Syntax.mk_Total uu____3134 in
+                        (binders1, uu____3133) in
+                      FStar_Syntax_Syntax.Tm_arrow uu____3120 in
                     mk1 uu____3119
                 | M a ->
                     let uu____3142 =
@@ -1683,76 +1505,71 @@ and (star_type' :
                           let uu____3163 =
                             let uu____3170 =
                               let uu____3175 =
-                                let uu____3176 = mk_star_to_type1 env a  in
-                                FStar_Syntax_Syntax.null_bv uu____3176  in
+                                let uu____3176 = mk_star_to_type1 env a in
+                                FStar_Syntax_Syntax.null_bv uu____3176 in
                               let uu____3177 =
-                                FStar_Syntax_Syntax.as_implicit false  in
-                              (uu____3175, uu____3177)  in
-                            [uu____3170]  in
-                          FStar_List.append binders1 uu____3163  in
+                                FStar_Syntax_Syntax.as_implicit false in
+                              (uu____3175, uu____3177) in
+                            [uu____3170] in
+                          FStar_List.append binders1 uu____3163 in
                         let uu____3190 =
                           FStar_Syntax_Syntax.mk_Total
-                            FStar_Syntax_Util.ktype0
-                           in
-                        (uu____3156, uu____3190)  in
-                      FStar_Syntax_Syntax.Tm_arrow uu____3143  in
+                            FStar_Syntax_Util.ktype0 in
+                        (uu____3156, uu____3190) in
+                      FStar_Syntax_Syntax.Tm_arrow uu____3143 in
                     mk1 uu____3142))
       | FStar_Syntax_Syntax.Tm_app (head1,args) ->
           let debug1 t2 s =
             let string_of_set f s1 =
-              let elts = FStar_Util.set_elements s1  in
+              let elts = FStar_Util.set_elements s1 in
               match elts with
               | [] -> "{}"
               | x::xs ->
-                  let strb = FStar_Util.new_string_builder ()  in
+                  let strb = FStar_Util.new_string_builder () in
                   (FStar_Util.string_builder_append strb "{";
-                   (let uu____3260 = f x  in
+                   (let uu____3260 = f x in
                     FStar_Util.string_builder_append strb uu____3260);
                    FStar_List.iter
                      (fun x1  ->
                         FStar_Util.string_builder_append strb ", ";
-                        (let uu____3267 = f x1  in
+                        (let uu____3267 = f x1 in
                          FStar_Util.string_builder_append strb uu____3267))
                      xs;
                    FStar_Util.string_builder_append strb "}";
-                   FStar_Util.string_of_string_builder strb)
-               in
+                   FStar_Util.string_of_string_builder strb) in
             let uu____3269 =
               let uu____3274 =
-                let uu____3275 = FStar_Syntax_Print.term_to_string t2  in
+                let uu____3275 = FStar_Syntax_Print.term_to_string t2 in
                 let uu____3276 =
-                  string_of_set FStar_Syntax_Print.bv_to_string s  in
+                  string_of_set FStar_Syntax_Print.bv_to_string s in
                 FStar_Util.format2 "Dependency found in term %s : %s"
-                  uu____3275 uu____3276
-                 in
-              (FStar_Errors.Warning_DependencyFound, uu____3274)  in
-            FStar_Errors.log_issue t2.FStar_Syntax_Syntax.pos uu____3269  in
+                  uu____3275 uu____3276 in
+              (FStar_Errors.Warning_DependencyFound, uu____3274) in
+            FStar_Errors.log_issue t2.FStar_Syntax_Syntax.pos uu____3269 in
           let rec is_non_dependent_arrow ty n1 =
             let uu____3284 =
-              let uu____3285 = FStar_Syntax_Subst.compress ty  in
-              uu____3285.FStar_Syntax_Syntax.n  in
+              let uu____3285 = FStar_Syntax_Subst.compress ty in
+              uu____3285.FStar_Syntax_Syntax.n in
             match uu____3284 with
             | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
                 let uu____3306 =
-                  let uu____3307 = FStar_Syntax_Util.is_tot_or_gtot_comp c
-                     in
-                  Prims.op_Negation uu____3307  in
+                  let uu____3307 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
+                  Prims.op_Negation uu____3307 in
                 if uu____3306
                 then false
                 else
                   (try
                      let non_dependent_or_raise s ty1 =
                        let sinter =
-                         let uu____3333 = FStar_Syntax_Free.names ty1  in
-                         FStar_Util.set_intersect uu____3333 s  in
+                         let uu____3333 = FStar_Syntax_Free.names ty1 in
+                         FStar_Util.set_intersect uu____3333 s in
                        let uu____3336 =
-                         let uu____3337 = FStar_Util.set_is_empty sinter  in
-                         Prims.op_Negation uu____3337  in
+                         let uu____3337 = FStar_Util.set_is_empty sinter in
+                         Prims.op_Negation uu____3337 in
                        if uu____3336
                        then (debug1 ty1 sinter; FStar_Exn.raise Not_found)
-                       else ()  in
-                     let uu____3340 = FStar_Syntax_Subst.open_comp binders c
-                        in
+                       else () in
+                     let uu____3340 = FStar_Syntax_Subst.open_comp binders c in
                      match uu____3340 with
                      | (binders1,c1) ->
                          let s =
@@ -1764,11 +1581,10 @@ and (star_type' :
                                       (non_dependent_or_raise s
                                          bv.FStar_Syntax_Syntax.sort;
                                        FStar_Util.set_add bv s))
-                             FStar_Syntax_Syntax.no_names binders1
-                            in
-                         let ct = FStar_Syntax_Util.comp_result c1  in
+                             FStar_Syntax_Syntax.no_names binders1 in
+                         let ct = FStar_Syntax_Util.comp_result c1 in
                          (non_dependent_or_raise s ct;
-                          (let k = n1 - (FStar_List.length binders1)  in
+                          (let k = n1 - (FStar_List.length binders1) in
                            if k > (Prims.parse_int "0")
                            then is_non_dependent_arrow ct k
                            else true))
@@ -1776,20 +1592,17 @@ and (star_type' :
             | uu____3386 ->
                 ((let uu____3388 =
                     let uu____3393 =
-                      let uu____3394 = FStar_Syntax_Print.term_to_string ty
-                         in
+                      let uu____3394 = FStar_Syntax_Print.term_to_string ty in
                       FStar_Util.format1 "Not a dependent arrow : %s"
-                        uu____3394
-                       in
-                    (FStar_Errors.Warning_NotDependentArrow, uu____3393)  in
+                        uu____3394 in
+                    (FStar_Errors.Warning_NotDependentArrow, uu____3393) in
                   FStar_Errors.log_issue ty.FStar_Syntax_Syntax.pos
                     uu____3388);
-                 false)
-             in
+                 false) in
           let rec is_valid_application head2 =
             let uu____3399 =
-              let uu____3400 = FStar_Syntax_Subst.compress head2  in
-              uu____3400.FStar_Syntax_Syntax.n  in
+              let uu____3400 = FStar_Syntax_Subst.compress head2 in
+              uu____3400.FStar_Syntax_Syntax.n in
             match uu____3399 with
             | FStar_Syntax_Syntax.Tm_fvar fv when
                 (((FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1801,18 +1614,17 @@ and (star_type' :
                    (FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.eq2_lid))
                   ||
-                  (let uu____3405 = FStar_Syntax_Subst.compress head2  in
+                  (let uu____3405 = FStar_Syntax_Subst.compress head2 in
                    FStar_Syntax_Util.is_tuple_constructor uu____3405)
                 -> true
             | FStar_Syntax_Syntax.Tm_fvar fv ->
                 let uu____3407 =
                   FStar_TypeChecker_Env.lookup_lid env.env
-                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                   in
+                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                 (match uu____3407 with
                  | ((uu____3416,ty),uu____3418) ->
                      let uu____3423 =
-                       is_non_dependent_arrow ty (FStar_List.length args)  in
+                       is_non_dependent_arrow ty (FStar_List.length args) in
                      if uu____3423
                      then
                        let res =
@@ -1820,26 +1632,22 @@ and (star_type' :
                            [FStar_TypeChecker_Normalize.EraseUniverses;
                            FStar_TypeChecker_Normalize.Inlining;
                            FStar_TypeChecker_Normalize.UnfoldUntil
-                             FStar_Syntax_Syntax.Delta_constant] env.env t1
-                          in
+                             FStar_Syntax_Syntax.Delta_constant] env.env t1 in
                        let uu____3431 =
-                         let uu____3432 = FStar_Syntax_Subst.compress res  in
-                         uu____3432.FStar_Syntax_Syntax.n  in
+                         let uu____3432 = FStar_Syntax_Subst.compress res in
+                         uu____3432.FStar_Syntax_Syntax.n in
                        (match uu____3431 with
                         | FStar_Syntax_Syntax.Tm_app uu____3435 -> true
                         | uu____3450 ->
                             ((let uu____3452 =
                                 let uu____3457 =
                                   let uu____3458 =
-                                    FStar_Syntax_Print.term_to_string head2
-                                     in
+                                    FStar_Syntax_Print.term_to_string head2 in
                                   FStar_Util.format1
                                     "Got a term which might be a non-dependent user-defined data-type %s\n"
-                                    uu____3458
-                                   in
+                                    uu____3458 in
                                 (FStar_Errors.Warning_NondependentUserDefinedDataType,
-                                  uu____3457)
-                                 in
+                                  uu____3457) in
                               FStar_Errors.log_issue
                                 head2.FStar_Syntax_Syntax.pos uu____3452);
                              false))
@@ -1848,8 +1656,8 @@ and (star_type' :
             | FStar_Syntax_Syntax.Tm_name uu____3461 -> true
             | FStar_Syntax_Syntax.Tm_uinst (t2,uu____3463) ->
                 is_valid_application t2
-            | uu____3468 -> false  in
-          let uu____3469 = is_valid_application head1  in
+            | uu____3468 -> false in
+          let uu____3469 = is_valid_application head1 in
           if uu____3469
           then
             let uu____3470 =
@@ -1859,54 +1667,50 @@ and (star_type' :
                     (fun uu____3507  ->
                        match uu____3507 with
                        | (t2,qual) ->
-                           let uu____3524 = star_type' env t2  in
-                           (uu____3524, qual)) args
-                   in
-                (head1, uu____3486)  in
-              FStar_Syntax_Syntax.Tm_app uu____3471  in
+                           let uu____3524 = star_type' env t2 in
+                           (uu____3524, qual)) args in
+                (head1, uu____3486) in
+              FStar_Syntax_Syntax.Tm_app uu____3471 in
             mk1 uu____3470
           else
             (let uu____3534 =
                let uu____3539 =
-                 let uu____3540 = FStar_Syntax_Print.term_to_string t1  in
+                 let uu____3540 = FStar_Syntax_Print.term_to_string t1 in
                  FStar_Util.format1
                    "For now, only [either], [option] and [eq2] are supported in the definition language (got: %s)"
-                   uu____3540
-                  in
-               (FStar_Errors.Fatal_WrongTerm, uu____3539)  in
+                   uu____3540 in
+               (FStar_Errors.Fatal_WrongTerm, uu____3539) in
              FStar_Errors.raise_err uu____3534)
       | FStar_Syntax_Syntax.Tm_bvar uu____3541 -> t1
       | FStar_Syntax_Syntax.Tm_name uu____3542 -> t1
       | FStar_Syntax_Syntax.Tm_type uu____3543 -> t1
       | FStar_Syntax_Syntax.Tm_fvar uu____3544 -> t1
       | FStar_Syntax_Syntax.Tm_abs (binders,repr,something) ->
-          let uu____3568 = FStar_Syntax_Subst.open_term binders repr  in
+          let uu____3568 = FStar_Syntax_Subst.open_term binders repr in
           (match uu____3568 with
            | (binders1,repr1) ->
                let env1 =
-                 let uu___82_3576 = env  in
+                 let uu___82_3576 = env in
                  let uu____3577 =
-                   FStar_TypeChecker_Env.push_binders env.env binders1  in
+                   FStar_TypeChecker_Env.push_binders env.env binders1 in
                  {
                    env = uu____3577;
                    subst = (uu___82_3576.subst);
                    tc_const = (uu___82_3576.tc_const)
-                 }  in
-               let repr2 = star_type' env1 repr1  in
+                 } in
+               let repr2 = star_type' env1 repr1 in
                FStar_Syntax_Util.abs binders1 repr2 something)
       | FStar_Syntax_Syntax.Tm_refine (x,t2) when false ->
-          let x1 = FStar_Syntax_Syntax.freshen_bv x  in
-          let sort = star_type' env x1.FStar_Syntax_Syntax.sort  in
-          let subst1 = [FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x1)]
-             in
-          let t3 = FStar_Syntax_Subst.subst subst1 t2  in
-          let t4 = star_type' env t3  in
-          let subst2 = [FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))]
-             in
-          let t5 = FStar_Syntax_Subst.subst subst2 t4  in
+          let x1 = FStar_Syntax_Syntax.freshen_bv x in
+          let sort = star_type' env x1.FStar_Syntax_Syntax.sort in
+          let subst1 = [FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), x1)] in
+          let t3 = FStar_Syntax_Subst.subst subst1 t2 in
+          let t4 = star_type' env t3 in
+          let subst2 = [FStar_Syntax_Syntax.NM (x1, (Prims.parse_int "0"))] in
+          let t5 = FStar_Syntax_Subst.subst subst2 t4 in
           mk1
             (FStar_Syntax_Syntax.Tm_refine
-               ((let uu___83_3597 = x1  in
+               ((let uu___83_3597 = x1 in
                  {
                    FStar_Syntax_Syntax.ppname =
                      (uu___83_3597.FStar_Syntax_Syntax.ppname);
@@ -1917,122 +1721,113 @@ and (star_type' :
       | FStar_Syntax_Syntax.Tm_meta (t2,m) ->
           let uu____3604 =
             let uu____3605 =
-              let uu____3612 = star_type' env t2  in (uu____3612, m)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3605  in
+              let uu____3612 = star_type' env t2 in (uu____3612, m) in
+            FStar_Syntax_Syntax.Tm_meta uu____3605 in
           mk1 uu____3604
       | FStar_Syntax_Syntax.Tm_ascribed
           (e,(FStar_Util.Inl t2,FStar_Pervasives_Native.None ),something) ->
           let uu____3660 =
             let uu____3661 =
-              let uu____3688 = star_type' env e  in
+              let uu____3688 = star_type' env e in
               let uu____3689 =
                 let uu____3704 =
-                  let uu____3711 = star_type' env t2  in
-                  FStar_Util.Inl uu____3711  in
-                (uu____3704, FStar_Pervasives_Native.None)  in
-              (uu____3688, uu____3689, something)  in
-            FStar_Syntax_Syntax.Tm_ascribed uu____3661  in
+                  let uu____3711 = star_type' env t2 in
+                  FStar_Util.Inl uu____3711 in
+                (uu____3704, FStar_Pervasives_Native.None) in
+              (uu____3688, uu____3689, something) in
+            FStar_Syntax_Syntax.Tm_ascribed uu____3661 in
           mk1 uu____3660
       | FStar_Syntax_Syntax.Tm_ascribed
           (e,(FStar_Util.Inr c,FStar_Pervasives_Native.None ),something) ->
           let uu____3789 =
             let uu____3790 =
-              let uu____3817 = star_type' env e  in
+              let uu____3817 = star_type' env e in
               let uu____3818 =
                 let uu____3833 =
                   let uu____3840 =
-                    star_type' env (FStar_Syntax_Util.comp_result c)  in
-                  FStar_Util.Inl uu____3840  in
-                (uu____3833, FStar_Pervasives_Native.None)  in
-              (uu____3817, uu____3818, something)  in
-            FStar_Syntax_Syntax.Tm_ascribed uu____3790  in
+                    star_type' env (FStar_Syntax_Util.comp_result c) in
+                  FStar_Util.Inl uu____3840 in
+                (uu____3833, FStar_Pervasives_Native.None) in
+              (uu____3817, uu____3818, something) in
+            FStar_Syntax_Syntax.Tm_ascribed uu____3790 in
           mk1 uu____3789
       | FStar_Syntax_Syntax.Tm_ascribed
           (uu____3871,(uu____3872,FStar_Pervasives_Native.Some uu____3873),uu____3874)
           ->
           let uu____3923 =
             let uu____3928 =
-              let uu____3929 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____3929 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
                 "Ascriptions with tactics are outside of the definition language: %s"
-                uu____3929
-               in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3928)  in
+                uu____3929 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3928) in
           FStar_Errors.raise_err uu____3923
       | FStar_Syntax_Syntax.Tm_refine uu____3930 ->
           let uu____3937 =
             let uu____3942 =
-              let uu____3943 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____3943 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
                 "Tm_refine is outside of the definition language: %s"
-                uu____3943
-               in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3942)  in
+                uu____3943 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3942) in
           FStar_Errors.raise_err uu____3937
       | FStar_Syntax_Syntax.Tm_uinst uu____3944 ->
           let uu____3951 =
             let uu____3956 =
-              let uu____3957 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____3957 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
                 "Tm_uinst is outside of the definition language: %s"
-                uu____3957
-               in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3956)  in
+                uu____3957 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3956) in
           FStar_Errors.raise_err uu____3951
       | FStar_Syntax_Syntax.Tm_constant uu____3958 ->
           let uu____3959 =
             let uu____3964 =
-              let uu____3965 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____3965 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
                 "Tm_constant is outside of the definition language: %s"
-                uu____3965
-               in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3964)  in
+                uu____3965 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3964) in
           FStar_Errors.raise_err uu____3959
       | FStar_Syntax_Syntax.Tm_match uu____3966 ->
           let uu____3989 =
             let uu____3994 =
-              let uu____3995 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____3995 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
                 "Tm_match is outside of the definition language: %s"
-                uu____3995
-               in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3994)  in
+                uu____3995 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____3994) in
           FStar_Errors.raise_err uu____3989
       | FStar_Syntax_Syntax.Tm_let uu____3996 ->
           let uu____4009 =
             let uu____4014 =
-              let uu____4015 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____4015 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
-                "Tm_let is outside of the definition language: %s" uu____4015
-               in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____4014)  in
+                "Tm_let is outside of the definition language: %s" uu____4015 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____4014) in
           FStar_Errors.raise_err uu____4009
       | FStar_Syntax_Syntax.Tm_uvar uu____4016 ->
           let uu____4033 =
             let uu____4038 =
-              let uu____4039 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____4039 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
                 "Tm_uvar is outside of the definition language: %s"
-                uu____4039
-               in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____4038)  in
+                uu____4039 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____4038) in
           FStar_Errors.raise_err uu____4033
       | FStar_Syntax_Syntax.Tm_unknown  ->
           let uu____4040 =
             let uu____4045 =
-              let uu____4046 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____4046 = FStar_Syntax_Print.term_to_string t1 in
               FStar_Util.format1
                 "Tm_unknown is outside of the definition language: %s"
-                uu____4046
-               in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____4045)  in
+                uu____4046 in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____4045) in
           FStar_Errors.raise_err uu____4040
       | FStar_Syntax_Syntax.Tm_delayed uu____4047 -> failwith "impossible"
-
-let (is_monadic :
+let is_monadic:
   FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
-    Prims.bool)
+    Prims.bool
   =
   fun uu___67_4076  ->
     match uu___67_4076 with
@@ -2044,29 +1839,27 @@ let (is_monadic :
                 match uu___66_4083 with
                 | FStar_Syntax_Syntax.CPS  -> true
                 | uu____4084 -> false))
-  
-let rec (is_C : FStar_Syntax_Syntax.typ -> Prims.bool) =
+let rec is_C: FStar_Syntax_Syntax.typ -> Prims.bool =
   fun t  ->
     let uu____4088 =
-      let uu____4089 = FStar_Syntax_Subst.compress t  in
-      uu____4089.FStar_Syntax_Syntax.n  in
+      let uu____4089 = FStar_Syntax_Subst.compress t in
+      uu____4089.FStar_Syntax_Syntax.n in
     match uu____4088 with
     | FStar_Syntax_Syntax.Tm_app (head1,args) when
         FStar_Syntax_Util.is_tuple_constructor head1 ->
         let r =
           let uu____4115 =
-            let uu____4116 = FStar_List.hd args  in
-            FStar_Pervasives_Native.fst uu____4116  in
-          is_C uu____4115  in
+            let uu____4116 = FStar_List.hd args in
+            FStar_Pervasives_Native.fst uu____4116 in
+          is_C uu____4115 in
         if r
         then
           ((let uu____4132 =
               let uu____4133 =
                 FStar_List.for_all
                   (fun uu____4141  ->
-                     match uu____4141 with | (h,uu____4147) -> is_C h) args
-                 in
-              Prims.op_Negation uu____4133  in
+                     match uu____4141 with | (h,uu____4147) -> is_C h) args in
+              Prims.op_Negation uu____4133 in
             if uu____4132 then failwith "not a C (A * C)" else ());
            true)
         else
@@ -2076,17 +1869,16 @@ let rec (is_C : FStar_Syntax_Syntax.typ -> Prims.bool) =
                   (fun uu____4161  ->
                      match uu____4161 with
                      | (h,uu____4167) ->
-                         let uu____4168 = is_C h  in
-                         Prims.op_Negation uu____4168) args
-                 in
-              Prims.op_Negation uu____4152  in
+                         let uu____4168 = is_C h in
+                         Prims.op_Negation uu____4168) args in
+              Prims.op_Negation uu____4152 in
             if uu____4151 then failwith "not a C (C * A)" else ());
            false)
     | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
-        let uu____4188 = nm_of_comp comp.FStar_Syntax_Syntax.n  in
+        let uu____4188 = nm_of_comp comp.FStar_Syntax_Syntax.n in
         (match uu____4188 with
          | M t1 ->
-             ((let uu____4191 = is_C t1  in
+             ((let uu____4191 = is_C t1 in
                if uu____4191 then failwith "not a C (C -> C)" else ());
               true)
          | N t1 -> is_C t1)
@@ -2094,54 +1886,48 @@ let rec (is_C : FStar_Syntax_Syntax.typ -> Prims.bool) =
     | FStar_Syntax_Syntax.Tm_uinst (t1,uu____4201) -> is_C t1
     | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____4207,uu____4208) -> is_C t1
     | uu____4249 -> false
-  
-let (mk_return :
+let mk_return:
   env ->
     FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  ->
       fun e  ->
         let mk1 x =
           FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-            e.FStar_Syntax_Syntax.pos
-           in
-        let p_type = mk_star_to_type mk1 env t  in
+            e.FStar_Syntax_Syntax.pos in
+        let p_type = mk_star_to_type mk1 env t in
         let p =
-          FStar_Syntax_Syntax.gen_bv "p'" FStar_Pervasives_Native.None p_type
-           in
+          FStar_Syntax_Syntax.gen_bv "p'" FStar_Pervasives_Native.None p_type in
         let body =
           let uu____4272 =
             let uu____4273 =
-              let uu____4288 = FStar_Syntax_Syntax.bv_to_name p  in
+              let uu____4288 = FStar_Syntax_Syntax.bv_to_name p in
               let uu____4289 =
                 let uu____4296 =
-                  let uu____4301 = FStar_Syntax_Syntax.as_implicit false  in
-                  (e, uu____4301)  in
-                [uu____4296]  in
-              (uu____4288, uu____4289)  in
-            FStar_Syntax_Syntax.Tm_app uu____4273  in
-          mk1 uu____4272  in
+                  let uu____4301 = FStar_Syntax_Syntax.as_implicit false in
+                  (e, uu____4301) in
+                [uu____4296] in
+              (uu____4288, uu____4289) in
+            FStar_Syntax_Syntax.Tm_app uu____4273 in
+          mk1 uu____4272 in
         let uu____4316 =
-          let uu____4317 = FStar_Syntax_Syntax.mk_binder p  in [uu____4317]
-           in
+          let uu____4317 = FStar_Syntax_Syntax.mk_binder p in [uu____4317] in
         FStar_Syntax_Util.abs uu____4316 body
           (FStar_Pervasives_Native.Some
              (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0))
-  
-let (is_unknown : FStar_Syntax_Syntax.term' -> Prims.bool) =
+let is_unknown: FStar_Syntax_Syntax.term' -> Prims.bool =
   fun uu___68_4320  ->
     match uu___68_4320 with
     | FStar_Syntax_Syntax.Tm_unknown  -> true
     | uu____4321 -> false
-  
-let rec (check :
+let rec check:
   env ->
     FStar_Syntax_Syntax.term ->
       nm ->
         (nm,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
@@ -2155,88 +1941,74 @@ let rec (check :
                     &&
                     (let uu____4525 =
                        let uu____4526 =
-                         FStar_TypeChecker_Rel.teq env.env t1 t2  in
-                       FStar_TypeChecker_Rel.is_trivial uu____4526  in
-                     Prims.op_Negation uu____4525)
-                   in
+                         FStar_TypeChecker_Rel.teq env.env t1 t2 in
+                       FStar_TypeChecker_Rel.is_trivial uu____4526 in
+                     Prims.op_Negation uu____4525) in
                 if uu____4523
                 then
                   let uu____4527 =
                     let uu____4532 =
-                      let uu____4533 = FStar_Syntax_Print.term_to_string e
-                         in
-                      let uu____4534 = FStar_Syntax_Print.term_to_string t1
-                         in
-                      let uu____4535 = FStar_Syntax_Print.term_to_string t2
-                         in
+                      let uu____4533 = FStar_Syntax_Print.term_to_string e in
+                      let uu____4534 = FStar_Syntax_Print.term_to_string t1 in
+                      let uu____4535 = FStar_Syntax_Print.term_to_string t2 in
                       FStar_Util.format3
                         "[check]: the expression [%s] has type [%s] but should have type [%s]"
-                        uu____4533 uu____4534 uu____4535
-                       in
-                    (FStar_Errors.Fatal_TypeMismatch, uu____4532)  in
+                        uu____4533 uu____4534 uu____4535 in
+                    (FStar_Errors.Fatal_TypeMismatch, uu____4532) in
                   FStar_Errors.raise_err uu____4527
-                else ()  in
+                else () in
               (match (rec_nm, context_nm) with
                | (N t1,N t2) -> (check1 t1 t2; (rec_nm, s_e, u_e))
                | (M t1,M t2) -> (check1 t1 t2; (rec_nm, s_e, u_e))
                | (N t1,M t2) ->
                    (check1 t1 t2;
-                    (let uu____4552 = mk_return env t1 s_e  in
+                    (let uu____4552 = mk_return env t1 s_e in
                      ((M t1), uu____4552, u_e)))
                | (M t1,N t2) ->
                    let uu____4555 =
                      let uu____4560 =
-                       let uu____4561 = FStar_Syntax_Print.term_to_string e
-                          in
-                       let uu____4562 = FStar_Syntax_Print.term_to_string t1
-                          in
-                       let uu____4563 = FStar_Syntax_Print.term_to_string t2
-                          in
+                       let uu____4561 = FStar_Syntax_Print.term_to_string e in
+                       let uu____4562 = FStar_Syntax_Print.term_to_string t1 in
+                       let uu____4563 = FStar_Syntax_Print.term_to_string t2 in
                        FStar_Util.format3
                          "[check %s]: got an effectful computation [%s] in lieu of a pure computation [%s]"
-                         uu____4561 uu____4562 uu____4563
-                        in
+                         uu____4561 uu____4562 uu____4563 in
                      (FStar_Errors.Fatal_EffectfulAndPureComputationMismatch,
-                       uu____4560)
-                      in
-                   FStar_Errors.raise_err uu____4555)
-           in
+                       uu____4560) in
+                   FStar_Errors.raise_err uu____4555) in
         let ensure_m env1 e2 =
           let strip_m uu___69_4604 =
             match uu___69_4604 with
             | (M t,s_e,u_e) -> (t, s_e, u_e)
-            | uu____4620 -> failwith "impossible"  in
+            | uu____4620 -> failwith "impossible" in
           match context_nm with
           | N t ->
               let uu____4640 =
                 let uu____4645 =
-                  let uu____4646 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____4646 = FStar_Syntax_Print.term_to_string t in
                   Prims.strcat
                     "let-bound monadic body has a non-monadic continuation or a branch of a match is monadic and the others aren't : "
-                    uu____4646
-                   in
-                (FStar_Errors.Fatal_LetBoundMonadicMismatch, uu____4645)  in
+                    uu____4646 in
+                (FStar_Errors.Fatal_LetBoundMonadicMismatch, uu____4645) in
               FStar_Errors.raise_error uu____4640 e2.FStar_Syntax_Syntax.pos
           | M uu____4653 ->
-              let uu____4654 = check env1 e2 context_nm  in
-              strip_m uu____4654
-           in
+              let uu____4654 = check env1 e2 context_nm in strip_m uu____4654 in
         let uu____4661 =
-          let uu____4662 = FStar_Syntax_Subst.compress e  in
-          uu____4662.FStar_Syntax_Syntax.n  in
+          let uu____4662 = FStar_Syntax_Subst.compress e in
+          uu____4662.FStar_Syntax_Syntax.n in
         match uu____4661 with
         | FStar_Syntax_Syntax.Tm_bvar uu____4671 ->
-            let uu____4672 = infer env e  in return_if uu____4672
+            let uu____4672 = infer env e in return_if uu____4672
         | FStar_Syntax_Syntax.Tm_name uu____4679 ->
-            let uu____4680 = infer env e  in return_if uu____4680
+            let uu____4680 = infer env e in return_if uu____4680
         | FStar_Syntax_Syntax.Tm_fvar uu____4687 ->
-            let uu____4688 = infer env e  in return_if uu____4688
+            let uu____4688 = infer env e in return_if uu____4688
         | FStar_Syntax_Syntax.Tm_abs uu____4695 ->
-            let uu____4712 = infer env e  in return_if uu____4712
+            let uu____4712 = infer env e in return_if uu____4712
         | FStar_Syntax_Syntax.Tm_constant uu____4719 ->
-            let uu____4720 = infer env e  in return_if uu____4720
+            let uu____4720 = infer env e in return_if uu____4720
         | FStar_Syntax_Syntax.Tm_app uu____4727 ->
-            let uu____4742 = infer env e  in return_if uu____4742
+            let uu____4742 = infer env e in return_if uu____4742
         | FStar_Syntax_Syntax.Tm_let ((false ,binding::[]),e2) ->
             mk_let env binding e2
               (fun env1  -> fun e21  -> check env1 e21 context_nm) ensure_m
@@ -2251,8 +2023,8 @@ let rec (check :
             check env e1 context_nm
         | FStar_Syntax_Syntax.Tm_let uu____4864 ->
             let uu____4877 =
-              let uu____4878 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "[check]: Tm_let %s" uu____4878  in
+              let uu____4878 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "[check]: Tm_let %s" uu____4878 in
             failwith uu____4877
         | FStar_Syntax_Syntax.Tm_type uu____4885 ->
             failwith "impossible (DM stratification)"
@@ -2260,45 +2032,42 @@ let rec (check :
             failwith "impossible (DM stratification)"
         | FStar_Syntax_Syntax.Tm_refine uu____4911 ->
             let uu____4918 =
-              let uu____4919 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "[check]: Tm_refine %s" uu____4919  in
+              let uu____4919 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "[check]: Tm_refine %s" uu____4919 in
             failwith uu____4918
         | FStar_Syntax_Syntax.Tm_uvar uu____4926 ->
             let uu____4943 =
-              let uu____4944 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "[check]: Tm_uvar %s" uu____4944  in
+              let uu____4944 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "[check]: Tm_uvar %s" uu____4944 in
             failwith uu____4943
         | FStar_Syntax_Syntax.Tm_delayed uu____4951 ->
             failwith "impossible (compressed)"
         | FStar_Syntax_Syntax.Tm_unknown  ->
             let uu____4982 =
-              let uu____4983 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "[check]: Tm_unknown %s" uu____4983  in
+              let uu____4983 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "[check]: Tm_unknown %s" uu____4983 in
             failwith uu____4982
-
-and (infer :
+and infer:
   env ->
     FStar_Syntax_Syntax.term ->
       (nm,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       let mk1 x =
         FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-          e.FStar_Syntax_Syntax.pos
-         in
+          e.FStar_Syntax_Syntax.pos in
       let normalize1 =
         FStar_TypeChecker_Normalize.normalize
           [FStar_TypeChecker_Normalize.Beta;
           FStar_TypeChecker_Normalize.Eager_unfolding;
           FStar_TypeChecker_Normalize.UnfoldUntil
             FStar_Syntax_Syntax.Delta_constant;
-          FStar_TypeChecker_Normalize.EraseUniverses] env.env
-         in
+          FStar_TypeChecker_Normalize.EraseUniverses] env.env in
       let uu____5007 =
-        let uu____5008 = FStar_Syntax_Subst.compress e  in
-        uu____5008.FStar_Syntax_Syntax.n  in
+        let uu____5008 = FStar_Syntax_Subst.compress e in
+        uu____5008.FStar_Syntax_Syntax.n in
       match uu____5007 with
       | FStar_Syntax_Syntax.Tm_bvar bv ->
           failwith "I failed to open a binder... boo"
@@ -2316,145 +2085,136 @@ and (infer :
             | FStar_Pervasives_Native.None  -> rc_opt1
             | FStar_Pervasives_Native.Some rc ->
                 let uu____5074 =
-                  let uu___84_5075 = rc  in
+                  let uu___84_5075 = rc in
                   let uu____5076 =
                     let uu____5081 =
                       let uu____5082 =
-                        FStar_Util.must rc.FStar_Syntax_Syntax.residual_typ
-                         in
-                      FStar_Syntax_Subst.subst subst1 uu____5082  in
-                    FStar_Pervasives_Native.Some uu____5081  in
+                        FStar_Util.must rc.FStar_Syntax_Syntax.residual_typ in
+                      FStar_Syntax_Subst.subst subst1 uu____5082 in
+                    FStar_Pervasives_Native.Some uu____5081 in
                   {
                     FStar_Syntax_Syntax.residual_effect =
                       (uu___84_5075.FStar_Syntax_Syntax.residual_effect);
                     FStar_Syntax_Syntax.residual_typ = uu____5076;
                     FStar_Syntax_Syntax.residual_flags =
                       (uu___84_5075.FStar_Syntax_Syntax.residual_flags)
-                  }  in
-                FStar_Pervasives_Native.Some uu____5074
-             in
-          let binders1 = FStar_Syntax_Subst.open_binders binders  in
-          let subst1 = FStar_Syntax_Subst.opening_of_binders binders1  in
-          let body1 = FStar_Syntax_Subst.subst subst1 body  in
-          let rc_opt1 = subst_rc_opt subst1 rc_opt  in
+                  } in
+                FStar_Pervasives_Native.Some uu____5074 in
+          let binders1 = FStar_Syntax_Subst.open_binders binders in
+          let subst1 = FStar_Syntax_Subst.opening_of_binders binders1 in
+          let body1 = FStar_Syntax_Subst.subst subst1 body in
+          let rc_opt1 = subst_rc_opt subst1 rc_opt in
           let env1 =
-            let uu___85_5092 = env  in
+            let uu___85_5092 = env in
             let uu____5093 =
-              FStar_TypeChecker_Env.push_binders env.env binders1  in
+              FStar_TypeChecker_Env.push_binders env.env binders1 in
             {
               env = uu____5093;
               subst = (uu___85_5092.subst);
               tc_const = (uu___85_5092.tc_const)
-            }  in
+            } in
           let s_binders =
             FStar_List.map
               (fun uu____5113  ->
                  match uu____5113 with
                  | (bv,qual) ->
-                     let sort = star_type' env1 bv.FStar_Syntax_Syntax.sort
-                        in
-                     ((let uu___86_5126 = bv  in
+                     let sort = star_type' env1 bv.FStar_Syntax_Syntax.sort in
+                     ((let uu___86_5126 = bv in
                        {
                          FStar_Syntax_Syntax.ppname =
                            (uu___86_5126.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
                            (uu___86_5126.FStar_Syntax_Syntax.index);
                          FStar_Syntax_Syntax.sort = sort
-                       }), qual)) binders1
-             in
+                       }), qual)) binders1 in
           let uu____5127 =
             FStar_List.fold_left
               (fun uu____5156  ->
                  fun uu____5157  ->
                    match (uu____5156, uu____5157) with
                    | ((env2,acc),(bv,qual)) ->
-                       let c = bv.FStar_Syntax_Syntax.sort  in
-                       let uu____5205 = is_C c  in
+                       let c = bv.FStar_Syntax_Syntax.sort in
+                       let uu____5205 = is_C c in
                        if uu____5205
                        then
                          let xw =
-                           let uu____5213 = star_type' env2 c  in
+                           let uu____5213 = star_type' env2 c in
                            FStar_Syntax_Syntax.gen_bv
                              (Prims.strcat
                                 (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                 "__w") FStar_Pervasives_Native.None
-                             uu____5213
-                            in
+                             uu____5213 in
                          let x =
-                           let uu___87_5215 = bv  in
+                           let uu___87_5215 = bv in
                            let uu____5216 =
                              let uu____5219 =
-                               FStar_Syntax_Syntax.bv_to_name xw  in
-                             trans_F_ env2 c uu____5219  in
+                               FStar_Syntax_Syntax.bv_to_name xw in
+                             trans_F_ env2 c uu____5219 in
                            {
                              FStar_Syntax_Syntax.ppname =
                                (uu___87_5215.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
                                (uu___87_5215.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = uu____5216
-                           }  in
+                           } in
                          let env3 =
-                           let uu___88_5221 = env2  in
+                           let uu___88_5221 = env2 in
                            let uu____5222 =
                              let uu____5225 =
                                let uu____5226 =
                                  let uu____5233 =
-                                   FStar_Syntax_Syntax.bv_to_name xw  in
-                                 (bv, uu____5233)  in
-                               FStar_Syntax_Syntax.NT uu____5226  in
-                             uu____5225 :: (env2.subst)  in
+                                   FStar_Syntax_Syntax.bv_to_name xw in
+                                 (bv, uu____5233) in
+                               FStar_Syntax_Syntax.NT uu____5226 in
+                             uu____5225 :: (env2.subst) in
                            {
                              env = (uu___88_5221.env);
                              subst = uu____5222;
                              tc_const = (uu___88_5221.tc_const)
-                           }  in
+                           } in
                          let uu____5234 =
-                           let uu____5237 = FStar_Syntax_Syntax.mk_binder x
-                              in
+                           let uu____5237 = FStar_Syntax_Syntax.mk_binder x in
                            let uu____5238 =
                              let uu____5241 =
-                               FStar_Syntax_Syntax.mk_binder xw  in
-                             uu____5241 :: acc  in
-                           uu____5237 :: uu____5238  in
+                               FStar_Syntax_Syntax.mk_binder xw in
+                             uu____5241 :: acc in
+                           uu____5237 :: uu____5238 in
                          (env3, uu____5234)
                        else
                          (let x =
-                            let uu___89_5246 = bv  in
+                            let uu___89_5246 = bv in
                             let uu____5247 =
-                              star_type' env2 bv.FStar_Syntax_Syntax.sort  in
+                              star_type' env2 bv.FStar_Syntax_Syntax.sort in
                             {
                               FStar_Syntax_Syntax.ppname =
                                 (uu___89_5246.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
                                 (uu___89_5246.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = uu____5247
-                            }  in
+                            } in
                           let uu____5250 =
-                            let uu____5253 = FStar_Syntax_Syntax.mk_binder x
-                               in
-                            uu____5253 :: acc  in
-                          (env2, uu____5250))) (env1, []) binders1
-             in
+                            let uu____5253 = FStar_Syntax_Syntax.mk_binder x in
+                            uu____5253 :: acc in
+                          (env2, uu____5250))) (env1, []) binders1 in
           (match uu____5127 with
            | (env2,u_binders) ->
-               let u_binders1 = FStar_List.rev u_binders  in
+               let u_binders1 = FStar_List.rev u_binders in
                let uu____5273 =
                  let check_what =
-                   let uu____5291 = is_monadic rc_opt1  in
-                   if uu____5291 then check_m else check_n  in
-                 let uu____5303 = check_what env2 body1  in
+                   let uu____5291 = is_monadic rc_opt1 in
+                   if uu____5291 then check_m else check_n in
+                 let uu____5303 = check_what env2 body1 in
                  match uu____5303 with
                  | (t,s_body,u_body) ->
                      let uu____5319 =
                        let uu____5320 =
-                         let uu____5321 = is_monadic rc_opt1  in
-                         if uu____5321 then M t else N t  in
-                       comp_of_nm uu____5320  in
-                     (uu____5319, s_body, u_body)
-                  in
+                         let uu____5321 = is_monadic rc_opt1 in
+                         if uu____5321 then M t else N t in
+                       comp_of_nm uu____5320 in
+                     (uu____5319, s_body, u_body) in
                (match uu____5273 with
                 | (comp,s_body,u_body) ->
-                    let t = FStar_Syntax_Util.arrow binders1 comp  in
+                    let t = FStar_Syntax_Util.arrow binders1 comp in
                     let s_rc_opt =
                       match rc_opt1 with
                       | FStar_Pervasives_Native.None  ->
@@ -2470,8 +2230,7 @@ and (infer :
                                         (fun uu___70_5350  ->
                                            match uu___70_5350 with
                                            | FStar_Syntax_Syntax.CPS  -> true
-                                           | uu____5351 -> false))
-                                    in
+                                           | uu____5351 -> false)) in
                                  if uu____5346
                                  then
                                    let uu____5352 =
@@ -2480,12 +2239,11 @@ and (infer :
                                           match uu___71_5356 with
                                           | FStar_Syntax_Syntax.CPS  -> false
                                           | uu____5357 -> true)
-                                       rc.FStar_Syntax_Syntax.residual_flags
-                                      in
+                                       rc.FStar_Syntax_Syntax.residual_flags in
                                    FStar_Syntax_Util.mk_residual_comp
                                      FStar_Parser_Const.effect_Tot_lid
                                      FStar_Pervasives_Native.None uu____5352
-                                 else rc  in
+                                 else rc in
                                FStar_Pervasives_Native.Some rc1
                            | FStar_Pervasives_Native.Some rt ->
                                let uu____5366 =
@@ -2495,8 +2253,7 @@ and (infer :
                                       (fun uu___72_5370  ->
                                          match uu___72_5370 with
                                          | FStar_Syntax_Syntax.CPS  -> true
-                                         | uu____5371 -> false))
-                                  in
+                                         | uu____5371 -> false)) in
                                if uu____5366
                                then
                                  let flags1 =
@@ -2505,25 +2262,21 @@ and (infer :
                                         match uu___73_5378 with
                                         | FStar_Syntax_Syntax.CPS  -> false
                                         | uu____5379 -> true)
-                                     rc.FStar_Syntax_Syntax.residual_flags
-                                    in
+                                     rc.FStar_Syntax_Syntax.residual_flags in
                                  let uu____5380 =
                                    let uu____5381 =
-                                     let uu____5386 = double_star rt  in
-                                     FStar_Pervasives_Native.Some uu____5386
-                                      in
+                                     let uu____5386 = double_star rt in
+                                     FStar_Pervasives_Native.Some uu____5386 in
                                    FStar_Syntax_Util.mk_residual_comp
                                      FStar_Parser_Const.effect_Tot_lid
-                                     uu____5381 flags1
-                                    in
+                                     uu____5381 flags1 in
                                  FStar_Pervasives_Native.Some uu____5380
                                else
                                  (let uu____5388 =
-                                    let uu___90_5389 = rc  in
+                                    let uu___90_5389 = rc in
                                     let uu____5390 =
-                                      let uu____5395 = star_type' env2 rt  in
-                                      FStar_Pervasives_Native.Some uu____5395
-                                       in
+                                      let uu____5395 = star_type' env2 rt in
+                                      FStar_Pervasives_Native.Some uu____5395 in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
                                         (uu___90_5389.FStar_Syntax_Syntax.residual_effect);
@@ -2531,60 +2284,54 @@ and (infer :
                                         uu____5390;
                                       FStar_Syntax_Syntax.residual_flags =
                                         (uu___90_5389.FStar_Syntax_Syntax.residual_flags)
-                                    }  in
-                                  FStar_Pervasives_Native.Some uu____5388))
-                       in
+                                    } in
+                                  FStar_Pervasives_Native.Some uu____5388)) in
                     let uu____5396 =
                       let comp1 =
-                        let uu____5406 = is_monadic rc_opt1  in
+                        let uu____5406 = is_monadic rc_opt1 in
                         let uu____5407 =
-                          FStar_Syntax_Subst.subst env2.subst s_body  in
+                          FStar_Syntax_Subst.subst env2.subst s_body in
                         trans_G env2 (FStar_Syntax_Util.comp_result comp)
-                          uu____5406 uu____5407
-                         in
+                          uu____5406 uu____5407 in
                       let uu____5408 =
                         FStar_Syntax_Util.ascribe u_body
                           ((FStar_Util.Inr comp1),
-                            FStar_Pervasives_Native.None)
-                         in
+                            FStar_Pervasives_Native.None) in
                       (uu____5408,
                         (FStar_Pervasives_Native.Some
-                           (FStar_Syntax_Util.residual_comp_of_comp comp1)))
-                       in
+                           (FStar_Syntax_Util.residual_comp_of_comp comp1))) in
                     (match uu____5396 with
                      | (u_body1,u_rc_opt) ->
                          let s_body1 =
-                           FStar_Syntax_Subst.close s_binders s_body  in
+                           FStar_Syntax_Subst.close s_binders s_body in
                          let s_binders1 =
-                           FStar_Syntax_Subst.close_binders s_binders  in
+                           FStar_Syntax_Subst.close_binders s_binders in
                          let s_term =
                            let uu____5450 =
                              let uu____5451 =
                                let uu____5468 =
                                  let uu____5471 =
                                    FStar_Syntax_Subst.closing_of_binders
-                                     s_binders1
-                                    in
-                                 subst_rc_opt uu____5471 s_rc_opt  in
-                               (s_binders1, s_body1, uu____5468)  in
-                             FStar_Syntax_Syntax.Tm_abs uu____5451  in
-                           mk1 uu____5450  in
+                                     s_binders1 in
+                                 subst_rc_opt uu____5471 s_rc_opt in
+                               (s_binders1, s_body1, uu____5468) in
+                             FStar_Syntax_Syntax.Tm_abs uu____5451 in
+                           mk1 uu____5450 in
                          let u_body2 =
-                           FStar_Syntax_Subst.close u_binders1 u_body1  in
+                           FStar_Syntax_Subst.close u_binders1 u_body1 in
                          let u_binders2 =
-                           FStar_Syntax_Subst.close_binders u_binders1  in
+                           FStar_Syntax_Subst.close_binders u_binders1 in
                          let u_term =
                            let uu____5481 =
                              let uu____5482 =
                                let uu____5499 =
                                  let uu____5502 =
                                    FStar_Syntax_Subst.closing_of_binders
-                                     u_binders2
-                                    in
-                                 subst_rc_opt uu____5502 u_rc_opt  in
-                               (u_binders2, u_body2, uu____5499)  in
-                             FStar_Syntax_Syntax.Tm_abs uu____5482  in
-                           mk1 uu____5481  in
+                                     u_binders2 in
+                                 subst_rc_opt uu____5502 u_rc_opt in
+                               (u_binders2, u_body2, uu____5499) in
+                             FStar_Syntax_Syntax.Tm_abs uu____5482 in
+                           mk1 uu____5481 in
                          ((N t), s_term, u_term))))
       | FStar_Syntax_Syntax.Tm_fvar
           {
@@ -2595,12 +2342,11 @@ and (infer :
             FStar_Syntax_Syntax.fv_qual = uu____5514;_}
           ->
           let uu____5517 =
-            let uu____5522 = FStar_TypeChecker_Env.lookup_lid env.env lid  in
-            FStar_All.pipe_left FStar_Pervasives_Native.fst uu____5522  in
+            let uu____5522 = FStar_TypeChecker_Env.lookup_lid env.env lid in
+            FStar_All.pipe_left FStar_Pervasives_Native.fst uu____5522 in
           (match uu____5517 with
            | (uu____5553,t) ->
-               let uu____5555 =
-                 let uu____5556 = normalize1 t  in N uu____5556  in
+               let uu____5555 = let uu____5556 = normalize1 t in N uu____5556 in
                (uu____5555, e, e))
       | FStar_Syntax_Syntax.Tm_app
           ({
@@ -2609,13 +2355,12 @@ and (infer :
              FStar_Syntax_Syntax.pos = uu____5557;
              FStar_Syntax_Syntax.vars = uu____5558;_},a::hd1::rest)
           ->
-          let rest1 = hd1 :: rest  in
-          let uu____5621 = FStar_Syntax_Util.head_and_args e  in
+          let rest1 = hd1 :: rest in
+          let uu____5621 = FStar_Syntax_Util.head_and_args e in
           (match uu____5621 with
            | (unary_op,uu____5643) ->
-               let head1 = mk1 (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                  in
-               let t = mk1 (FStar_Syntax_Syntax.Tm_app (head1, rest1))  in
+               let head1 = mk1 (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) in
+               let t = mk1 (FStar_Syntax_Syntax.Tm_app (head1, rest1)) in
                infer env t)
       | FStar_Syntax_Syntax.Tm_app
           ({
@@ -2624,13 +2369,13 @@ and (infer :
              FStar_Syntax_Syntax.pos = uu____5702;
              FStar_Syntax_Syntax.vars = uu____5703;_},a1::a2::hd1::rest)
           ->
-          let rest1 = hd1 :: rest  in
-          let uu____5779 = FStar_Syntax_Util.head_and_args e  in
+          let rest1 = hd1 :: rest in
+          let uu____5779 = FStar_Syntax_Util.head_and_args e in
           (match uu____5779 with
            | (unary_op,uu____5801) ->
                let head1 =
-                 mk1 (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))  in
-               let t = mk1 (FStar_Syntax_Syntax.Tm_app (head1, rest1))  in
+                 mk1 (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) in
+               let t = mk1 (FStar_Syntax_Syntax.Tm_app (head1, rest1)) in
                infer env t)
       | FStar_Syntax_Syntax.Tm_app
           ({
@@ -2640,36 +2385,35 @@ and (infer :
              FStar_Syntax_Syntax.vars = uu____5867;_},(a,FStar_Pervasives_Native.None
                                                        )::[])
           ->
-          let uu____5905 = infer env a  in
+          let uu____5905 = infer env a in
           (match uu____5905 with
            | (t,s,u) ->
-               let uu____5921 = FStar_Syntax_Util.head_and_args e  in
+               let uu____5921 = FStar_Syntax_Util.head_and_args e in
                (match uu____5921 with
                 | (head1,uu____5943) ->
                     let uu____5964 =
                       let uu____5965 =
                         FStar_Syntax_Syntax.tabbrev
-                          FStar_Parser_Const.range_lid
-                         in
-                      N uu____5965  in
+                          FStar_Parser_Const.range_lid in
+                      N uu____5965 in
                     let uu____5966 =
                       let uu____5969 =
                         let uu____5970 =
                           let uu____5985 =
-                            let uu____5988 = FStar_Syntax_Syntax.as_arg s  in
-                            [uu____5988]  in
-                          (head1, uu____5985)  in
-                        FStar_Syntax_Syntax.Tm_app uu____5970  in
-                      mk1 uu____5969  in
+                            let uu____5988 = FStar_Syntax_Syntax.as_arg s in
+                            [uu____5988] in
+                          (head1, uu____5985) in
+                        FStar_Syntax_Syntax.Tm_app uu____5970 in
+                      mk1 uu____5969 in
                     let uu____5993 =
                       let uu____5996 =
                         let uu____5997 =
                           let uu____6012 =
-                            let uu____6015 = FStar_Syntax_Syntax.as_arg u  in
-                            [uu____6015]  in
-                          (head1, uu____6012)  in
-                        FStar_Syntax_Syntax.Tm_app uu____5997  in
-                      mk1 uu____5996  in
+                            let uu____6015 = FStar_Syntax_Syntax.as_arg u in
+                            [uu____6015] in
+                          (head1, uu____6012) in
+                        FStar_Syntax_Syntax.Tm_app uu____5997 in
+                      mk1 uu____5996 in
                     (uu____5964, uu____5966, uu____5993)))
       | FStar_Syntax_Syntax.Tm_app
           ({
@@ -2678,30 +2422,30 @@ and (infer :
              FStar_Syntax_Syntax.pos = uu____6024;
              FStar_Syntax_Syntax.vars = uu____6025;_},(a1,uu____6027)::a2::[])
           ->
-          let uu____6069 = infer env a1  in
+          let uu____6069 = infer env a1 in
           (match uu____6069 with
            | (t,s,u) ->
-               let uu____6085 = FStar_Syntax_Util.head_and_args e  in
+               let uu____6085 = FStar_Syntax_Util.head_and_args e in
                (match uu____6085 with
                 | (head1,uu____6107) ->
                     let uu____6128 =
                       let uu____6131 =
                         let uu____6132 =
                           let uu____6147 =
-                            let uu____6150 = FStar_Syntax_Syntax.as_arg s  in
-                            [uu____6150; a2]  in
-                          (head1, uu____6147)  in
-                        FStar_Syntax_Syntax.Tm_app uu____6132  in
-                      mk1 uu____6131  in
+                            let uu____6150 = FStar_Syntax_Syntax.as_arg s in
+                            [uu____6150; a2] in
+                          (head1, uu____6147) in
+                        FStar_Syntax_Syntax.Tm_app uu____6132 in
+                      mk1 uu____6131 in
                     let uu____6167 =
                       let uu____6170 =
                         let uu____6171 =
                           let uu____6186 =
-                            let uu____6189 = FStar_Syntax_Syntax.as_arg u  in
-                            [uu____6189; a2]  in
-                          (head1, uu____6186)  in
-                        FStar_Syntax_Syntax.Tm_app uu____6171  in
-                      mk1 uu____6170  in
+                            let uu____6189 = FStar_Syntax_Syntax.as_arg u in
+                            [uu____6189; a2] in
+                          (head1, uu____6186) in
+                        FStar_Syntax_Syntax.Tm_app uu____6171 in
+                      mk1 uu____6170 in
                     (t, uu____6128, uu____6167)))
       | FStar_Syntax_Syntax.Tm_app
           ({
@@ -2712,10 +2456,9 @@ and (infer :
           ->
           let uu____6233 =
             let uu____6238 =
-              let uu____6239 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____6239
-               in
-            (FStar_Errors.Fatal_IllAppliedConstant, uu____6238)  in
+              let uu____6239 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____6239 in
+            (FStar_Errors.Fatal_IllAppliedConstant, uu____6238) in
           FStar_Errors.raise_error uu____6233 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app
           ({
@@ -2726,26 +2469,25 @@ and (infer :
           ->
           let uu____6269 =
             let uu____6274 =
-              let uu____6275 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____6275
-               in
-            (FStar_Errors.Fatal_IllAppliedConstant, uu____6274)  in
+              let uu____6275 = FStar_Syntax_Print.term_to_string e in
+              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____6275 in
+            (FStar_Errors.Fatal_IllAppliedConstant, uu____6274) in
           FStar_Errors.raise_error uu____6269 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-          let uu____6304 = check_n env head1  in
+          let uu____6304 = check_n env head1 in
           (match uu____6304 with
            | (t_head,s_head,u_head) ->
                let is_arrow t =
                  let uu____6324 =
-                   let uu____6325 = FStar_Syntax_Subst.compress t  in
-                   uu____6325.FStar_Syntax_Syntax.n  in
+                   let uu____6325 = FStar_Syntax_Subst.compress t in
+                   uu____6325.FStar_Syntax_Syntax.n in
                  match uu____6324 with
                  | FStar_Syntax_Syntax.Tm_arrow uu____6328 -> true
-                 | uu____6341 -> false  in
+                 | uu____6341 -> false in
                let rec flatten1 t =
                  let uu____6358 =
-                   let uu____6359 = FStar_Syntax_Subst.compress t  in
-                   uu____6359.FStar_Syntax_Syntax.n  in
+                   let uu____6359 = FStar_Syntax_Subst.compress t in
+                   uu____6359.FStar_Syntax_Syntax.n in
                  match uu____6358 with
                  | FStar_Syntax_Syntax.Tm_arrow
                      (binders,{
@@ -2754,7 +2496,7 @@ and (infer :
                                 FStar_Syntax_Syntax.pos = uu____6377;
                                 FStar_Syntax_Syntax.vars = uu____6378;_})
                      when is_arrow t1 ->
-                     let uu____6403 = flatten1 t1  in
+                     let uu____6403 = flatten1 t1 in
                      (match uu____6403 with
                       | (binders',comp) ->
                           ((FStar_List.append binders binders'), comp))
@@ -2766,38 +2508,34 @@ and (infer :
                      let uu____6528 =
                        let uu____6533 =
                          let uu____6534 =
-                           FStar_Syntax_Print.term_to_string t_head  in
+                           FStar_Syntax_Print.term_to_string t_head in
                          FStar_Util.format1 "%s: not a function type"
-                           uu____6534
-                          in
-                       (FStar_Errors.Fatal_NotFunctionType, uu____6533)  in
-                     FStar_Errors.raise_err uu____6528
-                  in
-               let uu____6547 = flatten1 t_head  in
+                           uu____6534 in
+                       (FStar_Errors.Fatal_NotFunctionType, uu____6533) in
+                     FStar_Errors.raise_err uu____6528 in
+               let uu____6547 = flatten1 t_head in
                (match uu____6547 with
                 | (binders,comp) ->
-                    let n1 = FStar_List.length binders  in
-                    let n' = FStar_List.length args  in
+                    let n1 = FStar_List.length binders in
+                    let n' = FStar_List.length args in
                     (if
                        (FStar_List.length binders) < (FStar_List.length args)
                      then
                        (let uu____6607 =
                           let uu____6612 =
-                            let uu____6613 = FStar_Util.string_of_int n1  in
+                            let uu____6613 = FStar_Util.string_of_int n1 in
                             let uu____6620 =
-                              FStar_Util.string_of_int (n' - n1)  in
-                            let uu____6631 = FStar_Util.string_of_int n1  in
+                              FStar_Util.string_of_int (n' - n1) in
+                            let uu____6631 = FStar_Util.string_of_int n1 in
                             FStar_Util.format3
                               "The head of this application, after being applied to %s arguments, is an effectful computation (leaving %s arguments to be applied). Please let-bind the head applied to the %s first arguments."
-                              uu____6613 uu____6620 uu____6631
-                             in
+                              uu____6613 uu____6620 uu____6631 in
                           (FStar_Errors.Fatal_BinderAndArgsLengthMismatch,
-                            uu____6612)
-                           in
+                            uu____6612) in
                         FStar_Errors.raise_err uu____6607)
                      else ();
                      (let uu____6639 =
-                        FStar_Syntax_Subst.open_comp binders comp  in
+                        FStar_Syntax_Subst.open_comp binders comp in
                       match uu____6639 with
                       | (binders1,comp1) ->
                           let rec final_type subst1 uu____6680 args1 =
@@ -2808,9 +2546,8 @@ and (infer :
                                      let uu____6754 =
                                        let uu____6755 =
                                          FStar_Syntax_Subst.subst_comp subst1
-                                           comp2
-                                          in
-                                       uu____6755.FStar_Syntax_Syntax.n  in
+                                           comp2 in
+                                       uu____6755.FStar_Syntax_Syntax.n in
                                      nm_of_comp uu____6754
                                  | (binders3,[]) ->
                                      let uu____6785 =
@@ -2819,15 +2556,12 @@ and (infer :
                                            let uu____6790 =
                                              mk1
                                                (FStar_Syntax_Syntax.Tm_arrow
-                                                  (binders3, comp2))
-                                              in
+                                                  (binders3, comp2)) in
                                            FStar_Syntax_Subst.subst subst1
-                                             uu____6790
-                                            in
+                                             uu____6790 in
                                          FStar_Syntax_Subst.compress
-                                           uu____6789
-                                          in
-                                       uu____6786.FStar_Syntax_Syntax.n  in
+                                           uu____6789 in
+                                       uu____6786.FStar_Syntax_Syntax.n in
                                      (match uu____6785 with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (binders4,comp3) ->
@@ -2836,13 +2570,11 @@ and (infer :
                                               let uu____6817 =
                                                 let uu____6830 =
                                                   FStar_Syntax_Subst.close_comp
-                                                    binders4 comp3
-                                                   in
-                                                (binders4, uu____6830)  in
+                                                    binders4 comp3 in
+                                                (binders4, uu____6830) in
                                               FStar_Syntax_Syntax.Tm_arrow
-                                                uu____6817
-                                               in
-                                            mk1 uu____6816  in
+                                                uu____6817 in
+                                            mk1 uu____6816 in
                                           N uu____6815
                                       | uu____6837 -> failwith "wat?")
                                  | ([],uu____6838::uu____6839) ->
@@ -2851,11 +2583,10 @@ and (infer :
                                      ->
                                      final_type
                                        ((FStar_Syntax_Syntax.NT (bv, arg)) ::
-                                       subst1) (binders3, comp2) args2)
-                             in
+                                       subst1) (binders3, comp2) args2) in
                           let final_type1 =
-                            final_type [] (binders1, comp1) args  in
-                          let uu____6935 = FStar_List.splitAt n' binders1  in
+                            final_type [] (binders1, comp1) args in
+                          let uu____6935 = FStar_List.splitAt n' binders1 in
                           (match uu____6935 with
                            | (binders2,uu____6967) ->
                                let uu____6992 =
@@ -2868,29 +2599,26 @@ and (infer :
                                               let uu____7123 =
                                                 let uu____7124 =
                                                   FStar_Syntax_Subst.compress
-                                                    bv.FStar_Syntax_Syntax.sort
-                                                   in
-                                                uu____7124.FStar_Syntax_Syntax.n
-                                                 in
+                                                    bv.FStar_Syntax_Syntax.sort in
+                                                uu____7124.FStar_Syntax_Syntax.n in
                                               (match uu____7123 with
                                                | FStar_Syntax_Syntax.Tm_type
                                                    uu____7143 ->
                                                    let uu____7144 =
                                                      let uu____7149 =
-                                                       star_type' env arg  in
-                                                     (uu____7149, q)  in
+                                                       star_type' env arg in
+                                                     (uu____7149, q) in
                                                    (uu____7144, [(arg, q)])
                                                | uu____7176 ->
                                                    let uu____7177 =
-                                                     check_n env arg  in
+                                                     check_n env arg in
                                                    (match uu____7177 with
                                                     | (uu____7200,s_arg,u_arg)
                                                         ->
                                                         let uu____7203 =
                                                           let uu____7210 =
                                                             is_C
-                                                              bv.FStar_Syntax_Syntax.sort
-                                                             in
+                                                              bv.FStar_Syntax_Syntax.sort in
                                                           if uu____7210
                                                           then
                                                             let uu____7217 =
@@ -2898,33 +2626,26 @@ and (infer :
                                                                 =
                                                                 FStar_Syntax_Subst.subst
                                                                   env.subst
-                                                                  s_arg
-                                                                 in
-                                                              (uu____7222, q)
-                                                               in
+                                                                  s_arg in
+                                                              (uu____7222, q) in
                                                             [uu____7217;
                                                             (u_arg, q)]
-                                                          else [(u_arg, q)]
-                                                           in
+                                                          else [(u_arg, q)] in
                                                         ((s_arg, q),
                                                           uu____7203))))
-                                     binders2 args
-                                    in
-                                 FStar_List.split uu____7013  in
+                                     binders2 args in
+                                 FStar_List.split uu____7013 in
                                (match uu____6992 with
                                 | (s_args,u_args) ->
-                                    let u_args1 = FStar_List.flatten u_args
-                                       in
+                                    let u_args1 = FStar_List.flatten u_args in
                                     let uu____7321 =
                                       mk1
                                         (FStar_Syntax_Syntax.Tm_app
-                                           (s_head, s_args))
-                                       in
+                                           (s_head, s_args)) in
                                     let uu____7330 =
                                       mk1
                                         (FStar_Syntax_Syntax.Tm_app
-                                           (u_head, u_args1))
-                                       in
+                                           (u_head, u_args1)) in
                                     (final_type1, uu____7321, uu____7330)))))))
       | FStar_Syntax_Syntax.Tm_let ((false ,binding::[]),e2) ->
           mk_let env binding e2 infer check_m
@@ -2935,13 +2656,12 @@ and (infer :
       | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____7410,uu____7411) ->
           infer env e1
       | FStar_Syntax_Syntax.Tm_constant c ->
-          let uu____7453 = let uu____7454 = env.tc_const c  in N uu____7454
-             in
+          let uu____7453 = let uu____7454 = env.tc_const c in N uu____7454 in
           (uu____7453, e, e)
       | FStar_Syntax_Syntax.Tm_let uu____7455 ->
           let uu____7468 =
-            let uu____7469 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_let %s" uu____7469  in
+            let uu____7469 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "[infer]: Tm_let %s" uu____7469 in
           failwith uu____7468
       | FStar_Syntax_Syntax.Tm_type uu____7476 ->
           failwith "impossible (DM stratification)"
@@ -2949,23 +2669,22 @@ and (infer :
           failwith "impossible (DM stratification)"
       | FStar_Syntax_Syntax.Tm_refine uu____7502 ->
           let uu____7509 =
-            let uu____7510 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_refine %s" uu____7510  in
+            let uu____7510 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "[infer]: Tm_refine %s" uu____7510 in
           failwith uu____7509
       | FStar_Syntax_Syntax.Tm_uvar uu____7517 ->
           let uu____7534 =
-            let uu____7535 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_uvar %s" uu____7535  in
+            let uu____7535 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "[infer]: Tm_uvar %s" uu____7535 in
           failwith uu____7534
       | FStar_Syntax_Syntax.Tm_delayed uu____7542 ->
           failwith "impossible (compressed)"
       | FStar_Syntax_Syntax.Tm_unknown  ->
           let uu____7573 =
-            let uu____7574 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_unknown %s" uu____7574  in
+            let uu____7574 = FStar_Syntax_Print.term_to_string e in
+            FStar_Util.format1 "[infer]: Tm_unknown %s" uu____7574 in
           failwith uu____7573
-
-and (mk_match :
+and mk_match:
   env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       (FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t,FStar_Syntax_Syntax.term'
@@ -2979,7 +2698,7 @@ and (mk_match :
                FStar_Pervasives_Native.tuple3)
           ->
           (nm,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e0  ->
@@ -2987,33 +2706,31 @@ and (mk_match :
         fun f  ->
           let mk1 x =
             FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-              e0.FStar_Syntax_Syntax.pos
-             in
-          let uu____7619 = check_n env e0  in
+              e0.FStar_Syntax_Syntax.pos in
+          let uu____7619 = check_n env e0 in
           match uu____7619 with
           | (uu____7632,s_e0,u_e0) ->
               let uu____7635 =
                 let uu____7664 =
                   FStar_List.map
                     (fun b  ->
-                       let uu____7725 = FStar_Syntax_Subst.open_branch b  in
+                       let uu____7725 = FStar_Syntax_Subst.open_branch b in
                        match uu____7725 with
                        | (pat,FStar_Pervasives_Native.None ,body) ->
                            let env1 =
-                             let uu___91_7767 = env  in
+                             let uu___91_7767 = env in
                              let uu____7768 =
                                let uu____7769 =
-                                 FStar_Syntax_Syntax.pat_bvs pat  in
+                                 FStar_Syntax_Syntax.pat_bvs pat in
                                FStar_List.fold_left
                                  FStar_TypeChecker_Env.push_bv env.env
-                                 uu____7769
-                                in
+                                 uu____7769 in
                              {
                                env = uu____7768;
                                subst = (uu___91_7767.subst);
                                tc_const = (uu___91_7767.tc_const)
-                             }  in
-                           let uu____7772 = f env1 body  in
+                             } in
+                           let uu____7772 = f env1 body in
                            (match uu____7772 with
                             | (nm,s_body,u_body) ->
                                 (nm,
@@ -3023,21 +2740,19 @@ and (mk_match :
                            FStar_Errors.raise_err
                              (FStar_Errors.Fatal_WhenClauseNotSupported,
                                "No when clauses in the definition language"))
-                    branches
-                   in
-                FStar_List.split uu____7664  in
+                    branches in
+                FStar_List.split uu____7664 in
               (match uu____7635 with
                | (nms,branches1) ->
                    let t1 =
-                     let uu____7946 = FStar_List.hd nms  in
-                     match uu____7946 with | M t1 -> t1 | N t1 -> t1  in
+                     let uu____7946 = FStar_List.hd nms in
+                     match uu____7946 with | M t1 -> t1 | N t1 -> t1 in
                    let has_m =
                      FStar_List.existsb
                        (fun uu___74_7952  ->
                           match uu___74_7952 with
                           | M uu____7953 -> true
-                          | uu____7954 -> false) nms
-                      in
+                          | uu____7954 -> false) nms in
                    let uu____7955 =
                      let uu____7992 =
                        FStar_List.map2
@@ -3054,24 +2769,22 @@ and (mk_match :
                                          (pat, guard, u_body))
                                    | (N t2,true ) ->
                                        let uu____8259 =
-                                         check env original_body (M t2)  in
+                                         check env original_body (M t2) in
                                        (match uu____8259 with
                                         | (uu____8296,s_body1,u_body1) ->
                                             ((M t2), (pat, guard, s_body1),
                                               (pat, guard, u_body1)))
                                    | (M uu____8335,false ) ->
-                                       failwith "impossible")) nms branches1
-                        in
-                     FStar_List.unzip3 uu____7992  in
+                                       failwith "impossible")) nms branches1 in
+                     FStar_List.unzip3 uu____7992 in
                    (match uu____7955 with
                     | (nms1,s_branches,u_branches) ->
                         if has_m
                         then
-                          let p_type = mk_star_to_type mk1 env t1  in
+                          let p_type = mk_star_to_type mk1 env t1 in
                           let p =
                             FStar_Syntax_Syntax.gen_bv "p''"
-                              FStar_Pervasives_Native.None p_type
-                             in
+                              FStar_Pervasives_Native.None p_type in
                           let s_branches1 =
                             FStar_List.map
                               (fun uu____8519  ->
@@ -3084,107 +2797,88 @@ and (mk_match :
                                              let uu____8593 =
                                                let uu____8598 =
                                                  FStar_Syntax_Syntax.bv_to_name
-                                                   p
-                                                  in
+                                                   p in
                                                let uu____8599 =
                                                  FStar_Syntax_Syntax.as_implicit
-                                                   false
-                                                  in
-                                               (uu____8598, uu____8599)  in
-                                             [uu____8593]  in
-                                           (s_body, uu____8586)  in
+                                                   false in
+                                               (uu____8598, uu____8599) in
+                                             [uu____8593] in
+                                           (s_body, uu____8586) in
                                          FStar_Syntax_Syntax.Tm_app
-                                           uu____8571
-                                          in
-                                       mk1 uu____8570  in
-                                     (pat, guard, s_body1)) s_branches
-                             in
+                                           uu____8571 in
+                                       mk1 uu____8570 in
+                                     (pat, guard, s_body1)) s_branches in
                           let s_branches2 =
                             FStar_List.map FStar_Syntax_Subst.close_branch
-                              s_branches1
-                             in
+                              s_branches1 in
                           let u_branches1 =
                             FStar_List.map FStar_Syntax_Subst.close_branch
-                              u_branches
-                             in
+                              u_branches in
                           let s_e =
                             let uu____8631 =
                               let uu____8632 =
-                                FStar_Syntax_Syntax.mk_binder p  in
-                              [uu____8632]  in
+                                FStar_Syntax_Syntax.mk_binder p in
+                              [uu____8632] in
                             let uu____8633 =
                               mk1
                                 (FStar_Syntax_Syntax.Tm_match
-                                   (s_e0, s_branches2))
-                               in
+                                   (s_e0, s_branches2)) in
                             FStar_Syntax_Util.abs uu____8631 uu____8633
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
-                                    FStar_Syntax_Util.ktype0))
-                             in
+                                    FStar_Syntax_Util.ktype0)) in
                           let t1_star =
                             let uu____8639 =
                               let uu____8646 =
                                 let uu____8647 =
                                   FStar_Syntax_Syntax.new_bv
-                                    FStar_Pervasives_Native.None p_type
-                                   in
+                                    FStar_Pervasives_Native.None p_type in
                                 FStar_All.pipe_left
-                                  FStar_Syntax_Syntax.mk_binder uu____8647
-                                 in
-                              [uu____8646]  in
+                                  FStar_Syntax_Syntax.mk_binder uu____8647 in
+                              [uu____8646] in
                             let uu____8648 =
                               FStar_Syntax_Syntax.mk_Total
-                                FStar_Syntax_Util.ktype0
-                               in
-                            FStar_Syntax_Util.arrow uu____8639 uu____8648  in
+                                FStar_Syntax_Util.ktype0 in
+                            FStar_Syntax_Util.arrow uu____8639 uu____8648 in
                           let uu____8651 =
                             mk1
                               (FStar_Syntax_Syntax.Tm_ascribed
                                  (s_e,
                                    ((FStar_Util.Inl t1_star),
                                      FStar_Pervasives_Native.None),
-                                   FStar_Pervasives_Native.None))
-                             in
+                                   FStar_Pervasives_Native.None)) in
                           let uu____8690 =
                             mk1
                               (FStar_Syntax_Syntax.Tm_match
-                                 (u_e0, u_branches1))
-                             in
+                                 (u_e0, u_branches1)) in
                           ((M t1), uu____8651, uu____8690)
                         else
                           (let s_branches1 =
                              FStar_List.map FStar_Syntax_Subst.close_branch
-                               s_branches
-                              in
+                               s_branches in
                            let u_branches1 =
                              FStar_List.map FStar_Syntax_Subst.close_branch
-                               u_branches
-                              in
-                           let t1_star = t1  in
+                               u_branches in
+                           let t1_star = t1 in
                            let uu____8707 =
                              let uu____8710 =
                                let uu____8711 =
                                  let uu____8738 =
                                    mk1
                                      (FStar_Syntax_Syntax.Tm_match
-                                        (s_e0, s_branches1))
-                                    in
+                                        (s_e0, s_branches1)) in
                                  (uu____8738,
                                    ((FStar_Util.Inl t1_star),
                                      FStar_Pervasives_Native.None),
-                                   FStar_Pervasives_Native.None)
-                                  in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____8711  in
-                             mk1 uu____8710  in
+                                   FStar_Pervasives_Native.None) in
+                               FStar_Syntax_Syntax.Tm_ascribed uu____8711 in
+                             mk1 uu____8710 in
                            let uu____8775 =
                              mk1
                                (FStar_Syntax_Syntax.Tm_match
-                                  (u_e0, u_branches1))
-                              in
+                                  (u_e0, u_branches1)) in
                            ((N t1), uu____8707, uu____8775))))
-
-and (mk_let :
+and mk_let:
   env_ ->
     FStar_Syntax_Syntax.letbinding ->
       FStar_Syntax_Syntax.term ->
@@ -3199,7 +2893,7 @@ and (mk_let :
                  FStar_Pervasives_Native.tuple3)
             ->
             (nm,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-              FStar_Pervasives_Native.tuple3)
+              FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun binding  ->
@@ -3208,28 +2902,27 @@ and (mk_let :
           fun ensure_m  ->
             let mk1 x =
               FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-                e2.FStar_Syntax_Syntax.pos
-               in
-            let e1 = binding.FStar_Syntax_Syntax.lbdef  in
-            let x = FStar_Util.left binding.FStar_Syntax_Syntax.lbname  in
+                e2.FStar_Syntax_Syntax.pos in
+            let e1 = binding.FStar_Syntax_Syntax.lbdef in
+            let x = FStar_Util.left binding.FStar_Syntax_Syntax.lbname in
             let x_binders =
-              let uu____8822 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____8822]  in
-            let uu____8823 = FStar_Syntax_Subst.open_term x_binders e2  in
+              let uu____8822 = FStar_Syntax_Syntax.mk_binder x in
+              [uu____8822] in
+            let uu____8823 = FStar_Syntax_Subst.open_term x_binders e2 in
             match uu____8823 with
             | (x_binders1,e21) ->
-                let uu____8836 = infer env e1  in
+                let uu____8836 = infer env e1 in
                 (match uu____8836 with
                  | (N t1,s_e1,u_e1) ->
                      let u_binding =
-                       let uu____8853 = is_C t1  in
+                       let uu____8853 = is_C t1 in
                        if uu____8853
                        then
-                         let uu___92_8854 = binding  in
+                         let uu___92_8854 = binding in
                          let uu____8855 =
                            let uu____8858 =
-                             FStar_Syntax_Subst.subst env.subst s_e1  in
-                           trans_F_ env t1 uu____8858  in
+                             FStar_Syntax_Subst.subst env.subst s_e1 in
+                           trans_F_ env t1 uu____8858 in
                          {
                            FStar_Syntax_Syntax.lbname =
                              (uu___92_8854.FStar_Syntax_Syntax.lbname);
@@ -3243,34 +2936,32 @@ and (mk_let :
                            FStar_Syntax_Syntax.lbattrs =
                              (uu___92_8854.FStar_Syntax_Syntax.lbattrs)
                          }
-                       else binding  in
+                       else binding in
                      let env1 =
-                       let uu___93_8861 = env  in
+                       let uu___93_8861 = env in
                        let uu____8862 =
                          FStar_TypeChecker_Env.push_bv env.env
-                           (let uu___94_8864 = x  in
+                           (let uu___94_8864 = x in
                             {
                               FStar_Syntax_Syntax.ppname =
                                 (uu___94_8864.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
                                 (uu___94_8864.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
-                            })
-                          in
+                            }) in
                        {
                          env = uu____8862;
                          subst = (uu___93_8861.subst);
                          tc_const = (uu___93_8861.tc_const)
-                       }  in
-                     let uu____8865 = proceed env1 e21  in
+                       } in
+                     let uu____8865 = proceed env1 e21 in
                      (match uu____8865 with
                       | (nm_rec,s_e2,u_e2) ->
                           let s_binding =
-                            let uu___95_8882 = binding  in
+                            let uu___95_8882 = binding in
                             let uu____8883 =
                               star_type' env1
-                                binding.FStar_Syntax_Syntax.lbtyp
-                               in
+                                binding.FStar_Syntax_Syntax.lbtyp in
                             {
                               FStar_Syntax_Syntax.lbname =
                                 (uu___95_8882.FStar_Syntax_Syntax.lbname);
@@ -3283,15 +2974,14 @@ and (mk_let :
                                 (uu___95_8882.FStar_Syntax_Syntax.lbdef);
                               FStar_Syntax_Syntax.lbattrs =
                                 (uu___95_8882.FStar_Syntax_Syntax.lbattrs)
-                            }  in
+                            } in
                           let uu____8886 =
                             let uu____8889 =
                               let uu____8890 =
                                 let uu____8903 =
-                                  FStar_Syntax_Subst.close x_binders1 s_e2
-                                   in
+                                  FStar_Syntax_Subst.close x_binders1 s_e2 in
                                 ((false,
-                                   [(let uu___96_8913 = s_binding  in
+                                   [(let uu___96_8913 = s_binding in
                                      {
                                        FStar_Syntax_Syntax.lbname =
                                          (uu___96_8913.FStar_Syntax_Syntax.lbname);
@@ -3304,18 +2994,16 @@ and (mk_let :
                                        FStar_Syntax_Syntax.lbdef = s_e1;
                                        FStar_Syntax_Syntax.lbattrs =
                                          (uu___96_8913.FStar_Syntax_Syntax.lbattrs)
-                                     })]), uu____8903)
-                                 in
-                              FStar_Syntax_Syntax.Tm_let uu____8890  in
-                            mk1 uu____8889  in
+                                     })]), uu____8903) in
+                              FStar_Syntax_Syntax.Tm_let uu____8890 in
+                            mk1 uu____8889 in
                           let uu____8914 =
                             let uu____8917 =
                               let uu____8918 =
                                 let uu____8931 =
-                                  FStar_Syntax_Subst.close x_binders1 u_e2
-                                   in
+                                  FStar_Syntax_Subst.close x_binders1 u_e2 in
                                 ((false,
-                                   [(let uu___97_8941 = u_binding  in
+                                   [(let uu___97_8941 = u_binding in
                                      {
                                        FStar_Syntax_Syntax.lbname =
                                          (uu___97_8941.FStar_Syntax_Syntax.lbname);
@@ -3328,14 +3016,13 @@ and (mk_let :
                                        FStar_Syntax_Syntax.lbdef = u_e1;
                                        FStar_Syntax_Syntax.lbattrs =
                                          (uu___97_8941.FStar_Syntax_Syntax.lbattrs)
-                                     })]), uu____8931)
-                                 in
-                              FStar_Syntax_Syntax.Tm_let uu____8918  in
-                            mk1 uu____8917  in
+                                     })]), uu____8931) in
+                              FStar_Syntax_Syntax.Tm_let uu____8918 in
+                            mk1 uu____8917 in
                           (nm_rec, uu____8886, uu____8914))
                  | (M t1,s_e1,u_e1) ->
                      let u_binding =
-                       let uu___98_8950 = binding  in
+                       let uu___98_8950 = binding in
                        {
                          FStar_Syntax_Syntax.lbname =
                            (uu___98_8950.FStar_Syntax_Syntax.lbname);
@@ -3348,85 +3035,78 @@ and (mk_let :
                            (uu___98_8950.FStar_Syntax_Syntax.lbdef);
                          FStar_Syntax_Syntax.lbattrs =
                            (uu___98_8950.FStar_Syntax_Syntax.lbattrs)
-                       }  in
+                       } in
                      let env1 =
-                       let uu___99_8952 = env  in
+                       let uu___99_8952 = env in
                        let uu____8953 =
                          FStar_TypeChecker_Env.push_bv env.env
-                           (let uu___100_8955 = x  in
+                           (let uu___100_8955 = x in
                             {
                               FStar_Syntax_Syntax.ppname =
                                 (uu___100_8955.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
                                 (uu___100_8955.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
-                            })
-                          in
+                            }) in
                        {
                          env = uu____8953;
                          subst = (uu___99_8952.subst);
                          tc_const = (uu___99_8952.tc_const)
-                       }  in
-                     let uu____8956 = ensure_m env1 e21  in
+                       } in
+                     let uu____8956 = ensure_m env1 e21 in
                      (match uu____8956 with
                       | (t2,s_e2,u_e2) ->
-                          let p_type = mk_star_to_type mk1 env1 t2  in
+                          let p_type = mk_star_to_type mk1 env1 t2 in
                           let p =
                             FStar_Syntax_Syntax.gen_bv "p''"
-                              FStar_Pervasives_Native.None p_type
-                             in
+                              FStar_Pervasives_Native.None p_type in
                           let s_e21 =
                             let uu____8979 =
                               let uu____8980 =
                                 let uu____8995 =
                                   let uu____9002 =
                                     let uu____9007 =
-                                      FStar_Syntax_Syntax.bv_to_name p  in
+                                      FStar_Syntax_Syntax.bv_to_name p in
                                     let uu____9008 =
-                                      FStar_Syntax_Syntax.as_implicit false
-                                       in
-                                    (uu____9007, uu____9008)  in
-                                  [uu____9002]  in
-                                (s_e2, uu____8995)  in
-                              FStar_Syntax_Syntax.Tm_app uu____8980  in
-                            mk1 uu____8979  in
+                                      FStar_Syntax_Syntax.as_implicit false in
+                                    (uu____9007, uu____9008) in
+                                  [uu____9002] in
+                                (s_e2, uu____8995) in
+                              FStar_Syntax_Syntax.Tm_app uu____8980 in
+                            mk1 uu____8979 in
                           let s_e22 =
                             FStar_Syntax_Util.abs x_binders1 s_e21
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
-                                    FStar_Syntax_Util.ktype0))
-                             in
+                                    FStar_Syntax_Util.ktype0)) in
                           let body =
                             let uu____9027 =
                               let uu____9028 =
                                 let uu____9043 =
                                   let uu____9050 =
                                     let uu____9055 =
-                                      FStar_Syntax_Syntax.as_implicit false
-                                       in
-                                    (s_e22, uu____9055)  in
-                                  [uu____9050]  in
-                                (s_e1, uu____9043)  in
-                              FStar_Syntax_Syntax.Tm_app uu____9028  in
-                            mk1 uu____9027  in
+                                      FStar_Syntax_Syntax.as_implicit false in
+                                    (s_e22, uu____9055) in
+                                  [uu____9050] in
+                                (s_e1, uu____9043) in
+                              FStar_Syntax_Syntax.Tm_app uu____9028 in
+                            mk1 uu____9027 in
                           let uu____9070 =
                             let uu____9071 =
                               let uu____9072 =
-                                FStar_Syntax_Syntax.mk_binder p  in
-                              [uu____9072]  in
+                                FStar_Syntax_Syntax.mk_binder p in
+                              [uu____9072] in
                             FStar_Syntax_Util.abs uu____9071 body
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
-                                    FStar_Syntax_Util.ktype0))
-                             in
+                                    FStar_Syntax_Util.ktype0)) in
                           let uu____9073 =
                             let uu____9076 =
                               let uu____9077 =
                                 let uu____9090 =
-                                  FStar_Syntax_Subst.close x_binders1 u_e2
-                                   in
+                                  FStar_Syntax_Subst.close x_binders1 u_e2 in
                                 ((false,
-                                   [(let uu___101_9100 = u_binding  in
+                                   [(let uu___101_9100 = u_binding in
                                      {
                                        FStar_Syntax_Syntax.lbname =
                                          (uu___101_9100.FStar_Syntax_Syntax.lbname);
@@ -3439,55 +3119,48 @@ and (mk_let :
                                        FStar_Syntax_Syntax.lbdef = u_e1;
                                        FStar_Syntax_Syntax.lbattrs =
                                          (uu___101_9100.FStar_Syntax_Syntax.lbattrs)
-                                     })]), uu____9090)
-                                 in
-                              FStar_Syntax_Syntax.Tm_let uu____9077  in
-                            mk1 uu____9076  in
+                                     })]), uu____9090) in
+                              FStar_Syntax_Syntax.Tm_let uu____9077 in
+                            mk1 uu____9076 in
                           ((M t2), uu____9070, uu____9073)))
-
-and (check_n :
+and check_n:
   env_ ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       let mn =
         let uu____9112 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-            FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-           in
-        N uu____9112  in
-      let uu____9113 = check env e mn  in
+            FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos in
+        N uu____9112 in
+      let uu____9113 = check env e mn in
       match uu____9113 with
       | (N t,s_e,u_e) -> (t, s_e, u_e)
       | uu____9129 -> failwith "[check_n]: impossible"
-
-and (check_m :
+and check_m:
   env_ ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       let mn =
         let uu____9151 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-            FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-           in
-        M uu____9151  in
-      let uu____9152 = check env e mn  in
+            FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos in
+        M uu____9151 in
+      let uu____9152 = check env e mn in
       match uu____9152 with
       | (M t,s_e,u_e) -> (t, s_e, u_e)
       | uu____9168 -> failwith "[check_m]: impossible"
-
-and (comp_of_nm : nm_ -> FStar_Syntax_Syntax.comp) =
+and comp_of_nm: nm_ -> FStar_Syntax_Syntax.comp =
   fun nm  ->
     match nm with | N t -> FStar_Syntax_Syntax.mk_Total t | M t -> mk_M t
-
-and (mk_M : FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.comp) =
+and mk_M: FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.comp =
   fun t  ->
     FStar_Syntax_Syntax.mk_Comp
       {
@@ -3498,33 +3171,30 @@ and (mk_M : FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.comp) =
         FStar_Syntax_Syntax.flags =
           [FStar_Syntax_Syntax.CPS; FStar_Syntax_Syntax.TOTAL]
       }
-
-and (type_of_comp :
+and type_of_comp:
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   = fun t  -> FStar_Syntax_Util.comp_result t
-
-and (trans_F_ :
+and trans_F_:
   env_ ->
     FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun c  ->
       fun wp  ->
         (let uu____9198 =
-           let uu____9199 = is_C c  in Prims.op_Negation uu____9199  in
+           let uu____9199 = is_C c in Prims.op_Negation uu____9199 in
          if uu____9198 then failwith "not a C" else ());
         (let mk1 x =
            FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-             c.FStar_Syntax_Syntax.pos
-            in
+             c.FStar_Syntax_Syntax.pos in
          let uu____9207 =
-           let uu____9208 = FStar_Syntax_Subst.compress c  in
-           uu____9208.FStar_Syntax_Syntax.n  in
+           let uu____9208 = FStar_Syntax_Subst.compress c in
+           uu____9208.FStar_Syntax_Syntax.n in
          match uu____9207 with
          | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-             let uu____9233 = FStar_Syntax_Util.head_and_args wp  in
+             let uu____9233 = FStar_Syntax_Util.head_and_args wp in
              (match uu____9233 with
               | (wp_head,wp_args) ->
                   ((let uu____9271 =
@@ -3536,13 +3206,10 @@ and (trans_F_ :
                            let uu____9286 =
                              FStar_Parser_Const.mk_tuple_data_lid
                                (FStar_List.length wp_args)
-                               FStar_Range.dummyRange
-                              in
+                               FStar_Range.dummyRange in
                            FStar_Syntax_Util.is_constructor wp_head
-                             uu____9286
-                            in
-                         Prims.op_Negation uu____9285)
-                       in
+                             uu____9286 in
+                         Prims.op_Negation uu____9285) in
                     if uu____9271 then failwith "mismatch" else ());
                    (let uu____9294 =
                       let uu____9295 =
@@ -3554,40 +3221,36 @@ and (trans_F_ :
                                  | ((arg,q),(wp_arg,q')) ->
                                      let print_implicit q1 =
                                        let uu____9376 =
-                                         FStar_Syntax_Syntax.is_implicit q1
-                                          in
+                                         FStar_Syntax_Syntax.is_implicit q1 in
                                        if uu____9376
                                        then "implicit"
-                                       else "explicit"  in
+                                       else "explicit" in
                                      (if q <> q'
                                       then
                                         (let uu____9379 =
                                            let uu____9384 =
                                              let uu____9385 =
-                                               print_implicit q  in
+                                               print_implicit q in
                                              let uu____9386 =
-                                               print_implicit q'  in
+                                               print_implicit q' in
                                              FStar_Util.format2
                                                "Incoherent implicit qualifiers %b %b\n"
-                                               uu____9385 uu____9386
-                                              in
+                                               uu____9385 uu____9386 in
                                            (FStar_Errors.Warning_IncoherentImplicitQualifier,
-                                             uu____9384)
-                                            in
+                                             uu____9384) in
                                          FStar_Errors.log_issue
                                            head1.FStar_Syntax_Syntax.pos
                                            uu____9379)
                                       else ();
                                       (let uu____9388 =
-                                         trans_F_ env arg wp_arg  in
-                                       (uu____9388, q)))) args wp_args
-                           in
-                        (head1, uu____9310)  in
-                      FStar_Syntax_Syntax.Tm_app uu____9295  in
+                                         trans_F_ env arg wp_arg in
+                                       (uu____9388, q)))) args wp_args in
+                        (head1, uu____9310) in
+                      FStar_Syntax_Syntax.Tm_app uu____9295 in
                     mk1 uu____9294)))
          | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
-             let binders1 = FStar_Syntax_Util.name_binders binders  in
-             let uu____9422 = FStar_Syntax_Subst.open_comp binders1 comp  in
+             let binders1 = FStar_Syntax_Util.name_binders binders in
+             let uu____9422 = FStar_Syntax_Subst.open_comp binders1 comp in
              (match uu____9422 with
               | (binders_orig,comp1) ->
                   let uu____9429 =
@@ -3596,18 +3259,17 @@ and (trans_F_ :
                         (fun uu____9478  ->
                            match uu____9478 with
                            | (bv,q) ->
-                               let h = bv.FStar_Syntax_Syntax.sort  in
-                               let uu____9498 = is_C h  in
+                               let h = bv.FStar_Syntax_Syntax.sort in
+                               let uu____9498 = is_C h in
                                if uu____9498
                                then
                                  let w' =
-                                   let uu____9510 = star_type' env h  in
+                                   let uu____9510 = star_type' env h in
                                    FStar_Syntax_Syntax.gen_bv
                                      (Prims.strcat
                                         (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                         "__w'") FStar_Pervasives_Native.None
-                                     uu____9510
-                                    in
+                                     uu____9510 in
                                  let uu____9511 =
                                    let uu____9518 =
                                      let uu____9525 =
@@ -3615,39 +3277,34 @@ and (trans_F_ :
                                          let uu____9531 =
                                            let uu____9532 =
                                              FStar_Syntax_Syntax.bv_to_name
-                                               w'
-                                              in
-                                           trans_F_ env h uu____9532  in
+                                               w' in
+                                           trans_F_ env h uu____9532 in
                                          FStar_Syntax_Syntax.null_bv
-                                           uu____9531
-                                          in
-                                       (uu____9530, q)  in
-                                     [uu____9525]  in
-                                   (w', q) :: uu____9518  in
+                                           uu____9531 in
+                                       (uu____9530, q) in
+                                     [uu____9525] in
+                                   (w', q) :: uu____9518 in
                                  (w', uu____9511)
                                else
                                  (let x =
-                                    let uu____9553 = star_type' env h  in
+                                    let uu____9553 = star_type' env h in
                                     FStar_Syntax_Syntax.gen_bv
                                       (Prims.strcat
                                          (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                          "__x") FStar_Pervasives_Native.None
-                                      uu____9553
-                                     in
-                                  (x, [(x, q)]))) binders_orig
-                       in
-                    FStar_List.split uu____9444  in
+                                      uu____9553 in
+                                  (x, [(x, q)]))) binders_orig in
+                    FStar_List.split uu____9444 in
                   (match uu____9429 with
                    | (bvs,binders2) ->
-                       let binders3 = FStar_List.flatten binders2  in
+                       let binders3 = FStar_List.flatten binders2 in
                        let comp2 =
                          let uu____9608 =
                            let uu____9611 =
-                             FStar_Syntax_Syntax.binders_of_list bvs  in
+                             FStar_Syntax_Syntax.binders_of_list bvs in
                            FStar_Syntax_Util.rename_binders binders_orig
-                             uu____9611
-                            in
-                         FStar_Syntax_Subst.subst_comp uu____9608 comp1  in
+                             uu____9611 in
+                         FStar_Syntax_Subst.subst_comp uu____9608 comp1 in
                        let app =
                          let uu____9615 =
                            let uu____9616 =
@@ -3655,28 +3312,25 @@ and (trans_F_ :
                                FStar_List.map
                                  (fun bv  ->
                                     let uu____9646 =
-                                      FStar_Syntax_Syntax.bv_to_name bv  in
+                                      FStar_Syntax_Syntax.bv_to_name bv in
                                     let uu____9647 =
-                                      FStar_Syntax_Syntax.as_implicit false
-                                       in
-                                    (uu____9646, uu____9647)) bvs
-                                in
-                             (wp, uu____9631)  in
-                           FStar_Syntax_Syntax.Tm_app uu____9616  in
-                         mk1 uu____9615  in
+                                      FStar_Syntax_Syntax.as_implicit false in
+                                    (uu____9646, uu____9647)) bvs in
+                             (wp, uu____9631) in
+                           FStar_Syntax_Syntax.Tm_app uu____9616 in
+                         mk1 uu____9615 in
                        let comp3 =
-                         let uu____9655 = type_of_comp comp2  in
-                         let uu____9656 = is_monadic_comp comp2  in
-                         trans_G env uu____9655 uu____9656 app  in
+                         let uu____9655 = type_of_comp comp2 in
+                         let uu____9656 = is_monadic_comp comp2 in
+                         trans_G env uu____9655 uu____9656 app in
                        FStar_Syntax_Util.arrow binders3 comp3))
          | FStar_Syntax_Syntax.Tm_ascribed (e,uu____9658,uu____9659) ->
              trans_F_ env e wp
          | uu____9700 -> failwith "impossible trans_F_")
-
-and (trans_G :
+and trans_G:
   env_ ->
     FStar_Syntax_Syntax.typ ->
-      Prims.bool -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.comp)
+      Prims.bool -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.comp
   =
   fun env  ->
     fun h  ->
@@ -3685,12 +3339,12 @@ and (trans_G :
           if is_monadic1
           then
             let uu____9705 =
-              let uu____9706 = star_type' env h  in
+              let uu____9706 = star_type' env h in
               let uu____9709 =
                 let uu____9718 =
-                  let uu____9723 = FStar_Syntax_Syntax.as_implicit false  in
-                  (wp, uu____9723)  in
-                [uu____9718]  in
+                  let uu____9723 = FStar_Syntax_Syntax.as_implicit false in
+                  (wp, uu____9723) in
+                [uu____9718] in
               {
                 FStar_Syntax_Syntax.comp_univs =
                   [FStar_Syntax_Syntax.U_unknown];
@@ -3699,15 +3353,14 @@ and (trans_G :
                 FStar_Syntax_Syntax.result_typ = uu____9706;
                 FStar_Syntax_Syntax.effect_args = uu____9709;
                 FStar_Syntax_Syntax.flags = []
-              }  in
+              } in
             FStar_Syntax_Syntax.mk_Comp uu____9705
           else
-            (let uu____9733 = trans_F_ env h wp  in
+            (let uu____9733 = trans_F_ env h wp in
              FStar_Syntax_Syntax.mk_Total uu____9733)
-
-let (n :
+let n:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   FStar_TypeChecker_Normalize.normalize
     [FStar_TypeChecker_Normalize.Beta;
@@ -3716,28 +3369,24 @@ let (n :
     FStar_TypeChecker_Normalize.NoDeltaSteps;
     FStar_TypeChecker_Normalize.Eager_unfolding;
     FStar_TypeChecker_Normalize.EraseUniverses]
-  
-let (star_type : env -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
+let star_type: env -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ =
   fun env  ->
-    fun t  -> let uu____9744 = n env.env t  in star_type' env uu____9744
-  
-let (star_expr :
+    fun t  -> let uu____9744 = n env.env t in star_type' env uu____9744
+let star_expr:
   env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
-    fun t  -> let uu____9759 = n env.env t  in check_n env uu____9759
-  
-let (trans_F :
+    fun t  -> let uu____9759 = n env.env t in check_n env uu____9759
+let trans_F:
   env ->
     FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun c  ->
       fun wp  ->
-        let uu____9769 = n env.env c  in
-        let uu____9770 = n env.env wp  in trans_F_ env uu____9769 uu____9770
-  
+        let uu____9769 = n env.env c in
+        let uu____9770 = n env.env wp in trans_F_ env uu____9769 uu____9770

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -1,181 +1,157 @@
 open Prims
 type binding =
-  | Binding_var of FStar_Syntax_Syntax.bv 
+  | Binding_var of FStar_Syntax_Syntax.bv
   | Binding_lid of (FStar_Ident.lident,FStar_Syntax_Syntax.tscheme)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Binding_sig of (FStar_Ident.lident Prims.list,FStar_Syntax_Syntax.sigelt)
-  FStar_Pervasives_Native.tuple2 
-  | Binding_univ of FStar_Syntax_Syntax.univ_name 
+  FStar_Pervasives_Native.tuple2
+  | Binding_univ of FStar_Syntax_Syntax.univ_name
   | Binding_sig_inst of
   (FStar_Ident.lident Prims.list,FStar_Syntax_Syntax.sigelt,FStar_Syntax_Syntax.universes)
-  FStar_Pervasives_Native.tuple3 [@@deriving show]
-let (uu___is_Binding_var : binding -> Prims.bool) =
+  FStar_Pervasives_Native.tuple3[@@deriving show]
+let uu___is_Binding_var: binding -> Prims.bool =
   fun projectee  ->
     match projectee with | Binding_var _0 -> true | uu____43 -> false
-  
-let (__proj__Binding_var__item___0 : binding -> FStar_Syntax_Syntax.bv) =
-  fun projectee  -> match projectee with | Binding_var _0 -> _0 
-let (uu___is_Binding_lid : binding -> Prims.bool) =
+let __proj__Binding_var__item___0: binding -> FStar_Syntax_Syntax.bv =
+  fun projectee  -> match projectee with | Binding_var _0 -> _0
+let uu___is_Binding_lid: binding -> Prims.bool =
   fun projectee  ->
     match projectee with | Binding_lid _0 -> true | uu____59 -> false
-  
-let (__proj__Binding_lid__item___0 :
+let __proj__Binding_lid__item___0:
   binding ->
     (FStar_Ident.lident,FStar_Syntax_Syntax.tscheme)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Binding_lid _0 -> _0 
-let (uu___is_Binding_sig : binding -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Binding_lid _0 -> _0
+let uu___is_Binding_sig: binding -> Prims.bool =
   fun projectee  ->
     match projectee with | Binding_sig _0 -> true | uu____89 -> false
-  
-let (__proj__Binding_sig__item___0 :
+let __proj__Binding_sig__item___0:
   binding ->
     (FStar_Ident.lident Prims.list,FStar_Syntax_Syntax.sigelt)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Binding_sig _0 -> _0 
-let (uu___is_Binding_univ : binding -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Binding_sig _0 -> _0
+let uu___is_Binding_univ: binding -> Prims.bool =
   fun projectee  ->
     match projectee with | Binding_univ _0 -> true | uu____119 -> false
-  
-let (__proj__Binding_univ__item___0 :
-  binding -> FStar_Syntax_Syntax.univ_name) =
-  fun projectee  -> match projectee with | Binding_univ _0 -> _0 
-let (uu___is_Binding_sig_inst : binding -> Prims.bool) =
+let __proj__Binding_univ__item___0: binding -> FStar_Syntax_Syntax.univ_name
+  = fun projectee  -> match projectee with | Binding_univ _0 -> _0
+let uu___is_Binding_sig_inst: binding -> Prims.bool =
   fun projectee  ->
     match projectee with | Binding_sig_inst _0 -> true | uu____139 -> false
-  
-let (__proj__Binding_sig_inst__item___0 :
+let __proj__Binding_sig_inst__item___0:
   binding ->
     (FStar_Ident.lident Prims.list,FStar_Syntax_Syntax.sigelt,FStar_Syntax_Syntax.universes)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Binding_sig_inst _0 -> _0 
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Binding_sig_inst _0 -> _0
 type delta_level =
-  | NoDelta 
-  | Inlining 
-  | Eager_unfolding_only 
-  | Unfold of FStar_Syntax_Syntax.delta_depth 
-  | UnfoldTac [@@deriving show]
-let (uu___is_NoDelta : delta_level -> Prims.bool) =
+  | NoDelta
+  | Inlining
+  | Eager_unfolding_only
+  | Unfold of FStar_Syntax_Syntax.delta_depth
+  | UnfoldTac[@@deriving show]
+let uu___is_NoDelta: delta_level -> Prims.bool =
   fun projectee  ->
     match projectee with | NoDelta  -> true | uu____178 -> false
-  
-let (uu___is_Inlining : delta_level -> Prims.bool) =
+let uu___is_Inlining: delta_level -> Prims.bool =
   fun projectee  ->
     match projectee with | Inlining  -> true | uu____182 -> false
-  
-let (uu___is_Eager_unfolding_only : delta_level -> Prims.bool) =
+let uu___is_Eager_unfolding_only: delta_level -> Prims.bool =
   fun projectee  ->
     match projectee with | Eager_unfolding_only  -> true | uu____186 -> false
-  
-let (uu___is_Unfold : delta_level -> Prims.bool) =
+let uu___is_Unfold: delta_level -> Prims.bool =
   fun projectee  ->
     match projectee with | Unfold _0 -> true | uu____191 -> false
-  
-let (__proj__Unfold__item___0 :
-  delta_level -> FStar_Syntax_Syntax.delta_depth) =
-  fun projectee  -> match projectee with | Unfold _0 -> _0 
-let (uu___is_UnfoldTac : delta_level -> Prims.bool) =
+let __proj__Unfold__item___0: delta_level -> FStar_Syntax_Syntax.delta_depth
+  = fun projectee  -> match projectee with | Unfold _0 -> _0
+let uu___is_UnfoldTac: delta_level -> Prims.bool =
   fun projectee  ->
     match projectee with | UnfoldTac  -> true | uu____202 -> false
-  
 type mlift =
   {
   mlift_wp:
     FStar_Syntax_Syntax.universe ->
       FStar_Syntax_Syntax.typ ->
-        FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
-    ;
+        FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ;
   mlift_term:
     (FStar_Syntax_Syntax.universe ->
        FStar_Syntax_Syntax.typ ->
          FStar_Syntax_Syntax.typ ->
            FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.option
-    }[@@deriving show]
-let (__proj__Mkmlift__item__mlift_wp :
+      FStar_Pervasives_Native.option;}[@@deriving show]
+let __proj__Mkmlift__item__mlift_wp:
   mlift ->
     FStar_Syntax_Syntax.universe ->
       FStar_Syntax_Syntax.typ ->
-        FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
+        FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
   =
   fun projectee  ->
     match projectee with
     | { mlift_wp = __fname__mlift_wp; mlift_term = __fname__mlift_term;_} ->
         __fname__mlift_wp
-  
-let (__proj__Mkmlift__item__mlift_term :
+let __proj__Mkmlift__item__mlift_term:
   mlift ->
     (FStar_Syntax_Syntax.universe ->
        FStar_Syntax_Syntax.typ ->
          FStar_Syntax_Syntax.typ ->
            FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun projectee  ->
     match projectee with
     | { mlift_wp = __fname__mlift_wp; mlift_term = __fname__mlift_term;_} ->
         __fname__mlift_term
-  
 type edge =
   {
-  msource: FStar_Ident.lident ;
-  mtarget: FStar_Ident.lident ;
-  mlift: mlift }[@@deriving show]
-let (__proj__Mkedge__item__msource : edge -> FStar_Ident.lident) =
+  msource: FStar_Ident.lident;
+  mtarget: FStar_Ident.lident;
+  mlift: mlift;}[@@deriving show]
+let __proj__Mkedge__item__msource: edge -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { msource = __fname__msource; mtarget = __fname__mtarget;
         mlift = __fname__mlift;_} -> __fname__msource
-  
-let (__proj__Mkedge__item__mtarget : edge -> FStar_Ident.lident) =
+let __proj__Mkedge__item__mtarget: edge -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { msource = __fname__msource; mtarget = __fname__mtarget;
         mlift = __fname__mlift;_} -> __fname__mtarget
-  
-let (__proj__Mkedge__item__mlift : edge -> mlift) =
+let __proj__Mkedge__item__mlift: edge -> mlift =
   fun projectee  ->
     match projectee with
     | { msource = __fname__msource; mtarget = __fname__mtarget;
         mlift = __fname__mlift;_} -> __fname__mlift
-  
 type effects =
   {
   decls:
     (FStar_Syntax_Syntax.eff_decl,FStar_Syntax_Syntax.qualifier Prims.list)
-      FStar_Pervasives_Native.tuple2 Prims.list
-    ;
-  order: edge Prims.list ;
+      FStar_Pervasives_Native.tuple2 Prims.list;
+  order: edge Prims.list;
   joins:
     (FStar_Ident.lident,FStar_Ident.lident,FStar_Ident.lident,mlift,mlift)
-      FStar_Pervasives_Native.tuple5 Prims.list
-    }[@@deriving show]
-let (__proj__Mkeffects__item__decls :
+      FStar_Pervasives_Native.tuple5 Prims.list;}[@@deriving show]
+let __proj__Mkeffects__item__decls:
   effects ->
     (FStar_Syntax_Syntax.eff_decl,FStar_Syntax_Syntax.qualifier Prims.list)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun projectee  ->
     match projectee with
     | { decls = __fname__decls; order = __fname__order;
         joins = __fname__joins;_} -> __fname__decls
-  
-let (__proj__Mkeffects__item__order : effects -> edge Prims.list) =
+let __proj__Mkeffects__item__order: effects -> edge Prims.list =
   fun projectee  ->
     match projectee with
     | { decls = __fname__decls; order = __fname__order;
         joins = __fname__joins;_} -> __fname__order
-  
-let (__proj__Mkeffects__item__joins :
+let __proj__Mkeffects__item__joins:
   effects ->
     (FStar_Ident.lident,FStar_Ident.lident,FStar_Ident.lident,mlift,mlift)
-      FStar_Pervasives_Native.tuple5 Prims.list)
+      FStar_Pervasives_Native.tuple5 Prims.list
   =
   fun projectee  ->
     match projectee with
     | { decls = __fname__decls; order = __fname__order;
         joins = __fname__joins;_} -> __fname__joins
-  
 type name_prefix = Prims.string Prims.list[@@deriving show]
 type proof_namespace =
   (name_prefix,Prims.bool) FStar_Pervasives_Native.tuple2 Prims.list[@@deriving
@@ -190,101 +166,91 @@ type cached_elt =
 type goal = FStar_Syntax_Syntax.term[@@deriving show]
 type env =
   {
-  solver: solver_t ;
-  range: FStar_Range.range ;
-  curmodule: FStar_Ident.lident ;
-  gamma: binding Prims.list ;
-  gamma_cache: cached_elt FStar_Util.smap ;
-  modules: FStar_Syntax_Syntax.modul Prims.list ;
-  expected_typ: FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option ;
-  sigtab: FStar_Syntax_Syntax.sigelt FStar_Util.smap ;
-  is_pattern: Prims.bool ;
-  instantiate_imp: Prims.bool ;
-  effects: effects ;
-  generalize: Prims.bool ;
+  solver: solver_t;
+  range: FStar_Range.range;
+  curmodule: FStar_Ident.lident;
+  gamma: binding Prims.list;
+  gamma_cache: cached_elt FStar_Util.smap;
+  modules: FStar_Syntax_Syntax.modul Prims.list;
+  expected_typ: FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option;
+  sigtab: FStar_Syntax_Syntax.sigelt FStar_Util.smap;
+  is_pattern: Prims.bool;
+  instantiate_imp: Prims.bool;
+  effects: effects;
+  generalize: Prims.bool;
   letrecs:
     (FStar_Syntax_Syntax.lbname,FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.univ_names)
-      FStar_Pervasives_Native.tuple3 Prims.list
-    ;
-  top_level: Prims.bool ;
-  check_uvars: Prims.bool ;
-  use_eq: Prims.bool ;
-  is_iface: Prims.bool ;
-  admit: Prims.bool ;
-  lax: Prims.bool ;
-  lax_universes: Prims.bool ;
-  failhard: Prims.bool ;
-  nosynth: Prims.bool ;
+      FStar_Pervasives_Native.tuple3 Prims.list;
+  top_level: Prims.bool;
+  check_uvars: Prims.bool;
+  use_eq: Prims.bool;
+  is_iface: Prims.bool;
+  admit: Prims.bool;
+  lax: Prims.bool;
+  lax_universes: Prims.bool;
+  failhard: Prims.bool;
+  nosynth: Prims.bool;
   tc_term:
     env ->
       FStar_Syntax_Syntax.term ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,guard_t)
-          FStar_Pervasives_Native.tuple3
-    ;
+          FStar_Pervasives_Native.tuple3;
   type_of:
     env ->
       FStar_Syntax_Syntax.term ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.typ,guard_t)
-          FStar_Pervasives_Native.tuple3
-    ;
+          FStar_Pervasives_Native.tuple3;
   universe_of:
-    env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe ;
+    env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe;
   check_type_of:
     Prims.bool ->
-      env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.typ -> guard_t
-    ;
-  use_bv_sorts: Prims.bool ;
+      env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.typ -> guard_t;
+  use_bv_sorts: Prims.bool;
   qname_and_index:
     (FStar_Ident.lident,Prims.int) FStar_Pervasives_Native.tuple2
-      FStar_Pervasives_Native.option
-    ;
-  proof_ns: proof_namespace ;
+      FStar_Pervasives_Native.option;
+  proof_ns: proof_namespace;
   synth:
     env ->
       FStar_Syntax_Syntax.typ ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
-    ;
-  is_native_tactic: FStar_Ident.lid -> Prims.bool ;
-  identifier_info: FStar_TypeChecker_Common.id_info_table FStar_ST.ref ;
-  tc_hooks: tcenv_hooks ;
-  dsenv: FStar_ToSyntax_Env.env ;
-  dep_graph: FStar_Parser_Dep.deps }[@@deriving show]
+        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term;
+  is_native_tactic: FStar_Ident.lid -> Prims.bool;
+  identifier_info: FStar_TypeChecker_Common.id_info_table FStar_ST.ref;
+  tc_hooks: tcenv_hooks;
+  dsenv: FStar_ToSyntax_Env.env;
+  dep_graph: FStar_Parser_Dep.deps;}[@@deriving show]
 and solver_t =
   {
-  init: env -> Prims.unit ;
-  push: Prims.string -> Prims.unit ;
-  pop: Prims.string -> Prims.unit ;
-  encode_modul: env -> FStar_Syntax_Syntax.modul -> Prims.unit ;
-  encode_sig: env -> FStar_Syntax_Syntax.sigelt -> Prims.unit ;
+  init: env -> Prims.unit;
+  push: Prims.string -> Prims.unit;
+  pop: Prims.string -> Prims.unit;
+  encode_modul: env -> FStar_Syntax_Syntax.modul -> Prims.unit;
+  encode_sig: env -> FStar_Syntax_Syntax.sigelt -> Prims.unit;
   preprocess:
     env ->
       goal ->
         (env,goal,FStar_Options.optionstate) FStar_Pervasives_Native.tuple3
-          Prims.list
-    ;
+          Prims.list;
   solve:
     (Prims.unit -> Prims.string) FStar_Pervasives_Native.option ->
-      env -> FStar_Syntax_Syntax.typ -> Prims.unit
-    ;
-  finish: Prims.unit -> Prims.unit ;
-  refresh: Prims.unit -> Prims.unit }[@@deriving show]
+      env -> FStar_Syntax_Syntax.typ -> Prims.unit;
+  finish: Prims.unit -> Prims.unit;
+  refresh: Prims.unit -> Prims.unit;}[@@deriving show]
 and guard_t =
   {
-  guard_f: FStar_TypeChecker_Common.guard_formula ;
-  deferred: FStar_TypeChecker_Common.deferred ;
+  guard_f: FStar_TypeChecker_Common.guard_formula;
+  deferred: FStar_TypeChecker_Common.deferred;
   univ_ineqs:
     (FStar_Syntax_Syntax.universe Prims.list,FStar_TypeChecker_Common.univ_ineq
                                                Prims.list)
-      FStar_Pervasives_Native.tuple2
-    ;
+      FStar_Pervasives_Native.tuple2;
   implicits:
     (Prims.string,env,FStar_Syntax_Syntax.uvar,FStar_Syntax_Syntax.term,
       FStar_Syntax_Syntax.typ,FStar_Range.range)
-      FStar_Pervasives_Native.tuple6 Prims.list
-    }[@@deriving show]
+      FStar_Pervasives_Native.tuple6 Prims.list;}[@@deriving show]
 and tcenv_hooks = {
-  tc_push_in_gamma_hook: env -> binding -> Prims.unit }[@@deriving show]
-let (__proj__Mkenv__item__solver : env -> solver_t) =
+  tc_push_in_gamma_hook: env -> binding -> Prims.unit;}[@@deriving show]
+let __proj__Mkenv__item__solver: env -> solver_t =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -309,8 +275,7 @@ let (__proj__Mkenv__item__solver : env -> solver_t) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__solver
-  
-let (__proj__Mkenv__item__range : env -> FStar_Range.range) =
+let __proj__Mkenv__item__range: env -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -335,8 +300,7 @@ let (__proj__Mkenv__item__range : env -> FStar_Range.range) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__range
-  
-let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
+let __proj__Mkenv__item__curmodule: env -> FStar_Ident.lident =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -361,8 +325,7 @@ let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__curmodule
-  
-let (__proj__Mkenv__item__gamma : env -> binding Prims.list) =
+let __proj__Mkenv__item__gamma: env -> binding Prims.list =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -387,8 +350,7 @@ let (__proj__Mkenv__item__gamma : env -> binding Prims.list) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__gamma
-  
-let (__proj__Mkenv__item__gamma_cache : env -> cached_elt FStar_Util.smap) =
+let __proj__Mkenv__item__gamma_cache: env -> cached_elt FStar_Util.smap =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -413,9 +375,8 @@ let (__proj__Mkenv__item__gamma_cache : env -> cached_elt FStar_Util.smap) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__gamma_cache
-  
-let (__proj__Mkenv__item__modules :
-  env -> FStar_Syntax_Syntax.modul Prims.list) =
+let __proj__Mkenv__item__modules: env -> FStar_Syntax_Syntax.modul Prims.list
+  =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -440,9 +401,8 @@ let (__proj__Mkenv__item__modules :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__modules
-  
-let (__proj__Mkenv__item__expected_typ :
-  env -> FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option) =
+let __proj__Mkenv__item__expected_typ:
+  env -> FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -467,9 +427,8 @@ let (__proj__Mkenv__item__expected_typ :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__expected_typ
-  
-let (__proj__Mkenv__item__sigtab :
-  env -> FStar_Syntax_Syntax.sigelt FStar_Util.smap) =
+let __proj__Mkenv__item__sigtab:
+  env -> FStar_Syntax_Syntax.sigelt FStar_Util.smap =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -494,8 +453,7 @@ let (__proj__Mkenv__item__sigtab :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__sigtab
-  
-let (__proj__Mkenv__item__is_pattern : env -> Prims.bool) =
+let __proj__Mkenv__item__is_pattern: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -520,8 +478,7 @@ let (__proj__Mkenv__item__is_pattern : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__is_pattern
-  
-let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
+let __proj__Mkenv__item__instantiate_imp: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -546,8 +503,7 @@ let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__instantiate_imp
-  
-let (__proj__Mkenv__item__effects : env -> effects) =
+let __proj__Mkenv__item__effects: env -> effects =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -572,8 +528,7 @@ let (__proj__Mkenv__item__effects : env -> effects) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__effects
-  
-let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
+let __proj__Mkenv__item__generalize: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -598,11 +553,10 @@ let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__generalize
-  
-let (__proj__Mkenv__item__letrecs :
+let __proj__Mkenv__item__letrecs:
   env ->
     (FStar_Syntax_Syntax.lbname,FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.univ_names)
-      FStar_Pervasives_Native.tuple3 Prims.list)
+      FStar_Pervasives_Native.tuple3 Prims.list
   =
   fun projectee  ->
     match projectee with
@@ -628,8 +582,7 @@ let (__proj__Mkenv__item__letrecs :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__letrecs
-  
-let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
+let __proj__Mkenv__item__top_level: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -654,8 +607,7 @@ let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__top_level
-  
-let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
+let __proj__Mkenv__item__check_uvars: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -680,8 +632,7 @@ let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__check_uvars
-  
-let (__proj__Mkenv__item__use_eq : env -> Prims.bool) =
+let __proj__Mkenv__item__use_eq: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -706,8 +657,7 @@ let (__proj__Mkenv__item__use_eq : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__use_eq
-  
-let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
+let __proj__Mkenv__item__is_iface: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -732,8 +682,7 @@ let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__is_iface
-  
-let (__proj__Mkenv__item__admit : env -> Prims.bool) =
+let __proj__Mkenv__item__admit: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -758,8 +707,7 @@ let (__proj__Mkenv__item__admit : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__admit
-  
-let (__proj__Mkenv__item__lax : env -> Prims.bool) =
+let __proj__Mkenv__item__lax: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -784,8 +732,7 @@ let (__proj__Mkenv__item__lax : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__lax
-  
-let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
+let __proj__Mkenv__item__lax_universes: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -810,8 +757,7 @@ let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__lax_universes
-  
-let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
+let __proj__Mkenv__item__failhard: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -836,8 +782,7 @@ let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__failhard
-  
-let (__proj__Mkenv__item__nosynth : env -> Prims.bool) =
+let __proj__Mkenv__item__nosynth: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -862,13 +807,12 @@ let (__proj__Mkenv__item__nosynth : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__nosynth
-  
-let (__proj__Mkenv__item__tc_term :
+let __proj__Mkenv__item__tc_term:
   env ->
     env ->
       FStar_Syntax_Syntax.term ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,guard_t)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun projectee  ->
     match projectee with
@@ -894,13 +838,12 @@ let (__proj__Mkenv__item__tc_term :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__tc_term
-  
-let (__proj__Mkenv__item__type_of :
+let __proj__Mkenv__item__type_of:
   env ->
     env ->
       FStar_Syntax_Syntax.term ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.typ,guard_t)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun projectee  ->
     match projectee with
@@ -926,9 +869,8 @@ let (__proj__Mkenv__item__type_of :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__type_of
-  
-let (__proj__Mkenv__item__universe_of :
-  env -> env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe) =
+let __proj__Mkenv__item__universe_of:
+  env -> env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -953,11 +895,10 @@ let (__proj__Mkenv__item__universe_of :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__universe_of
-  
-let (__proj__Mkenv__item__check_type_of :
+let __proj__Mkenv__item__check_type_of:
   env ->
     Prims.bool ->
-      env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.typ -> guard_t)
+      env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.typ -> guard_t
   =
   fun projectee  ->
     match projectee with
@@ -983,8 +924,7 @@ let (__proj__Mkenv__item__check_type_of :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__check_type_of
-  
-let (__proj__Mkenv__item__use_bv_sorts : env -> Prims.bool) =
+let __proj__Mkenv__item__use_bv_sorts: env -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -1009,11 +949,10 @@ let (__proj__Mkenv__item__use_bv_sorts : env -> Prims.bool) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__use_bv_sorts
-  
-let (__proj__Mkenv__item__qname_and_index :
+let __proj__Mkenv__item__qname_and_index:
   env ->
     (FStar_Ident.lident,Prims.int) FStar_Pervasives_Native.tuple2
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun projectee  ->
     match projectee with
@@ -1039,8 +978,7 @@ let (__proj__Mkenv__item__qname_and_index :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__qname_and_index
-  
-let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
+let __proj__Mkenv__item__proof_ns: env -> proof_namespace =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -1065,12 +1003,11 @@ let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__proof_ns
-  
-let (__proj__Mkenv__item__synth :
+let __proj__Mkenv__item__synth:
   env ->
     env ->
       FStar_Syntax_Syntax.typ ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun projectee  ->
     match projectee with
@@ -1096,9 +1033,8 @@ let (__proj__Mkenv__item__synth :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__synth
-  
-let (__proj__Mkenv__item__is_native_tactic :
-  env -> FStar_Ident.lid -> Prims.bool) =
+let __proj__Mkenv__item__is_native_tactic:
+  env -> FStar_Ident.lid -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -1123,9 +1059,8 @@ let (__proj__Mkenv__item__is_native_tactic :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__is_native_tactic
-  
-let (__proj__Mkenv__item__identifier_info :
-  env -> FStar_TypeChecker_Common.id_info_table FStar_ST.ref) =
+let __proj__Mkenv__item__identifier_info:
+  env -> FStar_TypeChecker_Common.id_info_table FStar_ST.ref =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -1150,8 +1085,7 @@ let (__proj__Mkenv__item__identifier_info :
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__identifier_info
-  
-let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
+let __proj__Mkenv__item__tc_hooks: env -> tcenv_hooks =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -1176,8 +1110,7 @@ let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__tc_hooks
-  
-let (__proj__Mkenv__item__dsenv : env -> FStar_ToSyntax_Env.env) =
+let __proj__Mkenv__item__dsenv: env -> FStar_ToSyntax_Env.env =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -1202,8 +1135,7 @@ let (__proj__Mkenv__item__dsenv : env -> FStar_ToSyntax_Env.env) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__dsenv
-  
-let (__proj__Mkenv__item__dep_graph : env -> FStar_Parser_Dep.deps) =
+let __proj__Mkenv__item__dep_graph: env -> FStar_Parser_Dep.deps =
   fun projectee  ->
     match projectee with
     | { solver = __fname__solver; range = __fname__range;
@@ -1228,8 +1160,7 @@ let (__proj__Mkenv__item__dep_graph : env -> FStar_Parser_Dep.deps) =
         identifier_info = __fname__identifier_info;
         tc_hooks = __fname__tc_hooks; dsenv = __fname__dsenv;
         dep_graph = __fname__dep_graph;_} -> __fname__dep_graph
-  
-let (__proj__Mksolver_t__item__init : solver_t -> env -> Prims.unit) =
+let __proj__Mksolver_t__item__init: solver_t -> env -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { init = __fname__init; push = __fname__push; pop = __fname__pop;
@@ -1237,9 +1168,7 @@ let (__proj__Mksolver_t__item__init : solver_t -> env -> Prims.unit) =
         encode_sig = __fname__encode_sig; preprocess = __fname__preprocess;
         solve = __fname__solve; finish = __fname__finish;
         refresh = __fname__refresh;_} -> __fname__init
-  
-let (__proj__Mksolver_t__item__push : solver_t -> Prims.string -> Prims.unit)
-  =
+let __proj__Mksolver_t__item__push: solver_t -> Prims.string -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { init = __fname__init; push = __fname__push; pop = __fname__pop;
@@ -1247,9 +1176,7 @@ let (__proj__Mksolver_t__item__push : solver_t -> Prims.string -> Prims.unit)
         encode_sig = __fname__encode_sig; preprocess = __fname__preprocess;
         solve = __fname__solve; finish = __fname__finish;
         refresh = __fname__refresh;_} -> __fname__push
-  
-let (__proj__Mksolver_t__item__pop : solver_t -> Prims.string -> Prims.unit)
-  =
+let __proj__Mksolver_t__item__pop: solver_t -> Prims.string -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { init = __fname__init; push = __fname__push; pop = __fname__pop;
@@ -1257,9 +1184,8 @@ let (__proj__Mksolver_t__item__pop : solver_t -> Prims.string -> Prims.unit)
         encode_sig = __fname__encode_sig; preprocess = __fname__preprocess;
         solve = __fname__solve; finish = __fname__finish;
         refresh = __fname__refresh;_} -> __fname__pop
-  
-let (__proj__Mksolver_t__item__encode_modul :
-  solver_t -> env -> FStar_Syntax_Syntax.modul -> Prims.unit) =
+let __proj__Mksolver_t__item__encode_modul:
+  solver_t -> env -> FStar_Syntax_Syntax.modul -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { init = __fname__init; push = __fname__push; pop = __fname__pop;
@@ -1267,9 +1193,8 @@ let (__proj__Mksolver_t__item__encode_modul :
         encode_sig = __fname__encode_sig; preprocess = __fname__preprocess;
         solve = __fname__solve; finish = __fname__finish;
         refresh = __fname__refresh;_} -> __fname__encode_modul
-  
-let (__proj__Mksolver_t__item__encode_sig :
-  solver_t -> env -> FStar_Syntax_Syntax.sigelt -> Prims.unit) =
+let __proj__Mksolver_t__item__encode_sig:
+  solver_t -> env -> FStar_Syntax_Syntax.sigelt -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { init = __fname__init; push = __fname__push; pop = __fname__pop;
@@ -1277,13 +1202,12 @@ let (__proj__Mksolver_t__item__encode_sig :
         encode_sig = __fname__encode_sig; preprocess = __fname__preprocess;
         solve = __fname__solve; finish = __fname__finish;
         refresh = __fname__refresh;_} -> __fname__encode_sig
-  
-let (__proj__Mksolver_t__item__preprocess :
+let __proj__Mksolver_t__item__preprocess:
   solver_t ->
     env ->
       goal ->
         (env,goal,FStar_Options.optionstate) FStar_Pervasives_Native.tuple3
-          Prims.list)
+          Prims.list
   =
   fun projectee  ->
     match projectee with
@@ -1292,11 +1216,10 @@ let (__proj__Mksolver_t__item__preprocess :
         encode_sig = __fname__encode_sig; preprocess = __fname__preprocess;
         solve = __fname__solve; finish = __fname__finish;
         refresh = __fname__refresh;_} -> __fname__preprocess
-  
-let (__proj__Mksolver_t__item__solve :
+let __proj__Mksolver_t__item__solve:
   solver_t ->
     (Prims.unit -> Prims.string) FStar_Pervasives_Native.option ->
-      env -> FStar_Syntax_Syntax.typ -> Prims.unit)
+      env -> FStar_Syntax_Syntax.typ -> Prims.unit
   =
   fun projectee  ->
     match projectee with
@@ -1305,9 +1228,7 @@ let (__proj__Mksolver_t__item__solve :
         encode_sig = __fname__encode_sig; preprocess = __fname__preprocess;
         solve = __fname__solve; finish = __fname__finish;
         refresh = __fname__refresh;_} -> __fname__solve
-  
-let (__proj__Mksolver_t__item__finish : solver_t -> Prims.unit -> Prims.unit)
-  =
+let __proj__Mksolver_t__item__finish: solver_t -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { init = __fname__init; push = __fname__push; pop = __fname__pop;
@@ -1315,9 +1236,7 @@ let (__proj__Mksolver_t__item__finish : solver_t -> Prims.unit -> Prims.unit)
         encode_sig = __fname__encode_sig; preprocess = __fname__preprocess;
         solve = __fname__solve; finish = __fname__finish;
         refresh = __fname__refresh;_} -> __fname__finish
-  
-let (__proj__Mksolver_t__item__refresh :
-  solver_t -> Prims.unit -> Prims.unit) =
+let __proj__Mksolver_t__item__refresh: solver_t -> Prims.unit -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { init = __fname__init; push = __fname__push; pop = __fname__pop;
@@ -1325,61 +1244,55 @@ let (__proj__Mksolver_t__item__refresh :
         encode_sig = __fname__encode_sig; preprocess = __fname__preprocess;
         solve = __fname__solve; finish = __fname__finish;
         refresh = __fname__refresh;_} -> __fname__refresh
-  
-let (__proj__Mkguard_t__item__guard_f :
-  guard_t -> FStar_TypeChecker_Common.guard_formula) =
+let __proj__Mkguard_t__item__guard_f:
+  guard_t -> FStar_TypeChecker_Common.guard_formula =
   fun projectee  ->
     match projectee with
     | { guard_f = __fname__guard_f; deferred = __fname__deferred;
         univ_ineqs = __fname__univ_ineqs; implicits = __fname__implicits;_}
         -> __fname__guard_f
-  
-let (__proj__Mkguard_t__item__deferred :
-  guard_t -> FStar_TypeChecker_Common.deferred) =
+let __proj__Mkguard_t__item__deferred:
+  guard_t -> FStar_TypeChecker_Common.deferred =
   fun projectee  ->
     match projectee with
     | { guard_f = __fname__guard_f; deferred = __fname__deferred;
         univ_ineqs = __fname__univ_ineqs; implicits = __fname__implicits;_}
         -> __fname__deferred
-  
-let (__proj__Mkguard_t__item__univ_ineqs :
+let __proj__Mkguard_t__item__univ_ineqs:
   guard_t ->
     (FStar_Syntax_Syntax.universe Prims.list,FStar_TypeChecker_Common.univ_ineq
                                                Prims.list)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun projectee  ->
     match projectee with
     | { guard_f = __fname__guard_f; deferred = __fname__deferred;
         univ_ineqs = __fname__univ_ineqs; implicits = __fname__implicits;_}
         -> __fname__univ_ineqs
-  
-let (__proj__Mkguard_t__item__implicits :
+let __proj__Mkguard_t__item__implicits:
   guard_t ->
     (Prims.string,env,FStar_Syntax_Syntax.uvar,FStar_Syntax_Syntax.term,
       FStar_Syntax_Syntax.typ,FStar_Range.range)
-      FStar_Pervasives_Native.tuple6 Prims.list)
+      FStar_Pervasives_Native.tuple6 Prims.list
   =
   fun projectee  ->
     match projectee with
     | { guard_f = __fname__guard_f; deferred = __fname__deferred;
         univ_ineqs = __fname__univ_ineqs; implicits = __fname__implicits;_}
         -> __fname__implicits
-  
-let (__proj__Mktcenv_hooks__item__tc_push_in_gamma_hook :
-  tcenv_hooks -> env -> binding -> Prims.unit) =
+let __proj__Mktcenv_hooks__item__tc_push_in_gamma_hook:
+  tcenv_hooks -> env -> binding -> Prims.unit =
   fun projectee  ->
     match projectee with
     | { tc_push_in_gamma_hook = __fname__tc_push_in_gamma_hook;_} ->
         __fname__tc_push_in_gamma_hook
-  
 type implicits =
   (Prims.string,env,FStar_Syntax_Syntax.uvar,FStar_Syntax_Syntax.term,
     FStar_Syntax_Syntax.typ,FStar_Range.range) FStar_Pervasives_Native.tuple6
     Prims.list[@@deriving show]
-let (rename_gamma :
+let rename_gamma:
   FStar_Syntax_Syntax.subst_elt Prims.list ->
-    binding Prims.list -> binding Prims.list)
+    binding Prims.list -> binding Prims.list
   =
   fun subst1  ->
     fun gamma  ->
@@ -1389,35 +1302,33 @@ let (rename_gamma :
               match uu___71_5525 with
               | Binding_var x ->
                   let y =
-                    let uu____5528 = FStar_Syntax_Syntax.bv_to_name x  in
-                    FStar_Syntax_Subst.subst subst1 uu____5528  in
+                    let uu____5528 = FStar_Syntax_Syntax.bv_to_name x in
+                    FStar_Syntax_Subst.subst subst1 uu____5528 in
                   let uu____5529 =
-                    let uu____5530 = FStar_Syntax_Subst.compress y  in
-                    uu____5530.FStar_Syntax_Syntax.n  in
+                    let uu____5530 = FStar_Syntax_Subst.compress y in
+                    uu____5530.FStar_Syntax_Syntax.n in
                   (match uu____5529 with
                    | FStar_Syntax_Syntax.Tm_name y1 ->
                        let uu____5534 =
-                         let uu___86_5535 = y1  in
+                         let uu___86_5535 = y1 in
                          let uu____5536 =
                            FStar_Syntax_Subst.subst subst1
-                             x.FStar_Syntax_Syntax.sort
-                            in
+                             x.FStar_Syntax_Syntax.sort in
                          {
                            FStar_Syntax_Syntax.ppname =
                              (uu___86_5535.FStar_Syntax_Syntax.ppname);
                            FStar_Syntax_Syntax.index =
                              (uu___86_5535.FStar_Syntax_Syntax.index);
                            FStar_Syntax_Syntax.sort = uu____5536
-                         }  in
+                         } in
                        Binding_var uu____5534
                    | uu____5539 -> failwith "Not a renaming")
               | b -> b))
-  
-let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
+let rename_env: FStar_Syntax_Syntax.subst_t -> env -> env =
   fun subst1  ->
     fun env  ->
-      let uu___87_5547 = env  in
-      let uu____5548 = rename_gamma subst1 env.gamma  in
+      let uu___87_5547 = env in
+      let uu____5548 = rename_gamma subst1 env.gamma in
       {
         solver = (uu___87_5547.solver);
         range = (uu___87_5547.range);
@@ -1455,14 +1366,13 @@ let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
         dsenv = (uu___87_5547.dsenv);
         dep_graph = (uu___87_5547.dep_graph)
       }
-  
-let (default_tc_hooks : tcenv_hooks) =
-  { tc_push_in_gamma_hook = (fun uu____5555  -> fun uu____5556  -> ()) } 
-let (tc_hooks : env -> tcenv_hooks) = fun env  -> env.tc_hooks 
-let (set_tc_hooks : env -> tcenv_hooks -> env) =
+let default_tc_hooks: tcenv_hooks =
+  { tc_push_in_gamma_hook = (fun uu____5555  -> fun uu____5556  -> ()) }
+let tc_hooks: env -> tcenv_hooks = fun env  -> env.tc_hooks
+let set_tc_hooks: env -> tcenv_hooks -> env =
   fun env  ->
     fun hooks  ->
-      let uu___88_5566 = env  in
+      let uu___88_5566 = env in
       {
         solver = (uu___88_5566.solver);
         range = (uu___88_5566.range);
@@ -1500,11 +1410,10 @@ let (set_tc_hooks : env -> tcenv_hooks -> env) =
         dsenv = (uu___88_5566.dsenv);
         dep_graph = (uu___88_5566.dep_graph)
       }
-  
-let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
+let set_dep_graph: env -> FStar_Parser_Dep.deps -> env =
   fun e  ->
     fun g  ->
-      let uu___89_5573 = e  in
+      let uu___89_5573 = e in
       {
         solver = (uu___89_5573.solver);
         range = (uu___89_5573.range);
@@ -1542,17 +1451,14 @@ let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
         dsenv = (uu___89_5573.dsenv);
         dep_graph = g
       }
-  
-let (dep_graph : env -> FStar_Parser_Dep.deps) = fun e  -> e.dep_graph 
+let dep_graph: env -> FStar_Parser_Dep.deps = fun e  -> e.dep_graph
 type env_t = env[@@deriving show]
 type sigtable = FStar_Syntax_Syntax.sigelt FStar_Util.smap[@@deriving show]
-let (should_verify : env -> Prims.bool) =
+let should_verify: env -> Prims.bool =
   fun env  ->
     ((Prims.op_Negation env.lax) && (Prims.op_Negation env.admit)) &&
       (FStar_Options.should_verify (env.curmodule).FStar_Ident.str)
-  
-let (visible_at : delta_level -> FStar_Syntax_Syntax.qualifier -> Prims.bool)
-  =
+let visible_at: delta_level -> FStar_Syntax_Syntax.qualifier -> Prims.bool =
   fun d  ->
     fun q  ->
       match (d, q) with
@@ -1565,14 +1471,13 @@ let (visible_at : delta_level -> FStar_Syntax_Syntax.qualifier -> Prims.bool)
       | (Unfold uu____5590,FStar_Syntax_Syntax.Visible_default ) -> true
       | (Inlining ,FStar_Syntax_Syntax.Inline_for_extraction ) -> true
       | uu____5591 -> false
-  
-let (default_table_size : Prims.int) = (Prims.parse_int "200") 
-let new_sigtab : 'Auu____5598 . Prims.unit -> 'Auu____5598 FStar_Util.smap =
-  fun uu____5604  -> FStar_Util.smap_create default_table_size 
-let new_gamma_cache :
+let default_table_size: Prims.int = Prims.parse_int "200"
+let new_sigtab: 'Auu____5598 . Prims.unit -> 'Auu____5598 FStar_Util.smap =
+  fun uu____5604  -> FStar_Util.smap_create default_table_size
+let new_gamma_cache:
   'Auu____5607 . Prims.unit -> 'Auu____5607 FStar_Util.smap =
-  fun uu____5613  -> FStar_Util.smap_create (Prims.parse_int "100") 
-let (initial_env :
+  fun uu____5613  -> FStar_Util.smap_create (Prims.parse_int "100")
+let initial_env:
   FStar_Parser_Dep.deps ->
     (env ->
        FStar_Syntax_Syntax.term ->
@@ -1588,7 +1493,7 @@ let (initial_env :
           (Prims.bool ->
              env ->
                FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.typ -> guard_t)
-            -> solver_t -> FStar_Ident.lident -> env)
+            -> solver_t -> FStar_Ident.lident -> env
   =
   fun deps  ->
     fun tc_term  ->
@@ -1597,14 +1502,13 @@ let (initial_env :
           fun check_type_of  ->
             fun solver  ->
               fun module_lid  ->
-                let uu____5709 = new_gamma_cache ()  in
-                let uu____5712 = new_sigtab ()  in
-                let uu____5715 = FStar_Options.using_facts_from ()  in
+                let uu____5709 = new_gamma_cache () in
+                let uu____5712 = new_sigtab () in
+                let uu____5715 = FStar_Options.using_facts_from () in
                 let uu____5716 =
                   FStar_Util.mk_ref
-                    FStar_TypeChecker_Common.id_info_table_empty
-                   in
-                let uu____5719 = FStar_ToSyntax_Env.empty_env ()  in
+                    FStar_TypeChecker_Common.id_info_table_empty in
+                let uu____5719 = FStar_ToSyntax_Env.empty_env () in
                 {
                   solver;
                   range = FStar_Range.dummyRange;
@@ -1645,69 +1549,63 @@ let (initial_env :
                   dsenv = uu____5719;
                   dep_graph = deps
                 }
-  
-let (sigtab : env -> FStar_Syntax_Syntax.sigelt FStar_Util.smap) =
-  fun env  -> env.sigtab 
-let (gamma_cache : env -> cached_elt FStar_Util.smap) =
-  fun env  -> env.gamma_cache 
-let (query_indices :
+let sigtab: env -> FStar_Syntax_Syntax.sigelt FStar_Util.smap =
+  fun env  -> env.sigtab
+let gamma_cache: env -> cached_elt FStar_Util.smap =
+  fun env  -> env.gamma_cache
+let query_indices:
   (FStar_Ident.lident,Prims.int) FStar_Pervasives_Native.tuple2 Prims.list
-    Prims.list FStar_ST.ref)
-  = FStar_Util.mk_ref [[]] 
-let (push_query_indices : Prims.unit -> Prims.unit) =
+    Prims.list FStar_ST.ref
+  = FStar_Util.mk_ref [[]]
+let push_query_indices: Prims.unit -> Prims.unit =
   fun uu____5833  ->
-    let uu____5834 = FStar_ST.op_Bang query_indices  in
+    let uu____5834 = FStar_ST.op_Bang query_indices in
     match uu____5834 with
     | [] -> failwith "Empty query indices!"
     | uu____5884 ->
         let uu____5893 =
           let uu____5902 =
-            let uu____5909 = FStar_ST.op_Bang query_indices  in
-            FStar_List.hd uu____5909  in
-          let uu____5959 = FStar_ST.op_Bang query_indices  in uu____5902 ::
-            uu____5959
-           in
+            let uu____5909 = FStar_ST.op_Bang query_indices in
+            FStar_List.hd uu____5909 in
+          let uu____5959 = FStar_ST.op_Bang query_indices in uu____5902 ::
+            uu____5959 in
         FStar_ST.op_Colon_Equals query_indices uu____5893
-  
-let (pop_query_indices : Prims.unit -> Prims.unit) =
+let pop_query_indices: Prims.unit -> Prims.unit =
   fun uu____6046  ->
-    let uu____6047 = FStar_ST.op_Bang query_indices  in
+    let uu____6047 = FStar_ST.op_Bang query_indices in
     match uu____6047 with
     | [] -> failwith "Empty query indices!"
     | hd1::tl1 -> FStar_ST.op_Colon_Equals query_indices tl1
-  
-let (add_query_index :
-  (FStar_Ident.lident,Prims.int) FStar_Pervasives_Native.tuple2 -> Prims.unit)
+let add_query_index:
+  (FStar_Ident.lident,Prims.int) FStar_Pervasives_Native.tuple2 -> Prims.unit
   =
   fun uu____6160  ->
     match uu____6160 with
     | (l,n1) ->
-        let uu____6167 = FStar_ST.op_Bang query_indices  in
+        let uu____6167 = FStar_ST.op_Bang query_indices in
         (match uu____6167 with
          | hd1::tl1 ->
              FStar_ST.op_Colon_Equals query_indices (((l, n1) :: hd1) :: tl1)
          | uu____6278 -> failwith "Empty query indices")
-  
-let (peek_query_indices :
+let peek_query_indices:
   Prims.unit ->
-    (FStar_Ident.lident,Prims.int) FStar_Pervasives_Native.tuple2 Prims.list)
+    (FStar_Ident.lident,Prims.int) FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun uu____6295  ->
-    let uu____6296 = FStar_ST.op_Bang query_indices  in
+    let uu____6296 = FStar_ST.op_Bang query_indices in
     FStar_List.hd uu____6296
-  
-let (stack : env Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
-let (push_stack : env -> env) =
+let stack: env Prims.list FStar_ST.ref = FStar_Util.mk_ref []
+let push_stack: env -> env =
   fun env  ->
     (let uu____6367 =
-       let uu____6370 = FStar_ST.op_Bang stack  in env :: uu____6370  in
+       let uu____6370 = FStar_ST.op_Bang stack in env :: uu____6370 in
      FStar_ST.op_Colon_Equals stack uu____6367);
-    (let uu___90_6419 = env  in
-     let uu____6420 = FStar_Util.smap_copy (gamma_cache env)  in
-     let uu____6423 = FStar_Util.smap_copy (sigtab env)  in
+    (let uu___90_6419 = env in
+     let uu____6420 = FStar_Util.smap_copy (gamma_cache env) in
+     let uu____6423 = FStar_Util.smap_copy (sigtab env) in
      let uu____6426 =
-       let uu____6429 = FStar_ST.op_Bang env.identifier_info  in
-       FStar_Util.mk_ref uu____6429  in
+       let uu____6429 = FStar_ST.op_Bang env.identifier_info in
+       FStar_Util.mk_ref uu____6429 in
      {
        solver = (uu___90_6419.solver);
        range = (uu___90_6419.range);
@@ -1745,25 +1643,21 @@ let (push_stack : env -> env) =
        dsenv = (uu___90_6419.dsenv);
        dep_graph = (uu___90_6419.dep_graph)
      })
-  
-let (pop_stack : Prims.unit -> env) =
+let pop_stack: Prims.unit -> env =
   fun uu____6473  ->
-    let uu____6474 = FStar_ST.op_Bang stack  in
+    let uu____6474 = FStar_ST.op_Bang stack in
     match uu____6474 with
     | env::tl1 -> (FStar_ST.op_Colon_Equals stack tl1; env)
     | uu____6528 -> failwith "Impossible: Too many pops"
-  
-let (push : env -> Prims.string -> env) =
+let push: env -> Prims.string -> env =
   fun env  ->
     fun msg  -> push_query_indices (); (env.solver).push msg; push_stack env
-  
-let (pop : env -> Prims.string -> env) =
+let pop: env -> Prims.string -> env =
   fun env  ->
     fun msg  -> (env.solver).pop msg; pop_query_indices (); pop_stack ()
-  
-let (incr_query_index : env -> env) =
+let incr_query_index: env -> env =
   fun env  ->
-    let qix = peek_query_indices ()  in
+    let qix = peek_query_indices () in
     match env.qname_and_index with
     | FStar_Pervasives_Native.None  -> env
     | FStar_Pervasives_Native.Some (l,n1) ->
@@ -1772,13 +1666,12 @@ let (incr_query_index : env -> env) =
             (FStar_List.tryFind
                (fun uu____6593  ->
                   match uu____6593 with
-                  | (m,uu____6599) -> FStar_Ident.lid_equals l m))
-           in
+                  | (m,uu____6599) -> FStar_Ident.lid_equals l m)) in
         (match uu____6567 with
          | FStar_Pervasives_Native.None  ->
-             let next = n1 + (Prims.parse_int "1")  in
+             let next = n1 + (Prims.parse_int "1") in
              (add_query_index (l, next);
-              (let uu___91_6606 = env  in
+              (let uu___91_6606 = env in
                {
                  solver = (uu___91_6606.solver);
                  range = (uu___91_6606.range);
@@ -1817,9 +1710,9 @@ let (incr_query_index : env -> env) =
                  dep_graph = (uu___91_6606.dep_graph)
                }))
          | FStar_Pervasives_Native.Some (uu____6611,m) ->
-             let next = m + (Prims.parse_int "1")  in
+             let next = m + (Prims.parse_int "1") in
              (add_query_index (l, next);
-              (let uu___92_6619 = env  in
+              (let uu___92_6619 = env in
                {
                  solver = (uu___92_6619.solver);
                  range = (uu___92_6619.range);
@@ -1857,18 +1750,16 @@ let (incr_query_index : env -> env) =
                  dsenv = (uu___92_6619.dsenv);
                  dep_graph = (uu___92_6619.dep_graph)
                })))
-  
-let (debug : env -> FStar_Options.debug_level_t -> Prims.bool) =
+let debug: env -> FStar_Options.debug_level_t -> Prims.bool =
   fun env  ->
     fun l  -> FStar_Options.debug_at_level (env.curmodule).FStar_Ident.str l
-  
-let (set_range : env -> FStar_Range.range -> env) =
+let set_range: env -> FStar_Range.range -> env =
   fun e  ->
     fun r  ->
       if r = FStar_Range.dummyRange
       then e
       else
-        (let uu___93_6637 = e  in
+        (let uu___93_6637 = e in
          {
            solver = (uu___93_6637.solver);
            range = r;
@@ -1906,53 +1797,47 @@ let (set_range : env -> FStar_Range.range -> env) =
            dsenv = (uu___93_6637.dsenv);
            dep_graph = (uu___93_6637.dep_graph)
          })
-  
-let (get_range : env -> FStar_Range.range) = fun e  -> e.range 
-let (toggle_id_info : env -> Prims.bool -> Prims.unit) =
+let get_range: env -> FStar_Range.range = fun e  -> e.range
+let toggle_id_info: env -> Prims.bool -> Prims.unit =
   fun env  ->
     fun enabled  ->
       let uu____6647 =
-        let uu____6648 = FStar_ST.op_Bang env.identifier_info  in
-        FStar_TypeChecker_Common.id_info_toggle uu____6648 enabled  in
+        let uu____6648 = FStar_ST.op_Bang env.identifier_info in
+        FStar_TypeChecker_Common.id_info_toggle uu____6648 enabled in
       FStar_ST.op_Colon_Equals env.identifier_info uu____6647
-  
-let (insert_bv_info :
-  env -> FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.typ -> Prims.unit) =
+let insert_bv_info:
+  env -> FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.typ -> Prims.unit =
   fun env  ->
     fun bv  ->
       fun ty  ->
         let uu____6696 =
-          let uu____6697 = FStar_ST.op_Bang env.identifier_info  in
-          FStar_TypeChecker_Common.id_info_insert_bv uu____6697 bv ty  in
+          let uu____6697 = FStar_ST.op_Bang env.identifier_info in
+          FStar_TypeChecker_Common.id_info_insert_bv uu____6697 bv ty in
         FStar_ST.op_Colon_Equals env.identifier_info uu____6696
-  
-let (insert_fv_info :
-  env -> FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.typ -> Prims.unit) =
+let insert_fv_info:
+  env -> FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.typ -> Prims.unit =
   fun env  ->
     fun fv  ->
       fun ty  ->
         let uu____6745 =
-          let uu____6746 = FStar_ST.op_Bang env.identifier_info  in
-          FStar_TypeChecker_Common.id_info_insert_fv uu____6746 fv ty  in
+          let uu____6746 = FStar_ST.op_Bang env.identifier_info in
+          FStar_TypeChecker_Common.id_info_insert_fv uu____6746 fv ty in
         FStar_ST.op_Colon_Equals env.identifier_info uu____6745
-  
-let (promote_id_info :
-  env -> (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) -> Prims.unit)
-  =
+let promote_id_info:
+  env -> (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) -> Prims.unit =
   fun env  ->
     fun ty_map  ->
       let uu____6796 =
-        let uu____6797 = FStar_ST.op_Bang env.identifier_info  in
-        FStar_TypeChecker_Common.id_info_promote uu____6797 ty_map  in
+        let uu____6797 = FStar_ST.op_Bang env.identifier_info in
+        FStar_TypeChecker_Common.id_info_promote uu____6797 ty_map in
       FStar_ST.op_Colon_Equals env.identifier_info uu____6796
-  
-let (modules : env -> FStar_Syntax_Syntax.modul Prims.list) =
-  fun env  -> env.modules 
-let (current_module : env -> FStar_Ident.lident) = fun env  -> env.curmodule 
-let (set_current_module : env -> FStar_Ident.lident -> env) =
+let modules: env -> FStar_Syntax_Syntax.modul Prims.list =
+  fun env  -> env.modules
+let current_module: env -> FStar_Ident.lident = fun env  -> env.curmodule
+let set_current_module: env -> FStar_Ident.lident -> env =
   fun env  ->
     fun lid  ->
-      let uu___94_6850 = env  in
+      let uu___94_6850 = env in
       {
         solver = (uu___94_6850.solver);
         range = (uu___94_6850.range);
@@ -1990,8 +1875,7 @@ let (set_current_module : env -> FStar_Ident.lident -> env) =
         dsenv = (uu___94_6850.dsenv);
         dep_graph = (uu___94_6850.dep_graph)
       }
-  
-let (has_interface : env -> FStar_Ident.lident -> Prims.bool) =
+let has_interface: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun l  ->
       FStar_All.pipe_right env.modules
@@ -1999,63 +1883,56 @@ let (has_interface : env -> FStar_Ident.lident -> Prims.bool) =
            (fun m  ->
               m.FStar_Syntax_Syntax.is_interface &&
                 (FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name l)))
-  
-let (find_in_sigtab :
+let find_in_sigtab:
   env ->
     FStar_Ident.lident ->
-      FStar_Syntax_Syntax.sigelt FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.sigelt FStar_Pervasives_Native.option
   =
   fun env  ->
     fun lid  ->
       FStar_Util.smap_try_find (sigtab env) (FStar_Ident.text_of_lid lid)
-  
-let (name_not_found :
+let name_not_found:
   FStar_Ident.lid ->
-    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun l  ->
     let uu____6876 =
-      FStar_Util.format1 "Name \"%s\" not found" l.FStar_Ident.str  in
+      FStar_Util.format1 "Name \"%s\" not found" l.FStar_Ident.str in
     (FStar_Errors.Fatal_NameNotFound, uu____6876)
-  
-let (variable_not_found :
+let variable_not_found:
   FStar_Syntax_Syntax.bv ->
-    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun v1  ->
     let uu____6884 =
-      let uu____6885 = FStar_Syntax_Print.bv_to_string v1  in
-      FStar_Util.format1 "Variable \"%s\" not found" uu____6885  in
+      let uu____6885 = FStar_Syntax_Print.bv_to_string v1 in
+      FStar_Util.format1 "Variable \"%s\" not found" uu____6885 in
     (FStar_Errors.Fatal_VariableNotFound, uu____6884)
-  
-let (new_u_univ : Prims.unit -> FStar_Syntax_Syntax.universe) =
+let new_u_univ: Prims.unit -> FStar_Syntax_Syntax.universe =
   fun uu____6888  ->
-    let uu____6889 = FStar_Syntax_Unionfind.univ_fresh ()  in
+    let uu____6889 = FStar_Syntax_Unionfind.univ_fresh () in
     FStar_Syntax_Syntax.U_unif uu____6889
-  
-let (inst_tscheme_with :
+let inst_tscheme_with:
   FStar_Syntax_Syntax.tscheme ->
     FStar_Syntax_Syntax.universes ->
       (FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun ts  ->
     fun us  ->
       match (ts, us) with
       | (([],t),[]) -> ([], t)
       | ((formals,t),uu____6927) ->
-          let n1 = (FStar_List.length formals) - (Prims.parse_int "1")  in
+          let n1 = (FStar_List.length formals) - (Prims.parse_int "1") in
           let vs =
             FStar_All.pipe_right us
               (FStar_List.mapi
-                 (fun i  -> fun u  -> FStar_Syntax_Syntax.UN ((n1 - i), u)))
-             in
-          let uu____6951 = FStar_Syntax_Subst.subst vs t  in (us, uu____6951)
-  
-let (inst_tscheme :
+                 (fun i  -> fun u  -> FStar_Syntax_Syntax.UN ((n1 - i), u))) in
+          let uu____6951 = FStar_Syntax_Subst.subst vs t in (us, uu____6951)
+let inst_tscheme:
   FStar_Syntax_Syntax.tscheme ->
     (FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun uu___72_6964  ->
     match uu___72_6964 with
@@ -2063,29 +1940,26 @@ let (inst_tscheme :
     | (us,t) ->
         let us' =
           FStar_All.pipe_right us
-            (FStar_List.map (fun uu____6988  -> new_u_univ ()))
-           in
+            (FStar_List.map (fun uu____6988  -> new_u_univ ())) in
         inst_tscheme_with (us, t) us'
-  
-let (inst_tscheme_with_range :
+let inst_tscheme_with_range:
   FStar_Range.range ->
     FStar_Syntax_Syntax.tscheme ->
       (FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun r  ->
     fun t  ->
-      let uu____7001 = inst_tscheme t  in
+      let uu____7001 = inst_tscheme t in
       match uu____7001 with
       | (us,t1) ->
-          let uu____7012 = FStar_Syntax_Subst.set_use_range r t1  in
+          let uu____7012 = FStar_Syntax_Subst.set_use_range r t1 in
           (us, uu____7012)
-  
-let (inst_effect_fun_with :
+let inst_effect_fun_with:
   FStar_Syntax_Syntax.universes ->
     env ->
       FStar_Syntax_Syntax.eff_decl ->
-        FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.term)
+        FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.term
   =
   fun insts  ->
     fun env  ->
@@ -2096,74 +1970,63 @@ let (inst_effect_fun_with :
               (match ed.FStar_Syntax_Syntax.binders with
                | [] ->
                    let univs1 =
-                     FStar_List.append ed.FStar_Syntax_Syntax.univs us  in
+                     FStar_List.append ed.FStar_Syntax_Syntax.univs us in
                    (if
                       (FStar_List.length insts) <> (FStar_List.length univs1)
                     then
                       (let uu____7039 =
                          let uu____7040 =
                            FStar_All.pipe_left FStar_Util.string_of_int
-                             (FStar_List.length univs1)
-                            in
+                             (FStar_List.length univs1) in
                          let uu____7041 =
                            FStar_All.pipe_left FStar_Util.string_of_int
-                             (FStar_List.length insts)
-                            in
+                             (FStar_List.length insts) in
                          let uu____7042 =
                            FStar_Syntax_Print.lid_to_string
-                             ed.FStar_Syntax_Syntax.mname
-                            in
-                         let uu____7043 = FStar_Syntax_Print.term_to_string t
-                            in
+                             ed.FStar_Syntax_Syntax.mname in
+                         let uu____7043 = FStar_Syntax_Print.term_to_string t in
                          FStar_Util.format4
                            "Expected %s instantiations; got %s; failed universe instantiation in effect %s\n\t%s\n"
-                           uu____7040 uu____7041 uu____7042 uu____7043
-                          in
+                           uu____7040 uu____7041 uu____7042 uu____7043 in
                        failwith uu____7039)
                     else ();
                     (let uu____7045 =
                        inst_tscheme_with
                          ((FStar_List.append ed.FStar_Syntax_Syntax.univs us),
-                           t) insts
-                        in
+                           t) insts in
                      FStar_Pervasives_Native.snd uu____7045))
                | uu____7052 ->
                    let uu____7053 =
                      let uu____7054 =
                        FStar_Syntax_Print.lid_to_string
-                         ed.FStar_Syntax_Syntax.mname
-                        in
+                         ed.FStar_Syntax_Syntax.mname in
                      FStar_Util.format1
                        "Unexpected use of an uninstantiated effect: %s\n"
-                       uu____7054
-                      in
+                       uu____7054 in
                    failwith uu____7053)
-  
 type tri =
-  | Yes 
-  | No 
-  | Maybe [@@deriving show]
-let (uu___is_Yes : tri -> Prims.bool) =
-  fun projectee  -> match projectee with | Yes  -> true | uu____7058 -> false 
-let (uu___is_No : tri -> Prims.bool) =
-  fun projectee  -> match projectee with | No  -> true | uu____7062 -> false 
-let (uu___is_Maybe : tri -> Prims.bool) =
+  | Yes
+  | No
+  | Maybe[@@deriving show]
+let uu___is_Yes: tri -> Prims.bool =
+  fun projectee  -> match projectee with | Yes  -> true | uu____7058 -> false
+let uu___is_No: tri -> Prims.bool =
+  fun projectee  -> match projectee with | No  -> true | uu____7062 -> false
+let uu___is_Maybe: tri -> Prims.bool =
   fun projectee  ->
     match projectee with | Maybe  -> true | uu____7066 -> false
-  
-let (in_cur_mod : env -> FStar_Ident.lident -> tri) =
+let in_cur_mod: env -> FStar_Ident.lident -> tri =
   fun env  ->
     fun l  ->
-      let cur = current_module env  in
+      let cur = current_module env in
       if l.FStar_Ident.nsstr = cur.FStar_Ident.str
       then Yes
       else
         if FStar_Util.starts_with l.FStar_Ident.nsstr cur.FStar_Ident.str
         then
-          (let lns = FStar_List.append l.FStar_Ident.ns [l.FStar_Ident.ident]
-              in
+          (let lns = FStar_List.append l.FStar_Ident.ns [l.FStar_Ident.ident] in
            let cur1 =
-             FStar_List.append cur.FStar_Ident.ns [cur.FStar_Ident.ident]  in
+             FStar_List.append cur.FStar_Ident.ns [cur.FStar_Ident.ident] in
            let rec aux c l1 =
              match (c, l1) with
              | ([],uu____7100) -> Maybe
@@ -2171,10 +2034,9 @@ let (in_cur_mod : env -> FStar_Ident.lident -> tri) =
              | (hd1::tl1,hd'::tl') when
                  hd1.FStar_Ident.idText = hd'.FStar_Ident.idText ->
                  aux tl1 tl'
-             | uu____7126 -> No  in
+             | uu____7126 -> No in
            aux cur1 lns)
         else No
-  
 type qninfo =
   (((FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.typ)
       FStar_Pervasives_Native.tuple2,(FStar_Syntax_Syntax.sigelt,FStar_Syntax_Syntax.universes
@@ -2183,19 +2045,18 @@ type qninfo =
      FStar_Util.either,FStar_Range.range)
     FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option[@@deriving
                                                                    show]
-let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
+let lookup_qname: env -> FStar_Ident.lident -> qninfo =
   fun env  ->
     fun lid  ->
-      let cur_mod = in_cur_mod env lid  in
+      let cur_mod = in_cur_mod env lid in
       let cache t =
         FStar_Util.smap_add (gamma_cache env) lid.FStar_Ident.str t;
-        FStar_Pervasives_Native.Some t  in
+        FStar_Pervasives_Native.Some t in
       let found =
         if cur_mod <> No
         then
           let uu____7211 =
-            FStar_Util.smap_try_find (gamma_cache env) lid.FStar_Ident.str
-             in
+            FStar_Util.smap_try_find (gamma_cache env) lid.FStar_Ident.str in
           match uu____7211 with
           | FStar_Pervasives_Native.None  ->
               FStar_Util.find_map env.gamma
@@ -2206,9 +2067,9 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                        then
                          let uu____7299 =
                            let uu____7318 =
-                             let uu____7333 = inst_tscheme t  in
-                             FStar_Util.Inl uu____7333  in
-                           (uu____7318, (FStar_Ident.range_of_lid l))  in
+                             let uu____7333 = inst_tscheme t in
+                             FStar_Util.Inl uu____7333 in
+                           (uu____7318, (FStar_Ident.range_of_lid l)) in
                          FStar_Pervasives_Native.Some uu____7299
                        else FStar_Pervasives_Native.None
                    | Binding_sig
@@ -2229,8 +2090,7 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                               FStar_All.pipe_right
                                 (FStar_Syntax_Util.lids_of_sigelt se)
                                 (FStar_Util.for_some
-                                   (FStar_Ident.lid_equals lid))
-                               in
+                                   (FStar_Ident.lid_equals lid)) in
                             if uu____7425
                             then
                               cache
@@ -2243,10 +2103,9 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                          match s.FStar_Syntax_Syntax.sigel with
                          | FStar_Syntax_Syntax.Sig_declare_typ uu____7471 ->
                              FStar_Pervasives_Native.Some t
-                         | uu____7478 -> cache t  in
+                         | uu____7478 -> cache t in
                        let uu____7479 =
-                         FStar_List.tryFind (FStar_Ident.lid_equals lid) lids
-                          in
+                         FStar_List.tryFind (FStar_Ident.lid_equals lid) lids in
                        (match uu____7479 with
                         | FStar_Pervasives_Native.None  ->
                             FStar_Pervasives_Native.None
@@ -2257,8 +2116,7 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                                 (FStar_Ident.range_of_lid l)))
                    | Binding_sig_inst (lids,s,us) ->
                        let uu____7554 =
-                         FStar_List.tryFind (FStar_Ident.lid_equals lid) lids
-                          in
+                         FStar_List.tryFind (FStar_Ident.lid_equals lid) lids in
                        (match uu____7554 with
                         | FStar_Pervasives_Native.None  ->
                             FStar_Pervasives_Native.None
@@ -2269,26 +2127,25 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                                 (FStar_Ident.range_of_lid l)))
                    | uu____7640 -> FStar_Pervasives_Native.None)
           | se -> se
-        else FStar_Pervasives_Native.None  in
+        else FStar_Pervasives_Native.None in
       if FStar_Util.is_some found
       then found
       else
-        (let uu____7700 = find_in_sigtab env lid  in
+        (let uu____7700 = find_in_sigtab env lid in
          match uu____7700 with
          | FStar_Pervasives_Native.Some se ->
              FStar_Pervasives_Native.Some
                ((FStar_Util.Inr (se, FStar_Pervasives_Native.None)),
                  (FStar_Syntax_Util.range_of_sigelt se))
          | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None)
-  
-let rec (add_sigelt : env -> FStar_Syntax_Syntax.sigelt -> Prims.unit) =
+let rec add_sigelt: env -> FStar_Syntax_Syntax.sigelt -> Prims.unit =
   fun env  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_bundle (ses,uu____7779) ->
           add_sigelts env ses
       | uu____7788 ->
-          let lids = FStar_Syntax_Util.lids_of_sigelt se  in
+          let lids = FStar_Syntax_Util.lids_of_sigelt se in
           (FStar_List.iter
              (fun l  -> FStar_Util.smap_add (sigtab env) l.FStar_Ident.str se)
              lids;
@@ -2299,23 +2156,19 @@ let rec (add_sigelt : env -> FStar_Syntax_Syntax.sigelt -> Prims.unit) =
                      (fun a  ->
                         let se_let =
                           FStar_Syntax_Util.action_as_lb
-                            ne.FStar_Syntax_Syntax.mname a
-                           in
+                            ne.FStar_Syntax_Syntax.mname a in
                         FStar_Util.smap_add (sigtab env)
                           (a.FStar_Syntax_Syntax.action_name).FStar_Ident.str
                           se_let))
             | uu____7802 -> ()))
-
-and (add_sigelts :
-  env -> FStar_Syntax_Syntax.sigelt Prims.list -> Prims.unit) =
+and add_sigelts: env -> FStar_Syntax_Syntax.sigelt Prims.list -> Prims.unit =
   fun env  ->
     fun ses  -> FStar_All.pipe_right ses (FStar_List.iter (add_sigelt env))
-
-let (try_lookup_bv :
+let try_lookup_bv:
   env ->
     FStar_Syntax_Syntax.bv ->
       (FStar_Syntax_Syntax.typ,FStar_Range.range)
-        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun bv  ->
@@ -2327,14 +2180,13 @@ let (try_lookup_bv :
                  ((id1.FStar_Syntax_Syntax.sort),
                    ((id1.FStar_Syntax_Syntax.ppname).FStar_Ident.idRange))
            | uu____7847 -> FStar_Pervasives_Native.None)
-  
-let (lookup_type_of_let :
+let lookup_type_of_let:
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.sigelt ->
       FStar_Ident.lident ->
         ((FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.term)
            FStar_Pervasives_Native.tuple2,FStar_Range.range)
-          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun us_opt  ->
     fun se  ->
@@ -2342,20 +2194,18 @@ let (lookup_type_of_let :
         let inst_tscheme1 ts =
           match us_opt with
           | FStar_Pervasives_Native.None  -> inst_tscheme ts
-          | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us  in
+          | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us in
         match se.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_let ((uu____7900,lb::[]),uu____7902) ->
             let uu____7915 =
               let uu____7924 =
                 inst_tscheme1
                   ((lb.FStar_Syntax_Syntax.lbunivs),
-                    (lb.FStar_Syntax_Syntax.lbtyp))
-                 in
+                    (lb.FStar_Syntax_Syntax.lbtyp)) in
               let uu____7933 =
                 FStar_Syntax_Syntax.range_of_lbname
-                  lb.FStar_Syntax_Syntax.lbname
-                 in
-              (uu____7924, uu____7933)  in
+                  lb.FStar_Syntax_Syntax.lbname in
+              (uu____7924, uu____7933) in
             FStar_Pervasives_Native.Some uu____7915
         | FStar_Syntax_Syntax.Sig_let ((uu____7946,lbs),uu____7948) ->
             FStar_Util.find_map lbs
@@ -2363,36 +2213,32 @@ let (lookup_type_of_let :
                  match lb.FStar_Syntax_Syntax.lbname with
                  | FStar_Util.Inl uu____7984 -> failwith "impossible"
                  | FStar_Util.Inr fv ->
-                     let uu____7996 = FStar_Syntax_Syntax.fv_eq_lid fv lid
-                        in
+                     let uu____7996 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
                      if uu____7996
                      then
                        let uu____8007 =
                          let uu____8016 =
                            inst_tscheme1
                              ((lb.FStar_Syntax_Syntax.lbunivs),
-                               (lb.FStar_Syntax_Syntax.lbtyp))
-                            in
-                         let uu____8025 = FStar_Syntax_Syntax.range_of_fv fv
-                            in
-                         (uu____8016, uu____8025)  in
+                               (lb.FStar_Syntax_Syntax.lbtyp)) in
+                         let uu____8025 = FStar_Syntax_Syntax.range_of_fv fv in
+                         (uu____8016, uu____8025) in
                        FStar_Pervasives_Native.Some uu____8007
                      else FStar_Pervasives_Native.None)
         | uu____8047 -> FStar_Pervasives_Native.None
-  
-let (effect_signature :
+let effect_signature:
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.sigelt ->
       ((FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.term)
          FStar_Pervasives_Native.tuple2,FStar_Range.range)
-        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun us_opt  ->
     fun se  ->
       let inst_tscheme1 ts =
         match us_opt with
         | FStar_Pervasives_Native.None  -> inst_tscheme ts
-        | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us  in
+        | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us in
       match se.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_new_effect ne ->
           let uu____8100 =
@@ -2401,14 +2247,12 @@ let (effect_signature :
                 let uu____8115 =
                   let uu____8118 =
                     FStar_Syntax_Syntax.mk_Total
-                      ne.FStar_Syntax_Syntax.signature
-                     in
+                      ne.FStar_Syntax_Syntax.signature in
                   FStar_Syntax_Util.arrow ne.FStar_Syntax_Syntax.binders
-                    uu____8118
-                   in
-                ((ne.FStar_Syntax_Syntax.univs), uu____8115)  in
-              inst_tscheme1 uu____8114  in
-            (uu____8109, (se.FStar_Syntax_Syntax.sigrng))  in
+                    uu____8118 in
+                ((ne.FStar_Syntax_Syntax.univs), uu____8115) in
+              inst_tscheme1 uu____8114 in
+            (uu____8109, (se.FStar_Syntax_Syntax.sigrng)) in
           FStar_Pervasives_Native.Some uu____8100
       | FStar_Syntax_Syntax.Sig_effect_abbrev
           (lid,us,binders,uu____8138,uu____8139) ->
@@ -2417,22 +2261,21 @@ let (effect_signature :
               let uu____8158 =
                 let uu____8159 =
                   let uu____8162 =
-                    FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.teff  in
-                  FStar_Syntax_Util.arrow binders uu____8162  in
-                (us, uu____8159)  in
-              inst_tscheme1 uu____8158  in
-            (uu____8153, (se.FStar_Syntax_Syntax.sigrng))  in
+                    FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.teff in
+                  FStar_Syntax_Util.arrow binders uu____8162 in
+                (us, uu____8159) in
+              inst_tscheme1 uu____8158 in
+            (uu____8153, (se.FStar_Syntax_Syntax.sigrng)) in
           FStar_Pervasives_Native.Some uu____8144
       | uu____8179 -> FStar_Pervasives_Native.None
-  
-let (try_lookup_lid_aux :
+let try_lookup_lid_aux:
   FStar_Syntax_Syntax.universes FStar_Pervasives_Native.option ->
     env ->
       FStar_Ident.lident ->
         ((FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.term'
                                           FStar_Syntax_Syntax.syntax)
            FStar_Pervasives_Native.tuple2,FStar_Range.range)
-          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun us_opt  ->
     fun env  ->
@@ -2440,7 +2283,7 @@ let (try_lookup_lid_aux :
         let inst_tscheme1 ts =
           match us_opt with
           | FStar_Pervasives_Native.None  -> inst_tscheme ts
-          | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us  in
+          | FStar_Pervasives_Native.Some us -> inst_tscheme_with ts us in
         let mapper uu____8257 =
           match uu____8257 with
           | (lr,rng) ->
@@ -2458,8 +2301,8 @@ let (try_lookup_lid_aux :
                     )
                    ->
                    let uu____8383 =
-                     let uu____8392 = inst_tscheme1 (uvs, t)  in
-                     (uu____8392, rng)  in
+                     let uu____8392 = inst_tscheme1 (uvs, t) in
+                     (uu____8392, rng) in
                    FStar_Pervasives_Native.Some uu____8383
                | FStar_Util.Inr
                    ({
@@ -2472,26 +2315,24 @@ let (try_lookup_lid_aux :
                     )
                    ->
                    let uu____8432 =
-                     let uu____8433 = in_cur_mod env l  in uu____8433 = Yes
-                      in
+                     let uu____8433 = in_cur_mod env l in uu____8433 = Yes in
                    if uu____8432
                    then
                      let uu____8444 =
                        (FStar_All.pipe_right qs
                           (FStar_List.contains FStar_Syntax_Syntax.Assumption))
-                         || env.is_iface
-                        in
+                         || env.is_iface in
                      (if uu____8444
                       then
                         let uu____8457 =
-                          let uu____8466 = inst_tscheme1 (uvs, t)  in
-                          (uu____8466, rng)  in
+                          let uu____8466 = inst_tscheme1 (uvs, t) in
+                          (uu____8466, rng) in
                         FStar_Pervasives_Native.Some uu____8457
                       else FStar_Pervasives_Native.None)
                    else
                      (let uu____8493 =
-                        let uu____8502 = inst_tscheme1 (uvs, t)  in
-                        (uu____8502, rng)  in
+                        let uu____8502 = inst_tscheme1 (uvs, t) in
+                        (uu____8502, rng) in
                       FStar_Pervasives_Native.Some uu____8493)
                | FStar_Util.Inr
                    ({
@@ -2507,8 +2348,8 @@ let (try_lookup_lid_aux :
                    (match tps with
                     | [] ->
                         let uu____8567 =
-                          let uu____8576 = inst_tscheme1 (uvs, k)  in
-                          (uu____8576, rng)  in
+                          let uu____8576 = inst_tscheme1 (uvs, k) in
+                          (uu____8576, rng) in
                         FStar_Pervasives_Native.Some uu____8567
                     | uu____8593 ->
                         let uu____8594 =
@@ -2516,12 +2357,11 @@ let (try_lookup_lid_aux :
                             let uu____8608 =
                               let uu____8609 =
                                 let uu____8612 =
-                                  FStar_Syntax_Syntax.mk_Total k  in
-                                FStar_Syntax_Util.flat_arrow tps uu____8612
-                                 in
-                              (uvs, uu____8609)  in
-                            inst_tscheme1 uu____8608  in
-                          (uu____8603, rng)  in
+                                  FStar_Syntax_Syntax.mk_Total k in
+                                FStar_Syntax_Util.flat_arrow tps uu____8612 in
+                              (uvs, uu____8609) in
+                            inst_tscheme1 uu____8608 in
+                          (uu____8603, rng) in
                         FStar_Pervasives_Native.Some uu____8594)
                | FStar_Util.Inr
                    ({
@@ -2537,8 +2377,8 @@ let (try_lookup_lid_aux :
                    (match tps with
                     | [] ->
                         let uu____8678 =
-                          let uu____8687 = inst_tscheme_with (uvs, k) us  in
-                          (uu____8687, rng)  in
+                          let uu____8687 = inst_tscheme_with (uvs, k) us in
+                          (uu____8687, rng) in
                         FStar_Pervasives_Native.Some uu____8678
                     | uu____8704 ->
                         let uu____8705 =
@@ -2546,12 +2386,11 @@ let (try_lookup_lid_aux :
                             let uu____8719 =
                               let uu____8720 =
                                 let uu____8723 =
-                                  FStar_Syntax_Syntax.mk_Total k  in
-                                FStar_Syntax_Util.flat_arrow tps uu____8723
-                                 in
-                              (uvs, uu____8720)  in
-                            inst_tscheme_with uu____8719 us  in
-                          (uu____8714, rng)  in
+                                  FStar_Syntax_Syntax.mk_Total k in
+                                FStar_Syntax_Util.flat_arrow tps uu____8723 in
+                              (uvs, uu____8720) in
+                            inst_tscheme_with uu____8719 us in
+                          (uu____8714, rng) in
                         FStar_Pervasives_Native.Some uu____8705)
                | FStar_Util.Inr se ->
                    let uu____8757 =
@@ -2568,22 +2407,20 @@ let (try_lookup_lid_aux :
                            (FStar_Pervasives_Native.fst se) lid
                      | uu____8797 ->
                          effect_signature us_opt
-                           (FStar_Pervasives_Native.fst se)
-                      in
+                           (FStar_Pervasives_Native.fst se) in
                    FStar_All.pipe_right uu____8757
                      (FStar_Util.map_option
                         (fun uu____8845  ->
                            match uu____8845 with
-                           | (us_t,rng1) -> (us_t, rng1))))
-           in
+                           | (us_t,rng1) -> (us_t, rng1)))) in
         let uu____8876 =
-          let uu____8887 = lookup_qname env lid  in
-          FStar_Util.bind_opt uu____8887 mapper  in
+          let uu____8887 = lookup_qname env lid in
+          FStar_Util.bind_opt uu____8887 mapper in
         match uu____8876 with
         | FStar_Pervasives_Native.Some ((us,t),r) ->
             FStar_Pervasives_Native.Some
               ((us,
-                 (let uu___95_8980 = t  in
+                 (let uu___95_8980 = t in
                   {
                     FStar_Syntax_Syntax.n =
                       (uu___95_8980.FStar_Syntax_Syntax.n);
@@ -2592,104 +2429,95 @@ let (try_lookup_lid_aux :
                       (uu___95_8980.FStar_Syntax_Syntax.vars)
                   })), r)
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
-  
-let (lid_exists : env -> FStar_Ident.lident -> Prims.bool) =
+let lid_exists: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun l  ->
-      let uu____9005 = lookup_qname env l  in
+      let uu____9005 = lookup_qname env l in
       match uu____9005 with
       | FStar_Pervasives_Native.None  -> false
       | FStar_Pervasives_Native.Some uu____9024 -> true
-  
-let (lookup_bv :
+let lookup_bv:
   env ->
     FStar_Syntax_Syntax.bv ->
       (FStar_Syntax_Syntax.typ,FStar_Range.range)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun bv  ->
-      let bvr = FStar_Syntax_Syntax.range_of_bv bv  in
-      let uu____9072 = try_lookup_bv env bv  in
+      let bvr = FStar_Syntax_Syntax.range_of_bv bv in
+      let uu____9072 = try_lookup_bv env bv in
       match uu____9072 with
       | FStar_Pervasives_Native.None  ->
-          let uu____9087 = variable_not_found bv  in
+          let uu____9087 = variable_not_found bv in
           FStar_Errors.raise_error uu____9087 bvr
       | FStar_Pervasives_Native.Some (t,r) ->
-          let uu____9102 = FStar_Syntax_Subst.set_use_range bvr t  in
+          let uu____9102 = FStar_Syntax_Subst.set_use_range bvr t in
           let uu____9103 =
-            let uu____9104 = FStar_Range.use_range bvr  in
-            FStar_Range.set_use_range r uu____9104  in
+            let uu____9104 = FStar_Range.use_range bvr in
+            FStar_Range.set_use_range r uu____9104 in
           (uu____9102, uu____9103)
-  
-let (try_lookup_lid :
+let try_lookup_lid:
   env ->
     FStar_Ident.lident ->
       ((FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.typ)
          FStar_Pervasives_Native.tuple2,FStar_Range.range)
-        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
-      let uu____9121 = try_lookup_lid_aux FStar_Pervasives_Native.None env l
-         in
+      let uu____9121 = try_lookup_lid_aux FStar_Pervasives_Native.None env l in
       match uu____9121 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some ((us,t),r) ->
-          let use_range1 = FStar_Ident.range_of_lid l  in
+          let use_range1 = FStar_Ident.range_of_lid l in
           let r1 =
-            let uu____9187 = FStar_Range.use_range use_range1  in
-            FStar_Range.set_use_range r uu____9187  in
+            let uu____9187 = FStar_Range.use_range use_range1 in
+            FStar_Range.set_use_range r uu____9187 in
           let uu____9188 =
             let uu____9197 =
-              let uu____9202 = FStar_Syntax_Subst.set_use_range use_range1 t
-                 in
-              (us, uu____9202)  in
-            (uu____9197, r1)  in
+              let uu____9202 = FStar_Syntax_Subst.set_use_range use_range1 t in
+              (us, uu____9202) in
+            (uu____9197, r1) in
           FStar_Pervasives_Native.Some uu____9188
-  
-let (try_lookup_and_inst_lid :
+let try_lookup_and_inst_lid:
   env ->
     FStar_Syntax_Syntax.universes ->
       FStar_Ident.lident ->
         (FStar_Syntax_Syntax.typ,FStar_Range.range)
-          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun us  ->
       fun l  ->
         let uu____9230 =
-          try_lookup_lid_aux (FStar_Pervasives_Native.Some us) env l  in
+          try_lookup_lid_aux (FStar_Pervasives_Native.Some us) env l in
         match uu____9230 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some ((uu____9263,t),r) ->
-            let use_range1 = FStar_Ident.range_of_lid l  in
+            let use_range1 = FStar_Ident.range_of_lid l in
             let r1 =
-              let uu____9288 = FStar_Range.use_range use_range1  in
-              FStar_Range.set_use_range r uu____9288  in
+              let uu____9288 = FStar_Range.use_range use_range1 in
+              FStar_Range.set_use_range r uu____9288 in
             let uu____9289 =
-              let uu____9294 = FStar_Syntax_Subst.set_use_range use_range1 t
-                 in
-              (uu____9294, r1)  in
+              let uu____9294 = FStar_Syntax_Subst.set_use_range use_range1 t in
+              (uu____9294, r1) in
             FStar_Pervasives_Native.Some uu____9289
-  
-let (lookup_lid :
+let lookup_lid:
   env ->
     FStar_Ident.lident ->
       ((FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.typ)
          FStar_Pervasives_Native.tuple2,FStar_Range.range)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun l  ->
-      let uu____9313 = try_lookup_lid env l  in
+      let uu____9313 = try_lookup_lid env l in
       match uu____9313 with
       | FStar_Pervasives_Native.None  ->
-          let uu____9340 = name_not_found l  in
+          let uu____9340 = name_not_found l in
           FStar_Errors.raise_error uu____9340 (FStar_Ident.range_of_lid l)
       | FStar_Pervasives_Native.Some v1 -> v1
-  
-let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
+let lookup_univ: env -> FStar_Syntax_Syntax.univ_name -> Prims.bool =
   fun env  ->
     fun x  ->
       FStar_All.pipe_right
@@ -2698,16 +2526,15 @@ let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
               match uu___75_9380 with
               | Binding_univ y -> x.FStar_Ident.idText = y.FStar_Ident.idText
               | uu____9382 -> false) env.gamma) FStar_Option.isSome
-  
-let (try_lookup_val_decl :
+let try_lookup_val_decl:
   env ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.tscheme,FStar_Syntax_Syntax.qualifier Prims.list)
-        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun lid  ->
-      let uu____9397 = lookup_qname env lid  in
+      let uu____9397 = lookup_qname env lid in
       match uu____9397 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -2724,22 +2551,20 @@ let (try_lookup_val_decl :
             let uu____9473 =
               let uu____9478 =
                 FStar_Syntax_Subst.set_use_range
-                  (FStar_Ident.range_of_lid lid) t
-                 in
-              (uvs, uu____9478)  in
-            (uu____9473, q)  in
+                  (FStar_Ident.range_of_lid lid) t in
+              (uvs, uu____9478) in
+            (uu____9473, q) in
           FStar_Pervasives_Native.Some uu____9462
       | uu____9495 -> FStar_Pervasives_Native.None
-  
-let (lookup_val_decl :
+let lookup_val_decl:
   env ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.typ)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun lid  ->
-      let uu____9512 = lookup_qname env lid  in
+      let uu____9512 = lookup_qname env lid in
       match uu____9512 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -2753,18 +2578,17 @@ let (lookup_val_decl :
             ),uu____9524)
           -> inst_tscheme_with_range (FStar_Ident.range_of_lid lid) (uvs, t)
       | uu____9573 ->
-          let uu____9574 = name_not_found lid  in
+          let uu____9574 = name_not_found lid in
           FStar_Errors.raise_error uu____9574 (FStar_Ident.range_of_lid lid)
-  
-let (lookup_datacon :
+let lookup_datacon:
   env ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.universes,FStar_Syntax_Syntax.typ)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun lid  ->
-      let uu____9593 = lookup_qname env lid  in
+      let uu____9593 = lookup_qname env lid in
       match uu____9593 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -2778,18 +2602,17 @@ let (lookup_datacon :
             ),uu____9608)
           -> inst_tscheme_with_range (FStar_Ident.range_of_lid lid) (uvs, t)
       | uu____9661 ->
-          let uu____9662 = name_not_found lid  in
+          let uu____9662 = name_not_found lid in
           FStar_Errors.raise_error uu____9662 (FStar_Ident.range_of_lid lid)
-  
-let (datacons_of_typ :
+let datacons_of_typ:
   env ->
     FStar_Ident.lident ->
       (Prims.bool,FStar_Ident.lident Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun lid  ->
-      let uu____9683 = lookup_qname env lid  in
+      let uu____9683 = lookup_qname env lid in
       match uu____9683 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -2803,11 +2626,10 @@ let (datacons_of_typ :
               FStar_Syntax_Syntax.sigattrs = uu____9699;_},uu____9700),uu____9701)
           -> (true, dcs)
       | uu____9762 -> (false, [])
-  
-let (typ_of_datacon : env -> FStar_Ident.lident -> FStar_Ident.lident) =
+let typ_of_datacon: env -> FStar_Ident.lident -> FStar_Ident.lident =
   fun env  ->
     fun lid  ->
-      let uu____9771 = lookup_qname env lid  in
+      let uu____9771 = lookup_qname env lid in
       match uu____9771 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -2821,16 +2643,15 @@ let (typ_of_datacon : env -> FStar_Ident.lident -> FStar_Ident.lident) =
           -> l
       | uu____9838 ->
           let uu____9839 =
-            let uu____9840 = FStar_Syntax_Print.lid_to_string lid  in
-            FStar_Util.format1 "Not a datacon: %s" uu____9840  in
+            let uu____9840 = FStar_Syntax_Print.lid_to_string lid in
+            FStar_Util.format1 "Not a datacon: %s" uu____9840 in
           failwith uu____9839
-  
-let (lookup_definition_qninfo :
+let lookup_definition_qninfo:
   delta_level Prims.list ->
     FStar_Ident.lident ->
       qninfo ->
         (FStar_Syntax_Syntax.univ_names,FStar_Syntax_Syntax.term)
-          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun delta_levels  ->
     fun lid  ->
@@ -2840,8 +2661,7 @@ let (lookup_definition_qninfo :
             (FStar_Util.for_some
                (fun dl  ->
                   FStar_All.pipe_right quals
-                    (FStar_Util.for_some (visible_at dl))))
-           in
+                    (FStar_Util.for_some (visible_at dl)))) in
         match qninfo with
         | FStar_Pervasives_Native.Some
             (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____9881) ->
@@ -2850,10 +2670,8 @@ let (lookup_definition_qninfo :
                  visible se.FStar_Syntax_Syntax.sigquals ->
                  FStar_Util.find_map lbs
                    (fun lb  ->
-                      let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname
-                         in
-                      let uu____9962 = FStar_Syntax_Syntax.fv_eq_lid fv lid
-                         in
+                      let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
+                      let uu____9962 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
                       if uu____9962
                       then
                         FStar_Pervasives_Native.Some
@@ -2862,24 +2680,22 @@ let (lookup_definition_qninfo :
                       else FStar_Pervasives_Native.None)
              | uu____9994 -> FStar_Pervasives_Native.None)
         | uu____9999 -> FStar_Pervasives_Native.None
-  
-let (lookup_definition :
+let lookup_definition:
   delta_level Prims.list ->
     env ->
       FStar_Ident.lident ->
         (FStar_Syntax_Syntax.univ_names,FStar_Syntax_Syntax.term)
-          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun delta_levels  ->
     fun env  ->
       fun lid  ->
-        let uu____10023 = lookup_qname env lid  in
+        let uu____10023 = lookup_qname env lid in
         FStar_All.pipe_left (lookup_definition_qninfo delta_levels lid)
           uu____10023
-  
-let (attrs_of_qninfo :
+let attrs_of_qninfo:
   qninfo ->
-    FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option
   =
   fun qninfo  ->
     match qninfo with
@@ -2887,62 +2703,56 @@ let (attrs_of_qninfo :
         (FStar_Util.Inr (se,uu____10046),uu____10047) ->
         FStar_Pervasives_Native.Some (se.FStar_Syntax_Syntax.sigattrs)
     | uu____10096 -> FStar_Pervasives_Native.None
-  
-let (lookup_attrs_of_lid :
+let lookup_attrs_of_lid:
   env ->
     FStar_Ident.lid ->
-      FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option
   =
   fun env  ->
     fun lid  ->
-      let uu____10113 = lookup_qname env lid  in
+      let uu____10113 = lookup_qname env lid in
       FStar_All.pipe_left attrs_of_qninfo uu____10113
-  
-let (try_lookup_effect_lid :
+let try_lookup_effect_lid:
   env ->
     FStar_Ident.lident ->
-      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun env  ->
     fun ftv  ->
-      let uu____10128 = lookup_qname env ftv  in
+      let uu____10128 = lookup_qname env ftv in
       match uu____10128 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr (se,FStar_Pervasives_Native.None ),uu____10132) ->
-          let uu____10177 = effect_signature FStar_Pervasives_Native.None se
-             in
+          let uu____10177 = effect_signature FStar_Pervasives_Native.None se in
           (match uu____10177 with
            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
            | FStar_Pervasives_Native.Some ((uu____10198,t),r) ->
                let uu____10213 =
                  FStar_Syntax_Subst.set_use_range
-                   (FStar_Ident.range_of_lid ftv) t
-                  in
+                   (FStar_Ident.range_of_lid ftv) t in
                FStar_Pervasives_Native.Some uu____10213)
       | uu____10214 -> FStar_Pervasives_Native.None
-  
-let (lookup_effect_lid :
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
+let lookup_effect_lid: env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term
+  =
   fun env  ->
     fun ftv  ->
-      let uu____10221 = try_lookup_effect_lid env ftv  in
+      let uu____10221 = try_lookup_effect_lid env ftv in
       match uu____10221 with
       | FStar_Pervasives_Native.None  ->
-          let uu____10224 = name_not_found ftv  in
+          let uu____10224 = name_not_found ftv in
           FStar_Errors.raise_error uu____10224 (FStar_Ident.range_of_lid ftv)
       | FStar_Pervasives_Native.Some k -> k
-  
-let (lookup_effect_abbrev :
+let lookup_effect_abbrev:
   env ->
     FStar_Syntax_Syntax.universes ->
       FStar_Ident.lident ->
         (FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.comp)
-          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun univ_insts  ->
       fun lid0  ->
-        let uu____10245 = lookup_qname env lid0  in
+        let uu____10245 = lookup_qname env lid0 in
         match uu____10245 with
         | FStar_Pervasives_Native.Some
             (FStar_Util.Inr
@@ -2959,19 +2769,17 @@ let (lookup_effect_abbrev :
             let lid1 =
               let uu____10315 =
                 let uu____10316 =
-                  FStar_Range.use_range (FStar_Ident.range_of_lid lid0)  in
+                  FStar_Range.use_range (FStar_Ident.range_of_lid lid0) in
                 FStar_Range.set_use_range (FStar_Ident.range_of_lid lid)
-                  uu____10316
-                 in
-              FStar_Ident.set_lid_range lid uu____10315  in
+                  uu____10316 in
+              FStar_Ident.set_lid_range lid uu____10315 in
             let uu____10317 =
               FStar_All.pipe_right quals
                 (FStar_Util.for_some
                    (fun uu___76_10321  ->
                       match uu___76_10321 with
                       | FStar_Syntax_Syntax.Irreducible  -> true
-                      | uu____10322 -> false))
-               in
+                      | uu____10322 -> false)) in
             if uu____10317
             then FStar_Pervasives_Native.None
             else
@@ -2983,98 +2791,83 @@ let (lookup_effect_abbrev :
                  else
                    (let uu____10336 =
                       let uu____10337 =
-                        let uu____10338 = get_range env  in
-                        FStar_Range.string_of_range uu____10338  in
-                      let uu____10339 = FStar_Syntax_Print.lid_to_string lid1
-                         in
+                        let uu____10338 = get_range env in
+                        FStar_Range.string_of_range uu____10338 in
+                      let uu____10339 = FStar_Syntax_Print.lid_to_string lid1 in
                       let uu____10340 =
                         FStar_All.pipe_right (FStar_List.length univ_insts)
-                          FStar_Util.string_of_int
-                         in
+                          FStar_Util.string_of_int in
                       FStar_Util.format3
                         "(%s) Unexpected instantiation of effect %s with %s universes"
-                        uu____10337 uu____10339 uu____10340
-                       in
-                    failwith uu____10336)
-                  in
+                        uu____10337 uu____10339 uu____10340 in
+                    failwith uu____10336) in
                match (binders, univs1) with
                | ([],uu____10347) ->
                    failwith
                      "Unexpected effect abbreviation with no arguments"
                | (uu____10364,uu____10365::uu____10366::uu____10367) ->
                    let uu____10372 =
-                     let uu____10373 = FStar_Syntax_Print.lid_to_string lid1
-                        in
+                     let uu____10373 = FStar_Syntax_Print.lid_to_string lid1 in
                      let uu____10374 =
                        FStar_All.pipe_left FStar_Util.string_of_int
-                         (FStar_List.length univs1)
-                        in
+                         (FStar_List.length univs1) in
                      FStar_Util.format2
                        "Unexpected effect abbreviation %s; polymorphic in %s universes"
-                       uu____10373 uu____10374
-                      in
+                       uu____10373 uu____10374 in
                    failwith uu____10372
                | uu____10381 ->
                    let uu____10386 =
                      let uu____10391 =
-                       let uu____10392 = FStar_Syntax_Util.arrow binders c
-                          in
-                       (univs1, uu____10392)  in
-                     inst_tscheme_with uu____10391 insts  in
+                       let uu____10392 = FStar_Syntax_Util.arrow binders c in
+                       (univs1, uu____10392) in
+                     inst_tscheme_with uu____10391 insts in
                    (match uu____10386 with
                     | (uu____10403,t) ->
                         let t1 =
                           FStar_Syntax_Subst.set_use_range
-                            (FStar_Ident.range_of_lid lid1) t
-                           in
+                            (FStar_Ident.range_of_lid lid1) t in
                         let uu____10406 =
-                          let uu____10407 = FStar_Syntax_Subst.compress t1
-                             in
-                          uu____10407.FStar_Syntax_Syntax.n  in
+                          let uu____10407 = FStar_Syntax_Subst.compress t1 in
+                          uu____10407.FStar_Syntax_Syntax.n in
                         (match uu____10406 with
                          | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
                              FStar_Pervasives_Native.Some (binders1, c1)
                          | uu____10454 -> failwith "Impossible")))
         | uu____10461 -> FStar_Pervasives_Native.None
-  
-let (norm_eff_name : env -> FStar_Ident.lident -> FStar_Ident.lident) =
-  let cache = FStar_Util.smap_create (Prims.parse_int "20")  in
+let norm_eff_name: env -> FStar_Ident.lident -> FStar_Ident.lident =
+  let cache = FStar_Util.smap_create (Prims.parse_int "20") in
   fun env  ->
     fun l  ->
       let rec find1 l1 =
         let uu____10481 =
-          lookup_effect_abbrev env [FStar_Syntax_Syntax.U_unknown] l1  in
+          lookup_effect_abbrev env [FStar_Syntax_Syntax.U_unknown] l1 in
         match uu____10481 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (uu____10494,c) ->
-            let l2 = FStar_Syntax_Util.comp_effect_name c  in
-            let uu____10501 = find1 l2  in
+            let l2 = FStar_Syntax_Util.comp_effect_name c in
+            let uu____10501 = find1 l2 in
             (match uu____10501 with
              | FStar_Pervasives_Native.None  ->
                  FStar_Pervasives_Native.Some l2
              | FStar_Pervasives_Native.Some l' ->
-                 FStar_Pervasives_Native.Some l')
-         in
+                 FStar_Pervasives_Native.Some l') in
       let res =
-        let uu____10508 = FStar_Util.smap_try_find cache l.FStar_Ident.str
-           in
+        let uu____10508 = FStar_Util.smap_try_find cache l.FStar_Ident.str in
         match uu____10508 with
         | FStar_Pervasives_Native.Some l1 -> l1
         | FStar_Pervasives_Native.None  ->
-            let uu____10512 = find1 l  in
+            let uu____10512 = find1 l in
             (match uu____10512 with
              | FStar_Pervasives_Native.None  -> l
              | FStar_Pervasives_Native.Some m ->
-                 (FStar_Util.smap_add cache l.FStar_Ident.str m; m))
-         in
+                 (FStar_Util.smap_add cache l.FStar_Ident.str m; m)) in
       FStar_Ident.set_lid_range res (FStar_Ident.range_of_lid l)
-  
-let (lookup_effect_quals :
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list) =
+let lookup_effect_quals:
+  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.qualifier Prims.list =
   fun env  ->
     fun l  ->
-      let l1 = norm_eff_name env l  in
-      let uu____10526 = lookup_qname env l1  in
+      let l1 = norm_eff_name env l in
+      let uu____10526 = lookup_qname env l1 in
       match uu____10526 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -3087,27 +2880,25 @@ let (lookup_effect_quals :
               FStar_Syntax_Syntax.sigattrs = uu____10533;_},uu____10534),uu____10535)
           -> q
       | uu____10586 -> []
-  
-let (lookup_projector :
-  env -> FStar_Ident.lident -> Prims.int -> FStar_Ident.lident) =
+let lookup_projector:
+  env -> FStar_Ident.lident -> Prims.int -> FStar_Ident.lident =
   fun env  ->
     fun lid  ->
       fun i  ->
         let fail uu____10599 =
           let uu____10600 =
-            let uu____10601 = FStar_Util.string_of_int i  in
-            let uu____10602 = FStar_Syntax_Print.lid_to_string lid  in
+            let uu____10601 = FStar_Util.string_of_int i in
+            let uu____10602 = FStar_Syntax_Print.lid_to_string lid in
             FStar_Util.format2
               "Impossible: projecting field #%s from constructor %s is undefined"
-              uu____10601 uu____10602
-             in
-          failwith uu____10600  in
-        let uu____10603 = lookup_datacon env lid  in
+              uu____10601 uu____10602 in
+          failwith uu____10600 in
+        let uu____10603 = lookup_datacon env lid in
         match uu____10603 with
         | (uu____10608,t) ->
             let uu____10610 =
-              let uu____10611 = FStar_Syntax_Subst.compress t  in
-              uu____10611.FStar_Syntax_Syntax.n  in
+              let uu____10611 = FStar_Syntax_Subst.compress t in
+              uu____10611.FStar_Syntax_Syntax.n in
             (match uu____10610 with
              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____10615) ->
                  if
@@ -3115,19 +2906,17 @@ let (lookup_projector :
                      (i >= (FStar_List.length binders))
                  then fail ()
                  else
-                   (let b = FStar_List.nth binders i  in
+                   (let b = FStar_List.nth binders i in
                     let uu____10646 =
                       FStar_Syntax_Util.mk_field_projector_name lid
-                        (FStar_Pervasives_Native.fst b) i
-                       in
+                        (FStar_Pervasives_Native.fst b) i in
                     FStar_All.pipe_right uu____10646
                       FStar_Pervasives_Native.fst)
              | uu____10655 -> fail ())
-  
-let (is_projector : env -> FStar_Ident.lident -> Prims.bool) =
+let is_projector: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun l  ->
-      let uu____10662 = lookup_qname env l  in
+      let uu____10662 = lookup_qname env l in
       match uu____10662 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -3145,11 +2934,10 @@ let (is_projector : env -> FStar_Ident.lident -> Prims.bool) =
                | FStar_Syntax_Syntax.Projector uu____10725 -> true
                | uu____10730 -> false) quals
       | uu____10731 -> false
-  
-let (is_datacon : env -> FStar_Ident.lident -> Prims.bool) =
+let is_datacon: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun lid  ->
-      let uu____10738 = lookup_qname env lid  in
+      let uu____10738 = lookup_qname env lid in
       match uu____10738 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -3162,11 +2950,10 @@ let (is_datacon : env -> FStar_Ident.lident -> Prims.bool) =
               FStar_Syntax_Syntax.sigattrs = uu____10748;_},uu____10749),uu____10750)
           -> true
       | uu____10805 -> false
-  
-let (is_record : env -> FStar_Ident.lident -> Prims.bool) =
+let is_record: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun lid  ->
-      let uu____10812 = lookup_qname env lid  in
+      let uu____10812 = lookup_qname env lid in
       match uu____10812 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -3186,8 +2973,7 @@ let (is_record : env -> FStar_Ident.lident -> Prims.bool) =
                | FStar_Syntax_Syntax.RecordConstructor uu____10895 -> true
                | uu____10904 -> false) quals
       | uu____10905 -> false
-  
-let (qninfo_is_action : qninfo -> Prims.bool) =
+let qninfo_is_action: qninfo -> Prims.bool =
   fun qninfo  ->
     match qninfo with
     | FStar_Pervasives_Native.Some
@@ -3206,14 +2992,12 @@ let (qninfo_is_action : qninfo -> Prims.bool) =
              | FStar_Syntax_Syntax.Action uu____10974 -> true
              | uu____10975 -> false) quals
     | uu____10976 -> false
-  
-let (is_action : env -> FStar_Ident.lident -> Prims.bool) =
+let is_action: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun lid  ->
-      let uu____10983 = lookup_qname env lid  in
+      let uu____10983 = lookup_qname env lid in
       FStar_All.pipe_left qninfo_is_action uu____10983
-  
-let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_interpreted: env -> FStar_Syntax_Syntax.term -> Prims.bool =
   let interpreted_symbols =
     [FStar_Parser_Const.op_Eq;
     FStar_Parser_Const.op_notEq;
@@ -3229,22 +3013,21 @@ let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
     FStar_Parser_Const.op_Modulus;
     FStar_Parser_Const.op_And;
     FStar_Parser_Const.op_Or;
-    FStar_Parser_Const.op_Negation]  in
+    FStar_Parser_Const.op_Negation] in
   fun env  ->
     fun head1  ->
       let uu____10993 =
-        let uu____10994 = FStar_Syntax_Util.un_uinst head1  in
-        uu____10994.FStar_Syntax_Syntax.n  in
+        let uu____10994 = FStar_Syntax_Util.un_uinst head1 in
+        uu____10994.FStar_Syntax_Syntax.n in
       match uu____10993 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           fv.FStar_Syntax_Syntax.fv_delta =
             FStar_Syntax_Syntax.Delta_equational
       | uu____10998 -> false
-  
-let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
+let is_irreducible: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun l  ->
-      let uu____11005 = lookup_qname env l  in
+      let uu____11005 = lookup_qname env l in
       match uu____11005 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr (se,uu____11007),uu____11008) ->
@@ -3254,8 +3037,7 @@ let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
                | FStar_Syntax_Syntax.Irreducible  -> true
                | uu____11057 -> false) se.FStar_Syntax_Syntax.sigquals
       | uu____11058 -> false
-  
-let (is_type_constructor : env -> FStar_Ident.lident -> Prims.bool) =
+let is_type_constructor: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun lid  ->
       let mapper x =
@@ -3269,19 +3051,17 @@ let (is_type_constructor : env -> FStar_Ident.lident -> Prims.bool) =
                       se.FStar_Syntax_Syntax.sigquals)
              | FStar_Syntax_Syntax.Sig_inductive_typ uu____11163 ->
                  FStar_Pervasives_Native.Some true
-             | uu____11180 -> FStar_Pervasives_Native.Some false)
-         in
+             | uu____11180 -> FStar_Pervasives_Native.Some false) in
       let uu____11181 =
-        let uu____11184 = lookup_qname env lid  in
-        FStar_Util.bind_opt uu____11184 mapper  in
+        let uu____11184 = lookup_qname env lid in
+        FStar_Util.bind_opt uu____11184 mapper in
       match uu____11181 with
       | FStar_Pervasives_Native.Some b -> b
       | FStar_Pervasives_Native.None  -> false
-  
-let (num_inductive_ty_params : env -> FStar_Ident.lident -> Prims.int) =
+let num_inductive_ty_params: env -> FStar_Ident.lident -> Prims.int =
   fun env  ->
     fun lid  ->
-      let uu____11230 = lookup_qname env lid  in
+      let uu____11230 = lookup_qname env lid in
       match uu____11230 with
       | FStar_Pervasives_Native.Some
           (FStar_Util.Inr
@@ -3295,14 +3075,13 @@ let (num_inductive_ty_params : env -> FStar_Ident.lident -> Prims.int) =
               FStar_Syntax_Syntax.sigattrs = uu____11240;_},uu____11241),uu____11242)
           -> FStar_List.length tps
       | uu____11305 ->
-          let uu____11306 = name_not_found lid  in
+          let uu____11306 = name_not_found lid in
           FStar_Errors.raise_error uu____11306 (FStar_Ident.range_of_lid lid)
-  
-let (effect_decl_opt :
+let effect_decl_opt:
   env ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.eff_decl,FStar_Syntax_Syntax.qualifier Prims.list)
-        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l  ->
@@ -3312,31 +3091,29 @@ let (effect_decl_opt :
               match uu____11350 with
               | (d,uu____11358) ->
                   FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l))
-  
-let (get_effect_decl :
-  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl) =
+let get_effect_decl:
+  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl =
   fun env  ->
     fun l  ->
-      let uu____11369 = effect_decl_opt env l  in
+      let uu____11369 = effect_decl_opt env l in
       match uu____11369 with
       | FStar_Pervasives_Native.None  ->
-          let uu____11384 = name_not_found l  in
+          let uu____11384 = name_not_found l in
           FStar_Errors.raise_error uu____11384 (FStar_Ident.range_of_lid l)
       | FStar_Pervasives_Native.Some md -> FStar_Pervasives_Native.fst md
-  
-let (identity_mlift : mlift) =
+let identity_mlift: mlift =
   {
     mlift_wp = (fun uu____11410  -> fun t  -> fun wp  -> wp);
     mlift_term =
       (FStar_Pervasives_Native.Some
          (fun uu____11425  ->
             fun t  -> fun wp  -> fun e  -> FStar_Util.return_all e))
-  } 
-let (join :
+  }
+let join:
   env ->
     FStar_Ident.lident ->
       FStar_Ident.lident ->
-        (FStar_Ident.lident,mlift,mlift) FStar_Pervasives_Native.tuple3)
+        (FStar_Ident.lident,mlift,mlift) FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun l1  ->
@@ -3363,30 +3140,24 @@ let (join :
                        match uu____11511 with
                        | (m1,m2,uu____11524,uu____11525,uu____11526) ->
                            (FStar_Ident.lid_equals l1 m1) &&
-                             (FStar_Ident.lid_equals l2 m2)))
-                in
+                             (FStar_Ident.lid_equals l2 m2))) in
              match uu____11458 with
              | FStar_Pervasives_Native.None  ->
                  let uu____11543 =
                    let uu____11548 =
-                     let uu____11549 = FStar_Syntax_Print.lid_to_string l1
-                        in
-                     let uu____11550 = FStar_Syntax_Print.lid_to_string l2
-                        in
+                     let uu____11549 = FStar_Syntax_Print.lid_to_string l1 in
+                     let uu____11550 = FStar_Syntax_Print.lid_to_string l2 in
                      FStar_Util.format2
                        "Effects %s and %s cannot be composed" uu____11549
-                       uu____11550
-                      in
-                   (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____11548)
-                    in
+                       uu____11550 in
+                   (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____11548) in
                  FStar_Errors.raise_error uu____11543 env.range
              | FStar_Pervasives_Native.Some
                  (uu____11557,uu____11558,m3,j1,j2) -> (m3, j1, j2))
-  
-let (monad_leq :
+let monad_leq:
   env ->
     FStar_Ident.lident ->
-      FStar_Ident.lident -> edge FStar_Pervasives_Native.option)
+      FStar_Ident.lident -> edge FStar_Pervasives_Native.option
   =
   fun env  ->
     fun l1  ->
@@ -3404,8 +3175,7 @@ let (monad_leq :
                (fun e  ->
                   (FStar_Ident.lid_equals l1 e.msource) &&
                     (FStar_Ident.lid_equals l2 e.mtarget)))
-  
-let wp_sig_aux :
+let wp_sig_aux:
   'Auu____11595 .
     (FStar_Syntax_Syntax.eff_decl,'Auu____11595)
       FStar_Pervasives_Native.tuple2 Prims.list ->
@@ -3422,25 +3192,22 @@ let wp_sig_aux :
              (fun uu____11648  ->
                 match uu____11648 with
                 | (d,uu____11654) ->
-                    FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m))
-         in
+                    FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m)) in
       match uu____11622 with
       | FStar_Pervasives_Native.None  ->
           let uu____11665 =
             FStar_Util.format1
               "Impossible: declaration for monad %s not found"
-              m.FStar_Ident.str
-             in
+              m.FStar_Ident.str in
           failwith uu____11665
       | FStar_Pervasives_Native.Some (md,_q) ->
           let uu____11678 =
             inst_tscheme
               ((md.FStar_Syntax_Syntax.univs),
-                (md.FStar_Syntax_Syntax.signature))
-             in
+                (md.FStar_Syntax_Syntax.signature)) in
           (match uu____11678 with
            | (uu____11689,s) ->
-               let s1 = FStar_Syntax_Subst.compress s  in
+               let s1 = FStar_Syntax_Subst.compress s in
                (match ((md.FStar_Syntax_Syntax.binders),
                         (s1.FStar_Syntax_Syntax.n))
                 with
@@ -3450,18 +3217,17 @@ let wp_sig_aux :
                       (FStar_Syntax_Util.comp_result c)
                     -> (a, (wp.FStar_Syntax_Syntax.sort))
                 | uu____11737 -> failwith "Impossible"))
-  
-let (wp_signature :
+let wp_signature:
   env ->
     FStar_Ident.lident ->
       (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.term)
-        FStar_Pervasives_Native.tuple2)
-  = fun env  -> fun m  -> wp_sig_aux (env.effects).decls m 
-let (null_wp_for_eff :
+        FStar_Pervasives_Native.tuple2
+  = fun env  -> fun m  -> wp_sig_aux (env.effects).decls m
+let null_wp_for_eff:
   env ->
     FStar_Ident.lident ->
       FStar_Syntax_Syntax.universe ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.comp)
+        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.comp
   =
   fun env  ->
     fun eff_name  ->
@@ -3480,53 +3246,49 @@ let (null_wp_for_eff :
               FStar_Syntax_Syntax.mk_GTotal' res_t
                 (FStar_Pervasives_Native.Some res_u)
             else
-              (let eff_name1 = norm_eff_name env eff_name  in
-               let ed = get_effect_decl env eff_name1  in
+              (let eff_name1 = norm_eff_name env eff_name in
+               let ed = get_effect_decl env eff_name1 in
                let null_wp =
                  inst_effect_fun_with [res_u] env ed
-                   ed.FStar_Syntax_Syntax.null_wp
-                  in
+                   ed.FStar_Syntax_Syntax.null_wp in
                let null_wp_res =
-                 let uu____11780 = get_range env  in
+                 let uu____11780 = get_range env in
                  let uu____11781 =
                    let uu____11784 =
                      let uu____11785 =
                        let uu____11800 =
-                         let uu____11803 = FStar_Syntax_Syntax.as_arg res_t
-                            in
-                         [uu____11803]  in
-                       (null_wp, uu____11800)  in
-                     FStar_Syntax_Syntax.Tm_app uu____11785  in
-                   FStar_Syntax_Syntax.mk uu____11784  in
-                 uu____11781 FStar_Pervasives_Native.None uu____11780  in
+                         let uu____11803 = FStar_Syntax_Syntax.as_arg res_t in
+                         [uu____11803] in
+                       (null_wp, uu____11800) in
+                     FStar_Syntax_Syntax.Tm_app uu____11785 in
+                   FStar_Syntax_Syntax.mk uu____11784 in
+                 uu____11781 FStar_Pervasives_Native.None uu____11780 in
                let uu____11809 =
                  let uu____11810 =
-                   let uu____11819 = FStar_Syntax_Syntax.as_arg null_wp_res
-                      in
-                   [uu____11819]  in
+                   let uu____11819 = FStar_Syntax_Syntax.as_arg null_wp_res in
+                   [uu____11819] in
                  {
                    FStar_Syntax_Syntax.comp_univs = [res_u];
                    FStar_Syntax_Syntax.effect_name = eff_name1;
                    FStar_Syntax_Syntax.result_typ = res_t;
                    FStar_Syntax_Syntax.effect_args = uu____11810;
                    FStar_Syntax_Syntax.flags = []
-                 }  in
+                 } in
                FStar_Syntax_Syntax.mk_Comp uu____11809)
-  
-let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
+let build_lattice: env -> FStar_Syntax_Syntax.sigelt -> env =
   fun env  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_new_effect ne ->
           let effects =
-            let uu___96_11828 = env.effects  in
+            let uu___96_11828 = env.effects in
             {
               decls = ((ne, (se.FStar_Syntax_Syntax.sigquals)) ::
                 ((env.effects).decls));
               order = (uu___96_11828.order);
               joins = (uu___96_11828.joins)
-            }  in
-          let uu___97_11837 = env  in
+            } in
+          let uu___97_11837 = env in
           {
             solver = (uu___97_11837.solver);
             range = (uu___97_11837.range);
@@ -3568,8 +3330,8 @@ let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
           let compose_edges e1 e2 =
             let composed_lift =
               let mlift_wp u r wp1 =
-                let uu____11857 = (e1.mlift).mlift_wp u r wp1  in
-                (e2.mlift).mlift_wp u r uu____11857  in
+                let uu____11857 = (e1.mlift).mlift_wp u r wp1 in
+                (e2.mlift).mlift_wp u r uu____11857 in
               let mlift_term =
                 match (((e1.mlift).mlift_term), ((e2.mlift).mlift_term)) with
                 | (FStar_Pervasives_Native.Some
@@ -3579,121 +3341,107 @@ let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
                           fun t  ->
                             fun wp  ->
                               fun e  ->
-                                let uu____11971 = (e1.mlift).mlift_wp u t wp
-                                   in
-                                let uu____11972 = l1 u t wp e  in
+                                let uu____11971 = (e1.mlift).mlift_wp u t wp in
+                                let uu____11972 = l1 u t wp e in
                                 l2 u t uu____11971 uu____11972))
-                | uu____11973 -> FStar_Pervasives_Native.None  in
-              { mlift_wp; mlift_term }  in
+                | uu____11973 -> FStar_Pervasives_Native.None in
+              { mlift_wp; mlift_term } in
             {
               msource = (e1.msource);
               mtarget = (e2.mtarget);
               mlift = composed_lift
-            }  in
+            } in
           let mk_mlift_wp lift_t u r wp1 =
-            let uu____12021 = inst_tscheme_with lift_t [u]  in
+            let uu____12021 = inst_tscheme_with lift_t [u] in
             match uu____12021 with
             | (uu____12028,lift_t1) ->
                 let uu____12030 =
                   let uu____12033 =
                     let uu____12034 =
                       let uu____12049 =
-                        let uu____12052 = FStar_Syntax_Syntax.as_arg r  in
+                        let uu____12052 = FStar_Syntax_Syntax.as_arg r in
                         let uu____12053 =
-                          let uu____12056 = FStar_Syntax_Syntax.as_arg wp1
-                             in
-                          [uu____12056]  in
-                        uu____12052 :: uu____12053  in
-                      (lift_t1, uu____12049)  in
-                    FStar_Syntax_Syntax.Tm_app uu____12034  in
-                  FStar_Syntax_Syntax.mk uu____12033  in
+                          let uu____12056 = FStar_Syntax_Syntax.as_arg wp1 in
+                          [uu____12056] in
+                        uu____12052 :: uu____12053 in
+                      (lift_t1, uu____12049) in
+                    FStar_Syntax_Syntax.Tm_app uu____12034 in
+                  FStar_Syntax_Syntax.mk uu____12033 in
                 uu____12030 FStar_Pervasives_Native.None
-                  wp1.FStar_Syntax_Syntax.pos
-             in
+                  wp1.FStar_Syntax_Syntax.pos in
           let sub_mlift_wp =
             match sub1.FStar_Syntax_Syntax.lift_wp with
             | FStar_Pervasives_Native.Some sub_lift_wp ->
                 mk_mlift_wp sub_lift_wp
             | FStar_Pervasives_Native.None  ->
-                failwith "sub effect should've been elaborated at this stage"
-             in
+                failwith "sub effect should've been elaborated at this stage" in
           let mk_mlift_term lift_t u r wp1 e =
-            let uu____12106 = inst_tscheme_with lift_t [u]  in
+            let uu____12106 = inst_tscheme_with lift_t [u] in
             match uu____12106 with
             | (uu____12113,lift_t1) ->
                 let uu____12115 =
                   let uu____12118 =
                     let uu____12119 =
                       let uu____12134 =
-                        let uu____12137 = FStar_Syntax_Syntax.as_arg r  in
+                        let uu____12137 = FStar_Syntax_Syntax.as_arg r in
                         let uu____12138 =
-                          let uu____12141 = FStar_Syntax_Syntax.as_arg wp1
-                             in
+                          let uu____12141 = FStar_Syntax_Syntax.as_arg wp1 in
                           let uu____12142 =
-                            let uu____12145 = FStar_Syntax_Syntax.as_arg e
-                               in
-                            [uu____12145]  in
-                          uu____12141 :: uu____12142  in
-                        uu____12137 :: uu____12138  in
-                      (lift_t1, uu____12134)  in
-                    FStar_Syntax_Syntax.Tm_app uu____12119  in
-                  FStar_Syntax_Syntax.mk uu____12118  in
+                            let uu____12145 = FStar_Syntax_Syntax.as_arg e in
+                            [uu____12145] in
+                          uu____12141 :: uu____12142 in
+                        uu____12137 :: uu____12138 in
+                      (lift_t1, uu____12134) in
+                    FStar_Syntax_Syntax.Tm_app uu____12119 in
+                  FStar_Syntax_Syntax.mk uu____12118 in
                 uu____12115 FStar_Pervasives_Native.None
-                  e.FStar_Syntax_Syntax.pos
-             in
+                  e.FStar_Syntax_Syntax.pos in
           let sub_mlift_term =
-            FStar_Util.map_opt sub1.FStar_Syntax_Syntax.lift mk_mlift_term
-             in
+            FStar_Util.map_opt sub1.FStar_Syntax_Syntax.lift mk_mlift_term in
           let edge =
             {
               msource = (sub1.FStar_Syntax_Syntax.source);
               mtarget = (sub1.FStar_Syntax_Syntax.target);
               mlift =
                 { mlift_wp = sub_mlift_wp; mlift_term = sub_mlift_term }
-            }  in
+            } in
           let id_edge l =
             {
               msource = (sub1.FStar_Syntax_Syntax.source);
               mtarget = (sub1.FStar_Syntax_Syntax.target);
               mlift = identity_mlift
-            }  in
+            } in
           let print_mlift l =
             let bogus_term s =
               let uu____12187 =
                 let uu____12188 =
-                  FStar_Ident.lid_of_path [s] FStar_Range.dummyRange  in
+                  FStar_Ident.lid_of_path [s] FStar_Range.dummyRange in
                 FStar_Syntax_Syntax.lid_as_fv uu____12188
                   FStar_Syntax_Syntax.Delta_constant
-                  FStar_Pervasives_Native.None
-                 in
-              FStar_Syntax_Syntax.fv_to_tm uu____12187  in
-            let arg = bogus_term "ARG"  in
-            let wp = bogus_term "WP"  in
-            let e = bogus_term "COMP"  in
+                  FStar_Pervasives_Native.None in
+              FStar_Syntax_Syntax.fv_to_tm uu____12187 in
+            let arg = bogus_term "ARG" in
+            let wp = bogus_term "WP" in
+            let e = bogus_term "COMP" in
             let uu____12192 =
-              let uu____12193 = l.mlift_wp FStar_Syntax_Syntax.U_zero arg wp
-                 in
-              FStar_Syntax_Print.term_to_string uu____12193  in
+              let uu____12193 = l.mlift_wp FStar_Syntax_Syntax.U_zero arg wp in
+              FStar_Syntax_Print.term_to_string uu____12193 in
             let uu____12194 =
               let uu____12195 =
                 FStar_Util.map_opt l.mlift_term
                   (fun l1  ->
-                     let uu____12217 = l1 FStar_Syntax_Syntax.U_zero arg wp e
-                        in
-                     FStar_Syntax_Print.term_to_string uu____12217)
-                 in
-              FStar_Util.dflt "none" uu____12195  in
+                     let uu____12217 = l1 FStar_Syntax_Syntax.U_zero arg wp e in
+                     FStar_Syntax_Print.term_to_string uu____12217) in
+              FStar_Util.dflt "none" uu____12195 in
             FStar_Util.format2 "{ wp : %s ; term : %s }" uu____12192
-              uu____12194
-             in
-          let order = edge :: ((env.effects).order)  in
+              uu____12194 in
+          let order = edge :: ((env.effects).order) in
           let ms =
             FStar_All.pipe_right (env.effects).decls
               (FStar_List.map
                  (fun uu____12243  ->
                     match uu____12243 with
-                    | (e,uu____12251) -> e.FStar_Syntax_Syntax.mname))
-             in
+                    | (e,uu____12251) -> e.FStar_Syntax_Syntax.mname)) in
           let find_edge order1 uu____12270 =
             match uu____12270 with
             | (i,j) ->
@@ -3706,8 +3454,7 @@ let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
                     (FStar_Util.find_opt
                        (fun e  ->
                           (FStar_Ident.lid_equals e.msource i) &&
-                            (FStar_Ident.lid_equals e.mtarget j)))
-             in
+                            (FStar_Ident.lid_equals e.mtarget j))) in
           let order1 =
             let fold_fun order1 k =
               let uu____12308 =
@@ -3725,28 +3472,26 @@ let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
                                   else
                                     (let uu____12329 =
                                        let uu____12338 =
-                                         find_edge order1 (i, k)  in
+                                         find_edge order1 (i, k) in
                                        let uu____12341 =
-                                         find_edge order1 (k, j)  in
-                                       (uu____12338, uu____12341)  in
+                                         find_edge order1 (k, j) in
+                                       (uu____12338, uu____12341) in
                                      match uu____12329 with
                                      | (FStar_Pervasives_Native.Some
                                         e1,FStar_Pervasives_Native.Some e2)
                                          ->
                                          let uu____12356 =
-                                           compose_edges e1 e2  in
+                                           compose_edges e1 e2 in
                                          [uu____12356]
-                                     | uu____12357 -> [])))))
-                 in
-              FStar_List.append order1 uu____12308  in
-            FStar_All.pipe_right ms (FStar_List.fold_left fold_fun order)  in
+                                     | uu____12357 -> []))))) in
+              FStar_List.append order1 uu____12308 in
+            FStar_All.pipe_right ms (FStar_List.fold_left fold_fun order) in
           let order2 =
             FStar_Util.remove_dups
               (fun e1  ->
                  fun e2  ->
                    (FStar_Ident.lid_equals e1.msource e2.msource) &&
-                     (FStar_Ident.lid_equals e1.mtarget e2.mtarget)) order1
-             in
+                     (FStar_Ident.lid_equals e1.mtarget e2.mtarget)) order1 in
           (FStar_All.pipe_right order2
              (FStar_List.iter
                 (fun edge1  ->
@@ -3755,23 +3500,20 @@ let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
                         FStar_Parser_Const.effect_DIV_lid)
                        &&
                        (let uu____12389 =
-                          lookup_effect_quals env edge1.mtarget  in
+                          lookup_effect_quals env edge1.mtarget in
                         FStar_All.pipe_right uu____12389
                           (FStar_List.contains
-                             FStar_Syntax_Syntax.TotalEffect))
-                      in
+                             FStar_Syntax_Syntax.TotalEffect)) in
                    if uu____12387
                    then
                      let uu____12394 =
                        let uu____12399 =
                          FStar_Util.format1
                            "Divergent computations cannot be included in an effect %s marked 'total'"
-                           (edge1.mtarget).FStar_Ident.str
-                          in
+                           (edge1.mtarget).FStar_Ident.str in
                        (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                         uu____12399)
-                        in
-                     let uu____12400 = get_range env  in
+                         uu____12399) in
+                     let uu____12400 = get_range env in
                      FStar_Errors.raise_error uu____12394 uu____12400
                    else ()));
            (let joins =
@@ -3793,10 +3535,10 @@ let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
                                           fun k  ->
                                             let uu____12525 =
                                               let uu____12534 =
-                                                find_edge order2 (i, k)  in
+                                                find_edge order2 (i, k) in
                                               let uu____12537 =
-                                                find_edge order2 (j, k)  in
-                                              (uu____12534, uu____12537)  in
+                                                find_edge order2 (j, k) in
+                                              (uu____12534, uu____12537) in
                                             match uu____12525 with
                                             | (FStar_Pervasives_Native.Some
                                                ik,FStar_Pervasives_Native.Some
@@ -3813,22 +3555,17 @@ let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
                                                        let uu____12592 =
                                                          let uu____12593 =
                                                            find_edge order2
-                                                             (k, ub)
-                                                            in
+                                                             (k, ub) in
                                                          FStar_Util.is_some
-                                                           uu____12593
-                                                          in
+                                                           uu____12593 in
                                                        let uu____12596 =
                                                          let uu____12597 =
                                                            find_edge order2
-                                                             (ub, k)
-                                                            in
+                                                             (ub, k) in
                                                          FStar_Util.is_some
-                                                           uu____12597
-                                                          in
+                                                           uu____12597 in
                                                        (uu____12592,
-                                                         uu____12596)
-                                                        in
+                                                         uu____12596) in
                                                      (match uu____12587 with
                                                       | (true ,true ) ->
                                                           if
@@ -3851,17 +3588,15 @@ let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
                                                       | (false ,true ) ->
                                                           bopt))
                                             | uu____12632 -> bopt)
-                                       FStar_Pervasives_Native.None)
-                                 in
+                                       FStar_Pervasives_Native.None) in
                               match join_opt with
                               | FStar_Pervasives_Native.None  -> []
                               | FStar_Pervasives_Native.Some (k,e1,e2) ->
-                                  [(i, j, k, (e1.mlift), (e2.mlift))]))))
-               in
+                                  [(i, j, k, (e1.mlift), (e2.mlift))])))) in
             let effects =
-              let uu___98_12705 = env.effects  in
-              { decls = (uu___98_12705.decls); order = order2; joins }  in
-            let uu___99_12706 = env  in
+              let uu___98_12705 = env.effects in
+              { decls = (uu___98_12705.decls); order = order2; joins } in
+            let uu___99_12706 = env in
             {
               solver = (uu___99_12706.solver);
               range = (uu___99_12706.range);
@@ -3900,35 +3635,32 @@ let (build_lattice : env -> FStar_Syntax_Syntax.sigelt -> env) =
               dep_graph = (uu___99_12706.dep_graph)
             }))
       | uu____12707 -> env
-  
-let (comp_to_comp_typ :
-  env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ) =
+let comp_to_comp_typ:
+  env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ =
   fun env  ->
     fun c  ->
       let c1 =
         match c.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Total (t,FStar_Pervasives_Native.None ) ->
-            let u = env.universe_of env t  in
+            let u = env.universe_of env t in
             FStar_Syntax_Syntax.mk_Total' t (FStar_Pervasives_Native.Some u)
         | FStar_Syntax_Syntax.GTotal (t,FStar_Pervasives_Native.None ) ->
-            let u = env.universe_of env t  in
+            let u = env.universe_of env t in
             FStar_Syntax_Syntax.mk_GTotal' t (FStar_Pervasives_Native.Some u)
-        | uu____12731 -> c  in
+        | uu____12731 -> c in
       FStar_Syntax_Util.comp_to_comp_typ c1
-  
-let rec (unfold_effect_abbrev :
-  env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ) =
+let rec unfold_effect_abbrev:
+  env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ =
   fun env  ->
     fun comp  ->
-      let c = comp_to_comp_typ env comp  in
+      let c = comp_to_comp_typ env comp in
       let uu____12739 =
         lookup_effect_abbrev env c.FStar_Syntax_Syntax.comp_univs
-          c.FStar_Syntax_Syntax.effect_name
-         in
+          c.FStar_Syntax_Syntax.effect_name in
       match uu____12739 with
       | FStar_Pervasives_Native.None  -> c
       | FStar_Pervasives_Native.Some (binders,cdef) ->
-          let uu____12756 = FStar_Syntax_Subst.open_comp binders cdef  in
+          let uu____12756 = FStar_Syntax_Subst.open_comp binders cdef in
           (match uu____12756 with
            | (binders1,cdef1) ->
                (if
@@ -3940,24 +3672,20 @@ let rec (unfold_effect_abbrev :
                      let uu____12779 =
                        let uu____12780 =
                          FStar_Util.string_of_int
-                           (FStar_List.length binders1)
-                          in
+                           (FStar_List.length binders1) in
                        let uu____12785 =
                          FStar_Util.string_of_int
                            ((FStar_List.length
                                c.FStar_Syntax_Syntax.effect_args)
-                              + (Prims.parse_int "1"))
-                          in
+                              + (Prims.parse_int "1")) in
                        let uu____12792 =
-                         let uu____12793 = FStar_Syntax_Syntax.mk_Comp c  in
-                         FStar_Syntax_Print.comp_to_string uu____12793  in
+                         let uu____12793 = FStar_Syntax_Syntax.mk_Comp c in
+                         FStar_Syntax_Print.comp_to_string uu____12793 in
                        FStar_Util.format3
                          "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s"
-                         uu____12780 uu____12785 uu____12792
-                        in
+                         uu____12780 uu____12785 uu____12792 in
                      (FStar_Errors.Fatal_ConstructorArgLengthMismatch,
-                       uu____12779)
-                      in
+                       uu____12779) in
                    FStar_Errors.raise_error uu____12774
                      comp.FStar_Syntax_Syntax.pos)
                 else ();
@@ -3965,21 +3693,19 @@ let rec (unfold_effect_abbrev :
                    let uu____12798 =
                      let uu____12807 =
                        FStar_Syntax_Syntax.as_arg
-                         c.FStar_Syntax_Syntax.result_typ
-                        in
-                     uu____12807 :: (c.FStar_Syntax_Syntax.effect_args)  in
+                         c.FStar_Syntax_Syntax.result_typ in
+                     uu____12807 :: (c.FStar_Syntax_Syntax.effect_args) in
                    FStar_List.map2
                      (fun uu____12824  ->
                         fun uu____12825  ->
                           match (uu____12824, uu____12825) with
                           | ((x,uu____12847),(t,uu____12849)) ->
                               FStar_Syntax_Syntax.NT (x, t)) binders1
-                     uu____12798
-                    in
-                 let c1 = FStar_Syntax_Subst.subst_comp inst1 cdef1  in
+                     uu____12798 in
+                 let c1 = FStar_Syntax_Subst.subst_comp inst1 cdef1 in
                  let c2 =
                    let uu____12868 =
-                     let uu___100_12869 = comp_to_comp_typ env c1  in
+                     let uu___100_12869 = comp_to_comp_typ env c1 in
                      {
                        FStar_Syntax_Syntax.comp_univs =
                          (uu___100_12869.FStar_Syntax_Syntax.comp_univs);
@@ -3991,27 +3717,25 @@ let rec (unfold_effect_abbrev :
                          (uu___100_12869.FStar_Syntax_Syntax.effect_args);
                        FStar_Syntax_Syntax.flags =
                          (c.FStar_Syntax_Syntax.flags)
-                     }  in
+                     } in
                    FStar_All.pipe_right uu____12868
-                     FStar_Syntax_Syntax.mk_Comp
-                    in
+                     FStar_Syntax_Syntax.mk_Comp in
                  unfold_effect_abbrev env c2)))
-  
-let (effect_repr_aux :
+let effect_repr_aux:
   Prims.bool ->
     env ->
       FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
         FStar_Syntax_Syntax.universe ->
           FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
-            FStar_Pervasives_Native.option)
+            FStar_Pervasives_Native.option
   =
   fun only_reifiable  ->
     fun env  ->
       fun c  ->
         fun u_c  ->
           let effect_name =
-            norm_eff_name env (FStar_Syntax_Util.comp_effect_name c)  in
-          let uu____12891 = effect_decl_opt env effect_name  in
+            norm_eff_name env (FStar_Syntax_Util.comp_effect_name c) in
+          let uu____12891 = effect_decl_opt env effect_name in
           match uu____12891 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some (ed,qualifiers) ->
@@ -4019,10 +3743,8 @@ let (effect_repr_aux :
                 only_reifiable &&
                   (let uu____12926 =
                      FStar_All.pipe_right qualifiers
-                       (FStar_List.contains FStar_Syntax_Syntax.Reifiable)
-                      in
-                   Prims.op_Negation uu____12926)
-                 in
+                       (FStar_List.contains FStar_Syntax_Syntax.Reifiable) in
+                   Prims.op_Negation uu____12926) in
               if uu____12924
               then FStar_Pervasives_Native.None
               else
@@ -4031,59 +3753,52 @@ let (effect_repr_aux :
                  | FStar_Syntax_Syntax.Tm_unknown  ->
                      FStar_Pervasives_Native.None
                  | uu____12942 ->
-                     let c1 = unfold_effect_abbrev env c  in
-                     let res_typ = c1.FStar_Syntax_Syntax.result_typ  in
+                     let c1 = unfold_effect_abbrev env c in
+                     let res_typ = c1.FStar_Syntax_Syntax.result_typ in
                      let wp =
                        match c1.FStar_Syntax_Syntax.effect_args with
                        | hd1::uu____12961 -> hd1
                        | [] ->
-                           let name = FStar_Ident.string_of_lid effect_name
-                              in
+                           let name = FStar_Ident.string_of_lid effect_name in
                            let message =
                              let uu____12990 =
                                FStar_Util.format1
-                                 "Not enough arguments for effect %s. " name
-                                in
+                                 "Not enough arguments for effect %s. " name in
                              Prims.strcat uu____12990
                                (Prims.strcat
                                   "This usually happens when you use a partially applied DM4F effect, "
-                                  "like [TAC int] instead of [Tac int].")
-                              in
-                           let uu____12991 = get_range env  in
+                                  "like [TAC int] instead of [Tac int].") in
+                           let uu____12991 = get_range env in
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
-                               message) uu____12991
-                        in
+                               message) uu____12991 in
                      let repr =
                        inst_effect_fun_with [u_c] env ed
-                         ([], (ed.FStar_Syntax_Syntax.repr))
-                        in
+                         ([], (ed.FStar_Syntax_Syntax.repr)) in
                      let uu____13001 =
-                       let uu____13004 = get_range env  in
+                       let uu____13004 = get_range env in
                        let uu____13005 =
                          let uu____13008 =
                            let uu____13009 =
                              let uu____13024 =
                                let uu____13027 =
-                                 FStar_Syntax_Syntax.as_arg res_typ  in
-                               [uu____13027; wp]  in
-                             (repr, uu____13024)  in
-                           FStar_Syntax_Syntax.Tm_app uu____13009  in
-                         FStar_Syntax_Syntax.mk uu____13008  in
-                       uu____13005 FStar_Pervasives_Native.None uu____13004
-                        in
+                                 FStar_Syntax_Syntax.as_arg res_typ in
+                               [uu____13027; wp] in
+                             (repr, uu____13024) in
+                           FStar_Syntax_Syntax.Tm_app uu____13009 in
+                         FStar_Syntax_Syntax.mk uu____13008 in
+                       uu____13005 FStar_Pervasives_Native.None uu____13004 in
                      FStar_Pervasives_Native.Some uu____13001)
-  
-let (effect_repr :
+let effect_repr:
   env ->
     FStar_Syntax_Syntax.comp ->
       FStar_Syntax_Syntax.universe ->
-        FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
-  = fun env  -> fun c  -> fun u_c  -> effect_repr_aux false env c u_c 
-let (reify_comp :
+        FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
+  = fun env  -> fun c  -> fun u_c  -> effect_repr_aux false env c u_c
+let reify_comp:
   env ->
     FStar_Syntax_Syntax.comp ->
-      FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun c  ->
@@ -4091,48 +3806,42 @@ let (reify_comp :
         let no_reify l =
           let uu____13073 =
             let uu____13078 =
-              let uu____13079 = FStar_Ident.string_of_lid l  in
-              FStar_Util.format1 "Effect %s cannot be reified" uu____13079
-               in
-            (FStar_Errors.Fatal_EffectCannotBeReified, uu____13078)  in
-          let uu____13080 = get_range env  in
-          FStar_Errors.raise_error uu____13073 uu____13080  in
-        let uu____13081 = effect_repr_aux true env c u_c  in
+              let uu____13079 = FStar_Ident.string_of_lid l in
+              FStar_Util.format1 "Effect %s cannot be reified" uu____13079 in
+            (FStar_Errors.Fatal_EffectCannotBeReified, uu____13078) in
+          let uu____13080 = get_range env in
+          FStar_Errors.raise_error uu____13073 uu____13080 in
+        let uu____13081 = effect_repr_aux true env c u_c in
         match uu____13081 with
         | FStar_Pervasives_Native.None  ->
             no_reify (FStar_Syntax_Util.comp_effect_name c)
         | FStar_Pervasives_Native.Some tm -> tm
-  
-let (is_reifiable_effect : env -> FStar_Ident.lident -> Prims.bool) =
+let is_reifiable_effect: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun effect_lid  ->
-      let quals = lookup_effect_quals env effect_lid  in
+      let quals = lookup_effect_quals env effect_lid in
       FStar_List.contains FStar_Syntax_Syntax.Reifiable quals
-  
-let (is_reifiable : env -> FStar_Syntax_Syntax.residual_comp -> Prims.bool) =
+let is_reifiable: env -> FStar_Syntax_Syntax.residual_comp -> Prims.bool =
   fun env  ->
     fun c  -> is_reifiable_effect env c.FStar_Syntax_Syntax.residual_effect
-  
-let (is_reifiable_comp : env -> FStar_Syntax_Syntax.comp -> Prims.bool) =
+let is_reifiable_comp: env -> FStar_Syntax_Syntax.comp -> Prims.bool =
   fun env  ->
     fun c  ->
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Comp ct ->
           is_reifiable_effect env ct.FStar_Syntax_Syntax.effect_name
       | uu____13115 -> false
-  
-let (is_reifiable_function : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_reifiable_function: env -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun env  ->
     fun t  ->
       let uu____13122 =
-        let uu____13123 = FStar_Syntax_Subst.compress t  in
-        uu____13123.FStar_Syntax_Syntax.n  in
+        let uu____13123 = FStar_Syntax_Subst.compress t in
+        uu____13123.FStar_Syntax_Syntax.n in
       match uu____13122 with
       | FStar_Syntax_Syntax.Tm_arrow (uu____13126,c) ->
           is_reifiable_comp env c
       | uu____13144 -> false
-  
-let (push_in_gamma : env -> binding -> env) =
+let push_in_gamma: env -> binding -> env =
   fun env  ->
     fun s  ->
       let rec push1 x rest =
@@ -4141,11 +3850,10 @@ let (push_in_gamma : env -> binding -> env) =
         | (Binding_sig_inst uu____13176)::uu____13177 -> x :: rest
         | [] -> [x]
         | local::rest1 ->
-            let uu____13192 = push1 x rest1  in local :: uu____13192
-         in
+            let uu____13192 = push1 x rest1 in local :: uu____13192 in
       (env.tc_hooks).tc_push_in_gamma_hook env s;
-      (let uu___101_13196 = env  in
-       let uu____13197 = push1 s env.gamma  in
+      (let uu___101_13196 = env in
+       let uu____13197 = push1 s env.gamma in
        {
          solver = (uu___101_13196.solver);
          range = (uu___101_13196.range);
@@ -4183,32 +3891,26 @@ let (push_in_gamma : env -> binding -> env) =
          dsenv = (uu___101_13196.dsenv);
          dep_graph = (uu___101_13196.dep_graph)
        })
-  
-let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
+let push_sigelt: env -> FStar_Syntax_Syntax.sigelt -> env =
   fun env  ->
     fun s  ->
       let env1 =
         push_in_gamma env
-          (Binding_sig ((FStar_Syntax_Util.lids_of_sigelt s), s))
-         in
+          (Binding_sig ((FStar_Syntax_Util.lids_of_sigelt s), s)) in
       build_lattice env1 s
-  
-let (push_sigelt_inst :
-  env -> FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.universes -> env)
-  =
+let push_sigelt_inst:
+  env -> FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.universes -> env =
   fun env  ->
     fun s  ->
       fun us  ->
         let env1 =
           push_in_gamma env
-            (Binding_sig_inst ((FStar_Syntax_Util.lids_of_sigelt s), s, us))
-           in
+            (Binding_sig_inst ((FStar_Syntax_Util.lids_of_sigelt s), s, us)) in
         build_lattice env1 s
-  
-let (push_local_binding : env -> binding -> env) =
+let push_local_binding: env -> binding -> env =
   fun env  ->
     fun b  ->
-      let uu___102_13227 = env  in
+      let uu___102_13227 = env in
       {
         solver = (uu___102_13227.solver);
         range = (uu___102_13227.range);
@@ -4246,20 +3948,19 @@ let (push_local_binding : env -> binding -> env) =
         dsenv = (uu___102_13227.dsenv);
         dep_graph = (uu___102_13227.dep_graph)
       }
-  
-let (push_bv : env -> FStar_Syntax_Syntax.bv -> env) =
-  fun env  -> fun x  -> push_local_binding env (Binding_var x) 
-let (pop_bv :
+let push_bv: env -> FStar_Syntax_Syntax.bv -> env =
+  fun env  -> fun x  -> push_local_binding env (Binding_var x)
+let pop_bv:
   env ->
     (FStar_Syntax_Syntax.bv,env) FStar_Pervasives_Native.tuple2
-      FStar_Pervasives_Native.option)
+      FStar_Pervasives_Native.option
   =
   fun env  ->
     match env.gamma with
     | (Binding_var x)::rest ->
         FStar_Pervasives_Native.Some
           (x,
-            (let uu___103_13258 = env  in
+            (let uu___103_13258 = env in
              {
                solver = (uu___103_13258.solver);
                range = (uu___103_13258.range);
@@ -4298,8 +3999,7 @@ let (pop_bv :
                dep_graph = (uu___103_13258.dep_graph)
              }))
     | uu____13259 -> FStar_Pervasives_Native.None
-  
-let (push_binders : env -> FStar_Syntax_Syntax.binders -> env) =
+let push_binders: env -> FStar_Syntax_Syntax.binders -> env =
   fun env  ->
     fun bs  ->
       FStar_List.fold_left
@@ -4307,41 +4007,38 @@ let (push_binders : env -> FStar_Syntax_Syntax.binders -> env) =
            fun uu____13281  ->
              match uu____13281 with | (x,uu____13287) -> push_bv env1 x) env
         bs
-  
-let (binding_of_lb :
+let binding_of_lb:
   FStar_Syntax_Syntax.lbname ->
     (FStar_Syntax_Syntax.univ_name Prims.list,FStar_Syntax_Syntax.term'
                                                 FStar_Syntax_Syntax.syntax)
-      FStar_Pervasives_Native.tuple2 -> binding)
+      FStar_Pervasives_Native.tuple2 -> binding
   =
   fun x  ->
     fun t  ->
       match x with
       | FStar_Util.Inl x1 ->
           let x2 =
-            let uu___104_13315 = x1  in
+            let uu___104_13315 = x1 in
             {
               FStar_Syntax_Syntax.ppname =
                 (uu___104_13315.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
                 (uu___104_13315.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = (FStar_Pervasives_Native.snd t)
-            }  in
+            } in
           Binding_var x2
       | FStar_Util.Inr fv ->
           Binding_lid
             (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v), t)
-  
-let (push_let_binding :
-  env -> FStar_Syntax_Syntax.lbname -> FStar_Syntax_Syntax.tscheme -> env) =
+let push_let_binding:
+  env -> FStar_Syntax_Syntax.lbname -> FStar_Syntax_Syntax.tscheme -> env =
   fun env  ->
     fun lb  -> fun ts  -> push_local_binding env (binding_of_lb lb ts)
-  
-let (push_module : env -> FStar_Syntax_Syntax.modul -> env) =
+let push_module: env -> FStar_Syntax_Syntax.modul -> env =
   fun env  ->
     fun m  ->
       add_sigelts env m.FStar_Syntax_Syntax.exports;
-      (let uu___105_13345 = env  in
+      (let uu___105_13345 = env in
        {
          solver = (uu___105_13345.solver);
          range = (uu___105_13345.range);
@@ -4379,37 +4076,34 @@ let (push_module : env -> FStar_Syntax_Syntax.modul -> env) =
          dsenv = (uu___105_13345.dsenv);
          dep_graph = (uu___105_13345.dep_graph)
        })
-  
-let (push_univ_vars : env -> FStar_Syntax_Syntax.univ_names -> env) =
+let push_univ_vars: env -> FStar_Syntax_Syntax.univ_names -> env =
   fun env  ->
     fun xs  ->
       FStar_List.fold_left
         (fun env1  -> fun x  -> push_local_binding env1 (Binding_univ x)) env
         xs
-  
-let (open_universes_in :
+let open_universes_in:
   env ->
     FStar_Syntax_Syntax.univ_names ->
       FStar_Syntax_Syntax.term Prims.list ->
         (env,FStar_Syntax_Syntax.univ_names,FStar_Syntax_Syntax.term
                                               Prims.list)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun uvs  ->
       fun terms  ->
-        let uu____13377 = FStar_Syntax_Subst.univ_var_opening uvs  in
+        let uu____13377 = FStar_Syntax_Subst.univ_var_opening uvs in
         match uu____13377 with
         | (univ_subst,univ_vars) ->
-            let env' = push_univ_vars env univ_vars  in
+            let env' = push_univ_vars env univ_vars in
             let uu____13405 =
-              FStar_List.map (FStar_Syntax_Subst.subst univ_subst) terms  in
+              FStar_List.map (FStar_Syntax_Subst.subst univ_subst) terms in
             (env', univ_vars, uu____13405)
-  
-let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
+let set_expected_typ: env -> FStar_Syntax_Syntax.typ -> env =
   fun env  ->
     fun t  ->
-      let uu___106_13418 = env  in
+      let uu___106_13418 = env in
       {
         solver = (uu___106_13418.solver);
         range = (uu___106_13418.range);
@@ -4447,22 +4141,20 @@ let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
         dsenv = (uu___106_13418.dsenv);
         dep_graph = (uu___106_13418.dep_graph)
       }
-  
-let (expected_typ :
-  env -> FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option) =
+let expected_typ:
+  env -> FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option =
   fun env  ->
     match env.expected_typ with
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
     | FStar_Pervasives_Native.Some t -> FStar_Pervasives_Native.Some t
-  
-let (clear_expected_typ :
+let clear_expected_typ:
   env ->
     (env,FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun env_  ->
-    let uu____13442 = expected_typ env_  in
-    ((let uu___107_13448 = env_  in
+    let uu____13442 = expected_typ env_ in
+    ((let uu___107_13448 = env_ in
       {
         solver = (uu___107_13448.solver);
         range = (uu___107_13448.range);
@@ -4500,9 +4192,8 @@ let (clear_expected_typ :
         dsenv = (uu___107_13448.dsenv);
         dep_graph = (uu___107_13448.dep_graph)
       }), uu____13442)
-  
-let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
-  let empty_lid = FStar_Ident.lid_of_ids [FStar_Ident.id_of_text ""]  in
+let finish_module: env -> FStar_Syntax_Syntax.modul -> env =
+  let empty_lid = FStar_Ident.lid_of_ids [FStar_Ident.id_of_text ""] in
   fun env  ->
     fun m  ->
       let sigs =
@@ -4516,12 +4207,11 @@ let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
                  (fun uu___81_13471  ->
                     match uu___81_13471 with
                     | Binding_sig (uu____13474,se) -> [se]
-                    | uu____13480 -> []))
-             in
+                    | uu____13480 -> [])) in
           FStar_All.pipe_right uu____13461 FStar_List.rev
-        else m.FStar_Syntax_Syntax.exports  in
+        else m.FStar_Syntax_Syntax.exports in
       add_sigelts env sigs;
-      (let uu___108_13487 = env  in
+      (let uu___108_13487 = env in
        {
          solver = (uu___108_13487.solver);
          range = (uu___108_13487.range);
@@ -4559,19 +4249,18 @@ let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
          dsenv = (uu___108_13487.dsenv);
          dep_graph = (uu___108_13487.dep_graph)
        })
-  
-let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
+let uvars_in_env: env -> FStar_Syntax_Syntax.uvars =
   fun env  ->
-    let no_uvs = FStar_Syntax_Free.new_uv_set ()  in
-    let ext out uvs = FStar_Util.set_union out uvs  in
+    let no_uvs = FStar_Syntax_Free.new_uv_set () in
+    let ext out uvs = FStar_Util.set_union out uvs in
     let rec aux out g =
       match g with
       | [] -> out
       | (Binding_univ uu____13568)::tl1 -> aux out tl1
       | (Binding_lid (uu____13572,(uu____13573,t)))::tl1 ->
           let uu____13588 =
-            let uu____13595 = FStar_Syntax_Free.uvars t  in
-            ext out uu____13595  in
+            let uu____13595 = FStar_Syntax_Free.uvars t in
+            ext out uu____13595 in
           aux uu____13588 tl1
       | (Binding_var
           { FStar_Syntax_Syntax.ppname = uu____13602;
@@ -4579,17 +4268,16 @@ let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
           let uu____13610 =
-            let uu____13617 = FStar_Syntax_Free.uvars t  in
-            ext out uu____13617  in
+            let uu____13617 = FStar_Syntax_Free.uvars t in
+            ext out uu____13617 in
           aux uu____13610 tl1
       | (Binding_sig uu____13624)::uu____13625 -> out
-      | (Binding_sig_inst uu____13634)::uu____13635 -> out  in
+      | (Binding_sig_inst uu____13634)::uu____13635 -> out in
     aux no_uvs env.gamma
-  
-let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
+let univ_vars: env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set =
   fun env  ->
-    let no_univs = FStar_Syntax_Free.new_universe_uvar_set ()  in
-    let ext out uvs = FStar_Util.set_union out uvs  in
+    let no_univs = FStar_Syntax_Free.new_universe_uvar_set () in
+    let ext out uvs = FStar_Util.set_union out uvs in
     let rec aux out g =
       match g with
       | [] -> out
@@ -4597,8 +4285,8 @@ let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
       | (Binding_univ uu____13702)::tl1 -> aux out tl1
       | (Binding_lid (uu____13706,(uu____13707,t)))::tl1 ->
           let uu____13722 =
-            let uu____13725 = FStar_Syntax_Free.univs t  in
-            ext out uu____13725  in
+            let uu____13725 = FStar_Syntax_Free.univs t in
+            ext out uu____13725 in
           aux uu____13722 tl1
       | (Binding_var
           { FStar_Syntax_Syntax.ppname = uu____13728;
@@ -4606,27 +4294,26 @@ let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
           let uu____13736 =
-            let uu____13739 = FStar_Syntax_Free.univs t  in
-            ext out uu____13739  in
+            let uu____13739 = FStar_Syntax_Free.univs t in
+            ext out uu____13739 in
           aux uu____13736 tl1
-      | (Binding_sig uu____13742)::uu____13743 -> out  in
+      | (Binding_sig uu____13742)::uu____13743 -> out in
     aux no_univs env.gamma
-  
-let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Util.fifo_set) =
+let univnames: env -> FStar_Syntax_Syntax.univ_name FStar_Util.fifo_set =
   fun env  ->
-    let no_univ_names = FStar_Syntax_Syntax.no_universe_names  in
-    let ext out uvs = FStar_Util.fifo_set_union out uvs  in
+    let no_univ_names = FStar_Syntax_Syntax.no_universe_names in
+    let ext out uvs = FStar_Util.fifo_set_union out uvs in
     let rec aux out g =
       match g with
       | [] -> out
       | (Binding_sig_inst uu____13796)::tl1 -> aux out tl1
       | (Binding_univ uname)::tl1 ->
-          let uu____13812 = FStar_Util.fifo_set_add uname out  in
+          let uu____13812 = FStar_Util.fifo_set_add uname out in
           aux uu____13812 tl1
       | (Binding_lid (uu____13815,(uu____13816,t)))::tl1 ->
           let uu____13831 =
-            let uu____13834 = FStar_Syntax_Free.univnames t  in
-            ext out uu____13834  in
+            let uu____13834 = FStar_Syntax_Free.univnames t in
+            ext out uu____13834 in
           aux uu____13831 tl1
       | (Binding_var
           { FStar_Syntax_Syntax.ppname = uu____13837;
@@ -4634,14 +4321,13 @@ let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Util.fifo_set) =
             FStar_Syntax_Syntax.sort = t;_})::tl1
           ->
           let uu____13845 =
-            let uu____13848 = FStar_Syntax_Free.univnames t  in
-            ext out uu____13848  in
+            let uu____13848 = FStar_Syntax_Free.univnames t in
+            ext out uu____13848 in
           aux uu____13845 tl1
-      | (Binding_sig uu____13851)::uu____13852 -> out  in
+      | (Binding_sig uu____13851)::uu____13852 -> out in
     aux no_univ_names env.gamma
-  
-let (bound_vars_of_bindings :
-  binding Prims.list -> FStar_Syntax_Syntax.bv Prims.list) =
+let bound_vars_of_bindings:
+  binding Prims.list -> FStar_Syntax_Syntax.bv Prims.list =
   fun bs  ->
     FStar_All.pipe_right bs
       (FStar_List.collect
@@ -4652,22 +4338,18 @@ let (bound_vars_of_bindings :
             | Binding_sig uu____13885 -> []
             | Binding_univ uu____13892 -> []
             | Binding_sig_inst uu____13893 -> []))
-  
-let (binders_of_bindings : binding Prims.list -> FStar_Syntax_Syntax.binders)
-  =
+let binders_of_bindings: binding Prims.list -> FStar_Syntax_Syntax.binders =
   fun bs  ->
     let uu____13909 =
-      let uu____13912 = bound_vars_of_bindings bs  in
+      let uu____13912 = bound_vars_of_bindings bs in
       FStar_All.pipe_right uu____13912
-        (FStar_List.map FStar_Syntax_Syntax.mk_binder)
-       in
+        (FStar_List.map FStar_Syntax_Syntax.mk_binder) in
     FStar_All.pipe_right uu____13909 FStar_List.rev
-  
-let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
-  fun env  -> bound_vars_of_bindings env.gamma 
-let (all_binders : env -> FStar_Syntax_Syntax.binders) =
-  fun env  -> binders_of_bindings env.gamma 
-let (print_gamma : env -> Prims.unit) =
+let bound_vars: env -> FStar_Syntax_Syntax.bv Prims.list =
+  fun env  -> bound_vars_of_bindings env.gamma
+let all_binders: env -> FStar_Syntax_Syntax.binders =
+  fun env  -> binders_of_bindings env.gamma
+let print_gamma: env -> Prims.unit =
   fun env  ->
     let uu____13934 =
       let uu____13935 =
@@ -4676,46 +4358,40 @@ let (print_gamma : env -> Prims.unit) =
              (fun uu___83_13945  ->
                 match uu___83_13945 with
                 | Binding_var x ->
-                    let uu____13947 = FStar_Syntax_Print.bv_to_string x  in
+                    let uu____13947 = FStar_Syntax_Print.bv_to_string x in
                     Prims.strcat "Binding_var " uu____13947
                 | Binding_univ u ->
                     Prims.strcat "Binding_univ " u.FStar_Ident.idText
                 | Binding_lid (l,uu____13950) ->
-                    let uu____13951 = FStar_Ident.string_of_lid l  in
+                    let uu____13951 = FStar_Ident.string_of_lid l in
                     Prims.strcat "Binding_lid " uu____13951
                 | Binding_sig (ls,uu____13953) ->
                     let uu____13958 =
                       let uu____13959 =
                         FStar_All.pipe_right ls
-                          (FStar_List.map FStar_Ident.string_of_lid)
-                         in
+                          (FStar_List.map FStar_Ident.string_of_lid) in
                       FStar_All.pipe_right uu____13959
-                        (FStar_String.concat ", ")
-                       in
+                        (FStar_String.concat ", ") in
                     Prims.strcat "Binding_sig " uu____13958
                 | Binding_sig_inst (ls,uu____13969,uu____13970) ->
                     let uu____13975 =
                       let uu____13976 =
                         FStar_All.pipe_right ls
-                          (FStar_List.map FStar_Ident.string_of_lid)
-                         in
+                          (FStar_List.map FStar_Ident.string_of_lid) in
                       FStar_All.pipe_right uu____13976
-                        (FStar_String.concat ", ")
-                       in
-                    Prims.strcat "Binding_sig_inst " uu____13975))
-         in
-      FStar_All.pipe_right uu____13935 (FStar_String.concat "::\n")  in
+                        (FStar_String.concat ", ") in
+                    Prims.strcat "Binding_sig_inst " uu____13975)) in
+      FStar_All.pipe_right uu____13935 (FStar_String.concat "::\n") in
     FStar_All.pipe_right uu____13934 (FStar_Util.print1 "%s\n")
-  
-let (eq_gamma : env -> env -> Prims.bool) =
+let eq_gamma: env -> env -> Prims.bool =
   fun env  ->
     fun env'  ->
-      let uu____13993 = FStar_Util.physical_equality env.gamma env'.gamma  in
+      let uu____13993 = FStar_Util.physical_equality env.gamma env'.gamma in
       if uu____13993
       then true
       else
-        (let g = all_binders env  in
-         let g' = all_binders env'  in
+        (let g = all_binders env in
+         let g' = all_binders env' in
          ((FStar_List.length g) = (FStar_List.length g')) &&
            (FStar_List.forall2
               (fun uu____14021  ->
@@ -4723,14 +4399,12 @@ let (eq_gamma : env -> env -> Prims.bool) =
                    match (uu____14021, uu____14022) with
                    | ((b1,uu____14040),(b2,uu____14042)) ->
                        FStar_Syntax_Syntax.bv_eq b1 b2) g g'))
-  
-let fold_env : 'a . env -> ('a -> binding -> 'a) -> 'a -> 'a =
+let fold_env: 'a . env -> ('a -> binding -> 'a) -> 'a -> 'a =
   fun env  ->
     fun f  ->
       fun a  ->
         FStar_List.fold_right (fun e  -> fun a1  -> f a1 e) env.gamma a
-  
-let (string_of_delta_level : delta_level -> Prims.string) =
+let string_of_delta_level: delta_level -> Prims.string =
   fun uu___84_14084  ->
     match uu___84_14084 with
     | NoDelta  -> "NoDelta"
@@ -4738,8 +4412,7 @@ let (string_of_delta_level : delta_level -> Prims.string) =
     | Eager_unfolding_only  -> "Eager_unfolding_only"
     | Unfold uu____14085 -> "Unfold _"
     | UnfoldTac  -> "UnfoldTac"
-  
-let (lidents : env -> FStar_Ident.lident Prims.list) =
+let lidents: env -> FStar_Ident.lident Prims.list =
   fun env  ->
     let keys =
       FStar_List.fold_left
@@ -4747,44 +4420,39 @@ let (lidents : env -> FStar_Ident.lident Prims.list) =
            fun uu___85_14103  ->
              match uu___85_14103 with
              | Binding_sig (lids,uu____14109) -> FStar_List.append lids keys
-             | uu____14114 -> keys) [] env.gamma
-       in
+             | uu____14114 -> keys) [] env.gamma in
     FStar_Util.smap_fold (sigtab env)
       (fun uu____14120  ->
          fun v1  ->
            fun keys1  ->
              FStar_List.append (FStar_Syntax_Util.lids_of_sigelt v1) keys1)
       keys
-  
-let (should_enc_path : env -> Prims.string Prims.list -> Prims.bool) =
+let should_enc_path: env -> Prims.string Prims.list -> Prims.bool =
   fun env  ->
     fun path  ->
       let rec list_prefix xs ys =
         match (xs, ys) with
         | ([],uu____14154) -> true
         | (x::xs1,y::ys1) -> (x = y) && (list_prefix xs1 ys1)
-        | (uu____14173,uu____14174) -> false  in
+        | (uu____14173,uu____14174) -> false in
       let uu____14183 =
         FStar_List.tryFind
           (fun uu____14201  ->
              match uu____14201 with | (p,uu____14209) -> list_prefix p path)
-          env.proof_ns
-         in
+          env.proof_ns in
       match uu____14183 with
       | FStar_Pervasives_Native.None  -> false
       | FStar_Pervasives_Native.Some (uu____14220,b) -> b
-  
-let (should_enc_lid : env -> FStar_Ident.lident -> Prims.bool) =
+let should_enc_lid: env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun lid  ->
-      let uu____14238 = FStar_Ident.path_of_lid lid  in
+      let uu____14238 = FStar_Ident.path_of_lid lid in
       should_enc_path env uu____14238
-  
-let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
+let cons_proof_ns: Prims.bool -> env -> name_prefix -> env =
   fun b  ->
     fun e  ->
       fun path  ->
-        let uu___109_14250 = e  in
+        let uu___109_14250 = e in
         {
           solver = (uu___109_14250.solver);
           range = (uu___109_14250.range);
@@ -4822,16 +4490,15 @@ let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
           dsenv = (uu___109_14250.dsenv);
           dep_graph = (uu___109_14250.dep_graph)
         }
-  
-let (add_proof_ns : env -> name_prefix -> env) =
-  fun e  -> fun path  -> cons_proof_ns true e path 
-let (rem_proof_ns : env -> name_prefix -> env) =
-  fun e  -> fun path  -> cons_proof_ns false e path 
-let (get_proof_ns : env -> proof_namespace) = fun e  -> e.proof_ns 
-let (set_proof_ns : proof_namespace -> env -> env) =
+let add_proof_ns: env -> name_prefix -> env =
+  fun e  -> fun path  -> cons_proof_ns true e path
+let rem_proof_ns: env -> name_prefix -> env =
+  fun e  -> fun path  -> cons_proof_ns false e path
+let get_proof_ns: env -> proof_namespace = fun e  -> e.proof_ns
+let set_proof_ns: proof_namespace -> env -> env =
   fun ns  ->
     fun e  ->
-      let uu___110_14276 = e  in
+      let uu___110_14276 = e in
       {
         solver = (uu___110_14276.solver);
         range = (uu___110_14276.range);
@@ -4869,28 +4536,24 @@ let (set_proof_ns : proof_namespace -> env -> env) =
         dsenv = (uu___110_14276.dsenv);
         dep_graph = (uu___110_14276.dep_graph)
       }
-  
-let (unbound_vars :
-  env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set) =
+let unbound_vars:
+  env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set =
   fun e  ->
     fun t  ->
-      let uu____14287 = FStar_Syntax_Free.names t  in
-      let uu____14290 = bound_vars e  in
+      let uu____14287 = FStar_Syntax_Free.names t in
+      let uu____14290 = bound_vars e in
       FStar_List.fold_left (fun s  -> fun bv  -> FStar_Util.set_remove bv s)
         uu____14287 uu____14290
-  
-let (closed : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let closed: env -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun e  ->
     fun t  ->
-      let uu____14307 = unbound_vars e t  in
+      let uu____14307 = unbound_vars e t in
       FStar_Util.set_is_empty uu____14307
-  
-let (closed' : FStar_Syntax_Syntax.term -> Prims.bool) =
+let closed': FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
-    let uu____14313 = FStar_Syntax_Free.names t  in
+    let uu____14313 = FStar_Syntax_Free.names t in
     FStar_Util.set_is_empty uu____14313
-  
-let (string_of_proof_ns : env -> Prims.string) =
+let string_of_proof_ns: env -> Prims.string =
   fun env  ->
     let aux uu____14328 =
       match uu____14328 with
@@ -4898,15 +4561,13 @@ let (string_of_proof_ns : env -> Prims.string) =
           if (p = []) && b
           then "*"
           else
-            (let uu____14344 = FStar_Ident.text_of_path p  in
-             Prims.strcat (if b then "+" else "-") uu____14344)
-       in
+            (let uu____14344 = FStar_Ident.text_of_path p in
+             Prims.strcat (if b then "+" else "-") uu____14344) in
     let uu____14346 =
-      let uu____14349 = FStar_List.map aux env.proof_ns  in
-      FStar_All.pipe_right uu____14349 FStar_List.rev  in
+      let uu____14349 = FStar_List.map aux env.proof_ns in
+      FStar_All.pipe_right uu____14349 FStar_List.rev in
     FStar_All.pipe_right uu____14346 (FStar_String.concat " ")
-  
-let (dummy_solver : solver_t) =
+let dummy_solver: solver_t =
   {
     init = (fun uu____14366  -> ());
     push = (fun uu____14368  -> ());
@@ -4917,10 +4578,9 @@ let (dummy_solver : solver_t) =
       (fun e  ->
          fun g  ->
            let uu____14384 =
-             let uu____14391 = FStar_Options.peek ()  in (e, g, uu____14391)
-              in
+             let uu____14391 = FStar_Options.peek () in (e, g, uu____14391) in
            [uu____14384]);
     solve = (fun uu____14407  -> fun uu____14408  -> fun uu____14409  -> ());
     finish = (fun uu____14415  -> ());
     refresh = (fun uu____14417  -> ())
-  } 
+  }

--- a/src/ocaml-output/FStar_TypeChecker_Err.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Err.ml
@@ -1,12 +1,12 @@
 open Prims
-let (info_at_pos :
+let info_at_pos:
   FStar_TypeChecker_Env.env ->
     Prims.string ->
       Prims.int ->
         Prims.int ->
           ((Prims.string,FStar_Ident.lid) FStar_Util.either,FStar_Syntax_Syntax.typ,
             FStar_Range.range) FStar_Pervasives_Native.tuple3
-            FStar_Pervasives_Native.option)
+            FStar_Pervasives_Native.option
   =
   fun env  ->
     fun file  ->
@@ -14,8 +14,8 @@ let (info_at_pos :
         fun col  ->
           let uu____25 =
             let uu____28 =
-              FStar_ST.op_Bang env.FStar_TypeChecker_Env.identifier_info  in
-            FStar_TypeChecker_Common.id_info_at_pos uu____28 file row col  in
+              FStar_ST.op_Bang env.FStar_TypeChecker_Env.identifier_info in
+            FStar_TypeChecker_Common.id_info_at_pos uu____28 file row col in
           match uu____25 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some info ->
@@ -23,30 +23,27 @@ let (info_at_pos :
                | FStar_Util.Inl bv ->
                    let uu____84 =
                      let uu____95 =
-                       let uu____100 = FStar_Syntax_Print.nm_to_string bv  in
-                       FStar_Util.Inl uu____100  in
-                     let uu____101 = FStar_Syntax_Syntax.range_of_bv bv  in
+                       let uu____100 = FStar_Syntax_Print.nm_to_string bv in
+                       FStar_Util.Inl uu____100 in
+                     let uu____101 = FStar_Syntax_Syntax.range_of_bv bv in
                      (uu____95,
                        (info.FStar_TypeChecker_Common.identifier_ty),
-                       uu____101)
-                      in
+                       uu____101) in
                    FStar_Pervasives_Native.Some uu____84
                | FStar_Util.Inr fv ->
                    let uu____117 =
                      let uu____128 =
-                       let uu____133 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                       FStar_Util.Inr uu____133  in
-                     let uu____134 = FStar_Syntax_Syntax.range_of_fv fv  in
+                       let uu____133 = FStar_Syntax_Syntax.lid_of_fv fv in
+                       FStar_Util.Inr uu____133 in
+                     let uu____134 = FStar_Syntax_Syntax.range_of_fv fv in
                      (uu____128,
                        (info.FStar_TypeChecker_Common.identifier_ty),
-                       uu____134)
-                      in
+                       uu____134) in
                    FStar_Pervasives_Native.Some uu____117)
-  
-let (add_errors :
+let add_errors:
   FStar_TypeChecker_Env.env ->
     (FStar_Errors.raw_error,Prims.string,FStar_Range.range)
-      FStar_Pervasives_Native.tuple3 Prims.list -> Prims.unit)
+      FStar_Pervasives_Native.tuple3 Prims.list -> Prims.unit
   =
   fun env  ->
     fun errs  ->
@@ -58,200 +55,182 @@ let (add_errors :
                 | (e,msg,r) ->
                     if r = FStar_Range.dummyRange
                     then
-                      let uu____235 = FStar_TypeChecker_Env.get_range env  in
+                      let uu____235 = FStar_TypeChecker_Env.get_range env in
                       (e, msg, uu____235)
                     else
                       (let r' =
-                         let uu____238 = FStar_Range.use_range r  in
-                         FStar_Range.set_def_range r uu____238  in
+                         let uu____238 = FStar_Range.use_range r in
+                         FStar_Range.set_def_range r uu____238 in
                        let uu____239 =
-                         let uu____240 = FStar_Range.file_of_range r'  in
+                         let uu____240 = FStar_Range.file_of_range r' in
                          let uu____241 =
                            let uu____242 =
-                             FStar_TypeChecker_Env.get_range env  in
-                           FStar_Range.file_of_range uu____242  in
-                         uu____240 <> uu____241  in
+                             FStar_TypeChecker_Env.get_range env in
+                           FStar_Range.file_of_range uu____242 in
+                         uu____240 <> uu____241 in
                        if uu____239
                        then
                          let uu____249 =
                            let uu____250 =
                              let uu____251 =
                                let uu____252 =
-                                 FStar_Range.string_of_use_range r  in
-                               Prims.strcat uu____252 ")"  in
-                             Prims.strcat "(Also see: " uu____251  in
-                           Prims.strcat msg uu____250  in
-                         let uu____253 = FStar_TypeChecker_Env.get_range env
-                            in
+                                 FStar_Range.string_of_use_range r in
+                               Prims.strcat uu____252 ")" in
+                             Prims.strcat "(Also see: " uu____251 in
+                           Prims.strcat msg uu____250 in
+                         let uu____253 = FStar_TypeChecker_Env.get_range env in
                          (e, uu____249, uu____253)
-                       else (e, msg, r))))
-         in
+                       else (e, msg, r)))) in
       FStar_Errors.add_errors errs1
-  
-let (err_msg_type_strings :
+let err_msg_type_strings:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
-        (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2)
+        (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let s1 = FStar_TypeChecker_Normalize.term_to_string env t1  in
-        let s2 = FStar_TypeChecker_Normalize.term_to_string env t2  in
+        let s1 = FStar_TypeChecker_Normalize.term_to_string env t1 in
+        let s2 = FStar_TypeChecker_Normalize.term_to_string env t2 in
         if s1 = s2
         then
           FStar_Options.with_saved_options
             (fun uu____286  ->
                (let uu____288 =
                   FStar_Options.set_options FStar_Options.Set
-                    "--print_full_names --print_universes"
-                   in
+                    "--print_full_names --print_universes" in
                 ());
                (let uu____289 =
-                  FStar_TypeChecker_Normalize.term_to_string env t1  in
+                  FStar_TypeChecker_Normalize.term_to_string env t1 in
                 let uu____290 =
-                  FStar_TypeChecker_Normalize.term_to_string env t2  in
+                  FStar_TypeChecker_Normalize.term_to_string env t2 in
                 (uu____289, uu____290)))
         else (s1, s2)
-  
-let (exhaustiveness_check : Prims.string) = "Patterns are incomplete" 
-let (subtyping_failed :
+let exhaustiveness_check: Prims.string = "Patterns are incomplete"
+let subtyping_failed:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.typ -> Prims.unit -> Prims.string)
+      FStar_Syntax_Syntax.typ -> Prims.unit -> Prims.string
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
         fun x  ->
-          let uu____304 = err_msg_type_strings env t1 t2  in
+          let uu____304 = err_msg_type_strings env t1 t2 in
           match uu____304 with
           | (s1,s2) ->
               FStar_Util.format2
                 "Subtyping check failed; expected type %s; got type %s" s2 s1
-  
-let (ill_kinded_type : Prims.string) = "Ill-kinded type" 
-let (totality_check : Prims.string) = "This term may not terminate" 
-let (unexpected_signature_for_monad :
+let ill_kinded_type: Prims.string = "Ill-kinded type"
+let totality_check: Prims.string = "This term may not terminate"
+let unexpected_signature_for_monad:
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
       FStar_Syntax_Syntax.term ->
-        (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+        (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun m  ->
       fun k  ->
         let uu____324 =
-          let uu____325 = FStar_TypeChecker_Normalize.term_to_string env k
-             in
+          let uu____325 = FStar_TypeChecker_Normalize.term_to_string env k in
           FStar_Util.format2
             "Unexpected signature for monad \"%s\". Expected a signature of the form (a:Type => WP a => Effect); got %s"
-            m.FStar_Ident.str uu____325
-           in
+            m.FStar_Ident.str uu____325 in
         (FStar_Errors.Fatal_UnexpectedSignatureForMonad, uu____324)
-  
-let (expected_a_term_of_type_t_got_a_function :
+let expected_a_term_of_type_t_got_a_function:
   FStar_TypeChecker_Env.env ->
     Prims.string ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Syntax.term ->
           (FStar_Errors.raw_error,Prims.string)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun msg  ->
       fun t  ->
         fun e  ->
           let uu____342 =
-            let uu____343 = FStar_TypeChecker_Normalize.term_to_string env t
-               in
-            let uu____344 = FStar_Syntax_Print.term_to_string e  in
+            let uu____343 = FStar_TypeChecker_Normalize.term_to_string env t in
+            let uu____344 = FStar_Syntax_Print.term_to_string e in
             FStar_Util.format3
               "Expected a term of type \"%s\"; got a function \"%s\" (%s)"
-              uu____343 uu____344 msg
-             in
+              uu____343 uu____344 msg in
           (FStar_Errors.Fatal_ExpectTermGotFunction, uu____342)
-  
-let (unexpected_implicit_argument :
-  (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2) =
+let unexpected_implicit_argument:
+  (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2 =
   (FStar_Errors.Fatal_UnexpectedImplicitArgument,
     "Unexpected instantiation of an implicit argument to a function that only expects explicit arguments")
-  
-let (expected_expression_of_type :
+let expected_expression_of_type:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Syntax.term ->
           (FStar_Errors.raw_error,Prims.string)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun t1  ->
       fun e  ->
         fun t2  ->
-          let uu____365 = err_msg_type_strings env t1 t2  in
+          let uu____365 = err_msg_type_strings env t1 t2 in
           match uu____365 with
           | (s1,s2) ->
               let uu____376 =
-                let uu____377 = FStar_Syntax_Print.term_to_string e  in
+                let uu____377 = FStar_Syntax_Print.term_to_string e in
                 FStar_Util.format3
                   "Expected expression of type \"%s\"; got expression \"%s\" of type \"%s\""
-                  s1 uu____377 s2
-                 in
+                  s1 uu____377 s2 in
               (FStar_Errors.Fatal_UnexpectedExpressionType, uu____376)
-  
-let (expected_function_with_parameter_of_type :
+let expected_function_with_parameter_of_type:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> Prims.string -> Prims.string)
+      FStar_Syntax_Syntax.term -> Prims.string -> Prims.string
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____389 = err_msg_type_strings env t1 t2  in
+        let uu____389 = err_msg_type_strings env t1 t2 in
         match uu____389 with
         | (s1,s2) ->
             FStar_Util.format3
               "Expected a function with a parameter of type \"%s\"; this function has a parameter of type \"%s\""
               s1 s2
-  
-let (expected_pattern_of_type :
+let expected_pattern_of_type:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Syntax.term ->
           (FStar_Errors.raw_error,Prims.string)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun t1  ->
       fun e  ->
         fun t2  ->
-          let uu____414 = err_msg_type_strings env t1 t2  in
+          let uu____414 = err_msg_type_strings env t1 t2 in
           match uu____414 with
           | (s1,s2) ->
               let uu____425 =
-                let uu____426 = FStar_Syntax_Print.term_to_string e  in
+                let uu____426 = FStar_Syntax_Print.term_to_string e in
                 FStar_Util.format3
                   "Expected pattern of type \"%s\"; got pattern \"%s\" of type \"%s\""
-                  s1 uu____426 s2
-                 in
+                  s1 uu____426 s2 in
               (FStar_Errors.Fatal_UnexpectedPattern, uu____425)
-  
-let (basic_type_error :
+let basic_type_error:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Syntax.term ->
           (FStar_Errors.raw_error,Prims.string)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun eopt  ->
       fun t1  ->
         fun t2  ->
-          let uu____447 = err_msg_type_strings env t1 t2  in
+          let uu____447 = err_msg_type_strings env t1 t2 in
           match uu____447 with
           | (s1,s2) ->
               let msg =
@@ -261,62 +240,51 @@ let (basic_type_error :
                       "Expected type \"%s\"; got type \"%s\"" s1 s2
                 | FStar_Pervasives_Native.Some e ->
                     let uu____460 =
-                      FStar_TypeChecker_Normalize.term_to_string env e  in
+                      FStar_TypeChecker_Normalize.term_to_string env e in
                     FStar_Util.format3
                       "Expected type \"%s\"; but \"%s\" has type \"%s\"" s1
-                      uu____460 s2
-                 in
+                      uu____460 s2 in
               (FStar_Errors.Error_TypeError, msg)
-  
-let (occurs_check :
-  (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2) =
+let occurs_check:
+  (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2 =
   (FStar_Errors.Fatal_PossibleInfiniteTyp,
     "Possibly infinite typ (occurs check failed)")
-  
-let (incompatible_kinds :
+let incompatible_kinds:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
-        (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+        (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun k1  ->
       fun k2  ->
         let uu____478 =
-          let uu____479 = FStar_TypeChecker_Normalize.term_to_string env k1
-             in
-          let uu____480 = FStar_TypeChecker_Normalize.term_to_string env k2
-             in
+          let uu____479 = FStar_TypeChecker_Normalize.term_to_string env k1 in
+          let uu____480 = FStar_TypeChecker_Normalize.term_to_string env k2 in
           FStar_Util.format2 "Kinds \"%s\" and \"%s\" are incompatible"
-            uu____479 uu____480
-           in
+            uu____479 uu____480 in
         (FStar_Errors.Fatal_IncompatibleKinds, uu____478)
-  
-let (constructor_builds_the_wrong_type :
+let constructor_builds_the_wrong_type:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Syntax.term ->
           (FStar_Errors.raw_error,Prims.string)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun d  ->
       fun t  ->
         fun t'  ->
           let uu____497 =
-            let uu____498 = FStar_Syntax_Print.term_to_string d  in
-            let uu____499 = FStar_TypeChecker_Normalize.term_to_string env t
-               in
-            let uu____500 = FStar_TypeChecker_Normalize.term_to_string env t'
-               in
+            let uu____498 = FStar_Syntax_Print.term_to_string d in
+            let uu____499 = FStar_TypeChecker_Normalize.term_to_string env t in
+            let uu____500 = FStar_TypeChecker_Normalize.term_to_string env t' in
             FStar_Util.format3
               "Constructor \"%s\" builds a value of type \"%s\"; expected \"%s\""
-              uu____498 uu____499 uu____500
-             in
+              uu____498 uu____499 uu____500 in
           (FStar_Errors.Fatal_ConstsructorBuildWrongType, uu____497)
-  
-let constructor_fails_the_positivity_check :
+let constructor_fails_the_positivity_check:
   'Auu____505 .
     'Auu____505 ->
       FStar_Syntax_Syntax.term ->
@@ -328,122 +296,105 @@ let constructor_fails_the_positivity_check :
     fun d  ->
       fun l  ->
         let uu____522 =
-          let uu____523 = FStar_Syntax_Print.term_to_string d  in
-          let uu____524 = FStar_Syntax_Print.lid_to_string l  in
+          let uu____523 = FStar_Syntax_Print.term_to_string d in
+          let uu____524 = FStar_Syntax_Print.lid_to_string l in
           FStar_Util.format2
             "Constructor \"%s\" fails the strict positivity check; the constructed type \"%s\" occurs to the left of a pure function type"
-            uu____523 uu____524
-           in
+            uu____523 uu____524 in
         (FStar_Errors.Fatal_ConstructorFailedCheck, uu____522)
-  
-let (inline_type_annotation_and_val_decl :
+let inline_type_annotation_and_val_decl:
   FStar_Ident.lid ->
-    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun l  ->
     let uu____532 =
-      let uu____533 = FStar_Syntax_Print.lid_to_string l  in
+      let uu____533 = FStar_Syntax_Print.lid_to_string l in
       FStar_Util.format1
         "\"%s\" has a val declaration as well as an inlined type annotation; remove one"
-        uu____533
-       in
+        uu____533 in
     (FStar_Errors.Fatal_DuplicateTypeAnnotationAndValDecl, uu____532)
-  
-let (inferred_type_causes_variable_to_escape :
+let inferred_type_causes_variable_to_escape:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.bv ->
-        (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+        (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun t  ->
       fun x  ->
         let uu____547 =
-          let uu____548 = FStar_TypeChecker_Normalize.term_to_string env t
-             in
-          let uu____549 = FStar_Syntax_Print.bv_to_string x  in
+          let uu____548 = FStar_TypeChecker_Normalize.term_to_string env t in
+          let uu____549 = FStar_Syntax_Print.bv_to_string x in
           FStar_Util.format2
             "Inferred type \"%s\" causes variable \"%s\" to escape its scope"
-            uu____548 uu____549
-           in
+            uu____548 uu____549 in
         (FStar_Errors.Fatal_InferredTypeCauseVarEscape, uu____547)
-  
-let (expected_function_typ :
+let expected_function_typ:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun t  ->
       let uu____560 =
-        let uu____561 = FStar_TypeChecker_Normalize.term_to_string env t  in
+        let uu____561 = FStar_TypeChecker_Normalize.term_to_string env t in
         FStar_Util.format1
-          "Expected a function; got an expression of type \"%s\"" uu____561
-         in
+          "Expected a function; got an expression of type \"%s\"" uu____561 in
       (FStar_Errors.Fatal_FunctionTypeExpected, uu____560)
-  
-let (expected_poly_typ :
+let expected_poly_typ:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Syntax.term ->
           (FStar_Errors.raw_error,Prims.string)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun f  ->
       fun t  ->
         fun targ  ->
           let uu____578 =
-            let uu____579 = FStar_Syntax_Print.term_to_string f  in
-            let uu____580 = FStar_TypeChecker_Normalize.term_to_string env t
-               in
+            let uu____579 = FStar_Syntax_Print.term_to_string f in
+            let uu____580 = FStar_TypeChecker_Normalize.term_to_string env t in
             let uu____581 =
-              FStar_TypeChecker_Normalize.term_to_string env targ  in
+              FStar_TypeChecker_Normalize.term_to_string env targ in
             FStar_Util.format3
               "Expected a polymorphic function; got an expression \"%s\" of type \"%s\" applied to a type \"%s\""
-              uu____579 uu____580 uu____581
-             in
+              uu____579 uu____580 uu____581 in
           (FStar_Errors.Fatal_PolyTypeExpected, uu____578)
-  
-let (nonlinear_pattern_variable :
+let nonlinear_pattern_variable:
   FStar_Syntax_Syntax.bv ->
-    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun x  ->
-    let m = FStar_Syntax_Print.bv_to_string x  in
+    let m = FStar_Syntax_Print.bv_to_string x in
     let uu____590 =
       FStar_Util.format1
-        "The pattern variable \"%s\" was used more than once" m
-       in
+        "The pattern variable \"%s\" was used more than once" m in
     (FStar_Errors.Fatal_NonLinearPatternVars, uu____590)
-  
-let (disjunctive_pattern_vars :
+let disjunctive_pattern_vars:
   FStar_Syntax_Syntax.bv Prims.list ->
     FStar_Syntax_Syntax.bv Prims.list ->
-      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun v1  ->
     fun v2  ->
       let vars v3 =
         let uu____617 =
           FStar_All.pipe_right v3
-            (FStar_List.map FStar_Syntax_Print.bv_to_string)
-           in
-        FStar_All.pipe_right uu____617 (FStar_String.concat ", ")  in
+            (FStar_List.map FStar_Syntax_Print.bv_to_string) in
+        FStar_All.pipe_right uu____617 (FStar_String.concat ", ") in
       let uu____626 =
-        let uu____627 = vars v1  in
-        let uu____628 = vars v2  in
+        let uu____627 = vars v1 in
+        let uu____628 = vars v2 in
         FStar_Util.format2
           "Every alternative of an 'or' pattern must bind the same variables; here one branch binds (\"%s\") and another (\"%s\")"
-          uu____627 uu____628
-         in
+          uu____627 uu____628 in
       (FStar_Errors.Fatal_DisjuctivePatternVarsMismatch, uu____626)
-  
-let (name_and_result :
+let name_and_result:
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     (Prims.string,FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
@@ -451,11 +402,9 @@ let (name_and_result :
     | FStar_Syntax_Syntax.GTotal (t,uu____661) -> ("GTot", t)
     | FStar_Syntax_Syntax.Comp ct ->
         let uu____673 =
-          FStar_Syntax_Print.lid_to_string ct.FStar_Syntax_Syntax.effect_name
-           in
+          FStar_Syntax_Print.lid_to_string ct.FStar_Syntax_Syntax.effect_name in
         (uu____673, (ct.FStar_Syntax_Syntax.result_typ))
-  
-let computed_computation_type_does_not_match_annotation :
+let computed_computation_type_does_not_match_annotation:
   'Auu____681 .
     FStar_TypeChecker_Env.env ->
       'Auu____681 ->
@@ -468,109 +417,96 @@ let computed_computation_type_does_not_match_annotation :
     fun e  ->
       fun c  ->
         fun c'  ->
-          let uu____710 = name_and_result c  in
+          let uu____710 = name_and_result c in
           match uu____710 with
           | (f1,r1) ->
-              let uu____727 = name_and_result c'  in
+              let uu____727 = name_and_result c' in
               (match uu____727 with
                | (f2,r2) ->
-                   let uu____744 = err_msg_type_strings env r1 r2  in
+                   let uu____744 = err_msg_type_strings env r1 r2 in
                    (match uu____744 with
                     | (s1,s2) ->
                         let uu____755 =
                           FStar_Util.format4
                             "Computed type \"%s\" and effect \"%s\" is not compatible with the annotated type \"%s\" effect \"%s\""
-                            s1 f1 s2 f2
-                           in
+                            s1 f1 s2 f2 in
                         (FStar_Errors.Fatal_ComputedTypeNotMatchAnnotation,
                           uu____755)))
-  
-let (unexpected_non_trivial_precondition_on_term :
+let unexpected_non_trivial_precondition_on_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun f  ->
       let uu____766 =
-        let uu____767 = FStar_TypeChecker_Normalize.term_to_string env f  in
+        let uu____767 = FStar_TypeChecker_Normalize.term_to_string env f in
         FStar_Util.format1
-          "Term has an unexpected non-trivial pre-condition: %s" uu____767
-         in
+          "Term has an unexpected non-trivial pre-condition: %s" uu____767 in
       (FStar_Errors.Fatal_UnExpectedPreCondition, uu____766)
-  
-let (expected_pure_expression :
+let expected_pure_expression:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun e  ->
     fun c  ->
       let uu____782 =
-        let uu____783 = FStar_Syntax_Print.term_to_string e  in
+        let uu____783 = FStar_Syntax_Print.term_to_string e in
         let uu____784 =
-          let uu____785 = name_and_result c  in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____785  in
+          let uu____785 = name_and_result c in
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____785 in
         FStar_Util.format2
           "Expected a pure expression; got an expression \"%s\" with effect \"%s\""
-          uu____783 uu____784
-         in
+          uu____783 uu____784 in
       (FStar_Errors.Fatal_ExpectedPureExpression, uu____782)
-  
-let (expected_ghost_expression :
+let expected_ghost_expression:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun e  ->
     fun c  ->
       let uu____814 =
-        let uu____815 = FStar_Syntax_Print.term_to_string e  in
+        let uu____815 = FStar_Syntax_Print.term_to_string e in
         let uu____816 =
-          let uu____817 = name_and_result c  in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____817  in
+          let uu____817 = name_and_result c in
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____817 in
         FStar_Util.format2
           "Expected a ghost expression; got an expression \"%s\" with effect \"%s\""
-          uu____815 uu____816
-         in
+          uu____815 uu____816 in
       (FStar_Errors.Fatal_ExpectedGhostExpression, uu____814)
-  
-let (expected_effect_1_got_effect_2 :
+let expected_effect_1_got_effect_2:
   FStar_Ident.lident ->
     FStar_Ident.lident ->
-      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun c1  ->
     fun c2  ->
       let uu____842 =
-        let uu____843 = FStar_Syntax_Print.lid_to_string c1  in
-        let uu____844 = FStar_Syntax_Print.lid_to_string c2  in
+        let uu____843 = FStar_Syntax_Print.lid_to_string c1 in
+        let uu____844 = FStar_Syntax_Print.lid_to_string c2 in
         FStar_Util.format2
           "Expected a computation with effect %s; but it has effect %s"
-          uu____843 uu____844
-         in
+          uu____843 uu____844 in
       (FStar_Errors.Fatal_UnexpectedEffect, uu____842)
-  
-let (failed_to_prove_specification_of :
+let failed_to_prove_specification_of:
   FStar_Syntax_Syntax.lbname ->
     Prims.string Prims.list ->
-      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun l  ->
     fun lbls  ->
       let uu____859 =
-        let uu____860 = FStar_Syntax_Print.lbname_to_string l  in
-        let uu____861 = FStar_All.pipe_right lbls (FStar_String.concat ", ")
-           in
+        let uu____860 = FStar_Syntax_Print.lbname_to_string l in
+        let uu____861 = FStar_All.pipe_right lbls (FStar_String.concat ", ") in
         FStar_Util.format2
           "Failed to prove specification of %s; assertions at [%s] may fail"
-          uu____860 uu____861
-         in
+          uu____860 uu____861 in
       (FStar_Errors.Error_TypeCheckerFailToProve, uu____859)
-  
-let (failed_to_prove_specification :
+let failed_to_prove_specification:
   Prims.string Prims.list ->
-    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+    (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun lbls  ->
     let msg =
@@ -579,31 +515,26 @@ let (failed_to_prove_specification :
           "An unknown assertion in the term at this location was not provable"
       | uu____876 ->
           let uu____879 =
-            FStar_All.pipe_right lbls (FStar_String.concat "\n\t")  in
+            FStar_All.pipe_right lbls (FStar_String.concat "\n\t") in
           FStar_Util.format1 "The following problems were found:\n\t%s"
-            uu____879
-       in
+            uu____879 in
     (FStar_Errors.Error_TypeCheckerFailToProve, msg)
-  
-let (top_level_effect :
-  (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2) =
+let top_level_effect:
+  (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2 =
   (FStar_Errors.Warning_TopLevelEffect,
     "Top-level let-bindings must be total; this term may have effects")
-  
-let (cardinality_constraint_violated :
+let cardinality_constraint_violated:
   FStar_Ident.lid ->
     FStar_Syntax_Syntax.bv FStar_Syntax_Syntax.withinfo_t ->
-      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2)
+      (FStar_Errors.raw_error,Prims.string) FStar_Pervasives_Native.tuple2
   =
   fun l  ->
     fun a  ->
       let uu____900 =
-        let uu____901 = FStar_Syntax_Print.lid_to_string l  in
+        let uu____901 = FStar_Syntax_Print.lid_to_string l in
         let uu____902 =
-          FStar_Syntax_Print.bv_to_string a.FStar_Syntax_Syntax.v  in
+          FStar_Syntax_Print.bv_to_string a.FStar_Syntax_Syntax.v in
         FStar_Util.format2
           "Constructor %s violates the cardinality of Type at parameter '%s'; type arguments are not allowed"
-          uu____901 uu____902
-         in
+          uu____901 uu____902 in
       (FStar_Errors.Fatal_CardinalityConstraintViolated, uu____900)
-  

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -1,129 +1,110 @@
 open Prims
 type step =
-  | Beta 
-  | Iota 
-  | Zeta 
-  | Exclude of step 
-  | Weak 
-  | HNF 
-  | Primops 
-  | Eager_unfolding 
-  | Inlining 
-  | NoDeltaSteps 
-  | UnfoldUntil of FStar_Syntax_Syntax.delta_depth 
-  | UnfoldOnly of FStar_Ident.lid Prims.list 
-  | UnfoldAttr of FStar_Syntax_Syntax.attribute 
-  | UnfoldTac 
-  | PureSubtermsWithinComputations 
-  | Simplify 
-  | EraseUniverses 
-  | AllowUnboundUniverses 
-  | Reify 
-  | CompressUvars 
-  | NoFullNorm 
-  | CheckNoUvars 
-  | Unmeta 
-  | Unascribe [@@deriving show]
-let (uu___is_Beta : step -> Prims.bool) =
-  fun projectee  -> match projectee with | Beta  -> true | uu____22 -> false 
-let (uu___is_Iota : step -> Prims.bool) =
-  fun projectee  -> match projectee with | Iota  -> true | uu____26 -> false 
-let (uu___is_Zeta : step -> Prims.bool) =
-  fun projectee  -> match projectee with | Zeta  -> true | uu____30 -> false 
-let (uu___is_Exclude : step -> Prims.bool) =
+  | Beta
+  | Iota
+  | Zeta
+  | Exclude of step
+  | Weak
+  | HNF
+  | Primops
+  | Eager_unfolding
+  | Inlining
+  | NoDeltaSteps
+  | UnfoldUntil of FStar_Syntax_Syntax.delta_depth
+  | UnfoldOnly of FStar_Ident.lid Prims.list
+  | UnfoldAttr of FStar_Syntax_Syntax.attribute
+  | UnfoldTac
+  | PureSubtermsWithinComputations
+  | Simplify
+  | EraseUniverses
+  | AllowUnboundUniverses
+  | Reify
+  | CompressUvars
+  | NoFullNorm
+  | CheckNoUvars
+  | Unmeta
+  | Unascribe[@@deriving show]
+let uu___is_Beta: step -> Prims.bool =
+  fun projectee  -> match projectee with | Beta  -> true | uu____22 -> false
+let uu___is_Iota: step -> Prims.bool =
+  fun projectee  -> match projectee with | Iota  -> true | uu____26 -> false
+let uu___is_Zeta: step -> Prims.bool =
+  fun projectee  -> match projectee with | Zeta  -> true | uu____30 -> false
+let uu___is_Exclude: step -> Prims.bool =
   fun projectee  ->
     match projectee with | Exclude _0 -> true | uu____35 -> false
-  
-let (__proj__Exclude__item___0 : step -> step) =
-  fun projectee  -> match projectee with | Exclude _0 -> _0 
-let (uu___is_Weak : step -> Prims.bool) =
-  fun projectee  -> match projectee with | Weak  -> true | uu____46 -> false 
-let (uu___is_HNF : step -> Prims.bool) =
-  fun projectee  -> match projectee with | HNF  -> true | uu____50 -> false 
-let (uu___is_Primops : step -> Prims.bool) =
+let __proj__Exclude__item___0: step -> step =
+  fun projectee  -> match projectee with | Exclude _0 -> _0
+let uu___is_Weak: step -> Prims.bool =
+  fun projectee  -> match projectee with | Weak  -> true | uu____46 -> false
+let uu___is_HNF: step -> Prims.bool =
+  fun projectee  -> match projectee with | HNF  -> true | uu____50 -> false
+let uu___is_Primops: step -> Prims.bool =
   fun projectee  ->
     match projectee with | Primops  -> true | uu____54 -> false
-  
-let (uu___is_Eager_unfolding : step -> Prims.bool) =
+let uu___is_Eager_unfolding: step -> Prims.bool =
   fun projectee  ->
     match projectee with | Eager_unfolding  -> true | uu____58 -> false
-  
-let (uu___is_Inlining : step -> Prims.bool) =
+let uu___is_Inlining: step -> Prims.bool =
   fun projectee  ->
     match projectee with | Inlining  -> true | uu____62 -> false
-  
-let (uu___is_NoDeltaSteps : step -> Prims.bool) =
+let uu___is_NoDeltaSteps: step -> Prims.bool =
   fun projectee  ->
     match projectee with | NoDeltaSteps  -> true | uu____66 -> false
-  
-let (uu___is_UnfoldUntil : step -> Prims.bool) =
+let uu___is_UnfoldUntil: step -> Prims.bool =
   fun projectee  ->
     match projectee with | UnfoldUntil _0 -> true | uu____71 -> false
-  
-let (__proj__UnfoldUntil__item___0 : step -> FStar_Syntax_Syntax.delta_depth)
-  = fun projectee  -> match projectee with | UnfoldUntil _0 -> _0 
-let (uu___is_UnfoldOnly : step -> Prims.bool) =
+let __proj__UnfoldUntil__item___0: step -> FStar_Syntax_Syntax.delta_depth =
+  fun projectee  -> match projectee with | UnfoldUntil _0 -> _0
+let uu___is_UnfoldOnly: step -> Prims.bool =
   fun projectee  ->
     match projectee with | UnfoldOnly _0 -> true | uu____85 -> false
-  
-let (__proj__UnfoldOnly__item___0 : step -> FStar_Ident.lid Prims.list) =
-  fun projectee  -> match projectee with | UnfoldOnly _0 -> _0 
-let (uu___is_UnfoldAttr : step -> Prims.bool) =
+let __proj__UnfoldOnly__item___0: step -> FStar_Ident.lid Prims.list =
+  fun projectee  -> match projectee with | UnfoldOnly _0 -> _0
+let uu___is_UnfoldAttr: step -> Prims.bool =
   fun projectee  ->
     match projectee with | UnfoldAttr _0 -> true | uu____103 -> false
-  
-let (__proj__UnfoldAttr__item___0 : step -> FStar_Syntax_Syntax.attribute) =
-  fun projectee  -> match projectee with | UnfoldAttr _0 -> _0 
-let (uu___is_UnfoldTac : step -> Prims.bool) =
+let __proj__UnfoldAttr__item___0: step -> FStar_Syntax_Syntax.attribute =
+  fun projectee  -> match projectee with | UnfoldAttr _0 -> _0
+let uu___is_UnfoldTac: step -> Prims.bool =
   fun projectee  ->
     match projectee with | UnfoldTac  -> true | uu____114 -> false
-  
-let (uu___is_PureSubtermsWithinComputations : step -> Prims.bool) =
+let uu___is_PureSubtermsWithinComputations: step -> Prims.bool =
   fun projectee  ->
     match projectee with
     | PureSubtermsWithinComputations  -> true
     | uu____118 -> false
-  
-let (uu___is_Simplify : step -> Prims.bool) =
+let uu___is_Simplify: step -> Prims.bool =
   fun projectee  ->
     match projectee with | Simplify  -> true | uu____122 -> false
-  
-let (uu___is_EraseUniverses : step -> Prims.bool) =
+let uu___is_EraseUniverses: step -> Prims.bool =
   fun projectee  ->
     match projectee with | EraseUniverses  -> true | uu____126 -> false
-  
-let (uu___is_AllowUnboundUniverses : step -> Prims.bool) =
+let uu___is_AllowUnboundUniverses: step -> Prims.bool =
   fun projectee  ->
     match projectee with
     | AllowUnboundUniverses  -> true
     | uu____130 -> false
-  
-let (uu___is_Reify : step -> Prims.bool) =
+let uu___is_Reify: step -> Prims.bool =
   fun projectee  ->
     match projectee with | Reify  -> true | uu____134 -> false
-  
-let (uu___is_CompressUvars : step -> Prims.bool) =
+let uu___is_CompressUvars: step -> Prims.bool =
   fun projectee  ->
     match projectee with | CompressUvars  -> true | uu____138 -> false
-  
-let (uu___is_NoFullNorm : step -> Prims.bool) =
+let uu___is_NoFullNorm: step -> Prims.bool =
   fun projectee  ->
     match projectee with | NoFullNorm  -> true | uu____142 -> false
-  
-let (uu___is_CheckNoUvars : step -> Prims.bool) =
+let uu___is_CheckNoUvars: step -> Prims.bool =
   fun projectee  ->
     match projectee with | CheckNoUvars  -> true | uu____146 -> false
-  
-let (uu___is_Unmeta : step -> Prims.bool) =
+let uu___is_Unmeta: step -> Prims.bool =
   fun projectee  ->
     match projectee with | Unmeta  -> true | uu____150 -> false
-  
-let (uu___is_Unascribe : step -> Prims.bool) =
+let uu___is_Unascribe: step -> Prims.bool =
   fun projectee  ->
     match projectee with | Unascribe  -> true | uu____154 -> false
-  
 type steps = step Prims.list[@@deriving show]
-let cases :
+let cases:
   'Auu____162 'Auu____163 .
     ('Auu____163 -> 'Auu____162) ->
       'Auu____162 ->
@@ -135,35 +116,34 @@ let cases :
         match uu___75_180 with
         | FStar_Pervasives_Native.Some x -> f x
         | FStar_Pervasives_Native.None  -> d
-  
 type fsteps =
   {
-  beta: Prims.bool ;
-  iota: Prims.bool ;
-  zeta: Prims.bool ;
-  weak: Prims.bool ;
-  hnf: Prims.bool ;
-  primops: Prims.bool ;
-  eager_unfolding: Prims.bool ;
-  inlining: Prims.bool ;
-  no_delta_steps: Prims.bool ;
+  beta: Prims.bool;
+  iota: Prims.bool;
+  zeta: Prims.bool;
+  weak: Prims.bool;
+  hnf: Prims.bool;
+  primops: Prims.bool;
+  eager_unfolding: Prims.bool;
+  inlining: Prims.bool;
+  no_delta_steps: Prims.bool;
   unfold_until:
-    FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option ;
-  unfold_only: FStar_Ident.lid Prims.list FStar_Pervasives_Native.option ;
+    FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option;
+  unfold_only: FStar_Ident.lid Prims.list FStar_Pervasives_Native.option;
   unfold_attr:
-    FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option ;
-  unfold_tac: Prims.bool ;
-  pure_subterms_within_computations: Prims.bool ;
-  simplify: Prims.bool ;
-  erase_universes: Prims.bool ;
-  allow_unbound_universes: Prims.bool ;
-  reify_: Prims.bool ;
-  compress_uvars: Prims.bool ;
-  no_full_norm: Prims.bool ;
-  check_no_uvars: Prims.bool ;
-  unmeta: Prims.bool ;
-  unascribe: Prims.bool }[@@deriving show]
-let (__proj__Mkfsteps__item__beta : fsteps -> Prims.bool) =
+    FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option;
+  unfold_tac: Prims.bool;
+  pure_subterms_within_computations: Prims.bool;
+  simplify: Prims.bool;
+  erase_universes: Prims.bool;
+  allow_unbound_universes: Prims.bool;
+  reify_: Prims.bool;
+  compress_uvars: Prims.bool;
+  no_full_norm: Prims.bool;
+  check_no_uvars: Prims.bool;
+  unmeta: Prims.bool;
+  unascribe: Prims.bool;}[@@deriving show]
+let __proj__Mkfsteps__item__beta: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -183,8 +163,7 @@ let (__proj__Mkfsteps__item__beta : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__beta
-  
-let (__proj__Mkfsteps__item__iota : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__iota: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -204,8 +183,7 @@ let (__proj__Mkfsteps__item__iota : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__iota
-  
-let (__proj__Mkfsteps__item__zeta : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__zeta: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -225,8 +203,7 @@ let (__proj__Mkfsteps__item__zeta : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__zeta
-  
-let (__proj__Mkfsteps__item__weak : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__weak: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -246,8 +223,7 @@ let (__proj__Mkfsteps__item__weak : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__weak
-  
-let (__proj__Mkfsteps__item__hnf : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__hnf: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -267,8 +243,7 @@ let (__proj__Mkfsteps__item__hnf : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__hnf
-  
-let (__proj__Mkfsteps__item__primops : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__primops: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -288,8 +263,7 @@ let (__proj__Mkfsteps__item__primops : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__primops
-  
-let (__proj__Mkfsteps__item__eager_unfolding : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__eager_unfolding: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -309,8 +283,7 @@ let (__proj__Mkfsteps__item__eager_unfolding : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__eager_unfolding
-  
-let (__proj__Mkfsteps__item__inlining : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__inlining: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -330,8 +303,7 @@ let (__proj__Mkfsteps__item__inlining : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__inlining
-  
-let (__proj__Mkfsteps__item__no_delta_steps : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__no_delta_steps: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -351,9 +323,8 @@ let (__proj__Mkfsteps__item__no_delta_steps : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__no_delta_steps
-  
-let (__proj__Mkfsteps__item__unfold_until :
-  fsteps -> FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option) =
+let __proj__Mkfsteps__item__unfold_until:
+  fsteps -> FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -373,9 +344,8 @@ let (__proj__Mkfsteps__item__unfold_until :
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__unfold_until
-  
-let (__proj__Mkfsteps__item__unfold_only :
-  fsteps -> FStar_Ident.lid Prims.list FStar_Pervasives_Native.option) =
+let __proj__Mkfsteps__item__unfold_only:
+  fsteps -> FStar_Ident.lid Prims.list FStar_Pervasives_Native.option =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -395,10 +365,9 @@ let (__proj__Mkfsteps__item__unfold_only :
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__unfold_only
-  
-let (__proj__Mkfsteps__item__unfold_attr :
+let __proj__Mkfsteps__item__unfold_attr:
   fsteps ->
-    FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option
   =
   fun projectee  ->
     match projectee with
@@ -419,8 +388,7 @@ let (__proj__Mkfsteps__item__unfold_attr :
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__unfold_attr
-  
-let (__proj__Mkfsteps__item__unfold_tac : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__unfold_tac: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -440,9 +408,8 @@ let (__proj__Mkfsteps__item__unfold_tac : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__unfold_tac
-  
-let (__proj__Mkfsteps__item__pure_subterms_within_computations :
-  fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__pure_subterms_within_computations:
+  fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -463,8 +430,7 @@ let (__proj__Mkfsteps__item__pure_subterms_within_computations :
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} ->
         __fname__pure_subterms_within_computations
-  
-let (__proj__Mkfsteps__item__simplify : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__simplify: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -484,8 +450,7 @@ let (__proj__Mkfsteps__item__simplify : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__simplify
-  
-let (__proj__Mkfsteps__item__erase_universes : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__erase_universes: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -505,9 +470,7 @@ let (__proj__Mkfsteps__item__erase_universes : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__erase_universes
-  
-let (__proj__Mkfsteps__item__allow_unbound_universes : fsteps -> Prims.bool)
-  =
+let __proj__Mkfsteps__item__allow_unbound_universes: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -527,8 +490,7 @@ let (__proj__Mkfsteps__item__allow_unbound_universes : fsteps -> Prims.bool)
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__allow_unbound_universes
-  
-let (__proj__Mkfsteps__item__reify_ : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__reify_: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -548,8 +510,7 @@ let (__proj__Mkfsteps__item__reify_ : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__reify_
-  
-let (__proj__Mkfsteps__item__compress_uvars : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__compress_uvars: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -569,8 +530,7 @@ let (__proj__Mkfsteps__item__compress_uvars : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__compress_uvars
-  
-let (__proj__Mkfsteps__item__no_full_norm : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__no_full_norm: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -590,8 +550,7 @@ let (__proj__Mkfsteps__item__no_full_norm : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__no_full_norm
-  
-let (__proj__Mkfsteps__item__check_no_uvars : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__check_no_uvars: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -611,8 +570,7 @@ let (__proj__Mkfsteps__item__check_no_uvars : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__check_no_uvars
-  
-let (__proj__Mkfsteps__item__unmeta : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__unmeta: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -632,8 +590,7 @@ let (__proj__Mkfsteps__item__unmeta : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__unmeta
-  
-let (__proj__Mkfsteps__item__unascribe : fsteps -> Prims.bool) =
+let __proj__Mkfsteps__item__unascribe: fsteps -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { beta = __fname__beta; iota = __fname__iota; zeta = __fname__zeta;
@@ -653,8 +610,7 @@ let (__proj__Mkfsteps__item__unascribe : fsteps -> Prims.bool) =
         no_full_norm = __fname__no_full_norm;
         check_no_uvars = __fname__check_no_uvars; unmeta = __fname__unmeta;
         unascribe = __fname__unascribe;_} -> __fname__unascribe
-  
-let (default_steps : fsteps) =
+let default_steps: fsteps =
   {
     beta = true;
     iota = true;
@@ -679,19 +635,18 @@ let (default_steps : fsteps) =
     check_no_uvars = false;
     unmeta = false;
     unascribe = false
-  } 
-let rec (to_fsteps : step Prims.list -> fsteps) =
+  }
+let rec to_fsteps: step Prims.list -> fsteps =
   fun s  ->
     let add_opt x uu___76_1161 =
       match uu___76_1161 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.Some [x]
       | FStar_Pervasives_Native.Some xs ->
-          FStar_Pervasives_Native.Some (x :: xs)
-       in
+          FStar_Pervasives_Native.Some (x :: xs) in
     let add_one1 s1 fs =
       match s1 with
       | Beta  ->
-          let uu___94_1188 = fs  in
+          let uu___94_1188 = fs in
           {
             beta = true;
             iota = (uu___94_1188.iota);
@@ -719,7 +674,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___94_1188.unascribe)
           }
       | Iota  ->
-          let uu___95_1189 = fs  in
+          let uu___95_1189 = fs in
           {
             beta = (uu___95_1189.beta);
             iota = true;
@@ -747,7 +702,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___95_1189.unascribe)
           }
       | Zeta  ->
-          let uu___96_1190 = fs  in
+          let uu___96_1190 = fs in
           {
             beta = (uu___96_1190.beta);
             iota = (uu___96_1190.iota);
@@ -775,7 +730,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___96_1190.unascribe)
           }
       | Exclude (Beta ) ->
-          let uu___97_1191 = fs  in
+          let uu___97_1191 = fs in
           {
             beta = false;
             iota = (uu___97_1191.iota);
@@ -803,7 +758,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___97_1191.unascribe)
           }
       | Exclude (Iota ) ->
-          let uu___98_1192 = fs  in
+          let uu___98_1192 = fs in
           {
             beta = (uu___98_1192.beta);
             iota = false;
@@ -831,7 +786,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___98_1192.unascribe)
           }
       | Exclude (Zeta ) ->
-          let uu___99_1193 = fs  in
+          let uu___99_1193 = fs in
           {
             beta = (uu___99_1193.beta);
             iota = (uu___99_1193.iota);
@@ -860,7 +815,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
           }
       | Exclude uu____1194 -> failwith "Bad exclude"
       | Weak  ->
-          let uu___100_1195 = fs  in
+          let uu___100_1195 = fs in
           {
             beta = (uu___100_1195.beta);
             iota = (uu___100_1195.iota);
@@ -888,7 +843,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___100_1195.unascribe)
           }
       | HNF  ->
-          let uu___101_1196 = fs  in
+          let uu___101_1196 = fs in
           {
             beta = (uu___101_1196.beta);
             iota = (uu___101_1196.iota);
@@ -916,7 +871,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___101_1196.unascribe)
           }
       | Primops  ->
-          let uu___102_1197 = fs  in
+          let uu___102_1197 = fs in
           {
             beta = (uu___102_1197.beta);
             iota = (uu___102_1197.iota);
@@ -944,7 +899,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___102_1197.unascribe)
           }
       | Eager_unfolding  ->
-          let uu___103_1198 = fs  in
+          let uu___103_1198 = fs in
           {
             beta = (uu___103_1198.beta);
             iota = (uu___103_1198.iota);
@@ -972,7 +927,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___103_1198.unascribe)
           }
       | Inlining  ->
-          let uu___104_1199 = fs  in
+          let uu___104_1199 = fs in
           {
             beta = (uu___104_1199.beta);
             iota = (uu___104_1199.iota);
@@ -1000,7 +955,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___104_1199.unascribe)
           }
       | NoDeltaSteps  ->
-          let uu___105_1200 = fs  in
+          let uu___105_1200 = fs in
           {
             beta = (uu___105_1200.beta);
             iota = (uu___105_1200.iota);
@@ -1028,7 +983,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___105_1200.unascribe)
           }
       | UnfoldUntil d ->
-          let uu___106_1202 = fs  in
+          let uu___106_1202 = fs in
           {
             beta = (uu___106_1202.beta);
             iota = (uu___106_1202.iota);
@@ -1056,7 +1011,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___106_1202.unascribe)
           }
       | UnfoldOnly lids ->
-          let uu___107_1206 = fs  in
+          let uu___107_1206 = fs in
           {
             beta = (uu___107_1206.beta);
             iota = (uu___107_1206.iota);
@@ -1084,7 +1039,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___107_1206.unascribe)
           }
       | UnfoldAttr attr ->
-          let uu___108_1210 = fs  in
+          let uu___108_1210 = fs in
           {
             beta = (uu___108_1210.beta);
             iota = (uu___108_1210.iota);
@@ -1112,7 +1067,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___108_1210.unascribe)
           }
       | UnfoldTac  ->
-          let uu___109_1211 = fs  in
+          let uu___109_1211 = fs in
           {
             beta = (uu___109_1211.beta);
             iota = (uu___109_1211.iota);
@@ -1140,7 +1095,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___109_1211.unascribe)
           }
       | PureSubtermsWithinComputations  ->
-          let uu___110_1212 = fs  in
+          let uu___110_1212 = fs in
           {
             beta = (uu___110_1212.beta);
             iota = (uu___110_1212.iota);
@@ -1167,7 +1122,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___110_1212.unascribe)
           }
       | Simplify  ->
-          let uu___111_1213 = fs  in
+          let uu___111_1213 = fs in
           {
             beta = (uu___111_1213.beta);
             iota = (uu___111_1213.iota);
@@ -1195,7 +1150,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___111_1213.unascribe)
           }
       | EraseUniverses  ->
-          let uu___112_1214 = fs  in
+          let uu___112_1214 = fs in
           {
             beta = (uu___112_1214.beta);
             iota = (uu___112_1214.iota);
@@ -1223,7 +1178,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___112_1214.unascribe)
           }
       | AllowUnboundUniverses  ->
-          let uu___113_1215 = fs  in
+          let uu___113_1215 = fs in
           {
             beta = (uu___113_1215.beta);
             iota = (uu___113_1215.iota);
@@ -1251,7 +1206,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___113_1215.unascribe)
           }
       | Reify  ->
-          let uu___114_1216 = fs  in
+          let uu___114_1216 = fs in
           {
             beta = (uu___114_1216.beta);
             iota = (uu___114_1216.iota);
@@ -1279,7 +1234,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___114_1216.unascribe)
           }
       | CompressUvars  ->
-          let uu___115_1217 = fs  in
+          let uu___115_1217 = fs in
           {
             beta = (uu___115_1217.beta);
             iota = (uu___115_1217.iota);
@@ -1307,7 +1262,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___115_1217.unascribe)
           }
       | NoFullNorm  ->
-          let uu___116_1218 = fs  in
+          let uu___116_1218 = fs in
           {
             beta = (uu___116_1218.beta);
             iota = (uu___116_1218.iota);
@@ -1335,7 +1290,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___116_1218.unascribe)
           }
       | CheckNoUvars  ->
-          let uu___117_1219 = fs  in
+          let uu___117_1219 = fs in
           {
             beta = (uu___117_1219.beta);
             iota = (uu___117_1219.iota);
@@ -1363,7 +1318,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___117_1219.unascribe)
           }
       | Unmeta  ->
-          let uu___118_1220 = fs  in
+          let uu___118_1220 = fs in
           {
             beta = (uu___118_1220.beta);
             iota = (uu___118_1220.iota);
@@ -1391,7 +1346,7 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             unascribe = (uu___118_1220.unascribe)
           }
       | Unascribe  ->
-          let uu___119_1221 = fs  in
+          let uu___119_1221 = fs in
           {
             beta = (uu___119_1221.beta);
             iota = (uu___119_1221.iota);
@@ -1417,62 +1372,55 @@ let rec (to_fsteps : step Prims.list -> fsteps) =
             check_no_uvars = (uu___119_1221.check_no_uvars);
             unmeta = (uu___119_1221.unmeta);
             unascribe = true
-          }
-       in
+          } in
     FStar_List.fold_right add_one1 s default_steps
-  
 type psc =
   {
-  psc_range: FStar_Range.range ;
-  psc_subst: Prims.unit -> FStar_Syntax_Syntax.subst_t }[@@deriving show]
-let (__proj__Mkpsc__item__psc_range : psc -> FStar_Range.range) =
+  psc_range: FStar_Range.range;
+  psc_subst: Prims.unit -> FStar_Syntax_Syntax.subst_t;}[@@deriving show]
+let __proj__Mkpsc__item__psc_range: psc -> FStar_Range.range =
   fun projectee  ->
     match projectee with
     | { psc_range = __fname__psc_range; psc_subst = __fname__psc_subst;_} ->
         __fname__psc_range
-  
-let (__proj__Mkpsc__item__psc_subst :
-  psc -> Prims.unit -> FStar_Syntax_Syntax.subst_t) =
+let __proj__Mkpsc__item__psc_subst:
+  psc -> Prims.unit -> FStar_Syntax_Syntax.subst_t =
   fun projectee  ->
     match projectee with
     | { psc_range = __fname__psc_range; psc_subst = __fname__psc_subst;_} ->
         __fname__psc_subst
-  
-let (null_psc : psc) =
-  { psc_range = FStar_Range.dummyRange; psc_subst = (fun uu____1253  -> []) } 
-let (psc_range : psc -> FStar_Range.range) = fun psc  -> psc.psc_range 
-let (psc_subst : psc -> FStar_Syntax_Syntax.subst_t) =
-  fun psc  -> psc.psc_subst () 
+let null_psc: psc =
+  { psc_range = FStar_Range.dummyRange; psc_subst = (fun uu____1253  -> []) }
+let psc_range: psc -> FStar_Range.range = fun psc  -> psc.psc_range
+let psc_subst: psc -> FStar_Syntax_Syntax.subst_t =
+  fun psc  -> psc.psc_subst ()
 type primitive_step =
   {
-  name: FStar_Ident.lid ;
-  arity: Prims.int ;
-  strong_reduction_ok: Prims.bool ;
-  requires_binder_substitution: Prims.bool ;
+  name: FStar_Ident.lid;
+  arity: Prims.int;
+  strong_reduction_ok: Prims.bool;
+  requires_binder_substitution: Prims.bool;
   interpretation:
     psc ->
       FStar_Syntax_Syntax.args ->
-        FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
-    }[@@deriving show]
-let (__proj__Mkprimitive_step__item__name :
-  primitive_step -> FStar_Ident.lid) =
+        FStar_Syntax_Syntax.term FStar_Pervasives_Native.option;}[@@deriving
+                                                                   show]
+let __proj__Mkprimitive_step__item__name: primitive_step -> FStar_Ident.lid =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; arity = __fname__arity;
         strong_reduction_ok = __fname__strong_reduction_ok;
         requires_binder_substitution = __fname__requires_binder_substitution;
         interpretation = __fname__interpretation;_} -> __fname__name
-  
-let (__proj__Mkprimitive_step__item__arity : primitive_step -> Prims.int) =
+let __proj__Mkprimitive_step__item__arity: primitive_step -> Prims.int =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; arity = __fname__arity;
         strong_reduction_ok = __fname__strong_reduction_ok;
         requires_binder_substitution = __fname__requires_binder_substitution;
         interpretation = __fname__interpretation;_} -> __fname__arity
-  
-let (__proj__Mkprimitive_step__item__strong_reduction_ok :
-  primitive_step -> Prims.bool) =
+let __proj__Mkprimitive_step__item__strong_reduction_ok:
+  primitive_step -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; arity = __fname__arity;
@@ -1480,9 +1428,8 @@ let (__proj__Mkprimitive_step__item__strong_reduction_ok :
         requires_binder_substitution = __fname__requires_binder_substitution;
         interpretation = __fname__interpretation;_} ->
         __fname__strong_reduction_ok
-  
-let (__proj__Mkprimitive_step__item__requires_binder_substitution :
-  primitive_step -> Prims.bool) =
+let __proj__Mkprimitive_step__item__requires_binder_substitution:
+  primitive_step -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { name = __fname__name; arity = __fname__arity;
@@ -1490,12 +1437,11 @@ let (__proj__Mkprimitive_step__item__requires_binder_substitution :
         requires_binder_substitution = __fname__requires_binder_substitution;
         interpretation = __fname__interpretation;_} ->
         __fname__requires_binder_substitution
-  
-let (__proj__Mkprimitive_step__item__interpretation :
+let __proj__Mkprimitive_step__item__interpretation:
   primitive_step ->
     psc ->
       FStar_Syntax_Syntax.args ->
-        FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+        FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun projectee  ->
     match projectee with
@@ -1504,7 +1450,6 @@ let (__proj__Mkprimitive_step__item__interpretation :
         requires_binder_substitution = __fname__requires_binder_substitution;
         interpretation = __fname__interpretation;_} ->
         __fname__interpretation
-  
 type closure =
   | Clos of
   ((FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option,closure)
@@ -1512,104 +1457,95 @@ type closure =
   ((FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option,closure)
      FStar_Pervasives_Native.tuple2 Prims.list,FStar_Syntax_Syntax.term)
     FStar_Pervasives_Native.tuple2 FStar_Syntax_Syntax.memo,Prims.bool)
-  FStar_Pervasives_Native.tuple4 
-  | Univ of FStar_Syntax_Syntax.universe 
-  | Dummy [@@deriving show]
-let (uu___is_Clos : closure -> Prims.bool) =
+  FStar_Pervasives_Native.tuple4
+  | Univ of FStar_Syntax_Syntax.universe
+  | Dummy[@@deriving show]
+let uu___is_Clos: closure -> Prims.bool =
   fun projectee  ->
     match projectee with | Clos _0 -> true | uu____1454 -> false
-  
-let (__proj__Clos__item___0 :
+let __proj__Clos__item___0:
   closure ->
     ((FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option,closure)
        FStar_Pervasives_Native.tuple2 Prims.list,FStar_Syntax_Syntax.term,
       ((FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option,closure)
          FStar_Pervasives_Native.tuple2 Prims.list,FStar_Syntax_Syntax.term)
         FStar_Pervasives_Native.tuple2 FStar_Syntax_Syntax.memo,Prims.bool)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | Clos _0 -> _0 
-let (uu___is_Univ : closure -> Prims.bool) =
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | Clos _0 -> _0
+let uu___is_Univ: closure -> Prims.bool =
   fun projectee  ->
     match projectee with | Univ _0 -> true | uu____1556 -> false
-  
-let (__proj__Univ__item___0 : closure -> FStar_Syntax_Syntax.universe) =
-  fun projectee  -> match projectee with | Univ _0 -> _0 
-let (uu___is_Dummy : closure -> Prims.bool) =
+let __proj__Univ__item___0: closure -> FStar_Syntax_Syntax.universe =
+  fun projectee  -> match projectee with | Univ _0 -> _0
+let uu___is_Dummy: closure -> Prims.bool =
   fun projectee  ->
     match projectee with | Dummy  -> true | uu____1567 -> false
-  
 type env =
   (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option,closure)
     FStar_Pervasives_Native.tuple2 Prims.list[@@deriving show]
-let (dummy :
+let dummy:
   (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option,closure)
-    FStar_Pervasives_Native.tuple2)
-  = (FStar_Pervasives_Native.None, Dummy) 
-let (closure_to_string : closure -> Prims.string) =
+    FStar_Pervasives_Native.tuple2
+  = (FStar_Pervasives_Native.None, Dummy)
+let closure_to_string: closure -> Prims.string =
   fun uu___77_1586  ->
     match uu___77_1586 with
     | Clos (uu____1587,t,uu____1589,uu____1590) ->
         FStar_Syntax_Print.term_to_string t
     | Univ uu____1635 -> "Univ"
     | Dummy  -> "dummy"
-  
 type debug_switches =
   {
-  gen: Prims.bool ;
-  primop: Prims.bool ;
-  b380: Prims.bool ;
-  norm_delayed: Prims.bool ;
-  print_normalized: Prims.bool }[@@deriving show]
-let (__proj__Mkdebug_switches__item__gen : debug_switches -> Prims.bool) =
+  gen: Prims.bool;
+  primop: Prims.bool;
+  b380: Prims.bool;
+  norm_delayed: Prims.bool;
+  print_normalized: Prims.bool;}[@@deriving show]
+let __proj__Mkdebug_switches__item__gen: debug_switches -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { gen = __fname__gen; primop = __fname__primop; b380 = __fname__b380;
         norm_delayed = __fname__norm_delayed;
         print_normalized = __fname__print_normalized;_} -> __fname__gen
-  
-let (__proj__Mkdebug_switches__item__primop : debug_switches -> Prims.bool) =
+let __proj__Mkdebug_switches__item__primop: debug_switches -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { gen = __fname__gen; primop = __fname__primop; b380 = __fname__b380;
         norm_delayed = __fname__norm_delayed;
         print_normalized = __fname__print_normalized;_} -> __fname__primop
-  
-let (__proj__Mkdebug_switches__item__b380 : debug_switches -> Prims.bool) =
+let __proj__Mkdebug_switches__item__b380: debug_switches -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { gen = __fname__gen; primop = __fname__primop; b380 = __fname__b380;
         norm_delayed = __fname__norm_delayed;
         print_normalized = __fname__print_normalized;_} -> __fname__b380
-  
-let (__proj__Mkdebug_switches__item__norm_delayed :
-  debug_switches -> Prims.bool) =
+let __proj__Mkdebug_switches__item__norm_delayed:
+  debug_switches -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { gen = __fname__gen; primop = __fname__primop; b380 = __fname__b380;
         norm_delayed = __fname__norm_delayed;
         print_normalized = __fname__print_normalized;_} ->
         __fname__norm_delayed
-  
-let (__proj__Mkdebug_switches__item__print_normalized :
-  debug_switches -> Prims.bool) =
+let __proj__Mkdebug_switches__item__print_normalized:
+  debug_switches -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { gen = __fname__gen; primop = __fname__primop; b380 = __fname__b380;
         norm_delayed = __fname__norm_delayed;
         print_normalized = __fname__print_normalized;_} ->
         __fname__print_normalized
-  
 type cfg =
   {
-  steps: fsteps ;
-  tcenv: FStar_TypeChecker_Env.env ;
-  debug: debug_switches ;
-  delta_level: FStar_TypeChecker_Env.delta_level Prims.list ;
-  primitive_steps: primitive_step FStar_Util.psmap ;
-  strong: Prims.bool ;
-  memoize_lazy: Prims.bool ;
-  normalize_pure_lets: Prims.bool }[@@deriving show]
-let (__proj__Mkcfg__item__steps : cfg -> fsteps) =
+  steps: fsteps;
+  tcenv: FStar_TypeChecker_Env.env;
+  debug: debug_switches;
+  delta_level: FStar_TypeChecker_Env.delta_level Prims.list;
+  primitive_steps: primitive_step FStar_Util.psmap;
+  strong: Prims.bool;
+  memoize_lazy: Prims.bool;
+  normalize_pure_lets: Prims.bool;}[@@deriving show]
+let __proj__Mkcfg__item__steps: cfg -> fsteps =
   fun projectee  ->
     match projectee with
     | { steps = __fname__steps; tcenv = __fname__tcenv;
@@ -1618,8 +1554,7 @@ let (__proj__Mkcfg__item__steps : cfg -> fsteps) =
         memoize_lazy = __fname__memoize_lazy;
         normalize_pure_lets = __fname__normalize_pure_lets;_} ->
         __fname__steps
-  
-let (__proj__Mkcfg__item__tcenv : cfg -> FStar_TypeChecker_Env.env) =
+let __proj__Mkcfg__item__tcenv: cfg -> FStar_TypeChecker_Env.env =
   fun projectee  ->
     match projectee with
     | { steps = __fname__steps; tcenv = __fname__tcenv;
@@ -1628,8 +1563,7 @@ let (__proj__Mkcfg__item__tcenv : cfg -> FStar_TypeChecker_Env.env) =
         memoize_lazy = __fname__memoize_lazy;
         normalize_pure_lets = __fname__normalize_pure_lets;_} ->
         __fname__tcenv
-  
-let (__proj__Mkcfg__item__debug : cfg -> debug_switches) =
+let __proj__Mkcfg__item__debug: cfg -> debug_switches =
   fun projectee  ->
     match projectee with
     | { steps = __fname__steps; tcenv = __fname__tcenv;
@@ -1638,9 +1572,8 @@ let (__proj__Mkcfg__item__debug : cfg -> debug_switches) =
         memoize_lazy = __fname__memoize_lazy;
         normalize_pure_lets = __fname__normalize_pure_lets;_} ->
         __fname__debug
-  
-let (__proj__Mkcfg__item__delta_level :
-  cfg -> FStar_TypeChecker_Env.delta_level Prims.list) =
+let __proj__Mkcfg__item__delta_level:
+  cfg -> FStar_TypeChecker_Env.delta_level Prims.list =
   fun projectee  ->
     match projectee with
     | { steps = __fname__steps; tcenv = __fname__tcenv;
@@ -1649,9 +1582,8 @@ let (__proj__Mkcfg__item__delta_level :
         memoize_lazy = __fname__memoize_lazy;
         normalize_pure_lets = __fname__normalize_pure_lets;_} ->
         __fname__delta_level
-  
-let (__proj__Mkcfg__item__primitive_steps :
-  cfg -> primitive_step FStar_Util.psmap) =
+let __proj__Mkcfg__item__primitive_steps:
+  cfg -> primitive_step FStar_Util.psmap =
   fun projectee  ->
     match projectee with
     | { steps = __fname__steps; tcenv = __fname__tcenv;
@@ -1660,8 +1592,7 @@ let (__proj__Mkcfg__item__primitive_steps :
         memoize_lazy = __fname__memoize_lazy;
         normalize_pure_lets = __fname__normalize_pure_lets;_} ->
         __fname__primitive_steps
-  
-let (__proj__Mkcfg__item__strong : cfg -> Prims.bool) =
+let __proj__Mkcfg__item__strong: cfg -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { steps = __fname__steps; tcenv = __fname__tcenv;
@@ -1670,8 +1601,7 @@ let (__proj__Mkcfg__item__strong : cfg -> Prims.bool) =
         memoize_lazy = __fname__memoize_lazy;
         normalize_pure_lets = __fname__normalize_pure_lets;_} ->
         __fname__strong
-  
-let (__proj__Mkcfg__item__memoize_lazy : cfg -> Prims.bool) =
+let __proj__Mkcfg__item__memoize_lazy: cfg -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { steps = __fname__steps; tcenv = __fname__tcenv;
@@ -1680,8 +1610,7 @@ let (__proj__Mkcfg__item__memoize_lazy : cfg -> Prims.bool) =
         memoize_lazy = __fname__memoize_lazy;
         normalize_pure_lets = __fname__normalize_pure_lets;_} ->
         __fname__memoize_lazy
-  
-let (__proj__Mkcfg__item__normalize_pure_lets : cfg -> Prims.bool) =
+let __proj__Mkcfg__item__normalize_pure_lets: cfg -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { steps = __fname__steps; tcenv = __fname__tcenv;
@@ -1690,10 +1619,9 @@ let (__proj__Mkcfg__item__normalize_pure_lets : cfg -> Prims.bool) =
         memoize_lazy = __fname__memoize_lazy;
         normalize_pure_lets = __fname__normalize_pure_lets;_} ->
         __fname__normalize_pure_lets
-  
-let (add_steps :
+let add_steps:
   primitive_step FStar_Util.psmap ->
-    primitive_step Prims.list -> primitive_step FStar_Util.psmap)
+    primitive_step Prims.list -> primitive_step FStar_Util.psmap
   =
   fun m  ->
     fun l  ->
@@ -1701,190 +1629,171 @@ let (add_steps :
         (fun p  ->
            fun m1  ->
              FStar_Util.psmap_add m1 (FStar_Ident.text_of_lid p.name) p) l m
-  
-let (prim_from_list :
-  primitive_step Prims.list -> primitive_step FStar_Util.psmap) =
+let prim_from_list:
+  primitive_step Prims.list -> primitive_step FStar_Util.psmap =
   fun l  ->
-    let uu____1897 = FStar_Util.psmap_empty ()  in add_steps uu____1897 l
-  
+    let uu____1897 = FStar_Util.psmap_empty () in add_steps uu____1897 l
 type branches =
   (FStar_Syntax_Syntax.pat,FStar_Syntax_Syntax.term
                              FStar_Pervasives_Native.option,FStar_Syntax_Syntax.term)
     FStar_Pervasives_Native.tuple3 Prims.list[@@deriving show]
 type stack_elt =
   | Arg of (closure,FStar_Syntax_Syntax.aqual,FStar_Range.range)
-  FStar_Pervasives_Native.tuple3 
+  FStar_Pervasives_Native.tuple3
   | UnivArgs of (FStar_Syntax_Syntax.universe Prims.list,FStar_Range.range)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | MemoLazy of (env,FStar_Syntax_Syntax.term) FStar_Pervasives_Native.tuple2
-  FStar_Syntax_Syntax.memo 
+  FStar_Syntax_Syntax.memo
   | Match of (env,branches,FStar_Range.range) FStar_Pervasives_Native.tuple3
-  
   | Abs of
   (env,FStar_Syntax_Syntax.binders,env,FStar_Syntax_Syntax.residual_comp
                                          FStar_Pervasives_Native.option,
-  FStar_Range.range) FStar_Pervasives_Native.tuple5 
+  FStar_Range.range) FStar_Pervasives_Native.tuple5
   | App of
   (env,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.aqual,FStar_Range.range)
-  FStar_Pervasives_Native.tuple4 
+  FStar_Pervasives_Native.tuple4
   | Meta of (FStar_Syntax_Syntax.metadata,FStar_Range.range)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | Let of
   (env,FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.letbinding,FStar_Range.range)
-  FStar_Pervasives_Native.tuple4 
-  | Cfg of cfg 
+  FStar_Pervasives_Native.tuple4
+  | Cfg of cfg
   | Debug of (FStar_Syntax_Syntax.term,FStar_Util.time)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let (uu___is_Arg : stack_elt -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_Arg: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | Arg _0 -> true | uu____2041 -> false
-  
-let (__proj__Arg__item___0 :
+let __proj__Arg__item___0:
   stack_elt ->
     (closure,FStar_Syntax_Syntax.aqual,FStar_Range.range)
-      FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Arg _0 -> _0 
-let (uu___is_UnivArgs : stack_elt -> Prims.bool) =
+      FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Arg _0 -> _0
+let uu___is_UnivArgs: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | UnivArgs _0 -> true | uu____2077 -> false
-  
-let (__proj__UnivArgs__item___0 :
+let __proj__UnivArgs__item___0:
   stack_elt ->
     (FStar_Syntax_Syntax.universe Prims.list,FStar_Range.range)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | UnivArgs _0 -> _0 
-let (uu___is_MemoLazy : stack_elt -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | UnivArgs _0 -> _0
+let uu___is_MemoLazy: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | MemoLazy _0 -> true | uu____2113 -> false
-  
-let (__proj__MemoLazy__item___0 :
+let __proj__MemoLazy__item___0:
   stack_elt ->
     (env,FStar_Syntax_Syntax.term) FStar_Pervasives_Native.tuple2
-      FStar_Syntax_Syntax.memo)
-  = fun projectee  -> match projectee with | MemoLazy _0 -> _0 
-let (uu___is_Match : stack_elt -> Prims.bool) =
+      FStar_Syntax_Syntax.memo
+  = fun projectee  -> match projectee with | MemoLazy _0 -> _0
+let uu___is_Match: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | Match _0 -> true | uu____2182 -> false
-  
-let (__proj__Match__item___0 :
+let __proj__Match__item___0:
   stack_elt ->
-    (env,branches,FStar_Range.range) FStar_Pervasives_Native.tuple3)
-  = fun projectee  -> match projectee with | Match _0 -> _0 
-let (uu___is_Abs : stack_elt -> Prims.bool) =
+    (env,branches,FStar_Range.range) FStar_Pervasives_Native.tuple3
+  = fun projectee  -> match projectee with | Match _0 -> _0
+let uu___is_Abs: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | Abs _0 -> true | uu____2224 -> false
-  
-let (__proj__Abs__item___0 :
+let __proj__Abs__item___0:
   stack_elt ->
     (env,FStar_Syntax_Syntax.binders,env,FStar_Syntax_Syntax.residual_comp
                                            FStar_Pervasives_Native.option,
-      FStar_Range.range) FStar_Pervasives_Native.tuple5)
-  = fun projectee  -> match projectee with | Abs _0 -> _0 
-let (uu___is_App : stack_elt -> Prims.bool) =
+      FStar_Range.range) FStar_Pervasives_Native.tuple5
+  = fun projectee  -> match projectee with | Abs _0 -> _0
+let uu___is_App: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | App _0 -> true | uu____2280 -> false
-  
-let (__proj__App__item___0 :
+let __proj__App__item___0:
   stack_elt ->
     (env,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.aqual,FStar_Range.range)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | App _0 -> _0 
-let (uu___is_Meta : stack_elt -> Prims.bool) =
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | App _0 -> _0
+let uu___is_Meta: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | Meta _0 -> true | uu____2320 -> false
-  
-let (__proj__Meta__item___0 :
+let __proj__Meta__item___0:
   stack_elt ->
     (FStar_Syntax_Syntax.metadata,FStar_Range.range)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Meta _0 -> _0 
-let (uu___is_Let : stack_elt -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Meta _0 -> _0
+let uu___is_Let: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | Let _0 -> true | uu____2352 -> false
-  
-let (__proj__Let__item___0 :
+let __proj__Let__item___0:
   stack_elt ->
     (env,FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.letbinding,FStar_Range.range)
-      FStar_Pervasives_Native.tuple4)
-  = fun projectee  -> match projectee with | Let _0 -> _0 
-let (uu___is_Cfg : stack_elt -> Prims.bool) =
+      FStar_Pervasives_Native.tuple4
+  = fun projectee  -> match projectee with | Let _0 -> _0
+let uu___is_Cfg: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | Cfg _0 -> true | uu____2388 -> false
-  
-let (__proj__Cfg__item___0 : stack_elt -> cfg) =
-  fun projectee  -> match projectee with | Cfg _0 -> _0 
-let (uu___is_Debug : stack_elt -> Prims.bool) =
+let __proj__Cfg__item___0: stack_elt -> cfg =
+  fun projectee  -> match projectee with | Cfg _0 -> _0
+let uu___is_Debug: stack_elt -> Prims.bool =
   fun projectee  ->
     match projectee with | Debug _0 -> true | uu____2404 -> false
-  
-let (__proj__Debug__item___0 :
+let __proj__Debug__item___0:
   stack_elt ->
-    (FStar_Syntax_Syntax.term,FStar_Util.time) FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Debug _0 -> _0 
+    (FStar_Syntax_Syntax.term,FStar_Util.time) FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Debug _0 -> _0
 type stack = stack_elt Prims.list[@@deriving show]
-let mk :
+let mk:
   'Auu____2429 .
     'Auu____2429 ->
       FStar_Range.range -> 'Auu____2429 FStar_Syntax_Syntax.syntax
   =
-  fun t  -> fun r  -> FStar_Syntax_Syntax.mk t FStar_Pervasives_Native.None r 
-let set_memo : 'a . cfg -> 'a FStar_Syntax_Syntax.memo -> 'a -> Prims.unit =
+  fun t  -> fun r  -> FStar_Syntax_Syntax.mk t FStar_Pervasives_Native.None r
+let set_memo: 'a . cfg -> 'a FStar_Syntax_Syntax.memo -> 'a -> Prims.unit =
   fun cfg  ->
     fun r  ->
       fun t  ->
         if cfg.memoize_lazy
         then
-          let uu____2483 = FStar_ST.op_Bang r  in
+          let uu____2483 = FStar_ST.op_Bang r in
           match uu____2483 with
           | FStar_Pervasives_Native.Some uu____2531 ->
               failwith "Unexpected set_memo: thunk already evaluated"
           | FStar_Pervasives_Native.None  ->
               FStar_ST.op_Colon_Equals r (FStar_Pervasives_Native.Some t)
         else ()
-  
-let (env_to_string : closure Prims.list -> Prims.string) =
+let env_to_string: closure Prims.list -> Prims.string =
   fun env  ->
-    let uu____2585 = FStar_List.map closure_to_string env  in
+    let uu____2585 = FStar_List.map closure_to_string env in
     FStar_All.pipe_right uu____2585 (FStar_String.concat "; ")
-  
-let (stack_elt_to_string : stack_elt -> Prims.string) =
+let stack_elt_to_string: stack_elt -> Prims.string =
   fun uu___78_2592  ->
     match uu___78_2592 with
     | Arg (c,uu____2594,uu____2595) ->
-        let uu____2596 = closure_to_string c  in
+        let uu____2596 = closure_to_string c in
         FStar_Util.format1 "Closure %s" uu____2596
     | MemoLazy uu____2597 -> "MemoLazy"
     | Abs (uu____2604,bs,uu____2606,uu____2607,uu____2608) ->
         let uu____2613 =
-          FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length bs)
-           in
+          FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length bs) in
         FStar_Util.format1 "Abs %s" uu____2613
     | UnivArgs uu____2618 -> "UnivArgs"
     | Match uu____2625 -> "Match"
     | App (uu____2632,t,uu____2634,uu____2635) ->
-        let uu____2636 = FStar_Syntax_Print.term_to_string t  in
+        let uu____2636 = FStar_Syntax_Print.term_to_string t in
         FStar_Util.format1 "App %s" uu____2636
     | Meta (m,uu____2638) -> "Meta"
     | Let uu____2639 -> "Let"
     | Cfg uu____2648 -> "Cfg"
     | Debug (t,uu____2650) ->
-        let uu____2651 = FStar_Syntax_Print.term_to_string t  in
+        let uu____2651 = FStar_Syntax_Print.term_to_string t in
         FStar_Util.format1 "Debug %s" uu____2651
-  
-let (stack_to_string : stack_elt Prims.list -> Prims.string) =
+let stack_to_string: stack_elt Prims.list -> Prims.string =
   fun s  ->
-    let uu____2659 = FStar_List.map stack_elt_to_string s  in
+    let uu____2659 = FStar_List.map stack_elt_to_string s in
     FStar_All.pipe_right uu____2659 (FStar_String.concat "; ")
-  
-let (log : cfg -> (Prims.unit -> Prims.unit) -> Prims.unit) =
-  fun cfg  -> fun f  -> if (cfg.debug).gen then f () else () 
-let (log_primops : cfg -> (Prims.unit -> Prims.unit) -> Prims.unit) =
-  fun cfg  -> fun f  -> if (cfg.debug).primop then f () else () 
-let is_empty : 'Auu____2690 . 'Auu____2690 Prims.list -> Prims.bool =
+let log: cfg -> (Prims.unit -> Prims.unit) -> Prims.unit =
+  fun cfg  -> fun f  -> if (cfg.debug).gen then f () else ()
+let log_primops: cfg -> (Prims.unit -> Prims.unit) -> Prims.unit =
+  fun cfg  -> fun f  -> if (cfg.debug).primop then f () else ()
+let is_empty: 'Auu____2690 . 'Auu____2690 Prims.list -> Prims.bool =
   fun uu___79_2696  ->
     match uu___79_2696 with | [] -> true | uu____2699 -> false
-  
-let lookup_bvar :
+let lookup_bvar:
   'Auu____2706 'Auu____2707 .
     ('Auu____2707,'Auu____2706) FStar_Pervasives_Native.tuple2 Prims.list ->
       FStar_Syntax_Syntax.bv -> 'Auu____2706
@@ -1892,17 +1801,16 @@ let lookup_bvar :
   fun env  ->
     fun x  ->
       try
-        let uu____2731 = FStar_List.nth env x.FStar_Syntax_Syntax.index  in
+        let uu____2731 = FStar_List.nth env x.FStar_Syntax_Syntax.index in
         FStar_Pervasives_Native.snd uu____2731
       with
       | uu____2744 ->
           let uu____2745 =
-            let uu____2746 = FStar_Syntax_Print.db_to_string x  in
-            FStar_Util.format1 "Failed to find %s\n" uu____2746  in
+            let uu____2746 = FStar_Syntax_Print.db_to_string x in
+            FStar_Util.format1 "Failed to find %s\n" uu____2746 in
           failwith uu____2745
-  
-let (downgrade_ghost_effect_name :
-  FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option) =
+let downgrade_ghost_effect_name:
+  FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option =
   fun l  ->
     if FStar_Ident.lid_equals l FStar_Parser_Const.effect_Ghost_lid
     then FStar_Pervasives_Native.Some FStar_Parser_Const.effect_Pure_lid
@@ -1913,43 +1821,40 @@ let (downgrade_ghost_effect_name :
         if FStar_Ident.lid_equals l FStar_Parser_Const.effect_GHOST_lid
         then FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
         else FStar_Pervasives_Native.None
-  
-let (norm_universe :
-  cfg -> env -> FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe)
+let norm_universe:
+  cfg -> env -> FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe
   =
   fun cfg  ->
     fun env  ->
       fun u  ->
         let norm_univs us =
-          let us1 = FStar_Util.sort_with FStar_Syntax_Util.compare_univs us
-             in
+          let us1 = FStar_Util.sort_with FStar_Syntax_Util.compare_univs us in
           let uu____2783 =
             FStar_List.fold_left
               (fun uu____2809  ->
                  fun u1  ->
                    match uu____2809 with
                    | (cur_kernel,cur_max,out) ->
-                       let uu____2834 = FStar_Syntax_Util.univ_kernel u1  in
+                       let uu____2834 = FStar_Syntax_Util.univ_kernel u1 in
                        (match uu____2834 with
                         | (k_u,n1) ->
                             let uu____2849 =
-                              FStar_Syntax_Util.eq_univs cur_kernel k_u  in
+                              FStar_Syntax_Util.eq_univs cur_kernel k_u in
                             if uu____2849
                             then (cur_kernel, u1, out)
                             else (k_u, u1, (cur_max :: out))))
               (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero, [])
-              us1
-             in
+              us1 in
           match uu____2783 with
-          | (uu____2867,u1,out) -> FStar_List.rev (u1 :: out)  in
+          | (uu____2867,u1,out) -> FStar_List.rev (u1 :: out) in
         let rec aux u1 =
-          let u2 = FStar_Syntax_Subst.compress_univ u1  in
+          let u2 = FStar_Syntax_Subst.compress_univ u1 in
           match u2 with
           | FStar_Syntax_Syntax.U_bvar x ->
               (try
                  let uu____2892 =
-                   let uu____2893 = FStar_List.nth env x  in
-                   FStar_Pervasives_Native.snd uu____2893  in
+                   let uu____2893 = FStar_List.nth env x in
+                   FStar_Pervasives_Native.snd uu____2893 in
                  match uu____2892 with
                  | Univ u3 -> aux u3
                  | Dummy  -> [u2]
@@ -1969,12 +1874,12 @@ let (norm_universe :
           | FStar_Syntax_Syntax.U_max [] -> [FStar_Syntax_Syntax.U_zero]
           | FStar_Syntax_Syntax.U_max us ->
               let us1 =
-                let uu____2950 = FStar_List.collect aux us  in
-                FStar_All.pipe_right uu____2950 norm_univs  in
+                let uu____2950 = FStar_List.collect aux us in
+                FStar_All.pipe_right uu____2950 norm_univs in
               (match us1 with
                | u_k::hd1::rest ->
-                   let rest1 = hd1 :: rest  in
-                   let uu____2967 = FStar_Syntax_Util.univ_kernel u_k  in
+                   let rest1 = hd1 :: rest in
+                   let uu____2967 = FStar_Syntax_Util.univ_kernel u_k in
                    (match uu____2967 with
                     | (FStar_Syntax_Syntax.U_zero ,n1) ->
                         let uu____2975 =
@@ -1982,22 +1887,20 @@ let (norm_universe :
                             (FStar_List.for_all
                                (fun u3  ->
                                   let uu____2983 =
-                                    FStar_Syntax_Util.univ_kernel u3  in
+                                    FStar_Syntax_Util.univ_kernel u3 in
                                   match uu____2983 with
-                                  | (uu____2988,m) -> n1 <= m))
-                           in
+                                  | (uu____2988,m) -> n1 <= m)) in
                         if uu____2975 then rest1 else us1
                     | uu____2993 -> us1)
                | uu____2998 -> us1)
           | FStar_Syntax_Syntax.U_succ u3 ->
-              let uu____3002 = aux u3  in
+              let uu____3002 = aux u3 in
               FStar_List.map (fun _0_40  -> FStar_Syntax_Syntax.U_succ _0_40)
-                uu____3002
-           in
+                uu____3002 in
         if (cfg.steps).erase_universes
         then FStar_Syntax_Syntax.U_unknown
         else
-          (let uu____3006 = aux u  in
+          (let uu____3006 = aux u in
            match uu____3006 with
            | [] -> FStar_Syntax_Syntax.U_zero
            | (FStar_Syntax_Syntax.U_zero )::[] -> FStar_Syntax_Syntax.U_zero
@@ -2006,16 +1909,15 @@ let (norm_universe :
                FStar_Syntax_Syntax.U_max us
            | u1::[] -> u1
            | us -> FStar_Syntax_Syntax.U_max us)
-  
-let rec (closure_as_term :
-  cfg -> env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let rec closure_as_term:
+  cfg -> env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun cfg  ->
     fun env  ->
       fun t  ->
         log cfg
           (fun uu____3110  ->
-             let uu____3111 = FStar_Syntax_Print.tag_of_term t  in
-             let uu____3112 = FStar_Syntax_Print.term_to_string t  in
+             let uu____3111 = FStar_Syntax_Print.tag_of_term t in
+             let uu____3112 = FStar_Syntax_Print.term_to_string t in
              FStar_Util.print2 ">>> %s Closure_as_term %s\n" uu____3111
                uu____3112);
         (match env with
@@ -2023,7 +1925,7 @@ let rec (closure_as_term :
              FStar_All.pipe_left Prims.op_Negation (cfg.steps).compress_uvars
              -> t
          | uu____3119 ->
-             let t1 = FStar_Syntax_Subst.compress t  in
+             let t1 = FStar_Syntax_Subst.compress t in
              (match t1.FStar_Syntax_Syntax.n with
               | FStar_Syntax_Syntax.Tm_delayed uu____3121 ->
                   failwith "Impossible"
@@ -2037,27 +1939,23 @@ let rec (closure_as_term :
                     let uu____3166 =
                       let uu____3167 =
                         FStar_Range.string_of_range
-                          t1.FStar_Syntax_Syntax.pos
-                         in
-                      let uu____3168 = FStar_Syntax_Print.term_to_string t1
-                         in
+                          t1.FStar_Syntax_Syntax.pos in
+                      let uu____3168 = FStar_Syntax_Print.term_to_string t1 in
                       FStar_Util.format2
                         "(%s): CheckNoUvars: Unexpected unification variable remains: %s"
-                        uu____3167 uu____3168
-                       in
+                        uu____3167 uu____3168 in
                     failwith uu____3166
                   else t1
               | FStar_Syntax_Syntax.Tm_type u ->
                   let uu____3171 =
-                    let uu____3172 = norm_universe cfg env u  in
-                    FStar_Syntax_Syntax.Tm_type uu____3172  in
+                    let uu____3172 = norm_universe cfg env u in
+                    FStar_Syntax_Syntax.Tm_type uu____3172 in
                   mk uu____3171 t1.FStar_Syntax_Syntax.pos
               | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
-                  let uu____3179 = FStar_List.map (norm_universe cfg env) us
-                     in
+                  let uu____3179 = FStar_List.map (norm_universe cfg env) us in
                   FStar_Syntax_Syntax.mk_Tm_uinst t' uu____3179
               | FStar_Syntax_Syntax.Tm_bvar x ->
-                  let uu____3181 = lookup_bvar env x  in
+                  let uu____3181 = lookup_bvar env x in
                   (match uu____3181 with
                    | Univ uu____3184 ->
                        failwith
@@ -2066,156 +1964,145 @@ let rec (closure_as_term :
                    | Clos (env1,t0,uu____3187,uu____3188) ->
                        closure_as_term cfg env1 t0)
               | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-                  let head2 = closure_as_term_delayed cfg env head1  in
-                  let args1 = closures_as_args_delayed cfg env args  in
+                  let head2 = closure_as_term_delayed cfg env head1 in
+                  let args1 = closures_as_args_delayed cfg env args in
                   mk (FStar_Syntax_Syntax.Tm_app (head2, args1))
                     t1.FStar_Syntax_Syntax.pos
               | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-                  let uu____3300 = closures_as_binders_delayed cfg env bs  in
+                  let uu____3300 = closures_as_binders_delayed cfg env bs in
                   (match uu____3300 with
                    | (bs1,env1) ->
-                       let body1 = closure_as_term_delayed cfg env1 body  in
+                       let body1 = closure_as_term_delayed cfg env1 body in
                        let uu____3328 =
                          let uu____3329 =
-                           let uu____3346 = close_lcomp_opt cfg env1 lopt  in
-                           (bs1, body1, uu____3346)  in
-                         FStar_Syntax_Syntax.Tm_abs uu____3329  in
+                           let uu____3346 = close_lcomp_opt cfg env1 lopt in
+                           (bs1, body1, uu____3346) in
+                         FStar_Syntax_Syntax.Tm_abs uu____3329 in
                        mk uu____3328 t1.FStar_Syntax_Syntax.pos)
               | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                  let uu____3377 = closures_as_binders_delayed cfg env bs  in
+                  let uu____3377 = closures_as_binders_delayed cfg env bs in
                   (match uu____3377 with
                    | (bs1,env1) ->
-                       let c1 = close_comp cfg env1 c  in
+                       let c1 = close_comp cfg env1 c in
                        mk (FStar_Syntax_Syntax.Tm_arrow (bs1, c1))
                          t1.FStar_Syntax_Syntax.pos)
               | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
                   let uu____3419 =
                     let uu____3430 =
-                      let uu____3437 = FStar_Syntax_Syntax.mk_binder x  in
-                      [uu____3437]  in
-                    closures_as_binders_delayed cfg env uu____3430  in
+                      let uu____3437 = FStar_Syntax_Syntax.mk_binder x in
+                      [uu____3437] in
+                    closures_as_binders_delayed cfg env uu____3430 in
                   (match uu____3419 with
                    | (x1,env1) ->
-                       let phi1 = closure_as_term_delayed cfg env1 phi  in
+                       let phi1 = closure_as_term_delayed cfg env1 phi in
                        let uu____3455 =
                          let uu____3456 =
                            let uu____3463 =
-                             let uu____3464 = FStar_List.hd x1  in
+                             let uu____3464 = FStar_List.hd x1 in
                              FStar_All.pipe_right uu____3464
-                               FStar_Pervasives_Native.fst
-                              in
-                           (uu____3463, phi1)  in
-                         FStar_Syntax_Syntax.Tm_refine uu____3456  in
+                               FStar_Pervasives_Native.fst in
+                           (uu____3463, phi1) in
+                         FStar_Syntax_Syntax.Tm_refine uu____3456 in
                        mk uu____3455 t1.FStar_Syntax_Syntax.pos)
               | FStar_Syntax_Syntax.Tm_ascribed (t11,(annot,tacopt),lopt) ->
                   let annot1 =
                     match annot with
                     | FStar_Util.Inl t2 ->
-                        let uu____3555 = closure_as_term_delayed cfg env t2
-                           in
+                        let uu____3555 = closure_as_term_delayed cfg env t2 in
                         FStar_Util.Inl uu____3555
                     | FStar_Util.Inr c ->
-                        let uu____3569 = close_comp cfg env c  in
-                        FStar_Util.Inr uu____3569
-                     in
+                        let uu____3569 = close_comp cfg env c in
+                        FStar_Util.Inr uu____3569 in
                   let tacopt1 =
                     FStar_Util.map_opt tacopt
-                      (closure_as_term_delayed cfg env)
-                     in
+                      (closure_as_term_delayed cfg env) in
                   let uu____3585 =
                     let uu____3586 =
-                      let uu____3613 = closure_as_term_delayed cfg env t11
-                         in
-                      (uu____3613, (annot1, tacopt1), lopt)  in
-                    FStar_Syntax_Syntax.Tm_ascribed uu____3586  in
+                      let uu____3613 = closure_as_term_delayed cfg env t11 in
+                      (uu____3613, (annot1, tacopt1), lopt) in
+                    FStar_Syntax_Syntax.Tm_ascribed uu____3586 in
                   mk uu____3585 t1.FStar_Syntax_Syntax.pos
               | FStar_Syntax_Syntax.Tm_meta
                   (t',FStar_Syntax_Syntax.Meta_pattern args) ->
                   let uu____3664 =
                     let uu____3665 =
-                      let uu____3672 = closure_as_term_delayed cfg env t'  in
+                      let uu____3672 = closure_as_term_delayed cfg env t' in
                       let uu____3675 =
                         let uu____3676 =
                           FStar_All.pipe_right args
                             (FStar_List.map
-                               (closures_as_args_delayed cfg env))
-                           in
-                        FStar_Syntax_Syntax.Meta_pattern uu____3676  in
-                      (uu____3672, uu____3675)  in
-                    FStar_Syntax_Syntax.Tm_meta uu____3665  in
+                               (closures_as_args_delayed cfg env)) in
+                        FStar_Syntax_Syntax.Meta_pattern uu____3676 in
+                      (uu____3672, uu____3675) in
+                    FStar_Syntax_Syntax.Tm_meta uu____3665 in
                   mk uu____3664 t1.FStar_Syntax_Syntax.pos
               | FStar_Syntax_Syntax.Tm_meta
                   (t',FStar_Syntax_Syntax.Meta_monadic (m,tbody)) ->
                   let uu____3736 =
                     let uu____3737 =
-                      let uu____3744 = closure_as_term_delayed cfg env t'  in
+                      let uu____3744 = closure_as_term_delayed cfg env t' in
                       let uu____3747 =
                         let uu____3748 =
                           let uu____3755 =
-                            closure_as_term_delayed cfg env tbody  in
-                          (m, uu____3755)  in
-                        FStar_Syntax_Syntax.Meta_monadic uu____3748  in
-                      (uu____3744, uu____3747)  in
-                    FStar_Syntax_Syntax.Tm_meta uu____3737  in
+                            closure_as_term_delayed cfg env tbody in
+                          (m, uu____3755) in
+                        FStar_Syntax_Syntax.Meta_monadic uu____3748 in
+                      (uu____3744, uu____3747) in
+                    FStar_Syntax_Syntax.Tm_meta uu____3737 in
                   mk uu____3736 t1.FStar_Syntax_Syntax.pos
               | FStar_Syntax_Syntax.Tm_meta
                   (t',FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,tbody)) ->
                   let uu____3774 =
                     let uu____3775 =
-                      let uu____3782 = closure_as_term_delayed cfg env t'  in
+                      let uu____3782 = closure_as_term_delayed cfg env t' in
                       let uu____3785 =
                         let uu____3786 =
                           let uu____3795 =
-                            closure_as_term_delayed cfg env tbody  in
-                          (m1, m2, uu____3795)  in
-                        FStar_Syntax_Syntax.Meta_monadic_lift uu____3786  in
-                      (uu____3782, uu____3785)  in
-                    FStar_Syntax_Syntax.Tm_meta uu____3775  in
+                            closure_as_term_delayed cfg env tbody in
+                          (m1, m2, uu____3795) in
+                        FStar_Syntax_Syntax.Meta_monadic_lift uu____3786 in
+                      (uu____3782, uu____3785) in
+                    FStar_Syntax_Syntax.Tm_meta uu____3775 in
                   mk uu____3774 t1.FStar_Syntax_Syntax.pos
               | FStar_Syntax_Syntax.Tm_meta (t',m) ->
                   let uu____3808 =
                     let uu____3809 =
-                      let uu____3816 = closure_as_term_delayed cfg env t'  in
-                      (uu____3816, m)  in
-                    FStar_Syntax_Syntax.Tm_meta uu____3809  in
+                      let uu____3816 = closure_as_term_delayed cfg env t' in
+                      (uu____3816, m) in
+                    FStar_Syntax_Syntax.Tm_meta uu____3809 in
                   mk uu____3808 t1.FStar_Syntax_Syntax.pos
               | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-                  let env0 = env  in
+                  let env0 = env in
                   let env1 =
                     FStar_List.fold_left
                       (fun env1  -> fun uu____3856  -> dummy :: env1) env
-                      lb.FStar_Syntax_Syntax.lbunivs
-                     in
+                      lb.FStar_Syntax_Syntax.lbunivs in
                   let typ =
                     closure_as_term_delayed cfg env1
-                      lb.FStar_Syntax_Syntax.lbtyp
-                     in
+                      lb.FStar_Syntax_Syntax.lbtyp in
                   let def =
-                    closure_as_term cfg env1 lb.FStar_Syntax_Syntax.lbdef  in
+                    closure_as_term cfg env1 lb.FStar_Syntax_Syntax.lbdef in
                   let uu____3875 =
-                    let uu____3886 = FStar_Syntax_Syntax.is_top_level [lb]
-                       in
+                    let uu____3886 = FStar_Syntax_Syntax.is_top_level [lb] in
                     if uu____3886
                     then ((lb.FStar_Syntax_Syntax.lbname), body)
                     else
-                      (let x = FStar_Util.left lb.FStar_Syntax_Syntax.lbname
-                          in
+                      (let x = FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                        let uu____3905 =
-                         closure_as_term cfg (dummy :: env0) body  in
+                         closure_as_term cfg (dummy :: env0) body in
                        ((FStar_Util.Inl
-                           (let uu___124_3917 = x  in
+                           (let uu___124_3917 = x in
                             {
                               FStar_Syntax_Syntax.ppname =
                                 (uu___124_3917.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
                                 (uu___124_3917.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = typ
-                            })), uu____3905))
-                     in
+                            })), uu____3905)) in
                   (match uu____3875 with
                    | (nm,body1) ->
                        let lb1 =
-                         let uu___125_3933 = lb  in
+                         let uu___125_3933 = lb in
                          {
                            FStar_Syntax_Syntax.lbname = nm;
                            FStar_Syntax_Syntax.lbunivs =
@@ -2226,7 +2113,7 @@ let rec (closure_as_term :
                            FStar_Syntax_Syntax.lbdef = def;
                            FStar_Syntax_Syntax.lbattrs =
                              (uu___125_3933.FStar_Syntax_Syntax.lbattrs)
-                         }  in
+                         } in
                        mk
                          (FStar_Syntax_Syntax.Tm_let ((false, [lb1]), body1))
                          t1.FStar_Syntax_Syntax.pos)
@@ -2235,44 +2122,37 @@ let rec (closure_as_term :
                     let env_univs =
                       FStar_List.fold_right
                         (fun uu____4003  -> fun env2  -> dummy :: env2)
-                        lb.FStar_Syntax_Syntax.lbunivs env1
-                       in
+                        lb.FStar_Syntax_Syntax.lbunivs env1 in
                     let env2 =
-                      let uu____4028 = FStar_Syntax_Syntax.is_top_level lbs
-                         in
+                      let uu____4028 = FStar_Syntax_Syntax.is_top_level lbs in
                       if uu____4028
                       then env_univs
                       else
                         FStar_List.fold_right
                           (fun uu____4048  -> fun env2  -> dummy :: env2) lbs
-                          env_univs
-                       in
+                          env_univs in
                     let ty =
                       closure_as_term cfg env_univs
-                        lb.FStar_Syntax_Syntax.lbtyp
-                       in
+                        lb.FStar_Syntax_Syntax.lbtyp in
                     let nm =
-                      let uu____4070 = FStar_Syntax_Syntax.is_top_level lbs
-                         in
+                      let uu____4070 = FStar_Syntax_Syntax.is_top_level lbs in
                       if uu____4070
                       then lb.FStar_Syntax_Syntax.lbname
                       else
                         (let x =
-                           FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
+                           FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                          FStar_All.pipe_right
-                           (let uu___126_4082 = x  in
+                           (let uu___126_4082 = x in
                             {
                               FStar_Syntax_Syntax.ppname =
                                 (uu___126_4082.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
                                 (uu___126_4082.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = ty
-                            }) (fun _0_41  -> FStar_Util.Inl _0_41))
-                       in
-                    let uu___127_4083 = lb  in
+                            }) (fun _0_41  -> FStar_Util.Inl _0_41)) in
+                    let uu___127_4083 = lb in
                     let uu____4084 =
-                      closure_as_term cfg env2 lb.FStar_Syntax_Syntax.lbdef
-                       in
+                      closure_as_term cfg env2 lb.FStar_Syntax_Syntax.lbdef in
                     {
                       FStar_Syntax_Syntax.lbname = nm;
                       FStar_Syntax_Syntax.lbunivs =
@@ -2283,22 +2163,20 @@ let rec (closure_as_term :
                       FStar_Syntax_Syntax.lbdef = uu____4084;
                       FStar_Syntax_Syntax.lbattrs =
                         (uu___127_4083.FStar_Syntax_Syntax.lbattrs)
-                    }  in
+                    } in
                   let lbs1 =
                     FStar_All.pipe_right lbs
-                      (FStar_List.map (norm_one_lb env))
-                     in
+                      (FStar_List.map (norm_one_lb env)) in
                   let body1 =
                     let body_env =
                       FStar_List.fold_right
                         (fun uu____4114  -> fun env1  -> dummy :: env1) lbs1
-                        env
-                       in
-                    closure_as_term cfg body_env body  in
+                        env in
+                    closure_as_term cfg body_env body in
                   mk (FStar_Syntax_Syntax.Tm_let ((true, lbs1), body1))
                     t1.FStar_Syntax_Syntax.pos
               | FStar_Syntax_Syntax.Tm_match (head1,branches) ->
-                  let head2 = closure_as_term cfg env head1  in
+                  let head2 = closure_as_term cfg env head1 in
                   let norm_one_branch env1 uu____4203 =
                     match uu____4203 with
                     | (pat,w_opt,tm) ->
@@ -2315,15 +2193,14 @@ let rec (closure_as_term :
                                           match (uu____4339, uu____4340) with
                                           | ((pats1,env3),(p1,b)) ->
                                               let uu____4431 =
-                                                norm_pat env3 p1  in
+                                                norm_pat env3 p1 in
                                               (match uu____4431 with
                                                | (p2,env4) ->
                                                    (((p2, b) :: pats1), env4)))
-                                     ([], env2))
-                                 in
+                                     ([], env2)) in
                               (match uu____4279 with
                                | (pats1,env3) ->
-                                   ((let uu___128_4513 = p  in
+                                   ((let uu___128_4513 = p in
                                      {
                                        FStar_Syntax_Syntax.v =
                                          (FStar_Syntax_Syntax.Pat_cons
@@ -2333,19 +2210,18 @@ let rec (closure_as_term :
                                      }), env3))
                           | FStar_Syntax_Syntax.Pat_var x ->
                               let x1 =
-                                let uu___129_4532 = x  in
+                                let uu___129_4532 = x in
                                 let uu____4533 =
                                   closure_as_term cfg env2
-                                    x.FStar_Syntax_Syntax.sort
-                                   in
+                                    x.FStar_Syntax_Syntax.sort in
                                 {
                                   FStar_Syntax_Syntax.ppname =
                                     (uu___129_4532.FStar_Syntax_Syntax.ppname);
                                   FStar_Syntax_Syntax.index =
                                     (uu___129_4532.FStar_Syntax_Syntax.index);
                                   FStar_Syntax_Syntax.sort = uu____4533
-                                }  in
-                              ((let uu___130_4547 = p  in
+                                } in
+                              ((let uu___130_4547 = p in
                                 {
                                   FStar_Syntax_Syntax.v =
                                     (FStar_Syntax_Syntax.Pat_var x1);
@@ -2354,19 +2230,18 @@ let rec (closure_as_term :
                                 }), (dummy :: env2))
                           | FStar_Syntax_Syntax.Pat_wild x ->
                               let x1 =
-                                let uu___131_4558 = x  in
+                                let uu___131_4558 = x in
                                 let uu____4559 =
                                   closure_as_term cfg env2
-                                    x.FStar_Syntax_Syntax.sort
-                                   in
+                                    x.FStar_Syntax_Syntax.sort in
                                 {
                                   FStar_Syntax_Syntax.ppname =
                                     (uu___131_4558.FStar_Syntax_Syntax.ppname);
                                   FStar_Syntax_Syntax.index =
                                     (uu___131_4558.FStar_Syntax_Syntax.index);
                                   FStar_Syntax_Syntax.sort = uu____4559
-                                }  in
-                              ((let uu___132_4573 = p  in
+                                } in
+                              ((let uu___132_4573 = p in
                                 {
                                   FStar_Syntax_Syntax.v =
                                     (FStar_Syntax_Syntax.Pat_wild x1);
@@ -2375,29 +2250,27 @@ let rec (closure_as_term :
                                 }), (dummy :: env2))
                           | FStar_Syntax_Syntax.Pat_dot_term (x,t2) ->
                               let x1 =
-                                let uu___133_4589 = x  in
+                                let uu___133_4589 = x in
                                 let uu____4590 =
                                   closure_as_term cfg env2
-                                    x.FStar_Syntax_Syntax.sort
-                                   in
+                                    x.FStar_Syntax_Syntax.sort in
                                 {
                                   FStar_Syntax_Syntax.ppname =
                                     (uu___133_4589.FStar_Syntax_Syntax.ppname);
                                   FStar_Syntax_Syntax.index =
                                     (uu___133_4589.FStar_Syntax_Syntax.index);
                                   FStar_Syntax_Syntax.sort = uu____4590
-                                }  in
-                              let t3 = closure_as_term cfg env2 t2  in
-                              ((let uu___134_4597 = p  in
+                                } in
+                              let t3 = closure_as_term cfg env2 t2 in
+                              ((let uu___134_4597 = p in
                                 {
                                   FStar_Syntax_Syntax.v =
                                     (FStar_Syntax_Syntax.Pat_dot_term
                                        (x1, t3));
                                   FStar_Syntax_Syntax.p =
                                     (uu___134_4597.FStar_Syntax_Syntax.p)
-                                }), env2)
-                           in
-                        let uu____4600 = norm_pat env1 pat  in
+                                }), env2) in
+                        let uu____4600 = norm_pat env1 pat in
                         (match uu____4600 with
                          | (pat1,env2) ->
                              let w_opt1 =
@@ -2406,27 +2279,23 @@ let rec (closure_as_term :
                                    FStar_Pervasives_Native.None
                                | FStar_Pervasives_Native.Some w ->
                                    let uu____4629 =
-                                     closure_as_term cfg env2 w  in
-                                   FStar_Pervasives_Native.Some uu____4629
-                                in
-                             let tm1 = closure_as_term cfg env2 tm  in
-                             (pat1, w_opt1, tm1))
-                     in
+                                     closure_as_term cfg env2 w in
+                                   FStar_Pervasives_Native.Some uu____4629 in
+                             let tm1 = closure_as_term cfg env2 tm in
+                             (pat1, w_opt1, tm1)) in
                   let uu____4635 =
                     let uu____4636 =
                       let uu____4659 =
                         FStar_All.pipe_right branches
-                          (FStar_List.map (norm_one_branch env))
-                         in
-                      (head2, uu____4659)  in
-                    FStar_Syntax_Syntax.Tm_match uu____4636  in
+                          (FStar_List.map (norm_one_branch env)) in
+                      (head2, uu____4659) in
+                    FStar_Syntax_Syntax.Tm_match uu____4636 in
                   mk uu____4635 t1.FStar_Syntax_Syntax.pos))
-
-and (closure_as_term_delayed :
+and closure_as_term_delayed:
   cfg ->
     env ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun cfg  ->
     fun env  ->
@@ -2436,14 +2305,13 @@ and (closure_as_term_delayed :
             FStar_All.pipe_left Prims.op_Negation (cfg.steps).compress_uvars
             -> t
         | uu____4745 -> closure_as_term cfg env t
-
-and (closures_as_args_delayed :
+and closures_as_args_delayed:
   cfg ->
     env ->
       (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
         FStar_Pervasives_Native.tuple2 Prims.list ->
         (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
-          FStar_Pervasives_Native.tuple2 Prims.list)
+          FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun cfg  ->
     fun env  ->
@@ -2457,17 +2325,16 @@ and (closures_as_args_delayed :
               (fun uu____4788  ->
                  match uu____4788 with
                  | (x,imp) ->
-                     let uu____4807 = closure_as_term_delayed cfg env x  in
+                     let uu____4807 = closure_as_term_delayed cfg env x in
                      (uu____4807, imp)) args
-
-and (closures_as_binders_delayed :
+and closures_as_binders_delayed:
   cfg ->
     env ->
       (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
         FStar_Pervasives_Native.tuple2 Prims.list ->
         ((FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
            FStar_Pervasives_Native.tuple2 Prims.list,env)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun cfg  ->
     fun env  ->
@@ -2480,28 +2347,25 @@ and (closures_as_binders_delayed :
                     match (uu____4870, uu____4871) with
                     | ((env1,out),(b,imp)) ->
                         let b1 =
-                          let uu___135_4941 = b  in
+                          let uu___135_4941 = b in
                           let uu____4942 =
                             closure_as_term_delayed cfg env1
-                              b.FStar_Syntax_Syntax.sort
-                             in
+                              b.FStar_Syntax_Syntax.sort in
                           {
                             FStar_Syntax_Syntax.ppname =
                               (uu___135_4941.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
                               (uu___135_4941.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = uu____4942
-                          }  in
-                        let env2 = dummy :: env1  in
-                        (env2, ((b1, imp) :: out))) (env, []))
-           in
+                          } in
+                        let env2 = dummy :: env1 in
+                        (env2, ((b1, imp) :: out))) (env, [])) in
         match uu____4821 with | (env1,bs1) -> ((FStar_List.rev bs1), env1)
-
-and (close_comp :
+and close_comp:
   cfg ->
     env ->
       FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
+        FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax
   =
   fun cfg  ->
     fun env  ->
@@ -2513,24 +2377,22 @@ and (close_comp :
         | uu____5035 ->
             (match c.FStar_Syntax_Syntax.n with
              | FStar_Syntax_Syntax.Total (t,uopt) ->
-                 let uu____5048 = closure_as_term_delayed cfg env t  in
+                 let uu____5048 = closure_as_term_delayed cfg env t in
                  let uu____5049 =
-                   FStar_Option.map (norm_universe cfg env) uopt  in
+                   FStar_Option.map (norm_universe cfg env) uopt in
                  FStar_Syntax_Syntax.mk_Total' uu____5048 uu____5049
              | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-                 let uu____5062 = closure_as_term_delayed cfg env t  in
+                 let uu____5062 = closure_as_term_delayed cfg env t in
                  let uu____5063 =
-                   FStar_Option.map (norm_universe cfg env) uopt  in
+                   FStar_Option.map (norm_universe cfg env) uopt in
                  FStar_Syntax_Syntax.mk_GTotal' uu____5062 uu____5063
              | FStar_Syntax_Syntax.Comp c1 ->
                  let rt =
                    closure_as_term_delayed cfg env
-                     c1.FStar_Syntax_Syntax.result_typ
-                    in
+                     c1.FStar_Syntax_Syntax.result_typ in
                  let args =
                    closures_as_args_delayed cfg env
-                     c1.FStar_Syntax_Syntax.effect_args
-                    in
+                     c1.FStar_Syntax_Syntax.effect_args in
                  let flags1 =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                      (FStar_List.map
@@ -2538,16 +2400,14 @@ and (close_comp :
                            match uu___80_5089 with
                            | FStar_Syntax_Syntax.DECREASES t ->
                                let uu____5093 =
-                                 closure_as_term_delayed cfg env t  in
+                                 closure_as_term_delayed cfg env t in
                                FStar_Syntax_Syntax.DECREASES uu____5093
-                           | f -> f))
-                    in
+                           | f -> f)) in
                  let uu____5097 =
-                   let uu___136_5098 = c1  in
+                   let uu___136_5098 = c1 in
                    let uu____5099 =
                      FStar_List.map (norm_universe cfg env)
-                       c1.FStar_Syntax_Syntax.comp_univs
-                      in
+                       c1.FStar_Syntax_Syntax.comp_univs in
                    {
                      FStar_Syntax_Syntax.comp_univs = uu____5099;
                      FStar_Syntax_Syntax.effect_name =
@@ -2555,12 +2415,11 @@ and (close_comp :
                      FStar_Syntax_Syntax.result_typ = rt;
                      FStar_Syntax_Syntax.effect_args = args;
                      FStar_Syntax_Syntax.flags = flags1
-                   }  in
+                   } in
                  FStar_Syntax_Syntax.mk_Comp uu____5097)
-
-and (filter_out_lcomp_cflags :
+and filter_out_lcomp_cflags:
   FStar_Syntax_Syntax.cflags Prims.list ->
-    FStar_Syntax_Syntax.cflags Prims.list)
+    FStar_Syntax_Syntax.cflags Prims.list
   =
   fun flags1  ->
     FStar_All.pipe_right flags1
@@ -2569,12 +2428,11 @@ and (filter_out_lcomp_cflags :
             match uu___81_5109 with
             | FStar_Syntax_Syntax.DECREASES uu____5110 -> false
             | uu____5113 -> true))
-
-and (close_lcomp_opt :
+and close_lcomp_opt:
   cfg ->
     env ->
       FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
-        FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option)
+        FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option
   =
   fun cfg  ->
     fun env  ->
@@ -2587,49 +2445,42 @@ and (close_lcomp_opt :
                    (fun uu___82_5131  ->
                       match uu___82_5131 with
                       | FStar_Syntax_Syntax.DECREASES uu____5132 -> false
-                      | uu____5135 -> true))
-               in
+                      | uu____5135 -> true)) in
             let rc1 =
-              let uu___137_5137 = rc  in
+              let uu___137_5137 = rc in
               let uu____5138 =
                 FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
-                  (closure_as_term cfg env)
-                 in
+                  (closure_as_term cfg env) in
               {
                 FStar_Syntax_Syntax.residual_effect =
                   (uu___137_5137.FStar_Syntax_Syntax.residual_effect);
                 FStar_Syntax_Syntax.residual_typ = uu____5138;
                 FStar_Syntax_Syntax.residual_flags = flags1
-              }  in
+              } in
             FStar_Pervasives_Native.Some rc1
         | uu____5145 -> lopt
-
-let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
+let built_in_primitive_steps: primitive_step FStar_Util.psmap =
   let arg_as_int a =
     FStar_All.pipe_right (FStar_Pervasives_Native.fst a)
-      FStar_Syntax_Embeddings.unembed_int_safe
-     in
+      FStar_Syntax_Embeddings.unembed_int_safe in
   let arg_as_bool a =
     FStar_All.pipe_right (FStar_Pervasives_Native.fst a)
-      FStar_Syntax_Embeddings.unembed_bool_safe
-     in
+      FStar_Syntax_Embeddings.unembed_bool_safe in
   let arg_as_char a =
     FStar_All.pipe_right (FStar_Pervasives_Native.fst a)
-      FStar_Syntax_Embeddings.unembed_char_safe
-     in
+      FStar_Syntax_Embeddings.unembed_char_safe in
   let arg_as_string a =
     FStar_All.pipe_right (FStar_Pervasives_Native.fst a)
-      FStar_Syntax_Embeddings.unembed_string_safe
-     in
+      FStar_Syntax_Embeddings.unembed_string_safe in
   let arg_as_list a u a =
-    let uu____5230 = FStar_Syntax_Embeddings.unembed_list_safe u  in
-    FStar_All.pipe_right (FStar_Pervasives_Native.fst a) uu____5230  in
+    let uu____5230 = FStar_Syntax_Embeddings.unembed_list_safe u in
+    FStar_All.pipe_right (FStar_Pervasives_Native.fst a) uu____5230 in
   let arg_as_bounded_int uu____5258 =
     match uu____5258 with
     | (a,uu____5270) ->
         let uu____5277 =
-          let uu____5278 = FStar_Syntax_Subst.compress a  in
-          uu____5278.FStar_Syntax_Syntax.n  in
+          let uu____5278 = FStar_Syntax_Subst.compress a in
+          uu____5278.FStar_Syntax_Syntax.n in
         (match uu____5277 with
          | FStar_Syntax_Syntax.Tm_app
              ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv1;
@@ -2652,22 +2503,21 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                "int_to_t"
              ->
              let uu____5332 =
-               let uu____5337 = FStar_BigInt.big_int_of_string i  in
-               (fv1, uu____5337)  in
+               let uu____5337 = FStar_BigInt.big_int_of_string i in
+               (fv1, uu____5337) in
              FStar_Pervasives_Native.Some uu____5332
-         | uu____5342 -> FStar_Pervasives_Native.None)
-     in
+         | uu____5342 -> FStar_Pervasives_Native.None) in
   let lift_unary a b f aopts =
     match aopts with
     | (FStar_Pervasives_Native.Some a)::[] ->
-        let uu____5382 = f a  in FStar_Pervasives_Native.Some uu____5382
-    | uu____5383 -> FStar_Pervasives_Native.None  in
+        let uu____5382 = f a in FStar_Pervasives_Native.Some uu____5382
+    | uu____5383 -> FStar_Pervasives_Native.None in
   let lift_binary a b f aopts =
     match aopts with
     | (FStar_Pervasives_Native.Some a0)::(FStar_Pervasives_Native.Some
         a1)::[] ->
-        let uu____5431 = f a0 a1  in FStar_Pervasives_Native.Some uu____5431
-    | uu____5432 -> FStar_Pervasives_Native.None  in
+        let uu____5431 = f a0 a1 in FStar_Pervasives_Native.Some uu____5431
+    | uu____5432 -> FStar_Pervasives_Native.None in
   let unary_op a416 a417 a418 a419 a420 =
     (Obj.magic
        (fun a  ->
@@ -2675,11 +2525,10 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
             fun f  ->
               fun res  ->
                 fun args  ->
-                  let uu____5474 = FStar_List.map as_a args  in
+                  let uu____5474 = FStar_List.map as_a args in
                   lift_unary () ()
                     (fun a415  -> (Obj.magic (f res.psc_range)) a415)
-                    uu____5474)) a416 a417 a418 a419 a420
-     in
+                    uu____5474)) a416 a417 a418 a419 a420 in
   let binary_op a423 a424 a425 a426 a427 =
     (Obj.magic
        (fun a  ->
@@ -2687,12 +2536,11 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
             fun f  ->
               fun res  ->
                 fun args  ->
-                  let uu____5523 = FStar_List.map as_a args  in
+                  let uu____5523 = FStar_List.map as_a args in
                   lift_binary () ()
                     (fun a421  ->
                        fun a422  -> (Obj.magic (f res.psc_range)) a421 a422)
-                    uu____5523)) a423 a424 a425 a426 a427
-     in
+                    uu____5523)) a423 a424 a425 a426 a427 in
   let as_primitive_step uu____5547 =
     match uu____5547 with
     | (l,arity,f) ->
@@ -2702,8 +2550,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
           strong_reduction_ok = true;
           requires_binder_substitution = false;
           interpretation = f
-        }
-     in
+        } in
   let unary_int_op f =
     unary_op () (fun a428  -> (Obj.magic arg_as_int) a428)
       (fun a429  ->
@@ -2711,9 +2558,8 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
            (Obj.magic
               (fun r  ->
                  fun x  ->
-                   let uu____5595 = f x  in
-                   FStar_Syntax_Embeddings.embed_int r uu____5595)) a429 a430)
-     in
+                   let uu____5595 = f x in
+                   FStar_Syntax_Embeddings.embed_int r uu____5595)) a429 a430) in
   let binary_int_op f =
     binary_op () (fun a431  -> (Obj.magic arg_as_int) a431)
       (fun a432  ->
@@ -2723,10 +2569,9 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                 (fun r  ->
                    fun x  ->
                      fun y  ->
-                       let uu____5623 = f x y  in
+                       let uu____5623 = f x y in
                        FStar_Syntax_Embeddings.embed_int r uu____5623)) a432
-               a433 a434)
-     in
+               a433 a434) in
   let unary_bool_op f =
     unary_op () (fun a435  -> (Obj.magic arg_as_bool) a435)
       (fun a436  ->
@@ -2734,10 +2579,9 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
            (Obj.magic
               (fun r  ->
                  fun x  ->
-                   let uu____5644 = f x  in
+                   let uu____5644 = f x in
                    FStar_Syntax_Embeddings.embed_bool r uu____5644)) a436
-             a437)
-     in
+             a437) in
   let binary_bool_op f =
     binary_op () (fun a438  -> (Obj.magic arg_as_bool) a438)
       (fun a439  ->
@@ -2747,10 +2591,9 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                 (fun r  ->
                    fun x  ->
                      fun y  ->
-                       let uu____5672 = f x y  in
+                       let uu____5672 = f x y in
                        FStar_Syntax_Embeddings.embed_bool r uu____5672)) a439
-               a440 a441)
-     in
+               a440 a441) in
   let binary_string_op f =
     binary_op () (fun a442  -> (Obj.magic arg_as_string) a442)
       (fun a443  ->
@@ -2760,92 +2603,86 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                 (fun r  ->
                    fun x  ->
                      fun y  ->
-                       let uu____5700 = f x y  in
+                       let uu____5700 = f x y in
                        FStar_Syntax_Embeddings.embed_string r uu____5700))
-               a443 a444 a445)
-     in
+               a443 a444 a445) in
   let mixed_binary_op a b c as_a as_b embed_c f res args =
     match args with
     | a::b::[] ->
         let uu____5808 =
-          let uu____5817 = as_a a  in
-          let uu____5820 = as_b b  in (uu____5817, uu____5820)  in
+          let uu____5817 = as_a a in
+          let uu____5820 = as_b b in (uu____5817, uu____5820) in
         (match uu____5808 with
          | (FStar_Pervasives_Native.Some a1,FStar_Pervasives_Native.Some b1)
              ->
              let uu____5835 =
-               let uu____5836 = f res.psc_range a1 b1  in
-               embed_c res.psc_range uu____5836  in
+               let uu____5836 = f res.psc_range a1 b1 in
+               embed_c res.psc_range uu____5836 in
              FStar_Pervasives_Native.Some uu____5835
          | uu____5837 -> FStar_Pervasives_Native.None)
-    | uu____5846 -> FStar_Pervasives_Native.None  in
+    | uu____5846 -> FStar_Pervasives_Native.None in
   let list_of_string' rng s =
     let name l =
       let uu____5860 =
         let uu____5861 =
           FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.Delta_constant
-            FStar_Pervasives_Native.None
-           in
-        FStar_Syntax_Syntax.Tm_fvar uu____5861  in
-      mk uu____5860 rng  in
-    let char_t = name FStar_Parser_Const.char_lid  in
+            FStar_Pervasives_Native.None in
+        FStar_Syntax_Syntax.Tm_fvar uu____5861 in
+      mk uu____5860 rng in
+    let char_t = name FStar_Parser_Const.char_lid in
     let charterm c =
-      mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c)) rng  in
+      mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c)) rng in
     let uu____5871 =
-      let uu____5874 = FStar_String.list_of_string s  in
-      FStar_List.map charterm uu____5874  in
-    FStar_All.pipe_left (FStar_Syntax_Util.mk_list char_t rng) uu____5871  in
+      let uu____5874 = FStar_String.list_of_string s in
+      FStar_List.map charterm uu____5874 in
+    FStar_All.pipe_left (FStar_Syntax_Util.mk_list char_t rng) uu____5871 in
   let string_of_list' rng l =
-    let s = FStar_String.string_of_list l  in FStar_Syntax_Util.exp_string s
-     in
+    let s = FStar_String.string_of_list l in FStar_Syntax_Util.exp_string s in
   let string_compare' rng s1 s2 =
-    let r = FStar_String.compare s1 s2  in
+    let r = FStar_String.compare s1 s2 in
     let uu____5906 =
-      let uu____5907 = FStar_Util.string_of_int r  in
-      FStar_BigInt.big_int_of_string uu____5907  in
-    FStar_Syntax_Embeddings.embed_int rng uu____5906  in
+      let uu____5907 = FStar_Util.string_of_int r in
+      FStar_BigInt.big_int_of_string uu____5907 in
+    FStar_Syntax_Embeddings.embed_int rng uu____5906 in
   let string_concat' psc args =
     match args with
     | a1::a2::[] ->
-        let uu____5925 = arg_as_string a1  in
+        let uu____5925 = arg_as_string a1 in
         (match uu____5925 with
          | FStar_Pervasives_Native.Some s1 ->
              let uu____5931 =
                Obj.magic
                  (arg_as_list ()
                     (Obj.magic FStar_Syntax_Embeddings.unembed_string_safe)
-                    a2)
-                in
+                    a2) in
              (match uu____5931 with
               | FStar_Pervasives_Native.Some s2 ->
-                  let r = FStar_String.concat s1 s2  in
+                  let r = FStar_String.concat s1 s2 in
                   let uu____5944 =
-                    FStar_Syntax_Embeddings.embed_string psc.psc_range r  in
+                    FStar_Syntax_Embeddings.embed_string psc.psc_range r in
                   FStar_Pervasives_Native.Some uu____5944
               | uu____5945 -> FStar_Pervasives_Native.None)
          | uu____5950 -> FStar_Pervasives_Native.None)
-    | uu____5953 -> FStar_Pervasives_Native.None  in
+    | uu____5953 -> FStar_Pervasives_Native.None in
   let string_of_int1 rng i =
-    let uu____5963 = FStar_BigInt.string_of_big_int i  in
-    FStar_Syntax_Embeddings.embed_string rng uu____5963  in
+    let uu____5963 = FStar_BigInt.string_of_big_int i in
+    FStar_Syntax_Embeddings.embed_string rng uu____5963 in
   let string_of_bool1 rng b =
-    FStar_Syntax_Embeddings.embed_string rng (if b then "true" else "false")
-     in
+    FStar_Syntax_Embeddings.embed_string rng (if b then "true" else "false") in
   let term_of_range r =
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range r))
-      FStar_Pervasives_Native.None r
-     in
+      FStar_Pervasives_Native.None r in
   let mk_range1 uu____5987 args =
     match args with
     | fn::from_line::from_col::to_line::to_col::[] ->
         let uu____5998 =
-          let uu____6019 = arg_as_string fn  in
-          let uu____6022 = arg_as_int from_line  in
-          let uu____6025 = arg_as_int from_col  in
-          let uu____6028 = arg_as_int to_line  in
-          let uu____6031 = arg_as_int to_col  in
-          (uu____6019, uu____6022, uu____6025, uu____6028, uu____6031)  in
+          let uu____6019 = arg_as_string fn in
+          let uu____6022 = arg_as_int from_line in
+          let uu____6025 = arg_as_int from_col in
+          let uu____6028 = arg_as_int to_line in
+          let uu____6031 = arg_as_int to_col in
+          (uu____6019, uu____6022, uu____6025, uu____6028, uu____6031) in
         (match uu____5998 with
          | (FStar_Pervasives_Native.Some fn1,FStar_Pervasives_Native.Some
             from_l,FStar_Pervasives_Native.Some
@@ -2853,40 +2690,38 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
             to_l,FStar_Pervasives_Native.Some to_c) ->
              let r =
                let uu____6062 =
-                 let uu____6063 = FStar_BigInt.to_int_fs from_l  in
-                 let uu____6064 = FStar_BigInt.to_int_fs from_c  in
-                 FStar_Range.mk_pos uu____6063 uu____6064  in
+                 let uu____6063 = FStar_BigInt.to_int_fs from_l in
+                 let uu____6064 = FStar_BigInt.to_int_fs from_c in
+                 FStar_Range.mk_pos uu____6063 uu____6064 in
                let uu____6065 =
-                 let uu____6066 = FStar_BigInt.to_int_fs to_l  in
-                 let uu____6067 = FStar_BigInt.to_int_fs to_c  in
-                 FStar_Range.mk_pos uu____6066 uu____6067  in
-               FStar_Range.mk_range fn1 uu____6062 uu____6065  in
-             let uu____6068 = term_of_range r  in
+                 let uu____6066 = FStar_BigInt.to_int_fs to_l in
+                 let uu____6067 = FStar_BigInt.to_int_fs to_c in
+                 FStar_Range.mk_pos uu____6066 uu____6067 in
+               FStar_Range.mk_range fn1 uu____6062 uu____6065 in
+             let uu____6068 = term_of_range r in
              FStar_Pervasives_Native.Some uu____6068
          | uu____6073 -> FStar_Pervasives_Native.None)
-    | uu____6094 -> FStar_Pervasives_Native.None  in
+    | uu____6094 -> FStar_Pervasives_Native.None in
   let decidable_eq neg psc args =
-    let r = psc.psc_range  in
+    let r = psc.psc_range in
     let tru =
-      mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true)) r
-       in
+      mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true)) r in
     let fal =
-      mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool false)) r
-       in
+      mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool false)) r in
     match args with
     | (_typ,uu____6121)::(a1,uu____6123)::(a2,uu____6125)::[] ->
-        let uu____6162 = FStar_Syntax_Util.eq_tm a1 a2  in
+        let uu____6162 = FStar_Syntax_Util.eq_tm a1 a2 in
         (match uu____6162 with
          | FStar_Syntax_Util.Equal  ->
              FStar_Pervasives_Native.Some (if neg then fal else tru)
          | FStar_Syntax_Util.NotEqual  ->
              FStar_Pervasives_Native.Some (if neg then tru else fal)
          | uu____6175 -> FStar_Pervasives_Native.None)
-    | uu____6176 -> failwith "Unexpected number of arguments"  in
+    | uu____6176 -> failwith "Unexpected number of arguments" in
   let idstep psc args =
     match args with
     | (a1,uu____6203)::[] -> FStar_Pervasives_Native.Some a1
-    | uu____6212 -> failwith "Unexpected number of arguments"  in
+    | uu____6212 -> failwith "Unexpected number of arguments" in
   let basic_ops =
     let uu____6236 =
       let uu____6251 =
@@ -2914,8 +2749,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                   FStar_Parser_Const.p2l
                                                     ["FStar";
                                                     "String";
-                                                    "list_of_string"]
-                                                   in
+                                                    "list_of_string"] in
                                                 (uu____6564,
                                                   (Prims.parse_int "1"),
                                                   (unary_op ()
@@ -2927,16 +2761,14 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                         fun a448  ->
                                                           (Obj.magic
                                                              list_of_string')
-                                                            a447 a448)))
-                                                 in
+                                                            a447 a448))) in
                                               let uu____6571 =
                                                 let uu____6586 =
                                                   let uu____6599 =
                                                     FStar_Parser_Const.p2l
                                                       ["FStar";
                                                       "String";
-                                                      "string_of_list"]
-                                                     in
+                                                      "string_of_list"] in
                                                   (uu____6599,
                                                     (Prims.parse_int "1"),
                                                     (unary_op ()
@@ -2950,60 +2782,49 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                           fun a451  ->
                                                             (Obj.magic
                                                                string_of_list')
-                                                              a450 a451)))
-                                                   in
+                                                              a450 a451))) in
                                                 let uu____6606 =
                                                   let uu____6621 =
                                                     let uu____6636 =
                                                       FStar_Parser_Const.p2l
                                                         ["FStar";
                                                         "String";
-                                                        "concat"]
-                                                       in
+                                                        "concat"] in
                                                     (uu____6636,
                                                       (Prims.parse_int "2"),
-                                                      string_concat')
-                                                     in
+                                                      string_concat') in
                                                   let uu____6645 =
                                                     let uu____6662 =
                                                       let uu____6677 =
                                                         FStar_Parser_Const.p2l
                                                           ["Prims";
-                                                          "mk_range"]
-                                                         in
+                                                          "mk_range"] in
                                                       (uu____6677,
                                                         (Prims.parse_int "5"),
-                                                        mk_range1)
-                                                       in
+                                                        mk_range1) in
                                                     let uu____6686 =
                                                       let uu____6703 =
                                                         let uu____6722 =
                                                           FStar_Parser_Const.p2l
                                                             ["FStar";
                                                             "Range";
-                                                            "prims_to_fstar_range"]
-                                                           in
+                                                            "prims_to_fstar_range"] in
                                                         (uu____6722,
-                                                          (Prims.parse_int "1"),
-                                                          idstep)
-                                                         in
-                                                      [uu____6703]  in
-                                                    uu____6662 :: uu____6686
-                                                     in
-                                                  uu____6621 :: uu____6645
-                                                   in
-                                                uu____6586 :: uu____6606  in
-                                              uu____6551 :: uu____6571  in
+                                                          (Prims.parse_int
+                                                             "1"), idstep) in
+                                                      [uu____6703] in
+                                                    uu____6662 :: uu____6686 in
+                                                  uu____6621 :: uu____6645 in
+                                                uu____6586 :: uu____6606 in
+                                              uu____6551 :: uu____6571 in
                                             (FStar_Parser_Const.op_notEq,
                                               (Prims.parse_int "3"),
                                               (decidable_eq true)) ::
-                                              uu____6536
-                                             in
+                                              uu____6536 in
                                           (FStar_Parser_Const.op_Eq,
                                             (Prims.parse_int "3"),
                                             (decidable_eq false)) ::
-                                            uu____6521
-                                           in
+                                            uu____6521 in
                                         (FStar_Parser_Const.string_compare,
                                           (Prims.parse_int "2"),
                                           (binary_op ()
@@ -3016,8 +2837,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                     (Obj.magic
                                                        string_compare') a453
                                                       a454 a455)))
-                                          :: uu____6506
-                                         in
+                                          :: uu____6506 in
                                       (FStar_Parser_Const.string_of_bool_lid,
                                         (Prims.parse_int "1"),
                                         (unary_op ()
@@ -3027,8 +2847,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                               fun a458  ->
                                                 (Obj.magic string_of_bool1)
                                                   a457 a458)))
-                                        :: uu____6491
-                                       in
+                                        :: uu____6491 in
                                     (FStar_Parser_Const.string_of_int_lid,
                                       (Prims.parse_int "1"),
                                       (unary_op ()
@@ -3038,8 +2857,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                             fun a461  ->
                                               (Obj.magic string_of_int1) a460
                                                 a461)))
-                                      :: uu____6476
-                                     in
+                                      :: uu____6476 in
                                   (FStar_Parser_Const.str_make_lid,
                                     (Prims.parse_int "2"),
                                     (mixed_binary_op () () ()
@@ -3061,43 +2879,35 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                       fun y  ->
                                                         let uu____6939 =
                                                           FStar_BigInt.to_int_fs
-                                                            x
-                                                           in
+                                                            x in
                                                         FStar_String.make
                                                           uu____6939 y)) a466
                                                 a467 a468)))
-                                    :: uu____6461
-                                   in
+                                    :: uu____6461 in
                                 (FStar_Parser_Const.strcat_lid',
                                   (Prims.parse_int "2"),
                                   (binary_string_op
                                      (fun x  -> fun y  -> Prims.strcat x y)))
-                                  :: uu____6446
-                                 in
+                                  :: uu____6446 in
                               (FStar_Parser_Const.strcat_lid,
                                 (Prims.parse_int "2"),
                                 (binary_string_op
                                    (fun x  -> fun y  -> Prims.strcat x y)))
-                                :: uu____6431
-                               in
+                                :: uu____6431 in
                             (FStar_Parser_Const.op_Or, (Prims.parse_int "2"),
                               (binary_bool_op (fun x  -> fun y  -> x || y)))
-                              :: uu____6416
-                             in
+                              :: uu____6416 in
                           (FStar_Parser_Const.op_And, (Prims.parse_int "2"),
                             (binary_bool_op (fun x  -> fun y  -> x && y))) ::
-                            uu____6401
-                           in
+                            uu____6401 in
                         (FStar_Parser_Const.op_Negation,
                           (Prims.parse_int "1"),
                           (unary_bool_op (fun x  -> Prims.op_Negation x))) ::
-                          uu____6386
-                         in
+                          uu____6386 in
                       (FStar_Parser_Const.op_Modulus, (Prims.parse_int "2"),
                         (binary_int_op
                            (fun x  -> fun y  -> FStar_BigInt.mod_big_int x y)))
-                        :: uu____6371
-                       in
+                        :: uu____6371 in
                     (FStar_Parser_Const.op_GTE, (Prims.parse_int "2"),
                       (binary_op ()
                          (fun a469  -> (Obj.magic arg_as_int) a469)
@@ -3109,11 +2919,10 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                       fun x  ->
                                         fun y  ->
                                           let uu____7106 =
-                                            FStar_BigInt.ge_big_int x y  in
+                                            FStar_BigInt.ge_big_int x y in
                                           FStar_Syntax_Embeddings.embed_bool
                                             r uu____7106)) a470 a471 a472)))
-                      :: uu____6356
-                     in
+                      :: uu____6356 in
                   (FStar_Parser_Const.op_GT, (Prims.parse_int "2"),
                     (binary_op () (fun a473  -> (Obj.magic arg_as_int) a473)
                        (fun a474  ->
@@ -3124,11 +2933,10 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                     fun x  ->
                                       fun y  ->
                                         let uu____7132 =
-                                          FStar_BigInt.gt_big_int x y  in
+                                          FStar_BigInt.gt_big_int x y in
                                         FStar_Syntax_Embeddings.embed_bool r
                                           uu____7132)) a474 a475 a476)))
-                    :: uu____6341
-                   in
+                    :: uu____6341 in
                 (FStar_Parser_Const.op_LTE, (Prims.parse_int "2"),
                   (binary_op () (fun a477  -> (Obj.magic arg_as_int) a477)
                      (fun a478  ->
@@ -3139,11 +2947,10 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                   fun x  ->
                                     fun y  ->
                                       let uu____7158 =
-                                        FStar_BigInt.le_big_int x y  in
+                                        FStar_BigInt.le_big_int x y in
                                       FStar_Syntax_Embeddings.embed_bool r
                                         uu____7158)) a478 a479 a480)))
-                  :: uu____6326
-                 in
+                  :: uu____6326 in
               (FStar_Parser_Const.op_LT, (Prims.parse_int "2"),
                 (binary_op () (fun a481  -> (Obj.magic arg_as_int) a481)
                    (fun a482  ->
@@ -3154,44 +2961,38 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                 fun x  ->
                                   fun y  ->
                                     let uu____7184 =
-                                      FStar_BigInt.lt_big_int x y  in
+                                      FStar_BigInt.lt_big_int x y in
                                     FStar_Syntax_Embeddings.embed_bool r
                                       uu____7184)) a482 a483 a484)))
-                :: uu____6311
-               in
+                :: uu____6311 in
             (FStar_Parser_Const.op_Division, (Prims.parse_int "2"),
               (binary_int_op
                  (fun x  -> fun y  -> FStar_BigInt.div_big_int x y)))
-              :: uu____6296
-             in
+              :: uu____6296 in
           (FStar_Parser_Const.op_Multiply, (Prims.parse_int "2"),
             (binary_int_op
                (fun x  -> fun y  -> FStar_BigInt.mult_big_int x y)))
-            :: uu____6281
-           in
+            :: uu____6281 in
         (FStar_Parser_Const.op_Subtraction, (Prims.parse_int "2"),
           (binary_int_op (fun x  -> fun y  -> FStar_BigInt.sub_big_int x y)))
-          :: uu____6266
-         in
+          :: uu____6266 in
       (FStar_Parser_Const.op_Addition, (Prims.parse_int "2"),
         (binary_int_op (fun x  -> fun y  -> FStar_BigInt.add_big_int x y)))
-        :: uu____6251
-       in
+        :: uu____6251 in
     (FStar_Parser_Const.op_Minus, (Prims.parse_int "1"),
-      (unary_int_op (fun x  -> FStar_BigInt.minus_big_int x))) :: uu____6236
-     in
+      (unary_int_op (fun x  -> FStar_BigInt.minus_big_int x))) :: uu____6236 in
   let bounded_arith_ops =
-    let bounded_signed_int_types = ["Int8"; "Int16"; "Int32"; "Int64"]  in
+    let bounded_signed_int_types = ["Int8"; "Int16"; "Int32"; "Int64"] in
     let bounded_unsigned_int_types =
-      ["UInt8"; "UInt16"; "UInt32"; "UInt64"; "UInt128"]  in
+      ["UInt8"; "UInt16"; "UInt32"; "UInt64"; "UInt128"] in
     let int_as_bounded r int_to_t1 n1 =
-      let c = FStar_Syntax_Embeddings.embed_int r n1  in
-      let int_to_t2 = FStar_Syntax_Syntax.fv_to_tm int_to_t1  in
+      let c = FStar_Syntax_Embeddings.embed_int r n1 in
+      let int_to_t2 = FStar_Syntax_Syntax.fv_to_tm int_to_t1 in
       let uu____7337 =
         let uu____7338 =
-          let uu____7339 = FStar_Syntax_Syntax.as_arg c  in [uu____7339]  in
-        FStar_Syntax_Syntax.mk_Tm_app int_to_t2 uu____7338  in
-      uu____7337 FStar_Pervasives_Native.None r  in
+          let uu____7339 = FStar_Syntax_Syntax.as_arg c in [uu____7339] in
+        FStar_Syntax_Syntax.mk_Tm_app int_to_t2 uu____7338 in
+      uu____7337 FStar_Pervasives_Native.None r in
     let add_sub_mul_v =
       FStar_All.pipe_right
         (FStar_List.append bounded_signed_int_types
@@ -3199,8 +3000,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
         (FStar_List.collect
            (fun m  ->
               let uu____7389 =
-                let uu____7402 = FStar_Parser_Const.p2l ["FStar"; m; "add"]
-                   in
+                let uu____7402 = FStar_Parser_Const.p2l ["FStar"; m; "add"] in
                 (uu____7402, (Prims.parse_int "2"),
                   (binary_op ()
                      (fun a485  -> (Obj.magic arg_as_bounded_int) a485)
@@ -3214,14 +3014,12 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                       match (uu____7418, uu____7419) with
                                       | ((int_to_t1,x),(uu____7438,y)) ->
                                           let uu____7448 =
-                                            FStar_BigInt.add_big_int x y  in
+                                            FStar_BigInt.add_big_int x y in
                                           int_as_bounded r int_to_t1
-                                            uu____7448)) a486 a487 a488)))
-                 in
+                                            uu____7448)) a486 a487 a488))) in
               let uu____7449 =
                 let uu____7464 =
-                  let uu____7477 = FStar_Parser_Const.p2l ["FStar"; m; "sub"]
-                     in
+                  let uu____7477 = FStar_Parser_Const.p2l ["FStar"; m; "sub"] in
                   (uu____7477, (Prims.parse_int "2"),
                     (binary_op ()
                        (fun a489  -> (Obj.magic arg_as_bounded_int) a489)
@@ -3235,15 +3033,13 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                         match (uu____7493, uu____7494) with
                                         | ((int_to_t1,x),(uu____7513,y)) ->
                                             let uu____7523 =
-                                              FStar_BigInt.sub_big_int x y
-                                               in
+                                              FStar_BigInt.sub_big_int x y in
                                             int_as_bounded r int_to_t1
-                                              uu____7523)) a490 a491 a492)))
-                   in
+                                              uu____7523)) a490 a491 a492))) in
                 let uu____7524 =
                   let uu____7539 =
                     let uu____7552 =
-                      FStar_Parser_Const.p2l ["FStar"; m; "mul"]  in
+                      FStar_Parser_Const.p2l ["FStar"; m; "mul"] in
                     (uu____7552, (Prims.parse_int "2"),
                       (binary_op ()
                          (fun a493  -> (Obj.magic arg_as_bounded_int) a493)
@@ -3257,15 +3053,13 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                           match (uu____7568, uu____7569) with
                                           | ((int_to_t1,x),(uu____7588,y)) ->
                                               let uu____7598 =
-                                                FStar_BigInt.mult_big_int x y
-                                                 in
+                                                FStar_BigInt.mult_big_int x y in
                                               int_as_bounded r int_to_t1
-                                                uu____7598)) a494 a495 a496)))
-                     in
+                                                uu____7598)) a494 a495 a496))) in
                   let uu____7599 =
                     let uu____7614 =
                       let uu____7627 =
-                        FStar_Parser_Const.p2l ["FStar"; m; "v"]  in
+                        FStar_Parser_Const.p2l ["FStar"; m; "v"] in
                       (uu____7627, (Prims.parse_int "1"),
                         (unary_op ()
                            (fun a497  -> (Obj.magic arg_as_bounded_int) a497)
@@ -3277,20 +3071,17 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                         match uu____7639 with
                                         | (int_to_t1,x) ->
                                             FStar_Syntax_Embeddings.embed_int
-                                              r x)) a498 a499)))
-                       in
-                    [uu____7614]  in
-                  uu____7539 :: uu____7599  in
-                uu____7464 :: uu____7524  in
-              uu____7389 :: uu____7449))
-       in
+                                              r x)) a498 a499))) in
+                    [uu____7614] in
+                  uu____7539 :: uu____7599 in
+                uu____7464 :: uu____7524 in
+              uu____7389 :: uu____7449)) in
     let div_mod_unsigned =
       FStar_All.pipe_right bounded_unsigned_int_types
         (FStar_List.collect
            (fun m  ->
               let uu____7753 =
-                let uu____7766 = FStar_Parser_Const.p2l ["FStar"; m; "div"]
-                   in
+                let uu____7766 = FStar_Parser_Const.p2l ["FStar"; m; "div"] in
                 (uu____7766, (Prims.parse_int "2"),
                   (binary_op ()
                      (fun a500  -> (Obj.magic arg_as_bounded_int) a500)
@@ -3304,14 +3095,12 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                       match (uu____7782, uu____7783) with
                                       | ((int_to_t1,x),(uu____7802,y)) ->
                                           let uu____7812 =
-                                            FStar_BigInt.div_big_int x y  in
+                                            FStar_BigInt.div_big_int x y in
                                           int_as_bounded r int_to_t1
-                                            uu____7812)) a501 a502 a503)))
-                 in
+                                            uu____7812)) a501 a502 a503))) in
               let uu____7813 =
                 let uu____7828 =
-                  let uu____7841 = FStar_Parser_Const.p2l ["FStar"; m; "rem"]
-                     in
+                  let uu____7841 = FStar_Parser_Const.p2l ["FStar"; m; "rem"] in
                   (uu____7841, (Prims.parse_int "2"),
                     (binary_op ()
                        (fun a504  -> (Obj.magic arg_as_bounded_int) a504)
@@ -3325,30 +3114,26 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                         match (uu____7857, uu____7858) with
                                         | ((int_to_t1,x),(uu____7877,y)) ->
                                             let uu____7887 =
-                                              FStar_BigInt.mod_big_int x y
-                                               in
+                                              FStar_BigInt.mod_big_int x y in
                                             int_as_bounded r int_to_t1
-                                              uu____7887)) a505 a506 a507)))
-                   in
-                [uu____7828]  in
-              uu____7753 :: uu____7813))
-       in
-    FStar_List.append add_sub_mul_v div_mod_unsigned  in
+                                              uu____7887)) a505 a506 a507))) in
+                [uu____7828] in
+              uu____7753 :: uu____7813)) in
+    FStar_List.append add_sub_mul_v div_mod_unsigned in
   let uu____7936 =
     FStar_List.map as_primitive_step
-      (FStar_List.append basic_ops bounded_arith_ops)
-     in
-  FStar_All.pipe_left prim_from_list uu____7936 
-let (equality_ops : primitive_step FStar_Util.psmap) =
+      (FStar_List.append basic_ops bounded_arith_ops) in
+  FStar_All.pipe_left prim_from_list uu____7936
+let equality_ops: primitive_step FStar_Util.psmap =
   let interp_prop psc args =
-    let r = psc.psc_range  in
+    let r = psc.psc_range in
     match args with
     | (_typ,uu____7984)::(a1,uu____7986)::(a2,uu____7988)::[] ->
-        let uu____8025 = FStar_Syntax_Util.eq_tm a1 a2  in
+        let uu____8025 = FStar_Syntax_Util.eq_tm a1 a2 in
         (match uu____8025 with
          | FStar_Syntax_Util.Equal  ->
              FStar_Pervasives_Native.Some
-               (let uu___138_8031 = FStar_Syntax_Util.t_true  in
+               (let uu___138_8031 = FStar_Syntax_Util.t_true in
                 {
                   FStar_Syntax_Syntax.n =
                     (uu___138_8031.FStar_Syntax_Syntax.n);
@@ -3358,7 +3143,7 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
                 })
          | FStar_Syntax_Util.NotEqual  ->
              FStar_Pervasives_Native.Some
-               (let uu___139_8035 = FStar_Syntax_Util.t_false  in
+               (let uu___139_8035 = FStar_Syntax_Util.t_false in
                 {
                   FStar_Syntax_Syntax.n =
                     (uu___139_8035.FStar_Syntax_Syntax.n);
@@ -3368,11 +3153,11 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
                 })
          | uu____8036 -> FStar_Pervasives_Native.None)
     | (_typ,uu____8038)::uu____8039::(a1,uu____8041)::(a2,uu____8043)::[] ->
-        let uu____8092 = FStar_Syntax_Util.eq_tm a1 a2  in
+        let uu____8092 = FStar_Syntax_Util.eq_tm a1 a2 in
         (match uu____8092 with
          | FStar_Syntax_Util.Equal  ->
              FStar_Pervasives_Native.Some
-               (let uu___138_8098 = FStar_Syntax_Util.t_true  in
+               (let uu___138_8098 = FStar_Syntax_Util.t_true in
                 {
                   FStar_Syntax_Syntax.n =
                     (uu___138_8098.FStar_Syntax_Syntax.n);
@@ -3382,7 +3167,7 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
                 })
          | FStar_Syntax_Util.NotEqual  ->
              FStar_Pervasives_Native.Some
-               (let uu___139_8102 = FStar_Syntax_Util.t_false  in
+               (let uu___139_8102 = FStar_Syntax_Util.t_false in
                 {
                   FStar_Syntax_Syntax.n =
                     (uu___139_8102.FStar_Syntax_Syntax.n);
@@ -3391,7 +3176,7 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
                     (uu___139_8102.FStar_Syntax_Syntax.vars)
                 })
          | uu____8103 -> FStar_Pervasives_Native.None)
-    | uu____8104 -> failwith "Unexpected number of arguments"  in
+    | uu____8104 -> failwith "Unexpected number of arguments" in
   let propositional_equality =
     {
       name = FStar_Parser_Const.eq2_lid;
@@ -3399,7 +3184,7 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
       strong_reduction_ok = true;
       requires_binder_substitution = false;
       interpretation = interp_prop
-    }  in
+    } in
   let hetero_propositional_equality =
     {
       name = FStar_Parser_Const.eq3_lid;
@@ -3407,21 +3192,20 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
       strong_reduction_ok = true;
       requires_binder_substitution = false;
       interpretation = interp_prop
-    }  in
-  prim_from_list [propositional_equality; hetero_propositional_equality] 
-let (unembed_binder :
+    } in
+  prim_from_list [propositional_equality; hetero_propositional_equality]
+let unembed_binder:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option
   =
   fun t  ->
     try
       let uu____8123 =
-        let uu____8124 = FStar_Syntax_Util.un_alien t  in
-        FStar_All.pipe_right uu____8124 FStar_Dyn.undyn  in
+        let uu____8124 = FStar_Syntax_Util.un_alien t in
+        FStar_All.pipe_right uu____8124 FStar_Dyn.undyn in
       FStar_Pervasives_Native.Some uu____8123
     with | uu____8130 -> FStar_Pervasives_Native.None
-  
-let mk_psc_subst :
+let mk_psc_subst:
   'Auu____8134 .
     cfg ->
       ((FStar_Syntax_Syntax.bv,'Auu____8134) FStar_Pervasives_Native.tuple2
@@ -3439,48 +3223,44 @@ let mk_psc_subst :
                  (match (binder_opt, closure) with
                   | (FStar_Pervasives_Native.Some b,Clos
                      (env1,term,uu____8235,uu____8236)) ->
-                      let uu____8295 = b  in
+                      let uu____8295 = b in
                       (match uu____8295 with
                        | (bv,uu____8303) ->
                            let uu____8304 =
                              let uu____8305 =
                                FStar_Syntax_Util.is_constructed_typ
                                  bv.FStar_Syntax_Syntax.sort
-                                 FStar_Parser_Const.fstar_reflection_types_binder_lid
-                                in
-                             Prims.op_Negation uu____8305  in
+                                 FStar_Parser_Const.fstar_reflection_types_binder_lid in
+                             Prims.op_Negation uu____8305 in
                            if uu____8304
                            then subst1
                            else
-                             (let term1 = closure_as_term cfg env1 term  in
-                              let uu____8310 = unembed_binder term1  in
+                             (let term1 = closure_as_term cfg env1 term in
+                              let uu____8310 = unembed_binder term1 in
                               match uu____8310 with
                               | FStar_Pervasives_Native.None  -> subst1
                               | FStar_Pervasives_Native.Some x ->
                                   let b1 =
                                     let uu____8317 =
-                                      let uu___142_8318 = bv  in
+                                      let uu___142_8318 = bv in
                                       let uu____8319 =
                                         FStar_Syntax_Subst.subst subst1
-                                          (FStar_Pervasives_Native.fst x).FStar_Syntax_Syntax.sort
-                                         in
+                                          (FStar_Pervasives_Native.fst x).FStar_Syntax_Syntax.sort in
                                       {
                                         FStar_Syntax_Syntax.ppname =
                                           (uu___142_8318.FStar_Syntax_Syntax.ppname);
                                         FStar_Syntax_Syntax.index =
                                           (uu___142_8318.FStar_Syntax_Syntax.index);
                                         FStar_Syntax_Syntax.sort = uu____8319
-                                      }  in
-                                    FStar_Syntax_Syntax.freshen_bv uu____8317
-                                     in
+                                      } in
+                                    FStar_Syntax_Syntax.freshen_bv uu____8317 in
                                   let b_for_x =
                                     let uu____8323 =
                                       let uu____8330 =
-                                        FStar_Syntax_Syntax.bv_to_name b1  in
+                                        FStar_Syntax_Syntax.bv_to_name b1 in
                                       ((FStar_Pervasives_Native.fst x),
-                                        uu____8330)
-                                       in
-                                    FStar_Syntax_Syntax.NT uu____8323  in
+                                        uu____8330) in
+                                    FStar_Syntax_Syntax.NT uu____8323 in
                                   let subst2 =
                                     FStar_List.filter
                                       (fun uu___83_8339  ->
@@ -3500,12 +3280,10 @@ let mk_psc_subst :
                                                (FStar_Ident.ident_equals
                                                   b1.FStar_Syntax_Syntax.ppname
                                                   b'.FStar_Syntax_Syntax.ppname)
-                                         | uu____8348 -> true) subst1
-                                     in
+                                         | uu____8348 -> true) subst1 in
                                   b_for_x :: subst2))
                   | uu____8349 -> subst1)) env []
-  
-let reduce_primops :
+let reduce_primops:
   'Auu____8366 'Auu____8367 .
     cfg ->
       ((FStar_Syntax_Syntax.bv,'Auu____8367) FStar_Pervasives_Native.tuple2
@@ -3520,19 +3298,18 @@ let reduce_primops :
           if Prims.op_Negation (cfg.steps).primops
           then tm
           else
-            (let uu____8409 = FStar_Syntax_Util.head_and_args tm  in
+            (let uu____8409 = FStar_Syntax_Util.head_and_args tm in
              match uu____8409 with
              | (head1,args) ->
                  let uu____8446 =
-                   let uu____8447 = FStar_Syntax_Util.un_uinst head1  in
-                   uu____8447.FStar_Syntax_Syntax.n  in
+                   let uu____8447 = FStar_Syntax_Util.un_uinst head1 in
+                   uu____8447.FStar_Syntax_Syntax.n in
                  (match uu____8446 with
                   | FStar_Syntax_Syntax.Tm_fvar fv ->
                       let uu____8451 =
                         FStar_Util.psmap_try_find cfg.primitive_steps
                           (FStar_Ident.text_of_lid
-                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                         in
+                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
                       (match uu____8451 with
                        | FStar_Pervasives_Native.Some prim_step when
                            prim_step.strong_reduction_ok ||
@@ -3544,15 +3321,12 @@ let reduce_primops :
                                 (fun uu____8466  ->
                                    let uu____8467 =
                                      FStar_Syntax_Print.lid_to_string
-                                       prim_step.name
-                                      in
+                                       prim_step.name in
                                    let uu____8468 =
                                      FStar_Util.string_of_int
-                                       (FStar_List.length args)
-                                      in
+                                       (FStar_List.length args) in
                                    let uu____8475 =
-                                     FStar_Util.string_of_int prim_step.arity
-                                      in
+                                     FStar_Util.string_of_int prim_step.arity in
                                    FStar_Util.print3
                                      "primop: found partially applied %s (%s/%s args)\n"
                                      uu____8467 uu____8468 uu____8475);
@@ -3561,7 +3335,7 @@ let reduce_primops :
                              (log_primops cfg
                                 (fun uu____8480  ->
                                    let uu____8481 =
-                                     FStar_Syntax_Print.term_to_string tm  in
+                                     FStar_Syntax_Print.term_to_string tm in
                                    FStar_Util.print1
                                      "primop: trying to reduce <%s>\n"
                                      uu____8481);
@@ -3575,17 +3349,16 @@ let reduce_primops :
                                           prim_step.requires_binder_substitution
                                         then mk_psc_subst cfg env
                                         else [])
-                                 }  in
+                                 } in
                                let uu____8486 =
-                                 prim_step.interpretation psc args  in
+                                 prim_step.interpretation psc args in
                                match uu____8486 with
                                | FStar_Pervasives_Native.None  ->
                                    (log_primops cfg
                                       (fun uu____8492  ->
                                          let uu____8493 =
                                            FStar_Syntax_Print.term_to_string
-                                             tm
-                                            in
+                                             tm in
                                          FStar_Util.print1
                                            "primop: <%s> did not reduce\n"
                                            uu____8493);
@@ -3595,12 +3368,10 @@ let reduce_primops :
                                       (fun uu____8499  ->
                                          let uu____8500 =
                                            FStar_Syntax_Print.term_to_string
-                                             tm
-                                            in
+                                             tm in
                                          let uu____8501 =
                                            FStar_Syntax_Print.term_to_string
-                                             reduced
-                                            in
+                                             reduced in
                                          FStar_Util.print2
                                            "primop: <%s> reduced to <%s>\n"
                                            uu____8500 uu____8501);
@@ -3609,7 +3380,7 @@ let reduce_primops :
                            (log_primops cfg
                               (fun uu____8506  ->
                                  let uu____8507 =
-                                   FStar_Syntax_Print.term_to_string tm  in
+                                   FStar_Syntax_Print.term_to_string tm in
                                  FStar_Util.print1
                                    "primop: not reducing <%s> since we're doing strong reduction\n"
                                    uu____8507);
@@ -3621,7 +3392,7 @@ let reduce_primops :
                       (log_primops cfg
                          (fun uu____8511  ->
                             let uu____8512 =
-                              FStar_Syntax_Print.term_to_string tm  in
+                              FStar_Syntax_Print.term_to_string tm in
                             FStar_Util.print1 "primop: reducing <%s>\n"
                               uu____8512);
                        (match args with
@@ -3636,16 +3407,16 @@ let reduce_primops :
                       (log_primops cfg
                          (fun uu____8543  ->
                             let uu____8544 =
-                              FStar_Syntax_Print.term_to_string tm  in
+                              FStar_Syntax_Print.term_to_string tm in
                             FStar_Util.print1 "primop: reducing <%s>\n"
                               uu____8544);
                        (match args with
                         | (t,uu____8546)::(r,uu____8548)::[] ->
                             let uu____8575 =
-                              FStar_Syntax_Embeddings.unembed_range r  in
+                              FStar_Syntax_Embeddings.unembed_range r in
                             (match uu____8575 with
                              | FStar_Pervasives_Native.Some rng ->
-                                 let uu___143_8579 = t  in
+                                 let uu___143_8579 = t in
                                  {
                                    FStar_Syntax_Syntax.n =
                                      (uu___143_8579.FStar_Syntax_Syntax.n);
@@ -3656,8 +3427,7 @@ let reduce_primops :
                              | FStar_Pervasives_Native.None  -> tm)
                         | uu____8582 -> tm))
                   | uu____8591 -> tm))
-  
-let reduce_equality :
+let reduce_equality:
   'Auu____8596 'Auu____8597 .
     cfg ->
       ((FStar_Syntax_Syntax.bv,'Auu____8597) FStar_Pervasives_Native.tuple2
@@ -3668,10 +3438,10 @@ let reduce_equality :
   fun cfg  ->
     fun tm  ->
       reduce_primops
-        (let uu___144_8635 = cfg  in
+        (let uu___144_8635 = cfg in
          {
            steps =
-             (let uu___145_8638 = default_steps  in
+             (let uu___145_8638 = default_steps in
               {
                 beta = (uu___145_8638.beta);
                 iota = (uu___145_8638.iota);
@@ -3707,8 +3477,7 @@ let reduce_equality :
            memoize_lazy = (uu___144_8635.memoize_lazy);
            normalize_pure_lets = (uu___144_8635.normalize_pure_lets)
          }) tm
-  
-let maybe_simplify_aux :
+let maybe_simplify_aux:
   'Auu____8645 'Auu____8646 .
     cfg ->
       ((FStar_Syntax_Syntax.bv,'Auu____8646) FStar_Pervasives_Native.tuple2
@@ -3720,21 +3489,21 @@ let maybe_simplify_aux :
     fun env  ->
       fun stack  ->
         fun tm  ->
-          let tm1 = reduce_primops cfg env stack tm  in
+          let tm1 = reduce_primops cfg env stack tm in
           let uu____8688 =
-            FStar_All.pipe_left Prims.op_Negation (cfg.steps).simplify  in
+            FStar_All.pipe_left Prims.op_Negation (cfg.steps).simplify in
           if uu____8688
           then tm1
           else
             (let w t =
-               let uu___146_8700 = t  in
+               let uu___146_8700 = t in
                {
                  FStar_Syntax_Syntax.n =
                    (uu___146_8700.FStar_Syntax_Syntax.n);
                  FStar_Syntax_Syntax.pos = (tm1.FStar_Syntax_Syntax.pos);
                  FStar_Syntax_Syntax.vars =
                    (uu___146_8700.FStar_Syntax_Syntax.vars)
-               }  in
+               } in
              let simp_t t =
                match t.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_meta
@@ -3761,35 +3530,31 @@ let maybe_simplify_aux :
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.false_lid
                    -> FStar_Pervasives_Native.Some false
-               | uu____8733 -> FStar_Pervasives_Native.None  in
+               | uu____8733 -> FStar_Pervasives_Native.None in
              let maybe_auto_squash t =
-               let uu____8738 = FStar_Syntax_Util.is_sub_singleton t  in
+               let uu____8738 = FStar_Syntax_Util.is_sub_singleton t in
                if uu____8738
                then t
                else
                  FStar_Syntax_Util.mk_auto_squash FStar_Syntax_Syntax.U_zero
-                   t
-                in
+                   t in
              let squashed_head_un_auto_squash_args t =
                let maybe_un_auto_squash_arg uu____8759 =
                  match uu____8759 with
                  | (t1,q) ->
-                     let uu____8772 = FStar_Syntax_Util.is_auto_squash t1  in
+                     let uu____8772 = FStar_Syntax_Util.is_auto_squash t1 in
                      (match uu____8772 with
                       | FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.U_zero ,t2) -> (t2, q)
-                      | uu____8800 -> (t1, q))
-                  in
-               let uu____8809 = FStar_Syntax_Util.head_and_args t  in
+                      | uu____8800 -> (t1, q)) in
+               let uu____8809 = FStar_Syntax_Util.head_and_args t in
                match uu____8809 with
                | (head1,args) ->
-                   let args1 = FStar_List.map maybe_un_auto_squash_arg args
-                      in
+                   let args1 = FStar_List.map maybe_un_auto_squash_arg args in
                    FStar_Syntax_Syntax.mk_Tm_app head1 args1
-                     FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-                in
+                     FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos in
              let simplify1 arg =
-               ((simp_t (FStar_Pervasives_Native.fst arg)), arg)  in
+               ((simp_t (FStar_Pervasives_Native.fst arg)), arg) in
              match tm1.FStar_Syntax_Syntax.n with
              | FStar_Syntax_Syntax.Tm_app
                  ({
@@ -3804,12 +3569,11 @@ let maybe_simplify_aux :
                  ->
                  let uu____8936 =
                    FStar_Syntax_Syntax.fv_eq_lid fv
-                     FStar_Parser_Const.and_lid
-                    in
+                     FStar_Parser_Const.and_lid in
                  if uu____8936
                  then
                    let uu____8937 =
-                     FStar_All.pipe_right args (FStar_List.map simplify1)  in
+                     FStar_All.pipe_right args (FStar_List.map simplify1) in
                    (match uu____8937 with
                     | (FStar_Pervasives_Native.Some (true ),uu____8992)::
                         (uu____8993,(arg,uu____8995))::[] ->
@@ -3826,13 +3590,11 @@ let maybe_simplify_aux :
                  else
                    (let uu____9272 =
                       FStar_Syntax_Syntax.fv_eq_lid fv
-                        FStar_Parser_Const.or_lid
-                       in
+                        FStar_Parser_Const.or_lid in
                     if uu____9272
                     then
                       let uu____9273 =
-                        FStar_All.pipe_right args (FStar_List.map simplify1)
-                         in
+                        FStar_All.pipe_right args (FStar_List.map simplify1) in
                       match uu____9273 with
                       | (FStar_Pervasives_Native.Some (true ),uu____9328)::uu____9329::[]
                           -> w FStar_Syntax_Util.t_true
@@ -3849,14 +3611,12 @@ let maybe_simplify_aux :
                     else
                       (let uu____9608 =
                          FStar_Syntax_Syntax.fv_eq_lid fv
-                           FStar_Parser_Const.imp_lid
-                          in
+                           FStar_Parser_Const.imp_lid in
                        if uu____9608
                        then
                          let uu____9609 =
                            FStar_All.pipe_right args
-                             (FStar_List.map simplify1)
-                            in
+                             (FStar_List.map simplify1) in
                          match uu____9609 with
                          | uu____9664::(FStar_Pervasives_Native.Some (true
                                         ),uu____9665)::[]
@@ -3868,8 +3628,7 @@ let maybe_simplify_aux :
                              maybe_auto_squash arg
                          | (uu____9860,(p,uu____9862))::(uu____9863,(q,uu____9865))::[]
                              ->
-                             let uu____9930 = FStar_Syntax_Util.term_eq p q
-                                in
+                             let uu____9930 = FStar_Syntax_Util.term_eq p q in
                              (if uu____9930
                               then w FStar_Syntax_Util.t_true
                               else squashed_head_un_auto_squash_args tm1)
@@ -3878,14 +3637,12 @@ let maybe_simplify_aux :
                        else
                          (let uu____9948 =
                             FStar_Syntax_Syntax.fv_eq_lid fv
-                              FStar_Parser_Const.not_lid
-                             in
+                              FStar_Parser_Const.not_lid in
                           if uu____9948
                           then
                             let uu____9949 =
                               FStar_All.pipe_right args
-                                (FStar_List.map simplify1)
-                               in
+                                (FStar_List.map simplify1) in
                             match uu____9949 with
                             | (FStar_Pervasives_Native.Some (true
                                ),uu____10004)::[] ->
@@ -3898,16 +3655,15 @@ let maybe_simplify_aux :
                           else
                             (let uu____10098 =
                                FStar_Syntax_Syntax.fv_eq_lid fv
-                                 FStar_Parser_Const.forall_lid
-                                in
+                                 FStar_Parser_Const.forall_lid in
                              if uu____10098
                              then
                                match args with
                                | (t,uu____10100)::[] ->
                                    let uu____10117 =
                                      let uu____10118 =
-                                       FStar_Syntax_Subst.compress t  in
-                                     uu____10118.FStar_Syntax_Syntax.n  in
+                                       FStar_Syntax_Subst.compress t in
+                                     uu____10118.FStar_Syntax_Syntax.n in
                                    (match uu____10117 with
                                     | FStar_Syntax_Syntax.Tm_abs
                                         (uu____10121::[],body,uu____10123) ->
@@ -3921,8 +3677,8 @@ let maybe_simplify_aux :
                                    (t,uu____10157)::[] ->
                                    let uu____10196 =
                                      let uu____10197 =
-                                       FStar_Syntax_Subst.compress t  in
-                                     uu____10197.FStar_Syntax_Syntax.n  in
+                                       FStar_Syntax_Subst.compress t in
+                                     uu____10197.FStar_Syntax_Syntax.n in
                                    (match uu____10196 with
                                     | FStar_Syntax_Syntax.Tm_abs
                                         (uu____10200::[],body,uu____10202) ->
@@ -3935,16 +3691,15 @@ let maybe_simplify_aux :
                              else
                                (let uu____10243 =
                                   FStar_Syntax_Syntax.fv_eq_lid fv
-                                    FStar_Parser_Const.exists_lid
-                                   in
+                                    FStar_Parser_Const.exists_lid in
                                 if uu____10243
                                 then
                                   match args with
                                   | (t,uu____10245)::[] ->
                                       let uu____10262 =
                                         let uu____10263 =
-                                          FStar_Syntax_Subst.compress t  in
-                                        uu____10263.FStar_Syntax_Syntax.n  in
+                                          FStar_Syntax_Subst.compress t in
+                                        uu____10263.FStar_Syntax_Syntax.n in
                                       (match uu____10262 with
                                        | FStar_Syntax_Syntax.Tm_abs
                                            (uu____10266::[],body,uu____10268)
@@ -3960,8 +3715,8 @@ let maybe_simplify_aux :
                                      uu____10300))::(t,uu____10302)::[] ->
                                       let uu____10341 =
                                         let uu____10342 =
-                                          FStar_Syntax_Subst.compress t  in
-                                        uu____10342.FStar_Syntax_Syntax.n  in
+                                          FStar_Syntax_Subst.compress t in
+                                        uu____10342.FStar_Syntax_Syntax.n in
                                       (match uu____10341 with
                                        | FStar_Syntax_Syntax.Tm_abs
                                            (uu____10345::[],body,uu____10347)
@@ -3976,8 +3731,7 @@ let maybe_simplify_aux :
                                 else
                                   (let uu____10388 =
                                      FStar_Syntax_Syntax.fv_eq_lid fv
-                                       FStar_Parser_Const.b2t_lid
-                                      in
+                                       FStar_Parser_Const.b2t_lid in
                                    if uu____10388
                                    then
                                      match args with
@@ -4002,8 +3756,7 @@ let maybe_simplify_aux :
                                      | uu____10427 -> tm1
                                    else
                                      (let uu____10437 =
-                                        FStar_Syntax_Util.is_auto_squash tm1
-                                         in
+                                        FStar_Syntax_Util.is_auto_squash tm1 in
                                       match uu____10437 with
                                       | FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.U_zero ,t)
@@ -4020,12 +3773,11 @@ let maybe_simplify_aux :
                  ->
                  let uu____10490 =
                    FStar_Syntax_Syntax.fv_eq_lid fv
-                     FStar_Parser_Const.and_lid
-                    in
+                     FStar_Parser_Const.and_lid in
                  if uu____10490
                  then
                    let uu____10491 =
-                     FStar_All.pipe_right args (FStar_List.map simplify1)  in
+                     FStar_All.pipe_right args (FStar_List.map simplify1) in
                    (match uu____10491 with
                     | (FStar_Pervasives_Native.Some (true ),uu____10546)::
                         (uu____10547,(arg,uu____10549))::[] ->
@@ -4042,13 +3794,11 @@ let maybe_simplify_aux :
                  else
                    (let uu____10826 =
                       FStar_Syntax_Syntax.fv_eq_lid fv
-                        FStar_Parser_Const.or_lid
-                       in
+                        FStar_Parser_Const.or_lid in
                     if uu____10826
                     then
                       let uu____10827 =
-                        FStar_All.pipe_right args (FStar_List.map simplify1)
-                         in
+                        FStar_All.pipe_right args (FStar_List.map simplify1) in
                       match uu____10827 with
                       | (FStar_Pervasives_Native.Some (true ),uu____10882)::uu____10883::[]
                           -> w FStar_Syntax_Util.t_true
@@ -4066,14 +3816,12 @@ let maybe_simplify_aux :
                     else
                       (let uu____11162 =
                          FStar_Syntax_Syntax.fv_eq_lid fv
-                           FStar_Parser_Const.imp_lid
-                          in
+                           FStar_Parser_Const.imp_lid in
                        if uu____11162
                        then
                          let uu____11163 =
                            FStar_All.pipe_right args
-                             (FStar_List.map simplify1)
-                            in
+                             (FStar_List.map simplify1) in
                          match uu____11163 with
                          | uu____11218::(FStar_Pervasives_Native.Some (true
                                          ),uu____11219)::[]
@@ -4087,8 +3835,7 @@ let maybe_simplify_aux :
                          | (uu____11414,(p,uu____11416))::(uu____11417,
                                                            (q,uu____11419))::[]
                              ->
-                             let uu____11484 = FStar_Syntax_Util.term_eq p q
-                                in
+                             let uu____11484 = FStar_Syntax_Util.term_eq p q in
                              (if uu____11484
                               then w FStar_Syntax_Util.t_true
                               else squashed_head_un_auto_squash_args tm1)
@@ -4097,14 +3844,12 @@ let maybe_simplify_aux :
                        else
                          (let uu____11502 =
                             FStar_Syntax_Syntax.fv_eq_lid fv
-                              FStar_Parser_Const.not_lid
-                             in
+                              FStar_Parser_Const.not_lid in
                           if uu____11502
                           then
                             let uu____11503 =
                               FStar_All.pipe_right args
-                                (FStar_List.map simplify1)
-                               in
+                                (FStar_List.map simplify1) in
                             match uu____11503 with
                             | (FStar_Pervasives_Native.Some (true
                                ),uu____11558)::[] ->
@@ -4117,16 +3862,15 @@ let maybe_simplify_aux :
                           else
                             (let uu____11652 =
                                FStar_Syntax_Syntax.fv_eq_lid fv
-                                 FStar_Parser_Const.forall_lid
-                                in
+                                 FStar_Parser_Const.forall_lid in
                              if uu____11652
                              then
                                match args with
                                | (t,uu____11654)::[] ->
                                    let uu____11671 =
                                      let uu____11672 =
-                                       FStar_Syntax_Subst.compress t  in
-                                     uu____11672.FStar_Syntax_Syntax.n  in
+                                       FStar_Syntax_Subst.compress t in
+                                     uu____11672.FStar_Syntax_Syntax.n in
                                    (match uu____11671 with
                                     | FStar_Syntax_Syntax.Tm_abs
                                         (uu____11675::[],body,uu____11677) ->
@@ -4140,8 +3884,8 @@ let maybe_simplify_aux :
                                    (t,uu____11711)::[] ->
                                    let uu____11750 =
                                      let uu____11751 =
-                                       FStar_Syntax_Subst.compress t  in
-                                     uu____11751.FStar_Syntax_Syntax.n  in
+                                       FStar_Syntax_Subst.compress t in
+                                     uu____11751.FStar_Syntax_Syntax.n in
                                    (match uu____11750 with
                                     | FStar_Syntax_Syntax.Tm_abs
                                         (uu____11754::[],body,uu____11756) ->
@@ -4154,16 +3898,15 @@ let maybe_simplify_aux :
                              else
                                (let uu____11797 =
                                   FStar_Syntax_Syntax.fv_eq_lid fv
-                                    FStar_Parser_Const.exists_lid
-                                   in
+                                    FStar_Parser_Const.exists_lid in
                                 if uu____11797
                                 then
                                   match args with
                                   | (t,uu____11799)::[] ->
                                       let uu____11816 =
                                         let uu____11817 =
-                                          FStar_Syntax_Subst.compress t  in
-                                        uu____11817.FStar_Syntax_Syntax.n  in
+                                          FStar_Syntax_Subst.compress t in
+                                        uu____11817.FStar_Syntax_Syntax.n in
                                       (match uu____11816 with
                                        | FStar_Syntax_Syntax.Tm_abs
                                            (uu____11820::[],body,uu____11822)
@@ -4179,8 +3922,8 @@ let maybe_simplify_aux :
                                      uu____11854))::(t,uu____11856)::[] ->
                                       let uu____11895 =
                                         let uu____11896 =
-                                          FStar_Syntax_Subst.compress t  in
-                                        uu____11896.FStar_Syntax_Syntax.n  in
+                                          FStar_Syntax_Subst.compress t in
+                                        uu____11896.FStar_Syntax_Syntax.n in
                                       (match uu____11895 with
                                        | FStar_Syntax_Syntax.Tm_abs
                                            (uu____11899::[],body,uu____11901)
@@ -4195,8 +3938,7 @@ let maybe_simplify_aux :
                                 else
                                   (let uu____11942 =
                                      FStar_Syntax_Syntax.fv_eq_lid fv
-                                       FStar_Parser_Const.b2t_lid
-                                      in
+                                       FStar_Parser_Const.b2t_lid in
                                    if uu____11942
                                    then
                                      match args with
@@ -4221,8 +3963,7 @@ let maybe_simplify_aux :
                                      | uu____11981 -> tm1
                                    else
                                      (let uu____11991 =
-                                        FStar_Syntax_Util.is_auto_squash tm1
-                                         in
+                                        FStar_Syntax_Util.is_auto_squash tm1 in
                                       match uu____11991 with
                                       | FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.U_zero ,t)
@@ -4239,8 +3980,7 @@ let maybe_simplify_aux :
                   | FStar_Pervasives_Native.Some (false ) -> tm1
                   | FStar_Pervasives_Native.None  -> tm1)
              | uu____12026 -> tm1)
-  
-let maybe_simplify :
+let maybe_simplify:
   'Auu____12033 'Auu____12034 .
     cfg ->
       ((FStar_Syntax_Syntax.bv,'Auu____12034) FStar_Pervasives_Native.tuple2
@@ -4252,18 +3992,17 @@ let maybe_simplify :
     fun env  ->
       fun stack  ->
         fun tm  ->
-          let tm' = maybe_simplify_aux cfg env stack tm  in
+          let tm' = maybe_simplify_aux cfg env stack tm in
           if (cfg.debug).b380
           then
-            (let uu____12077 = FStar_Syntax_Print.term_to_string tm  in
-             let uu____12078 = FStar_Syntax_Print.term_to_string tm'  in
+            (let uu____12077 = FStar_Syntax_Print.term_to_string tm in
+             let uu____12078 = FStar_Syntax_Print.term_to_string tm' in
              FStar_Util.print3 "%sSimplified\n\t%s to\n\t%s\n"
                (if (cfg.steps).simplify then "" else "NOT ") uu____12077
                uu____12078)
           else ();
           tm'
-  
-let is_norm_request :
+let is_norm_request:
   'Auu____12084 .
     FStar_Syntax_Syntax.term -> 'Auu____12084 Prims.list -> Prims.bool
   =
@@ -4271,9 +4010,9 @@ let is_norm_request :
     fun args  ->
       let uu____12097 =
         let uu____12104 =
-          let uu____12105 = FStar_Syntax_Util.un_uinst hd1  in
-          uu____12105.FStar_Syntax_Syntax.n  in
-        (uu____12104, args)  in
+          let uu____12105 = FStar_Syntax_Util.un_uinst hd1 in
+          uu____12105.FStar_Syntax_Syntax.n in
+        (uu____12104, args) in
       match uu____12097 with
       | (FStar_Syntax_Syntax.Tm_fvar fv,uu____12111::uu____12112::[]) ->
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.normalize_term
@@ -4282,8 +4021,7 @@ let is_norm_request :
       | (FStar_Syntax_Syntax.Tm_fvar fv,steps::uu____12121::uu____12122::[])
           -> FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.norm
       | uu____12125 -> false
-  
-let (tr_norm_step : FStar_Syntax_Embeddings.norm_step -> step Prims.list) =
+let tr_norm_step: FStar_Syntax_Embeddings.norm_step -> step Prims.list =
   fun uu___84_12136  ->
     match uu___84_12136 with
     | FStar_Syntax_Embeddings.Zeta  -> [Zeta]
@@ -4297,18 +4035,16 @@ let (tr_norm_step : FStar_Syntax_Embeddings.norm_step -> step Prims.list) =
     | FStar_Syntax_Embeddings.UnfoldOnly names1 ->
         let uu____12142 =
           let uu____12145 =
-            let uu____12146 = FStar_List.map FStar_Ident.lid_of_str names1
-               in
-            UnfoldOnly uu____12146  in
-          [uu____12145]  in
+            let uu____12146 = FStar_List.map FStar_Ident.lid_of_str names1 in
+            UnfoldOnly uu____12146 in
+          [uu____12145] in
         (UnfoldUntil FStar_Syntax_Syntax.Delta_constant) :: uu____12142
     | FStar_Syntax_Embeddings.UnfoldAttr t ->
         [UnfoldUntil FStar_Syntax_Syntax.Delta_constant; UnfoldAttr t]
-  
-let (tr_norm_steps :
-  FStar_Syntax_Embeddings.norm_step Prims.list -> step Prims.list) =
-  fun s  -> FStar_List.concatMap tr_norm_step s 
-let get_norm_request :
+let tr_norm_steps:
+  FStar_Syntax_Embeddings.norm_step Prims.list -> step Prims.list =
+  fun s  -> FStar_List.concatMap tr_norm_step s
+let get_norm_request:
   'Auu____12162 .
     (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
       (FStar_Syntax_Syntax.term,'Auu____12162) FStar_Pervasives_Native.tuple2
@@ -4325,13 +4061,12 @@ let get_norm_request :
               let uu____12221 =
                 let uu____12226 =
                   FStar_Syntax_Embeddings.unembed_list_safe
-                    FStar_Syntax_Embeddings.unembed_norm_step
-                   in
-                uu____12226 s  in
-              FStar_All.pipe_right uu____12221 FStar_Util.must  in
-            FStar_All.pipe_right uu____12218 tr_norm_steps  in
+                    FStar_Syntax_Embeddings.unembed_norm_step in
+                uu____12226 s in
+              FStar_All.pipe_right uu____12221 FStar_Util.must in
+            FStar_All.pipe_right uu____12218 tr_norm_steps in
           FStar_Pervasives_Native.Some uu____12215
-        with | uu____12254 -> FStar_Pervasives_Native.None  in
+        with | uu____12254 -> FStar_Pervasives_Native.None in
       match args with
       | uu____12265::(tm,uu____12267)::[] ->
           let s =
@@ -4340,7 +4075,7 @@ let get_norm_request :
             Iota;
             Primops;
             UnfoldUntil FStar_Syntax_Syntax.Delta_constant;
-            Reify]  in
+            Reify] in
           FStar_Pervasives_Native.Some (s, tm)
       | (tm,uu____12296)::[] ->
           let s =
@@ -4349,25 +4084,24 @@ let get_norm_request :
             Iota;
             Primops;
             UnfoldUntil FStar_Syntax_Syntax.Delta_constant;
-            Reify]  in
+            Reify] in
           FStar_Pervasives_Native.Some (s, tm)
       | (steps,uu____12317)::uu____12318::(tm,uu____12320)::[] ->
           let add_exclude s z =
             if Prims.op_Negation (FStar_List.contains z s)
             then (Exclude z) :: s
-            else s  in
+            else s in
           let uu____12357 =
-            let uu____12362 = full_norm steps  in parse_steps uu____12362  in
+            let uu____12362 = full_norm steps in parse_steps uu____12362 in
           (match uu____12357 with
            | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
            | FStar_Pervasives_Native.Some s ->
-               let s1 = Beta :: s  in
-               let s2 = add_exclude s1 Zeta  in
-               let s3 = add_exclude s2 Iota  in
+               let s1 = Beta :: s in
+               let s2 = add_exclude s1 Zeta in
+               let s3 = add_exclude s2 Iota in
                FStar_Pervasives_Native.Some (s3, tm))
       | uu____12401 -> FStar_Pervasives_Native.None
-  
-let (is_reify_head : stack_elt Prims.list -> Prims.bool) =
+let is_reify_head: stack_elt Prims.list -> Prims.bool =
   fun uu___85_12418  ->
     match uu___85_12418 with
     | (App
@@ -4379,8 +4113,7 @@ let (is_reify_head : stack_elt Prims.list -> Prims.bool) =
                        FStar_Syntax_Syntax.vars = uu____12423;_},uu____12424,uu____12425))::uu____12426
         -> true
     | uu____12433 -> false
-  
-let firstn :
+let firstn:
   'Auu____12439 .
     Prims.int ->
       'Auu____12439 Prims.list ->
@@ -4390,8 +4123,7 @@ let firstn :
   fun k  ->
     fun l  ->
       if (FStar_List.length l) < k then (l, []) else FStar_Util.first_N k l
-  
-let (should_reify : cfg -> stack_elt Prims.list -> Prims.bool) =
+let should_reify: cfg -> stack_elt Prims.list -> Prims.bool =
   fun cfg  ->
     fun stack  ->
       match stack with
@@ -4404,20 +4136,18 @@ let (should_reify : cfg -> stack_elt Prims.list -> Prims.bool) =
                          FStar_Syntax_Syntax.vars = uu____12477;_},uu____12478,uu____12479))::uu____12480
           -> (cfg.steps).reify_
       | uu____12487 -> false
-  
-let (attr_eq :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let attr_eq:
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun a  ->
     fun a'  ->
       let r =
-        let uu____12497 = FStar_Syntax_Util.eq_tm a a'  in
+        let uu____12497 = FStar_Syntax_Util.eq_tm a a' in
         match uu____12497 with
         | FStar_Syntax_Util.Equal  -> true
-        | uu____12498 -> false  in
+        | uu____12498 -> false in
       r
-  
-let rec (norm :
-  cfg -> env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+let rec norm:
+  cfg -> env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun cfg  ->
     fun env  ->
@@ -4428,24 +4158,23 @@ let rec (norm :
             then
               (match t.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_delayed uu____12640 ->
-                   let uu____12665 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____12665 = FStar_Syntax_Print.term_to_string t in
                    FStar_Util.print1 "NORM delayed: %s\n" uu____12665
                | uu____12666 -> ())
             else ();
-            FStar_Syntax_Subst.compress t  in
+            FStar_Syntax_Subst.compress t in
           log cfg
             (fun uu____12674  ->
-               let uu____12675 = FStar_Syntax_Print.tag_of_term t1  in
-               let uu____12676 = FStar_Syntax_Print.term_to_string t1  in
+               let uu____12675 = FStar_Syntax_Print.tag_of_term t1 in
+               let uu____12676 = FStar_Syntax_Print.term_to_string t1 in
                let uu____12677 =
-                 FStar_Util.string_of_int (FStar_List.length env)  in
+                 FStar_Util.string_of_int (FStar_List.length env) in
                let uu____12684 =
                  let uu____12685 =
-                   let uu____12688 = firstn (Prims.parse_int "4") stack  in
+                   let uu____12688 = firstn (Prims.parse_int "4") stack in
                    FStar_All.pipe_left FStar_Pervasives_Native.fst
-                     uu____12688
-                    in
-                 stack_to_string uu____12685  in
+                     uu____12688 in
+                 stack_to_string uu____12685 in
                FStar_Util.print4
                  ">>> %s\nNorm %s with with %s env elements top of the stack %s \n"
                  uu____12675 uu____12676 uu____12677 uu____12684);
@@ -4479,10 +4208,10 @@ let rec (norm :
                      (cfg.steps).no_delta_steps))
                  || (FStar_Syntax_Util.is_fstar_tactics_by_tactic hd1)
                ->
-               let args1 = closures_as_args_delayed cfg env args  in
-               let hd2 = closure_as_term cfg env hd1  in
+               let args1 = closures_as_args_delayed cfg env args in
+               let hd2 = closure_as_term cfg env hd1 in
                let t2 =
-                 let uu___149_12763 = t1  in
+                 let uu___149_12763 = t1 in
                  {
                    FStar_Syntax_Syntax.n =
                      (FStar_Syntax_Syntax.Tm_app (hd2, args1));
@@ -4490,7 +4219,7 @@ let rec (norm :
                      (uu___149_12763.FStar_Syntax_Syntax.pos);
                    FStar_Syntax_Syntax.vars =
                      (uu___149_12763.FStar_Syntax_Syntax.vars)
-                 }  in
+                 } in
                rebuild cfg env stack t2
            | FStar_Syntax_Syntax.Tm_app (hd1,args) when
                ((Prims.op_Negation (cfg.steps).no_full_norm) &&
@@ -4502,10 +4231,10 @@ let rec (norm :
                        FStar_Parser_Const.prims_lid))
                ->
                let cfg' =
-                 let uu___150_12801 = cfg  in
+                 let uu___150_12801 = cfg in
                  {
                    steps =
-                     (let uu___151_12804 = cfg.steps  in
+                     (let uu___151_12804 = cfg.steps in
                       {
                         beta = (uu___151_12804.beta);
                         iota = (uu___151_12804.iota);
@@ -4542,8 +4271,8 @@ let rec (norm :
                    strong = (uu___150_12801.strong);
                    memoize_lazy = (uu___150_12801.memoize_lazy);
                    normalize_pure_lets = true
-                 }  in
-               let uu____12807 = get_norm_request (norm cfg' env []) args  in
+                 } in
+               let uu____12807 = get_norm_request (norm cfg' env []) args in
                (match uu____12807 with
                 | FStar_Pervasives_Native.None  ->
                     let stack1 =
@@ -4559,22 +4288,18 @@ let rec (norm :
                                           let uu____12859 =
                                             let uu____12890 =
                                               FStar_Util.mk_ref
-                                                FStar_Pervasives_Native.None
-                                               in
-                                            (env, a, uu____12890, false)  in
-                                          Clos uu____12859  in
+                                                FStar_Pervasives_Native.None in
+                                            (env, a, uu____12890, false) in
+                                          Clos uu____12859 in
                                         (uu____12858, aq,
-                                          (t1.FStar_Syntax_Syntax.pos))
-                                         in
-                                      Arg uu____12851  in
-                                    uu____12850 :: stack1) args)
-                       in
+                                          (t1.FStar_Syntax_Syntax.pos)) in
+                                      Arg uu____12851 in
+                                    uu____12850 :: stack1) args) in
                     (log cfg
                        (fun uu____12974  ->
                           let uu____12975 =
                             FStar_All.pipe_left FStar_Util.string_of_int
-                              (FStar_List.length args)
-                             in
+                              (FStar_List.length args) in
                           FStar_Util.print1 "\tPushed %s arguments\n"
                             uu____12975);
                      norm cfg env stack1 hd1)
@@ -4587,16 +4312,15 @@ let rec (norm :
                                 match uu___86_13002 with
                                 | UnfoldUntil uu____13003 -> true
                                 | UnfoldOnly uu____13004 -> true
-                                | uu____13007 -> false))
-                         in
+                                | uu____13007 -> false)) in
                       if uu____12997
                       then
                         [FStar_TypeChecker_Env.Unfold
                            FStar_Syntax_Syntax.Delta_constant]
-                      else [FStar_TypeChecker_Env.NoDelta]  in
+                      else [FStar_TypeChecker_Env.NoDelta] in
                     let cfg'1 =
-                      let uu___152_13012 = cfg  in
-                      let uu____13013 = to_fsteps s  in
+                      let uu___152_13012 = cfg in
+                      let uu____13013 = to_fsteps s in
                       {
                         steps = uu____13013;
                         tcenv = (uu___152_13012.tcenv);
@@ -4606,25 +4330,24 @@ let rec (norm :
                         strong = (uu___152_13012.strong);
                         memoize_lazy = (uu___152_13012.memoize_lazy);
                         normalize_pure_lets = true
-                      }  in
+                      } in
                     let stack' =
-                      let tail1 = (Cfg cfg) :: stack  in
+                      let tail1 = (Cfg cfg) :: stack in
                       if (cfg.debug).print_normalized
                       then
                         let uu____13022 =
                           let uu____13023 =
-                            let uu____13028 = FStar_Util.now ()  in
-                            (t1, uu____13028)  in
-                          Debug uu____13023  in
+                            let uu____13028 = FStar_Util.now () in
+                            (t1, uu____13028) in
+                          Debug uu____13023 in
                         uu____13022 :: tail1
-                      else tail1  in
+                      else tail1 in
                     norm cfg'1 env stack' tm)
            | FStar_Syntax_Syntax.Tm_type u ->
-               let u1 = norm_universe cfg env u  in
+               let u1 = norm_universe cfg env u in
                let uu____13032 =
                  mk (FStar_Syntax_Syntax.Tm_type u1)
-                   t1.FStar_Syntax_Syntax.pos
-                  in
+                   t1.FStar_Syntax_Syntax.pos in
                rebuild cfg env stack uu____13032
            | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
                if (cfg.steps).erase_universes
@@ -4633,30 +4356,29 @@ let rec (norm :
                  (let us1 =
                     let uu____13041 =
                       let uu____13048 =
-                        FStar_List.map (norm_universe cfg env) us  in
-                      (uu____13048, (t1.FStar_Syntax_Syntax.pos))  in
-                    UnivArgs uu____13041  in
-                  let stack1 = us1 :: stack  in norm cfg env stack1 t')
+                        FStar_List.map (norm_universe cfg env) us in
+                      (uu____13048, (t1.FStar_Syntax_Syntax.pos)) in
+                    UnivArgs uu____13041 in
+                  let stack1 = us1 :: stack in norm cfg env stack1 t')
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                let qninfo =
-                 let uu____13058 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                 FStar_TypeChecker_Env.lookup_qname cfg.tcenv uu____13058  in
+                 let uu____13058 = FStar_Syntax_Syntax.lid_of_fv fv in
+                 FStar_TypeChecker_Env.lookup_qname cfg.tcenv uu____13058 in
                let uu____13059 =
-                 FStar_TypeChecker_Env.qninfo_is_action qninfo  in
+                 FStar_TypeChecker_Env.qninfo_is_action qninfo in
                if uu____13059
                then
-                 let b = should_reify cfg stack  in
+                 let b = should_reify cfg stack in
                  (log cfg
                     (fun uu____13065  ->
-                       let uu____13066 = FStar_Syntax_Print.term_to_string t1
-                          in
-                       let uu____13067 = FStar_Util.string_of_bool b  in
+                       let uu____13066 = FStar_Syntax_Print.term_to_string t1 in
+                       let uu____13067 = FStar_Util.string_of_bool b in
                        FStar_Util.print2
                          ">>> For DM4F action %s, should_reify = %s\n"
                          uu____13066 uu____13067);
                   if b
                   then
-                    (let uu____13068 = FStar_List.tl stack  in
+                    (let uu____13068 = FStar_List.tl stack in
                      do_unfold_fv cfg env uu____13068 t1 qninfo fv)
                   else rebuild cfg env stack t1)
                else
@@ -4672,21 +4394,19 @@ let rec (norm :
                                 true
                             | FStar_TypeChecker_Env.Unfold l ->
                                 FStar_TypeChecker_Common.delta_depth_greater_than
-                                  fv.FStar_Syntax_Syntax.fv_delta l))
-                     in
+                                  fv.FStar_Syntax_Syntax.fv_delta l)) in
                   let should_delta1 =
                     if Prims.op_Negation should_delta
                     then false
                     else
                       (let attrs =
-                         FStar_TypeChecker_Env.attrs_of_qninfo qninfo  in
+                         FStar_TypeChecker_Env.attrs_of_qninfo qninfo in
                        ((Prims.op_Negation (cfg.steps).unfold_tac) ||
                           (let uu____13087 =
                              cases
                                (FStar_Util.for_some
                                   (attr_eq FStar_Syntax_Util.tac_opaque_attr))
-                               false attrs
-                              in
+                               false attrs in
                            Prims.op_Negation uu____13087))
                          &&
                          ((match (cfg.steps).unfold_only with
@@ -4705,18 +4425,15 @@ let rec (norm :
                                    (fun at  ->
                                       FStar_Util.for_some (attr_eq at) ats')
                                    ats
-                             | (uu____13141,uu____13142) -> false)))
-                     in
+                             | (uu____13141,uu____13142) -> false))) in
                   log cfg
                     (fun uu____13164  ->
-                       let uu____13165 = FStar_Syntax_Print.term_to_string t1
-                          in
+                       let uu____13165 = FStar_Syntax_Print.term_to_string t1 in
                        let uu____13166 =
                          FStar_Range.string_of_range
-                           t1.FStar_Syntax_Syntax.pos
-                          in
+                           t1.FStar_Syntax_Syntax.pos in
                        let uu____13167 =
-                         FStar_Util.string_of_bool should_delta1  in
+                         FStar_Util.string_of_bool should_delta1 in
                        FStar_Util.print3
                          ">>> For %s (%s), should_delta = %s\n" uu____13165
                          uu____13166 uu____13167);
@@ -4724,7 +4441,7 @@ let rec (norm :
                   then do_unfold_fv cfg env stack t1 qninfo fv
                   else rebuild cfg env stack t1)
            | FStar_Syntax_Syntax.Tm_bvar x ->
-               let uu____13170 = lookup_bvar env x  in
+               let uu____13170 = lookup_bvar env x in
                (match uu____13170 with
                 | Univ uu____13173 ->
                     failwith
@@ -4733,22 +4450,22 @@ let rec (norm :
                 | Clos (env1,t0,r,fix) ->
                     if (Prims.op_Negation fix) || (cfg.steps).zeta
                     then
-                      let uu____13222 = FStar_ST.op_Bang r  in
+                      let uu____13222 = FStar_ST.op_Bang r in
                       (match uu____13222 with
                        | FStar_Pervasives_Native.Some (env2,t') ->
                            (log cfg
                               (fun uu____13340  ->
                                  let uu____13341 =
-                                   FStar_Syntax_Print.term_to_string t1  in
+                                   FStar_Syntax_Print.term_to_string t1 in
                                  let uu____13342 =
-                                   FStar_Syntax_Print.term_to_string t'  in
+                                   FStar_Syntax_Print.term_to_string t' in
                                  FStar_Util.print2
                                    "Lazy hit: %s cached to %s\n" uu____13341
                                    uu____13342);
                             (let uu____13343 =
                                let uu____13344 =
-                                 FStar_Syntax_Subst.compress t'  in
-                               uu____13344.FStar_Syntax_Syntax.n  in
+                                 FStar_Syntax_Subst.compress t' in
+                               uu____13344.FStar_Syntax_Syntax.n in
                              match uu____13343 with
                              | FStar_Syntax_Syntax.Tm_abs uu____13347 ->
                                  norm cfg env2 stack t'
@@ -4775,7 +4492,7 @@ let rec (norm :
                           | b::[] ->
                               (log cfg
                                  (fun uu____13490  ->
-                                    let uu____13491 = closure_to_string c  in
+                                    let uu____13491 = closure_to_string c in
                                     FStar_Util.print1 "\tShifted %s\n"
                                       uu____13491);
                                norm cfg
@@ -4784,15 +4501,14 @@ let rec (norm :
                           | b::tl1 ->
                               (log cfg
                                  (fun uu____13531  ->
-                                    let uu____13532 = closure_to_string c  in
+                                    let uu____13532 = closure_to_string c in
                                     FStar_Util.print1 "\tShifted %s\n"
                                       uu____13532);
                                (let body1 =
                                   mk
                                     (FStar_Syntax_Syntax.Tm_abs
                                        (tl1, body, lopt))
-                                    t1.FStar_Syntax_Syntax.pos
-                                   in
+                                    t1.FStar_Syntax_Syntax.pos in
                                 norm cfg
                                   (((FStar_Pervasives_Native.Some b), c) ::
                                   env) stack_rest body1))))
@@ -4802,25 +4518,24 @@ let rec (norm :
                      log cfg
                        (fun uu____13610  ->
                           let uu____13611 =
-                            FStar_Syntax_Print.term_to_string t1  in
+                            FStar_Syntax_Print.term_to_string t1 in
                           FStar_Util.print1 "\tSet memo %s\n" uu____13611);
                      norm cfg env stack1 t1)
                 | (Debug uu____13612)::uu____13613 ->
                     if (cfg.steps).weak
                     then
-                      let uu____13620 = closure_as_term cfg env t1  in
+                      let uu____13620 = closure_as_term cfg env t1 in
                       rebuild cfg env stack uu____13620
                     else
                       (let uu____13622 =
-                         FStar_Syntax_Subst.open_term' bs body  in
+                         FStar_Syntax_Subst.open_term' bs body in
                        match uu____13622 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____13664  -> dummy :: env1) env)
-                              in
+                                     fun uu____13664  -> dummy :: env1) env) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -4832,16 +4547,14 @@ let rec (norm :
                                        (fun t2  ->
                                           let uu____13701 =
                                             FStar_Syntax_Subst.subst opening
-                                              t2
-                                             in
+                                              t2 in
                                           norm cfg env' [] uu____13701)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
-                                       (FStar_Syntax_Subst.subst opening)
-                                    in
+                                       (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___153_13706 = rc  in
+                                   (let uu___153_13706 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
                                         (uu___153_13706.FStar_Syntax_Syntax.residual_effect);
@@ -4849,19 +4562,18 @@ let rec (norm :
                                       FStar_Syntax_Syntax.residual_flags =
                                         (uu___153_13706.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____13707 -> lopt  in
+                             | uu____13707 -> lopt in
                            (log cfg
                               (fun uu____13713  ->
                                  let uu____13714 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
-                                     (FStar_List.length bs1)
-                                    in
+                                     (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
                                    uu____13714);
-                            (let stack1 = (Cfg cfg) :: stack  in
+                            (let stack1 = (Cfg cfg) :: stack in
                              let cfg1 =
-                               let uu___154_13723 = cfg  in
+                               let uu___154_13723 = cfg in
                                {
                                  steps = (uu___154_13723.steps);
                                  tcenv = (uu___154_13723.tcenv);
@@ -4873,7 +4585,7 @@ let rec (norm :
                                  memoize_lazy = (uu___154_13723.memoize_lazy);
                                  normalize_pure_lets =
                                    (uu___154_13723.normalize_pure_lets)
-                               }  in
+                               } in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
@@ -4882,19 +4594,18 @@ let rec (norm :
                 | (Meta uu____13734)::uu____13735 ->
                     if (cfg.steps).weak
                     then
-                      let uu____13742 = closure_as_term cfg env t1  in
+                      let uu____13742 = closure_as_term cfg env t1 in
                       rebuild cfg env stack uu____13742
                     else
                       (let uu____13744 =
-                         FStar_Syntax_Subst.open_term' bs body  in
+                         FStar_Syntax_Subst.open_term' bs body in
                        match uu____13744 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____13786  -> dummy :: env1) env)
-                              in
+                                     fun uu____13786  -> dummy :: env1) env) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -4906,16 +4617,14 @@ let rec (norm :
                                        (fun t2  ->
                                           let uu____13823 =
                                             FStar_Syntax_Subst.subst opening
-                                              t2
-                                             in
+                                              t2 in
                                           norm cfg env' [] uu____13823)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
-                                       (FStar_Syntax_Subst.subst opening)
-                                    in
+                                       (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___153_13828 = rc  in
+                                   (let uu___153_13828 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
                                         (uu___153_13828.FStar_Syntax_Syntax.residual_effect);
@@ -4923,19 +4632,18 @@ let rec (norm :
                                       FStar_Syntax_Syntax.residual_flags =
                                         (uu___153_13828.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____13829 -> lopt  in
+                             | uu____13829 -> lopt in
                            (log cfg
                               (fun uu____13835  ->
                                  let uu____13836 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
-                                     (FStar_List.length bs1)
-                                    in
+                                     (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
                                    uu____13836);
-                            (let stack1 = (Cfg cfg) :: stack  in
+                            (let stack1 = (Cfg cfg) :: stack in
                              let cfg1 =
-                               let uu___154_13845 = cfg  in
+                               let uu___154_13845 = cfg in
                                {
                                  steps = (uu___154_13845.steps);
                                  tcenv = (uu___154_13845.tcenv);
@@ -4947,7 +4655,7 @@ let rec (norm :
                                  memoize_lazy = (uu___154_13845.memoize_lazy);
                                  normalize_pure_lets =
                                    (uu___154_13845.normalize_pure_lets)
-                               }  in
+                               } in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
@@ -4956,19 +4664,18 @@ let rec (norm :
                 | (Let uu____13856)::uu____13857 ->
                     if (cfg.steps).weak
                     then
-                      let uu____13868 = closure_as_term cfg env t1  in
+                      let uu____13868 = closure_as_term cfg env t1 in
                       rebuild cfg env stack uu____13868
                     else
                       (let uu____13870 =
-                         FStar_Syntax_Subst.open_term' bs body  in
+                         FStar_Syntax_Subst.open_term' bs body in
                        match uu____13870 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____13912  -> dummy :: env1) env)
-                              in
+                                     fun uu____13912  -> dummy :: env1) env) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -4980,16 +4687,14 @@ let rec (norm :
                                        (fun t2  ->
                                           let uu____13949 =
                                             FStar_Syntax_Subst.subst opening
-                                              t2
-                                             in
+                                              t2 in
                                           norm cfg env' [] uu____13949)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
-                                       (FStar_Syntax_Subst.subst opening)
-                                    in
+                                       (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___153_13954 = rc  in
+                                   (let uu___153_13954 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
                                         (uu___153_13954.FStar_Syntax_Syntax.residual_effect);
@@ -4997,19 +4702,18 @@ let rec (norm :
                                       FStar_Syntax_Syntax.residual_flags =
                                         (uu___153_13954.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____13955 -> lopt  in
+                             | uu____13955 -> lopt in
                            (log cfg
                               (fun uu____13961  ->
                                  let uu____13962 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
-                                     (FStar_List.length bs1)
-                                    in
+                                     (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
                                    uu____13962);
-                            (let stack1 = (Cfg cfg) :: stack  in
+                            (let stack1 = (Cfg cfg) :: stack in
                              let cfg1 =
-                               let uu___154_13971 = cfg  in
+                               let uu___154_13971 = cfg in
                                {
                                  steps = (uu___154_13971.steps);
                                  tcenv = (uu___154_13971.tcenv);
@@ -5021,7 +4725,7 @@ let rec (norm :
                                  memoize_lazy = (uu___154_13971.memoize_lazy);
                                  normalize_pure_lets =
                                    (uu___154_13971.normalize_pure_lets)
-                               }  in
+                               } in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
@@ -5030,19 +4734,18 @@ let rec (norm :
                 | (App uu____13982)::uu____13983 ->
                     if (cfg.steps).weak
                     then
-                      let uu____13994 = closure_as_term cfg env t1  in
+                      let uu____13994 = closure_as_term cfg env t1 in
                       rebuild cfg env stack uu____13994
                     else
                       (let uu____13996 =
-                         FStar_Syntax_Subst.open_term' bs body  in
+                         FStar_Syntax_Subst.open_term' bs body in
                        match uu____13996 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____14038  -> dummy :: env1) env)
-                              in
+                                     fun uu____14038  -> dummy :: env1) env) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -5054,16 +4757,14 @@ let rec (norm :
                                        (fun t2  ->
                                           let uu____14075 =
                                             FStar_Syntax_Subst.subst opening
-                                              t2
-                                             in
+                                              t2 in
                                           norm cfg env' [] uu____14075)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
-                                       (FStar_Syntax_Subst.subst opening)
-                                    in
+                                       (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___153_14080 = rc  in
+                                   (let uu___153_14080 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
                                         (uu___153_14080.FStar_Syntax_Syntax.residual_effect);
@@ -5071,19 +4772,18 @@ let rec (norm :
                                       FStar_Syntax_Syntax.residual_flags =
                                         (uu___153_14080.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____14081 -> lopt  in
+                             | uu____14081 -> lopt in
                            (log cfg
                               (fun uu____14087  ->
                                  let uu____14088 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
-                                     (FStar_List.length bs1)
-                                    in
+                                     (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
                                    uu____14088);
-                            (let stack1 = (Cfg cfg) :: stack  in
+                            (let stack1 = (Cfg cfg) :: stack in
                              let cfg1 =
-                               let uu___154_14097 = cfg  in
+                               let uu___154_14097 = cfg in
                                {
                                  steps = (uu___154_14097.steps);
                                  tcenv = (uu___154_14097.tcenv);
@@ -5095,7 +4795,7 @@ let rec (norm :
                                  memoize_lazy = (uu___154_14097.memoize_lazy);
                                  normalize_pure_lets =
                                    (uu___154_14097.normalize_pure_lets)
-                               }  in
+                               } in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
@@ -5104,19 +4804,18 @@ let rec (norm :
                 | (Abs uu____14108)::uu____14109 ->
                     if (cfg.steps).weak
                     then
-                      let uu____14124 = closure_as_term cfg env t1  in
+                      let uu____14124 = closure_as_term cfg env t1 in
                       rebuild cfg env stack uu____14124
                     else
                       (let uu____14126 =
-                         FStar_Syntax_Subst.open_term' bs body  in
+                         FStar_Syntax_Subst.open_term' bs body in
                        match uu____14126 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____14168  -> dummy :: env1) env)
-                              in
+                                     fun uu____14168  -> dummy :: env1) env) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -5128,16 +4827,14 @@ let rec (norm :
                                        (fun t2  ->
                                           let uu____14205 =
                                             FStar_Syntax_Subst.subst opening
-                                              t2
-                                             in
+                                              t2 in
                                           norm cfg env' [] uu____14205)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
-                                       (FStar_Syntax_Subst.subst opening)
-                                    in
+                                       (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___153_14210 = rc  in
+                                   (let uu___153_14210 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
                                         (uu___153_14210.FStar_Syntax_Syntax.residual_effect);
@@ -5145,19 +4842,18 @@ let rec (norm :
                                       FStar_Syntax_Syntax.residual_flags =
                                         (uu___153_14210.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____14211 -> lopt  in
+                             | uu____14211 -> lopt in
                            (log cfg
                               (fun uu____14217  ->
                                  let uu____14218 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
-                                     (FStar_List.length bs1)
-                                    in
+                                     (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
                                    uu____14218);
-                            (let stack1 = (Cfg cfg) :: stack  in
+                            (let stack1 = (Cfg cfg) :: stack in
                              let cfg1 =
-                               let uu___154_14227 = cfg  in
+                               let uu___154_14227 = cfg in
                                {
                                  steps = (uu___154_14227.steps);
                                  tcenv = (uu___154_14227.tcenv);
@@ -5169,7 +4865,7 @@ let rec (norm :
                                  memoize_lazy = (uu___154_14227.memoize_lazy);
                                  normalize_pure_lets =
                                    (uu___154_14227.normalize_pure_lets)
-                               }  in
+                               } in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
@@ -5178,19 +4874,18 @@ let rec (norm :
                 | [] ->
                     if (cfg.steps).weak
                     then
-                      let uu____14238 = closure_as_term cfg env t1  in
+                      let uu____14238 = closure_as_term cfg env t1 in
                       rebuild cfg env stack uu____14238
                     else
                       (let uu____14240 =
-                         FStar_Syntax_Subst.open_term' bs body  in
+                         FStar_Syntax_Subst.open_term' bs body in
                        match uu____14240 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____14282  -> dummy :: env1) env)
-                              in
+                                     fun uu____14282  -> dummy :: env1) env) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -5202,16 +4897,14 @@ let rec (norm :
                                        (fun t2  ->
                                           let uu____14319 =
                                             FStar_Syntax_Subst.subst opening
-                                              t2
-                                             in
+                                              t2 in
                                           norm cfg env' [] uu____14319)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
-                                       (FStar_Syntax_Subst.subst opening)
-                                    in
+                                       (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___153_14324 = rc  in
+                                   (let uu___153_14324 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
                                         (uu___153_14324.FStar_Syntax_Syntax.residual_effect);
@@ -5219,19 +4912,18 @@ let rec (norm :
                                       FStar_Syntax_Syntax.residual_flags =
                                         (uu___153_14324.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____14325 -> lopt  in
+                             | uu____14325 -> lopt in
                            (log cfg
                               (fun uu____14331  ->
                                  let uu____14332 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
-                                     (FStar_List.length bs1)
-                                    in
+                                     (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
                                    uu____14332);
-                            (let stack1 = (Cfg cfg) :: stack  in
+                            (let stack1 = (Cfg cfg) :: stack in
                              let cfg1 =
-                               let uu___154_14341 = cfg  in
+                               let uu___154_14341 = cfg in
                                {
                                  steps = (uu___154_14341.steps);
                                  tcenv = (uu___154_14341.tcenv);
@@ -5243,7 +4935,7 @@ let rec (norm :
                                  memoize_lazy = (uu___154_14341.memoize_lazy);
                                  normalize_pure_lets =
                                    (uu___154_14341.normalize_pure_lets)
-                               }  in
+                               } in
                              norm cfg1 env'
                                ((Abs
                                    (env, bs1, env', lopt1,
@@ -5263,22 +4955,18 @@ let rec (norm :
                                      let uu____14411 =
                                        let uu____14442 =
                                          FStar_Util.mk_ref
-                                           FStar_Pervasives_Native.None
-                                          in
-                                       (env, a, uu____14442, false)  in
-                                     Clos uu____14411  in
+                                           FStar_Pervasives_Native.None in
+                                       (env, a, uu____14442, false) in
+                                     Clos uu____14411 in
                                    (uu____14410, aq,
-                                     (t1.FStar_Syntax_Syntax.pos))
-                                    in
-                                 Arg uu____14403  in
-                               uu____14402 :: stack1) args)
-                  in
+                                     (t1.FStar_Syntax_Syntax.pos)) in
+                                 Arg uu____14403 in
+                               uu____14402 :: stack1) args) in
                (log cfg
                   (fun uu____14526  ->
                      let uu____14527 =
                        FStar_All.pipe_left FStar_Util.string_of_int
-                         (FStar_List.length args)
-                        in
+                         (FStar_List.length args) in
                      FStar_Util.print1 "\tPushed %s arguments\n" uu____14527);
                 norm cfg env stack1 head1)
            | FStar_Syntax_Syntax.Tm_refine (x,f) ->
@@ -5286,57 +4974,53 @@ let rec (norm :
                then
                  (match (env, stack) with
                   | ([],[]) ->
-                      let t_x = norm cfg env [] x.FStar_Syntax_Syntax.sort
-                         in
+                      let t_x = norm cfg env [] x.FStar_Syntax_Syntax.sort in
                       let t2 =
                         mk
                           (FStar_Syntax_Syntax.Tm_refine
-                             ((let uu___155_14563 = x  in
+                             ((let uu___155_14563 = x in
                                {
                                  FStar_Syntax_Syntax.ppname =
                                    (uu___155_14563.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
                                    (uu___155_14563.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = t_x
-                               }), f)) t1.FStar_Syntax_Syntax.pos
-                         in
+                               }), f)) t1.FStar_Syntax_Syntax.pos in
                       rebuild cfg env stack t2
                   | uu____14564 ->
-                      let uu____14569 = closure_as_term cfg env t1  in
+                      let uu____14569 = closure_as_term cfg env t1 in
                       rebuild cfg env stack uu____14569)
                else
-                 (let t_x = norm cfg env [] x.FStar_Syntax_Syntax.sort  in
+                 (let t_x = norm cfg env [] x.FStar_Syntax_Syntax.sort in
                   let uu____14572 =
                     FStar_Syntax_Subst.open_term
-                      [(x, FStar_Pervasives_Native.None)] f
-                     in
+                      [(x, FStar_Pervasives_Native.None)] f in
                   match uu____14572 with
                   | (closing,f1) ->
-                      let f2 = norm cfg (dummy :: env) [] f1  in
+                      let f2 = norm cfg (dummy :: env) [] f1 in
                       let t2 =
                         let uu____14603 =
                           let uu____14604 =
                             let uu____14611 =
-                              FStar_Syntax_Subst.close closing f2  in
-                            ((let uu___156_14613 = x  in
+                              FStar_Syntax_Subst.close closing f2 in
+                            ((let uu___156_14613 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
                                   (uu___156_14613.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
                                   (uu___156_14613.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t_x
-                              }), uu____14611)
-                             in
-                          FStar_Syntax_Syntax.Tm_refine uu____14604  in
-                        mk uu____14603 t1.FStar_Syntax_Syntax.pos  in
+                              }), uu____14611) in
+                          FStar_Syntax_Syntax.Tm_refine uu____14604 in
+                        mk uu____14603 t1.FStar_Syntax_Syntax.pos in
                       rebuild cfg env stack t2)
            | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                if (cfg.steps).weak
                then
-                 let uu____14632 = closure_as_term cfg env t1  in
+                 let uu____14632 = closure_as_term cfg env t1 in
                  rebuild cfg env stack uu____14632
                else
-                 (let uu____14634 = FStar_Syntax_Subst.open_comp bs c  in
+                 (let uu____14634 = FStar_Syntax_Subst.open_comp bs c in
                   match uu____14634 with
                   | (bs1,c1) ->
                       let c2 =
@@ -5344,12 +5028,11 @@ let rec (norm :
                           FStar_All.pipe_right bs1
                             (FStar_List.fold_left
                                (fun env1  ->
-                                  fun uu____14666  -> dummy :: env1) env)
-                           in
-                        norm_comp cfg uu____14642 c1  in
+                                  fun uu____14666  -> dummy :: env1) env) in
+                        norm_comp cfg uu____14642 c1 in
                       let t2 =
-                        let uu____14688 = norm_binders cfg env bs1  in
-                        FStar_Syntax_Util.arrow uu____14688 c2  in
+                        let uu____14688 = norm_binders cfg env bs1 in
+                        FStar_Syntax_Util.arrow uu____14688 c2 in
                       rebuild cfg env stack t2)
            | FStar_Syntax_Syntax.Tm_ascribed (t11,(tc,tacopt),l) when
                (cfg.steps).unascribe -> norm cfg env stack t11
@@ -5390,7 +5073,7 @@ let rec (norm :
                     (log cfg
                        (fun uu____14856  ->
                           FStar_Util.print_string "+++ Keeping ascription \n");
-                     (let t12 = norm cfg env [] t11  in
+                     (let t12 = norm cfg env [] t11 in
                       log cfg
                         (fun uu____14860  ->
                            FStar_Util.print_string
@@ -5398,41 +5081,38 @@ let rec (norm :
                       (let tc1 =
                          match tc with
                          | FStar_Util.Inl t2 ->
-                             let uu____14877 = norm cfg env [] t2  in
+                             let uu____14877 = norm cfg env [] t2 in
                              FStar_Util.Inl uu____14877
                          | FStar_Util.Inr c ->
-                             let uu____14885 = norm_comp cfg env c  in
-                             FStar_Util.Inr uu____14885
-                          in
+                             let uu____14885 = norm_comp cfg env c in
+                             FStar_Util.Inr uu____14885 in
                        let tacopt1 =
-                         FStar_Util.map_opt tacopt (norm cfg env [])  in
+                         FStar_Util.map_opt tacopt (norm cfg env []) in
                        match stack with
                        | (Cfg cfg1)::stack1 ->
                            let t2 =
                              let uu____14898 =
                                let uu____14899 =
                                  let uu____14926 =
-                                   FStar_Syntax_Util.unascribe t12  in
-                                 (uu____14926, (tc1, tacopt1), l)  in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____14899
-                                in
-                             mk uu____14898 t1.FStar_Syntax_Syntax.pos  in
+                                   FStar_Syntax_Util.unascribe t12 in
+                                 (uu____14926, (tc1, tacopt1), l) in
+                               FStar_Syntax_Syntax.Tm_ascribed uu____14899 in
+                             mk uu____14898 t1.FStar_Syntax_Syntax.pos in
                            norm cfg1 env stack1 t2
                        | uu____14945 ->
                            let uu____14946 =
                              let uu____14947 =
                                let uu____14948 =
                                  let uu____14975 =
-                                   FStar_Syntax_Util.unascribe t12  in
-                                 (uu____14975, (tc1, tacopt1), l)  in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____14948
-                                in
-                             mk uu____14947 t1.FStar_Syntax_Syntax.pos  in
+                                   FStar_Syntax_Util.unascribe t12 in
+                                 (uu____14975, (tc1, tacopt1), l) in
+                               FStar_Syntax_Syntax.Tm_ascribed uu____14948 in
+                             mk uu____14947 t1.FStar_Syntax_Syntax.pos in
                            rebuild cfg env stack uu____14946))))
            | FStar_Syntax_Syntax.Tm_match (head1,branches) ->
                let stack1 =
                  (Match (env, branches, (t1.FStar_Syntax_Syntax.pos))) ::
-                 stack  in
+                 stack in
                norm cfg env stack1 head1
            | FStar_Syntax_Syntax.Tm_let ((b,lbs),lbody) when
                (FStar_Syntax_Syntax.is_top_level lbs) &&
@@ -5444,16 +5124,14 @@ let rec (norm :
                       (fun lb  ->
                          let uu____15085 =
                            FStar_Syntax_Subst.univ_var_opening
-                             lb.FStar_Syntax_Syntax.lbunivs
-                            in
+                             lb.FStar_Syntax_Syntax.lbunivs in
                          match uu____15085 with
                          | (openings,lbunivs) ->
                              let cfg1 =
-                               let uu___157_15105 = cfg  in
+                               let uu___157_15105 = cfg in
                                let uu____15106 =
                                  FStar_TypeChecker_Env.push_univ_vars
-                                   cfg.tcenv lbunivs
-                                  in
+                                   cfg.tcenv lbunivs in
                                {
                                  steps = (uu___157_15105.steps);
                                  tcenv = uu____15106;
@@ -5465,20 +5143,17 @@ let rec (norm :
                                  memoize_lazy = (uu___157_15105.memoize_lazy);
                                  normalize_pure_lets =
                                    (uu___157_15105.normalize_pure_lets)
-                               }  in
+                               } in
                              let norm1 t2 =
                                let uu____15111 =
                                  let uu____15112 =
-                                   FStar_Syntax_Subst.subst openings t2  in
-                                 norm cfg1 env [] uu____15112  in
+                                   FStar_Syntax_Subst.subst openings t2 in
+                                 norm cfg1 env [] uu____15112 in
                                FStar_Syntax_Subst.close_univ_vars lbunivs
-                                 uu____15111
-                                in
-                             let lbtyp = norm1 lb.FStar_Syntax_Syntax.lbtyp
-                                in
-                             let lbdef = norm1 lb.FStar_Syntax_Syntax.lbdef
-                                in
-                             let uu___158_15115 = lb  in
+                                 uu____15111 in
+                             let lbtyp = norm1 lb.FStar_Syntax_Syntax.lbtyp in
+                             let lbdef = norm1 lb.FStar_Syntax_Syntax.lbdef in
+                             let uu___158_15115 = lb in
                              {
                                FStar_Syntax_Syntax.lbname =
                                  (uu___158_15115.FStar_Syntax_Syntax.lbname);
@@ -5489,12 +5164,10 @@ let rec (norm :
                                FStar_Syntax_Syntax.lbdef = lbdef;
                                FStar_Syntax_Syntax.lbattrs =
                                  (uu___158_15115.FStar_Syntax_Syntax.lbattrs)
-                             }))
-                  in
+                             })) in
                let uu____15116 =
                  mk (FStar_Syntax_Syntax.Tm_let ((b, lbs1), lbody))
-                   t1.FStar_Syntax_Syntax.pos
-                  in
+                   t1.FStar_Syntax_Syntax.pos in
                rebuild cfg env stack uu____15116
            | FStar_Syntax_Syntax.Tm_let
                ((uu____15127,{
@@ -5509,8 +5182,7 @@ let rec (norm :
            | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
                let n1 =
                  FStar_TypeChecker_Env.norm_eff_name cfg.tcenv
-                   lb.FStar_Syntax_Syntax.lbeff
-                  in
+                   lb.FStar_Syntax_Syntax.lbeff in
                let uu____15175 =
                  (Prims.op_Negation (cfg.steps).no_delta_steps) &&
                    ((((cfg.steps).pure_subterms_within_computations &&
@@ -5528,26 +5200,24 @@ let rec (norm :
                       ||
                       ((FStar_Syntax_Util.is_ghost_effect n1) &&
                          (Prims.op_Negation
-                            (cfg.steps).pure_subterms_within_computations)))
-                  in
+                            (cfg.steps).pure_subterms_within_computations))) in
                if uu____15175
                then
                  let binder =
                    let uu____15177 =
-                     FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                   FStar_Syntax_Syntax.mk_binder uu____15177  in
+                     FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
+                   FStar_Syntax_Syntax.mk_binder uu____15177 in
                  let env1 =
                    let uu____15187 =
                      let uu____15194 =
                        let uu____15195 =
                          let uu____15226 =
-                           FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+                           FStar_Util.mk_ref FStar_Pervasives_Native.None in
                          (env, (lb.FStar_Syntax_Syntax.lbdef), uu____15226,
-                           false)
-                          in
-                       Clos uu____15195  in
-                     ((FStar_Pervasives_Native.Some binder), uu____15194)  in
-                   uu____15187 :: env  in
+                           false) in
+                       Clos uu____15195 in
+                     ((FStar_Pervasives_Native.Some binder), uu____15194) in
+                   uu____15187 :: env in
                  (log cfg
                     (fun uu____15319  ->
                        FStar_Util.print_string "+++ Reducing Tm_let\n");
@@ -5558,7 +5228,7 @@ let rec (norm :
                    (log cfg
                       (fun uu____15323  ->
                          FStar_Util.print_string "+++ Not touching Tm_let\n");
-                    (let uu____15324 = closure_as_term cfg env t1  in
+                    (let uu____15324 = closure_as_term cfg env t1 in
                      rebuild cfg env stack uu____15324))
                  else
                    (let uu____15326 =
@@ -5566,13 +5236,11 @@ let rec (norm :
                         let uu____15332 =
                           let uu____15333 =
                             FStar_All.pipe_right
-                              lb.FStar_Syntax_Syntax.lbname FStar_Util.left
-                             in
+                              lb.FStar_Syntax_Syntax.lbname FStar_Util.left in
                           FStar_All.pipe_right uu____15333
-                            FStar_Syntax_Syntax.mk_binder
-                           in
-                        [uu____15332]  in
-                      FStar_Syntax_Subst.open_term uu____15331 body  in
+                            FStar_Syntax_Syntax.mk_binder in
+                        [uu____15332] in
+                      FStar_Syntax_Subst.open_term uu____15331 body in
                     match uu____15326 with
                     | (bs,body1) ->
                         (log cfg
@@ -5580,30 +5248,28 @@ let rec (norm :
                               FStar_Util.print_string
                                 "+++ Normalizing Tm_let -- type");
                          (let ty =
-                            norm cfg env [] lb.FStar_Syntax_Syntax.lbtyp  in
+                            norm cfg env [] lb.FStar_Syntax_Syntax.lbtyp in
                           let lbname =
                             let x =
-                              let uu____15350 = FStar_List.hd bs  in
-                              FStar_Pervasives_Native.fst uu____15350  in
+                              let uu____15350 = FStar_List.hd bs in
+                              FStar_Pervasives_Native.fst uu____15350 in
                             FStar_Util.Inl
-                              (let uu___159_15360 = x  in
+                              (let uu___159_15360 = x in
                                {
                                  FStar_Syntax_Syntax.ppname =
                                    (uu___159_15360.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
                                    (uu___159_15360.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = ty
-                               })
-                             in
+                               }) in
                           log cfg
                             (fun uu____15363  ->
                                FStar_Util.print_string
                                  "+++ Normalizing Tm_let -- definiens\n");
                           (let lb1 =
-                             let uu___160_15365 = lb  in
+                             let uu___160_15365 = lb in
                              let uu____15366 =
-                               norm cfg env [] lb.FStar_Syntax_Syntax.lbdef
-                                in
+                               norm cfg env [] lb.FStar_Syntax_Syntax.lbdef in
                              {
                                FStar_Syntax_Syntax.lbname = lbname;
                                FStar_Syntax_Syntax.lbunivs =
@@ -5614,16 +5280,15 @@ let rec (norm :
                                FStar_Syntax_Syntax.lbdef = uu____15366;
                                FStar_Syntax_Syntax.lbattrs =
                                  (uu___160_15365.FStar_Syntax_Syntax.lbattrs)
-                             }  in
+                             } in
                            let env' =
                              FStar_All.pipe_right bs
                                (FStar_List.fold_left
                                   (fun env1  ->
-                                     fun uu____15401  -> dummy :: env1) env)
-                              in
-                           let stack1 = (Cfg cfg) :: stack  in
+                                     fun uu____15401  -> dummy :: env1) env) in
+                           let stack1 = (Cfg cfg) :: stack in
                            let cfg1 =
-                             let uu___161_15424 = cfg  in
+                             let uu___161_15424 = cfg in
                              {
                                steps = (uu___161_15424.steps);
                                tcenv = (uu___161_15424.tcenv);
@@ -5635,7 +5300,7 @@ let rec (norm :
                                memoize_lazy = (uu___161_15424.memoize_lazy);
                                normalize_pure_lets =
                                  (uu___161_15424.normalize_pure_lets)
-                             }  in
+                             } in
                            log cfg1
                              (fun uu____15427  ->
                                 FStar_Util.print_string
@@ -5649,59 +5314,53 @@ let rec (norm :
                  ((Prims.op_Negation (cfg.steps).zeta) &&
                     (cfg.steps).pure_subterms_within_computations)
                ->
-               let uu____15444 = FStar_Syntax_Subst.open_let_rec lbs body  in
+               let uu____15444 = FStar_Syntax_Subst.open_let_rec lbs body in
                (match uu____15444 with
                 | (lbs1,body1) ->
                     let lbs2 =
                       FStar_List.map
                         (fun lb  ->
                            let ty =
-                             norm cfg env [] lb.FStar_Syntax_Syntax.lbtyp  in
+                             norm cfg env [] lb.FStar_Syntax_Syntax.lbtyp in
                            let lbname =
                              let uu____15480 =
                                let uu___162_15481 =
                                  FStar_Util.left
-                                   lb.FStar_Syntax_Syntax.lbname
-                                  in
+                                   lb.FStar_Syntax_Syntax.lbname in
                                {
                                  FStar_Syntax_Syntax.ppname =
                                    (uu___162_15481.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
                                    (uu___162_15481.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = ty
-                               }  in
-                             FStar_Util.Inl uu____15480  in
+                               } in
+                             FStar_Util.Inl uu____15480 in
                            let uu____15482 =
                              FStar_Syntax_Util.abs_formals
-                               lb.FStar_Syntax_Syntax.lbdef
-                              in
+                               lb.FStar_Syntax_Syntax.lbdef in
                            match uu____15482 with
                            | (xs,def_body,lopt) ->
-                               let xs1 = norm_binders cfg env xs  in
+                               let xs1 = norm_binders cfg env xs in
                                let env1 =
                                  let uu____15508 =
                                    FStar_List.map (fun uu____15524  -> dummy)
-                                     lbs1
-                                    in
+                                     lbs1 in
                                  let uu____15525 =
                                    let uu____15534 =
                                      FStar_List.map
-                                       (fun uu____15554  -> dummy) xs1
-                                      in
-                                   FStar_List.append uu____15534 env  in
-                                 FStar_List.append uu____15508 uu____15525
-                                  in
-                               let def_body1 = norm cfg env1 [] def_body  in
+                                       (fun uu____15554  -> dummy) xs1 in
+                                   FStar_List.append uu____15534 env in
+                                 FStar_List.append uu____15508 uu____15525 in
+                               let def_body1 = norm cfg env1 [] def_body in
                                let lopt1 =
                                  match lopt with
                                  | FStar_Pervasives_Native.Some rc ->
                                      let uu____15578 =
-                                       let uu___163_15579 = rc  in
+                                       let uu___163_15579 = rc in
                                        let uu____15580 =
                                          FStar_Util.map_opt
                                            rc.FStar_Syntax_Syntax.residual_typ
-                                           (norm cfg env1 [])
-                                          in
+                                           (norm cfg env1 []) in
                                        {
                                          FStar_Syntax_Syntax.residual_effect
                                            =
@@ -5710,13 +5369,12 @@ let rec (norm :
                                            uu____15580;
                                          FStar_Syntax_Syntax.residual_flags =
                                            (uu___163_15579.FStar_Syntax_Syntax.residual_flags)
-                                       }  in
+                                       } in
                                      FStar_Pervasives_Native.Some uu____15578
-                                 | uu____15587 -> lopt  in
+                                 | uu____15587 -> lopt in
                                let def =
-                                 FStar_Syntax_Util.abs xs1 def_body1 lopt1
-                                  in
-                               let uu___164_15591 = lb  in
+                                 FStar_Syntax_Util.abs xs1 def_body1 lopt1 in
+                               let uu___164_15591 = lb in
                                {
                                  FStar_Syntax_Syntax.lbname = lbname;
                                  FStar_Syntax_Syntax.lbunivs =
@@ -5727,19 +5385,18 @@ let rec (norm :
                                  FStar_Syntax_Syntax.lbdef = def;
                                  FStar_Syntax_Syntax.lbattrs =
                                    (uu___164_15591.FStar_Syntax_Syntax.lbattrs)
-                               }) lbs1
-                       in
+                               }) lbs1 in
                     let env' =
                       let uu____15601 =
-                        FStar_List.map (fun uu____15617  -> dummy) lbs2  in
-                      FStar_List.append uu____15601 env  in
-                    let body2 = norm cfg env' [] body1  in
+                        FStar_List.map (fun uu____15617  -> dummy) lbs2 in
+                      FStar_List.append uu____15601 env in
+                    let body2 = norm cfg env' [] body1 in
                     let uu____15625 =
-                      FStar_Syntax_Subst.close_let_rec lbs2 body2  in
+                      FStar_Syntax_Subst.close_let_rec lbs2 body2 in
                     (match uu____15625 with
                      | (lbs3,body3) ->
                          let t2 =
-                           let uu___165_15641 = t1  in
+                           let uu___165_15641 = t1 in
                            {
                              FStar_Syntax_Syntax.n =
                                (FStar_Syntax_Syntax.Tm_let
@@ -5748,11 +5405,11 @@ let rec (norm :
                                (uu___165_15641.FStar_Syntax_Syntax.pos);
                              FStar_Syntax_Syntax.vars =
                                (uu___165_15641.FStar_Syntax_Syntax.vars)
-                           }  in
+                           } in
                          rebuild cfg env stack t2))
            | FStar_Syntax_Syntax.Tm_let (lbs,body) when
                Prims.op_Negation (cfg.steps).zeta ->
-               let uu____15668 = closure_as_term cfg env t1  in
+               let uu____15668 = closure_as_term cfg env t1 in
                rebuild cfg env stack uu____15668
            | FStar_Syntax_Syntax.Tm_let (lbs,body) ->
                let uu____15687 =
@@ -5763,32 +5420,28 @@ let rec (norm :
                         | (rec_env,memos,i) ->
                             let bv =
                               let uu___166_15884 =
-                                FStar_Util.left lb.FStar_Syntax_Syntax.lbname
-                                 in
+                                FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                               {
                                 FStar_Syntax_Syntax.ppname =
                                   (uu___166_15884.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index = i;
                                 FStar_Syntax_Syntax.sort =
                                   (uu___166_15884.FStar_Syntax_Syntax.sort)
-                              }  in
-                            let f_i = FStar_Syntax_Syntax.bv_to_tm bv  in
+                              } in
+                            let f_i = FStar_Syntax_Syntax.bv_to_tm bv in
                             let fix_f_i =
                               mk (FStar_Syntax_Syntax.Tm_let (lbs, f_i))
-                                t1.FStar_Syntax_Syntax.pos
-                               in
+                                t1.FStar_Syntax_Syntax.pos in
                             let memo =
-                              FStar_Util.mk_ref FStar_Pervasives_Native.None
-                               in
+                              FStar_Util.mk_ref FStar_Pervasives_Native.None in
                             let rec_env1 =
                               (FStar_Pervasives_Native.None,
                                 (Clos (env, fix_f_i, memo, true)))
-                              :: rec_env  in
+                              :: rec_env in
                             (rec_env1, (memo :: memos),
                               (i + (Prims.parse_int "1"))))
                    (FStar_Pervasives_Native.snd lbs)
-                   (env, [], (Prims.parse_int "0"))
-                  in
+                   (env, [], (Prims.parse_int "0")) in
                (match uu____15687 with
                 | (rec_env,memos,uu____16097) ->
                     let uu____16150 =
@@ -5798,8 +5451,7 @@ let rec (norm :
                              FStar_ST.op_Colon_Equals memo
                                (FStar_Pervasives_Native.Some
                                   (rec_env, (lb.FStar_Syntax_Syntax.lbdef))))
-                        (FStar_Pervasives_Native.snd lbs) memos
-                       in
+                        (FStar_Pervasives_Native.snd lbs) memos in
                     let body_env =
                       FStar_List.fold_right
                         (fun lb  ->
@@ -5809,23 +5461,19 @@ let rec (norm :
                                  let uu____16469 =
                                    let uu____16500 =
                                      FStar_Util.mk_ref
-                                       FStar_Pervasives_Native.None
-                                      in
+                                       FStar_Pervasives_Native.None in
                                    (rec_env, (lb.FStar_Syntax_Syntax.lbdef),
-                                     uu____16500, false)
-                                    in
-                                 Clos uu____16469  in
-                               (FStar_Pervasives_Native.None, uu____16468)
-                                in
+                                     uu____16500, false) in
+                                 Clos uu____16469 in
+                               (FStar_Pervasives_Native.None, uu____16468) in
                              uu____16461 :: env1)
-                        (FStar_Pervasives_Native.snd lbs) env
-                       in
+                        (FStar_Pervasives_Native.snd lbs) env in
                     norm cfg body_env stack body)
            | FStar_Syntax_Syntax.Tm_meta (head1,m) ->
                (log cfg
                   (fun uu____16610  ->
                      let uu____16611 =
-                       FStar_Syntax_Print.metadata_to_string m  in
+                       FStar_Syntax_Print.metadata_to_string m in
                      FStar_Util.print1 ">> metadata = %s\n" uu____16611);
                 (match m with
                  | FStar_Syntax_Syntax.Meta_monadic (m1,t2) ->
@@ -5847,8 +5495,7 @@ let rec (norm :
                              | FStar_Syntax_Syntax.Meta_alien uu____16642 ->
                                  rebuild cfg env stack t1
                              | FStar_Syntax_Syntax.Meta_pattern args ->
-                                 let args1 = norm_pattern_args cfg env args
-                                    in
+                                 let args1 = norm_pattern_args cfg env args in
                                  norm cfg env
                                    ((Meta
                                        ((FStar_Syntax_Syntax.Meta_pattern
@@ -5857,25 +5504,24 @@ let rec (norm :
                                    stack) head1
                              | uu____16673 -> norm cfg env stack head1)
                         | [] ->
-                            let head2 = norm cfg env [] head1  in
+                            let head2 = norm cfg env [] head1 in
                             let m1 =
                               match m with
                               | FStar_Syntax_Syntax.Meta_pattern args ->
                                   let uu____16687 =
-                                    norm_pattern_args cfg env args  in
+                                    norm_pattern_args cfg env args in
                                   FStar_Syntax_Syntax.Meta_pattern
                                     uu____16687
-                              | uu____16698 -> m  in
+                              | uu____16698 -> m in
                             let t2 =
                               mk (FStar_Syntax_Syntax.Tm_meta (head2, m1))
-                                t1.FStar_Syntax_Syntax.pos
-                               in
+                                t1.FStar_Syntax_Syntax.pos in
                             rebuild cfg env stack t2)))
            | FStar_Syntax_Syntax.Tm_delayed uu____16702 ->
-               let t2 = FStar_Syntax_Subst.compress t1  in
+               let t2 = FStar_Syntax_Subst.compress t1 in
                norm cfg env stack t2
            | FStar_Syntax_Syntax.Tm_uvar uu____16728 ->
-               let t2 = FStar_Syntax_Subst.compress t1  in
+               let t2 = FStar_Syntax_Subst.compress t1 in
                (match t2.FStar_Syntax_Syntax.n with
                 | FStar_Syntax_Syntax.Tm_uvar uu____16746 ->
                     if (cfg.steps).check_no_uvars
@@ -5883,25 +5529,22 @@ let rec (norm :
                       let uu____16763 =
                         let uu____16764 =
                           FStar_Range.string_of_range
-                            t2.FStar_Syntax_Syntax.pos
-                           in
+                            t2.FStar_Syntax_Syntax.pos in
                         let uu____16765 =
-                          FStar_Syntax_Print.term_to_string t2  in
+                          FStar_Syntax_Print.term_to_string t2 in
                         FStar_Util.format2
                           "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
-                          uu____16764 uu____16765
-                         in
+                          uu____16764 uu____16765 in
                       failwith uu____16763
                     else rebuild cfg env stack t2
                 | uu____16767 -> norm cfg env stack t2))
-
-and (do_unfold_fv :
+and do_unfold_fv:
   cfg ->
     env ->
       stack_elt Prims.list ->
         FStar_Syntax_Syntax.term ->
           FStar_TypeChecker_Env.qninfo ->
-            FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
+            FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term
   =
   fun cfg  ->
     fun env  ->
@@ -5910,14 +5553,13 @@ and (do_unfold_fv :
           fun qninfo  ->
             fun f  ->
               let r_env =
-                let uu____16777 = FStar_Syntax_Syntax.range_of_fv f  in
-                FStar_TypeChecker_Env.set_range cfg.tcenv uu____16777  in
+                let uu____16777 = FStar_Syntax_Syntax.range_of_fv f in
+                FStar_TypeChecker_Env.set_range cfg.tcenv uu____16777 in
               let uu____16778 =
                 FStar_TypeChecker_Env.lookup_definition_qninfo
                   cfg.delta_level
                   (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                  qninfo
-                 in
+                  qninfo in
               match uu____16778 with
               | FStar_Pervasives_Native.None  ->
                   (log cfg
@@ -5928,9 +5570,8 @@ and (do_unfold_fv :
                   (log cfg
                      (fun uu____16802  ->
                         let uu____16803 =
-                          FStar_Syntax_Print.term_to_string t0  in
-                        let uu____16804 = FStar_Syntax_Print.term_to_string t
-                           in
+                          FStar_Syntax_Print.term_to_string t0 in
+                        let uu____16804 = FStar_Syntax_Print.term_to_string t in
                         FStar_Util.print2 ">>> Unfolded %s to %s\n"
                           uu____16803 uu____16804);
                    (let t1 =
@@ -5944,9 +5585,8 @@ and (do_unfold_fv :
                         FStar_Syntax_Subst.set_use_range
                           (FStar_Ident.range_of_lid
                              (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                          t
-                       in
-                    let n1 = FStar_List.length us  in
+                          t in
+                    let n1 = FStar_List.length us in
                     if n1 > (Prims.parse_int "0")
                     then
                       match stack with
@@ -5958,8 +5598,7 @@ and (do_unfold_fv :
                                     fun u  ->
                                       (FStar_Pervasives_Native.None,
                                         (Univ u))
-                                      :: env1) env)
-                             in
+                                      :: env1) env) in
                           norm cfg env1 stack1 t1
                       | uu____16872 when (cfg.steps).erase_universes ->
                           norm cfg env stack t1
@@ -5967,16 +5606,13 @@ and (do_unfold_fv :
                           let uu____16878 =
                             let uu____16879 =
                               FStar_Syntax_Print.lid_to_string
-                                (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                               in
+                                (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                             FStar_Util.format1
                               "Impossible: missing universe instantiation on %s"
-                              uu____16879
-                             in
+                              uu____16879 in
                           failwith uu____16878
                     else norm cfg env stack t1))
-
-and (reduce_impure_comp :
+and reduce_impure_comp:
   cfg ->
     env ->
       stack ->
@@ -5985,7 +5621,7 @@ and (reduce_impure_comp :
                                             FStar_Syntax_Syntax.monad_name)
                                             FStar_Pervasives_Native.tuple2)
             FStar_Util.either ->
-            FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term)
+            FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
   =
   fun cfg  ->
     fun env  ->
@@ -5993,12 +5629,12 @@ and (reduce_impure_comp :
         fun head1  ->
           fun m  ->
             fun t  ->
-              let t1 = norm cfg env [] t  in
-              let stack1 = (Cfg cfg) :: stack  in
+              let t1 = norm cfg env [] t in
+              let stack1 = (Cfg cfg) :: stack in
               let cfg1 =
                 if (cfg.steps).pure_subterms_within_computations
                 then
-                  let uu___167_16900 = cfg  in
+                  let uu___167_16900 = cfg in
                   let uu____16901 =
                     to_fsteps
                       [PureSubtermsWithinComputations;
@@ -6006,8 +5642,7 @@ and (reduce_impure_comp :
                       AllowUnboundUniverses;
                       EraseUniverses;
                       Exclude Zeta;
-                      Inlining]
-                     in
+                      Inlining] in
                   {
                     steps = uu____16901;
                     tcenv = (uu___167_16900.tcenv);
@@ -6022,10 +5657,10 @@ and (reduce_impure_comp :
                       (uu___167_16900.normalize_pure_lets)
                   }
                 else
-                  (let uu___168_16903 = cfg  in
+                  (let uu___168_16903 = cfg in
                    {
                      steps =
-                       (let uu___169_16906 = cfg.steps  in
+                       (let uu___169_16906 = cfg.steps in
                         {
                           beta = (uu___169_16906.beta);
                           iota = (uu___169_16906.iota);
@@ -6061,27 +5696,24 @@ and (reduce_impure_comp :
                      memoize_lazy = (uu___168_16903.memoize_lazy);
                      normalize_pure_lets =
                        (uu___168_16903.normalize_pure_lets)
-                   })
-                 in
+                   }) in
               let metadata =
                 match m with
                 | FStar_Util.Inl m1 ->
                     FStar_Syntax_Syntax.Meta_monadic (m1, t1)
                 | FStar_Util.Inr (m1,m') ->
-                    FStar_Syntax_Syntax.Meta_monadic_lift (m1, m', t1)
-                 in
+                    FStar_Syntax_Syntax.Meta_monadic_lift (m1, m', t1) in
               norm cfg1 env
                 ((Meta (metadata, (head1.FStar_Syntax_Syntax.pos))) ::
                 stack1) head1
-
-and (do_reify_monadic :
+and do_reify_monadic:
   (Prims.unit -> FStar_Syntax_Syntax.term) ->
     cfg ->
       env ->
         stack_elt Prims.list ->
           FStar_Syntax_Syntax.term ->
             FStar_Syntax_Syntax.monad_name ->
-              FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term)
+              FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
   =
   fun fallback  ->
     fun cfg  ->
@@ -6090,24 +5722,23 @@ and (do_reify_monadic :
           fun head1  ->
             fun m  ->
               fun t  ->
-                let head0 = head1  in
-                let head2 = FStar_Syntax_Util.unascribe head1  in
+                let head0 = head1 in
+                let head2 = FStar_Syntax_Util.unascribe head1 in
                 log cfg
                   (fun uu____16936  ->
-                     let uu____16937 = FStar_Syntax_Print.tag_of_term head2
-                        in
+                     let uu____16937 = FStar_Syntax_Print.tag_of_term head2 in
                      let uu____16938 =
-                       FStar_Syntax_Print.term_to_string head2  in
+                       FStar_Syntax_Print.term_to_string head2 in
                      FStar_Util.print2 "Reifying: (%s) %s\n" uu____16937
                        uu____16938);
                 (let uu____16939 =
-                   let uu____16940 = FStar_Syntax_Subst.compress head2  in
-                   uu____16940.FStar_Syntax_Syntax.n  in
+                   let uu____16940 = FStar_Syntax_Subst.compress head2 in
+                   uu____16940.FStar_Syntax_Syntax.n in
                  match uu____16939 with
                  | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
                      let ed =
-                       FStar_TypeChecker_Env.get_effect_decl cfg.tcenv m  in
-                     let uu____16958 = ed.FStar_Syntax_Syntax.bind_repr  in
+                       FStar_TypeChecker_Env.get_effect_decl cfg.tcenv m in
+                     let uu____16958 = ed.FStar_Syntax_Syntax.bind_repr in
                      (match uu____16958 with
                       | (uu____16959,bind_repr) ->
                           (match lb.FStar_Syntax_Syntax.lbname with
@@ -6118,8 +5749,8 @@ and (do_reify_monadic :
                                let is_return e =
                                  let uu____16973 =
                                    let uu____16974 =
-                                     FStar_Syntax_Subst.compress e  in
-                                   uu____16974.FStar_Syntax_Syntax.n  in
+                                     FStar_Syntax_Subst.compress e in
+                                   uu____16974.FStar_Syntax_Syntax.n in
                                  match uu____16973 with
                                  | FStar_Syntax_Syntax.Tm_meta
                                      (e1,FStar_Syntax_Syntax.Meta_monadic
@@ -6127,8 +5758,8 @@ and (do_reify_monadic :
                                      ->
                                      let uu____16990 =
                                        let uu____16991 =
-                                         FStar_Syntax_Subst.compress e1  in
-                                       uu____16991.FStar_Syntax_Syntax.n  in
+                                         FStar_Syntax_Subst.compress e1 in
+                                       uu____16991.FStar_Syntax_Syntax.n in
                                      (match uu____16990 with
                                       | FStar_Syntax_Syntax.Tm_meta
                                           (e2,FStar_Syntax_Syntax.Meta_monadic_lift
@@ -6138,21 +5769,19 @@ and (do_reify_monadic :
                                             msrc
                                           ->
                                           let uu____17008 =
-                                            FStar_Syntax_Subst.compress e2
-                                             in
+                                            FStar_Syntax_Subst.compress e2 in
                                           FStar_Pervasives_Native.Some
                                             uu____17008
                                       | uu____17009 ->
                                           FStar_Pervasives_Native.None)
                                  | uu____17010 ->
-                                     FStar_Pervasives_Native.None
-                                  in
+                                     FStar_Pervasives_Native.None in
                                let uu____17011 =
-                                 is_return lb.FStar_Syntax_Syntax.lbdef  in
+                                 is_return lb.FStar_Syntax_Syntax.lbdef in
                                (match uu____17011 with
                                 | FStar_Pervasives_Native.Some e ->
                                     let lb1 =
-                                      let uu___170_17016 = lb  in
+                                      let uu___170_17016 = lb in
                                       {
                                         FStar_Syntax_Syntax.lbname =
                                           (uu___170_17016.FStar_Syntax_Syntax.lbname);
@@ -6165,29 +5794,25 @@ and (do_reify_monadic :
                                         FStar_Syntax_Syntax.lbdef = e;
                                         FStar_Syntax_Syntax.lbattrs =
                                           (uu___170_17016.FStar_Syntax_Syntax.lbattrs)
-                                      }  in
-                                    let uu____17017 = FStar_List.tl stack  in
+                                      } in
+                                    let uu____17017 = FStar_List.tl stack in
                                     let uu____17018 =
                                       let uu____17019 =
                                         let uu____17022 =
                                           let uu____17023 =
                                             let uu____17036 =
-                                              FStar_Syntax_Util.mk_reify body
-                                               in
-                                            ((false, [lb1]), uu____17036)  in
+                                              FStar_Syntax_Util.mk_reify body in
+                                            ((false, [lb1]), uu____17036) in
                                           FStar_Syntax_Syntax.Tm_let
-                                            uu____17023
-                                           in
-                                        FStar_Syntax_Syntax.mk uu____17022
-                                         in
+                                            uu____17023 in
+                                        FStar_Syntax_Syntax.mk uu____17022 in
                                       uu____17019
                                         FStar_Pervasives_Native.None
-                                        head2.FStar_Syntax_Syntax.pos
-                                       in
+                                        head2.FStar_Syntax_Syntax.pos in
                                     norm cfg env uu____17017 uu____17018
                                 | FStar_Pervasives_Native.None  ->
                                     let uu____17052 =
-                                      let uu____17053 = is_return body  in
+                                      let uu____17053 = is_return body in
                                       match uu____17053 with
                                       | FStar_Pervasives_Native.Some
                                           {
@@ -6198,23 +5823,21 @@ and (do_reify_monadic :
                                             FStar_Syntax_Syntax.vars =
                                               uu____17058;_}
                                           -> FStar_Syntax_Syntax.bv_eq x y
-                                      | uu____17063 -> false  in
+                                      | uu____17063 -> false in
                                     if uu____17052
                                     then
                                       norm cfg env stack
                                         lb.FStar_Syntax_Syntax.lbdef
                                     else
                                       (let rng =
-                                         head2.FStar_Syntax_Syntax.pos  in
+                                         head2.FStar_Syntax_Syntax.pos in
                                        let head3 =
                                          FStar_All.pipe_left
                                            FStar_Syntax_Util.mk_reify
-                                           lb.FStar_Syntax_Syntax.lbdef
-                                          in
+                                           lb.FStar_Syntax_Syntax.lbdef in
                                        let body1 =
                                          FStar_All.pipe_left
-                                           FStar_Syntax_Util.mk_reify body
-                                          in
+                                           FStar_Syntax_Util.mk_reify body in
                                        let body_rc =
                                          {
                                            FStar_Syntax_Syntax.residual_effect
@@ -6223,7 +5846,7 @@ and (do_reify_monadic :
                                              (FStar_Pervasives_Native.Some t);
                                            FStar_Syntax_Syntax.residual_flags
                                              = []
-                                         }  in
+                                         } in
                                        let body2 =
                                          let uu____17086 =
                                            let uu____17089 =
@@ -6231,32 +5854,24 @@ and (do_reify_monadic :
                                                let uu____17107 =
                                                  let uu____17110 =
                                                    FStar_Syntax_Syntax.mk_binder
-                                                     x
-                                                    in
-                                                 [uu____17110]  in
+                                                     x in
+                                                 [uu____17110] in
                                                (uu____17107, body1,
                                                  (FStar_Pervasives_Native.Some
-                                                    body_rc))
-                                                in
+                                                    body_rc)) in
                                              FStar_Syntax_Syntax.Tm_abs
-                                               uu____17090
-                                              in
-                                           FStar_Syntax_Syntax.mk uu____17089
-                                            in
+                                               uu____17090 in
+                                           FStar_Syntax_Syntax.mk uu____17089 in
                                          uu____17086
                                            FStar_Pervasives_Native.None
-                                           body1.FStar_Syntax_Syntax.pos
-                                          in
-                                       let close1 = closure_as_term cfg env
-                                          in
+                                           body1.FStar_Syntax_Syntax.pos in
+                                       let close1 = closure_as_term cfg env in
                                        let bind_inst =
                                          let uu____17126 =
                                            let uu____17127 =
                                              FStar_Syntax_Subst.compress
-                                               bind_repr
-                                              in
-                                           uu____17127.FStar_Syntax_Syntax.n
-                                            in
+                                               bind_repr in
+                                           uu____17127.FStar_Syntax_Syntax.n in
                                          match uu____17126 with
                                          | FStar_Syntax_Syntax.Tm_uinst
                                              (bind1,uu____17133::uu____17134::[])
@@ -6268,38 +5883,31 @@ and (do_reify_monadic :
                                                      let uu____17155 =
                                                        let uu____17156 =
                                                          close1
-                                                           lb.FStar_Syntax_Syntax.lbtyp
-                                                          in
+                                                           lb.FStar_Syntax_Syntax.lbtyp in
                                                        (cfg.tcenv).FStar_TypeChecker_Env.universe_of
                                                          cfg.tcenv
-                                                         uu____17156
-                                                        in
+                                                         uu____17156 in
                                                      let uu____17157 =
                                                        let uu____17160 =
                                                          let uu____17161 =
-                                                           close1 t  in
+                                                           close1 t in
                                                          (cfg.tcenv).FStar_TypeChecker_Env.universe_of
                                                            cfg.tcenv
-                                                           uu____17161
-                                                          in
-                                                       [uu____17160]  in
+                                                           uu____17161 in
+                                                       [uu____17160] in
                                                      uu____17155 ::
-                                                       uu____17157
-                                                      in
-                                                   (bind1, uu____17152)  in
+                                                       uu____17157 in
+                                                   (bind1, uu____17152) in
                                                  FStar_Syntax_Syntax.Tm_uinst
-                                                   uu____17145
-                                                  in
+                                                   uu____17145 in
                                                FStar_Syntax_Syntax.mk
-                                                 uu____17144
-                                                in
+                                                 uu____17144 in
                                              uu____17141
                                                FStar_Pervasives_Native.None
                                                rng
                                          | uu____17169 ->
                                              failwith
-                                               "NIY : Reification of indexed effects"
-                                          in
+                                               "NIY : Reification of indexed effects" in
                                        let reified =
                                          let uu____17175 =
                                            let uu____17178 =
@@ -6307,76 +5915,59 @@ and (do_reify_monadic :
                                                let uu____17194 =
                                                  let uu____17197 =
                                                    FStar_Syntax_Syntax.as_arg
-                                                     lb.FStar_Syntax_Syntax.lbtyp
-                                                    in
+                                                     lb.FStar_Syntax_Syntax.lbtyp in
                                                  let uu____17198 =
                                                    let uu____17201 =
                                                      FStar_Syntax_Syntax.as_arg
-                                                       t
-                                                      in
+                                                       t in
                                                    let uu____17202 =
                                                      let uu____17205 =
                                                        FStar_Syntax_Syntax.as_arg
-                                                         FStar_Syntax_Syntax.tun
-                                                        in
+                                                         FStar_Syntax_Syntax.tun in
                                                      let uu____17206 =
                                                        let uu____17209 =
                                                          FStar_Syntax_Syntax.as_arg
-                                                           head3
-                                                          in
+                                                           head3 in
                                                        let uu____17210 =
                                                          let uu____17213 =
                                                            FStar_Syntax_Syntax.as_arg
-                                                             FStar_Syntax_Syntax.tun
-                                                            in
+                                                             FStar_Syntax_Syntax.tun in
                                                          let uu____17214 =
                                                            let uu____17217 =
                                                              FStar_Syntax_Syntax.as_arg
-                                                               body2
-                                                              in
-                                                           [uu____17217]  in
+                                                               body2 in
+                                                           [uu____17217] in
                                                          uu____17213 ::
-                                                           uu____17214
-                                                          in
+                                                           uu____17214 in
                                                        uu____17209 ::
-                                                         uu____17210
-                                                        in
+                                                         uu____17210 in
                                                      uu____17205 ::
-                                                       uu____17206
-                                                      in
-                                                   uu____17201 :: uu____17202
-                                                    in
-                                                 uu____17197 :: uu____17198
-                                                  in
-                                               (bind_inst, uu____17194)  in
+                                                       uu____17206 in
+                                                   uu____17201 :: uu____17202 in
+                                                 uu____17197 :: uu____17198 in
+                                               (bind_inst, uu____17194) in
                                              FStar_Syntax_Syntax.Tm_app
-                                               uu____17179
-                                              in
-                                           FStar_Syntax_Syntax.mk uu____17178
-                                            in
+                                               uu____17179 in
+                                           FStar_Syntax_Syntax.mk uu____17178 in
                                          uu____17175
-                                           FStar_Pervasives_Native.None rng
-                                          in
+                                           FStar_Pervasives_Native.None rng in
                                        log cfg
                                          (fun uu____17229  ->
                                             let uu____17230 =
                                               FStar_Syntax_Print.term_to_string
-                                                head0
-                                               in
+                                                head0 in
                                             let uu____17231 =
                                               FStar_Syntax_Print.term_to_string
-                                                reified
-                                               in
+                                                reified in
                                             FStar_Util.print2
                                               "Reified (1) <%s> to %s\n"
                                               uu____17230 uu____17231);
-                                       (let uu____17232 = FStar_List.tl stack
-                                           in
+                                       (let uu____17232 = FStar_List.tl stack in
                                         norm cfg env uu____17232 reified)))))
                  | FStar_Syntax_Syntax.Tm_app (head_app,args) ->
                      let ed =
-                       FStar_TypeChecker_Env.get_effect_decl cfg.tcenv m  in
-                     let uu____17256 = ed.FStar_Syntax_Syntax.bind_repr  in
+                       FStar_TypeChecker_Env.get_effect_decl cfg.tcenv m in
+                     let uu____17256 = ed.FStar_Syntax_Syntax.bind_repr in
                      (match uu____17256 with
                       | (uu____17257,bind_repr) ->
                           let maybe_unfold_action head3 =
@@ -6384,50 +5975,46 @@ and (do_reify_monadic :
                               let t2 =
                                 let uu____17292 =
                                   let uu____17293 =
-                                    FStar_Syntax_Subst.compress t1  in
-                                  uu____17293.FStar_Syntax_Syntax.n  in
+                                    FStar_Syntax_Subst.compress t1 in
+                                  uu____17293.FStar_Syntax_Syntax.n in
                                 match uu____17292 with
                                 | FStar_Syntax_Syntax.Tm_uinst
                                     (t2,uu____17299) -> t2
-                                | uu____17304 -> head3  in
+                                | uu____17304 -> head3 in
                               let uu____17305 =
                                 let uu____17306 =
-                                  FStar_Syntax_Subst.compress t2  in
-                                uu____17306.FStar_Syntax_Syntax.n  in
+                                  FStar_Syntax_Subst.compress t2 in
+                                uu____17306.FStar_Syntax_Syntax.n in
                               match uu____17305 with
                               | FStar_Syntax_Syntax.Tm_fvar x ->
                                   FStar_Pervasives_Native.Some x
-                              | uu____17312 -> FStar_Pervasives_Native.None
-                               in
-                            let uu____17313 = maybe_extract_fv head3  in
+                              | uu____17312 -> FStar_Pervasives_Native.None in
+                            let uu____17313 = maybe_extract_fv head3 in
                             match uu____17313 with
                             | FStar_Pervasives_Native.Some x when
                                 let uu____17323 =
-                                  FStar_Syntax_Syntax.lid_of_fv x  in
+                                  FStar_Syntax_Syntax.lid_of_fv x in
                                 FStar_TypeChecker_Env.is_action cfg.tcenv
                                   uu____17323
                                 ->
-                                let head4 = norm cfg env [] head3  in
+                                let head4 = norm cfg env [] head3 in
                                 let action_unfolded =
-                                  let uu____17328 = maybe_extract_fv head4
-                                     in
+                                  let uu____17328 = maybe_extract_fv head4 in
                                   match uu____17328 with
                                   | FStar_Pervasives_Native.Some uu____17333
                                       -> FStar_Pervasives_Native.Some true
                                   | uu____17334 ->
-                                      FStar_Pervasives_Native.Some false
-                                   in
+                                      FStar_Pervasives_Native.Some false in
                                 (head4, action_unfolded)
                             | uu____17339 ->
-                                (head3, FStar_Pervasives_Native.None)
-                             in
+                                (head3, FStar_Pervasives_Native.None) in
                           ((let is_arg_impure uu____17354 =
                               match uu____17354 with
                               | (e,q) ->
                                   let uu____17361 =
                                     let uu____17362 =
-                                      FStar_Syntax_Subst.compress e  in
-                                    uu____17362.FStar_Syntax_Syntax.n  in
+                                      FStar_Syntax_Subst.compress e in
+                                    uu____17362.FStar_Syntax_Syntax.n in
                                   (match uu____17361 with
                                    | FStar_Syntax_Syntax.Tm_meta
                                        (e0,FStar_Syntax_Syntax.Meta_monadic_lift
@@ -6435,40 +6022,34 @@ and (do_reify_monadic :
                                        ->
                                        Prims.op_Negation
                                          (FStar_Syntax_Util.is_pure_effect m1)
-                                   | uu____17377 -> false)
-                               in
+                                   | uu____17377 -> false) in
                             let uu____17378 =
                               let uu____17379 =
                                 let uu____17386 =
-                                  FStar_Syntax_Syntax.as_arg head_app  in
-                                uu____17386 :: args  in
-                              FStar_Util.for_some is_arg_impure uu____17379
-                               in
+                                  FStar_Syntax_Syntax.as_arg head_app in
+                                uu____17386 :: args in
+                              FStar_Util.for_some is_arg_impure uu____17379 in
                             if uu____17378
                             then
                               let uu____17391 =
                                 let uu____17392 =
-                                  FStar_Syntax_Print.term_to_string head2  in
+                                  FStar_Syntax_Print.term_to_string head2 in
                                 FStar_Util.format1
                                   "Incompability between typechecker and normalizer; this monadic application contains impure terms %s\n"
-                                  uu____17392
-                                 in
+                                  uu____17392 in
                               failwith uu____17391
                             else ());
-                           (let uu____17394 = maybe_unfold_action head_app
-                               in
+                           (let uu____17394 = maybe_unfold_action head_app in
                             match uu____17394 with
                             | (head_app1,found_action) ->
                                 let mk1 tm =
                                   FStar_Syntax_Syntax.mk tm
                                     FStar_Pervasives_Native.None
-                                    head2.FStar_Syntax_Syntax.pos
-                                   in
+                                    head2.FStar_Syntax_Syntax.pos in
                                 let body =
                                   mk1
                                     (FStar_Syntax_Syntax.Tm_app
-                                       (head_app1, args))
-                                   in
+                                       (head_app1, args)) in
                                 let body1 =
                                   match found_action with
                                   | FStar_Pervasives_Native.None  ->
@@ -6480,22 +6061,19 @@ and (do_reify_monadic :
                                              (FStar_Syntax_Syntax.Meta_monadic
                                                 (m, t))))
                                   | FStar_Pervasives_Native.Some (true ) ->
-                                      body
-                                   in
+                                      body in
                                 (log cfg
                                    (fun uu____17435  ->
                                       let uu____17436 =
                                         FStar_Syntax_Print.term_to_string
-                                          head0
-                                         in
+                                          head0 in
                                       let uu____17437 =
                                         FStar_Syntax_Print.term_to_string
-                                          body1
-                                         in
+                                          body1 in
                                       FStar_Util.print2
                                         "Reified (2) <%s> to %s\n"
                                         uu____17436 uu____17437);
-                                 (let uu____17438 = FStar_List.tl stack  in
+                                 (let uu____17438 = FStar_List.tl stack in
                                   norm cfg env uu____17438 body1)))))
                  | FStar_Syntax_Syntax.Tm_meta
                      (e,FStar_Syntax_Syntax.Meta_monadic uu____17440) ->
@@ -6504,15 +6082,15 @@ and (do_reify_monadic :
                      (e,FStar_Syntax_Syntax.Meta_monadic_lift (msrc,mtgt,t'))
                      ->
                      let lifted =
-                       let uu____17464 = closure_as_term cfg env t'  in
-                       reify_lift cfg e msrc mtgt uu____17464  in
+                       let uu____17464 = closure_as_term cfg env t' in
+                       reify_lift cfg e msrc mtgt uu____17464 in
                      (log cfg
                         (fun uu____17468  ->
                            let uu____17469 =
-                             FStar_Syntax_Print.term_to_string lifted  in
+                             FStar_Syntax_Print.term_to_string lifted in
                            FStar_Util.print1 "Reified lift to (2): %s\n"
                              uu____17469);
-                      (let uu____17470 = FStar_List.tl stack  in
+                      (let uu____17470 = FStar_List.tl stack in
                        norm cfg env uu____17470 lifted))
                  | FStar_Syntax_Syntax.Tm_meta (e,uu____17472) ->
                      do_reify_monadic fallback cfg env stack e m t
@@ -6524,48 +6102,45 @@ and (do_reify_monadic :
                                match uu____17597 with
                                | (pat,wopt,tm) ->
                                    let uu____17645 =
-                                     FStar_Syntax_Util.mk_reify tm  in
-                                   (pat, wopt, uu____17645)))
-                        in
+                                     FStar_Syntax_Util.mk_reify tm in
+                                   (pat, wopt, uu____17645))) in
                      let tm =
                        mk (FStar_Syntax_Syntax.Tm_match (e, branches1))
-                         head2.FStar_Syntax_Syntax.pos
-                        in
-                     let uu____17677 = FStar_List.tl stack  in
+                         head2.FStar_Syntax_Syntax.pos in
+                     let uu____17677 = FStar_List.tl stack in
                      norm cfg env uu____17677 tm
                  | uu____17678 -> fallback ())
-
-and (reify_lift :
+and reify_lift:
   cfg ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       FStar_Syntax_Syntax.monad_name ->
         FStar_Syntax_Syntax.monad_name ->
-          FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+          FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun cfg  ->
     fun e  ->
       fun msrc  ->
         fun mtgt  ->
           fun t  ->
-            let env = cfg.tcenv  in
+            let env = cfg.tcenv in
             log cfg
               (fun uu____17692  ->
-                 let uu____17693 = FStar_Ident.string_of_lid msrc  in
-                 let uu____17694 = FStar_Ident.string_of_lid mtgt  in
-                 let uu____17695 = FStar_Syntax_Print.term_to_string e  in
+                 let uu____17693 = FStar_Ident.string_of_lid msrc in
+                 let uu____17694 = FStar_Ident.string_of_lid mtgt in
+                 let uu____17695 = FStar_Syntax_Print.term_to_string e in
                  FStar_Util.print3 "Reifying lift %s -> %s: %s\n" uu____17693
                    uu____17694 uu____17695);
             if FStar_Syntax_Util.is_pure_effect msrc
             then
-              (let ed = FStar_TypeChecker_Env.get_effect_decl env mtgt  in
-               let uu____17697 = ed.FStar_Syntax_Syntax.return_repr  in
+              (let ed = FStar_TypeChecker_Env.get_effect_decl env mtgt in
+               let uu____17697 = ed.FStar_Syntax_Syntax.return_repr in
                match uu____17697 with
                | (uu____17698,return_repr) ->
                    let return_inst =
                      let uu____17707 =
                        let uu____17708 =
-                         FStar_Syntax_Subst.compress return_repr  in
-                       uu____17708.FStar_Syntax_Syntax.n  in
+                         FStar_Syntax_Subst.compress return_repr in
+                       uu____17708.FStar_Syntax_Syntax.n in
                      match uu____17707 with
                      | FStar_Syntax_Syntax.Tm_uinst
                          (return_tm,uu____17714::[]) ->
@@ -6575,43 +6150,39 @@ and (reify_lift :
                                let uu____17732 =
                                  let uu____17735 =
                                    env.FStar_TypeChecker_Env.universe_of env
-                                     t
-                                    in
-                                 [uu____17735]  in
-                               (return_tm, uu____17732)  in
-                             FStar_Syntax_Syntax.Tm_uinst uu____17725  in
-                           FStar_Syntax_Syntax.mk uu____17724  in
+                                     t in
+                                 [uu____17735] in
+                               (return_tm, uu____17732) in
+                             FStar_Syntax_Syntax.Tm_uinst uu____17725 in
+                           FStar_Syntax_Syntax.mk uu____17724 in
                          uu____17721 FStar_Pervasives_Native.None
                            e.FStar_Syntax_Syntax.pos
                      | uu____17743 ->
-                         failwith "NIY : Reification of indexed effects"
-                      in
+                         failwith "NIY : Reification of indexed effects" in
                    let uu____17746 =
                      let uu____17749 =
                        let uu____17750 =
                          let uu____17765 =
-                           let uu____17768 = FStar_Syntax_Syntax.as_arg t  in
+                           let uu____17768 = FStar_Syntax_Syntax.as_arg t in
                            let uu____17769 =
-                             let uu____17772 = FStar_Syntax_Syntax.as_arg e
-                                in
-                             [uu____17772]  in
-                           uu____17768 :: uu____17769  in
-                         (return_inst, uu____17765)  in
-                       FStar_Syntax_Syntax.Tm_app uu____17750  in
-                     FStar_Syntax_Syntax.mk uu____17749  in
+                             let uu____17772 = FStar_Syntax_Syntax.as_arg e in
+                             [uu____17772] in
+                           uu____17768 :: uu____17769 in
+                         (return_inst, uu____17765) in
+                       FStar_Syntax_Syntax.Tm_app uu____17750 in
+                     FStar_Syntax_Syntax.mk uu____17749 in
                    uu____17746 FStar_Pervasives_Native.None
                      e.FStar_Syntax_Syntax.pos)
             else
               (let uu____17781 =
-                 FStar_TypeChecker_Env.monad_leq env msrc mtgt  in
+                 FStar_TypeChecker_Env.monad_leq env msrc mtgt in
                match uu____17781 with
                | FStar_Pervasives_Native.None  ->
                    let uu____17784 =
                      FStar_Util.format2
                        "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
                        (FStar_Ident.text_of_lid msrc)
-                       (FStar_Ident.text_of_lid mtgt)
-                      in
+                       (FStar_Ident.text_of_lid mtgt) in
                    failwith uu____17784
                | FStar_Pervasives_Native.Some
                    { FStar_TypeChecker_Env.msource = uu____17785;
@@ -6625,8 +6196,7 @@ and (reify_lift :
                      FStar_Util.format2
                        "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
                        (FStar_Ident.text_of_lid msrc)
-                       (FStar_Ident.text_of_lid mtgt)
-                      in
+                       (FStar_Ident.text_of_lid mtgt) in
                    failwith uu____17802
                | FStar_Pervasives_Native.Some
                    { FStar_TypeChecker_Env.msource = uu____17803;
@@ -6637,17 +6207,16 @@ and (reify_lift :
                            FStar_Pervasives_Native.Some lift;_};_}
                    ->
                    let uu____17829 =
-                     env.FStar_TypeChecker_Env.universe_of env t  in
-                   let uu____17830 = FStar_Syntax_Util.mk_reify e  in
+                     env.FStar_TypeChecker_Env.universe_of env t in
+                   let uu____17830 = FStar_Syntax_Util.mk_reify e in
                    lift uu____17829 t FStar_Syntax_Syntax.tun uu____17830)
-
-and (norm_pattern_args :
+and norm_pattern_args:
   cfg ->
     env ->
       (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
         FStar_Pervasives_Native.tuple2 Prims.list Prims.list ->
         (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
-          FStar_Pervasives_Native.tuple2 Prims.list Prims.list)
+          FStar_Pervasives_Native.tuple2 Prims.list Prims.list
   =
   fun cfg  ->
     fun env  ->
@@ -6658,24 +6227,23 @@ and (norm_pattern_args :
                 (fun uu____17886  ->
                    match uu____17886 with
                    | (a,imp) ->
-                       let uu____17897 = norm cfg env [] a  in
+                       let uu____17897 = norm cfg env [] a in
                        (uu____17897, imp))))
-
-and (norm_comp :
-  cfg -> env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp) =
+and norm_comp:
+  cfg -> env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp =
   fun cfg  ->
     fun env  ->
       fun comp  ->
         match comp.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Total (t,uopt) ->
-            let uu___171_17911 = comp  in
+            let uu___171_17911 = comp in
             let uu____17912 =
               let uu____17913 =
-                let uu____17922 = norm cfg env [] t  in
+                let uu____17922 = norm cfg env [] t in
                 let uu____17923 =
-                  FStar_Option.map (norm_universe cfg env) uopt  in
-                (uu____17922, uu____17923)  in
-              FStar_Syntax_Syntax.Total uu____17913  in
+                  FStar_Option.map (norm_universe cfg env) uopt in
+                (uu____17922, uu____17923) in
+              FStar_Syntax_Syntax.Total uu____17913 in
             {
               FStar_Syntax_Syntax.n = uu____17912;
               FStar_Syntax_Syntax.pos =
@@ -6684,14 +6252,14 @@ and (norm_comp :
                 (uu___171_17911.FStar_Syntax_Syntax.vars)
             }
         | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-            let uu___172_17938 = comp  in
+            let uu___172_17938 = comp in
             let uu____17939 =
               let uu____17940 =
-                let uu____17949 = norm cfg env [] t  in
+                let uu____17949 = norm cfg env [] t in
                 let uu____17950 =
-                  FStar_Option.map (norm_universe cfg env) uopt  in
-                (uu____17949, uu____17950)  in
-              FStar_Syntax_Syntax.GTotal uu____17940  in
+                  FStar_Option.map (norm_universe cfg env) uopt in
+                (uu____17949, uu____17950) in
+              FStar_Syntax_Syntax.GTotal uu____17940 in
             {
               FStar_Syntax_Syntax.n = uu____17939;
               FStar_Syntax_Syntax.pos =
@@ -6706,31 +6274,28 @@ and (norm_comp :
                    (fun uu____18002  ->
                       match uu____18002 with
                       | (a,i) ->
-                          let uu____18013 = norm cfg env [] a  in
-                          (uu____18013, i)))
-               in
+                          let uu____18013 = norm cfg env [] a in
+                          (uu____18013, i))) in
             let flags1 =
               FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                 (FStar_List.map
                    (fun uu___88_18024  ->
                       match uu___88_18024 with
                       | FStar_Syntax_Syntax.DECREASES t ->
-                          let uu____18028 = norm cfg env [] t  in
+                          let uu____18028 = norm cfg env [] t in
                           FStar_Syntax_Syntax.DECREASES uu____18028
-                      | f -> f))
-               in
-            let uu___173_18032 = comp  in
+                      | f -> f)) in
+            let uu___173_18032 = comp in
             let uu____18033 =
               let uu____18034 =
-                let uu___174_18035 = ct  in
+                let uu___174_18035 = ct in
                 let uu____18036 =
                   FStar_List.map (norm_universe cfg env)
-                    ct.FStar_Syntax_Syntax.comp_univs
-                   in
+                    ct.FStar_Syntax_Syntax.comp_univs in
                 let uu____18037 =
-                  norm cfg env [] ct.FStar_Syntax_Syntax.result_typ  in
+                  norm cfg env [] ct.FStar_Syntax_Syntax.result_typ in
                 let uu____18040 =
-                  norm_args ct.FStar_Syntax_Syntax.effect_args  in
+                  norm_args ct.FStar_Syntax_Syntax.effect_args in
                 {
                   FStar_Syntax_Syntax.comp_univs = uu____18036;
                   FStar_Syntax_Syntax.effect_name =
@@ -6738,8 +6303,8 @@ and (norm_comp :
                   FStar_Syntax_Syntax.result_typ = uu____18037;
                   FStar_Syntax_Syntax.effect_args = uu____18040;
                   FStar_Syntax_Syntax.flags = flags1
-                }  in
-              FStar_Syntax_Syntax.Comp uu____18034  in
+                } in
+              FStar_Syntax_Syntax.Comp uu____18034 in
             {
               FStar_Syntax_Syntax.n = uu____18033;
               FStar_Syntax_Syntax.pos =
@@ -6747,29 +6312,26 @@ and (norm_comp :
               FStar_Syntax_Syntax.vars =
                 (uu___173_18032.FStar_Syntax_Syntax.vars)
             }
-
-and (norm_binder :
-  cfg -> env -> FStar_Syntax_Syntax.binder -> FStar_Syntax_Syntax.binder) =
+and norm_binder:
+  cfg -> env -> FStar_Syntax_Syntax.binder -> FStar_Syntax_Syntax.binder =
   fun cfg  ->
     fun env  ->
       fun uu____18051  ->
         match uu____18051 with
         | (x,imp) ->
             let uu____18054 =
-              let uu___175_18055 = x  in
-              let uu____18056 = norm cfg env [] x.FStar_Syntax_Syntax.sort
-                 in
+              let uu___175_18055 = x in
+              let uu____18056 = norm cfg env [] x.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
                   (uu___175_18055.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
                   (uu___175_18055.FStar_Syntax_Syntax.index);
                 FStar_Syntax_Syntax.sort = uu____18056
-              }  in
+              } in
             (uu____18054, imp)
-
-and (norm_binders :
-  cfg -> env -> FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders) =
+and norm_binders:
+  cfg -> env -> FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders =
   fun cfg  ->
     fun env  ->
       fun bs  ->
@@ -6779,16 +6341,14 @@ and (norm_binders :
                fun b  ->
                  match uu____18080 with
                  | (nbs',env1) ->
-                     let b1 = norm_binder cfg env1 b  in
-                     ((b1 :: nbs'), (dummy :: env1))) ([], env) bs
-           in
+                     let b1 = norm_binder cfg env1 b in
+                     ((b1 :: nbs'), (dummy :: env1))) ([], env) bs in
         match uu____18062 with | (nbs,uu____18120) -> FStar_List.rev nbs
-
-and (norm_lcomp_opt :
+and norm_lcomp_opt:
   cfg ->
     env ->
       FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
-        FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option)
+        FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option
   =
   fun cfg  ->
     fun env  ->
@@ -6796,26 +6356,23 @@ and (norm_lcomp_opt :
         match lopt with
         | FStar_Pervasives_Native.Some rc ->
             let flags1 =
-              filter_out_lcomp_cflags rc.FStar_Syntax_Syntax.residual_flags
-               in
+              filter_out_lcomp_cflags rc.FStar_Syntax_Syntax.residual_flags in
             let uu____18136 =
-              let uu___176_18137 = rc  in
+              let uu___176_18137 = rc in
               let uu____18138 =
                 FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
-                  (norm cfg env [])
-                 in
+                  (norm cfg env []) in
               {
                 FStar_Syntax_Syntax.residual_effect =
                   (uu___176_18137.FStar_Syntax_Syntax.residual_effect);
                 FStar_Syntax_Syntax.residual_typ = uu____18138;
                 FStar_Syntax_Syntax.residual_flags =
                   (uu___176_18137.FStar_Syntax_Syntax.residual_flags)
-              }  in
+              } in
             FStar_Pervasives_Native.Some uu____18136
         | uu____18145 -> lopt
-
-and (rebuild :
-  cfg -> env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+and rebuild:
+  cfg -> env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun cfg  ->
     fun env  ->
@@ -6823,138 +6380,128 @@ and (rebuild :
         fun t  ->
           log cfg
             (fun uu____18158  ->
-               let uu____18159 = FStar_Syntax_Print.tag_of_term t  in
-               let uu____18160 = FStar_Syntax_Print.term_to_string t  in
+               let uu____18159 = FStar_Syntax_Print.tag_of_term t in
+               let uu____18160 = FStar_Syntax_Print.term_to_string t in
                let uu____18161 =
-                 FStar_Util.string_of_int (FStar_List.length env)  in
+                 FStar_Util.string_of_int (FStar_List.length env) in
                let uu____18168 =
                  let uu____18169 =
-                   let uu____18172 = firstn (Prims.parse_int "4") stack  in
+                   let uu____18172 = firstn (Prims.parse_int "4") stack in
                    FStar_All.pipe_left FStar_Pervasives_Native.fst
-                     uu____18172
-                    in
-                 stack_to_string uu____18169  in
+                     uu____18172 in
+                 stack_to_string uu____18169 in
                FStar_Util.print4
                  ">>> %s\nRebuild %s with %s env elements and top of the stack %s \n"
                  uu____18159 uu____18160 uu____18161 uu____18168);
-          (let t1 = maybe_simplify cfg env stack t  in
+          (let t1 = maybe_simplify cfg env stack t in
            match stack with
            | [] -> t1
            | (Debug (tm,time_then))::stack1 ->
                (if (cfg.debug).print_normalized
                 then
-                  (let time_now = FStar_Util.now ()  in
+                  (let time_now = FStar_Util.now () in
                    let uu____18203 =
                      let uu____18204 =
                        let uu____18205 =
-                         FStar_Util.time_diff time_then time_now  in
-                       FStar_Pervasives_Native.snd uu____18205  in
-                     FStar_Util.string_of_int uu____18204  in
-                   let uu____18210 = FStar_Syntax_Print.term_to_string tm  in
-                   let uu____18211 = FStar_Syntax_Print.term_to_string t1  in
+                         FStar_Util.time_diff time_then time_now in
+                       FStar_Pervasives_Native.snd uu____18205 in
+                     FStar_Util.string_of_int uu____18204 in
+                   let uu____18210 = FStar_Syntax_Print.term_to_string tm in
+                   let uu____18211 = FStar_Syntax_Print.term_to_string t1 in
                    FStar_Util.print3 "Normalized (%s ms) %s\n\tto %s\n"
                      uu____18203 uu____18210 uu____18211)
                 else ();
                 rebuild cfg env stack1 t1)
            | (Cfg cfg1)::stack1 -> rebuild cfg1 env stack1 t1
            | (Meta (m,r))::stack1 ->
-               let t2 = mk (FStar_Syntax_Syntax.Tm_meta (t1, m)) r  in
+               let t2 = mk (FStar_Syntax_Syntax.Tm_meta (t1, m)) r in
                rebuild cfg env stack1 t2
            | (MemoLazy r)::stack1 ->
                (set_memo cfg r (env, t1);
                 log cfg
                   (fun uu____18265  ->
-                     let uu____18266 = FStar_Syntax_Print.term_to_string t1
-                        in
+                     let uu____18266 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.print1 "\tSet memo %s\n" uu____18266);
                 rebuild cfg env stack1 t1)
            | (Let (env',bs,lb,r))::stack1 ->
-               let body = FStar_Syntax_Subst.close bs t1  in
+               let body = FStar_Syntax_Subst.close bs t1 in
                let t2 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_let ((false, [lb]), body))
-                   FStar_Pervasives_Native.None r
-                  in
+                   FStar_Pervasives_Native.None r in
                rebuild cfg env' stack1 t2
            | (Abs (env',bs,env'',lopt,r))::stack1 ->
-               let bs1 = norm_binders cfg env' bs  in
-               let lopt1 = norm_lcomp_opt cfg env'' lopt  in
+               let bs1 = norm_binders cfg env' bs in
+               let lopt1 = norm_lcomp_opt cfg env'' lopt in
                let uu____18302 =
-                 let uu___177_18303 = FStar_Syntax_Util.abs bs1 t1 lopt1  in
+                 let uu___177_18303 = FStar_Syntax_Util.abs bs1 t1 lopt1 in
                  {
                    FStar_Syntax_Syntax.n =
                      (uu___177_18303.FStar_Syntax_Syntax.n);
                    FStar_Syntax_Syntax.pos = r;
                    FStar_Syntax_Syntax.vars =
                      (uu___177_18303.FStar_Syntax_Syntax.vars)
-                 }  in
+                 } in
                rebuild cfg env stack1 uu____18302
            | (Arg (Univ uu____18304,uu____18305,uu____18306))::uu____18307 ->
                failwith "Impossible"
            | (Arg (Dummy ,uu____18310,uu____18311))::uu____18312 ->
                failwith "Impossible"
            | (UnivArgs (us,r))::stack1 ->
-               let t2 = FStar_Syntax_Syntax.mk_Tm_uinst t1 us  in
+               let t2 = FStar_Syntax_Syntax.mk_Tm_uinst t1 us in
                rebuild cfg env stack1 t2
            | (Arg (Clos (env_arg,tm,m,uu____18328),aq,r))::stack1 ->
                (log cfg
                   (fun uu____18381  ->
-                     let uu____18382 = FStar_Syntax_Print.term_to_string tm
-                        in
+                     let uu____18382 = FStar_Syntax_Print.term_to_string tm in
                      FStar_Util.print1 "Rebuilding with arg %s\n" uu____18382);
                 if Prims.op_Negation (cfg.steps).iota
                 then
                   (if (cfg.steps).hnf
                    then
-                     let arg = closure_as_term cfg env_arg tm  in
+                     let arg = closure_as_term cfg env_arg tm in
                      let t2 =
                        FStar_Syntax_Syntax.extend_app t1 (arg, aq)
-                         FStar_Pervasives_Native.None r
-                        in
+                         FStar_Pervasives_Native.None r in
                      rebuild cfg env_arg stack1 t2
                    else
-                     (let stack2 = (App (env, t1, aq, r)) :: stack1  in
+                     (let stack2 = (App (env, t1, aq, r)) :: stack1 in
                       norm cfg env_arg stack2 tm))
                 else
-                  (let uu____18392 = FStar_ST.op_Bang m  in
+                  (let uu____18392 = FStar_ST.op_Bang m in
                    match uu____18392 with
                    | FStar_Pervasives_Native.None  ->
                        if (cfg.steps).hnf
                        then
-                         let arg = closure_as_term cfg env_arg tm  in
+                         let arg = closure_as_term cfg env_arg tm in
                          let t2 =
                            FStar_Syntax_Syntax.extend_app t1 (arg, aq)
-                             FStar_Pervasives_Native.None r
-                            in
+                             FStar_Pervasives_Native.None r in
                          rebuild cfg env_arg stack1 t2
                        else
                          (let stack2 = (MemoLazy m) :: (App (env, t1, aq, r))
-                            :: stack1  in
+                            :: stack1 in
                           norm cfg env_arg stack2 tm)
                    | FStar_Pervasives_Native.Some (uu____18529,a) ->
                        let t2 =
                          FStar_Syntax_Syntax.extend_app t1 (a, aq)
-                           FStar_Pervasives_Native.None r
-                          in
+                           FStar_Pervasives_Native.None r in
                        rebuild cfg env_arg stack1 t2))
            | (App (env1,head1,aq,r))::stack' when should_reify cfg stack ->
-               let t0 = t1  in
+               let t0 = t1 in
                let fallback msg uu____18576 =
                  log cfg
                    (fun uu____18580  ->
-                      let uu____18581 = FStar_Syntax_Print.term_to_string t1
-                         in
+                      let uu____18581 = FStar_Syntax_Print.term_to_string t1 in
                       FStar_Util.print2 "Not reifying%s: %s\n" msg
                         uu____18581);
                  (let t2 =
                     FStar_Syntax_Syntax.extend_app head1 (t1, aq)
-                      FStar_Pervasives_Native.None r
-                     in
-                  rebuild cfg env1 stack' t2)
-                  in
+                      FStar_Pervasives_Native.None r in
+                  rebuild cfg env1 stack' t2) in
                let uu____18585 =
-                 let uu____18586 = FStar_Syntax_Subst.compress t1  in
-                 uu____18586.FStar_Syntax_Syntax.n  in
+                 let uu____18586 = FStar_Syntax_Subst.compress t1 in
+                 uu____18586.FStar_Syntax_Syntax.n in
                (match uu____18585 with
                 | FStar_Syntax_Syntax.Tm_meta
                     (t2,FStar_Syntax_Syntax.Meta_monadic (m,ty)) ->
@@ -6963,15 +6510,15 @@ and (rebuild :
                     (t2,FStar_Syntax_Syntax.Meta_monadic_lift (msrc,mtgt,ty))
                     ->
                     let lifted =
-                      let uu____18613 = closure_as_term cfg env1 ty  in
-                      reify_lift cfg t2 msrc mtgt uu____18613  in
+                      let uu____18613 = closure_as_term cfg env1 ty in
+                      reify_lift cfg t2 msrc mtgt uu____18613 in
                     (log cfg
                        (fun uu____18617  ->
                           let uu____18618 =
-                            FStar_Syntax_Print.term_to_string lifted  in
+                            FStar_Syntax_Print.term_to_string lifted in
                           FStar_Util.print1 "Reified lift to (1): %s\n"
                             uu____18618);
-                     (let uu____18619 = FStar_List.tl stack  in
+                     (let uu____18619 = FStar_List.tl stack in
                       norm cfg env1 uu____18619 lifted))
                 | FStar_Syntax_Syntax.Tm_app
                     ({
@@ -6985,23 +6532,21 @@ and (rebuild :
            | (App (env1,head1,aq,r))::stack1 ->
                let t2 =
                  FStar_Syntax_Syntax.extend_app head1 (t1, aq)
-                   FStar_Pervasives_Native.None r
-                  in
+                   FStar_Pervasives_Native.None r in
                rebuild cfg env1 stack1 t2
            | (Match (env1,branches,r))::stack1 ->
                (log cfg
                   (fun uu____18673  ->
-                     let uu____18674 = FStar_Syntax_Print.term_to_string t1
-                        in
+                     let uu____18674 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.print1
                        "Rebuilding with match, scrutinee is %s ...\n"
                        uu____18674);
-                (let scrutinee = t1  in
+                (let scrutinee = t1 in
                  let norm_and_rebuild_match uu____18679 =
                    log cfg
                      (fun uu____18684  ->
                         let uu____18685 =
-                          FStar_Syntax_Print.term_to_string scrutinee  in
+                          FStar_Syntax_Print.term_to_string scrutinee in
                         let uu____18686 =
                           let uu____18687 =
                             FStar_All.pipe_right branches
@@ -7009,15 +6554,13 @@ and (rebuild :
                                  (fun uu____18704  ->
                                     match uu____18704 with
                                     | (p,uu____18714,uu____18715) ->
-                                        FStar_Syntax_Print.pat_to_string p))
-                             in
+                                        FStar_Syntax_Print.pat_to_string p)) in
                           FStar_All.pipe_right uu____18687
-                            (FStar_String.concat "\n\t")
-                           in
+                            (FStar_String.concat "\n\t") in
                         FStar_Util.print2
                           "match is irreducible: scrutinee=%s\nbranches=%s\n"
                           uu____18685 uu____18686);
-                   (let whnf = (cfg.steps).weak || (cfg.steps).hnf  in
+                   (let whnf = (cfg.steps).weak || (cfg.steps).hnf in
                     let cfg_exclude_iota_zeta =
                       let new_delta =
                         FStar_All.pipe_right cfg.delta_level
@@ -7027,12 +6570,11 @@ and (rebuild :
                                 | FStar_TypeChecker_Env.Inlining  -> true
                                 | FStar_TypeChecker_Env.Eager_unfolding_only 
                                     -> true
-                                | uu____18733 -> false))
-                         in
-                      let uu___178_18734 = cfg  in
+                                | uu____18733 -> false)) in
+                      let uu___178_18734 = cfg in
                       {
                         steps =
-                          (let uu___179_18737 = cfg.steps  in
+                          (let uu___179_18737 = cfg.steps in
                            {
                              beta = (uu___179_18737.beta);
                              iota = (uu___179_18737.iota);
@@ -7070,11 +6612,11 @@ and (rebuild :
                         memoize_lazy = (uu___178_18734.memoize_lazy);
                         normalize_pure_lets =
                           (uu___178_18734.normalize_pure_lets)
-                      }  in
+                      } in
                     let norm_or_whnf env2 t2 =
                       if whnf
                       then closure_as_term cfg_exclude_iota_zeta env2 t2
-                      else norm cfg_exclude_iota_zeta env2 [] t2  in
+                      else norm cfg_exclude_iota_zeta env2 [] t2 in
                     let rec norm_pat env2 p =
                       match p.FStar_Syntax_Syntax.v with
                       | FStar_Syntax_Syntax.Pat_constant uu____18769 ->
@@ -7087,16 +6629,14 @@ and (rebuild :
                                     fun uu____18851  ->
                                       match (uu____18850, uu____18851) with
                                       | ((pats1,env3),(p1,b)) ->
-                                          let uu____18942 = norm_pat env3 p1
-                                             in
+                                          let uu____18942 = norm_pat env3 p1 in
                                           (match uu____18942 with
                                            | (p2,env4) ->
                                                (((p2, b) :: pats1), env4)))
-                                 ([], env2))
-                             in
+                                 ([], env2)) in
                           (match uu____18790 with
                            | (pats1,env3) ->
-                               ((let uu___180_19024 = p  in
+                               ((let uu___180_19024 = p in
                                  {
                                    FStar_Syntax_Syntax.v =
                                      (FStar_Syntax_Syntax.Pat_cons
@@ -7106,18 +6646,17 @@ and (rebuild :
                                  }), env3))
                       | FStar_Syntax_Syntax.Pat_var x ->
                           let x1 =
-                            let uu___181_19043 = x  in
+                            let uu___181_19043 = x in
                             let uu____19044 =
-                              norm_or_whnf env2 x.FStar_Syntax_Syntax.sort
-                               in
+                              norm_or_whnf env2 x.FStar_Syntax_Syntax.sort in
                             {
                               FStar_Syntax_Syntax.ppname =
                                 (uu___181_19043.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
                                 (uu___181_19043.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = uu____19044
-                            }  in
-                          ((let uu___182_19058 = p  in
+                            } in
+                          ((let uu___182_19058 = p in
                             {
                               FStar_Syntax_Syntax.v =
                                 (FStar_Syntax_Syntax.Pat_var x1);
@@ -7126,18 +6665,17 @@ and (rebuild :
                             }), (dummy :: env2))
                       | FStar_Syntax_Syntax.Pat_wild x ->
                           let x1 =
-                            let uu___183_19069 = x  in
+                            let uu___183_19069 = x in
                             let uu____19070 =
-                              norm_or_whnf env2 x.FStar_Syntax_Syntax.sort
-                               in
+                              norm_or_whnf env2 x.FStar_Syntax_Syntax.sort in
                             {
                               FStar_Syntax_Syntax.ppname =
                                 (uu___183_19069.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
                                 (uu___183_19069.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = uu____19070
-                            }  in
-                          ((let uu___184_19084 = p  in
+                            } in
+                          ((let uu___184_19084 = p in
                             {
                               FStar_Syntax_Syntax.v =
                                 (FStar_Syntax_Syntax.Pat_wild x1);
@@ -7146,26 +6684,24 @@ and (rebuild :
                             }), (dummy :: env2))
                       | FStar_Syntax_Syntax.Pat_dot_term (x,t2) ->
                           let x1 =
-                            let uu___185_19100 = x  in
+                            let uu___185_19100 = x in
                             let uu____19101 =
-                              norm_or_whnf env2 x.FStar_Syntax_Syntax.sort
-                               in
+                              norm_or_whnf env2 x.FStar_Syntax_Syntax.sort in
                             {
                               FStar_Syntax_Syntax.ppname =
                                 (uu___185_19100.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
                                 (uu___185_19100.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = uu____19101
-                            }  in
-                          let t3 = norm_or_whnf env2 t2  in
-                          ((let uu___186_19108 = p  in
+                            } in
+                          let t3 = norm_or_whnf env2 t2 in
+                          ((let uu___186_19108 = p in
                             {
                               FStar_Syntax_Syntax.v =
                                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t3));
                               FStar_Syntax_Syntax.p =
                                 (uu___186_19108.FStar_Syntax_Syntax.p)
-                            }), env2)
-                       in
+                            }), env2) in
                     let branches1 =
                       match env1 with
                       | [] when whnf -> branches
@@ -7174,11 +6710,10 @@ and (rebuild :
                             (FStar_List.map
                                (fun branch1  ->
                                   let uu____19132 =
-                                    FStar_Syntax_Subst.open_branch branch1
-                                     in
+                                    FStar_Syntax_Subst.open_branch branch1 in
                                   match uu____19132 with
                                   | (p,wopt,e) ->
-                                      let uu____19152 = norm_pat env1 p  in
+                                      let uu____19152 = norm_pat env1 p in
                                       (match uu____19152 with
                                        | (p1,env2) ->
                                            let wopt1 =
@@ -7189,21 +6724,17 @@ and (rebuild :
                                              | FStar_Pervasives_Native.Some w
                                                  ->
                                                  let uu____19177 =
-                                                   norm_or_whnf env2 w  in
+                                                   norm_or_whnf env2 w in
                                                  FStar_Pervasives_Native.Some
-                                                   uu____19177
-                                              in
-                                           let e1 = norm_or_whnf env2 e  in
+                                                   uu____19177 in
+                                           let e1 = norm_or_whnf env2 e in
                                            FStar_Syntax_Util.branch
-                                             (p1, wopt1, e1))))
-                       in
+                                             (p1, wopt1, e1)))) in
                     let uu____19183 =
                       mk
                         (FStar_Syntax_Syntax.Tm_match (scrutinee, branches1))
-                        r
-                       in
-                    rebuild cfg env1 stack1 uu____19183)
-                    in
+                        r in
+                    rebuild cfg env1 stack1 uu____19183) in
                  let rec is_cons head1 =
                    match head1.FStar_Syntax_Syntax.n with
                    | FStar_Syntax_Syntax.Tm_uinst (h,uu____19193) ->
@@ -7223,24 +6754,21 @@ and (rebuild :
                            FStar_Pervasives_Native.Some
                            (FStar_Syntax_Syntax.Record_ctor uu____19203);_}
                        -> true
-                   | uu____19210 -> false  in
+                   | uu____19210 -> false in
                  let guard_when_clause wopt b rest =
                    match wopt with
                    | FStar_Pervasives_Native.None  -> b
                    | FStar_Pervasives_Native.Some w ->
-                       let then_branch = b  in
+                       let then_branch = b in
                        let else_branch =
                          mk (FStar_Syntax_Syntax.Tm_match (scrutinee, rest))
-                           r
-                          in
+                           r in
                        FStar_Syntax_Util.if_then_else w then_branch
-                         else_branch
-                    in
+                         else_branch in
                  let rec matches_pat scrutinee_orig p =
-                   let scrutinee1 = FStar_Syntax_Util.unmeta scrutinee_orig
-                      in
+                   let scrutinee1 = FStar_Syntax_Util.unmeta scrutinee_orig in
                    let uu____19355 =
-                     FStar_Syntax_Util.head_and_args scrutinee1  in
+                     FStar_Syntax_Util.head_and_args scrutinee1 in
                    match uu____19355 with
                    | (head1,args) ->
                        (match p.FStar_Syntax_Syntax.v with
@@ -7257,41 +6785,39 @@ and (rebuild :
                                  FStar_Util.Inl []
                              | uu____19481 ->
                                  let uu____19482 =
-                                   let uu____19483 = is_cons head1  in
-                                   Prims.op_Negation uu____19483  in
+                                   let uu____19483 = is_cons head1 in
+                                   Prims.op_Negation uu____19483 in
                                  FStar_Util.Inr uu____19482)
                         | FStar_Syntax_Syntax.Pat_cons (fv,arg_pats) ->
                             let uu____19508 =
                               let uu____19509 =
-                                FStar_Syntax_Util.un_uinst head1  in
-                              uu____19509.FStar_Syntax_Syntax.n  in
+                                FStar_Syntax_Util.un_uinst head1 in
+                              uu____19509.FStar_Syntax_Syntax.n in
                             (match uu____19508 with
                              | FStar_Syntax_Syntax.Tm_fvar fv' when
                                  FStar_Syntax_Syntax.fv_eq fv fv' ->
                                  matches_args [] args arg_pats
                              | uu____19527 ->
                                  let uu____19528 =
-                                   let uu____19529 = is_cons head1  in
-                                   Prims.op_Negation uu____19529  in
+                                   let uu____19529 = is_cons head1 in
+                                   Prims.op_Negation uu____19529 in
                                  FStar_Util.Inr uu____19528))
-                 
                  and matches_args out a p =
                    match (a, p) with
                    | ([],[]) -> FStar_Util.Inl out
                    | ((t2,uu____19598)::rest_a,(p1,uu____19601)::rest_p) ->
-                       let uu____19645 = matches_pat t2 p1  in
+                       let uu____19645 = matches_pat t2 p1 in
                        (match uu____19645 with
                         | FStar_Util.Inl s ->
                             matches_args (FStar_List.append out s) rest_a
                               rest_p
                         | m -> m)
-                   | uu____19694 -> FStar_Util.Inr false
-                  in
+                   | uu____19694 -> FStar_Util.Inr false in
                  let rec matches scrutinee1 p =
                    match p with
                    | [] -> norm_and_rebuild_match ()
                    | (p1,wopt,b)::rest ->
-                       let uu____19800 = matches_pat scrutinee1 p1  in
+                       let uu____19800 = matches_pat scrutinee1 p1 in
                        (match uu____19800 with
                         | FStar_Util.Inr (false ) -> matches scrutinee1 rest
                         | FStar_Util.Inr (true ) -> norm_and_rebuild_match ()
@@ -7299,7 +6825,7 @@ and (rebuild :
                             (log cfg
                                (fun uu____19840  ->
                                   let uu____19841 =
-                                    FStar_Syntax_Print.pat_to_string p1  in
+                                    FStar_Syntax_Print.pat_to_string p1 in
                                   let uu____19842 =
                                     let uu____19843 =
                                       FStar_List.map
@@ -7307,11 +6833,9 @@ and (rebuild :
                                            match uu____19853 with
                                            | (uu____19858,t2) ->
                                                FStar_Syntax_Print.term_to_string
-                                                 t2) s
-                                       in
+                                                 t2) s in
                                     FStar_All.pipe_right uu____19843
-                                      (FStar_String.concat "; ")
-                                     in
+                                      (FStar_String.concat "; ") in
                                   FStar_Util.print2
                                     "Matches pattern %s with subst = %s\n"
                                     uu____19841 uu____19842);
@@ -7325,35 +6849,27 @@ and (rebuild :
                                              let uu____19919 =
                                                let uu____19922 =
                                                  FStar_Syntax_Syntax.mk_binder
-                                                   bv
-                                                  in
+                                                   bv in
                                                FStar_Pervasives_Native.Some
-                                                 uu____19922
-                                                in
+                                                 uu____19922 in
                                              let uu____19923 =
                                                let uu____19924 =
                                                  let uu____19955 =
                                                    FStar_Util.mk_ref
                                                      (FStar_Pervasives_Native.Some
-                                                        ([], t2))
-                                                    in
-                                                 ([], t2, uu____19955, false)
-                                                  in
-                                               Clos uu____19924  in
-                                             (uu____19919, uu____19923)  in
-                                           uu____19912 :: env2) env1 s
-                                 in
-                              let uu____20072 = guard_when_clause wopt b rest
-                                 in
-                              norm cfg env2 stack1 uu____20072)))
-                    in
+                                                        ([], t2)) in
+                                                 ([], t2, uu____19955, false) in
+                                               Clos uu____19924 in
+                                             (uu____19919, uu____19923) in
+                                           uu____19912 :: env2) env1 s in
+                              let uu____20072 = guard_when_clause wopt b rest in
+                              norm cfg env2 stack1 uu____20072))) in
                  if Prims.op_Negation (cfg.steps).iota
                  then norm_and_rebuild_match ()
                  else matches scrutinee branches)))
-
-let (config' :
+let config':
   primitive_step Prims.list ->
-    step Prims.list -> FStar_TypeChecker_Env.env -> cfg)
+    step Prims.list -> FStar_TypeChecker_Env.env -> cfg
   =
   fun psteps  ->
     fun s  ->
@@ -7368,43 +6884,38 @@ let (config' :
                       [FStar_TypeChecker_Env.Eager_unfolding_only]
                   | Inlining  -> [FStar_TypeChecker_Env.Inlining]
                   | UnfoldTac  -> [FStar_TypeChecker_Env.UnfoldTac]
-                  | uu____20104 -> []))
-           in
+                  | uu____20104 -> [])) in
         let d1 =
           match d with
           | [] -> [FStar_TypeChecker_Env.NoDelta]
-          | uu____20110 -> d  in
-        let uu____20113 = to_fsteps s  in
+          | uu____20110 -> d in
+        let uu____20113 = to_fsteps s in
         let uu____20114 =
           let uu____20115 =
-            FStar_TypeChecker_Env.debug e (FStar_Options.Other "Norm")  in
+            FStar_TypeChecker_Env.debug e (FStar_Options.Other "Norm") in
           let uu____20116 =
-            FStar_TypeChecker_Env.debug e (FStar_Options.Other "Primops")  in
+            FStar_TypeChecker_Env.debug e (FStar_Options.Other "Primops") in
           let uu____20117 =
-            FStar_TypeChecker_Env.debug e (FStar_Options.Other "380")  in
+            FStar_TypeChecker_Env.debug e (FStar_Options.Other "380") in
           let uu____20118 =
-            FStar_TypeChecker_Env.debug e (FStar_Options.Other "NormDelayed")
-             in
+            FStar_TypeChecker_Env.debug e (FStar_Options.Other "NormDelayed") in
           let uu____20119 =
             FStar_TypeChecker_Env.debug e
-              (FStar_Options.Other "print_normalized_terms")
-             in
+              (FStar_Options.Other "print_normalized_terms") in
           {
             gen = uu____20115;
             primop = uu____20116;
             b380 = uu____20117;
             norm_delayed = uu____20118;
             print_normalized = uu____20119
-          }  in
-        let uu____20120 = add_steps built_in_primitive_steps psteps  in
+          } in
+        let uu____20120 = add_steps built_in_primitive_steps psteps in
         let uu____20123 =
           (FStar_Options.normalize_pure_terms_for_extraction ()) ||
             (let uu____20125 =
                FStar_All.pipe_right s
-                 (FStar_List.contains PureSubtermsWithinComputations)
-                in
-             Prims.op_Negation uu____20125)
-           in
+                 (FStar_List.contains PureSubtermsWithinComputations) in
+             Prims.op_Negation uu____20125) in
         {
           steps = uu____20113;
           tcenv = e;
@@ -7415,43 +6926,39 @@ let (config' :
           memoize_lazy = true;
           normalize_pure_lets = uu____20123
         }
-  
-let (config : step Prims.list -> FStar_TypeChecker_Env.env -> cfg) =
-  fun s  -> fun e  -> config' [] s e 
-let (normalize_with_primitive_steps :
+let config: step Prims.list -> FStar_TypeChecker_Env.env -> cfg =
+  fun s  -> fun e  -> config' [] s e
+let normalize_with_primitive_steps:
   primitive_step Prims.list ->
     step Prims.list ->
       FStar_TypeChecker_Env.env ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun ps  ->
-    fun s  -> fun e  -> fun t  -> let c = config' ps s e  in norm c [] [] t
-  
-let (normalize :
+    fun s  -> fun e  -> fun t  -> let c = config' ps s e in norm c [] [] t
+let normalize:
   steps ->
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  = fun s  -> fun e  -> fun t  -> normalize_with_primitive_steps [] s e t 
-let (normalize_comp :
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
+  = fun s  -> fun e  -> fun t  -> normalize_with_primitive_steps [] s e t
+let normalize_comp:
   steps ->
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
+      FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
   =
   fun s  ->
     fun e  ->
-      fun t  -> let uu____20183 = config s e  in norm_comp uu____20183 [] t
-  
-let (normalize_universe :
+      fun t  -> let uu____20183 = config s e in norm_comp uu____20183 [] t
+let normalize_universe:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe)
+    FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe
   =
   fun env  ->
     fun u  ->
-      let uu____20196 = config [] env  in norm_universe uu____20196 [] u
-  
-let (ghost_to_pure :
+      let uu____20196 = config [] env in norm_universe uu____20196 [] u
+let ghost_to_pure:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
+    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
   =
   fun env  ->
     fun c  ->
@@ -7459,15 +6966,14 @@ let (ghost_to_pure :
         config
           [UnfoldUntil FStar_Syntax_Syntax.Delta_constant;
           AllowUnboundUniverses;
-          EraseUniverses] env
-         in
+          EraseUniverses] env in
       let non_info t =
-        let uu____20214 = norm cfg [] [] t  in
-        FStar_Syntax_Util.non_informative uu____20214  in
+        let uu____20214 = norm cfg [] [] t in
+        FStar_Syntax_Util.non_informative uu____20214 in
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Total uu____20221 -> c
       | FStar_Syntax_Syntax.GTotal (t,uopt) when non_info t ->
-          let uu___187_20240 = c  in
+          let uu___187_20240 = c in
           {
             FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Total (t, uopt));
             FStar_Syntax_Syntax.pos =
@@ -7478,12 +6984,10 @@ let (ghost_to_pure :
       | FStar_Syntax_Syntax.Comp ct ->
           let l =
             FStar_TypeChecker_Env.norm_eff_name cfg.tcenv
-              ct.FStar_Syntax_Syntax.effect_name
-             in
+              ct.FStar_Syntax_Syntax.effect_name in
           let uu____20247 =
             (FStar_Syntax_Util.is_ghost_effect l) &&
-              (non_info ct.FStar_Syntax_Syntax.result_typ)
-             in
+              (non_info ct.FStar_Syntax_Syntax.result_typ) in
           if uu____20247
           then
             let ct1 =
@@ -7497,8 +7001,8 @@ let (ghost_to_pure :
                         FStar_Parser_Const.effect_Tot_lid
                     then FStar_Syntax_Syntax.TOTAL ::
                       (ct.FStar_Syntax_Syntax.flags)
-                    else ct.FStar_Syntax_Syntax.flags  in
-                  let uu___188_20256 = ct  in
+                    else ct.FStar_Syntax_Syntax.flags in
+                  let uu___188_20256 = ct in
                   {
                     FStar_Syntax_Syntax.comp_univs =
                       (uu___188_20256.FStar_Syntax_Syntax.comp_univs);
@@ -7511,9 +7015,8 @@ let (ghost_to_pure :
                   }
               | FStar_Pervasives_Native.None  ->
                   let ct1 =
-                    FStar_TypeChecker_Env.unfold_effect_abbrev cfg.tcenv c
-                     in
-                  let uu___189_20258 = ct1  in
+                    FStar_TypeChecker_Env.unfold_effect_abbrev cfg.tcenv c in
+                  let uu___189_20258 = ct1 in
                   {
                     FStar_Syntax_Syntax.comp_univs =
                       (uu___189_20258.FStar_Syntax_Syntax.comp_univs);
@@ -7525,9 +7028,8 @@ let (ghost_to_pure :
                       (uu___189_20258.FStar_Syntax_Syntax.effect_args);
                     FStar_Syntax_Syntax.flags =
                       (uu___189_20258.FStar_Syntax_Syntax.flags)
-                  }
-               in
-            let uu___190_20259 = c  in
+                  } in
+            let uu___190_20259 = c in
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
               FStar_Syntax_Syntax.pos =
@@ -7537,10 +7039,9 @@ let (ghost_to_pure :
             }
           else c
       | uu____20261 -> c
-  
-let (ghost_to_pure_lcomp :
+let ghost_to_pure_lcomp:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp)
+    FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
   =
   fun env  ->
     fun lc  ->
@@ -7549,15 +7050,13 @@ let (ghost_to_pure_lcomp :
           [Eager_unfolding;
           UnfoldUntil FStar_Syntax_Syntax.Delta_constant;
           EraseUniverses;
-          AllowUnboundUniverses] env
-         in
+          AllowUnboundUniverses] env in
       let non_info t =
-        let uu____20273 = norm cfg [] [] t  in
-        FStar_Syntax_Util.non_informative uu____20273  in
+        let uu____20273 = norm cfg [] [] t in
+        FStar_Syntax_Util.non_informative uu____20273 in
       let uu____20280 =
         (FStar_Syntax_Util.is_ghost_effect lc.FStar_Syntax_Syntax.eff_name)
-          && (non_info lc.FStar_Syntax_Syntax.res_typ)
-         in
+          && (non_info lc.FStar_Syntax_Syntax.res_typ) in
       if uu____20280
       then
         match downgrade_ghost_effect_name lc.FStar_Syntax_Syntax.eff_name
@@ -7566,13 +7065,12 @@ let (ghost_to_pure_lcomp :
             FStar_Syntax_Syntax.mk_lcomp pure_eff
               lc.FStar_Syntax_Syntax.res_typ lc.FStar_Syntax_Syntax.cflags
               (fun uu____20284  ->
-                 let uu____20285 = FStar_Syntax_Syntax.lcomp_comp lc  in
+                 let uu____20285 = FStar_Syntax_Syntax.lcomp_comp lc in
                  ghost_to_pure env uu____20285)
         | FStar_Pervasives_Native.None  -> lc
       else lc
-  
-let (term_to_string :
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.string) =
+let term_to_string:
+  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.string =
   fun env  ->
     fun t  ->
       let t1 =
@@ -7581,79 +7079,70 @@ let (term_to_string :
         | e ->
             ((let uu____20302 =
                 let uu____20307 =
-                  let uu____20308 = FStar_Util.message_of_exn e  in
+                  let uu____20308 = FStar_Util.message_of_exn e in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____20308
-                   in
-                (FStar_Errors.Warning_NormalizationFailure, uu____20307)  in
+                    uu____20308 in
+                (FStar_Errors.Warning_NormalizationFailure, uu____20307) in
               FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____20302);
-             t)
-         in
+             t) in
       FStar_Syntax_Print.term_to_string t1
-  
-let (comp_to_string :
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.comp -> Prims.string) =
+let comp_to_string:
+  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.comp -> Prims.string =
   fun env  ->
     fun c  ->
       let c1 =
         try
-          let uu____20319 = config [AllowUnboundUniverses] env  in
+          let uu____20319 = config [AllowUnboundUniverses] env in
           norm_comp uu____20319 [] c
         with
         | e ->
             ((let uu____20332 =
                 let uu____20337 =
-                  let uu____20338 = FStar_Util.message_of_exn e  in
+                  let uu____20338 = FStar_Util.message_of_exn e in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____20338
-                   in
-                (FStar_Errors.Warning_NormalizationFailure, uu____20337)  in
+                    uu____20338 in
+                (FStar_Errors.Warning_NormalizationFailure, uu____20337) in
               FStar_Errors.log_issue c.FStar_Syntax_Syntax.pos uu____20332);
-             c)
-         in
+             c) in
       FStar_Syntax_Print.comp_to_string c1
-  
-let (normalize_refinement :
+let normalize_refinement:
   steps ->
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
+      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
   =
   fun steps  ->
     fun env  ->
       fun t0  ->
-        let t = normalize (FStar_List.append steps [Beta]) env t0  in
+        let t = normalize (FStar_List.append steps [Beta]) env t0 in
         let rec aux t1 =
-          let t2 = FStar_Syntax_Subst.compress t1  in
+          let t2 = FStar_Syntax_Subst.compress t1 in
           match t2.FStar_Syntax_Syntax.n with
           | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-              let t01 = aux x.FStar_Syntax_Syntax.sort  in
+              let t01 = aux x.FStar_Syntax_Syntax.sort in
               (match t01.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_refine (y,phi1) ->
                    let uu____20375 =
                      let uu____20376 =
-                       let uu____20383 = FStar_Syntax_Util.mk_conj phi1 phi
-                          in
-                       (y, uu____20383)  in
-                     FStar_Syntax_Syntax.Tm_refine uu____20376  in
+                       let uu____20383 = FStar_Syntax_Util.mk_conj phi1 phi in
+                       (y, uu____20383) in
+                     FStar_Syntax_Syntax.Tm_refine uu____20376 in
                    mk uu____20375 t01.FStar_Syntax_Syntax.pos
                | uu____20388 -> t2)
-          | uu____20389 -> t2  in
+          | uu____20389 -> t2 in
         aux t
-  
-let (unfold_whnf :
+let unfold_whnf:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  ->
       normalize
         [Weak; HNF; UnfoldUntil FStar_Syntax_Syntax.Delta_constant; Beta] env
         t
-  
-let (reduce_or_remove_uvar_solutions :
+let reduce_or_remove_uvar_solutions:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun remove  ->
     fun env  ->
@@ -7666,30 +7155,29 @@ let (reduce_or_remove_uvar_solutions :
              Exclude Zeta;
              Exclude Iota;
              NoFullNorm]) env t
-  
-let (reduce_uvar_solutions :
+let reduce_uvar_solutions:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  = fun env  -> fun t  -> reduce_or_remove_uvar_solutions false env t 
-let (remove_uvar_solutions :
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
+  = fun env  -> fun t  -> reduce_or_remove_uvar_solutions false env t
+let remove_uvar_solutions:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  = fun env  -> fun t  -> reduce_or_remove_uvar_solutions true env t 
-let (eta_expand_with_type :
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
+  = fun env  -> fun t  -> reduce_or_remove_uvar_solutions true env t
+let eta_expand_with_type:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun e  ->
       fun t_e  ->
-        let uu____20429 = FStar_Syntax_Util.arrow_formals_comp t_e  in
+        let uu____20429 = FStar_Syntax_Util.arrow_formals_comp t_e in
         match uu____20429 with
         | (formals,c) ->
             (match formals with
              | [] -> e
              | uu____20458 ->
-                 let uu____20465 = FStar_Syntax_Util.abs_formals e  in
+                 let uu____20465 = FStar_Syntax_Util.abs_formals e in
                  (match uu____20465 with
                   | (actuals,uu____20475,uu____20476) ->
                       if
@@ -7699,22 +7187,19 @@ let (eta_expand_with_type :
                       else
                         (let uu____20490 =
                            FStar_All.pipe_right formals
-                             FStar_Syntax_Util.args_of_binders
-                            in
+                             FStar_Syntax_Util.args_of_binders in
                          match uu____20490 with
                          | (binders,args) ->
                              let uu____20507 =
                                FStar_Syntax_Syntax.mk_Tm_app e args
                                  FStar_Pervasives_Native.None
-                                 e.FStar_Syntax_Syntax.pos
-                                in
+                                 e.FStar_Syntax_Syntax.pos in
                              FStar_Syntax_Util.abs binders uu____20507
                                (FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.residual_comp_of_comp c)))))
-  
-let (eta_expand :
+let eta_expand:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  ->
@@ -7722,16 +7207,15 @@ let (eta_expand :
       | FStar_Syntax_Syntax.Tm_name x ->
           eta_expand_with_type env t x.FStar_Syntax_Syntax.sort
       | uu____20515 ->
-          let uu____20516 = FStar_Syntax_Util.head_and_args t  in
+          let uu____20516 = FStar_Syntax_Util.head_and_args t in
           (match uu____20516 with
            | (head1,args) ->
                let uu____20553 =
-                 let uu____20554 = FStar_Syntax_Subst.compress head1  in
-                 uu____20554.FStar_Syntax_Syntax.n  in
+                 let uu____20554 = FStar_Syntax_Subst.compress head1 in
+                 uu____20554.FStar_Syntax_Syntax.n in
                (match uu____20553 with
                 | FStar_Syntax_Syntax.Tm_uvar (uu____20557,thead) ->
-                    let uu____20583 = FStar_Syntax_Util.arrow_formals thead
-                       in
+                    let uu____20583 = FStar_Syntax_Util.arrow_formals thead in
                     (match uu____20583 with
                      | (formals,tres) ->
                          if
@@ -7741,7 +7225,7 @@ let (eta_expand :
                          else
                            (let uu____20625 =
                               env.FStar_TypeChecker_Env.type_of
-                                (let uu___195_20633 = env  in
+                                (let uu___195_20633 = env in
                                  {
                                    FStar_TypeChecker_Env.solver =
                                      (uu___195_20633.FStar_TypeChecker_Env.solver);
@@ -7811,15 +7295,14 @@ let (eta_expand :
                                      (uu___195_20633.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.dep_graph =
                                      (uu___195_20633.FStar_TypeChecker_Env.dep_graph)
-                                 }) t
-                               in
+                                 }) t in
                             match uu____20625 with
                             | (uu____20634,ty,uu____20636) ->
                                 eta_expand_with_type env t ty))
                 | uu____20637 ->
                     let uu____20638 =
                       env.FStar_TypeChecker_Env.type_of
-                        (let uu___196_20646 = env  in
+                        (let uu___196_20646 = env in
                          {
                            FStar_TypeChecker_Env.solver =
                              (uu___196_20646.FStar_TypeChecker_Env.solver);
@@ -7889,31 +7372,27 @@ let (eta_expand :
                              (uu___196_20646.FStar_TypeChecker_Env.dsenv);
                            FStar_TypeChecker_Env.dep_graph =
                              (uu___196_20646.FStar_TypeChecker_Env.dep_graph)
-                         }) t
-                       in
+                         }) t in
                     (match uu____20638 with
                      | (uu____20647,ty,uu____20649) ->
                          eta_expand_with_type env t ty)))
-  
-let rec (elim_delayed_subst_term :
-  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let rec elim_delayed_subst_term:
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun t  ->
     let mk1 x =
       FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-        t.FStar_Syntax_Syntax.pos
-       in
-    let t1 = FStar_Syntax_Subst.compress t  in
+        t.FStar_Syntax_Syntax.pos in
+    let t1 = FStar_Syntax_Subst.compress t in
     let elim_bv x =
-      let uu___197_20706 = x  in
-      let uu____20707 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort
-         in
+      let uu___197_20706 = x in
+      let uu____20707 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort in
       {
         FStar_Syntax_Syntax.ppname =
           (uu___197_20706.FStar_Syntax_Syntax.ppname);
         FStar_Syntax_Syntax.index =
           (uu___197_20706.FStar_Syntax_Syntax.index);
         FStar_Syntax_Syntax.sort = uu____20707
-      }  in
+      } in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_delayed uu____20710 -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_bvar uu____20735 -> t1
@@ -7925,90 +7404,88 @@ let rec (elim_delayed_subst_term :
     | FStar_Syntax_Syntax.Tm_unknown  -> t1
     | FStar_Syntax_Syntax.Tm_abs (bs,t2,rc_opt) ->
         let elim_rc rc =
-          let uu___198_20774 = rc  in
+          let uu___198_20774 = rc in
           let uu____20775 =
             FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
-              elim_delayed_subst_term
-             in
+              elim_delayed_subst_term in
           let uu____20782 =
-            elim_delayed_subst_cflags rc.FStar_Syntax_Syntax.residual_flags
-             in
+            elim_delayed_subst_cflags rc.FStar_Syntax_Syntax.residual_flags in
           {
             FStar_Syntax_Syntax.residual_effect =
               (uu___198_20774.FStar_Syntax_Syntax.residual_effect);
             FStar_Syntax_Syntax.residual_typ = uu____20775;
             FStar_Syntax_Syntax.residual_flags = uu____20782
-          }  in
+          } in
         let uu____20785 =
           let uu____20786 =
-            let uu____20803 = elim_delayed_subst_binders bs  in
-            let uu____20810 = elim_delayed_subst_term t2  in
-            let uu____20811 = FStar_Util.map_opt rc_opt elim_rc  in
-            (uu____20803, uu____20810, uu____20811)  in
-          FStar_Syntax_Syntax.Tm_abs uu____20786  in
+            let uu____20803 = elim_delayed_subst_binders bs in
+            let uu____20810 = elim_delayed_subst_term t2 in
+            let uu____20811 = FStar_Util.map_opt rc_opt elim_rc in
+            (uu____20803, uu____20810, uu____20811) in
+          FStar_Syntax_Syntax.Tm_abs uu____20786 in
         mk1 uu____20785
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
         let uu____20840 =
           let uu____20841 =
-            let uu____20854 = elim_delayed_subst_binders bs  in
-            let uu____20861 = elim_delayed_subst_comp c  in
-            (uu____20854, uu____20861)  in
-          FStar_Syntax_Syntax.Tm_arrow uu____20841  in
+            let uu____20854 = elim_delayed_subst_binders bs in
+            let uu____20861 = elim_delayed_subst_comp c in
+            (uu____20854, uu____20861) in
+          FStar_Syntax_Syntax.Tm_arrow uu____20841 in
         mk1 uu____20840
     | FStar_Syntax_Syntax.Tm_refine (bv,phi) ->
         let uu____20874 =
           let uu____20875 =
-            let uu____20882 = elim_bv bv  in
-            let uu____20883 = elim_delayed_subst_term phi  in
-            (uu____20882, uu____20883)  in
-          FStar_Syntax_Syntax.Tm_refine uu____20875  in
+            let uu____20882 = elim_bv bv in
+            let uu____20883 = elim_delayed_subst_term phi in
+            (uu____20882, uu____20883) in
+          FStar_Syntax_Syntax.Tm_refine uu____20875 in
         mk1 uu____20874
     | FStar_Syntax_Syntax.Tm_app (t2,args) ->
         let uu____20906 =
           let uu____20907 =
-            let uu____20922 = elim_delayed_subst_term t2  in
-            let uu____20923 = elim_delayed_subst_args args  in
-            (uu____20922, uu____20923)  in
-          FStar_Syntax_Syntax.Tm_app uu____20907  in
+            let uu____20922 = elim_delayed_subst_term t2 in
+            let uu____20923 = elim_delayed_subst_args args in
+            (uu____20922, uu____20923) in
+          FStar_Syntax_Syntax.Tm_app uu____20907 in
         mk1 uu____20906
     | FStar_Syntax_Syntax.Tm_match (t2,branches) ->
         let rec elim_pat p =
           match p.FStar_Syntax_Syntax.v with
           | FStar_Syntax_Syntax.Pat_var x ->
-              let uu___199_20987 = p  in
+              let uu___199_20987 = p in
               let uu____20988 =
-                let uu____20989 = elim_bv x  in
-                FStar_Syntax_Syntax.Pat_var uu____20989  in
+                let uu____20989 = elim_bv x in
+                FStar_Syntax_Syntax.Pat_var uu____20989 in
               {
                 FStar_Syntax_Syntax.v = uu____20988;
                 FStar_Syntax_Syntax.p =
                   (uu___199_20987.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_wild x ->
-              let uu___200_20991 = p  in
+              let uu___200_20991 = p in
               let uu____20992 =
-                let uu____20993 = elim_bv x  in
-                FStar_Syntax_Syntax.Pat_wild uu____20993  in
+                let uu____20993 = elim_bv x in
+                FStar_Syntax_Syntax.Pat_wild uu____20993 in
               {
                 FStar_Syntax_Syntax.v = uu____20992;
                 FStar_Syntax_Syntax.p =
                   (uu___200_20991.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
-              let uu___201_21000 = p  in
+              let uu___201_21000 = p in
               let uu____21001 =
                 let uu____21002 =
-                  let uu____21009 = elim_bv x  in
-                  let uu____21010 = elim_delayed_subst_term t0  in
-                  (uu____21009, uu____21010)  in
-                FStar_Syntax_Syntax.Pat_dot_term uu____21002  in
+                  let uu____21009 = elim_bv x in
+                  let uu____21010 = elim_delayed_subst_term t0 in
+                  (uu____21009, uu____21010) in
+                FStar_Syntax_Syntax.Pat_dot_term uu____21002 in
               {
                 FStar_Syntax_Syntax.v = uu____21001;
                 FStar_Syntax_Syntax.p =
                   (uu___201_21000.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-              let uu___202_21029 = p  in
+              let uu___202_21029 = p in
               let uu____21030 =
                 let uu____21031 =
                   let uu____21044 =
@@ -8016,32 +7493,30 @@ let rec (elim_delayed_subst_term :
                       (fun uu____21067  ->
                          match uu____21067 with
                          | (x,b) ->
-                             let uu____21080 = elim_pat x  in
-                             (uu____21080, b)) pats
-                     in
-                  (fv, uu____21044)  in
-                FStar_Syntax_Syntax.Pat_cons uu____21031  in
+                             let uu____21080 = elim_pat x in (uu____21080, b))
+                      pats in
+                  (fv, uu____21044) in
+                FStar_Syntax_Syntax.Pat_cons uu____21031 in
               {
                 FStar_Syntax_Syntax.v = uu____21030;
                 FStar_Syntax_Syntax.p =
                   (uu___202_21029.FStar_Syntax_Syntax.p)
               }
-          | uu____21093 -> p  in
+          | uu____21093 -> p in
         let elim_branch uu____21115 =
           match uu____21115 with
           | (pat,wopt,t3) ->
-              let uu____21141 = elim_pat pat  in
+              let uu____21141 = elim_pat pat in
               let uu____21144 =
-                FStar_Util.map_opt wopt elim_delayed_subst_term  in
-              let uu____21147 = elim_delayed_subst_term t3  in
-              (uu____21141, uu____21144, uu____21147)
-           in
+                FStar_Util.map_opt wopt elim_delayed_subst_term in
+              let uu____21147 = elim_delayed_subst_term t3 in
+              (uu____21141, uu____21144, uu____21147) in
         let uu____21152 =
           let uu____21153 =
-            let uu____21176 = elim_delayed_subst_term t2  in
-            let uu____21177 = FStar_List.map elim_branch branches  in
-            (uu____21176, uu____21177)  in
-          FStar_Syntax_Syntax.Tm_match uu____21153  in
+            let uu____21176 = elim_delayed_subst_term t2 in
+            let uu____21177 = FStar_List.map elim_branch branches in
+            (uu____21176, uu____21177) in
+          FStar_Syntax_Syntax.Tm_match uu____21153 in
         mk1 uu____21152
     | FStar_Syntax_Syntax.Tm_ascribed (t2,a,lopt) ->
         let elim_ascription uu____21286 =
@@ -8050,30 +7525,28 @@ let rec (elim_delayed_subst_term :
               let uu____21321 =
                 match tc with
                 | FStar_Util.Inl t3 ->
-                    let uu____21331 = elim_delayed_subst_term t3  in
+                    let uu____21331 = elim_delayed_subst_term t3 in
                     FStar_Util.Inl uu____21331
                 | FStar_Util.Inr c ->
-                    let uu____21333 = elim_delayed_subst_comp c  in
-                    FStar_Util.Inr uu____21333
-                 in
+                    let uu____21333 = elim_delayed_subst_comp c in
+                    FStar_Util.Inr uu____21333 in
               let uu____21334 =
-                FStar_Util.map_opt topt elim_delayed_subst_term  in
-              (uu____21321, uu____21334)
-           in
+                FStar_Util.map_opt topt elim_delayed_subst_term in
+              (uu____21321, uu____21334) in
         let uu____21343 =
           let uu____21344 =
-            let uu____21371 = elim_delayed_subst_term t2  in
-            let uu____21372 = elim_ascription a  in
-            (uu____21371, uu____21372, lopt)  in
-          FStar_Syntax_Syntax.Tm_ascribed uu____21344  in
+            let uu____21371 = elim_delayed_subst_term t2 in
+            let uu____21372 = elim_ascription a in
+            (uu____21371, uu____21372, lopt) in
+          FStar_Syntax_Syntax.Tm_ascribed uu____21344 in
         mk1 uu____21343
     | FStar_Syntax_Syntax.Tm_let (lbs,t2) ->
         let elim_lb lb =
-          let uu___203_21417 = lb  in
+          let uu___203_21417 = lb in
           let uu____21418 =
-            elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbtyp  in
+            elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbtyp in
           let uu____21421 =
-            elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbdef  in
+            elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbdef in
           {
             FStar_Syntax_Syntax.lbname =
               (uu___203_21417.FStar_Syntax_Syntax.lbname);
@@ -8085,77 +7558,73 @@ let rec (elim_delayed_subst_term :
             FStar_Syntax_Syntax.lbdef = uu____21421;
             FStar_Syntax_Syntax.lbattrs =
               (uu___203_21417.FStar_Syntax_Syntax.lbattrs)
-          }  in
+          } in
         let uu____21424 =
           let uu____21425 =
             let uu____21438 =
               let uu____21445 =
-                FStar_List.map elim_lb (FStar_Pervasives_Native.snd lbs)  in
-              ((FStar_Pervasives_Native.fst lbs), uu____21445)  in
-            let uu____21454 = elim_delayed_subst_term t2  in
-            (uu____21438, uu____21454)  in
-          FStar_Syntax_Syntax.Tm_let uu____21425  in
+                FStar_List.map elim_lb (FStar_Pervasives_Native.snd lbs) in
+              ((FStar_Pervasives_Native.fst lbs), uu____21445) in
+            let uu____21454 = elim_delayed_subst_term t2 in
+            (uu____21438, uu____21454) in
+          FStar_Syntax_Syntax.Tm_let uu____21425 in
         mk1 uu____21424
     | FStar_Syntax_Syntax.Tm_uvar (uv,t2) ->
         let uu____21487 =
           let uu____21488 =
-            let uu____21505 = elim_delayed_subst_term t2  in
-            (uv, uu____21505)  in
-          FStar_Syntax_Syntax.Tm_uvar uu____21488  in
+            let uu____21505 = elim_delayed_subst_term t2 in (uv, uu____21505) in
+          FStar_Syntax_Syntax.Tm_uvar uu____21488 in
         mk1 uu____21487
     | FStar_Syntax_Syntax.Tm_meta (t2,md) ->
         let uu____21522 =
           let uu____21523 =
-            let uu____21530 = elim_delayed_subst_term t2  in
-            let uu____21531 = elim_delayed_subst_meta md  in
-            (uu____21530, uu____21531)  in
-          FStar_Syntax_Syntax.Tm_meta uu____21523  in
+            let uu____21530 = elim_delayed_subst_term t2 in
+            let uu____21531 = elim_delayed_subst_meta md in
+            (uu____21530, uu____21531) in
+          FStar_Syntax_Syntax.Tm_meta uu____21523 in
         mk1 uu____21522
-
-and (elim_delayed_subst_cflags :
+and elim_delayed_subst_cflags:
   FStar_Syntax_Syntax.cflags Prims.list ->
-    FStar_Syntax_Syntax.cflags Prims.list)
+    FStar_Syntax_Syntax.cflags Prims.list
   =
   fun flags1  ->
     FStar_List.map
       (fun uu___91_21538  ->
          match uu___91_21538 with
          | FStar_Syntax_Syntax.DECREASES t ->
-             let uu____21542 = elim_delayed_subst_term t  in
+             let uu____21542 = elim_delayed_subst_term t in
              FStar_Syntax_Syntax.DECREASES uu____21542
          | f -> f) flags1
-
-and (elim_delayed_subst_comp :
-  FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp) =
+and elim_delayed_subst_comp:
+  FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp =
   fun c  ->
     let mk1 x =
       FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-        c.FStar_Syntax_Syntax.pos
-       in
+        c.FStar_Syntax_Syntax.pos in
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total (t,uopt) ->
         let uu____21563 =
           let uu____21564 =
-            let uu____21573 = elim_delayed_subst_term t  in
-            (uu____21573, uopt)  in
-          FStar_Syntax_Syntax.Total uu____21564  in
+            let uu____21573 = elim_delayed_subst_term t in
+            (uu____21573, uopt) in
+          FStar_Syntax_Syntax.Total uu____21564 in
         mk1 uu____21563
     | FStar_Syntax_Syntax.GTotal (t,uopt) ->
         let uu____21586 =
           let uu____21587 =
-            let uu____21596 = elim_delayed_subst_term t  in
-            (uu____21596, uopt)  in
-          FStar_Syntax_Syntax.GTotal uu____21587  in
+            let uu____21596 = elim_delayed_subst_term t in
+            (uu____21596, uopt) in
+          FStar_Syntax_Syntax.GTotal uu____21587 in
         mk1 uu____21586
     | FStar_Syntax_Syntax.Comp ct ->
         let ct1 =
-          let uu___204_21601 = ct  in
+          let uu___204_21601 = ct in
           let uu____21602 =
-            elim_delayed_subst_term ct.FStar_Syntax_Syntax.result_typ  in
+            elim_delayed_subst_term ct.FStar_Syntax_Syntax.result_typ in
           let uu____21605 =
-            elim_delayed_subst_args ct.FStar_Syntax_Syntax.effect_args  in
+            elim_delayed_subst_args ct.FStar_Syntax_Syntax.effect_args in
           let uu____21614 =
-            elim_delayed_subst_cflags ct.FStar_Syntax_Syntax.flags  in
+            elim_delayed_subst_cflags ct.FStar_Syntax_Syntax.flags in
           {
             FStar_Syntax_Syntax.comp_univs =
               (uu___204_21601.FStar_Syntax_Syntax.comp_univs);
@@ -8164,52 +7633,47 @@ and (elim_delayed_subst_comp :
             FStar_Syntax_Syntax.result_typ = uu____21602;
             FStar_Syntax_Syntax.effect_args = uu____21605;
             FStar_Syntax_Syntax.flags = uu____21614
-          }  in
+          } in
         mk1 (FStar_Syntax_Syntax.Comp ct1)
-
-and (elim_delayed_subst_meta :
-  FStar_Syntax_Syntax.metadata -> FStar_Syntax_Syntax.metadata) =
+and elim_delayed_subst_meta:
+  FStar_Syntax_Syntax.metadata -> FStar_Syntax_Syntax.metadata =
   fun uu___92_21617  ->
     match uu___92_21617 with
     | FStar_Syntax_Syntax.Meta_pattern args ->
-        let uu____21629 = FStar_List.map elim_delayed_subst_args args  in
+        let uu____21629 = FStar_List.map elim_delayed_subst_args args in
         FStar_Syntax_Syntax.Meta_pattern uu____21629
     | FStar_Syntax_Syntax.Meta_monadic (m,t) ->
         let uu____21662 =
-          let uu____21669 = elim_delayed_subst_term t  in (m, uu____21669)
-           in
+          let uu____21669 = elim_delayed_subst_term t in (m, uu____21669) in
         FStar_Syntax_Syntax.Meta_monadic uu____21662
     | FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,t) ->
         let uu____21677 =
-          let uu____21686 = elim_delayed_subst_term t  in
-          (m1, m2, uu____21686)  in
+          let uu____21686 = elim_delayed_subst_term t in
+          (m1, m2, uu____21686) in
         FStar_Syntax_Syntax.Meta_monadic_lift uu____21677
     | FStar_Syntax_Syntax.Meta_alien (d,s,t) ->
         let uu____21694 =
-          let uu____21703 = elim_delayed_subst_term t  in (d, s, uu____21703)
-           in
+          let uu____21703 = elim_delayed_subst_term t in (d, s, uu____21703) in
         FStar_Syntax_Syntax.Meta_alien uu____21694
     | m -> m
-
-and (elim_delayed_subst_args :
+and elim_delayed_subst_args:
   (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
     FStar_Pervasives_Native.tuple2 Prims.list ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun args  ->
     FStar_List.map
       (fun uu____21726  ->
          match uu____21726 with
          | (t,q) ->
-             let uu____21737 = elim_delayed_subst_term t  in (uu____21737, q))
+             let uu____21737 = elim_delayed_subst_term t in (uu____21737, q))
       args
-
-and (elim_delayed_subst_binders :
+and elim_delayed_subst_binders:
   (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
     FStar_Pervasives_Native.tuple2 Prims.list ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun bs  ->
     FStar_List.map
@@ -8217,19 +7681,18 @@ and (elim_delayed_subst_binders :
          match uu____21757 with
          | (x,q) ->
              let uu____21768 =
-               let uu___205_21769 = x  in
+               let uu___205_21769 = x in
                let uu____21770 =
-                 elim_delayed_subst_term x.FStar_Syntax_Syntax.sort  in
+                 elim_delayed_subst_term x.FStar_Syntax_Syntax.sort in
                {
                  FStar_Syntax_Syntax.ppname =
                    (uu___205_21769.FStar_Syntax_Syntax.ppname);
                  FStar_Syntax_Syntax.index =
                    (uu___205_21769.FStar_Syntax_Syntax.index);
                  FStar_Syntax_Syntax.sort = uu____21770
-               }  in
+               } in
              (uu____21768, q)) bs
-
-let (elim_uvars_aux_tc :
+let elim_uvars_aux_tc:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.univ_names ->
       FStar_Syntax_Syntax.binders ->
@@ -8241,7 +7704,7 @@ let (elim_uvars_aux_tc :
                                                          FStar_Syntax_Syntax.comp'
                                                            FStar_Syntax_Syntax.syntax)
                                                          FStar_Util.either)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun univ_names  ->
@@ -8260,29 +7723,27 @@ let (elim_uvars_aux_tc :
                 let uu____21858 =
                   let uu____21861 =
                     let uu____21862 =
-                      let uu____21875 = FStar_Syntax_Syntax.mk_Total t  in
-                      (binders, uu____21875)  in
-                    FStar_Syntax_Syntax.Tm_arrow uu____21862  in
-                  FStar_Syntax_Syntax.mk uu____21861  in
+                      let uu____21875 = FStar_Syntax_Syntax.mk_Total t in
+                      (binders, uu____21875) in
+                    FStar_Syntax_Syntax.Tm_arrow uu____21862 in
+                  FStar_Syntax_Syntax.mk uu____21861 in
                 uu____21858 FStar_Pervasives_Native.None
-                  t.FStar_Syntax_Syntax.pos
-             in
-          let uu____21879 = FStar_Syntax_Subst.open_univ_vars univ_names t
-             in
+                  t.FStar_Syntax_Syntax.pos in
+          let uu____21879 = FStar_Syntax_Subst.open_univ_vars univ_names t in
           match uu____21879 with
           | (univ_names1,t1) ->
-              let t2 = remove_uvar_solutions env t1  in
-              let t3 = FStar_Syntax_Subst.close_univ_vars univ_names1 t2  in
-              let t4 = elim_delayed_subst_term t3  in
+              let t2 = remove_uvar_solutions env t1 in
+              let t3 = FStar_Syntax_Subst.close_univ_vars univ_names1 t2 in
+              let t4 = elim_delayed_subst_term t3 in
               let uu____21907 =
                 match binders with
                 | [] -> ([], (FStar_Util.Inl t4))
                 | uu____21962 ->
                     let uu____21963 =
                       let uu____21972 =
-                        let uu____21973 = FStar_Syntax_Subst.compress t4  in
-                        uu____21973.FStar_Syntax_Syntax.n  in
-                      (uu____21972, tc)  in
+                        let uu____21973 = FStar_Syntax_Subst.compress t4 in
+                        uu____21973.FStar_Syntax_Syntax.n in
+                      (uu____21972, tc) in
                     (match uu____21963 with
                      | (FStar_Syntax_Syntax.Tm_arrow
                         (binders1,c),FStar_Util.Inr uu____21998) ->
@@ -8293,12 +7754,10 @@ let (elim_uvars_aux_tc :
                            (FStar_Util.Inl (FStar_Syntax_Util.comp_result c)))
                      | (uu____22074,FStar_Util.Inl uu____22075) ->
                          ([], (FStar_Util.Inl t4))
-                     | uu____22098 -> failwith "Impossible")
-                 in
+                     | uu____22098 -> failwith "Impossible") in
               (match uu____21907 with
                | (binders1,tc1) -> (univ_names1, binders1, tc1))
-  
-let (elim_uvars_aux_t :
+let elim_uvars_aux_t:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.univ_names ->
       FStar_Syntax_Syntax.binders ->
@@ -8306,20 +7765,19 @@ let (elim_uvars_aux_t :
           (FStar_Syntax_Syntax.univ_names,(FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
                                             FStar_Pervasives_Native.tuple2
                                             Prims.list,FStar_Syntax_Syntax.term)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun univ_names  ->
       fun binders  ->
         fun t  ->
           let uu____22203 =
-            elim_uvars_aux_tc env univ_names binders (FStar_Util.Inl t)  in
+            elim_uvars_aux_tc env univ_names binders (FStar_Util.Inl t) in
           match uu____22203 with
           | (univ_names1,binders1,tc) ->
-              let uu____22261 = FStar_Util.left tc  in
+              let uu____22261 = FStar_Util.left tc in
               (univ_names1, binders1, uu____22261)
-  
-let (elim_uvars_aux_c :
+let elim_uvars_aux_c:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.univ_names ->
       FStar_Syntax_Syntax.binders ->
@@ -8328,32 +7786,31 @@ let (elim_uvars_aux_c :
                                             FStar_Pervasives_Native.tuple2
                                             Prims.list,FStar_Syntax_Syntax.comp'
                                                          FStar_Syntax_Syntax.syntax)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun univ_names  ->
       fun binders  ->
         fun c  ->
           let uu____22296 =
-            elim_uvars_aux_tc env univ_names binders (FStar_Util.Inr c)  in
+            elim_uvars_aux_tc env univ_names binders (FStar_Util.Inr c) in
           match uu____22296 with
           | (univ_names1,binders1,tc) ->
-              let uu____22356 = FStar_Util.right tc  in
+              let uu____22356 = FStar_Util.right tc in
               (univ_names1, binders1, uu____22356)
-  
-let rec (elim_uvars :
+let rec elim_uvars:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt)
+    FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt
   =
   fun env  ->
     fun s  ->
       match s.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_inductive_typ
           (lid,univ_names,binders,typ,lids,lids') ->
-          let uu____22389 = elim_uvars_aux_t env univ_names binders typ  in
+          let uu____22389 = elim_uvars_aux_t env univ_names binders typ in
           (match uu____22389 with
            | (univ_names1,binders1,typ1) ->
-               let uu___206_22417 = s  in
+               let uu___206_22417 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_inductive_typ
@@ -8368,12 +7825,12 @@ let rec (elim_uvars :
                    (uu___206_22417.FStar_Syntax_Syntax.sigattrs)
                })
       | FStar_Syntax_Syntax.Sig_bundle (sigs,lids) ->
-          let uu___207_22438 = s  in
+          let uu___207_22438 = s in
           let uu____22439 =
             let uu____22440 =
-              let uu____22449 = FStar_List.map (elim_uvars env) sigs  in
-              (uu____22449, lids)  in
-            FStar_Syntax_Syntax.Sig_bundle uu____22440  in
+              let uu____22449 = FStar_List.map (elim_uvars env) sigs in
+              (uu____22449, lids) in
+            FStar_Syntax_Syntax.Sig_bundle uu____22440 in
           {
             FStar_Syntax_Syntax.sigel = uu____22439;
             FStar_Syntax_Syntax.sigrng =
@@ -8386,10 +7843,10 @@ let rec (elim_uvars :
               (uu___207_22438.FStar_Syntax_Syntax.sigattrs)
           }
       | FStar_Syntax_Syntax.Sig_datacon (lid,univ_names,typ,lident,i,lids) ->
-          let uu____22466 = elim_uvars_aux_t env univ_names [] typ  in
+          let uu____22466 = elim_uvars_aux_t env univ_names [] typ in
           (match uu____22466 with
            | (univ_names1,uu____22484,typ1) ->
-               let uu___208_22498 = s  in
+               let uu___208_22498 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_datacon
@@ -8404,10 +7861,10 @@ let rec (elim_uvars :
                    (uu___208_22498.FStar_Syntax_Syntax.sigattrs)
                })
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,univ_names,typ) ->
-          let uu____22504 = elim_uvars_aux_t env univ_names [] typ  in
+          let uu____22504 = elim_uvars_aux_t env univ_names [] typ in
           (match uu____22504 with
            | (univ_names1,uu____22522,typ1) ->
-               let uu___209_22536 = s  in
+               let uu___209_22536 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_declare_typ
@@ -8428,23 +7885,21 @@ let rec (elim_uvars :
                  (fun lb  ->
                     let uu____22570 =
                       FStar_Syntax_Subst.univ_var_opening
-                        lb.FStar_Syntax_Syntax.lbunivs
-                       in
+                        lb.FStar_Syntax_Syntax.lbunivs in
                     match uu____22570 with
                     | (opening,lbunivs) ->
                         let elim t =
                           let uu____22593 =
                             let uu____22594 =
                               let uu____22595 =
-                                FStar_Syntax_Subst.subst opening t  in
-                              remove_uvar_solutions env uu____22595  in
+                                FStar_Syntax_Subst.subst opening t in
+                              remove_uvar_solutions env uu____22595 in
                             FStar_Syntax_Subst.close_univ_vars lbunivs
-                              uu____22594
-                             in
-                          elim_delayed_subst_term uu____22593  in
-                        let lbtyp = elim lb.FStar_Syntax_Syntax.lbtyp  in
-                        let lbdef = elim lb.FStar_Syntax_Syntax.lbdef  in
-                        let uu___210_22598 = lb  in
+                              uu____22594 in
+                          elim_delayed_subst_term uu____22593 in
+                        let lbtyp = elim lb.FStar_Syntax_Syntax.lbtyp in
+                        let lbdef = elim lb.FStar_Syntax_Syntax.lbdef in
+                        let uu___210_22598 = lb in
                         {
                           FStar_Syntax_Syntax.lbname =
                             (uu___210_22598.FStar_Syntax_Syntax.lbname);
@@ -8455,9 +7910,8 @@ let rec (elim_uvars :
                           FStar_Syntax_Syntax.lbdef = lbdef;
                           FStar_Syntax_Syntax.lbattrs =
                             (uu___210_22598.FStar_Syntax_Syntax.lbattrs)
-                        }))
-             in
-          let uu___211_22599 = s  in
+                        })) in
+          let uu___211_22599 = s in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_let ((b, lbs1), lids));
@@ -8471,10 +7925,10 @@ let rec (elim_uvars :
               (uu___211_22599.FStar_Syntax_Syntax.sigattrs)
           }
       | FStar_Syntax_Syntax.Sig_main t ->
-          let uu___212_22611 = s  in
+          let uu___212_22611 = s in
           let uu____22612 =
-            let uu____22613 = remove_uvar_solutions env t  in
-            FStar_Syntax_Syntax.Sig_main uu____22613  in
+            let uu____22613 = remove_uvar_solutions env t in
+            FStar_Syntax_Syntax.Sig_main uu____22613 in
           {
             FStar_Syntax_Syntax.sigel = uu____22612;
             FStar_Syntax_Syntax.sigrng =
@@ -8487,10 +7941,10 @@ let rec (elim_uvars :
               (uu___212_22611.FStar_Syntax_Syntax.sigattrs)
           }
       | FStar_Syntax_Syntax.Sig_assume (l,us,t) ->
-          let uu____22617 = elim_uvars_aux_t env us [] t  in
+          let uu____22617 = elim_uvars_aux_t env us [] t in
           (match uu____22617 with
            | (us1,uu____22635,t1) ->
-               let uu___213_22649 = s  in
+               let uu___213_22649 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_assume (l, us1, t1));
@@ -8508,53 +7962,47 @@ let rec (elim_uvars :
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
           let uu____22652 =
             elim_uvars_aux_t env ed.FStar_Syntax_Syntax.univs
-              ed.FStar_Syntax_Syntax.binders ed.FStar_Syntax_Syntax.signature
-             in
+              ed.FStar_Syntax_Syntax.binders ed.FStar_Syntax_Syntax.signature in
           (match uu____22652 with
            | (univs1,binders,signature) ->
                let uu____22680 =
-                 let uu____22689 = FStar_Syntax_Subst.univ_var_opening univs1
-                    in
+                 let uu____22689 = FStar_Syntax_Subst.univ_var_opening univs1 in
                  match uu____22689 with
                  | (univs_opening,univs2) ->
                      let uu____22716 =
-                       FStar_Syntax_Subst.univ_var_closing univs2  in
-                     (univs_opening, uu____22716)
-                  in
+                       FStar_Syntax_Subst.univ_var_closing univs2 in
+                     (univs_opening, uu____22716) in
                (match uu____22680 with
                 | (univs_opening,univs_closing) ->
                     let uu____22733 =
-                      let binders1 = FStar_Syntax_Subst.open_binders binders
-                         in
+                      let binders1 = FStar_Syntax_Subst.open_binders binders in
                       let uu____22739 =
-                        FStar_Syntax_Subst.opening_of_binders binders1  in
+                        FStar_Syntax_Subst.opening_of_binders binders1 in
                       let uu____22740 =
-                        FStar_Syntax_Subst.closing_of_binders binders1  in
-                      (uu____22739, uu____22740)  in
+                        FStar_Syntax_Subst.closing_of_binders binders1 in
+                      (uu____22739, uu____22740) in
                     (match uu____22733 with
                      | (b_opening,b_closing) ->
-                         let n1 = FStar_List.length univs1  in
-                         let n_binders = FStar_List.length binders  in
+                         let n1 = FStar_List.length univs1 in
+                         let n_binders = FStar_List.length binders in
                          let elim_tscheme uu____22762 =
                            match uu____22762 with
                            | (us,t) ->
-                               let n_us = FStar_List.length us  in
+                               let n_us = FStar_List.length us in
                                let uu____22780 =
-                                 FStar_Syntax_Subst.open_univ_vars us t  in
+                                 FStar_Syntax_Subst.open_univ_vars us t in
                                (match uu____22780 with
                                 | (us1,t1) ->
                                     let uu____22791 =
                                       let uu____22796 =
                                         FStar_All.pipe_right b_opening
                                           (FStar_Syntax_Subst.shift_subst
-                                             n_us)
-                                         in
+                                             n_us) in
                                       let uu____22803 =
                                         FStar_All.pipe_right b_closing
                                           (FStar_Syntax_Subst.shift_subst
-                                             n_us)
-                                         in
-                                      (uu____22796, uu____22803)  in
+                                             n_us) in
+                                      (uu____22796, uu____22803) in
                                     (match uu____22791 with
                                      | (b_opening1,b_closing1) ->
                                          let uu____22816 =
@@ -8562,29 +8010,24 @@ let rec (elim_uvars :
                                              FStar_All.pipe_right
                                                univs_opening
                                                (FStar_Syntax_Subst.shift_subst
-                                                  n_us)
-                                              in
+                                                  n_us) in
                                            let uu____22830 =
                                              FStar_All.pipe_right
                                                univs_closing
                                                (FStar_Syntax_Subst.shift_subst
-                                                  n_us)
-                                              in
-                                           (uu____22821, uu____22830)  in
+                                                  n_us) in
+                                           (uu____22821, uu____22830) in
                                          (match uu____22816 with
                                           | (univs_opening1,univs_closing1)
                                               ->
                                               let t2 =
                                                 let uu____22846 =
                                                   FStar_Syntax_Subst.subst
-                                                    b_opening1 t1
-                                                   in
+                                                    b_opening1 t1 in
                                                 FStar_Syntax_Subst.subst
-                                                  univs_opening1 uu____22846
-                                                 in
+                                                  univs_opening1 uu____22846 in
                                               let uu____22847 =
-                                                elim_uvars_aux_t env [] [] t2
-                                                 in
+                                                elim_uvars_aux_t env [] [] t2 in
                                               (match uu____22847 with
                                                | (uu____22868,uu____22869,t3)
                                                    ->
@@ -8592,23 +8035,19 @@ let rec (elim_uvars :
                                                      let uu____22884 =
                                                        let uu____22885 =
                                                          FStar_Syntax_Subst.close_univ_vars
-                                                           us1 t3
-                                                          in
+                                                           us1 t3 in
                                                        FStar_Syntax_Subst.subst
                                                          b_closing1
-                                                         uu____22885
-                                                        in
+                                                         uu____22885 in
                                                      FStar_Syntax_Subst.subst
                                                        univs_closing1
-                                                       uu____22884
-                                                      in
-                                                   (us1, t4)))))
-                            in
+                                                       uu____22884 in
+                                                   (us1, t4))))) in
                          let elim_term t =
                            let uu____22890 =
-                             elim_uvars_aux_t env univs1 binders t  in
+                             elim_uvars_aux_t env univs1 binders t in
                            match uu____22890 with
-                           | (uu____22903,uu____22904,t1) -> t1  in
+                           | (uu____22903,uu____22904,t1) -> t1 in
                          let elim_action a =
                            let action_typ_templ =
                              let body =
@@ -8620,8 +8059,7 @@ let rec (elim_uvars :
                                         FStar_Pervasives_Native.None),
                                       FStar_Pervasives_Native.None))
                                  FStar_Pervasives_Native.None
-                                 (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
-                                in
+                                 (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                              match a.FStar_Syntax_Syntax.action_params with
                              | [] -> body
                              | uu____22964 ->
@@ -8630,50 +8068,45 @@ let rec (elim_uvars :
                                       ((a.FStar_Syntax_Syntax.action_params),
                                         body, FStar_Pervasives_Native.None))
                                    FStar_Pervasives_Native.None
-                                   (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
-                              in
+                                   (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                            let destruct_action_body body =
                              let uu____22981 =
                                let uu____22982 =
-                                 FStar_Syntax_Subst.compress body  in
-                               uu____22982.FStar_Syntax_Syntax.n  in
+                                 FStar_Syntax_Subst.compress body in
+                               uu____22982.FStar_Syntax_Syntax.n in
                              match uu____22981 with
                              | FStar_Syntax_Syntax.Tm_ascribed
                                  (defn,(FStar_Util.Inl
                                         typ,FStar_Pervasives_Native.None ),FStar_Pervasives_Native.None
                                   )
                                  -> (defn, typ)
-                             | uu____23041 -> failwith "Impossible"  in
+                             | uu____23041 -> failwith "Impossible" in
                            let destruct_action_typ_templ t =
                              let uu____23070 =
                                let uu____23071 =
-                                 FStar_Syntax_Subst.compress t  in
-                               uu____23071.FStar_Syntax_Syntax.n  in
+                                 FStar_Syntax_Subst.compress t in
+                               uu____23071.FStar_Syntax_Syntax.n in
                              match uu____23070 with
                              | FStar_Syntax_Syntax.Tm_abs
                                  (pars,body,uu____23092) ->
-                                 let uu____23113 = destruct_action_body body
-                                    in
+                                 let uu____23113 = destruct_action_body body in
                                  (match uu____23113 with
                                   | (defn,typ) -> (pars, defn, typ))
                              | uu____23158 ->
-                                 let uu____23159 = destruct_action_body t  in
+                                 let uu____23159 = destruct_action_body t in
                                  (match uu____23159 with
-                                  | (defn,typ) -> ([], defn, typ))
-                              in
+                                  | (defn,typ) -> ([], defn, typ)) in
                            let uu____23208 =
                              elim_tscheme
                                ((a.FStar_Syntax_Syntax.action_univs),
-                                 action_typ_templ)
-                              in
+                                 action_typ_templ) in
                            match uu____23208 with
                            | (action_univs,t) ->
-                               let uu____23217 = destruct_action_typ_templ t
-                                  in
+                               let uu____23217 = destruct_action_typ_templ t in
                                (match uu____23217 with
                                 | (action_params,action_defn,action_typ) ->
                                     let a' =
-                                      let uu___214_23258 = a  in
+                                      let uu___214_23258 = a in
                                       {
                                         FStar_Syntax_Syntax.action_name =
                                           (uu___214_23258.FStar_Syntax_Syntax.action_name);
@@ -8688,44 +8121,39 @@ let rec (elim_uvars :
                                           action_defn;
                                         FStar_Syntax_Syntax.action_typ =
                                           action_typ
-                                      }  in
-                                    a')
-                            in
+                                      } in
+                                    a') in
                          let ed1 =
-                           let uu___215_23260 = ed  in
+                           let uu___215_23260 = ed in
                            let uu____23261 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.ret_wp  in
+                             elim_tscheme ed.FStar_Syntax_Syntax.ret_wp in
                            let uu____23262 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.bind_wp  in
+                             elim_tscheme ed.FStar_Syntax_Syntax.bind_wp in
                            let uu____23263 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.if_then_else
-                              in
+                             elim_tscheme ed.FStar_Syntax_Syntax.if_then_else in
                            let uu____23264 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.ite_wp  in
+                             elim_tscheme ed.FStar_Syntax_Syntax.ite_wp in
                            let uu____23265 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.stronger  in
+                             elim_tscheme ed.FStar_Syntax_Syntax.stronger in
                            let uu____23266 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.close_wp  in
+                             elim_tscheme ed.FStar_Syntax_Syntax.close_wp in
                            let uu____23267 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.assert_p  in
+                             elim_tscheme ed.FStar_Syntax_Syntax.assert_p in
                            let uu____23268 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.assume_p  in
+                             elim_tscheme ed.FStar_Syntax_Syntax.assume_p in
                            let uu____23269 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.null_wp  in
+                             elim_tscheme ed.FStar_Syntax_Syntax.null_wp in
                            let uu____23270 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.trivial  in
+                             elim_tscheme ed.FStar_Syntax_Syntax.trivial in
                            let uu____23271 =
-                             elim_term ed.FStar_Syntax_Syntax.repr  in
+                             elim_term ed.FStar_Syntax_Syntax.repr in
                            let uu____23272 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.return_repr
-                              in
+                             elim_tscheme ed.FStar_Syntax_Syntax.return_repr in
                            let uu____23273 =
-                             elim_tscheme ed.FStar_Syntax_Syntax.bind_repr
-                              in
+                             elim_tscheme ed.FStar_Syntax_Syntax.bind_repr in
                            let uu____23274 =
                              FStar_List.map elim_action
-                               ed.FStar_Syntax_Syntax.actions
-                              in
+                               ed.FStar_Syntax_Syntax.actions in
                            {
                              FStar_Syntax_Syntax.cattributes =
                                (uu___215_23260.FStar_Syntax_Syntax.cattributes);
@@ -8748,8 +8176,8 @@ let rec (elim_uvars :
                              FStar_Syntax_Syntax.return_repr = uu____23272;
                              FStar_Syntax_Syntax.bind_repr = uu____23273;
                              FStar_Syntax_Syntax.actions = uu____23274
-                           }  in
-                         let uu___216_23277 = s  in
+                           } in
+                         let uu___216_23277 = s in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_new_effect ed1);
@@ -8767,17 +8195,16 @@ let rec (elim_uvars :
             match uu___93_23294 with
             | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
             | FStar_Pervasives_Native.Some (us,t) ->
-                let uu____23321 = elim_uvars_aux_t env us [] t  in
+                let uu____23321 = elim_uvars_aux_t env us [] t in
                 (match uu____23321 with
                  | (us1,uu____23345,t1) ->
-                     FStar_Pervasives_Native.Some (us1, t1))
-             in
+                     FStar_Pervasives_Native.Some (us1, t1)) in
           let sub_eff1 =
-            let uu___217_23364 = sub_eff  in
+            let uu___217_23364 = sub_eff in
             let uu____23365 =
-              elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift_wp  in
+              elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift_wp in
             let uu____23368 =
-              elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift  in
+              elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift in
             {
               FStar_Syntax_Syntax.source =
                 (uu___217_23364.FStar_Syntax_Syntax.source);
@@ -8785,8 +8212,8 @@ let rec (elim_uvars :
                 (uu___217_23364.FStar_Syntax_Syntax.target);
               FStar_Syntax_Syntax.lift_wp = uu____23365;
               FStar_Syntax_Syntax.lift = uu____23368
-            }  in
-          let uu___218_23371 = s  in
+            } in
+          let uu___218_23371 = s in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_sub_effect sub_eff1);
@@ -8801,10 +8228,10 @@ let rec (elim_uvars :
           }
       | FStar_Syntax_Syntax.Sig_effect_abbrev
           (lid,univ_names,binders,comp,flags1) ->
-          let uu____23381 = elim_uvars_aux_c env univ_names binders comp  in
+          let uu____23381 = elim_uvars_aux_c env univ_names binders comp in
           (match uu____23381 with
            | (univ_names1,binders1,comp1) ->
-               let uu___219_23415 = s  in
+               let uu___219_23415 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_effect_abbrev
@@ -8819,11 +8246,9 @@ let rec (elim_uvars :
                    (uu___219_23415.FStar_Syntax_Syntax.sigattrs)
                })
       | FStar_Syntax_Syntax.Sig_pragma uu____23426 -> s
-  
-let (erase_universes :
+let erase_universes:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  -> normalize [EraseUniverses; AllowUnboundUniverses] env t
-  

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -1,6 +1,6 @@
 open Prims
-let (guard_of_guard_formula :
-  FStar_TypeChecker_Common.guard_formula -> FStar_TypeChecker_Env.guard_t) =
+let guard_of_guard_formula:
+  FStar_TypeChecker_Common.guard_formula -> FStar_TypeChecker_Env.guard_t =
   fun g  ->
     {
       FStar_TypeChecker_Env.guard_f = g;
@@ -8,11 +8,10 @@ let (guard_of_guard_formula :
       FStar_TypeChecker_Env.univ_ineqs = ([], []);
       FStar_TypeChecker_Env.implicits = []
     }
-  
-let (guard_form :
-  FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Common.guard_formula) =
-  fun g  -> g.FStar_TypeChecker_Env.guard_f 
-let (is_trivial : FStar_TypeChecker_Env.guard_t -> Prims.bool) =
+let guard_form:
+  FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Common.guard_formula =
+  fun g  -> g.FStar_TypeChecker_Env.guard_f
+let is_trivial: FStar_TypeChecker_Env.guard_t -> Prims.bool =
   fun g  ->
     match g with
     | { FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial ;
@@ -20,17 +19,16 @@ let (is_trivial : FStar_TypeChecker_Env.guard_t -> Prims.bool) =
         FStar_TypeChecker_Env.univ_ineqs = uu____30;
         FStar_TypeChecker_Env.implicits = uu____31;_} -> true
     | uu____58 -> false
-  
-let (trivial_guard : FStar_TypeChecker_Env.guard_t) =
+let trivial_guard: FStar_TypeChecker_Env.guard_t =
   {
     FStar_TypeChecker_Env.guard_f = FStar_TypeChecker_Common.Trivial;
     FStar_TypeChecker_Env.deferred = [];
     FStar_TypeChecker_Env.univ_ineqs = ([], []);
     FStar_TypeChecker_Env.implicits = []
-  } 
-let (abstract_guard_n :
+  }
+let abstract_guard_n:
   FStar_Syntax_Syntax.binder Prims.list ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun bs  ->
     fun g  ->
@@ -40,9 +38,8 @@ let (abstract_guard_n :
           let f' =
             FStar_Syntax_Util.abs bs f
               (FStar_Pervasives_Native.Some
-                 (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0))
-             in
-          let uu___114_91 = g  in
+                 (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0)) in
+          let uu___114_91 = g in
           {
             FStar_TypeChecker_Env.guard_f =
               (FStar_TypeChecker_Common.NonTrivial f');
@@ -53,14 +50,13 @@ let (abstract_guard_n :
             FStar_TypeChecker_Env.implicits =
               (uu___114_91.FStar_TypeChecker_Env.implicits)
           }
-  
-let (abstract_guard :
+let abstract_guard:
   FStar_Syntax_Syntax.binder ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
-  = fun b  -> fun g  -> abstract_guard_n [b] g 
-let (guard_unbound_vars :
+    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
+  = fun b  -> fun g  -> abstract_guard_n [b] g
+let guard_unbound_vars:
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Env.guard_t -> FStar_Syntax_Syntax.bv FStar_Util.set)
+    FStar_TypeChecker_Env.guard_t -> FStar_Syntax_Syntax.bv FStar_Util.set
   =
   fun env  ->
     fun g  ->
@@ -69,16 +65,15 @@ let (guard_unbound_vars :
           FStar_Util.new_set FStar_Syntax_Syntax.order_bv
       | FStar_TypeChecker_Common.NonTrivial f ->
           FStar_TypeChecker_Env.unbound_vars env f
-  
-let (check_guard :
+let check_guard:
   Prims.string ->
-    FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.unit)
+    FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.unit
   =
   fun msg  ->
     fun env  ->
       fun g  ->
-        let s = guard_unbound_vars env g  in
-        let uu____121 = FStar_Util.set_is_empty s  in
+        let s = guard_unbound_vars env g in
+        let uu____121 = FStar_Util.set_is_empty s in
         if uu____121
         then ()
         else
@@ -86,77 +81,67 @@ let (check_guard :
              let uu____128 =
                let uu____129 =
                  let uu____130 =
-                   let uu____133 = FStar_Util.set_elements s  in
+                   let uu____133 = FStar_Util.set_elements s in
                    FStar_All.pipe_right uu____133
-                     (FStar_List.map FStar_Syntax_Syntax.mk_binder)
-                    in
+                     (FStar_List.map FStar_Syntax_Syntax.mk_binder) in
                  FStar_All.pipe_right uu____130
-                   (FStar_Syntax_Print.binders_to_string ", ")
-                  in
+                   (FStar_Syntax_Print.binders_to_string ", ") in
                FStar_Util.format2 "Guard has free variables (%s): %s" msg
-                 uu____129
-                in
-             (FStar_Errors.Fatal_FreeVariables, uu____128)  in
+                 uu____129 in
+             (FStar_Errors.Fatal_FreeVariables, uu____128) in
            FStar_Errors.raise_err uu____123)
-  
-let (check_term :
+let check_term:
   Prims.string ->
-    FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.unit)
+    FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.unit
   =
   fun msg  ->
     fun env  ->
       fun t  ->
-        let s = FStar_TypeChecker_Env.unbound_vars env t  in
-        let uu____154 = FStar_Util.set_is_empty s  in
+        let s = FStar_TypeChecker_Env.unbound_vars env t in
+        let uu____154 = FStar_Util.set_is_empty s in
         if uu____154
         then ()
         else
           (let uu____156 =
              let uu____161 =
-               let uu____162 = FStar_Syntax_Print.term_to_string t  in
+               let uu____162 = FStar_Syntax_Print.term_to_string t in
                let uu____163 =
                  let uu____164 =
-                   let uu____167 = FStar_Util.set_elements s  in
+                   let uu____167 = FStar_Util.set_elements s in
                    FStar_All.pipe_right uu____167
-                     (FStar_List.map FStar_Syntax_Syntax.mk_binder)
-                    in
+                     (FStar_List.map FStar_Syntax_Syntax.mk_binder) in
                  FStar_All.pipe_right uu____164
-                   (FStar_Syntax_Print.binders_to_string ", ")
-                  in
+                   (FStar_Syntax_Print.binders_to_string ", ") in
                FStar_Util.format3 "Term <%s> has free variables (%s): %s"
-                 uu____162 msg uu____163
-                in
-             (FStar_Errors.Fatal_FreeVariables, uu____161)  in
+                 uu____162 msg uu____163 in
+             (FStar_Errors.Fatal_FreeVariables, uu____161) in
            FStar_Errors.raise_err uu____156)
-  
-let (apply_guard :
+let apply_guard:
   FStar_TypeChecker_Env.guard_t ->
-    FStar_Syntax_Syntax.term -> FStar_TypeChecker_Env.guard_t)
+    FStar_Syntax_Syntax.term -> FStar_TypeChecker_Env.guard_t
   =
   fun g  ->
     fun e  ->
       match g.FStar_TypeChecker_Env.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___115_183 = g  in
+          let uu___115_183 = g in
           let uu____184 =
             let uu____185 =
               let uu____186 =
                 let uu____189 =
                   let uu____190 =
                     let uu____205 =
-                      let uu____208 = FStar_Syntax_Syntax.as_arg e  in
-                      [uu____208]  in
-                    (f, uu____205)  in
-                  FStar_Syntax_Syntax.Tm_app uu____190  in
-                FStar_Syntax_Syntax.mk uu____189  in
+                      let uu____208 = FStar_Syntax_Syntax.as_arg e in
+                      [uu____208] in
+                    (f, uu____205) in
+                  FStar_Syntax_Syntax.Tm_app uu____190 in
+                FStar_Syntax_Syntax.mk uu____189 in
               uu____186 FStar_Pervasives_Native.None
-                f.FStar_Syntax_Syntax.pos
-               in
+                f.FStar_Syntax_Syntax.pos in
             FStar_All.pipe_left
               (fun _0_40  -> FStar_TypeChecker_Common.NonTrivial _0_40)
-              uu____185
-             in
+              uu____185 in
           {
             FStar_TypeChecker_Env.guard_f = uu____184;
             FStar_TypeChecker_Env.deferred =
@@ -166,21 +151,20 @@ let (apply_guard :
             FStar_TypeChecker_Env.implicits =
               (uu___115_183.FStar_TypeChecker_Env.implicits)
           }
-  
-let (map_guard :
+let map_guard:
   FStar_TypeChecker_Env.guard_t ->
     (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
-      FStar_TypeChecker_Env.guard_t)
+      FStar_TypeChecker_Env.guard_t
   =
   fun g  ->
     fun map1  ->
       match g.FStar_TypeChecker_Env.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___116_226 = g  in
+          let uu___116_226 = g in
           let uu____227 =
-            let uu____228 = map1 f  in
-            FStar_TypeChecker_Common.NonTrivial uu____228  in
+            let uu____228 = map1 f in
+            FStar_TypeChecker_Common.NonTrivial uu____228 in
           {
             FStar_TypeChecker_Env.guard_f = uu____227;
             FStar_TypeChecker_Env.deferred =
@@ -190,17 +174,15 @@ let (map_guard :
             FStar_TypeChecker_Env.implicits =
               (uu___116_226.FStar_TypeChecker_Env.implicits)
           }
-  
-let (trivial : FStar_TypeChecker_Common.guard_formula -> Prims.unit) =
+let trivial: FStar_TypeChecker_Common.guard_formula -> Prims.unit =
   fun t  ->
     match t with
     | FStar_TypeChecker_Common.Trivial  -> ()
     | FStar_TypeChecker_Common.NonTrivial uu____232 -> failwith "impossible"
-  
-let (conj_guard_f :
+let conj_guard_f:
   FStar_TypeChecker_Common.guard_formula ->
     FStar_TypeChecker_Common.guard_formula ->
-      FStar_TypeChecker_Common.guard_formula)
+      FStar_TypeChecker_Common.guard_formula
   =
   fun g1  ->
     fun g2  ->
@@ -209,25 +191,23 @@ let (conj_guard_f :
       | (g,FStar_TypeChecker_Common.Trivial ) -> g
       | (FStar_TypeChecker_Common.NonTrivial
          f1,FStar_TypeChecker_Common.NonTrivial f2) ->
-          let uu____243 = FStar_Syntax_Util.mk_conj f1 f2  in
+          let uu____243 = FStar_Syntax_Util.mk_conj f1 f2 in
           FStar_TypeChecker_Common.NonTrivial uu____243
-  
-let (check_trivial :
-  FStar_Syntax_Syntax.term -> FStar_TypeChecker_Common.guard_formula) =
+let check_trivial:
+  FStar_Syntax_Syntax.term -> FStar_TypeChecker_Common.guard_formula =
   fun t  ->
     let uu____247 =
-      let uu____248 = FStar_Syntax_Util.unmeta t  in
-      uu____248.FStar_Syntax_Syntax.n  in
+      let uu____248 = FStar_Syntax_Util.unmeta t in
+      uu____248.FStar_Syntax_Syntax.n in
     match uu____247 with
     | FStar_Syntax_Syntax.Tm_fvar tc when
         FStar_Syntax_Syntax.fv_eq_lid tc FStar_Parser_Const.true_lid ->
         FStar_TypeChecker_Common.Trivial
     | uu____252 -> FStar_TypeChecker_Common.NonTrivial t
-  
-let (imp_guard_f :
+let imp_guard_f:
   FStar_TypeChecker_Common.guard_formula ->
     FStar_TypeChecker_Common.guard_formula ->
-      FStar_TypeChecker_Common.guard_formula)
+      FStar_TypeChecker_Common.guard_formula
   =
   fun g1  ->
     fun g2  ->
@@ -237,22 +217,20 @@ let (imp_guard_f :
           FStar_TypeChecker_Common.Trivial
       | (FStar_TypeChecker_Common.NonTrivial
          f1,FStar_TypeChecker_Common.NonTrivial f2) ->
-          let imp = FStar_Syntax_Util.mk_imp f1 f2  in check_trivial imp
-  
-let (binop_guard :
+          let imp = FStar_Syntax_Util.mk_imp f1 f2 in check_trivial imp
+let binop_guard:
   (FStar_TypeChecker_Common.guard_formula ->
      FStar_TypeChecker_Common.guard_formula ->
        FStar_TypeChecker_Common.guard_formula)
     ->
     FStar_TypeChecker_Env.guard_t ->
-      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun f  ->
     fun g1  ->
       fun g2  ->
         let uu____283 =
-          f g1.FStar_TypeChecker_Env.guard_f g2.FStar_TypeChecker_Env.guard_f
-           in
+          f g1.FStar_TypeChecker_Env.guard_f g2.FStar_TypeChecker_Env.guard_f in
         {
           FStar_TypeChecker_Env.guard_f = uu____283;
           FStar_TypeChecker_Env.deferred =
@@ -273,19 +251,18 @@ let (binop_guard :
             (FStar_List.append g1.FStar_TypeChecker_Env.implicits
                g2.FStar_TypeChecker_Env.implicits)
         }
-  
-let (conj_guard :
+let conj_guard:
   FStar_TypeChecker_Env.guard_t ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
-  = fun g1  -> fun g2  -> binop_guard conj_guard_f g1 g2 
-let (imp_guard :
+    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
+  = fun g1  -> fun g2  -> binop_guard conj_guard_f g1 g2
+let imp_guard:
   FStar_TypeChecker_Env.guard_t ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
-  = fun g1  -> fun g2  -> binop_guard imp_guard_f g1 g2 
-let (close_guard_univs :
+    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
+  = fun g1  -> fun g2  -> binop_guard imp_guard_f g1 g2
+let close_guard_univs:
   FStar_Syntax_Syntax.universes ->
     FStar_Syntax_Syntax.binders ->
-      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun us  ->
     fun bs  ->
@@ -298,15 +275,13 @@ let (close_guard_univs :
                 (fun u  ->
                    fun b  ->
                      fun f1  ->
-                       let uu____350 = FStar_Syntax_Syntax.is_null_binder b
-                          in
+                       let uu____350 = FStar_Syntax_Syntax.is_null_binder b in
                        if uu____350
                        then f1
                        else
                          FStar_Syntax_Util.mk_forall u
-                           (FStar_Pervasives_Native.fst b) f1) us bs f
-               in
-            let uu___117_352 = g  in
+                           (FStar_Pervasives_Native.fst b) f1) us bs f in
+            let uu___117_352 = g in
             {
               FStar_TypeChecker_Env.guard_f =
                 (FStar_TypeChecker_Common.NonTrivial f1);
@@ -317,11 +292,10 @@ let (close_guard_univs :
               FStar_TypeChecker_Env.implicits =
                 (uu___117_352.FStar_TypeChecker_Env.implicits)
             }
-  
-let (close_forall :
+let close_forall:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binder Prims.list ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
+      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
   =
   fun env  ->
     fun bs  ->
@@ -329,21 +303,19 @@ let (close_forall :
         FStar_List.fold_right
           (fun b  ->
              fun f1  ->
-               let uu____371 = FStar_Syntax_Syntax.is_null_binder b  in
+               let uu____371 = FStar_Syntax_Syntax.is_null_binder b in
                if uu____371
                then f1
                else
                  (let u =
                     env.FStar_TypeChecker_Env.universe_of env
-                      (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                     in
+                      (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
                   FStar_Syntax_Util.mk_forall u
                     (FStar_Pervasives_Native.fst b) f1)) bs f
-  
-let (close_guard :
+let close_guard:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
-      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun env  ->
     fun binders  ->
@@ -351,10 +323,10 @@ let (close_guard :
         match g.FStar_TypeChecker_Env.guard_f with
         | FStar_TypeChecker_Common.Trivial  -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___118_384 = g  in
+            let uu___118_384 = g in
             let uu____385 =
-              let uu____386 = close_forall env binders f  in
-              FStar_TypeChecker_Common.NonTrivial uu____386  in
+              let uu____386 = close_forall env binders f in
+              FStar_TypeChecker_Common.NonTrivial uu____386 in
             {
               FStar_TypeChecker_Env.guard_f = uu____385;
               FStar_TypeChecker_Env.deferred =
@@ -364,110 +336,99 @@ let (close_guard :
               FStar_TypeChecker_Env.implicits =
                 (uu___118_384.FStar_TypeChecker_Env.implicits)
             }
-  
-let (new_uvar :
+let new_uvar:
   FStar_Range.range ->
     FStar_Syntax_Syntax.binders ->
       FStar_Syntax_Syntax.typ ->
         (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.typ)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun r  ->
     fun binders  ->
       fun k  ->
-        let uv = FStar_Syntax_Unionfind.fresh ()  in
+        let uv = FStar_Syntax_Unionfind.fresh () in
         match binders with
         | [] ->
             let uv1 =
               FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar (uv, k))
-                FStar_Pervasives_Native.None r
-               in
+                FStar_Pervasives_Native.None r in
             (uv1, uv1)
         | uu____416 ->
             let args =
               FStar_All.pipe_right binders
-                (FStar_List.map FStar_Syntax_Util.arg_of_non_null_binder)
-               in
+                (FStar_List.map FStar_Syntax_Util.arg_of_non_null_binder) in
             let k' =
-              let uu____441 = FStar_Syntax_Syntax.mk_Total k  in
-              FStar_Syntax_Util.arrow binders uu____441  in
+              let uu____441 = FStar_Syntax_Syntax.mk_Total k in
+              FStar_Syntax_Util.arrow binders uu____441 in
             let uv1 =
               FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar (uv, k'))
-                FStar_Pervasives_Native.None r
-               in
+                FStar_Pervasives_Native.None r in
             let uu____449 =
               FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (uv1, args))
-                FStar_Pervasives_Native.None r
-               in
+                FStar_Pervasives_Native.None r in
             (uu____449, uv1)
-  
-let (mk_eq2 :
+let mk_eq2:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____477 = FStar_Syntax_Util.type_u ()  in
+        let uu____477 = FStar_Syntax_Util.type_u () in
         match uu____477 with
         | (t_type,u) ->
             let uu____484 =
-              let uu____489 = FStar_TypeChecker_Env.all_binders env  in
-              new_uvar t1.FStar_Syntax_Syntax.pos uu____489 t_type  in
+              let uu____489 = FStar_TypeChecker_Env.all_binders env in
+              new_uvar t1.FStar_Syntax_Syntax.pos uu____489 t_type in
             (match uu____484 with
              | (tt,uu____491) -> FStar_Syntax_Util.mk_eq2 u tt t1 t2)
-  
 type uvi =
   | TERM of
   ((FStar_Syntax_Syntax.uvar,FStar_Syntax_Syntax.typ)
      FStar_Pervasives_Native.tuple2,FStar_Syntax_Syntax.term)
-  FStar_Pervasives_Native.tuple2 
+  FStar_Pervasives_Native.tuple2
   | UNIV of (FStar_Syntax_Syntax.universe_uvar,FStar_Syntax_Syntax.universe)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let (uu___is_TERM : uvi -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_TERM: uvi -> Prims.bool =
   fun projectee  ->
     match projectee with | TERM _0 -> true | uu____524 -> false
-  
-let (__proj__TERM__item___0 :
+let __proj__TERM__item___0:
   uvi ->
     ((FStar_Syntax_Syntax.uvar,FStar_Syntax_Syntax.typ)
        FStar_Pervasives_Native.tuple2,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | TERM _0 -> _0 
-let (uu___is_UNIV : uvi -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | TERM _0 -> _0
+let uu___is_UNIV: uvi -> Prims.bool =
   fun projectee  ->
     match projectee with | UNIV _0 -> true | uu____564 -> false
-  
-let (__proj__UNIV__item___0 :
+let __proj__UNIV__item___0:
   uvi ->
     (FStar_Syntax_Syntax.universe_uvar,FStar_Syntax_Syntax.universe)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | UNIV _0 -> _0 
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | UNIV _0 -> _0
 type worklist =
   {
-  attempting: FStar_TypeChecker_Common.probs ;
+  attempting: FStar_TypeChecker_Common.probs;
   wl_deferred:
     (Prims.int,Prims.string,FStar_TypeChecker_Common.prob)
-      FStar_Pervasives_Native.tuple3 Prims.list
-    ;
-  ctr: Prims.int ;
-  defer_ok: Prims.bool ;
-  smt_ok: Prims.bool ;
-  tcenv: FStar_TypeChecker_Env.env }[@@deriving show]
-let (__proj__Mkworklist__item__attempting :
-  worklist -> FStar_TypeChecker_Common.probs) =
+      FStar_Pervasives_Native.tuple3 Prims.list;
+  ctr: Prims.int;
+  defer_ok: Prims.bool;
+  smt_ok: Prims.bool;
+  tcenv: FStar_TypeChecker_Env.env;}[@@deriving show]
+let __proj__Mkworklist__item__attempting:
+  worklist -> FStar_TypeChecker_Common.probs =
   fun projectee  ->
     match projectee with
     | { attempting = __fname__attempting; wl_deferred = __fname__wl_deferred;
         ctr = __fname__ctr; defer_ok = __fname__defer_ok;
         smt_ok = __fname__smt_ok; tcenv = __fname__tcenv;_} ->
         __fname__attempting
-  
-let (__proj__Mkworklist__item__wl_deferred :
+let __proj__Mkworklist__item__wl_deferred:
   worklist ->
     (Prims.int,Prims.string,FStar_TypeChecker_Common.prob)
-      FStar_Pervasives_Native.tuple3 Prims.list)
+      FStar_Pervasives_Native.tuple3 Prims.list
   =
   fun projectee  ->
     match projectee with
@@ -475,74 +436,62 @@ let (__proj__Mkworklist__item__wl_deferred :
         ctr = __fname__ctr; defer_ok = __fname__defer_ok;
         smt_ok = __fname__smt_ok; tcenv = __fname__tcenv;_} ->
         __fname__wl_deferred
-  
-let (__proj__Mkworklist__item__ctr : worklist -> Prims.int) =
+let __proj__Mkworklist__item__ctr: worklist -> Prims.int =
   fun projectee  ->
     match projectee with
     | { attempting = __fname__attempting; wl_deferred = __fname__wl_deferred;
         ctr = __fname__ctr; defer_ok = __fname__defer_ok;
         smt_ok = __fname__smt_ok; tcenv = __fname__tcenv;_} -> __fname__ctr
-  
-let (__proj__Mkworklist__item__defer_ok : worklist -> Prims.bool) =
+let __proj__Mkworklist__item__defer_ok: worklist -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { attempting = __fname__attempting; wl_deferred = __fname__wl_deferred;
         ctr = __fname__ctr; defer_ok = __fname__defer_ok;
         smt_ok = __fname__smt_ok; tcenv = __fname__tcenv;_} ->
         __fname__defer_ok
-  
-let (__proj__Mkworklist__item__smt_ok : worklist -> Prims.bool) =
+let __proj__Mkworklist__item__smt_ok: worklist -> Prims.bool =
   fun projectee  ->
     match projectee with
     | { attempting = __fname__attempting; wl_deferred = __fname__wl_deferred;
         ctr = __fname__ctr; defer_ok = __fname__defer_ok;
         smt_ok = __fname__smt_ok; tcenv = __fname__tcenv;_} ->
         __fname__smt_ok
-  
-let (__proj__Mkworklist__item__tcenv : worklist -> FStar_TypeChecker_Env.env)
-  =
+let __proj__Mkworklist__item__tcenv: worklist -> FStar_TypeChecker_Env.env =
   fun projectee  ->
     match projectee with
     | { attempting = __fname__attempting; wl_deferred = __fname__wl_deferred;
         ctr = __fname__ctr; defer_ok = __fname__defer_ok;
         smt_ok = __fname__smt_ok; tcenv = __fname__tcenv;_} -> __fname__tcenv
-  
 type solution =
-  | Success of FStar_TypeChecker_Common.deferred 
+  | Success of FStar_TypeChecker_Common.deferred
   | Failed of (FStar_TypeChecker_Common.prob,Prims.string)
-  FStar_Pervasives_Native.tuple2 [@@deriving show]
-let (uu___is_Success : solution -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2[@@deriving show]
+let uu___is_Success: solution -> Prims.bool =
   fun projectee  ->
     match projectee with | Success _0 -> true | uu____750 -> false
-  
-let (__proj__Success__item___0 :
-  solution -> FStar_TypeChecker_Common.deferred) =
-  fun projectee  -> match projectee with | Success _0 -> _0 
-let (uu___is_Failed : solution -> Prims.bool) =
+let __proj__Success__item___0: solution -> FStar_TypeChecker_Common.deferred
+  = fun projectee  -> match projectee with | Success _0 -> _0
+let uu___is_Failed: solution -> Prims.bool =
   fun projectee  ->
     match projectee with | Failed _0 -> true | uu____766 -> false
-  
-let (__proj__Failed__item___0 :
+let __proj__Failed__item___0:
   solution ->
     (FStar_TypeChecker_Common.prob,Prims.string)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | Failed _0 -> _0 
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | Failed _0 -> _0
 type variance =
-  | COVARIANT 
-  | CONTRAVARIANT 
-  | INVARIANT [@@deriving show]
-let (uu___is_COVARIANT : variance -> Prims.bool) =
+  | COVARIANT
+  | CONTRAVARIANT
+  | INVARIANT[@@deriving show]
+let uu___is_COVARIANT: variance -> Prims.bool =
   fun projectee  ->
     match projectee with | COVARIANT  -> true | uu____789 -> false
-  
-let (uu___is_CONTRAVARIANT : variance -> Prims.bool) =
+let uu___is_CONTRAVARIANT: variance -> Prims.bool =
   fun projectee  ->
     match projectee with | CONTRAVARIANT  -> true | uu____793 -> false
-  
-let (uu___is_INVARIANT : variance -> Prims.bool) =
+let uu___is_INVARIANT: variance -> Prims.bool =
   fun projectee  ->
     match projectee with | INVARIANT  -> true | uu____797 -> false
-  
 type tprob =
   (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.term)
     FStar_TypeChecker_Common.problem[@@deriving show]
@@ -551,40 +500,38 @@ type cprob =
 [@@deriving show]
 type ('a,'b) problem_t = ('a,'b) FStar_TypeChecker_Common.problem[@@deriving
                                                                    show]
-let (rel_to_string : FStar_TypeChecker_Common.rel -> Prims.string) =
+let rel_to_string: FStar_TypeChecker_Common.rel -> Prims.string =
   fun uu___85_820  ->
     match uu___85_820 with
     | FStar_TypeChecker_Common.EQ  -> "="
     | FStar_TypeChecker_Common.SUB  -> "<:"
     | FStar_TypeChecker_Common.SUBINV  -> ":>"
-  
-let (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
+let term_to_string: FStar_Syntax_Syntax.term -> Prims.string =
   fun t  ->
-    let compact = FStar_Syntax_Print.term_to_string t  in
+    let compact = FStar_Syntax_Print.term_to_string t in
     let detail =
       let uu____826 =
-        let uu____827 = FStar_Syntax_Subst.compress t  in
-        uu____827.FStar_Syntax_Syntax.n  in
+        let uu____827 = FStar_Syntax_Subst.compress t in
+        uu____827.FStar_Syntax_Syntax.n in
       match uu____826 with
       | FStar_Syntax_Syntax.Tm_uvar (u,t1) ->
-          let uu____856 = FStar_Syntax_Print.uvar_to_string u  in
-          let uu____857 = FStar_Syntax_Print.term_to_string t1  in
+          let uu____856 = FStar_Syntax_Print.uvar_to_string u in
+          let uu____857 = FStar_Syntax_Print.term_to_string t1 in
           FStar_Util.format2 "%s : %s" uu____856 uu____857
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (u,ty);
              FStar_Syntax_Syntax.pos = uu____860;
              FStar_Syntax_Syntax.vars = uu____861;_},args)
           ->
-          let uu____907 = FStar_Syntax_Print.uvar_to_string u  in
-          let uu____908 = FStar_Syntax_Print.term_to_string ty  in
-          let uu____909 = FStar_Syntax_Print.args_to_string args  in
+          let uu____907 = FStar_Syntax_Print.uvar_to_string u in
+          let uu____908 = FStar_Syntax_Print.term_to_string ty in
+          let uu____909 = FStar_Syntax_Print.args_to_string args in
           FStar_Util.format3 "(%s : %s) %s" uu____907 uu____908 uu____909
-      | uu____910 -> "--"  in
-    let uu____911 = FStar_Syntax_Print.tag_of_term t  in
+      | uu____910 -> "--" in
+    let uu____911 = FStar_Syntax_Print.tag_of_term t in
     FStar_Util.format3 "%s (%s)\t%s" compact uu____911 detail
-  
-let (prob_to_string :
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.prob -> Prims.string)
+let prob_to_string:
+  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.prob -> Prims.string
   =
   fun env  ->
     fun uu___86_917  ->
@@ -592,81 +539,68 @@ let (prob_to_string :
       | FStar_TypeChecker_Common.TProb p ->
           let uu____923 =
             let uu____926 =
-              FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid  in
+              FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid in
             let uu____927 =
-              let uu____930 = term_to_string p.FStar_TypeChecker_Common.lhs
-                 in
+              let uu____930 = term_to_string p.FStar_TypeChecker_Common.lhs in
               let uu____931 =
                 let uu____934 =
                   let uu____937 =
-                    term_to_string p.FStar_TypeChecker_Common.rhs  in
-                  [uu____937]  in
+                    term_to_string p.FStar_TypeChecker_Common.rhs in
+                  [uu____937] in
                 (rel_to_string p.FStar_TypeChecker_Common.relation) ::
-                  uu____934
-                 in
-              uu____930 :: uu____931  in
-            uu____926 :: uu____927  in
+                  uu____934 in
+              uu____930 :: uu____931 in
+            uu____926 :: uu____927 in
           FStar_Util.format "\n%s:\t%s \n\t\t%s\n\t%s" uu____923
       | FStar_TypeChecker_Common.CProb p ->
           let uu____943 =
-            FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid  in
+            FStar_Util.string_of_int p.FStar_TypeChecker_Common.pid in
           let uu____944 =
             FStar_TypeChecker_Normalize.comp_to_string env
-              p.FStar_TypeChecker_Common.lhs
-             in
+              p.FStar_TypeChecker_Common.lhs in
           let uu____945 =
             FStar_TypeChecker_Normalize.comp_to_string env
-              p.FStar_TypeChecker_Common.rhs
-             in
+              p.FStar_TypeChecker_Common.rhs in
           FStar_Util.format4 "\n%s:\t%s \n\t\t%s\n\t%s" uu____943 uu____944
             (rel_to_string p.FStar_TypeChecker_Common.relation) uu____945
-  
-let (uvi_to_string : FStar_TypeChecker_Env.env -> uvi -> Prims.string) =
+let uvi_to_string: FStar_TypeChecker_Env.env -> uvi -> Prims.string =
   fun env  ->
     fun uu___87_951  ->
       match uu___87_951 with
       | UNIV (u,t) ->
           let x =
-            let uu____955 = FStar_Options.hide_uvar_nums ()  in
+            let uu____955 = FStar_Options.hide_uvar_nums () in
             if uu____955
             then "?"
             else
-              (let uu____957 = FStar_Syntax_Unionfind.univ_uvar_id u  in
-               FStar_All.pipe_right uu____957 FStar_Util.string_of_int)
-             in
-          let uu____958 = FStar_Syntax_Print.univ_to_string t  in
+              (let uu____957 = FStar_Syntax_Unionfind.univ_uvar_id u in
+               FStar_All.pipe_right uu____957 FStar_Util.string_of_int) in
+          let uu____958 = FStar_Syntax_Print.univ_to_string t in
           FStar_Util.format2 "UNIV %s %s" x uu____958
       | TERM ((u,uu____960),t) ->
           let x =
-            let uu____967 = FStar_Options.hide_uvar_nums ()  in
+            let uu____967 = FStar_Options.hide_uvar_nums () in
             if uu____967
             then "?"
             else
-              (let uu____969 = FStar_Syntax_Unionfind.uvar_id u  in
-               FStar_All.pipe_right uu____969 FStar_Util.string_of_int)
-             in
-          let uu____970 = FStar_TypeChecker_Normalize.term_to_string env t
-             in
+              (let uu____969 = FStar_Syntax_Unionfind.uvar_id u in
+               FStar_All.pipe_right uu____969 FStar_Util.string_of_int) in
+          let uu____970 = FStar_TypeChecker_Normalize.term_to_string env t in
           FStar_Util.format2 "TERM %s %s" x uu____970
-  
-let (uvis_to_string :
-  FStar_TypeChecker_Env.env -> uvi Prims.list -> Prims.string) =
+let uvis_to_string:
+  FStar_TypeChecker_Env.env -> uvi Prims.list -> Prims.string =
   fun env  ->
     fun uvis  ->
-      let uu____981 = FStar_List.map (uvi_to_string env) uvis  in
+      let uu____981 = FStar_List.map (uvi_to_string env) uvis in
       FStar_All.pipe_right uu____981 (FStar_String.concat ", ")
-  
-let (names_to_string : FStar_Syntax_Syntax.bv FStar_Util.set -> Prims.string)
-  =
+let names_to_string: FStar_Syntax_Syntax.bv FStar_Util.set -> Prims.string =
   fun nms  ->
     let uu____993 =
-      let uu____996 = FStar_Util.set_elements nms  in
+      let uu____996 = FStar_Util.set_elements nms in
       FStar_All.pipe_right uu____996
-        (FStar_List.map FStar_Syntax_Print.bv_to_string)
-       in
+        (FStar_List.map FStar_Syntax_Print.bv_to_string) in
     FStar_All.pipe_right uu____993 (FStar_String.concat ", ")
-  
-let args_to_string :
+let args_to_string:
   'Auu____1007 .
     (FStar_Syntax_Syntax.term,'Auu____1007) FStar_Pervasives_Native.tuple2
       Prims.list -> Prims.string
@@ -677,15 +611,13 @@ let args_to_string :
         (FStar_List.map
            (fun uu____1042  ->
               match uu____1042 with
-              | (x,uu____1048) -> FStar_Syntax_Print.term_to_string x))
-       in
+              | (x,uu____1048) -> FStar_Syntax_Print.term_to_string x)) in
     FStar_All.pipe_right uu____1024 (FStar_String.concat " ")
-  
-let (empty_worklist : FStar_TypeChecker_Env.env -> worklist) =
+let empty_worklist: FStar_TypeChecker_Env.env -> worklist =
   fun env  ->
     let uu____1054 =
-      let uu____1055 = FStar_Options.eager_inference ()  in
-      Prims.op_Negation uu____1055  in
+      let uu____1055 = FStar_Options.eager_inference () in
+      Prims.op_Negation uu____1055 in
     {
       attempting = [];
       wl_deferred = [];
@@ -694,15 +626,14 @@ let (empty_worklist : FStar_TypeChecker_Env.env -> worklist) =
       smt_ok = true;
       tcenv = env
     }
-  
-let (singleton' :
+let singleton':
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.prob -> Prims.bool -> worklist)
+    FStar_TypeChecker_Common.prob -> Prims.bool -> worklist
   =
   fun env  ->
     fun prob  ->
       fun smt_ok  ->
-        let uu___119_1071 = empty_worklist env  in
+        let uu___119_1071 = empty_worklist env in
         {
           attempting = [prob];
           wl_deferred = (uu___119_1071.wl_deferred);
@@ -711,11 +642,10 @@ let (singleton' :
           smt_ok;
           tcenv = (uu___119_1071.tcenv)
         }
-  
-let (singleton :
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.prob -> worklist) =
-  fun env  -> fun prob  -> singleton' env prob true 
-let wl_of_guard :
+let singleton:
+  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.prob -> worklist =
+  fun env  -> fun prob  -> singleton' env prob true
+let wl_of_guard:
   'Auu____1081 .
     FStar_TypeChecker_Env.env ->
       ('Auu____1081,FStar_TypeChecker_Common.prob)
@@ -723,8 +653,8 @@ let wl_of_guard :
   =
   fun env  ->
     fun g  ->
-      let uu___120_1102 = empty_worklist env  in
-      let uu____1103 = FStar_List.map FStar_Pervasives_Native.snd g  in
+      let uu___120_1102 = empty_worklist env in
+      let uu____1103 = FStar_List.map FStar_Pervasives_Native.snd g in
       {
         attempting = uu____1103;
         wl_deferred = (uu___120_1102.wl_deferred);
@@ -733,13 +663,12 @@ let wl_of_guard :
         smt_ok = (uu___120_1102.smt_ok);
         tcenv = (uu___120_1102.tcenv)
       }
-  
-let (defer :
-  Prims.string -> FStar_TypeChecker_Common.prob -> worklist -> worklist) =
+let defer:
+  Prims.string -> FStar_TypeChecker_Common.prob -> worklist -> worklist =
   fun reason  ->
     fun prob  ->
       fun wl  ->
-        let uu___121_1117 = wl  in
+        let uu___121_1117 = wl in
         {
           attempting = (uu___121_1117.attempting);
           wl_deferred = (((wl.ctr), reason, prob) :: (wl.wl_deferred));
@@ -748,12 +677,11 @@ let (defer :
           smt_ok = (uu___121_1117.smt_ok);
           tcenv = (uu___121_1117.tcenv)
         }
-  
-let (attempt :
-  FStar_TypeChecker_Common.prob Prims.list -> worklist -> worklist) =
+let attempt: FStar_TypeChecker_Common.prob Prims.list -> worklist -> worklist
+  =
   fun probs  ->
     fun wl  ->
-      let uu___122_1134 = wl  in
+      let uu___122_1134 = wl in
       {
         attempting = (FStar_List.append probs wl.attempting);
         wl_deferred = (uu___122_1134.wl_deferred);
@@ -762,40 +690,36 @@ let (attempt :
         smt_ok = (uu___122_1134.smt_ok);
         tcenv = (uu___122_1134.tcenv)
       }
-  
-let (giveup :
+let giveup:
   FStar_TypeChecker_Env.env ->
-    Prims.string -> FStar_TypeChecker_Common.prob -> solution)
+    Prims.string -> FStar_TypeChecker_Common.prob -> solution
   =
   fun env  ->
     fun reason  ->
       fun prob  ->
         (let uu____1145 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "Rel")
-            in
+             (FStar_Options.Other "Rel") in
          if uu____1145
          then
-           let uu____1146 = prob_to_string env prob  in
+           let uu____1146 = prob_to_string env prob in
            FStar_Util.print2 "Failed %s:\n%s\n" reason uu____1146
          else ());
         Failed (prob, reason)
-  
-let (invert_rel :
-  FStar_TypeChecker_Common.rel -> FStar_TypeChecker_Common.rel) =
+let invert_rel: FStar_TypeChecker_Common.rel -> FStar_TypeChecker_Common.rel
+  =
   fun uu___88_1150  ->
     match uu___88_1150 with
     | FStar_TypeChecker_Common.EQ  -> FStar_TypeChecker_Common.EQ
     | FStar_TypeChecker_Common.SUB  -> FStar_TypeChecker_Common.SUBINV
     | FStar_TypeChecker_Common.SUBINV  -> FStar_TypeChecker_Common.SUB
-  
-let invert :
+let invert:
   'Auu____1154 'Auu____1155 .
     ('Auu____1155,'Auu____1154) FStar_TypeChecker_Common.problem ->
       ('Auu____1155,'Auu____1154) FStar_TypeChecker_Common.problem
   =
   fun p  ->
-    let uu___123_1172 = p  in
+    let uu___123_1172 = p in
     {
       FStar_TypeChecker_Common.pid =
         (uu___123_1172.FStar_TypeChecker_Common.pid);
@@ -816,8 +740,7 @@ let invert :
       FStar_TypeChecker_Common.rank =
         (uu___123_1172.FStar_TypeChecker_Common.rank)
     }
-  
-let maybe_invert :
+let maybe_invert:
   'Auu____1180 'Auu____1181 .
     ('Auu____1181,'Auu____1180) FStar_TypeChecker_Common.problem ->
       ('Auu____1181,'Auu____1180) FStar_TypeChecker_Common.problem
@@ -826,9 +749,8 @@ let maybe_invert :
     if p.FStar_TypeChecker_Common.relation = FStar_TypeChecker_Common.SUBINV
     then invert p
     else p
-  
-let (maybe_invert_p :
-  FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob) =
+let maybe_invert_p:
+  FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob =
   fun uu___89_1201  ->
     match uu___89_1201 with
     | FStar_TypeChecker_Common.TProb p ->
@@ -837,44 +759,38 @@ let (maybe_invert_p :
     | FStar_TypeChecker_Common.CProb p ->
         FStar_All.pipe_right (maybe_invert p)
           (fun _0_42  -> FStar_TypeChecker_Common.CProb _0_42)
-  
-let (vary_rel :
-  FStar_TypeChecker_Common.rel -> variance -> FStar_TypeChecker_Common.rel) =
+let vary_rel:
+  FStar_TypeChecker_Common.rel -> variance -> FStar_TypeChecker_Common.rel =
   fun rel  ->
     fun uu___90_1225  ->
       match uu___90_1225 with
       | INVARIANT  -> FStar_TypeChecker_Common.EQ
       | CONTRAVARIANT  -> invert_rel rel
       | COVARIANT  -> rel
-  
-let (p_pid : FStar_TypeChecker_Common.prob -> Prims.int) =
+let p_pid: FStar_TypeChecker_Common.prob -> Prims.int =
   fun uu___91_1228  ->
     match uu___91_1228 with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.pid
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.pid
-  
-let (p_rel : FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.rel) =
+let p_rel: FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.rel =
   fun uu___92_1241  ->
     match uu___92_1241 with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.relation
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.relation
-  
-let (p_reason : FStar_TypeChecker_Common.prob -> Prims.string Prims.list) =
+let p_reason: FStar_TypeChecker_Common.prob -> Prims.string Prims.list =
   fun uu___93_1256  ->
     match uu___93_1256 with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.reason
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.reason
-  
-let (p_loc : FStar_TypeChecker_Common.prob -> FStar_Range.range) =
+let p_loc: FStar_TypeChecker_Common.prob -> FStar_Range.range =
   fun uu___94_1271  ->
     match uu___94_1271 with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.loc
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.loc
-  
-let (p_guard :
+let p_guard:
   FStar_TypeChecker_Common.prob ->
     (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun uu___95_1288  ->
     match uu___95_1288 with
@@ -882,16 +798,13 @@ let (p_guard :
         p.FStar_TypeChecker_Common.logical_guard
     | FStar_TypeChecker_Common.CProb p ->
         p.FStar_TypeChecker_Common.logical_guard
-  
-let (p_scope : FStar_TypeChecker_Common.prob -> FStar_Syntax_Syntax.binders)
-  =
+let p_scope: FStar_TypeChecker_Common.prob -> FStar_Syntax_Syntax.binders =
   fun uu___96_1305  ->
     match uu___96_1305 with
     | FStar_TypeChecker_Common.TProb p -> p.FStar_TypeChecker_Common.scope
     | FStar_TypeChecker_Common.CProb p -> p.FStar_TypeChecker_Common.scope
-  
-let (p_invert :
-  FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob) =
+let p_invert: FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob
+  =
   fun uu___97_1318  ->
     match uu___97_1318 with
     | FStar_TypeChecker_Common.TProb p ->
@@ -900,16 +813,14 @@ let (p_invert :
     | FStar_TypeChecker_Common.CProb p ->
         FStar_All.pipe_left
           (fun _0_44  -> FStar_TypeChecker_Common.CProb _0_44) (invert p)
-  
-let (is_top_level_prob : FStar_TypeChecker_Common.prob -> Prims.bool) =
+let is_top_level_prob: FStar_TypeChecker_Common.prob -> Prims.bool =
   fun p  ->
-    let uu____1340 = FStar_All.pipe_right (p_reason p) FStar_List.length  in
+    let uu____1340 = FStar_All.pipe_right (p_reason p) FStar_List.length in
     uu____1340 = (Prims.parse_int "1")
-  
-let (next_pid : Prims.unit -> Prims.int) =
-  let ctr = FStar_Util.mk_ref (Prims.parse_int "0")  in
-  fun uu____1352  -> FStar_Util.incr ctr; FStar_ST.op_Bang ctr 
-let mk_problem :
+let next_pid: Prims.unit -> Prims.int =
+  let ctr = FStar_Util.mk_ref (Prims.parse_int "0") in
+  fun uu____1352  -> FStar_Util.incr ctr; FStar_ST.op_Bang ctr
+let mk_problem:
   'Auu____1437 'Auu____1438 .
     FStar_Syntax_Syntax.binders ->
       FStar_TypeChecker_Common.prob ->
@@ -928,11 +839,10 @@ let mk_problem :
           fun rhs  ->
             fun elt  ->
               fun reason  ->
-                let uu____1475 = next_pid ()  in
+                let uu____1475 = next_pid () in
                 let uu____1476 =
                   new_uvar FStar_Range.dummyRange scope
-                    FStar_Syntax_Util.ktype0
-                   in
+                    FStar_Syntax_Util.ktype0 in
                 {
                   FStar_TypeChecker_Common.pid = uu____1475;
                   FStar_TypeChecker_Common.lhs = lhs;
@@ -947,8 +857,7 @@ let mk_problem :
                   FStar_TypeChecker_Common.rank =
                     FStar_Pervasives_Native.None
                 }
-  
-let new_problem :
+let new_problem:
   'Auu____1490 'Auu____1491 .
     FStar_TypeChecker_Env.env ->
       'Auu____1491 ->
@@ -967,12 +876,11 @@ let new_problem :
           fun elt  ->
             fun loc  ->
               fun reason  ->
-                let scope = FStar_TypeChecker_Env.all_binders env  in
-                let uu____1529 = next_pid ()  in
+                let scope = FStar_TypeChecker_Env.all_binders env in
+                let uu____1529 = next_pid () in
                 let uu____1530 =
                   new_uvar FStar_Range.dummyRange scope
-                    FStar_Syntax_Util.ktype0
-                   in
+                    FStar_Syntax_Util.ktype0 in
                 {
                   FStar_TypeChecker_Common.pid = uu____1529;
                   FStar_TypeChecker_Common.lhs = lhs;
@@ -986,8 +894,7 @@ let new_problem :
                   FStar_TypeChecker_Common.rank =
                     FStar_Pervasives_Native.None
                 }
-  
-let problem_using_guard :
+let problem_using_guard:
   'Auu____1543 'Auu____1544 .
     FStar_TypeChecker_Common.prob ->
       'Auu____1544 ->
@@ -1003,7 +910,7 @@ let problem_using_guard :
         fun rhs  ->
           fun elt  ->
             fun reason  ->
-              let uu____1577 = next_pid ()  in
+              let uu____1577 = next_pid () in
               {
                 FStar_TypeChecker_Common.pid = uu____1577;
                 FStar_TypeChecker_Common.lhs = lhs;
@@ -1016,8 +923,7 @@ let problem_using_guard :
                 FStar_TypeChecker_Common.loc = (p_loc orig);
                 FStar_TypeChecker_Common.rank = FStar_Pervasives_Native.None
               }
-  
-let guard_on_element :
+let guard_on_element:
   'Auu____1583 .
     worklist ->
       ('Auu____1583,FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
@@ -1033,70 +939,60 @@ let guard_on_element :
           | FStar_Pervasives_Native.None  ->
               let u =
                 (wl.tcenv).FStar_TypeChecker_Env.universe_of wl.tcenv
-                  x.FStar_Syntax_Syntax.sort
-                 in
+                  x.FStar_Syntax_Syntax.sort in
               FStar_Syntax_Util.mk_forall u x phi
           | FStar_Pervasives_Native.Some e ->
               FStar_Syntax_Subst.subst [FStar_Syntax_Syntax.NT (x, e)] phi
-  
-let (explain :
+let explain:
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.prob -> Prims.string -> Prims.string)
+    FStar_TypeChecker_Common.prob -> Prims.string -> Prims.string
   =
   fun env  ->
     fun d  ->
       fun s  ->
         let uu____1633 =
           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-            (FStar_Options.Other "ExplainRel")
-           in
+            (FStar_Options.Other "ExplainRel") in
         if uu____1633
         then
           let uu____1634 =
-            FStar_All.pipe_left FStar_Range.string_of_range (p_loc d)  in
-          let uu____1635 = prob_to_string env d  in
+            FStar_All.pipe_left FStar_Range.string_of_range (p_loc d) in
+          let uu____1635 = prob_to_string env d in
           let uu____1636 =
-            FStar_All.pipe_right (p_reason d) (FStar_String.concat "\n\t>")
-             in
+            FStar_All.pipe_right (p_reason d) (FStar_String.concat "\n\t>") in
           FStar_Util.format4
             "(%s) Failed to solve the sub-problem\n%s\nWhich arose because:\n\t%s\nFailed because:%s\n"
             uu____1634 uu____1635 uu____1636 s
         else
-          (let d1 = maybe_invert_p d  in
+          (let d1 = maybe_invert_p d in
            let rel =
              match p_rel d1 with
              | FStar_TypeChecker_Common.EQ  -> "equal to"
              | FStar_TypeChecker_Common.SUB  -> "a subtype of"
-             | uu____1642 -> failwith "impossible"  in
+             | uu____1642 -> failwith "impossible" in
            let uu____1643 =
              match d1 with
              | FStar_TypeChecker_Common.TProb tp ->
                  let uu____1657 =
                    FStar_TypeChecker_Normalize.term_to_string env
-                     tp.FStar_TypeChecker_Common.lhs
-                    in
+                     tp.FStar_TypeChecker_Common.lhs in
                  let uu____1658 =
                    FStar_TypeChecker_Normalize.term_to_string env
-                     tp.FStar_TypeChecker_Common.rhs
-                    in
+                     tp.FStar_TypeChecker_Common.rhs in
                  (uu____1657, uu____1658)
              | FStar_TypeChecker_Common.CProb cp ->
                  let uu____1664 =
                    FStar_TypeChecker_Normalize.comp_to_string env
-                     cp.FStar_TypeChecker_Common.lhs
-                    in
+                     cp.FStar_TypeChecker_Common.lhs in
                  let uu____1665 =
                    FStar_TypeChecker_Normalize.comp_to_string env
-                     cp.FStar_TypeChecker_Common.rhs
-                    in
-                 (uu____1664, uu____1665)
-              in
+                     cp.FStar_TypeChecker_Common.rhs in
+                 (uu____1664, uu____1665) in
            match uu____1643 with
            | (lhs,rhs) ->
                FStar_Util.format3 "%s is not %s the expected type %s" lhs rel
                  rhs)
-  
-let (commit : uvi Prims.list -> Prims.unit) =
+let commit: uvi Prims.list -> Prims.unit =
   fun uvis  ->
     FStar_All.pipe_right uvis
       (FStar_List.iter
@@ -1108,10 +1004,9 @@ let (commit : uvi Prims.list -> Prims.unit) =
                      FStar_Syntax_Unionfind.univ_union u u'
                  | uu____1693 -> FStar_Syntax_Unionfind.univ_change u t)
             | TERM ((u,uu____1695),t) -> FStar_Syntax_Util.set_uvar u t))
-  
-let (find_term_uvar :
+let find_term_uvar:
   FStar_Syntax_Syntax.uvar ->
-    uvi Prims.list -> FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+    uvi Prims.list -> FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun uv  ->
     fun s  ->
@@ -1120,15 +1015,14 @@ let (find_term_uvar :
            match uu___99_1715 with
            | UNIV uu____1718 -> FStar_Pervasives_Native.None
            | TERM ((u,uu____1724),t) ->
-               let uu____1730 = FStar_Syntax_Unionfind.equiv uv u  in
+               let uu____1730 = FStar_Syntax_Unionfind.equiv uv u in
                if uu____1730
                then FStar_Pervasives_Native.Some t
                else FStar_Pervasives_Native.None)
-  
-let (find_univ_uvar :
+let find_univ_uvar:
   FStar_Syntax_Syntax.universe_uvar ->
     uvi Prims.list ->
-      FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
   =
   fun u  ->
     fun s  ->
@@ -1136,40 +1030,35 @@ let (find_univ_uvar :
         (fun uu___100_1750  ->
            match uu___100_1750 with
            | UNIV (u',t) ->
-               let uu____1755 = FStar_Syntax_Unionfind.univ_equiv u u'  in
+               let uu____1755 = FStar_Syntax_Unionfind.univ_equiv u u' in
                if uu____1755
                then FStar_Pervasives_Native.Some t
                else FStar_Pervasives_Native.None
            | uu____1759 -> FStar_Pervasives_Native.None)
-  
-let (whnf :
+let whnf:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  ->
       let uu____1766 =
-        let uu____1767 = FStar_Syntax_Util.unmeta t  in
+        let uu____1767 = FStar_Syntax_Util.unmeta t in
         FStar_TypeChecker_Normalize.normalize
           [FStar_TypeChecker_Normalize.Beta;
           FStar_TypeChecker_Normalize.Weak;
-          FStar_TypeChecker_Normalize.HNF] env uu____1767
-         in
+          FStar_TypeChecker_Normalize.HNF] env uu____1767 in
       FStar_Syntax_Subst.compress uu____1766
-  
-let (sn :
+let sn:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  ->
       let uu____1774 =
         FStar_TypeChecker_Normalize.normalize
-          [FStar_TypeChecker_Normalize.Beta] env t
-         in
+          [FStar_TypeChecker_Normalize.Beta] env t in
       FStar_Syntax_Subst.compress uu____1774
-  
-let norm_arg :
+let norm_arg:
   'Auu____1778 .
     FStar_TypeChecker_Env.env ->
       (FStar_Syntax_Syntax.term,'Auu____1778) FStar_Pervasives_Native.tuple2
@@ -1179,14 +1068,13 @@ let norm_arg :
   =
   fun env  ->
     fun t  ->
-      let uu____1799 = sn env (FStar_Pervasives_Native.fst t)  in
+      let uu____1799 = sn env (FStar_Pervasives_Native.fst t) in
       (uu____1799, (FStar_Pervasives_Native.snd t))
-  
-let (sn_binders :
+let sn_binders:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
       (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
-        FStar_Pervasives_Native.tuple2 Prims.list)
+        FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun env  ->
     fun binders  ->
@@ -1196,34 +1084,32 @@ let (sn_binders :
               match uu____1830 with
               | (x,imp) ->
                   let uu____1841 =
-                    let uu___124_1842 = x  in
-                    let uu____1843 = sn env x.FStar_Syntax_Syntax.sort  in
+                    let uu___124_1842 = x in
+                    let uu____1843 = sn env x.FStar_Syntax_Syntax.sort in
                     {
                       FStar_Syntax_Syntax.ppname =
                         (uu___124_1842.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
                         (uu___124_1842.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort = uu____1843
-                    }  in
+                    } in
                   (uu____1841, imp)))
-  
-let (norm_univ :
-  worklist -> FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe) =
+let norm_univ:
+  worklist -> FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe =
   fun wl  ->
     fun u  ->
       let rec aux u1 =
-        let u2 = FStar_Syntax_Subst.compress_univ u1  in
+        let u2 = FStar_Syntax_Subst.compress_univ u1 in
         match u2 with
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____1858 = aux u3  in FStar_Syntax_Syntax.U_succ uu____1858
+            let uu____1858 = aux u3 in FStar_Syntax_Syntax.U_succ uu____1858
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____1862 = FStar_List.map aux us  in
+            let uu____1862 = FStar_List.map aux us in
             FStar_Syntax_Syntax.U_max uu____1862
-        | uu____1865 -> u2  in
-      let uu____1866 = aux u  in
+        | uu____1865 -> u2 in
+      let uu____1866 = aux u in
       FStar_TypeChecker_Normalize.normalize_universe wl.tcenv uu____1866
-  
-let (base_and_refinement_maybe_delta :
+let base_and_refinement_maybe_delta:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term ->
@@ -1232,7 +1118,7 @@ let (base_and_refinement_maybe_delta :
                                                                   FStar_Syntax_Syntax.syntax)
                                                                 FStar_Pervasives_Native.tuple2
                                                                 FStar_Pervasives_Native.option)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun should_delta  ->
     fun env  ->
@@ -1247,11 +1133,10 @@ let (base_and_refinement_maybe_delta :
                 FStar_Syntax_Syntax.Delta_constant]
             else
               [FStar_TypeChecker_Normalize.Weak;
-              FStar_TypeChecker_Normalize.HNF]
-             in
-          FStar_TypeChecker_Normalize.normalize_refinement steps env1 t  in
+              FStar_TypeChecker_Normalize.HNF] in
+          FStar_TypeChecker_Normalize.normalize_refinement steps env1 t in
         let rec aux norm1 t11 =
-          let t12 = FStar_Syntax_Util.unmeta t11  in
+          let t12 = FStar_Syntax_Util.unmeta t11 in
           match t12.FStar_Syntax_Syntax.n with
           | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
               if norm1
@@ -1259,7 +1144,7 @@ let (base_and_refinement_maybe_delta :
                 ((x.FStar_Syntax_Syntax.sort),
                   (FStar_Pervasives_Native.Some (x, phi)))
               else
-                (let uu____1978 = norm_refinement env t12  in
+                (let uu____1978 = norm_refinement env t12 in
                  match uu____1978 with
                  | {
                      FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine
@@ -1270,21 +1155,19 @@ let (base_and_refinement_maybe_delta :
                        (FStar_Pervasives_Native.Some (x1, phi1)))
                  | tt ->
                      let uu____2022 =
-                       let uu____2023 = FStar_Syntax_Print.term_to_string tt
-                          in
-                       let uu____2024 = FStar_Syntax_Print.tag_of_term tt  in
+                       let uu____2023 = FStar_Syntax_Print.term_to_string tt in
+                       let uu____2024 = FStar_Syntax_Print.tag_of_term tt in
                        FStar_Util.format2 "impossible: Got %s ... %s\n"
-                         uu____2023 uu____2024
-                        in
+                         uu____2023 uu____2024 in
                      failwith uu____2022)
           | FStar_Syntax_Syntax.Tm_uinst uu____2039 ->
               if norm1
               then (t12, FStar_Pervasives_Native.None)
               else
-                (let t1' = norm_refinement env t12  in
+                (let t1' = norm_refinement env t12 in
                  let uu____2076 =
-                   let uu____2077 = FStar_Syntax_Subst.compress t1'  in
-                   uu____2077.FStar_Syntax_Syntax.n  in
+                   let uu____2077 = FStar_Syntax_Subst.compress t1' in
+                   uu____2077.FStar_Syntax_Syntax.n in
                  match uu____2076 with
                  | FStar_Syntax_Syntax.Tm_refine uu____2094 -> aux true t1'
                  | uu____2101 -> (t12, FStar_Pervasives_Native.None))
@@ -1292,10 +1175,10 @@ let (base_and_refinement_maybe_delta :
               if norm1
               then (t12, FStar_Pervasives_Native.None)
               else
-                (let t1' = norm_refinement env t12  in
+                (let t1' = norm_refinement env t12 in
                  let uu____2147 =
-                   let uu____2148 = FStar_Syntax_Subst.compress t1'  in
-                   uu____2148.FStar_Syntax_Syntax.n  in
+                   let uu____2148 = FStar_Syntax_Subst.compress t1' in
+                   uu____2148.FStar_Syntax_Syntax.n in
                  match uu____2147 with
                  | FStar_Syntax_Syntax.Tm_refine uu____2165 -> aux true t1'
                  | uu____2172 -> (t12, FStar_Pervasives_Native.None))
@@ -1303,10 +1186,10 @@ let (base_and_refinement_maybe_delta :
               if norm1
               then (t12, FStar_Pervasives_Native.None)
               else
-                (let t1' = norm_refinement env t12  in
+                (let t1' = norm_refinement env t12 in
                  let uu____2232 =
-                   let uu____2233 = FStar_Syntax_Subst.compress t1'  in
-                   uu____2233.FStar_Syntax_Syntax.n  in
+                   let uu____2233 = FStar_Syntax_Subst.compress t1' in
+                   uu____2233.FStar_Syntax_Syntax.n in
                  match uu____2232 with
                  | FStar_Syntax_Syntax.Tm_refine uu____2250 -> aux true t1'
                  | uu____2257 -> (t12, FStar_Pervasives_Native.None))
@@ -1330,48 +1213,42 @@ let (base_and_refinement_maybe_delta :
               (t12, FStar_Pervasives_Native.None)
           | FStar_Syntax_Syntax.Tm_meta uu____2485 ->
               let uu____2492 =
-                let uu____2493 = FStar_Syntax_Print.term_to_string t12  in
-                let uu____2494 = FStar_Syntax_Print.tag_of_term t12  in
+                let uu____2493 = FStar_Syntax_Print.term_to_string t12 in
+                let uu____2494 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____2493 uu____2494
-                 in
+                  uu____2493 uu____2494 in
               failwith uu____2492
           | FStar_Syntax_Syntax.Tm_ascribed uu____2509 ->
               let uu____2536 =
-                let uu____2537 = FStar_Syntax_Print.term_to_string t12  in
-                let uu____2538 = FStar_Syntax_Print.tag_of_term t12  in
+                let uu____2537 = FStar_Syntax_Print.term_to_string t12 in
+                let uu____2538 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____2537 uu____2538
-                 in
+                  uu____2537 uu____2538 in
               failwith uu____2536
           | FStar_Syntax_Syntax.Tm_delayed uu____2553 ->
               let uu____2578 =
-                let uu____2579 = FStar_Syntax_Print.term_to_string t12  in
-                let uu____2580 = FStar_Syntax_Print.tag_of_term t12  in
+                let uu____2579 = FStar_Syntax_Print.term_to_string t12 in
+                let uu____2580 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____2579 uu____2580
-                 in
+                  uu____2579 uu____2580 in
               failwith uu____2578
           | FStar_Syntax_Syntax.Tm_unknown  ->
               let uu____2595 =
-                let uu____2596 = FStar_Syntax_Print.term_to_string t12  in
-                let uu____2597 = FStar_Syntax_Print.tag_of_term t12  in
+                let uu____2596 = FStar_Syntax_Print.term_to_string t12 in
+                let uu____2597 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____2596 uu____2597
-                 in
-              failwith uu____2595
-           in
-        let uu____2612 = whnf env t1  in aux false uu____2612
-  
-let (base_and_refinement :
+                  uu____2596 uu____2597 in
+              failwith uu____2595 in
+        let uu____2612 = whnf env t1 in aux false uu____2612
+let base_and_refinement:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,(FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.term)
                                   FStar_Pervasives_Native.tuple2
                                   FStar_Pervasives_Native.option)
-        FStar_Pervasives_Native.tuple2)
-  = fun env  -> fun t  -> base_and_refinement_maybe_delta false env t 
-let normalize_refinement :
+        FStar_Pervasives_Native.tuple2
+  = fun env  -> fun t  -> base_and_refinement_maybe_delta false env t
+let normalize_refinement:
   'Auu____2634 .
     FStar_TypeChecker_Normalize.steps ->
       FStar_TypeChecker_Env.env ->
@@ -1382,26 +1259,23 @@ let normalize_refinement :
       fun wl  ->
         fun t0  ->
           FStar_TypeChecker_Normalize.normalize_refinement steps env t0
-  
-let (unrefine :
+let unrefine:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
+    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
   =
   fun env  ->
     fun t  ->
-      let uu____2657 = base_and_refinement env t  in
+      let uu____2657 = base_and_refinement env t in
       FStar_All.pipe_right uu____2657 FStar_Pervasives_Native.fst
-  
-let (trivial_refinement :
+let trivial_refinement:
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
-    let uu____2691 = FStar_Syntax_Syntax.null_bv t  in
+    let uu____2691 = FStar_Syntax_Syntax.null_bv t in
     (uu____2691, FStar_Syntax_Util.t_true)
-  
-let as_refinement :
+let as_refinement:
   'Auu____2697 .
     Prims.bool ->
       FStar_TypeChecker_Env.env ->
@@ -1414,19 +1288,18 @@ let as_refinement :
     fun env  ->
       fun wl  ->
         fun t  ->
-          let uu____2718 = base_and_refinement_maybe_delta delta1 env t  in
+          let uu____2718 = base_and_refinement_maybe_delta delta1 env t in
           match uu____2718 with
           | (t_base,refinement) ->
               (match refinement with
                | FStar_Pervasives_Native.None  -> trivial_refinement t_base
                | FStar_Pervasives_Native.Some (x,phi) -> (x, phi))
-  
-let (force_refinement :
+let force_refinement:
   (FStar_Syntax_Syntax.term,(FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.term)
                               FStar_Pervasives_Native.tuple2
                               FStar_Pervasives_Native.option)
     FStar_Pervasives_Native.tuple2 ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun uu____2797  ->
     match uu____2797 with
@@ -1434,16 +1307,15 @@ let (force_refinement :
         let uu____2824 =
           match refopt with
           | FStar_Pervasives_Native.Some (y,phi) -> (y, phi)
-          | FStar_Pervasives_Native.None  -> trivial_refinement t_base  in
+          | FStar_Pervasives_Native.None  -> trivial_refinement t_base in
         (match uu____2824 with
          | (y,phi) ->
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_refine (y, phi))
                FStar_Pervasives_Native.None t_base.FStar_Syntax_Syntax.pos)
-  
-let (wl_prob_to_string :
-  worklist -> FStar_TypeChecker_Common.prob -> Prims.string) =
-  fun wl  -> fun prob  -> prob_to_string wl.tcenv prob 
-let (wl_to_string : worklist -> Prims.string) =
+let wl_prob_to_string:
+  worklist -> FStar_TypeChecker_Common.prob -> Prims.string =
+  fun wl  -> fun prob  -> prob_to_string wl.tcenv prob
+let wl_to_string: worklist -> Prims.string =
   fun wl  ->
     let uu____2856 =
       let uu____2859 =
@@ -1451,43 +1323,39 @@ let (wl_to_string : worklist -> Prims.string) =
           FStar_All.pipe_right wl.wl_deferred
             (FStar_List.map
                (fun uu____2885  ->
-                  match uu____2885 with | (uu____2892,uu____2893,x) -> x))
-           in
-        FStar_List.append wl.attempting uu____2862  in
-      FStar_List.map (wl_prob_to_string wl) uu____2859  in
+                  match uu____2885 with | (uu____2892,uu____2893,x) -> x)) in
+        FStar_List.append wl.attempting uu____2862 in
+      FStar_List.map (wl_prob_to_string wl) uu____2859 in
     FStar_All.pipe_right uu____2856 (FStar_String.concat "\n\t")
-  
-let (u_abs :
+let u_abs:
   FStar_Syntax_Syntax.typ ->
     FStar_Syntax_Syntax.binders ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun k  ->
     fun ys  ->
       fun t  ->
         let uu____2906 =
           let uu____2919 =
-            let uu____2920 = FStar_Syntax_Subst.compress k  in
-            uu____2920.FStar_Syntax_Syntax.n  in
+            let uu____2920 = FStar_Syntax_Subst.compress k in
+            uu____2920.FStar_Syntax_Syntax.n in
           match uu____2919 with
           | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
               if (FStar_List.length bs) = (FStar_List.length ys)
               then
-                let uu____2973 = FStar_Syntax_Subst.open_comp bs c  in
+                let uu____2973 = FStar_Syntax_Subst.open_comp bs c in
                 ((ys, t), uu____2973)
               else
-                (let uu____2987 = FStar_Syntax_Util.abs_formals t  in
+                (let uu____2987 = FStar_Syntax_Util.abs_formals t in
                  match uu____2987 with
                  | (ys',t1,uu____3010) ->
-                     let uu____3015 = FStar_Syntax_Util.arrow_formals_comp k
-                        in
+                     let uu____3015 = FStar_Syntax_Util.arrow_formals_comp k in
                      (((FStar_List.append ys ys'), t1), uu____3015))
           | uu____3056 ->
               let uu____3057 =
-                let uu____3068 = FStar_Syntax_Syntax.mk_Total k  in
-                ([], uu____3068)  in
-              ((ys, t), uu____3057)
-           in
+                let uu____3068 = FStar_Syntax_Syntax.mk_Total k in
+                ([], uu____3068) in
+              ((ys, t), uu____3057) in
         match uu____2906 with
         | ((ys1,t1),(xs,c)) ->
             if (FStar_List.length xs) <> (FStar_List.length ys1)
@@ -1499,17 +1367,16 @@ let (u_abs :
                       FStar_Pervasives_Native.None []))
             else
               (let c1 =
-                 let uu____3117 = FStar_Syntax_Util.rename_binders xs ys1  in
-                 FStar_Syntax_Subst.subst_comp uu____3117 c  in
+                 let uu____3117 = FStar_Syntax_Util.rename_binders xs ys1 in
+                 FStar_Syntax_Subst.subst_comp uu____3117 c in
                FStar_Syntax_Util.abs ys1 t1
                  (FStar_Pervasives_Native.Some
                     (FStar_Syntax_Util.residual_comp_of_comp c1)))
-  
-let (solve_prob' :
+let solve_prob':
   Prims.bool ->
     FStar_TypeChecker_Common.prob ->
       FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
-        uvi Prims.list -> worklist -> worklist)
+        uvi Prims.list -> worklist -> worklist
   =
   fun resolve_ok  ->
     fun prob  ->
@@ -1519,30 +1386,29 @@ let (solve_prob' :
             let phi =
               match logical_guard with
               | FStar_Pervasives_Native.None  -> FStar_Syntax_Util.t_true
-              | FStar_Pervasives_Native.Some phi -> phi  in
-            let uu____3145 = p_guard prob  in
+              | FStar_Pervasives_Native.Some phi -> phi in
+            let uu____3145 = p_guard prob in
             match uu____3145 with
             | (uu____3150,uv) ->
                 ((let uu____3153 =
-                    let uu____3154 = FStar_Syntax_Subst.compress uv  in
-                    uu____3154.FStar_Syntax_Syntax.n  in
+                    let uu____3154 = FStar_Syntax_Subst.compress uv in
+                    uu____3154.FStar_Syntax_Syntax.n in
                   match uu____3153 with
                   | FStar_Syntax_Syntax.Tm_uvar (uvar,k) ->
-                      let bs = p_scope prob  in
-                      let phi1 = u_abs k bs phi  in
+                      let bs = p_scope prob in
+                      let phi1 = u_abs k bs phi in
                       ((let uu____3186 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug wl.tcenv)
-                            (FStar_Options.Other "Rel")
-                           in
+                            (FStar_Options.Other "Rel") in
                         if uu____3186
                         then
                           let uu____3187 =
-                            FStar_Util.string_of_int (p_pid prob)  in
+                            FStar_Util.string_of_int (p_pid prob) in
                           let uu____3188 =
-                            FStar_Syntax_Print.term_to_string uv  in
+                            FStar_Syntax_Print.term_to_string uv in
                           let uu____3189 =
-                            FStar_Syntax_Print.term_to_string phi1  in
+                            FStar_Syntax_Print.term_to_string phi1 in
                           FStar_Util.print3
                             "Solving %s (%s) with formula %s\n" uu____3187
                             uu____3188 uu____3189
@@ -1555,7 +1421,7 @@ let (solve_prob' :
                           "Impossible: this instance has already been assigned a solution"
                       else ());
                  commit uvis;
-                 (let uu___125_3194 = wl  in
+                 (let uu___125_3194 = wl in
                   {
                     attempting = (uu___125_3194.attempting);
                     wl_deferred = (uu___125_3194.wl_deferred);
@@ -1564,25 +1430,23 @@ let (solve_prob' :
                     smt_ok = (uu___125_3194.smt_ok);
                     tcenv = (uu___125_3194.tcenv)
                   }))
-  
-let (extend_solution : Prims.int -> uvi Prims.list -> worklist -> worklist) =
+let extend_solution: Prims.int -> uvi Prims.list -> worklist -> worklist =
   fun pid  ->
     fun sol  ->
       fun wl  ->
         (let uu____3209 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
-             (FStar_Options.Other "RelCheck")
-            in
+             (FStar_Options.Other "RelCheck") in
          if uu____3209
          then
-           let uu____3210 = FStar_Util.string_of_int pid  in
+           let uu____3210 = FStar_Util.string_of_int pid in
            let uu____3211 =
-             let uu____3212 = FStar_List.map (uvi_to_string wl.tcenv) sol  in
-             FStar_All.pipe_right uu____3212 (FStar_String.concat ", ")  in
+             let uu____3212 = FStar_List.map (uvi_to_string wl.tcenv) sol in
+             FStar_All.pipe_right uu____3212 (FStar_String.concat ", ") in
            FStar_Util.print2 "Solving %s: with %s\n" uu____3210 uu____3211
          else ());
         commit sol;
-        (let uu___126_3219 = wl  in
+        (let uu___126_3219 = wl in
          {
            attempting = (uu___126_3219.attempting);
            wl_deferred = (uu___126_3219.wl_deferred);
@@ -1591,11 +1455,10 @@ let (extend_solution : Prims.int -> uvi Prims.list -> worklist -> worklist) =
            smt_ok = (uu___126_3219.smt_ok);
            tcenv = (uu___126_3219.tcenv)
          })
-  
-let (solve_prob :
+let solve_prob:
   FStar_TypeChecker_Common.prob ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
-      uvi Prims.list -> worklist -> worklist)
+      uvi Prims.list -> worklist -> worklist
   =
   fun prob  ->
     fun logical_guard  ->
@@ -1609,26 +1472,22 @@ let (solve_prob :
                 FStar_Pervasives_Native.Some f
             | (FStar_Pervasives_Native.Some
                t1,FStar_TypeChecker_Common.NonTrivial f) ->
-                let uu____3269 = FStar_Syntax_Util.mk_conj t1 f  in
-                FStar_Pervasives_Native.Some uu____3269
-             in
+                let uu____3269 = FStar_Syntax_Util.mk_conj t1 f in
+                FStar_Pervasives_Native.Some uu____3269 in
           (let uu____3275 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
-               (FStar_Options.Other "RelCheck")
-              in
+               (FStar_Options.Other "RelCheck") in
            if uu____3275
            then
              let uu____3276 =
-               FStar_All.pipe_left FStar_Util.string_of_int (p_pid prob)  in
+               FStar_All.pipe_left FStar_Util.string_of_int (p_pid prob) in
              let uu____3277 =
-               let uu____3278 = FStar_List.map (uvi_to_string wl.tcenv) uvis
-                  in
-               FStar_All.pipe_right uu____3278 (FStar_String.concat ", ")  in
+               let uu____3278 = FStar_List.map (uvi_to_string wl.tcenv) uvis in
+               FStar_All.pipe_right uu____3278 (FStar_String.concat ", ") in
              FStar_Util.print2 "Solving %s: with %s\n" uu____3276 uu____3277
            else ());
           solve_prob' false prob logical_guard uvis wl
-  
-let rec occurs :
+let rec occurs:
   'b .
     worklist ->
       (FStar_Syntax_Syntax.uvar,'b) FStar_Pervasives_Native.tuple2 ->
@@ -1638,8 +1497,8 @@ let rec occurs :
     fun uk  ->
       fun t  ->
         let uu____3310 =
-          let uu____3317 = FStar_Syntax_Free.uvars t  in
-          FStar_All.pipe_right uu____3317 FStar_Util.set_elements  in
+          let uu____3317 = FStar_Syntax_Free.uvars t in
+          FStar_All.pipe_right uu____3317 FStar_Util.set_elements in
         FStar_All.pipe_right uu____3310
           (FStar_Util.for_some
              (fun uu____3353  ->
@@ -1647,8 +1506,7 @@ let rec occurs :
                 | (uv,uu____3359) ->
                     FStar_Syntax_Unionfind.equiv uv
                       (FStar_Pervasives_Native.fst uk)))
-  
-let occurs_check :
+let occurs_check:
   'Auu____3366 'Auu____3367 .
     'Auu____3367 ->
       worklist ->
@@ -1663,8 +1521,7 @@ let occurs_check :
       fun uk  ->
         fun t  ->
           let occurs_ok =
-            let uu____3399 = occurs wl uk t  in Prims.op_Negation uu____3399
-             in
+            let uu____3399 = occurs wl uk t in Prims.op_Negation uu____3399 in
           let msg =
             if occurs_ok
             then FStar_Pervasives_Native.None
@@ -1672,17 +1529,13 @@ let occurs_check :
               (let uu____3406 =
                  let uu____3407 =
                    FStar_Syntax_Print.uvar_to_string
-                     (FStar_Pervasives_Native.fst uk)
-                    in
-                 let uu____3408 = FStar_Syntax_Print.term_to_string t  in
+                     (FStar_Pervasives_Native.fst uk) in
+                 let uu____3408 = FStar_Syntax_Print.term_to_string t in
                  FStar_Util.format2 "occurs-check failed (%s occurs in %s)"
-                   uu____3407 uu____3408
-                  in
-               FStar_Pervasives_Native.Some uu____3406)
-             in
+                   uu____3407 uu____3408 in
+               FStar_Pervasives_Native.Some uu____3406) in
           (occurs_ok, msg)
-  
-let occurs_and_freevars_check :
+let occurs_and_freevars_check:
   'Auu____3418 'Auu____3419 .
     'Auu____3419 ->
       worklist ->
@@ -1702,14 +1555,13 @@ let occurs_and_freevars_check :
       fun uk  ->
         fun fvs  ->
           fun t  ->
-            let fvs_t = FStar_Syntax_Free.names t  in
-            let uu____3473 = occurs_check env wl uk t  in
+            let fvs_t = FStar_Syntax_Free.names t in
+            let uu____3473 = occurs_check env wl uk t in
             match uu____3473 with
             | (occurs_ok,msg) ->
-                let uu____3504 = FStar_Util.set_is_subset_of fvs_t fvs  in
+                let uu____3504 = FStar_Util.set_is_subset_of fvs_t fvs in
                 (occurs_ok, uu____3504, (msg, fvs, fvs_t))
-  
-let intersect_vars :
+let intersect_vars:
   'Auu____3527 'Auu____3528 .
     (FStar_Syntax_Syntax.bv,'Auu____3528) FStar_Pervasives_Native.tuple2
       Prims.list ->
@@ -1726,9 +1578,8 @@ let intersect_vars :
              (fun out  ->
                 fun x  ->
                   FStar_Util.set_add (FStar_Pervasives_Native.fst x) out)
-             FStar_Syntax_Syntax.no_names)
-         in
-      let v1_set = as_set1 v1  in
+             FStar_Syntax_Syntax.no_names) in
+      let v1_set = as_set1 v1 in
       let uu____3612 =
         FStar_All.pipe_right v2
           (FStar_List.fold_left
@@ -1737,27 +1588,23 @@ let intersect_vars :
                   match (uu____3666, uu____3667) with
                   | ((isect,isect_set),(x,imp)) ->
                       let uu____3748 =
-                        let uu____3749 = FStar_Util.set_mem x v1_set  in
-                        FStar_All.pipe_left Prims.op_Negation uu____3749  in
+                        let uu____3749 = FStar_Util.set_mem x v1_set in
+                        FStar_All.pipe_left Prims.op_Negation uu____3749 in
                       if uu____3748
                       then (isect, isect_set)
                       else
                         (let fvs =
-                           FStar_Syntax_Free.names x.FStar_Syntax_Syntax.sort
-                            in
+                           FStar_Syntax_Free.names x.FStar_Syntax_Syntax.sort in
                          let uu____3774 =
-                           FStar_Util.set_is_subset_of fvs isect_set  in
+                           FStar_Util.set_is_subset_of fvs isect_set in
                          if uu____3774
                          then
-                           let uu____3787 = FStar_Util.set_add x isect_set
-                              in
+                           let uu____3787 = FStar_Util.set_add x isect_set in
                            (((x, imp) :: isect), uu____3787)
                          else (isect, isect_set)))
-             ([], FStar_Syntax_Syntax.no_names))
-         in
+             ([], FStar_Syntax_Syntax.no_names)) in
       match uu____3612 with | (isect,uu____3828) -> FStar_List.rev isect
-  
-let binders_eq :
+let binders_eq:
   'Auu____3853 'Auu____3854 .
     (FStar_Syntax_Syntax.bv,'Auu____3854) FStar_Pervasives_Native.tuple2
       Prims.list ->
@@ -1773,8 +1620,7 @@ let binders_eq :
                 match (uu____3909, uu____3910) with
                 | ((a,uu____3928),(b,uu____3930)) ->
                     FStar_Syntax_Syntax.bv_eq a b) v1 v2)
-  
-let pat_var_opt :
+let pat_var_opt:
   'Auu____3944 'Auu____3945 .
     FStar_TypeChecker_Env.env ->
       (FStar_Syntax_Syntax.bv,'Auu____3945) FStar_Pervasives_Native.tuple2
@@ -1787,7 +1633,7 @@ let pat_var_opt :
   fun env  ->
     fun seen  ->
       fun arg  ->
-        let hd1 = norm_arg env arg  in
+        let hd1 = norm_arg env arg in
         match (FStar_Pervasives_Native.fst hd1).FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_name a ->
             let uu____3996 =
@@ -1795,22 +1641,20 @@ let pat_var_opt :
                 (FStar_Util.for_some
                    (fun uu____4010  ->
                       match uu____4010 with
-                      | (b,uu____4016) -> FStar_Syntax_Syntax.bv_eq a b))
-               in
+                      | (b,uu____4016) -> FStar_Syntax_Syntax.bv_eq a b)) in
             if uu____3996
             then FStar_Pervasives_Native.None
             else
               FStar_Pervasives_Native.Some
                 (a, (FStar_Pervasives_Native.snd hd1))
         | uu____4032 -> FStar_Pervasives_Native.None
-  
-let rec (pat_vars :
+let rec pat_vars:
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
       FStar_Pervasives_Native.tuple2 Prims.list ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.aqual)
         FStar_Pervasives_Native.tuple2 Prims.list ->
-        FStar_Syntax_Syntax.binders FStar_Pervasives_Native.option)
+        FStar_Syntax_Syntax.binders FStar_Pervasives_Native.option
   =
   fun env  ->
     fun seen  ->
@@ -1818,30 +1662,27 @@ let rec (pat_vars :
         match args with
         | [] -> FStar_Pervasives_Native.Some (FStar_List.rev seen)
         | hd1::rest ->
-            let uu____4105 = pat_var_opt env seen hd1  in
+            let uu____4105 = pat_var_opt env seen hd1 in
             (match uu____4105 with
              | FStar_Pervasives_Native.None  ->
                  ((let uu____4119 =
                      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                       (FStar_Options.Other "Rel")
-                      in
+                       (FStar_Options.Other "Rel") in
                    if uu____4119
                    then
                      let uu____4120 =
                        FStar_All.pipe_left FStar_Syntax_Print.term_to_string
-                         (FStar_Pervasives_Native.fst hd1)
-                        in
+                         (FStar_Pervasives_Native.fst hd1) in
                      FStar_Util.print1 "Not a pattern: %s\n" uu____4120
                    else ());
                   FStar_Pervasives_Native.None)
              | FStar_Pervasives_Native.Some x ->
                  pat_vars env (x :: seen) rest)
-  
-let (is_flex : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_flex: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____4138 =
-      let uu____4139 = FStar_Syntax_Subst.compress t  in
-      uu____4139.FStar_Syntax_Syntax.n  in
+      let uu____4139 = FStar_Syntax_Subst.compress t in
+      uu____4139.FStar_Syntax_Syntax.n in
     match uu____4138 with
     | FStar_Syntax_Syntax.Tm_uvar uu____4142 -> true
     | FStar_Syntax_Syntax.Tm_app
@@ -1850,8 +1691,7 @@ let (is_flex : FStar_Syntax_Syntax.term -> Prims.bool) =
            FStar_Syntax_Syntax.vars = uu____4161;_},uu____4162)
         -> true
     | uu____4199 -> false
-  
-let (destruct_flex_t :
+let destruct_flex_t:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,(FStar_Syntax_Syntax.term'
                                                              FStar_Syntax_Syntax.syntax
@@ -1864,7 +1704,7 @@ let (destruct_flex_t :
                                                              FStar_Syntax_Syntax.aqual)
                                                              FStar_Pervasives_Native.tuple2
                                                              Prims.list)
-      FStar_Pervasives_Native.tuple4)
+      FStar_Pervasives_Native.tuple4
   =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
@@ -1875,8 +1715,7 @@ let (destruct_flex_t :
            FStar_Syntax_Syntax.vars = uu____4324;_},args)
         -> (t, uv, k, args)
     | uu____4392 -> failwith "Not a flex-uvar"
-  
-let (destruct_flex_pattern :
+let destruct_flex_pattern:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,(FStar_Syntax_Syntax.term'
@@ -1892,66 +1731,59 @@ let (destruct_flex_pattern :
                                                                 Prims.list)
          FStar_Pervasives_Native.tuple4,FStar_Syntax_Syntax.binders
                                           FStar_Pervasives_Native.option)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun t  ->
-      let uu____4469 = destruct_flex_t t  in
+      let uu____4469 = destruct_flex_t t in
       match uu____4469 with
       | (t1,uv,k,args) ->
-          let uu____4584 = pat_vars env [] args  in
+          let uu____4584 = pat_vars env [] args in
           (match uu____4584 with
            | FStar_Pervasives_Native.Some vars ->
                ((t1, uv, k, args), (FStar_Pervasives_Native.Some vars))
            | uu____4682 -> ((t1, uv, k, args), FStar_Pervasives_Native.None))
-  
 type match_result =
   | MisMatch of
   (FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option,FStar_Syntax_Syntax.delta_depth
                                                                     FStar_Pervasives_Native.option)
-  FStar_Pervasives_Native.tuple2 
-  | HeadMatch 
-  | FullMatch [@@deriving show]
-let (uu___is_MisMatch : match_result -> Prims.bool) =
+  FStar_Pervasives_Native.tuple2
+  | HeadMatch
+  | FullMatch[@@deriving show]
+let uu___is_MisMatch: match_result -> Prims.bool =
   fun projectee  ->
     match projectee with | MisMatch _0 -> true | uu____4763 -> false
-  
-let (__proj__MisMatch__item___0 :
+let __proj__MisMatch__item___0:
   match_result ->
     (FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option,FStar_Syntax_Syntax.delta_depth
                                                                     FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | MisMatch _0 -> _0 
-let (uu___is_HeadMatch : match_result -> Prims.bool) =
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | MisMatch _0 -> _0
+let uu___is_HeadMatch: match_result -> Prims.bool =
   fun projectee  ->
     match projectee with | HeadMatch  -> true | uu____4798 -> false
-  
-let (uu___is_FullMatch : match_result -> Prims.bool) =
+let uu___is_FullMatch: match_result -> Prims.bool =
   fun projectee  ->
     match projectee with | FullMatch  -> true | uu____4802 -> false
-  
-let (head_match : match_result -> match_result) =
+let head_match: match_result -> match_result =
   fun uu___101_4805  ->
     match uu___101_4805 with
     | MisMatch (i,j) -> MisMatch (i, j)
     | uu____4820 -> HeadMatch
-  
-let (and_match :
-  match_result -> (Prims.unit -> match_result) -> match_result) =
+let and_match: match_result -> (Prims.unit -> match_result) -> match_result =
   fun m1  ->
     fun m2  ->
       match m1 with
       | MisMatch (i,j) -> MisMatch (i, j)
       | HeadMatch  ->
-          let uu____4846 = m2 ()  in
+          let uu____4846 = m2 () in
           (match uu____4846 with
            | MisMatch (i,j) -> MisMatch (i, j)
            | uu____4861 -> HeadMatch)
       | FullMatch  -> m2 ()
-  
-let (fv_delta_depth :
+let fv_delta_depth:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.delta_depth)
+    FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.delta_depth
   =
   fun env  ->
     fun fv  ->
@@ -1967,22 +1799,20 @@ let (fv_delta_depth :
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Unfold
                  FStar_Syntax_Syntax.Delta_constant] env
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           (match uu____4871 with
            | FStar_Pervasives_Native.None  ->
                FStar_Syntax_Syntax.Delta_constant
            | uu____4882 -> fv.FStar_Syntax_Syntax.fv_delta)
       | d -> d
-  
-let rec (delta_depth_of_term :
+let rec delta_depth_of_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option
   =
   fun env  ->
     fun t  ->
-      let t1 = FStar_Syntax_Util.unmeta t  in
+      let t1 = FStar_Syntax_Util.unmeta t in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta uu____4901 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_delayed uu____4910 -> failwith "Impossible"
@@ -2016,18 +1846,17 @@ let rec (delta_depth_of_term :
       | FStar_Syntax_Syntax.Tm_abs uu____5088 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Delta_constant
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____5106 = fv_delta_depth env fv  in
+          let uu____5106 = fv_delta_depth env fv in
           FStar_Pervasives_Native.Some uu____5106
-  
-let rec (head_matches :
+let rec head_matches:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> match_result)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> match_result
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let t11 = FStar_Syntax_Util.unmeta t1  in
-        let t21 = FStar_Syntax_Util.unmeta t2  in
+        let t11 = FStar_Syntax_Util.unmeta t1 in
+        let t21 = FStar_Syntax_Util.unmeta t2 in
         match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
         | (FStar_Syntax_Syntax.Tm_name x,FStar_Syntax_Syntax.Tm_name y) ->
             if FStar_Syntax_Syntax.bv_eq x y
@@ -2036,26 +1865,26 @@ let rec (head_matches :
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_fvar f,FStar_Syntax_Syntax.Tm_fvar g) ->
-            let uu____5133 = FStar_Syntax_Syntax.fv_eq f g  in
+            let uu____5133 = FStar_Syntax_Syntax.fv_eq f g in
             if uu____5133
             then FullMatch
             else
               (let uu____5135 =
                  let uu____5144 =
-                   let uu____5147 = fv_delta_depth env f  in
-                   FStar_Pervasives_Native.Some uu____5147  in
+                   let uu____5147 = fv_delta_depth env f in
+                   FStar_Pervasives_Native.Some uu____5147 in
                  let uu____5148 =
-                   let uu____5151 = fv_delta_depth env g  in
-                   FStar_Pervasives_Native.Some uu____5151  in
-                 (uu____5144, uu____5148)  in
+                   let uu____5151 = fv_delta_depth env g in
+                   FStar_Pervasives_Native.Some uu____5151 in
+                 (uu____5144, uu____5148) in
                MisMatch uu____5135)
         | (FStar_Syntax_Syntax.Tm_uinst
            (f,uu____5157),FStar_Syntax_Syntax.Tm_uinst (g,uu____5159)) ->
-            let uu____5168 = head_matches env f g  in
+            let uu____5168 = head_matches env f g in
             FStar_All.pipe_right uu____5168 head_match
         | (FStar_Syntax_Syntax.Tm_constant c,FStar_Syntax_Syntax.Tm_constant
            d) ->
-            let uu____5171 = FStar_Const.eq_const c d  in
+            let uu____5171 = FStar_Const.eq_const c d in
             if uu____5171
             then FullMatch
             else
@@ -2063,7 +1892,7 @@ let rec (head_matches :
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_uvar
            (uv,uu____5178),FStar_Syntax_Syntax.Tm_uvar (uv',uu____5180)) ->
-            let uu____5229 = FStar_Syntax_Unionfind.equiv uv uv'  in
+            let uu____5229 = FStar_Syntax_Unionfind.equiv uv uv' in
             if uu____5229
             then FullMatch
             else
@@ -2073,16 +1902,13 @@ let rec (head_matches :
            (x,uu____5236),FStar_Syntax_Syntax.Tm_refine (y,uu____5238)) ->
             let uu____5247 =
               head_matches env x.FStar_Syntax_Syntax.sort
-                y.FStar_Syntax_Syntax.sort
-               in
+                y.FStar_Syntax_Syntax.sort in
             FStar_All.pipe_right uu____5247 head_match
         | (FStar_Syntax_Syntax.Tm_refine (x,uu____5249),uu____5250) ->
-            let uu____5255 = head_matches env x.FStar_Syntax_Syntax.sort t21
-               in
+            let uu____5255 = head_matches env x.FStar_Syntax_Syntax.sort t21 in
             FStar_All.pipe_right uu____5255 head_match
         | (uu____5256,FStar_Syntax_Syntax.Tm_refine (x,uu____5258)) ->
-            let uu____5263 = head_matches env t11 x.FStar_Syntax_Syntax.sort
-               in
+            let uu____5263 = head_matches env t11 x.FStar_Syntax_Syntax.sort in
             FStar_All.pipe_right uu____5263 head_match
         | (FStar_Syntax_Syntax.Tm_type uu____5264,FStar_Syntax_Syntax.Tm_type
            uu____5265) -> HeadMatch
@@ -2093,8 +1919,8 @@ let rec (head_matches :
             if (FStar_List.length bs1) = (FStar_List.length bs2)
             then
               let uu____5396 =
-                let uu____5397 = FStar_List.zip bs1 bs2  in
-                let uu____5432 = head_matches env t12 t22  in
+                let uu____5397 = FStar_List.zip bs1 bs2 in
+                let uu____5432 = head_matches env t12 t22 in
                 FStar_List.fold_right
                   (fun uu____5441  ->
                      fun a  ->
@@ -2102,8 +1928,7 @@ let rec (head_matches :
                        | (b1,b2) ->
                            and_match a
                              (fun uu____5450  -> branch_matches env b1 b2))
-                  uu____5397 uu____5432
-                 in
+                  uu____5397 uu____5432 in
               FStar_All.pipe_right uu____5396 head_match
             else
               MisMatch
@@ -2111,24 +1936,23 @@ let rec (head_matches :
         | (FStar_Syntax_Syntax.Tm_app
            (head1,uu____5457),FStar_Syntax_Syntax.Tm_app (head',uu____5459))
             ->
-            let uu____5500 = head_matches env head1 head'  in
+            let uu____5500 = head_matches env head1 head' in
             FStar_All.pipe_right uu____5500 head_match
         | (FStar_Syntax_Syntax.Tm_app (head1,uu____5502),uu____5503) ->
-            let uu____5524 = head_matches env head1 t21  in
+            let uu____5524 = head_matches env head1 t21 in
             FStar_All.pipe_right uu____5524 head_match
         | (uu____5525,FStar_Syntax_Syntax.Tm_app (head1,uu____5527)) ->
-            let uu____5548 = head_matches env t11 head1  in
+            let uu____5548 = head_matches env t11 head1 in
             FStar_All.pipe_right uu____5548 head_match
         | uu____5549 ->
             let uu____5554 =
-              let uu____5563 = delta_depth_of_term env t11  in
-              let uu____5566 = delta_depth_of_term env t21  in
-              (uu____5563, uu____5566)  in
+              let uu____5563 = delta_depth_of_term env t11 in
+              let uu____5566 = delta_depth_of_term env t21 in
+              (uu____5563, uu____5566) in
             MisMatch uu____5554
-
-and (branch_matches :
+and branch_matches:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch -> match_result)
+    FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch -> match_result
   =
   fun env  ->
     fun b1  ->
@@ -2139,26 +1963,25 @@ and (branch_matches :
               true
           | (FStar_Pervasives_Native.Some x,FStar_Pervasives_Native.Some y)
               -> f x y
-          | (uu____5618,uu____5619) -> false  in
-        let uu____5628 = b1  in
+          | (uu____5618,uu____5619) -> false in
+        let uu____5628 = b1 in
         match uu____5628 with
         | (p1,w1,t1) ->
-            let uu____5648 = b2  in
+            let uu____5648 = b2 in
             (match uu____5648 with
              | (p2,w2,t2) ->
-                 let uu____5668 = FStar_Syntax_Syntax.eq_pat p1 p2  in
+                 let uu____5668 = FStar_Syntax_Syntax.eq_pat p1 p2 in
                  if uu____5668
                  then
                    let uu____5669 =
-                     (let uu____5672 = FStar_Syntax_Util.eq_tm t1 t2  in
+                     (let uu____5672 = FStar_Syntax_Util.eq_tm t1 t2 in
                       uu____5672 = FStar_Syntax_Util.Equal) &&
                        (related_by
                           (fun t11  ->
                              fun t21  ->
                                let uu____5681 =
-                                 FStar_Syntax_Util.eq_tm t11 t21  in
-                               uu____5681 = FStar_Syntax_Util.Equal) w1 w2)
-                      in
+                                 FStar_Syntax_Util.eq_tm t11 t21 in
+                               uu____5681 = FStar_Syntax_Util.Equal) w1 w2) in
                    (if uu____5669
                     then FullMatch
                     else
@@ -2169,8 +1992,7 @@ and (branch_matches :
                    MisMatch
                      (FStar_Pervasives_Native.None,
                        FStar_Pervasives_Native.None))
-
-let head_matches_delta :
+let head_matches_delta:
   'Auu____5697 .
     FStar_TypeChecker_Env.env ->
       'Auu____5697 ->
@@ -2186,43 +2008,38 @@ let head_matches_delta :
       fun t1  ->
         fun t2  ->
           let maybe_inline t =
-            let uu____5730 = FStar_Syntax_Util.head_and_args t  in
+            let uu____5730 = FStar_Syntax_Util.head_and_args t in
             match uu____5730 with
             | (head1,uu____5748) ->
                 let uu____5769 =
-                  let uu____5770 = FStar_Syntax_Util.un_uinst head1  in
-                  uu____5770.FStar_Syntax_Syntax.n  in
+                  let uu____5770 = FStar_Syntax_Util.un_uinst head1 in
+                  uu____5770.FStar_Syntax_Syntax.n in
                 (match uu____5769 with
                  | FStar_Syntax_Syntax.Tm_fvar fv ->
                      let uu____5776 =
                        let uu____5777 =
                          FStar_TypeChecker_Env.lookup_definition
                            [FStar_TypeChecker_Env.Eager_unfolding_only] env
-                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                          in
-                       FStar_All.pipe_right uu____5777 FStar_Option.isSome
-                        in
+                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                       FStar_All.pipe_right uu____5777 FStar_Option.isSome in
                      if uu____5776
                      then
                        let uu____5796 =
                          FStar_TypeChecker_Normalize.normalize
                            [FStar_TypeChecker_Normalize.Beta;
-                           FStar_TypeChecker_Normalize.Eager_unfolding] env t
-                          in
+                           FStar_TypeChecker_Normalize.Eager_unfolding] env t in
                        FStar_All.pipe_right uu____5796
                          (fun _0_45  -> FStar_Pervasives_Native.Some _0_45)
                      else FStar_Pervasives_Native.None
-                 | uu____5800 -> FStar_Pervasives_Native.None)
-             in
+                 | uu____5800 -> FStar_Pervasives_Native.None) in
           let success d r t11 t21 =
             (r,
               (if d > (Prims.parse_int "0")
                then FStar_Pervasives_Native.Some (t11, t21)
-               else FStar_Pervasives_Native.None))
-             in
-          let fail r = (r, FStar_Pervasives_Native.None)  in
+               else FStar_Pervasives_Native.None)) in
+          let fail r = (r, FStar_Pervasives_Native.None) in
           let rec aux retry n_delta t11 t21 =
-            let r = head_matches env t11 t21  in
+            let r = head_matches env t11 t21 in
             match r with
             | MisMatch
                 (FStar_Pervasives_Native.Some
@@ -2232,9 +2049,9 @@ let head_matches_delta :
                 then fail r
                 else
                   (let uu____5921 =
-                     let uu____5930 = maybe_inline t11  in
-                     let uu____5933 = maybe_inline t21  in
-                     (uu____5930, uu____5933)  in
+                     let uu____5930 = maybe_inline t11 in
+                     let uu____5933 = maybe_inline t21 in
+                     (uu____5930, uu____5933) in
                    match uu____5921 with
                    | (FStar_Pervasives_Native.None
                       ,FStar_Pervasives_Native.None ) -> fail r
@@ -2255,9 +2072,9 @@ let head_matches_delta :
                 then fail r
                 else
                   (let uu____5988 =
-                     let uu____5997 = maybe_inline t11  in
-                     let uu____6000 = maybe_inline t21  in
-                     (uu____5997, uu____6000)  in
+                     let uu____5997 = maybe_inline t11 in
+                     let uu____6000 = maybe_inline t21 in
+                     (uu____5997, uu____6000) in
                    match uu____5988 with
                    | (FStar_Pervasives_Native.None
                       ,FStar_Pervasives_Native.None ) -> fail r
@@ -2274,8 +2091,7 @@ let head_matches_delta :
                 (FStar_Pervasives_Native.Some d1,FStar_Pervasives_Native.Some
                  d2)
                 when d1 = d2 ->
-                let uu____6043 = FStar_TypeChecker_Common.decr_delta_depth d1
-                   in
+                let uu____6043 = FStar_TypeChecker_Common.decr_delta_depth d1 in
                 (match uu____6043 with
                  | FStar_Pervasives_Native.None  -> fail r
                  | FStar_Pervasives_Native.Some d ->
@@ -2283,21 +2099,19 @@ let head_matches_delta :
                        normalize_refinement
                          [FStar_TypeChecker_Normalize.UnfoldUntil d;
                          FStar_TypeChecker_Normalize.Weak;
-                         FStar_TypeChecker_Normalize.HNF] env wl t11
-                        in
+                         FStar_TypeChecker_Normalize.HNF] env wl t11 in
                      let t22 =
                        normalize_refinement
                          [FStar_TypeChecker_Normalize.UnfoldUntil d;
                          FStar_TypeChecker_Normalize.Weak;
-                         FStar_TypeChecker_Normalize.HNF] env wl t21
-                        in
+                         FStar_TypeChecker_Normalize.HNF] env wl t21 in
                      aux retry (n_delta + (Prims.parse_int "1")) t12 t22)
             | MisMatch
                 (FStar_Pervasives_Native.Some d1,FStar_Pervasives_Native.Some
                  d2)
                 ->
                 let d1_greater_than_d2 =
-                  FStar_TypeChecker_Common.delta_depth_greater_than d1 d2  in
+                  FStar_TypeChecker_Common.delta_depth_greater_than d1 d2 in
                 let uu____6066 =
                   if d1_greater_than_d2
                   then
@@ -2305,70 +2119,63 @@ let head_matches_delta :
                       normalize_refinement
                         [FStar_TypeChecker_Normalize.UnfoldUntil d2;
                         FStar_TypeChecker_Normalize.Weak;
-                        FStar_TypeChecker_Normalize.HNF] env wl t11
-                       in
+                        FStar_TypeChecker_Normalize.HNF] env wl t11 in
                     (t1', t21)
                   else
                     (let t2' =
                        normalize_refinement
                          [FStar_TypeChecker_Normalize.UnfoldUntil d1;
                          FStar_TypeChecker_Normalize.Weak;
-                         FStar_TypeChecker_Normalize.HNF] env wl t21
-                        in
-                     (t11, t2'))
-                   in
+                         FStar_TypeChecker_Normalize.HNF] env wl t21 in
+                     (t11, t2')) in
                 (match uu____6066 with
                  | (t12,t22) ->
                      aux retry (n_delta + (Prims.parse_int "1")) t12 t22)
             | MisMatch uu____6090 -> fail r
-            | uu____6099 -> success n_delta r t11 t21  in
+            | uu____6099 -> success n_delta r t11 t21 in
           aux true (Prims.parse_int "0") t1 t2
-  
 type tc =
   | T of
   (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.binders ->
                               FStar_Range.range -> FStar_Syntax_Syntax.term)
-  FStar_Pervasives_Native.tuple2 
-  | C of FStar_Syntax_Syntax.comp [@@deriving show]
-let (uu___is_T : tc -> Prims.bool) =
-  fun projectee  -> match projectee with | T _0 -> true | uu____6132 -> false 
-let (__proj__T__item___0 :
+  FStar_Pervasives_Native.tuple2
+  | C of FStar_Syntax_Syntax.comp[@@deriving show]
+let uu___is_T: tc -> Prims.bool =
+  fun projectee  -> match projectee with | T _0 -> true | uu____6132 -> false
+let __proj__T__item___0:
   tc ->
     (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.binders ->
                                 FStar_Range.range -> FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
-  = fun projectee  -> match projectee with | T _0 -> _0 
-let (uu___is_C : tc -> Prims.bool) =
-  fun projectee  -> match projectee with | C _0 -> true | uu____6168 -> false 
-let (__proj__C__item___0 : tc -> FStar_Syntax_Syntax.comp) =
-  fun projectee  -> match projectee with | C _0 -> _0 
+      FStar_Pervasives_Native.tuple2
+  = fun projectee  -> match projectee with | T _0 -> _0
+let uu___is_C: tc -> Prims.bool =
+  fun projectee  -> match projectee with | C _0 -> true | uu____6168 -> false
+let __proj__C__item___0: tc -> FStar_Syntax_Syntax.comp =
+  fun projectee  -> match projectee with | C _0 -> _0
 type tcs = tc Prims.list[@@deriving show]
-let (tc_to_string : tc -> Prims.string) =
+let tc_to_string: tc -> Prims.string =
   fun uu___102_6180  ->
     match uu___102_6180 with
     | T (t,uu____6182) -> term_to_string t
     | C c -> FStar_Syntax_Print.comp_to_string c
-  
-let (generic_kind :
-  FStar_Syntax_Syntax.binders -> FStar_Range.range -> FStar_Syntax_Syntax.typ)
+let generic_kind:
+  FStar_Syntax_Syntax.binders -> FStar_Range.range -> FStar_Syntax_Syntax.typ
   =
   fun binders  ->
     fun r  ->
-      let uu____6198 = FStar_Syntax_Util.type_u ()  in
+      let uu____6198 = FStar_Syntax_Util.type_u () in
       match uu____6198 with
       | (t,uu____6204) ->
-          let uu____6205 = new_uvar r binders t  in
+          let uu____6205 = new_uvar r binders t in
           FStar_Pervasives_Native.fst uu____6205
-  
-let (kind_type :
-  FStar_Syntax_Syntax.binders -> FStar_Range.range -> FStar_Syntax_Syntax.typ)
+let kind_type:
+  FStar_Syntax_Syntax.binders -> FStar_Range.range -> FStar_Syntax_Syntax.typ
   =
   fun binders  ->
     fun r  ->
-      let uu____6216 = FStar_Syntax_Util.type_u ()  in
+      let uu____6216 = FStar_Syntax_Util.type_u () in
       FStar_All.pipe_right uu____6216 FStar_Pervasives_Native.fst
-  
-let rec (decompose :
+let rec decompose:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (tc Prims.list -> FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.term ->
@@ -2378,16 +2185,16 @@ let rec (decompose :
                                                                 tc)
                                                                 FStar_Pervasives_Native.tuple3
                                                                 Prims.list)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun t  ->
-      let t1 = FStar_Syntax_Util.unmeta t  in
+      let t1 = FStar_Syntax_Util.unmeta t in
       let matches t' =
-        let uu____6280 = head_matches env t1 t'  in
+        let uu____6280 = head_matches env t1 t' in
         match uu____6280 with
         | MisMatch uu____6281 -> false
-        | uu____6290 -> true  in
+        | uu____6290 -> true in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
           let rebuild args' =
@@ -2398,11 +2205,9 @@ let rec (decompose :
                      match (x, y) with
                      | ((uu____6386,imp),T (t2,uu____6389)) -> (t2, imp)
                      | uu____6408 -> failwith "Bad reconstruction") args
-                args'
-               in
+                args' in
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (hd1, args1))
-              FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
-             in
+              FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos in
           let tcs =
             FStar_All.pipe_right args
               (FStar_List.map
@@ -2410,11 +2215,10 @@ let rec (decompose :
                     match uu____6475 with
                     | (t2,uu____6489) ->
                         (FStar_Pervasives_Native.None, INVARIANT,
-                          (T (t2, generic_kind)))))
-             in
+                          (T (t2, generic_kind))))) in
           (rebuild, matches, tcs)
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____6532 = FStar_Syntax_Subst.open_comp bs c  in
+          let uu____6532 = FStar_Syntax_Subst.open_comp bs c in
           (match uu____6532 with
            | (bs1,c1) ->
                let rebuild tcs =
@@ -2422,7 +2226,7 @@ let rec (decompose :
                    match (bs2, tcs1) with
                    | ((x,imp)::bs3,(T (t2,uu____6607))::tcs2) ->
                        aux
-                         (((let uu___127_6642 = x  in
+                         (((let uu___127_6642 = x in
                             {
                               FStar_Syntax_Syntax.ppname =
                                 (uu___127_6642.FStar_Syntax_Syntax.ppname);
@@ -2432,8 +2236,8 @@ let rec (decompose :
                             }), imp) :: out) bs3 tcs2
                    | ([],(C c2)::[]) ->
                        FStar_Syntax_Util.arrow (FStar_List.rev out) c2
-                   | uu____6660 -> failwith "Bad reconstruction"  in
-                 aux [] bs1 tcs  in
+                   | uu____6660 -> failwith "Bad reconstruction" in
+                 aux [] bs1 tcs in
                let rec decompose1 out uu___103_6713 =
                  match uu___103_6713 with
                  | [] ->
@@ -2445,30 +2249,26 @@ let rec (decompose :
                        (((FStar_Pervasives_Native.Some hd1), CONTRAVARIANT,
                           (T
                              (((FStar_Pervasives_Native.fst hd1).FStar_Syntax_Syntax.sort),
-                               kind_type))) :: out) rest
-                  in
-               let uu____6830 = decompose1 [] bs1  in
+                               kind_type))) :: out) rest in
+               let uu____6830 = decompose1 [] bs1 in
                (rebuild, matches, uu____6830))
       | uu____6879 ->
           let rebuild uu___104_6885 =
             match uu___104_6885 with
             | [] -> t1
-            | uu____6888 -> failwith "Bad reconstruction"  in
+            | uu____6888 -> failwith "Bad reconstruction" in
           (rebuild, ((fun t2  -> FStar_Util.return_all true)), [])
-  
-let (un_T : tc -> FStar_Syntax_Syntax.term) =
+let un_T: tc -> FStar_Syntax_Syntax.term =
   fun uu___105_6919  ->
     match uu___105_6919 with
     | T (t,uu____6921) -> t
     | uu____6930 -> failwith "Impossible"
-  
-let (arg_of_tc : tc -> FStar_Syntax_Syntax.arg) =
+let arg_of_tc: tc -> FStar_Syntax_Syntax.arg =
   fun uu___106_6933  ->
     match uu___106_6933 with
     | T (t,uu____6935) -> FStar_Syntax_Syntax.as_arg t
     | uu____6944 -> failwith "Impossible"
-  
-let (imitation_sub_probs :
+let imitation_sub_probs:
   FStar_TypeChecker_Common.prob ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.binders ->
@@ -2476,20 +2276,20 @@ let (imitation_sub_probs :
           (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option,
             variance,tc) FStar_Pervasives_Native.tuple3 Prims.list ->
             (FStar_TypeChecker_Common.prob Prims.list,tc Prims.list,FStar_Syntax_Syntax.formula)
-              FStar_Pervasives_Native.tuple3)
+              FStar_Pervasives_Native.tuple3
   =
   fun orig  ->
     fun env  ->
       fun scope  ->
         fun ps  ->
           fun qs  ->
-            let r = p_loc orig  in
-            let rel = p_rel orig  in
+            let r = p_loc orig in
+            let rel = p_rel orig in
             let sub_prob scope1 args q =
               match q with
               | (uu____7050,variance,T (ti,mk_kind)) ->
-                  let k = mk_kind scope1 r  in
-                  let uu____7075 = new_uvar r scope1 k  in
+                  let k = mk_kind scope1 r in
+                  let uu____7075 = new_uvar r scope1 k in
                   (match uu____7075 with
                    | (gi_xs,gi) ->
                        let gi_ps =
@@ -2498,21 +2298,18 @@ let (imitation_sub_probs :
                          | uu____7093 ->
                              FStar_Syntax_Syntax.mk
                                (FStar_Syntax_Syntax.Tm_app (gi, args))
-                               FStar_Pervasives_Native.None r
-                          in
+                               FStar_Pervasives_Native.None r in
                        let uu____7110 =
                          let uu____7111 =
                            mk_problem scope1 orig gi_ps
                              (vary_rel rel variance) ti
-                             FStar_Pervasives_Native.None "type subterm"
-                            in
+                             FStar_Pervasives_Native.None "type subterm" in
                          FStar_All.pipe_left
                            (fun _0_46  ->
                               FStar_TypeChecker_Common.TProb _0_46)
-                           uu____7111
-                          in
+                           uu____7111 in
                        ((T (gi_xs, mk_kind)), uu____7110))
-              | (uu____7124,uu____7125,C uu____7126) -> failwith "impos"  in
+              | (uu____7124,uu____7125,C uu____7126) -> failwith "impos" in
             let rec aux scope1 args qs1 =
               match qs1 with
               | [] -> ([], [], FStar_Syntax_Util.t_true)
@@ -2528,16 +2325,14 @@ let (imitation_sub_probs :
                         ->
                         let uu____7314 =
                           sub_prob scope1 args
-                            (bopt, variance, (T (ti, kind_type)))
-                           in
+                            (bopt, variance, (T (ti, kind_type))) in
                         (match uu____7314 with
                          | (T (gi_xs,uu____7338),prob) ->
                              let uu____7348 =
                                let uu____7349 =
-                                 FStar_Syntax_Syntax.mk_Total' gi_xs uopt  in
+                                 FStar_Syntax_Syntax.mk_Total' gi_xs uopt in
                                FStar_All.pipe_left (fun _0_47  -> C _0_47)
-                                 uu____7349
-                                in
+                                 uu____7349 in
                              (uu____7348, [prob])
                          | uu____7352 -> failwith "impossible")
                     | (bopt,variance,C
@@ -2549,17 +2344,14 @@ let (imitation_sub_probs :
                         ->
                         let uu____7391 =
                           sub_prob scope1 args
-                            (bopt, variance, (T (ti, kind_type)))
-                           in
+                            (bopt, variance, (T (ti, kind_type))) in
                         (match uu____7391 with
                          | (T (gi_xs,uu____7415),prob) ->
                              let uu____7425 =
                                let uu____7426 =
-                                 FStar_Syntax_Syntax.mk_GTotal' gi_xs uopt
-                                  in
+                                 FStar_Syntax_Syntax.mk_GTotal' gi_xs uopt in
                                FStar_All.pipe_left (fun _0_48  -> C _0_48)
-                                 uu____7426
-                                in
+                                 uu____7426 in
                              (uu____7425, [prob])
                          | uu____7429 -> failwith "impossible")
                     | (uu____7440,uu____7441,C
@@ -2575,32 +2367,28 @@ let (imitation_sub_probs :
                                   (FStar_Pervasives_Native.None, INVARIANT,
                                     (T
                                        ((FStar_Pervasives_Native.fst t),
-                                         generic_kind)))))
-                           in
+                                         generic_kind))))) in
                         let components1 =
                           (FStar_Pervasives_Native.None, COVARIANT,
                             (T
                                ((c.FStar_Syntax_Syntax.result_typ),
                                  kind_type)))
-                          :: components  in
+                          :: components in
                         let uu____7575 =
                           let uu____7584 =
-                            FStar_List.map (sub_prob scope1 args) components1
-                             in
-                          FStar_All.pipe_right uu____7584 FStar_List.unzip
-                           in
+                            FStar_List.map (sub_prob scope1 args) components1 in
+                          FStar_All.pipe_right uu____7584 FStar_List.unzip in
                         (match uu____7575 with
                          | (tcs,sub_probs) ->
                              let gi_xs =
                                let uu____7638 =
                                  let uu____7639 =
-                                   let uu____7642 = FStar_List.hd tcs  in
-                                   FStar_All.pipe_right uu____7642 un_T  in
+                                   let uu____7642 = FStar_List.hd tcs in
+                                   FStar_All.pipe_right uu____7642 un_T in
                                  let uu____7643 =
-                                   let uu____7652 = FStar_List.tl tcs  in
+                                   let uu____7652 = FStar_List.tl tcs in
                                    FStar_All.pipe_right uu____7652
-                                     (FStar_List.map arg_of_tc)
-                                    in
+                                     (FStar_List.map arg_of_tc) in
                                  {
                                    FStar_Syntax_Syntax.comp_univs =
                                      (c.FStar_Syntax_Syntax.comp_univs);
@@ -2612,16 +2400,14 @@ let (imitation_sub_probs :
                                      uu____7643;
                                    FStar_Syntax_Syntax.flags =
                                      (c.FStar_Syntax_Syntax.flags)
-                                 }  in
+                                 } in
                                FStar_All.pipe_left
-                                 FStar_Syntax_Syntax.mk_Comp uu____7638
-                                in
+                                 FStar_Syntax_Syntax.mk_Comp uu____7638 in
                              ((C gi_xs), sub_probs))
                     | uu____7661 ->
-                        let uu____7674 = sub_prob scope1 args q  in
+                        let uu____7674 = sub_prob scope1 args q in
                         (match uu____7674 with
-                         | (ktec,prob) -> (ktec, [prob]))
-                     in
+                         | (ktec,prob) -> (ktec, [prob])) in
                   (match uu____7273 with
                    | (tc,probs) ->
                        let uu____7705 =
@@ -2630,28 +2416,25 @@ let (imitation_sub_probs :
                              (b,imp),uu____7768,uu____7769),T
                             (t,uu____7771)) ->
                              let b1 =
-                               ((let uu___128_7808 = b  in
+                               ((let uu___128_7808 = b in
                                  {
                                    FStar_Syntax_Syntax.ppname =
                                      (uu___128_7808.FStar_Syntax_Syntax.ppname);
                                    FStar_Syntax_Syntax.index =
                                      (uu___128_7808.FStar_Syntax_Syntax.index);
                                    FStar_Syntax_Syntax.sort = t
-                                 }), imp)
-                                in
+                                 }), imp) in
                              let uu____7809 =
                                let uu____7816 =
-                                 FStar_Syntax_Util.arg_of_non_null_binder b1
-                                  in
-                               uu____7816 :: args  in
+                                 FStar_Syntax_Util.arg_of_non_null_binder b1 in
+                               uu____7816 :: args in
                              ((FStar_Pervasives_Native.Some b1), (b1 ::
                                scope1), uu____7809)
                          | uu____7851 ->
-                             (FStar_Pervasives_Native.None, scope1, args)
-                          in
+                             (FStar_Pervasives_Native.None, scope1, args) in
                        (match uu____7705 with
                         | (bopt,scope2,args1) ->
-                            let uu____7935 = aux scope2 args1 qs2  in
+                            let uu____7935 = aux scope2 args1 qs2 in
                             (match uu____7935 with
                              | (sub_probs,tcs,f) ->
                                  let f1 =
@@ -2664,38 +2447,31 @@ let (imitation_sub_probs :
                                                 (fun prob  ->
                                                    FStar_All.pipe_right
                                                      (p_guard prob)
-                                                     FStar_Pervasives_Native.fst))
-                                            in
-                                         f :: uu____7975  in
+                                                     FStar_Pervasives_Native.fst)) in
+                                         f :: uu____7975 in
                                        FStar_Syntax_Util.mk_conj_l uu____7972
                                    | FStar_Pervasives_Native.Some b ->
                                        let u_b =
                                          env.FStar_TypeChecker_Env.universe_of
                                            env
-                                           (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                                          in
+                                           (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
                                        let uu____7998 =
                                          let uu____8001 =
                                            FStar_Syntax_Util.mk_forall u_b
                                              (FStar_Pervasives_Native.fst b)
-                                             f
-                                            in
+                                             f in
                                          let uu____8002 =
                                            FStar_All.pipe_right probs
                                              (FStar_List.map
                                                 (fun prob  ->
                                                    FStar_All.pipe_right
                                                      (p_guard prob)
-                                                     FStar_Pervasives_Native.fst))
-                                            in
-                                         uu____8001 :: uu____8002  in
-                                       FStar_Syntax_Util.mk_conj_l uu____7998
-                                    in
+                                                     FStar_Pervasives_Native.fst)) in
+                                         uu____8001 :: uu____8002 in
+                                       FStar_Syntax_Util.mk_conj_l uu____7998 in
                                  ((FStar_List.append probs sub_probs), (tc ::
-                                   tcs), f1))))
-               in
+                                   tcs), f1)))) in
             aux scope ps qs
-  
 type flex_t =
   (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.uvar,FStar_Syntax_Syntax.typ,
     FStar_Syntax_Syntax.args) FStar_Pervasives_Native.tuple4[@@deriving show]
@@ -2712,15 +2488,15 @@ type im_or_proj_t =
                                                              Prims.list)
       FStar_Pervasives_Native.tuple3)
     FStar_Pervasives_Native.tuple3[@@deriving show]
-let (rigid_rigid : Prims.int) = (Prims.parse_int "0") 
-let (flex_rigid_eq : Prims.int) = (Prims.parse_int "1") 
-let (flex_refine_inner : Prims.int) = (Prims.parse_int "2") 
-let (flex_refine : Prims.int) = (Prims.parse_int "3") 
-let (flex_rigid : Prims.int) = (Prims.parse_int "4") 
-let (rigid_flex : Prims.int) = (Prims.parse_int "5") 
-let (refine_flex : Prims.int) = (Prims.parse_int "6") 
-let (flex_flex : Prims.int) = (Prims.parse_int "7") 
-let compress_tprob :
+let rigid_rigid: Prims.int = Prims.parse_int "0"
+let flex_rigid_eq: Prims.int = Prims.parse_int "1"
+let flex_refine_inner: Prims.int = Prims.parse_int "2"
+let flex_refine: Prims.int = Prims.parse_int "3"
+let flex_rigid: Prims.int = Prims.parse_int "4"
+let rigid_flex: Prims.int = Prims.parse_int "5"
+let refine_flex: Prims.int = Prims.parse_int "6"
+let flex_flex: Prims.int = Prims.parse_int "7"
+let compress_tprob:
   'Auu____8070 .
     worklist ->
       (FStar_Syntax_Syntax.term,'Auu____8070)
@@ -2730,9 +2506,9 @@ let compress_tprob :
   =
   fun wl  ->
     fun p  ->
-      let uu___129_8091 = p  in
-      let uu____8096 = whnf wl.tcenv p.FStar_TypeChecker_Common.lhs  in
-      let uu____8097 = whnf wl.tcenv p.FStar_TypeChecker_Common.rhs  in
+      let uu___129_8091 = p in
+      let uu____8096 = whnf wl.tcenv p.FStar_TypeChecker_Common.lhs in
+      let uu____8097 = whnf wl.tcenv p.FStar_TypeChecker_Common.rhs in
       {
         FStar_TypeChecker_Common.pid =
           (uu___129_8091.FStar_TypeChecker_Common.pid);
@@ -2753,41 +2529,37 @@ let compress_tprob :
         FStar_TypeChecker_Common.rank =
           (uu___129_8091.FStar_TypeChecker_Common.rank)
       }
-  
-let (compress_prob :
-  worklist -> FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob)
+let compress_prob:
+  worklist -> FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob
   =
   fun wl  ->
     fun p  ->
       match p with
       | FStar_TypeChecker_Common.TProb p1 ->
-          let uu____8109 = compress_tprob wl p1  in
+          let uu____8109 = compress_tprob wl p1 in
           FStar_All.pipe_right uu____8109
             (fun _0_49  -> FStar_TypeChecker_Common.TProb _0_49)
       | FStar_TypeChecker_Common.CProb uu____8118 -> p
-  
-let (rank :
+let rank:
   worklist ->
     FStar_TypeChecker_Common.prob ->
       (Prims.int,FStar_TypeChecker_Common.prob)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun wl  ->
     fun pr  ->
       let prob =
-        let uu____8138 = compress_prob wl pr  in
-        FStar_All.pipe_right uu____8138 maybe_invert_p  in
+        let uu____8138 = compress_prob wl pr in
+        FStar_All.pipe_right uu____8138 maybe_invert_p in
       match prob with
       | FStar_TypeChecker_Common.TProb tp ->
           let uu____8148 =
-            FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs
-             in
+            FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs in
           (match uu____8148 with
            | (lh,uu____8168) ->
                let uu____8189 =
                  FStar_Syntax_Util.head_and_args
-                   tp.FStar_TypeChecker_Common.rhs
-                  in
+                   tp.FStar_TypeChecker_Common.rhs in
                (match uu____8189 with
                 | (rh,uu____8209) ->
                     let uu____8230 =
@@ -2813,8 +2585,7 @@ let (rank :
                           ->
                           let uu____8347 =
                             base_and_refinement wl.tcenv
-                              tp.FStar_TypeChecker_Common.rhs
-                             in
+                              tp.FStar_TypeChecker_Common.rhs in
                           (match uu____8347 with
                            | (b,ref_opt) ->
                                (match ref_opt with
@@ -2822,15 +2593,14 @@ let (rank :
                                     (flex_rigid, tp)
                                 | uu____8396 ->
                                     let rank =
-                                      let uu____8404 = is_top_level_prob prob
-                                         in
+                                      let uu____8404 = is_top_level_prob prob in
                                       if uu____8404
                                       then flex_refine
-                                      else flex_refine_inner  in
+                                      else flex_refine_inner in
                                     let uu____8406 =
-                                      let uu___130_8411 = tp  in
+                                      let uu___130_8411 = tp in
                                       let uu____8416 =
-                                        force_refinement (b, ref_opt)  in
+                                        force_refinement (b, ref_opt) in
                                       {
                                         FStar_TypeChecker_Common.pid =
                                           (uu___130_8411.FStar_TypeChecker_Common.pid);
@@ -2853,14 +2623,13 @@ let (rank :
                                           (uu___130_8411.FStar_TypeChecker_Common.loc);
                                         FStar_TypeChecker_Common.rank =
                                           (uu___130_8411.FStar_TypeChecker_Common.rank)
-                                      }  in
+                                      } in
                                     (rank, uu____8406)))
                       | (uu____8427,FStar_Syntax_Syntax.Tm_uvar uu____8428)
                           ->
                           let uu____8445 =
                             base_and_refinement wl.tcenv
-                              tp.FStar_TypeChecker_Common.lhs
-                             in
+                              tp.FStar_TypeChecker_Common.lhs in
                           (match uu____8445 with
                            | (b,ref_opt) ->
                                (match ref_opt with
@@ -2868,9 +2637,9 @@ let (rank :
                                     (rigid_flex, tp)
                                 | uu____8494 ->
                                     let uu____8501 =
-                                      let uu___131_8508 = tp  in
+                                      let uu___131_8508 = tp in
                                       let uu____8513 =
-                                        force_refinement (b, ref_opt)  in
+                                        force_refinement (b, ref_opt) in
                                       {
                                         FStar_TypeChecker_Common.pid =
                                           (uu___131_8508.FStar_TypeChecker_Common.pid);
@@ -2893,14 +2662,14 @@ let (rank :
                                           (uu___131_8508.FStar_TypeChecker_Common.loc);
                                         FStar_TypeChecker_Common.rank =
                                           (uu___131_8508.FStar_TypeChecker_Common.rank)
-                                      }  in
+                                      } in
                                     (refine_flex, uu____8501)))
-                      | (uu____8530,uu____8531) -> (rigid_rigid, tp)  in
+                      | (uu____8530,uu____8531) -> (rigid_rigid, tp) in
                     (match uu____8230 with
                      | (rank,tp1) ->
                          let uu____8550 =
                            FStar_All.pipe_right
-                             (let uu___132_8556 = tp1  in
+                             (let uu___132_8556 = tp1 in
                               {
                                 FStar_TypeChecker_Common.pid =
                                   (uu___132_8556.FStar_TypeChecker_Common.pid);
@@ -2924,13 +2693,12 @@ let (rank :
                                   (FStar_Pervasives_Native.Some rank)
                               })
                              (fun _0_50  ->
-                                FStar_TypeChecker_Common.TProb _0_50)
-                            in
+                                FStar_TypeChecker_Common.TProb _0_50) in
                          (rank, uu____8550))))
       | FStar_TypeChecker_Common.CProb cp ->
           let uu____8566 =
             FStar_All.pipe_right
-              (let uu___133_8572 = cp  in
+              (let uu___133_8572 = cp in
                {
                  FStar_TypeChecker_Common.pid =
                    (uu___133_8572.FStar_TypeChecker_Common.pid);
@@ -2952,15 +2720,13 @@ let (rank :
                    (uu___133_8572.FStar_TypeChecker_Common.loc);
                  FStar_TypeChecker_Common.rank =
                    (FStar_Pervasives_Native.Some rigid_rigid)
-               }) (fun _0_51  -> FStar_TypeChecker_Common.CProb _0_51)
-             in
+               }) (fun _0_51  -> FStar_TypeChecker_Common.CProb _0_51) in
           (rigid_rigid, uu____8566)
-  
-let (next_prob :
+let next_prob:
   worklist ->
     (FStar_TypeChecker_Common.prob FStar_Pervasives_Native.option,FStar_TypeChecker_Common.prob
                                                                     Prims.list,
-      Prims.int) FStar_Pervasives_Native.tuple3)
+      Prims.int) FStar_Pervasives_Native.tuple3
   =
   fun wl  ->
     let rec aux uu____8627 probs =
@@ -2969,7 +2735,7 @@ let (next_prob :
           (match probs with
            | [] -> (min1, out, min_rank)
            | hd1::tl1 ->
-               let uu____8680 = rank wl hd1  in
+               let uu____8680 = rank wl hd1 in
                (match uu____8680 with
                 | (rank1,hd2) ->
                     if rank1 <= flex_rigid_eq
@@ -2993,67 +2759,61 @@ let (next_prob :
                              aux
                                (rank1, (FStar_Pervasives_Native.Some hd2), (m
                                  :: out)) tl1)
-                      else aux (min_rank, min1, (hd2 :: out)) tl1))
-       in
+                      else aux (min_rank, min1, (hd2 :: out)) tl1)) in
     aux
       ((flex_flex + (Prims.parse_int "1")), FStar_Pervasives_Native.None, [])
       wl.attempting
-  
-let (is_flex_rigid : Prims.int -> Prims.bool) =
-  fun rank1  -> (flex_refine_inner <= rank1) && (rank1 <= flex_rigid) 
-let (is_rigid_flex : Prims.int -> Prims.bool) =
-  fun rank1  -> (rigid_flex <= rank1) && (rank1 <= refine_flex) 
+let is_flex_rigid: Prims.int -> Prims.bool =
+  fun rank1  -> (flex_refine_inner <= rank1) && (rank1 <= flex_rigid)
+let is_rigid_flex: Prims.int -> Prims.bool =
+  fun rank1  -> (rigid_flex <= rank1) && (rank1 <= refine_flex)
 type univ_eq_sol =
-  | UDeferred of worklist 
-  | USolved of worklist 
-  | UFailed of Prims.string [@@deriving show]
-let (uu___is_UDeferred : univ_eq_sol -> Prims.bool) =
+  | UDeferred of worklist
+  | USolved of worklist
+  | UFailed of Prims.string[@@deriving show]
+let uu___is_UDeferred: univ_eq_sol -> Prims.bool =
   fun projectee  ->
     match projectee with | UDeferred _0 -> true | uu____8787 -> false
-  
-let (__proj__UDeferred__item___0 : univ_eq_sol -> worklist) =
-  fun projectee  -> match projectee with | UDeferred _0 -> _0 
-let (uu___is_USolved : univ_eq_sol -> Prims.bool) =
+let __proj__UDeferred__item___0: univ_eq_sol -> worklist =
+  fun projectee  -> match projectee with | UDeferred _0 -> _0
+let uu___is_USolved: univ_eq_sol -> Prims.bool =
   fun projectee  ->
     match projectee with | USolved _0 -> true | uu____8799 -> false
-  
-let (__proj__USolved__item___0 : univ_eq_sol -> worklist) =
-  fun projectee  -> match projectee with | USolved _0 -> _0 
-let (uu___is_UFailed : univ_eq_sol -> Prims.bool) =
+let __proj__USolved__item___0: univ_eq_sol -> worklist =
+  fun projectee  -> match projectee with | USolved _0 -> _0
+let uu___is_UFailed: univ_eq_sol -> Prims.bool =
   fun projectee  ->
     match projectee with | UFailed _0 -> true | uu____8811 -> false
-  
-let (__proj__UFailed__item___0 : univ_eq_sol -> Prims.string) =
-  fun projectee  -> match projectee with | UFailed _0 -> _0 
-let rec (really_solve_universe_eq :
+let __proj__UFailed__item___0: univ_eq_sol -> Prims.string =
+  fun projectee  -> match projectee with | UFailed _0 -> _0
+let rec really_solve_universe_eq:
   Prims.int ->
     worklist ->
       FStar_Syntax_Syntax.universe ->
-        FStar_Syntax_Syntax.universe -> univ_eq_sol)
+        FStar_Syntax_Syntax.universe -> univ_eq_sol
   =
   fun pid_orig  ->
     fun wl  ->
       fun u1  ->
         fun u2  ->
           let u11 =
-            FStar_TypeChecker_Normalize.normalize_universe wl.tcenv u1  in
+            FStar_TypeChecker_Normalize.normalize_universe wl.tcenv u1 in
           let u21 =
-            FStar_TypeChecker_Normalize.normalize_universe wl.tcenv u2  in
+            FStar_TypeChecker_Normalize.normalize_universe wl.tcenv u2 in
           let rec occurs_univ v1 u =
             match u with
             | FStar_Syntax_Syntax.U_max us ->
                 FStar_All.pipe_right us
                   (FStar_Util.for_some
                      (fun u3  ->
-                        let uu____8851 = FStar_Syntax_Util.univ_kernel u3  in
+                        let uu____8851 = FStar_Syntax_Util.univ_kernel u3 in
                         match uu____8851 with
                         | (k,uu____8857) ->
                             (match k with
                              | FStar_Syntax_Syntax.U_unif v2 ->
                                  FStar_Syntax_Unionfind.univ_equiv v1 v2
                              | uu____8867 -> false)))
-            | uu____8868 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u])
-             in
+            | uu____8868 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u]) in
           let try_umax_components u12 u22 msg =
             match (u12, u22) with
             | (FStar_Syntax_Syntax.U_max us1,FStar_Syntax_Syntax.U_max us2)
@@ -3064,22 +2824,19 @@ let rec (really_solve_universe_eq :
                     match (us11, us21) with
                     | (u13::us12,u23::us22) ->
                         let uu____8919 =
-                          really_solve_universe_eq pid_orig wl1 u13 u23  in
+                          really_solve_universe_eq pid_orig wl1 u13 u23 in
                         (match uu____8919 with
                          | USolved wl2 -> aux wl2 us12 us22
                          | failed -> failed)
-                    | uu____8922 -> USolved wl1  in
+                    | uu____8922 -> USolved wl1 in
                   aux wl us1 us2
                 else
                   (let uu____8932 =
-                     let uu____8933 = FStar_Syntax_Print.univ_to_string u12
-                        in
-                     let uu____8934 = FStar_Syntax_Print.univ_to_string u22
-                        in
+                     let uu____8933 = FStar_Syntax_Print.univ_to_string u12 in
+                     let uu____8934 = FStar_Syntax_Print.univ_to_string u22 in
                      FStar_Util.format2
                        "Unable to unify universes: %s and %s" uu____8933
-                       uu____8934
-                      in
+                       uu____8934 in
                    UFailed uu____8932)
             | (FStar_Syntax_Syntax.U_max us,u') ->
                 let rec aux wl1 us1 =
@@ -3087,11 +2844,10 @@ let rec (really_solve_universe_eq :
                   | [] -> USolved wl1
                   | u::us2 ->
                       let uu____8954 =
-                        really_solve_universe_eq pid_orig wl1 u u'  in
+                        really_solve_universe_eq pid_orig wl1 u u' in
                       (match uu____8954 with
                        | USolved wl2 -> aux wl2 us2
-                       | failed -> failed)
-                   in
+                       | failed -> failed) in
                 aux wl us
             | (u',FStar_Syntax_Syntax.U_max us) ->
                 let rec aux wl1 us1 =
@@ -3099,58 +2855,51 @@ let rec (really_solve_universe_eq :
                   | [] -> USolved wl1
                   | u::us2 ->
                       let uu____8976 =
-                        really_solve_universe_eq pid_orig wl1 u u'  in
+                        really_solve_universe_eq pid_orig wl1 u u' in
                       (match uu____8976 with
                        | USolved wl2 -> aux wl2 us2
-                       | failed -> failed)
-                   in
+                       | failed -> failed) in
                 aux wl us
             | uu____8979 ->
                 let uu____8984 =
-                  let uu____8985 = FStar_Syntax_Print.univ_to_string u12  in
-                  let uu____8986 = FStar_Syntax_Print.univ_to_string u22  in
+                  let uu____8985 = FStar_Syntax_Print.univ_to_string u12 in
+                  let uu____8986 = FStar_Syntax_Print.univ_to_string u22 in
                   FStar_Util.format3
                     "Unable to unify universes: %s and %s (%s)" uu____8985
-                    uu____8986 msg
-                   in
-                UFailed uu____8984
-             in
+                    uu____8986 msg in
+                UFailed uu____8984 in
           match (u11, u21) with
           | (FStar_Syntax_Syntax.U_bvar uu____8987,uu____8988) ->
               let uu____8989 =
-                let uu____8990 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____8991 = FStar_Syntax_Print.univ_to_string u21  in
+                let uu____8990 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu____8991 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____8990 uu____8991
-                 in
+                  uu____8990 uu____8991 in
               failwith uu____8989
           | (FStar_Syntax_Syntax.U_unknown ,uu____8992) ->
               let uu____8993 =
-                let uu____8994 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____8995 = FStar_Syntax_Print.univ_to_string u21  in
+                let uu____8994 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu____8995 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____8994 uu____8995
-                 in
+                  uu____8994 uu____8995 in
               failwith uu____8993
           | (uu____8996,FStar_Syntax_Syntax.U_bvar uu____8997) ->
               let uu____8998 =
-                let uu____8999 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____9000 = FStar_Syntax_Print.univ_to_string u21  in
+                let uu____8999 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu____9000 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____8999 uu____9000
-                 in
+                  uu____8999 uu____9000 in
               failwith uu____8998
           | (uu____9001,FStar_Syntax_Syntax.U_unknown ) ->
               let uu____9002 =
-                let uu____9003 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____9004 = FStar_Syntax_Print.univ_to_string u21  in
+                let uu____9003 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu____9004 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____9003 uu____9004
-                 in
+                  uu____9003 uu____9004 in
               failwith uu____9002
           | (FStar_Syntax_Syntax.U_name x,FStar_Syntax_Syntax.U_name y) ->
               if x.FStar_Ident.idText = y.FStar_Ident.idText
@@ -3161,57 +2910,51 @@ let rec (really_solve_universe_eq :
           | (FStar_Syntax_Syntax.U_succ u12,FStar_Syntax_Syntax.U_succ u22)
               -> really_solve_universe_eq pid_orig wl u12 u22
           | (FStar_Syntax_Syntax.U_unif v1,FStar_Syntax_Syntax.U_unif v2) ->
-              let uu____9028 = FStar_Syntax_Unionfind.univ_equiv v1 v2  in
+              let uu____9028 = FStar_Syntax_Unionfind.univ_equiv v1 v2 in
               if uu____9028
               then USolved wl
               else
-                (let wl1 = extend_solution pid_orig [UNIV (v1, u21)] wl  in
+                (let wl1 = extend_solution pid_orig [UNIV (v1, u21)] wl in
                  USolved wl1)
           | (FStar_Syntax_Syntax.U_unif v1,u) ->
-              let u3 = norm_univ wl u  in
-              let uu____9050 = occurs_univ v1 u3  in
+              let u3 = norm_univ wl u in
+              let uu____9050 = occurs_univ v1 u3 in
               if uu____9050
               then
                 let uu____9051 =
                   let uu____9052 =
                     FStar_Syntax_Print.univ_to_string
-                      (FStar_Syntax_Syntax.U_unif v1)
-                     in
-                  let uu____9053 = FStar_Syntax_Print.univ_to_string u3  in
+                      (FStar_Syntax_Syntax.U_unif v1) in
+                  let uu____9053 = FStar_Syntax_Print.univ_to_string u3 in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____9052 uu____9053
-                   in
+                    uu____9052 uu____9053 in
                 try_umax_components u11 u21 uu____9051
               else
-                (let uu____9055 = extend_solution pid_orig [UNIV (v1, u3)] wl
-                    in
+                (let uu____9055 = extend_solution pid_orig [UNIV (v1, u3)] wl in
                  USolved uu____9055)
           | (u,FStar_Syntax_Syntax.U_unif v1) ->
-              let u3 = norm_univ wl u  in
-              let uu____9075 = occurs_univ v1 u3  in
+              let u3 = norm_univ wl u in
+              let uu____9075 = occurs_univ v1 u3 in
               if uu____9075
               then
                 let uu____9076 =
                   let uu____9077 =
                     FStar_Syntax_Print.univ_to_string
-                      (FStar_Syntax_Syntax.U_unif v1)
-                     in
-                  let uu____9078 = FStar_Syntax_Print.univ_to_string u3  in
+                      (FStar_Syntax_Syntax.U_unif v1) in
+                  let uu____9078 = FStar_Syntax_Print.univ_to_string u3 in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____9077 uu____9078
-                   in
+                    uu____9077 uu____9078 in
                 try_umax_components u11 u21 uu____9076
               else
-                (let uu____9080 = extend_solution pid_orig [UNIV (v1, u3)] wl
-                    in
+                (let uu____9080 = extend_solution pid_orig [UNIV (v1, u3)] wl in
                  USolved uu____9080)
           | (FStar_Syntax_Syntax.U_max uu____9089,uu____9090) ->
               if wl.defer_ok
               then UDeferred wl
               else
-                (let u12 = norm_univ wl u11  in
-                 let u22 = norm_univ wl u21  in
-                 let uu____9096 = FStar_Syntax_Util.eq_univs u12 u22  in
+                (let u12 = norm_univ wl u11 in
+                 let u22 = norm_univ wl u21 in
+                 let uu____9096 = FStar_Syntax_Util.eq_univs u12 u22 in
                  if uu____9096
                  then USolved wl
                  else try_umax_components u12 u22 "")
@@ -3219,9 +2962,9 @@ let rec (really_solve_universe_eq :
               if wl.defer_ok
               then UDeferred wl
               else
-                (let u12 = norm_univ wl u11  in
-                 let u22 = norm_univ wl u21  in
-                 let uu____9105 = FStar_Syntax_Util.eq_univs u12 u22  in
+                (let u12 = norm_univ wl u11 in
+                 let u22 = norm_univ wl u21 in
+                 let uu____9105 = FStar_Syntax_Util.eq_univs u12 u22 in
                  if uu____9105
                  then USolved wl
                  else try_umax_components u12 u22 "")
@@ -3237,12 +2980,11 @@ let rec (really_solve_universe_eq :
              uu____9113) -> UFailed "Incompatible universes"
           | (FStar_Syntax_Syntax.U_name uu____9114,FStar_Syntax_Syntax.U_zero
              ) -> UFailed "Incompatible universes"
-  
-let (solve_universe_eq :
+let solve_universe_eq:
   Prims.int ->
     worklist ->
       FStar_Syntax_Syntax.universe ->
-        FStar_Syntax_Syntax.universe -> univ_eq_sol)
+        FStar_Syntax_Syntax.universe -> univ_eq_sol
   =
   fun orig  ->
     fun wl  ->
@@ -3251,8 +2993,7 @@ let (solve_universe_eq :
           if (wl.tcenv).FStar_TypeChecker_Env.lax_universes
           then USolved wl
           else really_solve_universe_eq orig wl u1 u2
-  
-let match_num_binders :
+let match_num_binders:
   'a 'b .
     ('a Prims.list,'a Prims.list -> 'b) FStar_Pervasives_Native.tuple2 ->
       ('a Prims.list,'a Prims.list -> 'b) FStar_Pervasives_Native.tuple2 ->
@@ -3263,57 +3004,54 @@ let match_num_binders :
   =
   fun bc1  ->
     fun bc2  ->
-      let uu____9200 = bc1  in
+      let uu____9200 = bc1 in
       match uu____9200 with
       | (bs1,mk_cod1) ->
-          let uu____9241 = bc2  in
+          let uu____9241 = bc2 in
           (match uu____9241 with
            | (bs2,mk_cod2) ->
                let curry n1 bs mk_cod =
-                 let uu____9311 = FStar_Util.first_N n1 bs  in
+                 let uu____9311 = FStar_Util.first_N n1 bs in
                  match uu____9311 with
                  | (bs3,rest) ->
-                     let uu____9336 = mk_cod rest  in (bs3, uu____9336)
-                  in
-               let l1 = FStar_List.length bs1  in
-               let l2 = FStar_List.length bs2  in
+                     let uu____9336 = mk_cod rest in (bs3, uu____9336) in
+               let l1 = FStar_List.length bs1 in
+               let l2 = FStar_List.length bs2 in
                if l1 = l2
                then
                  let uu____9365 =
-                   let uu____9372 = mk_cod1 []  in (bs1, uu____9372)  in
+                   let uu____9372 = mk_cod1 [] in (bs1, uu____9372) in
                  let uu____9375 =
-                   let uu____9382 = mk_cod2 []  in (bs2, uu____9382)  in
+                   let uu____9382 = mk_cod2 [] in (bs2, uu____9382) in
                  (uu____9365, uu____9375)
                else
                  if l1 > l2
                  then
-                   (let uu____9424 = curry l2 bs1 mk_cod1  in
+                   (let uu____9424 = curry l2 bs1 mk_cod1 in
                     let uu____9437 =
-                      let uu____9444 = mk_cod2 []  in (bs2, uu____9444)  in
+                      let uu____9444 = mk_cod2 [] in (bs2, uu____9444) in
                     (uu____9424, uu____9437))
                  else
                    (let uu____9460 =
-                      let uu____9467 = mk_cod1 []  in (bs1, uu____9467)  in
-                    let uu____9470 = curry l1 bs2 mk_cod2  in
+                      let uu____9467 = mk_cod1 [] in (bs1, uu____9467) in
+                    let uu____9470 = curry l1 bs2 mk_cod2 in
                     (uu____9460, uu____9470)))
-  
-let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
+let rec solve: FStar_TypeChecker_Env.env -> worklist -> solution =
   fun env  ->
     fun probs  ->
       (let uu____9591 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "RelCheck")
-          in
+           (FStar_Options.Other "RelCheck") in
        if uu____9591
        then
-         let uu____9592 = wl_to_string probs  in
+         let uu____9592 = wl_to_string probs in
          FStar_Util.print1 "solve:\n\t%s\n" uu____9592
        else ());
-      (let uu____9594 = next_prob probs  in
+      (let uu____9594 = next_prob probs in
        match uu____9594 with
        | (FStar_Pervasives_Native.Some hd1,tl1,rank1) ->
            let probs1 =
-             let uu___134_9615 = probs  in
+             let uu___134_9615 = probs in
              {
                attempting = tl1;
                wl_deferred = (uu___134_9615.wl_deferred);
@@ -3321,7 +3059,7 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                defer_ok = (uu___134_9615.defer_ok);
                smt_ok = (uu___134_9615.smt_ok);
                tcenv = (uu___134_9615.tcenv)
-             }  in
+             } in
            (match hd1 with
             | FStar_TypeChecker_Common.CProb cp ->
                 solve_c env (maybe_invert cp) probs1
@@ -3331,7 +3069,7 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                      (flex_refine_inner <= rank1))
                     && (rank1 <= flex_rigid)
                 then
-                  let uu____9626 = solve_flex_rigid_join env tp probs1  in
+                  let uu____9626 = solve_flex_rigid_join env tp probs1 in
                   (match uu____9626 with
                    | FStar_Pervasives_Native.None  ->
                        solve_t' env (maybe_invert tp) probs1
@@ -3342,7 +3080,7 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                        (rigid_flex <= rank1))
                       && (rank1 <= refine_flex)
                   then
-                    (let uu____9631 = solve_rigid_flex_meet env tp probs1  in
+                    (let uu____9631 = solve_rigid_flex_meet env tp probs1 in
                      match uu____9631 with
                      | FStar_Pervasives_Native.None  ->
                          solve_t' env (maybe_invert tp) probs1
@@ -3357,8 +3095,7 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                     (FStar_List.partition
                        (fun uu____9722  ->
                           match uu____9722 with
-                          | (c,uu____9730,uu____9731) -> c < probs.ctr))
-                   in
+                          | (c,uu____9730,uu____9731) -> c < probs.ctr)) in
                 (match uu____9663 with
                  | (attempt1,rest) ->
                      (match attempt1 with
@@ -3368,19 +3105,17 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                               (fun uu____9787  ->
                                  match uu____9787 with
                                  | (uu____9798,x,y) -> (x, y))
-                              probs.wl_deferred
-                             in
+                              probs.wl_deferred in
                           Success uu____9772
                       | uu____9801 ->
                           let uu____9810 =
-                            let uu___135_9811 = probs  in
+                            let uu___135_9811 = probs in
                             let uu____9812 =
                               FStar_All.pipe_right attempt1
                                 (FStar_List.map
                                    (fun uu____9833  ->
                                       match uu____9833 with
-                                      | (uu____9840,uu____9841,y) -> y))
-                               in
+                                      | (uu____9840,uu____9841,y) -> y)) in
                             {
                               attempting = uu____9812;
                               wl_deferred = rest;
@@ -3388,34 +3123,32 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                               defer_ok = (uu___135_9811.defer_ok);
                               smt_ok = (uu___135_9811.smt_ok);
                               tcenv = (uu___135_9811.tcenv)
-                            }  in
+                            } in
                           solve env uu____9810))))
-
-and (solve_one_universe_eq :
+and solve_one_universe_eq:
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
       FStar_Syntax_Syntax.universe ->
-        FStar_Syntax_Syntax.universe -> worklist -> solution)
+        FStar_Syntax_Syntax.universe -> worklist -> solution
   =
   fun env  ->
     fun orig  ->
       fun u1  ->
         fun u2  ->
           fun wl  ->
-            let uu____9848 = solve_universe_eq (p_pid orig) wl u1 u2  in
+            let uu____9848 = solve_universe_eq (p_pid orig) wl u1 u2 in
             match uu____9848 with
             | USolved wl1 ->
                 let uu____9850 =
-                  solve_prob orig FStar_Pervasives_Native.None [] wl1  in
+                  solve_prob orig FStar_Pervasives_Native.None [] wl1 in
                 solve env uu____9850
             | UFailed msg -> giveup env msg orig
             | UDeferred wl1 -> solve env (defer "" orig wl1)
-
-and (solve_maybe_uinsts :
+and solve_maybe_uinsts:
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
       FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term -> worklist -> univ_eq_sol)
+        FStar_Syntax_Syntax.term -> worklist -> univ_eq_sol
   =
   fun env  ->
     fun orig  ->
@@ -3426,14 +3159,13 @@ and (solve_maybe_uinsts :
               match (us1, us2) with
               | ([],[]) -> USolved wl1
               | (u1::us11,u2::us21) ->
-                  let uu____9896 = solve_universe_eq (p_pid orig) wl1 u1 u2
-                     in
+                  let uu____9896 = solve_universe_eq (p_pid orig) wl1 u1 u2 in
                   (match uu____9896 with
                    | USolved wl2 -> aux wl2 us11 us21
                    | failed_or_deferred -> failed_or_deferred)
-              | uu____9899 -> UFailed "Unequal number of universes"  in
-            let t11 = whnf env t1  in
-            let t21 = whnf env t2  in
+              | uu____9899 -> UFailed "Unequal number of universes" in
+            let t11 = whnf env t1 in
+            let t21 = whnf env t2 in
             match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n))
             with
             | (FStar_Syntax_Syntax.Tm_uinst
@@ -3443,16 +3175,15 @@ and (solve_maybe_uinsts :
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar g;
                   FStar_Syntax_Syntax.pos = uu____9915;
                   FStar_Syntax_Syntax.vars = uu____9916;_},us2))
-                -> let b = FStar_Syntax_Syntax.fv_eq f g  in aux wl us1 us2
+                -> let b = FStar_Syntax_Syntax.fv_eq f g in aux wl us1 us2
             | (FStar_Syntax_Syntax.Tm_uinst uu____9930,uu____9931) ->
                 failwith "Impossible: expect head symbols to match"
             | (uu____9938,FStar_Syntax_Syntax.Tm_uinst uu____9939) ->
                 failwith "Impossible: expect head symbols to match"
             | uu____9946 -> USolved wl
-
-and (giveup_or_defer :
+and giveup_or_defer:
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.prob -> worklist -> Prims.string -> solution)
+    FStar_TypeChecker_Common.prob -> worklist -> Prims.string -> solution
   =
   fun env  ->
     fun orig  ->
@@ -3462,42 +3193,38 @@ and (giveup_or_defer :
           then
             ((let uu____9956 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "Rel")
-                 in
+                  (FStar_Options.Other "Rel") in
               if uu____9956
               then
-                let uu____9957 = prob_to_string env orig  in
+                let uu____9957 = prob_to_string env orig in
                 FStar_Util.print2 "\n\t\tDeferring %s\n\t\tBecause %s\n"
                   uu____9957 msg
               else ());
              solve env (defer msg orig wl))
           else giveup env msg orig
-
-and (solve_rigid_flex_meet :
+and solve_rigid_flex_meet:
   FStar_TypeChecker_Env.env ->
-    tprob -> worklist -> worklist FStar_Pervasives_Native.option)
+    tprob -> worklist -> worklist FStar_Pervasives_Native.option
   =
   fun env  ->
     fun tp  ->
       fun wl  ->
         (let uu____9966 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "RelCheck")
-            in
+             (FStar_Options.Other "RelCheck") in
          if uu____9966
          then
            let uu____9967 =
-             FStar_Util.string_of_int tp.FStar_TypeChecker_Common.pid  in
+             FStar_Util.string_of_int tp.FStar_TypeChecker_Common.pid in
            FStar_Util.print1 "Trying to solve by meeting refinements:%s\n"
              uu____9967
          else ());
         (let uu____9969 =
-           FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.rhs
-            in
+           FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.rhs in
          match uu____9969 with
          | (u,args) ->
              let rec disjoin t1 t2 =
-               let uu____10031 = head_matches_delta env () t1 t2  in
+               let uu____10031 = head_matches_delta env () t1 t2 in
                match uu____10031 with
                | (mr,ts) ->
                    (match mr with
@@ -3513,17 +3240,16 @@ and (solve_rigid_flex_meet :
                           match ts with
                           | FStar_Pervasives_Native.Some (t11,t21) ->
                               let uu____10136 =
-                                FStar_Syntax_Subst.compress t11  in
+                                FStar_Syntax_Subst.compress t11 in
                               let uu____10137 =
-                                FStar_Syntax_Subst.compress t21  in
+                                FStar_Syntax_Subst.compress t21 in
                               (uu____10136, uu____10137)
                           | FStar_Pervasives_Native.None  ->
                               let uu____10142 =
-                                FStar_Syntax_Subst.compress t1  in
+                                FStar_Syntax_Subst.compress t1 in
                               let uu____10143 =
-                                FStar_Syntax_Subst.compress t2  in
-                              (uu____10142, uu____10143)
-                           in
+                                FStar_Syntax_Subst.compress t2 in
+                              (uu____10142, uu____10143) in
                         (match uu____10121 with
                          | (t11,t21) ->
                              let eq_prob t12 t22 =
@@ -3532,13 +3258,11 @@ and (solve_rigid_flex_meet :
                                    FStar_TypeChecker_Common.EQ t22
                                    FStar_Pervasives_Native.None
                                    t12.FStar_Syntax_Syntax.pos
-                                   "meeting refinements"
-                                  in
+                                   "meeting refinements" in
                                FStar_All.pipe_left
                                  (fun _0_52  ->
                                     FStar_TypeChecker_Common.TProb _0_52)
-                                 uu____10169
-                                in
+                                 uu____10169 in
                              (match ((t11.FStar_Syntax_Syntax.n),
                                       (t21.FStar_Syntax_Syntax.n))
                               with
@@ -3552,25 +3276,20 @@ and (solve_rigid_flex_meet :
                                           let uu____10216 =
                                             let uu____10223 =
                                               FStar_Syntax_Util.mk_disj phi1
-                                                phi2
-                                               in
-                                            (x, uu____10223)  in
+                                                phi2 in
+                                            (x, uu____10223) in
                                           FStar_Syntax_Syntax.Tm_refine
-                                            uu____10216
-                                           in
-                                        FStar_Syntax_Syntax.mk uu____10215
-                                         in
+                                            uu____10216 in
+                                        FStar_Syntax_Syntax.mk uu____10215 in
                                       uu____10212
                                         FStar_Pervasives_Native.None
-                                        t11.FStar_Syntax_Syntax.pos
-                                       in
+                                        t11.FStar_Syntax_Syntax.pos in
                                     let uu____10231 =
                                       let uu____10234 =
                                         eq_prob x.FStar_Syntax_Syntax.sort
-                                          y.FStar_Syntax_Syntax.sort
-                                         in
-                                      [uu____10234]  in
-                                    (uu____10209, uu____10231)  in
+                                          y.FStar_Syntax_Syntax.sort in
+                                      [uu____10234] in
+                                    (uu____10209, uu____10231) in
                                   FStar_Pervasives_Native.Some uu____10200
                               | (uu____10247,FStar_Syntax_Syntax.Tm_refine
                                  (x,uu____10249)) ->
@@ -3578,10 +3297,9 @@ and (solve_rigid_flex_meet :
                                     let uu____10261 =
                                       let uu____10264 =
                                         eq_prob x.FStar_Syntax_Syntax.sort
-                                          t11
-                                         in
-                                      [uu____10264]  in
-                                    (t11, uu____10261)  in
+                                          t11 in
+                                      [uu____10264] in
+                                    (t11, uu____10261) in
                                   FStar_Pervasives_Native.Some uu____10254
                               | (FStar_Syntax_Syntax.Tm_refine
                                  (x,uu____10274),uu____10275) ->
@@ -3589,22 +3307,19 @@ and (solve_rigid_flex_meet :
                                     let uu____10287 =
                                       let uu____10290 =
                                         eq_prob x.FStar_Syntax_Syntax.sort
-                                          t21
-                                         in
-                                      [uu____10290]  in
-                                    (t21, uu____10287)  in
+                                          t21 in
+                                      [uu____10290] in
+                                    (t21, uu____10287) in
                                   FStar_Pervasives_Native.Some uu____10280
                               | uu____10299 ->
                                   let uu____10304 =
-                                    FStar_Syntax_Util.head_and_args t11  in
+                                    FStar_Syntax_Util.head_and_args t11 in
                                   (match uu____10304 with
                                    | (head1,uu____10328) ->
                                        let uu____10349 =
                                          let uu____10350 =
-                                           FStar_Syntax_Util.un_uinst head1
-                                            in
-                                         uu____10350.FStar_Syntax_Syntax.n
-                                          in
+                                           FStar_Syntax_Util.un_uinst head1 in
+                                         uu____10350.FStar_Syntax_Syntax.n in
                                        (match uu____10349 with
                                         | FStar_Syntax_Syntax.Tm_fvar
                                             {
@@ -3622,27 +3337,23 @@ and (solve_rigid_flex_meet :
                                                 FStar_Syntax_Syntax.Delta_defined_at_level
                                                   (i - (Prims.parse_int "1"))
                                               else
-                                                FStar_Syntax_Syntax.Delta_constant
-                                               in
+                                                FStar_Syntax_Syntax.Delta_constant in
                                             let t12 =
                                               FStar_TypeChecker_Normalize.normalize
                                                 [FStar_TypeChecker_Normalize.Weak;
                                                 FStar_TypeChecker_Normalize.HNF;
                                                 FStar_TypeChecker_Normalize.UnfoldUntil
-                                                  prev] env t11
-                                               in
+                                                  prev] env t11 in
                                             let t22 =
                                               FStar_TypeChecker_Normalize.normalize
                                                 [FStar_TypeChecker_Normalize.Weak;
                                                 FStar_TypeChecker_Normalize.HNF;
                                                 FStar_TypeChecker_Normalize.UnfoldUntil
-                                                  prev] env t21
-                                               in
+                                                  prev] env t21 in
                                             disjoin t12 t22
                                         | uu____10370 ->
-                                            FStar_Pervasives_Native.None)))))
-                in
-             let tt = u  in
+                                            FStar_Pervasives_Native.None))))) in
+             let tt = u in
              (match tt.FStar_Syntax_Syntax.n with
               | FStar_Syntax_Syntax.Tm_uvar (uv,uu____10383) ->
                   let uu____10408 =
@@ -3656,14 +3367,12 @@ and (solve_rigid_flex_meet :
                                      is_rigid_flex rank1 ->
                                      let uu____10441 =
                                        FStar_Syntax_Util.head_and_args
-                                         tp1.FStar_TypeChecker_Common.rhs
-                                        in
+                                         tp1.FStar_TypeChecker_Common.rhs in
                                      (match uu____10441 with
                                       | (u',uu____10457) ->
                                           let uu____10478 =
-                                            let uu____10479 = whnf env u'  in
-                                            uu____10479.FStar_Syntax_Syntax.n
-                                             in
+                                            let uu____10479 = whnf env u' in
+                                            uu____10479.FStar_Syntax_Syntax.n in
                                           (match uu____10478 with
                                            | FStar_Syntax_Syntax.Tm_uvar
                                                (uv',uu____10483) ->
@@ -3671,8 +3380,7 @@ and (solve_rigid_flex_meet :
                                                  uv uv'
                                            | uu____10508 -> false))
                                  | uu____10509 -> false)
-                            | uu____10512 -> false))
-                     in
+                            | uu____10512 -> false)) in
                   (match uu____10408 with
                    | (lower_bounds,rest) ->
                        let rec make_lower_bound uu____10546 tps =
@@ -3686,9 +3394,8 @@ and (solve_rigid_flex_meet :
                                   let uu____10594 =
                                     let uu____10603 =
                                       whnf env
-                                        hd1.FStar_TypeChecker_Common.lhs
-                                       in
-                                    disjoin bound uu____10603  in
+                                        hd1.FStar_TypeChecker_Common.lhs in
+                                    disjoin bound uu____10603 in
                                   (match uu____10594 with
                                    | FStar_Pervasives_Native.Some
                                        (bound1,sub1) ->
@@ -3698,21 +3405,19 @@ and (solve_rigid_flex_meet :
                                          tl1
                                    | FStar_Pervasives_Native.None  ->
                                        FStar_Pervasives_Native.None)
-                              | uu____10638 -> FStar_Pervasives_Native.None)
-                          in
+                              | uu____10638 -> FStar_Pervasives_Native.None) in
                        let uu____10647 =
                          let uu____10656 =
                            let uu____10663 =
-                             whnf env tp.FStar_TypeChecker_Common.lhs  in
-                           (uu____10663, [])  in
-                         make_lower_bound uu____10656 lower_bounds  in
+                             whnf env tp.FStar_TypeChecker_Common.lhs in
+                           (uu____10663, []) in
+                         make_lower_bound uu____10656 lower_bounds in
                        (match uu____10647 with
                         | FStar_Pervasives_Native.None  ->
                             ((let uu____10675 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
-                                  (FStar_Options.Other "RelCheck")
-                                 in
+                                  (FStar_Options.Other "RelCheck") in
                               if uu____10675
                               then
                                 FStar_Util.print_string "No lower bounds\n"
@@ -3726,17 +3431,15 @@ and (solve_rigid_flex_meet :
                                 tp.FStar_TypeChecker_Common.rhs
                                 FStar_Pervasives_Native.None
                                 tp.FStar_TypeChecker_Common.loc
-                                "meeting refinements"
-                               in
+                                "meeting refinements" in
                             ((let uu____10695 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
-                                  (FStar_Options.Other "RelCheck")
-                                 in
+                                  (FStar_Options.Other "RelCheck") in
                               if uu____10695
                               then
                                 let wl' =
-                                  let uu___136_10697 = wl  in
+                                  let uu___136_10697 = wl in
                                   {
                                     attempting =
                                       ((FStar_TypeChecker_Common.TProb
@@ -3747,15 +3450,15 @@ and (solve_rigid_flex_meet :
                                     defer_ok = (uu___136_10697.defer_ok);
                                     smt_ok = (uu___136_10697.smt_ok);
                                     tcenv = (uu___136_10697.tcenv)
-                                  }  in
-                                let uu____10698 = wl_to_string wl'  in
+                                  } in
+                                let uu____10698 = wl_to_string wl' in
                                 FStar_Util.print1
                                   "After meeting refinements: %s\n"
                                   uu____10698
                               else ());
                              (let uu____10700 =
                                 solve_t env eq_prob
-                                  (let uu___137_10702 = wl  in
+                                  (let uu___137_10702 = wl in
                                    {
                                      attempting = sub_probs;
                                      wl_deferred =
@@ -3764,12 +3467,11 @@ and (solve_rigid_flex_meet :
                                      defer_ok = (uu___137_10702.defer_ok);
                                      smt_ok = (uu___137_10702.smt_ok);
                                      tcenv = (uu___137_10702.tcenv)
-                                   })
-                                 in
+                                   }) in
                               match uu____10700 with
                               | Success uu____10705 ->
                                   let wl1 =
-                                    let uu___138_10707 = wl  in
+                                    let uu___138_10707 = wl in
                                     {
                                       attempting = rest;
                                       wl_deferred =
@@ -3778,61 +3480,54 @@ and (solve_rigid_flex_meet :
                                       defer_ok = (uu___138_10707.defer_ok);
                                       smt_ok = (uu___138_10707.smt_ok);
                                       tcenv = (uu___138_10707.tcenv)
-                                    }  in
+                                    } in
                                   let wl2 =
                                     solve_prob' false
                                       (FStar_TypeChecker_Common.TProb tp)
-                                      FStar_Pervasives_Native.None [] wl1
-                                     in
+                                      FStar_Pervasives_Native.None [] wl1 in
                                   let uu____10709 =
                                     FStar_List.fold_left
                                       (fun wl3  ->
                                          fun p  ->
                                            solve_prob' true p
                                              FStar_Pervasives_Native.None []
-                                             wl3) wl2 lower_bounds
-                                     in
+                                             wl3) wl2 lower_bounds in
                                   FStar_Pervasives_Native.Some wl2
                               | uu____10714 -> FStar_Pervasives_Native.None))))
               | uu____10715 -> failwith "Impossible: Not a rigid-flex"))
-
-and (solve_flex_rigid_join :
+and solve_flex_rigid_join:
   FStar_TypeChecker_Env.env ->
-    tprob -> worklist -> worklist FStar_Pervasives_Native.option)
+    tprob -> worklist -> worklist FStar_Pervasives_Native.option
   =
   fun env  ->
     fun tp  ->
       fun wl  ->
         (let uu____10724 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "RelCheck")
-            in
+             (FStar_Options.Other "RelCheck") in
          if uu____10724
          then
            let uu____10725 =
-             FStar_Util.string_of_int tp.FStar_TypeChecker_Common.pid  in
+             FStar_Util.string_of_int tp.FStar_TypeChecker_Common.pid in
            FStar_Util.print1 "Trying to solve by joining refinements:%s\n"
              uu____10725
          else ());
         (let uu____10727 =
-           FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs
-            in
+           FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs in
          match uu____10727 with
          | (u,args) ->
              let uu____10766 =
                ((Prims.parse_int "0"), (Prims.parse_int "1"),
                  (Prims.parse_int "2"), (Prims.parse_int "3"),
-                 (Prims.parse_int "4"))
-                in
+                 (Prims.parse_int "4")) in
              (match uu____10766 with
               | (ok,head_match1,partial_match,fallback,failed_match) ->
-                  let max1 i j = if i < j then j else i  in
+                  let max1 i j = if i < j then j else i in
                   let base_types_match t1 t2 =
-                    let uu____10807 = FStar_Syntax_Util.head_and_args t1  in
+                    let uu____10807 = FStar_Syntax_Util.head_and_args t1 in
                     match uu____10807 with
                     | (h1,args1) ->
-                        let uu____10848 = FStar_Syntax_Util.head_and_args t2
-                           in
+                        let uu____10848 = FStar_Syntax_Util.head_and_args t2 in
                         (match uu____10848 with
                          | (h2,uu____10868) ->
                              (match ((h1.FStar_Syntax_Syntax.n),
@@ -3841,7 +3536,7 @@ and (solve_flex_rigid_join :
                               | (FStar_Syntax_Syntax.Tm_fvar
                                  tc1,FStar_Syntax_Syntax.Tm_fvar tc2) ->
                                   let uu____10895 =
-                                    FStar_Syntax_Syntax.fv_eq tc1 tc2  in
+                                    FStar_Syntax_Syntax.fv_eq tc1 tc2 in
                                   if uu____10895
                                   then
                                     (if
@@ -3857,14 +3552,12 @@ and (solve_flex_rigid_join :
                                                 t2
                                                 FStar_Pervasives_Native.None
                                                 t1.FStar_Syntax_Syntax.pos
-                                                "joining refinements"
-                                               in
+                                                "joining refinements" in
                                             FStar_All.pipe_left
                                               (fun _0_53  ->
                                                  FStar_TypeChecker_Common.TProb
-                                                   _0_53) uu____10917
-                                             in
-                                          [uu____10916]  in
+                                                   _0_53) uu____10917 in
+                                          [uu____10916] in
                                         FStar_Pervasives_Native.Some
                                           uu____10913))
                                   else FStar_Pervasives_Native.None
@@ -3885,19 +3578,16 @@ and (solve_flex_rigid_join :
                                                 t2
                                                 FStar_Pervasives_Native.None
                                                 t1.FStar_Syntax_Syntax.pos
-                                                "joining refinements"
-                                               in
+                                                "joining refinements" in
                                             FStar_All.pipe_left
                                               (fun _0_54  ->
                                                  FStar_TypeChecker_Common.TProb
-                                                   _0_54) uu____10954
-                                             in
-                                          [uu____10953]  in
+                                                   _0_54) uu____10954 in
+                                          [uu____10953] in
                                         FStar_Pervasives_Native.Some
                                           uu____10950))
                                   else FStar_Pervasives_Native.None
-                              | uu____10968 -> FStar_Pervasives_Native.None))
-                     in
+                              | uu____10968 -> FStar_Pervasives_Native.None)) in
                   let conjoin t1 t2 =
                     match ((t1.FStar_Syntax_Syntax.n),
                             (t2.FStar_Syntax_Syntax.n))
@@ -3906,32 +3596,28 @@ and (solve_flex_rigid_join :
                        (x,phi1),FStar_Syntax_Syntax.Tm_refine (y,phi2)) ->
                         let m =
                           base_types_match x.FStar_Syntax_Syntax.sort
-                            y.FStar_Syntax_Syntax.sort
-                           in
+                            y.FStar_Syntax_Syntax.sort in
                         (match m with
                          | FStar_Pervasives_Native.None  ->
                              FStar_Pervasives_Native.None
                          | FStar_Pervasives_Native.Some m1 ->
-                             let x1 = FStar_Syntax_Syntax.freshen_bv x  in
+                             let x1 = FStar_Syntax_Syntax.freshen_bv x in
                              let subst1 =
                                [FStar_Syntax_Syntax.DB
-                                  ((Prims.parse_int "0"), x1)]
-                                in
-                             let phi11 = FStar_Syntax_Subst.subst subst1 phi1
-                                in
-                             let phi21 = FStar_Syntax_Subst.subst subst1 phi2
-                                in
+                                  ((Prims.parse_int "0"), x1)] in
+                             let phi11 = FStar_Syntax_Subst.subst subst1 phi1 in
+                             let phi21 = FStar_Syntax_Subst.subst subst1 phi2 in
                              let uu____11058 =
                                let uu____11067 =
                                  let uu____11070 =
-                                   FStar_Syntax_Util.mk_conj phi11 phi21  in
-                                 FStar_Syntax_Util.refine x1 uu____11070  in
-                               (uu____11067, m1)  in
+                                   FStar_Syntax_Util.mk_conj phi11 phi21 in
+                                 FStar_Syntax_Util.refine x1 uu____11070 in
+                               (uu____11067, m1) in
                              FStar_Pervasives_Native.Some uu____11058)
                     | (uu____11083,FStar_Syntax_Syntax.Tm_refine
                        (y,uu____11085)) ->
                         let m =
-                          base_types_match t1 y.FStar_Syntax_Syntax.sort  in
+                          base_types_match t1 y.FStar_Syntax_Syntax.sort in
                         (match m with
                          | FStar_Pervasives_Native.None  ->
                              FStar_Pervasives_Native.None
@@ -3940,21 +3626,20 @@ and (solve_flex_rigid_join :
                     | (FStar_Syntax_Syntax.Tm_refine
                        (x,uu____11133),uu____11134) ->
                         let m =
-                          base_types_match x.FStar_Syntax_Syntax.sort t2  in
+                          base_types_match x.FStar_Syntax_Syntax.sort t2 in
                         (match m with
                          | FStar_Pervasives_Native.None  ->
                              FStar_Pervasives_Native.None
                          | FStar_Pervasives_Native.Some m1 ->
                              FStar_Pervasives_Native.Some (t1, m1))
                     | uu____11181 ->
-                        let m = base_types_match t1 t2  in
+                        let m = base_types_match t1 t2 in
                         (match m with
                          | FStar_Pervasives_Native.None  ->
                              FStar_Pervasives_Native.None
                          | FStar_Pervasives_Native.Some m1 ->
-                             FStar_Pervasives_Native.Some (t1, m1))
-                     in
-                  let tt = u  in
+                             FStar_Pervasives_Native.Some (t1, m1)) in
+                  let tt = u in
                   (match tt.FStar_Syntax_Syntax.n with
                    | FStar_Syntax_Syntax.Tm_uvar (uv,uu____11234) ->
                        let uu____11259 =
@@ -3969,15 +3654,13 @@ and (solve_flex_rigid_join :
                                           when is_flex_rigid rank1 ->
                                           let uu____11292 =
                                             FStar_Syntax_Util.head_and_args
-                                              tp1.FStar_TypeChecker_Common.lhs
-                                             in
+                                              tp1.FStar_TypeChecker_Common.lhs in
                                           (match uu____11292 with
                                            | (u',uu____11308) ->
                                                let uu____11329 =
                                                  let uu____11330 =
-                                                   whnf env u'  in
-                                                 uu____11330.FStar_Syntax_Syntax.n
-                                                  in
+                                                   whnf env u' in
+                                                 uu____11330.FStar_Syntax_Syntax.n in
                                                (match uu____11329 with
                                                 | FStar_Syntax_Syntax.Tm_uvar
                                                     (uv',uu____11334) ->
@@ -3985,8 +3668,7 @@ and (solve_flex_rigid_join :
                                                       uv uv'
                                                 | uu____11359 -> false))
                                       | uu____11360 -> false)
-                                 | uu____11363 -> false))
-                          in
+                                 | uu____11363 -> false)) in
                        (match uu____11259 with
                         | (upper_bounds,rest) ->
                             let rec make_upper_bound uu____11401 tps =
@@ -4001,9 +3683,8 @@ and (solve_flex_rigid_join :
                                        let uu____11463 =
                                          let uu____11474 =
                                            whnf env
-                                             hd1.FStar_TypeChecker_Common.rhs
-                                            in
-                                         conjoin bound uu____11474  in
+                                             hd1.FStar_TypeChecker_Common.rhs in
+                                         conjoin bound uu____11474 in
                                        (match uu____11463 with
                                         | FStar_Pervasives_Native.Some
                                             (bound1,sub1) ->
@@ -4014,22 +3695,19 @@ and (solve_flex_rigid_join :
                                         | FStar_Pervasives_Native.None  ->
                                             FStar_Pervasives_Native.None)
                                    | uu____11525 ->
-                                       FStar_Pervasives_Native.None)
-                               in
+                                       FStar_Pervasives_Native.None) in
                             let uu____11536 =
                               let uu____11547 =
                                 let uu____11556 =
-                                  whnf env tp.FStar_TypeChecker_Common.rhs
-                                   in
-                                (uu____11556, [])  in
-                              make_upper_bound uu____11547 upper_bounds  in
+                                  whnf env tp.FStar_TypeChecker_Common.rhs in
+                                (uu____11556, []) in
+                              make_upper_bound uu____11547 upper_bounds in
                             (match uu____11536 with
                              | FStar_Pervasives_Native.None  ->
                                  ((let uu____11570 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env)
-                                       (FStar_Options.Other "RelCheck")
-                                      in
+                                       (FStar_Options.Other "RelCheck") in
                                    if uu____11570
                                    then
                                      FStar_Util.print_string
@@ -4044,17 +3722,15 @@ and (solve_flex_rigid_join :
                                      FStar_TypeChecker_Common.EQ rhs_bound
                                      FStar_Pervasives_Native.None
                                      tp.FStar_TypeChecker_Common.loc
-                                     "joining refinements"
-                                    in
+                                     "joining refinements" in
                                  ((let uu____11596 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env)
-                                       (FStar_Options.Other "RelCheck")
-                                      in
+                                       (FStar_Options.Other "RelCheck") in
                                    if uu____11596
                                    then
                                      let wl' =
-                                       let uu___139_11598 = wl  in
+                                       let uu___139_11598 = wl in
                                        {
                                          attempting =
                                            ((FStar_TypeChecker_Common.TProb
@@ -4065,15 +3741,15 @@ and (solve_flex_rigid_join :
                                          defer_ok = (uu___139_11598.defer_ok);
                                          smt_ok = (uu___139_11598.smt_ok);
                                          tcenv = (uu___139_11598.tcenv)
-                                       }  in
-                                     let uu____11599 = wl_to_string wl'  in
+                                       } in
+                                     let uu____11599 = wl_to_string wl' in
                                      FStar_Util.print1
                                        "After joining refinements: %s\n"
                                        uu____11599
                                    else ());
                                   (let uu____11601 =
                                      solve_t env eq_prob
-                                       (let uu___140_11603 = wl  in
+                                       (let uu___140_11603 = wl in
                                         {
                                           attempting = sub_probs;
                                           wl_deferred =
@@ -4083,12 +3759,11 @@ and (solve_flex_rigid_join :
                                             (uu___140_11603.defer_ok);
                                           smt_ok = (uu___140_11603.smt_ok);
                                           tcenv = (uu___140_11603.tcenv)
-                                        })
-                                      in
+                                        }) in
                                    match uu____11601 with
                                    | Success uu____11606 ->
                                        let wl1 =
-                                         let uu___141_11608 = wl  in
+                                         let uu___141_11608 = wl in
                                          {
                                            attempting = rest;
                                            wl_deferred =
@@ -4098,27 +3773,24 @@ and (solve_flex_rigid_join :
                                              (uu___141_11608.defer_ok);
                                            smt_ok = (uu___141_11608.smt_ok);
                                            tcenv = (uu___141_11608.tcenv)
-                                         }  in
+                                         } in
                                        let wl2 =
                                          solve_prob' false
                                            (FStar_TypeChecker_Common.TProb tp)
                                            FStar_Pervasives_Native.None []
-                                           wl1
-                                          in
+                                           wl1 in
                                        let uu____11610 =
                                          FStar_List.fold_left
                                            (fun wl3  ->
                                               fun p  ->
                                                 solve_prob' true p
                                                   FStar_Pervasives_Native.None
-                                                  [] wl3) wl2 upper_bounds
-                                          in
+                                                  [] wl3) wl2 upper_bounds in
                                        FStar_Pervasives_Native.Some wl2
                                    | uu____11615 ->
                                        FStar_Pervasives_Native.None))))
                    | uu____11616 -> failwith "Impossible: Not a flex-rigid")))
-
-and (solve_binders :
+and solve_binders:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
       FStar_Syntax_Syntax.binders ->
@@ -4128,7 +3800,7 @@ and (solve_binders :
                FStar_TypeChecker_Env.env ->
                  FStar_Syntax_Syntax.subst_elt Prims.list ->
                    FStar_TypeChecker_Common.prob)
-              -> solution)
+              -> solution
   =
   fun env  ->
     fun bs1  ->
@@ -4139,138 +3811,121 @@ and (solve_binders :
               let rec aux scope env1 subst1 xs ys =
                 match (xs, ys) with
                 | ([],[]) ->
-                    let rhs_prob = rhs scope env1 subst1  in
+                    let rhs_prob = rhs scope env1 subst1 in
                     ((let uu____11691 =
                         FStar_All.pipe_left
                           (FStar_TypeChecker_Env.debug env1)
-                          (FStar_Options.Other "Rel")
-                         in
+                          (FStar_Options.Other "Rel") in
                       if uu____11691
                       then
-                        let uu____11692 = prob_to_string env1 rhs_prob  in
+                        let uu____11692 = prob_to_string env1 rhs_prob in
                         FStar_Util.print1 "rhs_prob = %s\n" uu____11692
                       else ());
                      (let formula =
                         FStar_All.pipe_right (p_guard rhs_prob)
-                          FStar_Pervasives_Native.fst
-                         in
+                          FStar_Pervasives_Native.fst in
                       FStar_Util.Inl ([rhs_prob], formula)))
                 | ((hd1,imp)::xs1,(hd2,imp')::ys1) when imp = imp' ->
                     let hd11 =
-                      let uu___142_11746 = hd1  in
+                      let uu___142_11746 = hd1 in
                       let uu____11747 =
                         FStar_Syntax_Subst.subst subst1
-                          hd1.FStar_Syntax_Syntax.sort
-                         in
+                          hd1.FStar_Syntax_Syntax.sort in
                       {
                         FStar_Syntax_Syntax.ppname =
                           (uu___142_11746.FStar_Syntax_Syntax.ppname);
                         FStar_Syntax_Syntax.index =
                           (uu___142_11746.FStar_Syntax_Syntax.index);
                         FStar_Syntax_Syntax.sort = uu____11747
-                      }  in
+                      } in
                     let hd21 =
-                      let uu___143_11751 = hd2  in
+                      let uu___143_11751 = hd2 in
                       let uu____11752 =
                         FStar_Syntax_Subst.subst subst1
-                          hd2.FStar_Syntax_Syntax.sort
-                         in
+                          hd2.FStar_Syntax_Syntax.sort in
                       {
                         FStar_Syntax_Syntax.ppname =
                           (uu___143_11751.FStar_Syntax_Syntax.ppname);
                         FStar_Syntax_Syntax.index =
                           (uu___143_11751.FStar_Syntax_Syntax.index);
                         FStar_Syntax_Syntax.sort = uu____11752
-                      }  in
+                      } in
                     let prob =
                       let uu____11756 =
                         let uu____11761 =
-                          FStar_All.pipe_left invert_rel (p_rel orig)  in
+                          FStar_All.pipe_left invert_rel (p_rel orig) in
                         mk_problem scope orig hd11.FStar_Syntax_Syntax.sort
                           uu____11761 hd21.FStar_Syntax_Syntax.sort
-                          FStar_Pervasives_Native.None "Formal parameter"
-                         in
+                          FStar_Pervasives_Native.None "Formal parameter" in
                       FStar_All.pipe_left
                         (fun _0_55  -> FStar_TypeChecker_Common.TProb _0_55)
-                        uu____11756
-                       in
-                    let hd12 = FStar_Syntax_Syntax.freshen_bv hd11  in
+                        uu____11756 in
+                    let hd12 = FStar_Syntax_Syntax.freshen_bv hd11 in
                     let subst2 =
                       let uu____11772 =
                         FStar_Syntax_Subst.shift_subst (Prims.parse_int "1")
-                          subst1
-                         in
+                          subst1 in
                       (FStar_Syntax_Syntax.DB ((Prims.parse_int "0"), hd12))
-                        :: uu____11772
-                       in
-                    let env2 = FStar_TypeChecker_Env.push_bv env1 hd12  in
+                        :: uu____11772 in
+                    let env2 = FStar_TypeChecker_Env.push_bv env1 hd12 in
                     let uu____11776 =
                       aux (FStar_List.append scope [(hd12, imp)]) env2 subst2
-                        xs1 ys1
-                       in
+                        xs1 ys1 in
                     (match uu____11776 with
                      | FStar_Util.Inl (sub_probs,phi) ->
                          let phi1 =
                            let uu____11814 =
                              FStar_All.pipe_right (p_guard prob)
-                               FStar_Pervasives_Native.fst
-                              in
+                               FStar_Pervasives_Native.fst in
                            let uu____11819 =
-                             close_forall env2 [(hd12, imp)] phi  in
-                           FStar_Syntax_Util.mk_conj uu____11814 uu____11819
-                            in
+                             close_forall env2 [(hd12, imp)] phi in
+                           FStar_Syntax_Util.mk_conj uu____11814 uu____11819 in
                          ((let uu____11829 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env2)
-                               (FStar_Options.Other "Rel")
-                              in
+                               (FStar_Options.Other "Rel") in
                            if uu____11829
                            then
                              let uu____11830 =
-                               FStar_Syntax_Print.term_to_string phi1  in
+                               FStar_Syntax_Print.term_to_string phi1 in
                              let uu____11831 =
-                               FStar_Syntax_Print.bv_to_string hd12  in
+                               FStar_Syntax_Print.bv_to_string hd12 in
                              FStar_Util.print2 "Formula is %s\n\thd1=%s\n"
                                uu____11830 uu____11831
                            else ());
                           FStar_Util.Inl ((prob :: sub_probs), phi1))
                      | fail -> fail)
                 | uu____11854 ->
-                    FStar_Util.Inr "arity or argument-qualifier mismatch"
-                 in
-              let scope = p_scope orig  in
-              let uu____11864 = aux scope env [] bs1 bs2  in
+                    FStar_Util.Inr "arity or argument-qualifier mismatch" in
+              let scope = p_scope orig in
+              let uu____11864 = aux scope env [] bs1 bs2 in
               match uu____11864 with
               | FStar_Util.Inr msg -> giveup env msg orig
               | FStar_Util.Inl (sub_probs,phi) ->
                   let wl1 =
-                    solve_prob orig (FStar_Pervasives_Native.Some phi) [] wl
-                     in
+                    solve_prob orig (FStar_Pervasives_Native.Some phi) [] wl in
                   solve env (attempt sub_probs wl1)
-
-and (solve_t : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
+and solve_t: FStar_TypeChecker_Env.env -> tprob -> worklist -> solution =
   fun env  ->
     fun problem  ->
       fun wl  ->
-        let uu____11888 = compress_tprob wl problem  in
+        let uu____11888 = compress_tprob wl problem in
         solve_t' env uu____11888 wl
-
-and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
+and solve_t': FStar_TypeChecker_Env.env -> tprob -> worklist -> solution =
   fun env  ->
     fun problem  ->
       fun wl  ->
-        let giveup_or_defer1 orig msg = giveup_or_defer env orig wl msg  in
+        let giveup_or_defer1 orig msg = giveup_or_defer env orig wl msg in
         let rigid_rigid_delta env1 orig wl1 head1 head2 t1 t2 =
-          let uu____11921 = head_matches_delta env1 wl1 t1 t2  in
+          let uu____11921 = head_matches_delta env1 wl1 t1 t2 in
           match uu____11921 with
           | (m,o) ->
               (match (m, o) with
                | (MisMatch uu____11952,uu____11953) ->
                    let rec may_relate head3 =
                      let uu____11978 =
-                       let uu____11979 = FStar_Syntax_Subst.compress head3
-                          in
-                       uu____11979.FStar_Syntax_Syntax.n  in
+                       let uu____11979 = FStar_Syntax_Subst.compress head3 in
+                       uu____11979.FStar_Syntax_Syntax.n in
                      match uu____11978 with
                      | FStar_Syntax_Syntax.Tm_name uu____11982 -> true
                      | FStar_Syntax_Syntax.Tm_match uu____11983 -> true
@@ -4294,10 +3949,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          may_relate t
                      | FStar_Syntax_Syntax.Tm_meta (t,uu____12065) ->
                          may_relate t
-                     | uu____12070 -> false  in
+                     | uu____12070 -> false in
                    let uu____12071 =
-                     ((may_relate head1) || (may_relate head2)) && wl1.smt_ok
-                      in
+                     ((may_relate head1) || (may_relate head2)) && wl1.smt_ok in
                    if uu____12071
                    then
                      let guard =
@@ -4314,44 +3968,37 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                             | FStar_Pervasives_Native.None  ->
                                 let x =
                                   FStar_Syntax_Syntax.new_bv
-                                    FStar_Pervasives_Native.None t11
-                                   in
+                                    FStar_Pervasives_Native.None t11 in
                                 let u_x =
                                   env1.FStar_TypeChecker_Env.universe_of env1
-                                    t11
-                                   in
+                                    t11 in
                                 let uu____12088 =
                                   let uu____12089 =
-                                    FStar_Syntax_Syntax.bv_to_name x  in
+                                    FStar_Syntax_Syntax.bv_to_name x in
                                   FStar_Syntax_Util.mk_has_type t11
-                                    uu____12089 t21
-                                   in
-                                FStar_Syntax_Util.mk_forall u_x x uu____12088
-                             in
+                                    uu____12089 t21 in
+                                FStar_Syntax_Util.mk_forall u_x x uu____12088 in
                           if
                             problem.FStar_TypeChecker_Common.relation =
                               FStar_TypeChecker_Common.SUB
                           then has_type_guard t1 t2
-                          else has_type_guard t2 t1)
-                        in
+                          else has_type_guard t2 t1) in
                      let uu____12091 =
                        solve_prob orig (FStar_Pervasives_Native.Some guard)
-                         [] wl1
-                        in
+                         [] wl1 in
                      solve env1 uu____12091
                    else
                      (let uu____12093 =
                         let uu____12094 =
-                          FStar_Syntax_Print.term_to_string head1  in
+                          FStar_Syntax_Print.term_to_string head1 in
                         let uu____12095 =
-                          FStar_Syntax_Print.term_to_string head2  in
+                          FStar_Syntax_Print.term_to_string head2 in
                         FStar_Util.format2 "head mismatch (%s vs %s)"
-                          uu____12094 uu____12095
-                         in
+                          uu____12094 uu____12095 in
                       giveup env1 uu____12093 orig)
                | (uu____12096,FStar_Pervasives_Native.Some (t11,t21)) ->
                    solve_t env1
-                     (let uu___144_12110 = problem  in
+                     (let uu___144_12110 = problem in
                       {
                         FStar_TypeChecker_Common.pid =
                           (uu___144_12110.FStar_TypeChecker_Common.pid);
@@ -4375,68 +4022,55 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                | (uu____12111,FStar_Pervasives_Native.None ) ->
                    ((let uu____12123 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
-                         (FStar_Options.Other "Rel")
-                        in
+                         (FStar_Options.Other "Rel") in
                      if uu____12123
                      then
-                       let uu____12124 = FStar_Syntax_Print.term_to_string t1
-                          in
-                       let uu____12125 = FStar_Syntax_Print.tag_of_term t1
-                          in
-                       let uu____12126 = FStar_Syntax_Print.term_to_string t2
-                          in
-                       let uu____12127 = FStar_Syntax_Print.tag_of_term t2
-                          in
+                       let uu____12124 = FStar_Syntax_Print.term_to_string t1 in
+                       let uu____12125 = FStar_Syntax_Print.tag_of_term t1 in
+                       let uu____12126 = FStar_Syntax_Print.term_to_string t2 in
+                       let uu____12127 = FStar_Syntax_Print.tag_of_term t2 in
                        FStar_Util.print4
                          "Head matches: %s (%s) and %s (%s)\n" uu____12124
                          uu____12125 uu____12126 uu____12127
                      else ());
-                    (let uu____12129 = FStar_Syntax_Util.head_and_args t1  in
+                    (let uu____12129 = FStar_Syntax_Util.head_and_args t1 in
                      match uu____12129 with
                      | (head11,args1) ->
-                         let uu____12166 = FStar_Syntax_Util.head_and_args t2
-                            in
+                         let uu____12166 = FStar_Syntax_Util.head_and_args t2 in
                          (match uu____12166 with
                           | (head21,args2) ->
-                              let nargs = FStar_List.length args1  in
+                              let nargs = FStar_List.length args1 in
                               if nargs <> (FStar_List.length args2)
                               then
                                 let uu____12220 =
                                   let uu____12221 =
-                                    FStar_Syntax_Print.term_to_string head11
-                                     in
-                                  let uu____12222 = args_to_string args1  in
+                                    FStar_Syntax_Print.term_to_string head11 in
+                                  let uu____12222 = args_to_string args1 in
                                   let uu____12223 =
-                                    FStar_Syntax_Print.term_to_string head21
-                                     in
-                                  let uu____12224 = args_to_string args2  in
+                                    FStar_Syntax_Print.term_to_string head21 in
+                                  let uu____12224 = args_to_string args2 in
                                   FStar_Util.format4
                                     "unequal number of arguments: %s[%s] and %s[%s]"
                                     uu____12221 uu____12222 uu____12223
-                                    uu____12224
-                                   in
+                                    uu____12224 in
                                 giveup env1 uu____12220 orig
                               else
                                 (let uu____12226 =
                                    (nargs = (Prims.parse_int "0")) ||
                                      (let uu____12232 =
-                                        FStar_Syntax_Util.eq_args args1 args2
-                                         in
-                                      uu____12232 = FStar_Syntax_Util.Equal)
-                                    in
+                                        FStar_Syntax_Util.eq_args args1 args2 in
+                                      uu____12232 = FStar_Syntax_Util.Equal) in
                                  if uu____12226
                                  then
                                    let uu____12233 =
                                      solve_maybe_uinsts env1 orig head11
-                                       head21 wl1
-                                      in
+                                       head21 wl1 in
                                    match uu____12233 with
                                    | USolved wl2 ->
                                        let uu____12235 =
                                          solve_prob orig
                                            FStar_Pervasives_Native.None []
-                                           wl2
-                                          in
+                                           wl2 in
                                        solve env1 uu____12235
                                    | UFailed msg -> giveup env1 msg orig
                                    | UDeferred wl2 ->
@@ -4445,11 +4079,11 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                             wl2)
                                  else
                                    (let uu____12239 =
-                                      base_and_refinement env1 t1  in
+                                      base_and_refinement env1 t1 in
                                     match uu____12239 with
                                     | (base1,refinement1) ->
                                         let uu____12264 =
-                                          base_and_refinement env1 t2  in
+                                          base_and_refinement env1 t2 in
                                         (match uu____12264 with
                                          | (base2,refinement2) ->
                                              (match (refinement1,
@@ -4460,8 +4094,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                  ) ->
                                                   let uu____12321 =
                                                     solve_maybe_uinsts env1
-                                                      orig head11 head21 wl1
-                                                     in
+                                                      orig head11 head21 wl1 in
                                                   (match uu____12321 with
                                                    | UFailed msg ->
                                                        giveup env1 msg orig
@@ -4493,47 +4126,40 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     FStar_TypeChecker_Common.EQ
                                                                     a'
                                                                     FStar_Pervasives_Native.None
-                                                                    "index"
-                                                                     in
+                                                                    "index" in
                                                                     FStar_All.pipe_left
                                                                     (fun
                                                                     _0_56  ->
                                                                     FStar_TypeChecker_Common.TProb
                                                                     _0_56)
                                                                     uu____12373)
-                                                           args1 args2
-                                                          in
+                                                           args1 args2 in
                                                        let formula =
                                                          let uu____12383 =
                                                            FStar_List.map
                                                              (fun p  ->
                                                                 FStar_Pervasives_Native.fst
                                                                   (p_guard p))
-                                                             subprobs
-                                                            in
+                                                             subprobs in
                                                          FStar_Syntax_Util.mk_conj_l
-                                                           uu____12383
-                                                          in
+                                                           uu____12383 in
                                                        let wl3 =
                                                          solve_prob orig
                                                            (FStar_Pervasives_Native.Some
-                                                              formula) [] wl2
-                                                          in
+                                                              formula) [] wl2 in
                                                        solve env1
                                                          (attempt subprobs
                                                             wl3))
                                               | uu____12389 ->
                                                   let lhs =
                                                     force_refinement
-                                                      (base1, refinement1)
-                                                     in
+                                                      (base1, refinement1) in
                                                   let rhs =
                                                     force_refinement
-                                                      (base2, refinement2)
-                                                     in
+                                                      (base2, refinement2) in
                                                   solve_t env1
                                                     (let uu___145_12425 =
-                                                       problem  in
+                                                       problem in
                                                      {
                                                        FStar_TypeChecker_Common.pid
                                                          =
@@ -4563,23 +4189,21 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                        FStar_TypeChecker_Common.rank
                                                          =
                                                          (uu___145_12425.FStar_TypeChecker_Common.rank)
-                                                     }) wl1))))))))
-           in
+                                                     }) wl1)))))))) in
         let force_quasi_pattern xs_opt uu____12458 =
           match uu____12458 with
           | (t,u,k,args) ->
               let debug1 f =
                 let uu____12500 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                    (FStar_Options.Other "Rel")
-                   in
-                if uu____12500 then f () else ()  in
+                    (FStar_Options.Other "Rel") in
+                if uu____12500 then f () else () in
               let rec aux pat_args pat_args_set pattern_vars pattern_var_set
                 seen_formals formals res_t args1 =
                 debug1
                   (fun uu____12596  ->
                      let uu____12597 =
-                       FStar_Syntax_Print.binders_to_string ", " pat_args  in
+                       FStar_Syntax_Print.binders_to_string ", " pat_args in
                      FStar_Util.print1 "pat_args so far: {%s}\n" uu____12597);
                 (match (formals, args1) with
                  | ([],[]) ->
@@ -4590,60 +4214,52 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                match uu____12665 with
                                | (x,imp) ->
                                    let uu____12676 =
-                                     FStar_Syntax_Syntax.bv_to_name x  in
-                                   (uu____12676, imp)))
-                        in
-                     let pattern_vars1 = FStar_List.rev pattern_vars  in
+                                     FStar_Syntax_Syntax.bv_to_name x in
+                                   (uu____12676, imp))) in
+                     let pattern_vars1 = FStar_List.rev pattern_vars in
                      let kk =
-                       let uu____12689 = FStar_Syntax_Util.type_u ()  in
+                       let uu____12689 = FStar_Syntax_Util.type_u () in
                        match uu____12689 with
                        | (t1,uu____12695) ->
                            let uu____12696 =
                              new_uvar t1.FStar_Syntax_Syntax.pos
-                               pattern_vars1 t1
-                              in
-                           FStar_Pervasives_Native.fst uu____12696
-                        in
+                               pattern_vars1 t1 in
+                           FStar_Pervasives_Native.fst uu____12696 in
                      let uu____12701 =
-                       new_uvar t.FStar_Syntax_Syntax.pos pattern_vars1 kk
-                        in
+                       new_uvar t.FStar_Syntax_Syntax.pos pattern_vars1 kk in
                      (match uu____12701 with
                       | (t',tm_u1) ->
-                          let uu____12714 = destruct_flex_t t'  in
+                          let uu____12714 = destruct_flex_t t' in
                           (match uu____12714 with
                            | (uu____12751,u1,k1,uu____12754) ->
-                               let all_formals = FStar_List.rev seen_formals
-                                  in
+                               let all_formals = FStar_List.rev seen_formals in
                                let k2 =
                                  let uu____12813 =
-                                   FStar_Syntax_Syntax.mk_Total res_t  in
+                                   FStar_Syntax_Syntax.mk_Total res_t in
                                  FStar_Syntax_Util.arrow all_formals
-                                   uu____12813
-                                  in
+                                   uu____12813 in
                                let sol =
                                  let uu____12817 =
-                                   let uu____12826 = u_abs k2 all_formals t'
-                                      in
-                                   ((u, k2), uu____12826)  in
-                                 TERM uu____12817  in
+                                   let uu____12826 = u_abs k2 all_formals t' in
+                                   ((u, k2), uu____12826) in
+                                 TERM uu____12817 in
                                let t_app =
                                  FStar_Syntax_Syntax.mk_Tm_app tm_u1
                                    pat_args1 FStar_Pervasives_Native.None
-                                   t.FStar_Syntax_Syntax.pos
-                                  in
+                                   t.FStar_Syntax_Syntax.pos in
                                FStar_Pervasives_Native.Some
                                  (sol, (t_app, u1, k1, pat_args1))))
                  | (formal::formals1,hd1::tl1) ->
                      (debug1
                         (fun uu____12961  ->
                            let uu____12962 =
-                             FStar_Syntax_Print.binder_to_string formal  in
+                             FStar_Syntax_Print.binder_to_string formal in
                            let uu____12963 =
-                             FStar_Syntax_Print.args_to_string [hd1]  in
+                             FStar_Syntax_Print.args_to_string [hd1] in
                            FStar_Util.print2
                              "force_quasi_pattern (case 2): formal=%s, hd=%s\n"
                              uu____12962 uu____12963);
-                      (let uu____12976 = pat_var_opt env pat_args hd1  in
+                      (let uu____12976 = pat_var_opt env pat_args hd1 in
                        match uu____12976 with
                        | FStar_Pervasives_Native.None  ->
                            (debug1
@@ -4664,8 +4280,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                          match uu____13039 with
                                          | (x,uu____13045) ->
                                              FStar_Syntax_Syntax.bv_eq x
-                                               (FStar_Pervasives_Native.fst y)))
-                              in
+                                               (FStar_Pervasives_Native.fst y))) in
                            if Prims.op_Negation maybe_pat
                            then
                              aux pat_args pat_args_set pattern_vars
@@ -4675,24 +4290,20 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              (debug1
                                 (fun uu____13060  ->
                                    let uu____13061 =
-                                     FStar_Syntax_Print.args_to_string [hd1]
-                                      in
+                                     FStar_Syntax_Print.args_to_string [hd1] in
                                    let uu____13074 =
-                                     FStar_Syntax_Print.binder_to_string y
-                                      in
+                                     FStar_Syntax_Print.binder_to_string y in
                                    FStar_Util.print2
                                      "%s (var = %s) maybe pat\n" uu____13061
                                      uu____13074);
                               (let fvs =
                                  FStar_Syntax_Free.names
-                                   (FStar_Pervasives_Native.fst y).FStar_Syntax_Syntax.sort
-                                  in
+                                   (FStar_Pervasives_Native.fst y).FStar_Syntax_Syntax.sort in
                                let uu____13078 =
                                  let uu____13079 =
                                    FStar_Util.set_is_subset_of fvs
-                                     pat_args_set
-                                    in
-                                 Prims.op_Negation uu____13079  in
+                                     pat_args_set in
+                                 Prims.op_Negation uu____13079 in
                                if uu____13078
                                then
                                  (debug1
@@ -4700,32 +4311,28 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                        let uu____13092 =
                                          let uu____13095 =
                                            FStar_Syntax_Print.args_to_string
-                                             [hd1]
-                                            in
+                                             [hd1] in
                                          let uu____13108 =
                                            let uu____13111 =
                                              FStar_Syntax_Print.binder_to_string
-                                               y
-                                              in
+                                               y in
                                            let uu____13112 =
                                              let uu____13115 =
                                                FStar_Syntax_Print.term_to_string
                                                  (FStar_Pervasives_Native.fst
-                                                    y).FStar_Syntax_Syntax.sort
-                                                in
+                                                    y).FStar_Syntax_Syntax.sort in
                                              let uu____13116 =
                                                let uu____13119 =
-                                                 names_to_string fvs  in
+                                                 names_to_string fvs in
                                                let uu____13120 =
                                                  let uu____13123 =
                                                    names_to_string
-                                                     pattern_var_set
-                                                    in
-                                                 [uu____13123]  in
-                                               uu____13119 :: uu____13120  in
-                                             uu____13115 :: uu____13116  in
-                                           uu____13111 :: uu____13112  in
-                                         uu____13095 :: uu____13108  in
+                                                     pattern_var_set in
+                                                 [uu____13123] in
+                                               uu____13119 :: uu____13120 in
+                                             uu____13115 :: uu____13116 in
+                                           uu____13111 :: uu____13112 in
+                                         uu____13095 :: uu____13108 in
                                        FStar_Util.print
                                          "BUT! %s (var = %s) is not a pat because its type %s contains {%s} fvs which are not included in the pattern vars so far {%s}\n"
                                          uu____13092);
@@ -4736,22 +4343,19 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                  (let uu____13125 =
                                     FStar_Util.set_add
                                       (FStar_Pervasives_Native.fst y)
-                                      pat_args_set
-                                     in
+                                      pat_args_set in
                                   let uu____13128 =
                                     FStar_Util.set_add
                                       (FStar_Pervasives_Native.fst formal)
-                                      pattern_var_set
-                                     in
+                                      pattern_var_set in
                                   aux (y :: pat_args) uu____13125 (formal ::
                                     pattern_vars) uu____13128 (formal ::
                                     seen_formals) formals1 res_t tl1)))))
                  | ([],uu____13135::uu____13136) ->
                      let uu____13167 =
                        let uu____13180 =
-                         FStar_TypeChecker_Normalize.unfold_whnf env res_t
-                          in
-                       FStar_Syntax_Util.arrow_formals uu____13180  in
+                         FStar_TypeChecker_Normalize.unfold_whnf env res_t in
+                       FStar_Syntax_Util.arrow_formals uu____13180 in
                      (match uu____13167 with
                       | (more_formals,res_t1) ->
                           (match more_formals with
@@ -4761,147 +4365,131 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                  pattern_var_set seen_formals more_formals
                                  res_t1 args1))
                  | (uu____13226::uu____13227,[]) ->
-                     FStar_Pervasives_Native.None)
-                 in
+                     FStar_Pervasives_Native.None) in
               let uu____13250 =
                 let uu____13263 =
-                  FStar_TypeChecker_Normalize.unfold_whnf env k  in
-                FStar_Syntax_Util.arrow_formals uu____13263  in
+                  FStar_TypeChecker_Normalize.unfold_whnf env k in
+                FStar_Syntax_Util.arrow_formals uu____13263 in
               (match uu____13250 with
                | (all_formals,res_t) ->
                    (debug1
                       (fun uu____13299  ->
                          let uu____13300 =
-                           FStar_Syntax_Print.term_to_string t  in
+                           FStar_Syntax_Print.term_to_string t in
                          let uu____13301 =
                            FStar_Syntax_Print.binders_to_string ", "
-                             all_formals
-                            in
+                             all_formals in
                          let uu____13302 =
-                           FStar_Syntax_Print.term_to_string res_t  in
+                           FStar_Syntax_Print.term_to_string res_t in
                          let uu____13303 =
-                           FStar_Syntax_Print.args_to_string args  in
+                           FStar_Syntax_Print.args_to_string args in
                          FStar_Util.print4
                            "force_quasi_pattern of %s with all_formals={%s}, res_t={%s} and args={%s}\n"
                            uu____13300 uu____13301 uu____13302 uu____13303);
-                    (let uu____13304 = FStar_Syntax_Syntax.new_bv_set ()  in
-                     let uu____13307 = FStar_Syntax_Syntax.new_bv_set ()  in
+                    (let uu____13304 = FStar_Syntax_Syntax.new_bv_set () in
+                     let uu____13307 = FStar_Syntax_Syntax.new_bv_set () in
                      aux [] uu____13304 [] uu____13307 [] all_formals res_t
-                       args)))
-           in
+                       args))) in
         let use_pattern_equality orig env1 wl1 lhs pat_vars1 rhs =
-          let uu____13341 = lhs  in
+          let uu____13341 = lhs in
           match uu____13341 with
           | (t1,uv,k_uv,args_lhs) ->
               let sol =
                 match pat_vars1 with
                 | [] -> rhs
                 | uu____13351 ->
-                    let uu____13352 = sn_binders env1 pat_vars1  in
-                    u_abs k_uv uu____13352 rhs
-                 in
+                    let uu____13352 = sn_binders env1 pat_vars1 in
+                    u_abs k_uv uu____13352 rhs in
               let wl2 =
                 solve_prob orig FStar_Pervasives_Native.None
-                  [TERM ((uv, k_uv), sol)] wl1
-                 in
-              solve env1 wl2
-           in
+                  [TERM ((uv, k_uv), sol)] wl1 in
+              solve env1 wl2 in
         let imitate orig env1 wl1 p =
-          let uu____13375 = p  in
+          let uu____13375 = p in
           match uu____13375 with
           | (((u,k),xs,c),ps,(h,uu____13386,qs)) ->
-              let xs1 = sn_binders env1 xs  in
-              let r = FStar_TypeChecker_Env.get_range env1  in
-              let uu____13468 = imitation_sub_probs orig env1 xs1 ps qs  in
+              let xs1 = sn_binders env1 xs in
+              let r = FStar_TypeChecker_Env.get_range env1 in
+              let uu____13468 = imitation_sub_probs orig env1 xs1 ps qs in
               (match uu____13468 with
                | (sub_probs,gs_xs,formula) ->
                    let im =
-                     let uu____13491 = h gs_xs  in
+                     let uu____13491 = h gs_xs in
                      let uu____13492 =
                        FStar_All.pipe_right
                          (FStar_Syntax_Util.residual_comp_of_comp c)
-                         (fun _0_57  -> FStar_Pervasives_Native.Some _0_57)
-                        in
-                     FStar_Syntax_Util.abs xs1 uu____13491 uu____13492  in
+                         (fun _0_57  -> FStar_Pervasives_Native.Some _0_57) in
+                     FStar_Syntax_Util.abs xs1 uu____13491 uu____13492 in
                    ((let uu____13498 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
-                         (FStar_Options.Other "Rel")
-                        in
+                         (FStar_Options.Other "Rel") in
                      if uu____13498
                      then
                        let uu____13499 =
                          let uu____13502 =
                            let uu____13503 =
-                             FStar_List.map tc_to_string gs_xs  in
+                             FStar_List.map tc_to_string gs_xs in
                            FStar_All.pipe_right uu____13503
-                             (FStar_String.concat "\n\t>")
-                            in
+                             (FStar_String.concat "\n\t>") in
                          let uu____13508 =
                            let uu____13511 =
-                             FStar_Syntax_Print.binders_to_string ", " xs1
-                              in
+                             FStar_Syntax_Print.binders_to_string ", " xs1 in
                            let uu____13512 =
                              let uu____13515 =
-                               FStar_Syntax_Print.comp_to_string c  in
+                               FStar_Syntax_Print.comp_to_string c in
                              let uu____13516 =
                                let uu____13519 =
-                                 FStar_Syntax_Print.term_to_string im  in
+                                 FStar_Syntax_Print.term_to_string im in
                                let uu____13520 =
                                  let uu____13523 =
-                                   FStar_Syntax_Print.tag_of_term im  in
+                                   FStar_Syntax_Print.tag_of_term im in
                                  let uu____13524 =
                                    let uu____13527 =
                                      let uu____13528 =
                                        FStar_List.map (prob_to_string env1)
-                                         sub_probs
-                                        in
+                                         sub_probs in
                                      FStar_All.pipe_right uu____13528
-                                       (FStar_String.concat ", ")
-                                      in
+                                       (FStar_String.concat ", ") in
                                    let uu____13533 =
                                      let uu____13536 =
                                        FStar_TypeChecker_Normalize.term_to_string
-                                         env1 formula
-                                        in
-                                     [uu____13536]  in
-                                   uu____13527 :: uu____13533  in
-                                 uu____13523 :: uu____13524  in
-                               uu____13519 :: uu____13520  in
-                             uu____13515 :: uu____13516  in
-                           uu____13511 :: uu____13512  in
-                         uu____13502 :: uu____13508  in
+                                         env1 formula in
+                                     [uu____13536] in
+                                   uu____13527 :: uu____13533 in
+                                 uu____13523 :: uu____13524 in
+                               uu____13519 :: uu____13520 in
+                             uu____13515 :: uu____13516 in
+                           uu____13511 :: uu____13512 in
+                         uu____13502 :: uu____13508 in
                        FStar_Util.print
                          "Imitating gs_xs=\n\t>%s\n\t binders are {%s}, comp=%s\n\t%s (%s)\nsub_probs = %s\nformula=%s\n"
                          uu____13499
                      else ());
                     (let wl2 =
                        solve_prob orig (FStar_Pervasives_Native.Some formula)
-                         [TERM ((u, k), im)] wl1
-                        in
-                     solve env1 (attempt sub_probs wl2))))
-           in
+                         [TERM ((u, k), im)] wl1 in
+                     solve env1 (attempt sub_probs wl2)))) in
         let imitate' orig env1 wl1 uu___109_13557 =
           match uu___109_13557 with
           | FStar_Pervasives_Native.None  ->
               giveup env1 "unable to compute subterms" orig
-          | FStar_Pervasives_Native.Some p -> imitate orig env1 wl1 p  in
+          | FStar_Pervasives_Native.Some p -> imitate orig env1 wl1 p in
         let project orig env1 wl1 i p =
-          let uu____13589 = p  in
+          let uu____13589 = p in
           match uu____13589 with
           | ((u,xs,c),ps,(h,matches,qs)) ->
-              let r = FStar_TypeChecker_Env.get_range env1  in
-              let uu____13680 = FStar_List.nth ps i  in
+              let r = FStar_TypeChecker_Env.get_range env1 in
+              let uu____13680 = FStar_List.nth ps i in
               (match uu____13680 with
                | (pi,uu____13684) ->
-                   let uu____13689 = FStar_List.nth xs i  in
+                   let uu____13689 = FStar_List.nth xs i in
                    (match uu____13689 with
                     | (xi,uu____13701) ->
                         let rec gs k =
                           let uu____13714 =
                             let uu____13727 =
-                              FStar_TypeChecker_Normalize.unfold_whnf env1 k
-                               in
-                            FStar_Syntax_Util.arrow_formals uu____13727  in
+                              FStar_TypeChecker_Normalize.unfold_whnf env1 k in
+                            FStar_Syntax_Util.arrow_formals uu____13727 in
                           match uu____13714 with
                           | (bs,k1) ->
                               let rec aux subst1 bs1 =
@@ -4910,108 +4498,88 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                 | (a,uu____13802)::tl1 ->
                                     let k_a =
                                       FStar_Syntax_Subst.subst subst1
-                                        a.FStar_Syntax_Syntax.sort
-                                       in
-                                    let uu____13815 = new_uvar r xs k_a  in
+                                        a.FStar_Syntax_Syntax.sort in
+                                    let uu____13815 = new_uvar r xs k_a in
                                     (match uu____13815 with
                                      | (gi_xs,gi) ->
                                          let gi_xs1 =
                                            FStar_TypeChecker_Normalize.eta_expand
-                                             env1 gi_xs
-                                            in
+                                             env1 gi_xs in
                                          let gi_ps =
                                            FStar_Syntax_Syntax.mk_Tm_app gi
                                              ps FStar_Pervasives_Native.None
-                                             r
-                                            in
+                                             r in
                                          let subst2 =
                                            (FStar_Syntax_Syntax.NT
                                               (a, gi_xs1))
-                                           :: subst1  in
-                                         let uu____13837 = aux subst2 tl1  in
+                                           :: subst1 in
+                                         let uu____13837 = aux subst2 tl1 in
                                          (match uu____13837 with
                                           | (gi_xs',gi_ps') ->
                                               let uu____13864 =
                                                 let uu____13867 =
                                                   FStar_Syntax_Syntax.as_arg
-                                                    gi_xs1
-                                                   in
-                                                uu____13867 :: gi_xs'  in
+                                                    gi_xs1 in
+                                                uu____13867 :: gi_xs' in
                                               let uu____13868 =
                                                 let uu____13871 =
                                                   FStar_Syntax_Syntax.as_arg
-                                                    gi_ps
-                                                   in
-                                                uu____13871 :: gi_ps'  in
-                                              (uu____13864, uu____13868)))
-                                 in
-                              aux [] bs
-                           in
+                                                    gi_ps in
+                                                uu____13871 :: gi_ps' in
+                                              (uu____13864, uu____13868))) in
+                              aux [] bs in
                         let uu____13876 =
-                          let uu____13877 = matches pi  in
-                          FStar_All.pipe_left Prims.op_Negation uu____13877
-                           in
+                          let uu____13877 = matches pi in
+                          FStar_All.pipe_left Prims.op_Negation uu____13877 in
                         if uu____13876
                         then FStar_Pervasives_Native.None
                         else
-                          (let uu____13881 = gs xi.FStar_Syntax_Syntax.sort
-                              in
+                          (let uu____13881 = gs xi.FStar_Syntax_Syntax.sort in
                            match uu____13881 with
                            | (g_xs,uu____13893) ->
-                               let xi1 = FStar_Syntax_Syntax.bv_to_name xi
-                                  in
+                               let xi1 = FStar_Syntax_Syntax.bv_to_name xi in
                                let proj =
                                  let uu____13904 =
                                    FStar_Syntax_Syntax.mk_Tm_app xi1 g_xs
-                                     FStar_Pervasives_Native.None r
-                                    in
+                                     FStar_Pervasives_Native.None r in
                                  let uu____13905 =
                                    FStar_All.pipe_right
                                      (FStar_Syntax_Util.residual_comp_of_comp
                                         c)
                                      (fun _0_58  ->
-                                        FStar_Pervasives_Native.Some _0_58)
-                                    in
+                                        FStar_Pervasives_Native.Some _0_58) in
                                  FStar_Syntax_Util.abs xs uu____13904
-                                   uu____13905
-                                  in
+                                   uu____13905 in
                                let sub1 =
                                  let uu____13911 =
                                    let uu____13916 =
                                      FStar_Syntax_Syntax.mk_Tm_app proj ps
-                                       FStar_Pervasives_Native.None r
-                                      in
+                                       FStar_Pervasives_Native.None r in
                                    let uu____13919 =
                                      let uu____13922 =
                                        FStar_List.map
                                          (fun uu____13937  ->
                                             match uu____13937 with
                                             | (uu____13946,uu____13947,y) ->
-                                                y) qs
-                                        in
-                                     FStar_All.pipe_left h uu____13922  in
+                                                y) qs in
+                                     FStar_All.pipe_left h uu____13922 in
                                    mk_problem (p_scope orig) orig uu____13916
                                      (p_rel orig) uu____13919
                                      FStar_Pervasives_Native.None
-                                     "projection"
-                                    in
+                                     "projection" in
                                  FStar_All.pipe_left
                                    (fun _0_59  ->
                                       FStar_TypeChecker_Common.TProb _0_59)
-                                   uu____13911
-                                  in
+                                   uu____13911 in
                                ((let uu____13962 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env1)
-                                     (FStar_Options.Other "Rel")
-                                    in
+                                     (FStar_Options.Other "Rel") in
                                  if uu____13962
                                  then
                                    let uu____13963 =
-                                     FStar_Syntax_Print.term_to_string proj
-                                      in
-                                   let uu____13964 = prob_to_string env1 sub1
-                                      in
+                                     FStar_Syntax_Print.term_to_string proj in
+                                   let uu____13964 = prob_to_string env1 sub1 in
                                    FStar_Util.print2
                                      "Projecting %s\n\tsubprob=%s\n"
                                      uu____13963 uu____13964
@@ -5021,67 +4589,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                      let uu____13970 =
                                        FStar_All.pipe_left
                                          FStar_Pervasives_Native.fst
-                                         (p_guard sub1)
-                                        in
-                                     FStar_Pervasives_Native.Some uu____13970
-                                      in
+                                         (p_guard sub1) in
+                                     FStar_Pervasives_Native.Some uu____13970 in
                                    solve_prob orig uu____13967
-                                     [TERM (u, proj)] wl1
-                                    in
+                                     [TERM (u, proj)] wl1 in
                                  let uu____13979 =
-                                   solve env1 (attempt [sub1] wl2)  in
+                                   solve env1 (attempt [sub1] wl2) in
                                  FStar_All.pipe_left
                                    (fun _0_60  ->
                                       FStar_Pervasives_Native.Some _0_60)
-                                   uu____13979)))))
-           in
+                                   uu____13979))))) in
         let solve_t_flex_rigid patterns_only orig lhs t2 wl1 =
-          let uu____14010 = lhs  in
+          let uu____14010 = lhs in
           match uu____14010 with
           | ((t1,uv,k_uv,args_lhs),maybe_pat_vars) ->
               let subterms ps =
-                let uu____14046 = FStar_Syntax_Util.arrow_formals_comp k_uv
-                   in
+                let uu____14046 = FStar_Syntax_Util.arrow_formals_comp k_uv in
                 match uu____14046 with
                 | (xs,c) ->
                     if (FStar_List.length xs) = (FStar_List.length ps)
                     then
                       let uu____14079 =
-                        let uu____14126 = decompose env t2  in
-                        (((uv, k_uv), xs, c), ps, uu____14126)  in
+                        let uu____14126 = decompose env t2 in
+                        (((uv, k_uv), xs, c), ps, uu____14126) in
                       FStar_Pervasives_Native.Some uu____14079
                     else
                       (let rec elim k args =
                          let k1 =
-                           FStar_TypeChecker_Normalize.unfold_whnf env k  in
+                           FStar_TypeChecker_Normalize.unfold_whnf env k in
                          let uu____14270 =
                            let uu____14277 =
-                             let uu____14278 = FStar_Syntax_Subst.compress k1
-                                in
-                             uu____14278.FStar_Syntax_Syntax.n  in
-                           (uu____14277, args)  in
+                             let uu____14278 = FStar_Syntax_Subst.compress k1 in
+                             uu____14278.FStar_Syntax_Syntax.n in
+                           (uu____14277, args) in
                          match uu____14270 with
                          | (uu____14289,[]) ->
                              let uu____14292 =
                                let uu____14303 =
-                                 FStar_Syntax_Syntax.mk_Total k1  in
-                               ([], uu____14303)  in
+                                 FStar_Syntax_Syntax.mk_Total k1 in
+                               ([], uu____14303) in
                              FStar_Pervasives_Native.Some uu____14292
                          | (FStar_Syntax_Syntax.Tm_uvar
                             uu____14324,uu____14325) ->
                              let uu____14346 =
-                               FStar_Syntax_Util.head_and_args k1  in
+                               FStar_Syntax_Util.head_and_args k1 in
                              (match uu____14346 with
                               | (uv1,uv_args) ->
                                   let uu____14389 =
                                     let uu____14390 =
-                                      FStar_Syntax_Subst.compress uv1  in
-                                    uu____14390.FStar_Syntax_Syntax.n  in
+                                      FStar_Syntax_Subst.compress uv1 in
+                                    uu____14390.FStar_Syntax_Syntax.n in
                                   (match uu____14389 with
                                    | FStar_Syntax_Syntax.Tm_uvar
                                        (uvar,uu____14400) ->
                                        let uu____14425 =
-                                         pat_vars env [] uv_args  in
+                                         pat_vars env [] uv_args in
                                        (match uu____14425 with
                                         | FStar_Pervasives_Native.None  ->
                                             FStar_Pervasives_Native.None
@@ -5098,75 +4660,58 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                               let uu____14461
                                                                 =
                                                                 FStar_Syntax_Util.type_u
-                                                                  ()
-                                                                 in
+                                                                  () in
                                                               FStar_All.pipe_right
                                                                 uu____14461
-                                                                FStar_Pervasives_Native.fst
-                                                               in
+                                                                FStar_Pervasives_Native.fst in
                                                             new_uvar
                                                               k1.FStar_Syntax_Syntax.pos
                                                               scope
-                                                              uu____14460
-                                                             in
+                                                              uu____14460 in
                                                           FStar_Pervasives_Native.fst
-                                                            uu____14455
-                                                           in
+                                                            uu____14455 in
                                                         FStar_Syntax_Syntax.new_bv
                                                           (FStar_Pervasives_Native.Some
                                                              (k1.FStar_Syntax_Syntax.pos))
-                                                          uu____14454
-                                                         in
+                                                          uu____14454 in
                                                       FStar_All.pipe_left
                                                         FStar_Syntax_Syntax.mk_binder
-                                                        uu____14453))
-                                               in
+                                                        uu____14453)) in
                                             let c1 =
                                               let uu____14471 =
                                                 let uu____14472 =
                                                   let uu____14477 =
                                                     let uu____14478 =
                                                       FStar_Syntax_Util.type_u
-                                                        ()
-                                                       in
+                                                        () in
                                                     FStar_All.pipe_right
                                                       uu____14478
-                                                      FStar_Pervasives_Native.fst
-                                                     in
+                                                      FStar_Pervasives_Native.fst in
                                                   new_uvar
                                                     k1.FStar_Syntax_Syntax.pos
-                                                    scope uu____14477
-                                                   in
+                                                    scope uu____14477 in
                                                 FStar_Pervasives_Native.fst
-                                                  uu____14472
-                                                 in
+                                                  uu____14472 in
                                               FStar_Syntax_Syntax.mk_Total
-                                                uu____14471
-                                               in
+                                                uu____14471 in
                                             let k' =
-                                              FStar_Syntax_Util.arrow xs1 c1
-                                               in
+                                              FStar_Syntax_Util.arrow xs1 c1 in
                                             let uv_sol =
                                               let uu____14491 =
                                                 let uu____14494 =
                                                   let uu____14495 =
                                                     let uu____14498 =
                                                       FStar_Syntax_Util.type_u
-                                                        ()
-                                                       in
+                                                        () in
                                                     FStar_All.pipe_right
                                                       uu____14498
-                                                      FStar_Pervasives_Native.fst
-                                                     in
+                                                      FStar_Pervasives_Native.fst in
                                                   FStar_Syntax_Util.residual_tot
-                                                    uu____14495
-                                                   in
+                                                    uu____14495 in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____14494
-                                                 in
+                                                  uu____14494 in
                                               FStar_Syntax_Util.abs scope k'
-                                                uu____14491
-                                               in
+                                                uu____14491 in
                                             (FStar_Syntax_Unionfind.change
                                                uvar uv_sol;
                                              FStar_Pervasives_Native.Some
@@ -5176,18 +4721,18 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          | (FStar_Syntax_Syntax.Tm_app
                             uu____14521,uu____14522) ->
                              let uu____14541 =
-                               FStar_Syntax_Util.head_and_args k1  in
+                               FStar_Syntax_Util.head_and_args k1 in
                              (match uu____14541 with
                               | (uv1,uv_args) ->
                                   let uu____14584 =
                                     let uu____14585 =
-                                      FStar_Syntax_Subst.compress uv1  in
-                                    uu____14585.FStar_Syntax_Syntax.n  in
+                                      FStar_Syntax_Subst.compress uv1 in
+                                    uu____14585.FStar_Syntax_Syntax.n in
                                   (match uu____14584 with
                                    | FStar_Syntax_Syntax.Tm_uvar
                                        (uvar,uu____14595) ->
                                        let uu____14620 =
-                                         pat_vars env [] uv_args  in
+                                         pat_vars env [] uv_args in
                                        (match uu____14620 with
                                         | FStar_Pervasives_Native.None  ->
                                             FStar_Pervasives_Native.None
@@ -5204,75 +4749,58 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                               let uu____14656
                                                                 =
                                                                 FStar_Syntax_Util.type_u
-                                                                  ()
-                                                                 in
+                                                                  () in
                                                               FStar_All.pipe_right
                                                                 uu____14656
-                                                                FStar_Pervasives_Native.fst
-                                                               in
+                                                                FStar_Pervasives_Native.fst in
                                                             new_uvar
                                                               k1.FStar_Syntax_Syntax.pos
                                                               scope
-                                                              uu____14655
-                                                             in
+                                                              uu____14655 in
                                                           FStar_Pervasives_Native.fst
-                                                            uu____14650
-                                                           in
+                                                            uu____14650 in
                                                         FStar_Syntax_Syntax.new_bv
                                                           (FStar_Pervasives_Native.Some
                                                              (k1.FStar_Syntax_Syntax.pos))
-                                                          uu____14649
-                                                         in
+                                                          uu____14649 in
                                                       FStar_All.pipe_left
                                                         FStar_Syntax_Syntax.mk_binder
-                                                        uu____14648))
-                                               in
+                                                        uu____14648)) in
                                             let c1 =
                                               let uu____14666 =
                                                 let uu____14667 =
                                                   let uu____14672 =
                                                     let uu____14673 =
                                                       FStar_Syntax_Util.type_u
-                                                        ()
-                                                       in
+                                                        () in
                                                     FStar_All.pipe_right
                                                       uu____14673
-                                                      FStar_Pervasives_Native.fst
-                                                     in
+                                                      FStar_Pervasives_Native.fst in
                                                   new_uvar
                                                     k1.FStar_Syntax_Syntax.pos
-                                                    scope uu____14672
-                                                   in
+                                                    scope uu____14672 in
                                                 FStar_Pervasives_Native.fst
-                                                  uu____14667
-                                                 in
+                                                  uu____14667 in
                                               FStar_Syntax_Syntax.mk_Total
-                                                uu____14666
-                                               in
+                                                uu____14666 in
                                             let k' =
-                                              FStar_Syntax_Util.arrow xs1 c1
-                                               in
+                                              FStar_Syntax_Util.arrow xs1 c1 in
                                             let uv_sol =
                                               let uu____14686 =
                                                 let uu____14689 =
                                                   let uu____14690 =
                                                     let uu____14693 =
                                                       FStar_Syntax_Util.type_u
-                                                        ()
-                                                       in
+                                                        () in
                                                     FStar_All.pipe_right
                                                       uu____14693
-                                                      FStar_Pervasives_Native.fst
-                                                     in
+                                                      FStar_Pervasives_Native.fst in
                                                   FStar_Syntax_Util.residual_tot
-                                                    uu____14690
-                                                   in
+                                                    uu____14690 in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____14689
-                                                 in
+                                                  uu____14689 in
                                               FStar_Syntax_Util.abs scope k'
-                                                uu____14686
-                                               in
+                                                uu____14686 in
                                             (FStar_Syntax_Unionfind.change
                                                uvar uv_sol;
                                              FStar_Pervasives_Native.Some
@@ -5281,12 +4809,12 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                        FStar_Pervasives_Native.None))
                          | (FStar_Syntax_Syntax.Tm_arrow
                             (xs1,c1),uu____14718) ->
-                             let n_args = FStar_List.length args  in
-                             let n_xs = FStar_List.length xs1  in
+                             let n_args = FStar_List.length args in
+                             let n_xs = FStar_List.length xs1 in
                              if n_xs = n_args
                              then
                                let uu____14759 =
-                                 FStar_Syntax_Subst.open_comp xs1 c1  in
+                                 FStar_Syntax_Subst.open_comp xs1 c1 in
                                FStar_All.pipe_right uu____14759
                                  (fun _0_61  ->
                                     FStar_Pervasives_Native.Some _0_61)
@@ -5294,19 +4822,17 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                if n_xs < n_args
                                then
                                  (let uu____14795 =
-                                    FStar_Util.first_N n_xs args  in
+                                    FStar_Util.first_N n_xs args in
                                   match uu____14795 with
                                   | (args1,rest) ->
                                       let uu____14824 =
-                                        FStar_Syntax_Subst.open_comp xs1 c1
-                                         in
+                                        FStar_Syntax_Subst.open_comp xs1 c1 in
                                       (match uu____14824 with
                                        | (xs2,c2) ->
                                            let uu____14837 =
                                              elim
                                                (FStar_Syntax_Util.comp_result
-                                                  c2) rest
-                                              in
+                                                  c2) rest in
                                            FStar_Util.bind_opt uu____14837
                                              (fun uu____14861  ->
                                                 match uu____14861 with
@@ -5316,7 +4842,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                           xs'), c3))))
                                else
                                  (let uu____14901 =
-                                    FStar_Util.first_N n_args xs1  in
+                                    FStar_Util.first_N n_args xs1 in
                                   match uu____14901 with
                                   | (xs2,rest) ->
                                       let t =
@@ -5324,14 +4850,12 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                           (FStar_Syntax_Syntax.Tm_arrow
                                              (rest, c1))
                                           FStar_Pervasives_Native.None
-                                          k1.FStar_Syntax_Syntax.pos
-                                         in
+                                          k1.FStar_Syntax_Syntax.pos in
                                       let uu____14969 =
                                         let uu____14974 =
-                                          FStar_Syntax_Syntax.mk_Total t  in
+                                          FStar_Syntax_Syntax.mk_Total t in
                                         FStar_Syntax_Subst.open_comp xs2
-                                          uu____14974
-                                         in
+                                          uu____14974 in
                                       FStar_All.pipe_right uu____14969
                                         (fun _0_62  ->
                                            FStar_Pervasives_Native.Some _0_62))
@@ -5339,41 +4863,36 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              let uu____14996 =
                                let uu____15001 =
                                  let uu____15002 =
-                                   FStar_Syntax_Print.uvar_to_string uv  in
+                                   FStar_Syntax_Print.uvar_to_string uv in
                                  let uu____15003 =
-                                   FStar_Syntax_Print.term_to_string k1  in
+                                   FStar_Syntax_Print.term_to_string k1 in
                                  let uu____15004 =
-                                   FStar_Syntax_Print.term_to_string k_uv  in
+                                   FStar_Syntax_Print.term_to_string k_uv in
                                  FStar_Util.format3
                                    "Impossible: ill-typed application %s : %s\n\t%s"
-                                   uu____15002 uu____15003 uu____15004
-                                  in
-                               (FStar_Errors.Fatal_IllTyped, uu____15001)  in
+                                   uu____15002 uu____15003 uu____15004 in
+                               (FStar_Errors.Fatal_IllTyped, uu____15001) in
                              FStar_Errors.raise_error uu____14996
-                               t1.FStar_Syntax_Syntax.pos
-                          in
-                       let uu____15011 = elim k_uv ps  in
+                               t1.FStar_Syntax_Syntax.pos in
+                       let uu____15011 = elim k_uv ps in
                        FStar_Util.bind_opt uu____15011
                          (fun uu____15066  ->
                             match uu____15066 with
                             | (xs1,c1) ->
                                 let uu____15115 =
-                                  let uu____15156 = decompose env t2  in
-                                  (((uv, k_uv), xs1, c1), ps, uu____15156)
-                                   in
-                                FStar_Pervasives_Native.Some uu____15115))
-                 in
+                                  let uu____15156 = decompose env t2 in
+                                  (((uv, k_uv), xs1, c1), ps, uu____15156) in
+                                FStar_Pervasives_Native.Some uu____15115)) in
               let imitate_or_project n1 lhs1 rhs stopt =
                 let fail uu____15277 =
                   giveup env
-                    "flex-rigid case failed all backtracking attempts" orig
-                   in
+                    "flex-rigid case failed all backtracking attempts" orig in
                 let rec try_project st i =
                   if i >= n1
                   then fail ()
                   else
-                    (let tx = FStar_Syntax_Unionfind.new_transaction ()  in
-                     let uu____15291 = project orig env wl1 i st  in
+                    (let tx = FStar_Syntax_Unionfind.new_transaction () in
+                     let uu____15291 = project orig env wl1 i st in
                      match uu____15291 with
                      | FStar_Pervasives_Native.None  ->
                          (FStar_Syntax_Unionfind.rollback tx;
@@ -5381,84 +4900,75 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      | FStar_Pervasives_Native.Some (Failed uu____15305) ->
                          (FStar_Syntax_Unionfind.rollback tx;
                           try_project st (i + (Prims.parse_int "1")))
-                     | FStar_Pervasives_Native.Some sol -> sol)
-                   in
+                     | FStar_Pervasives_Native.Some sol -> sol) in
                 if FStar_Option.isSome stopt
                 then
-                  let st = FStar_Util.must stopt  in
-                  let tx = FStar_Syntax_Unionfind.new_transaction ()  in
-                  let uu____15320 = imitate orig env wl1 st  in
+                  let st = FStar_Util.must stopt in
+                  let tx = FStar_Syntax_Unionfind.new_transaction () in
+                  let uu____15320 = imitate orig env wl1 st in
                   match uu____15320 with
                   | Failed uu____15325 ->
                       (FStar_Syntax_Unionfind.rollback tx;
                        try_project st (Prims.parse_int "0"))
                   | sol -> sol
-                else fail ()  in
+                else fail () in
               let pattern_eq_imitate_or_project n1 lhs1 rhs stopt =
                 let uu____15356 =
-                  force_quasi_pattern FStar_Pervasives_Native.None lhs1  in
+                  force_quasi_pattern FStar_Pervasives_Native.None lhs1 in
                 match uu____15356 with
                 | FStar_Pervasives_Native.None  ->
                     imitate_or_project n1 lhs1 rhs stopt
                 | FStar_Pervasives_Native.Some (sol,forced_lhs_pattern) ->
-                    let uu____15379 = forced_lhs_pattern  in
+                    let uu____15379 = forced_lhs_pattern in
                     (match uu____15379 with
                      | (lhs_t,uu____15381,uu____15382,uu____15383) ->
                          ((let uu____15385 =
                              FStar_TypeChecker_Env.debug env
-                               (FStar_Options.Other "Rel")
-                              in
+                               (FStar_Options.Other "Rel") in
                            if uu____15385
                            then
-                             let uu____15386 = lhs1  in
+                             let uu____15386 = lhs1 in
                              match uu____15386 with
                              | (t0,uu____15388,uu____15389,uu____15390) ->
-                                 let uu____15391 = forced_lhs_pattern  in
+                                 let uu____15391 = forced_lhs_pattern in
                                  (match uu____15391 with
                                   | (t11,uu____15393,uu____15394,uu____15395)
                                       ->
                                       let uu____15396 =
-                                        FStar_Syntax_Print.term_to_string t0
-                                         in
+                                        FStar_Syntax_Print.term_to_string t0 in
                                       let uu____15397 =
-                                        FStar_Syntax_Print.term_to_string t11
-                                         in
+                                        FStar_Syntax_Print.term_to_string t11 in
                                       FStar_Util.print2
                                         "force_quasi_pattern succeeded, turning %s into %s\n"
                                         uu____15396 uu____15397)
                            else ());
-                          (let rhs_vars = FStar_Syntax_Free.names rhs  in
-                           let lhs_vars = FStar_Syntax_Free.names lhs_t  in
+                          (let rhs_vars = FStar_Syntax_Free.names rhs in
+                           let lhs_vars = FStar_Syntax_Free.names lhs_t in
                            let uu____15405 =
-                             FStar_Util.set_is_subset_of rhs_vars lhs_vars
-                              in
+                             FStar_Util.set_is_subset_of rhs_vars lhs_vars in
                            if uu____15405
                            then
                              ((let uu____15407 =
                                  FStar_TypeChecker_Env.debug env
-                                   (FStar_Options.Other "Rel")
-                                  in
+                                   (FStar_Options.Other "Rel") in
                                if uu____15407
                                then
                                  let uu____15408 =
-                                   FStar_Syntax_Print.term_to_string rhs  in
-                                 let uu____15409 = names_to_string rhs_vars
-                                    in
-                                 let uu____15410 = names_to_string lhs_vars
-                                    in
+                                   FStar_Syntax_Print.term_to_string rhs in
+                                 let uu____15409 = names_to_string rhs_vars in
+                                 let uu____15410 = names_to_string lhs_vars in
                                  FStar_Util.print3
                                    "fvar check succeeded for quasi pattern ...\n\trhs = %s, rhs_vars=%s\nlhs_vars=%s ... proceeding\n"
                                    uu____15408 uu____15409 uu____15410
                                else ());
                               (let tx =
-                                 FStar_Syntax_Unionfind.new_transaction ()
-                                  in
+                                 FStar_Syntax_Unionfind.new_transaction () in
                                let wl2 =
-                                 extend_solution (p_pid orig) [sol] wl1  in
+                                 extend_solution (p_pid orig) [sol] wl1 in
                                let uu____15414 =
                                  let uu____15415 =
-                                   FStar_TypeChecker_Common.as_tprob orig  in
-                                 solve_t env uu____15415 wl2  in
+                                   FStar_TypeChecker_Common.as_tprob orig in
+                                 solve_t env uu____15415 wl2 in
                                match uu____15414 with
                                | Failed uu____15416 ->
                                    (FStar_Syntax_Unionfind.rollback tx;
@@ -5467,17 +4977,15 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                            else
                              ((let uu____15425 =
                                  FStar_TypeChecker_Env.debug env
-                                   (FStar_Options.Other "Rel")
-                                  in
+                                   (FStar_Options.Other "Rel") in
                                if uu____15425
                                then
                                  FStar_Util.print_string
                                    "fvar check failed for quasi pattern ... im/proj\n"
                                else ());
-                              imitate_or_project n1 lhs1 rhs stopt))))
-                 in
+                              imitate_or_project n1 lhs1 rhs stopt)))) in
               let check_head fvs1 t21 =
-                let uu____15438 = FStar_Syntax_Util.head_and_args t21  in
+                let uu____15438 = FStar_Syntax_Util.head_and_args t21 in
                 match uu____15438 with
                 | (hd1,uu____15454) ->
                     (match hd1.FStar_Syntax_Syntax.n with
@@ -5485,72 +4993,64 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      | FStar_Syntax_Syntax.Tm_constant uu____15488 -> true
                      | FStar_Syntax_Syntax.Tm_abs uu____15489 -> true
                      | uu____15506 ->
-                         let fvs_hd = FStar_Syntax_Free.names hd1  in
+                         let fvs_hd = FStar_Syntax_Free.names hd1 in
                          let uu____15510 =
-                           FStar_Util.set_is_subset_of fvs_hd fvs1  in
+                           FStar_Util.set_is_subset_of fvs_hd fvs1 in
                          if uu____15510
                          then true
                          else
                            ((let uu____15513 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env)
-                                 (FStar_Options.Other "Rel")
-                                in
+                                 (FStar_Options.Other "Rel") in
                              if uu____15513
                              then
-                               let uu____15514 = names_to_string fvs_hd  in
+                               let uu____15514 = names_to_string fvs_hd in
                                FStar_Util.print1 "Free variables are %s\n"
                                  uu____15514
                              else ());
-                            false))
-                 in
+                            false)) in
               (match maybe_pat_vars with
                | FStar_Pervasives_Native.Some vars ->
-                   let t11 = sn env t1  in
-                   let t21 = sn env t2  in
-                   let lhs1 = (t11, uv, k_uv, args_lhs)  in
-                   let fvs1 = FStar_Syntax_Free.names t11  in
-                   let fvs2 = FStar_Syntax_Free.names t21  in
-                   let uu____15534 = occurs_check env wl1 (uv, k_uv) t21  in
+                   let t11 = sn env t1 in
+                   let t21 = sn env t2 in
+                   let lhs1 = (t11, uv, k_uv, args_lhs) in
+                   let fvs1 = FStar_Syntax_Free.names t11 in
+                   let fvs2 = FStar_Syntax_Free.names t21 in
+                   let uu____15534 = occurs_check env wl1 (uv, k_uv) t21 in
                    (match uu____15534 with
                     | (occurs_ok,msg) ->
                         if Prims.op_Negation occurs_ok
                         then
                           let uu____15547 =
-                            let uu____15548 = FStar_Option.get msg  in
-                            Prims.strcat "occurs-check failed: " uu____15548
-                             in
+                            let uu____15548 = FStar_Option.get msg in
+                            Prims.strcat "occurs-check failed: " uu____15548 in
                           giveup_or_defer1 orig uu____15547
                         else
                           (let uu____15550 =
-                             FStar_Util.set_is_subset_of fvs2 fvs1  in
+                             FStar_Util.set_is_subset_of fvs2 fvs1 in
                            if uu____15550
                            then
                              let uu____15551 =
                                ((Prims.op_Negation patterns_only) &&
                                   (FStar_Syntax_Util.is_function_typ t21))
                                  &&
-                                 ((p_rel orig) <> FStar_TypeChecker_Common.EQ)
-                                in
+                                 ((p_rel orig) <> FStar_TypeChecker_Common.EQ) in
                              (if uu____15551
                               then
-                                let uu____15552 = subterms args_lhs  in
+                                let uu____15552 = subterms args_lhs in
                                 imitate' orig env wl1 uu____15552
                               else
                                 ((let uu____15557 =
                                     FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
-                                      (FStar_Options.Other "Rel")
-                                     in
+                                      (FStar_Options.Other "Rel") in
                                   if uu____15557
                                   then
                                     let uu____15558 =
-                                      FStar_Syntax_Print.term_to_string t11
-                                       in
-                                    let uu____15559 = names_to_string fvs1
-                                       in
-                                    let uu____15560 = names_to_string fvs2
-                                       in
+                                      FStar_Syntax_Print.term_to_string t11 in
+                                    let uu____15559 = names_to_string fvs1 in
+                                    let uu____15560 = names_to_string fvs2 in
                                     FStar_Util.print3
                                       "Pattern %s with fvars=%s succeeded fvar check: %s\n"
                                       uu____15558 uu____15559 uu____15560
@@ -5571,29 +5071,24 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              else
                                (let uu____15564 =
                                   (Prims.op_Negation patterns_only) &&
-                                    (check_head fvs1 t21)
-                                   in
+                                    (check_head fvs1 t21) in
                                 if uu____15564
                                 then
                                   ((let uu____15566 =
                                       FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env)
-                                        (FStar_Options.Other "Rel")
-                                       in
+                                        (FStar_Options.Other "Rel") in
                                     if uu____15566
                                     then
                                       let uu____15567 =
-                                        FStar_Syntax_Print.term_to_string t11
-                                         in
-                                      let uu____15568 = names_to_string fvs1
-                                         in
-                                      let uu____15569 = names_to_string fvs2
-                                         in
+                                        FStar_Syntax_Print.term_to_string t11 in
+                                      let uu____15568 = names_to_string fvs1 in
+                                      let uu____15569 = names_to_string fvs2 in
                                       FStar_Util.print3
                                         "Pattern %s with fvars=%s failed fvar check: %s ... imitate_or_project\n"
                                         uu____15567 uu____15568 uu____15569
                                     else ());
-                                   (let uu____15571 = subterms args_lhs  in
+                                   (let uu____15571 = subterms args_lhs in
                                     imitate_or_project
                                       (FStar_List.length args_lhs) lhs1 t21
                                       uu____15571))
@@ -5608,31 +5103,29 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                    then solve env (defer "not a pattern" orig wl1)
                    else
                      (let uu____15582 =
-                        let uu____15583 = FStar_Syntax_Free.names t1  in
-                        check_head uu____15583 t2  in
+                        let uu____15583 = FStar_Syntax_Free.names t1 in
+                        check_head uu____15583 t2 in
                       if uu____15582
                       then
-                        let n_args_lhs = FStar_List.length args_lhs  in
+                        let n_args_lhs = FStar_List.length args_lhs in
                         ((let uu____15594 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
-                              (FStar_Options.Other "Rel")
-                             in
+                              (FStar_Options.Other "Rel") in
                           if uu____15594
                           then
                             let uu____15595 =
-                              FStar_Syntax_Print.term_to_string t1  in
+                              FStar_Syntax_Print.term_to_string t1 in
                             let uu____15596 =
-                              FStar_Util.string_of_int n_args_lhs  in
+                              FStar_Util.string_of_int n_args_lhs in
                             FStar_Util.print2
                               "Not a pattern (%s) ... (lhs has %s args)\n"
                               uu____15595 uu____15596
                           else ());
-                         (let uu____15604 = subterms args_lhs  in
+                         (let uu____15604 = subterms args_lhs in
                           pattern_eq_imitate_or_project n_args_lhs
                             (FStar_Pervasives_Native.fst lhs) t2 uu____15604))
-                      else giveup env "head-symbol is free" orig))
-           in
+                      else giveup env "head-symbol is free" orig)) in
         let flex_flex1 orig lhs rhs =
           if wl.defer_ok && ((p_rel orig) <> FStar_TypeChecker_Common.EQ)
           then solve env (defer "flex-flex deferred" orig wl)
@@ -5642,123 +5135,110 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                | ((u1,k1,xs,args1),(u2,k2,ys,args2)) ->
                    let uu____15880 =
                      (FStar_Syntax_Unionfind.equiv u1 u2) &&
-                       (binders_eq xs ys)
-                      in
+                       (binders_eq xs ys) in
                    if uu____15880
                    then
                      let uu____15881 =
-                       solve_prob orig FStar_Pervasives_Native.None [] wl1
-                        in
+                       solve_prob orig FStar_Pervasives_Native.None [] wl1 in
                      solve env uu____15881
                    else
-                     (let xs1 = sn_binders env xs  in
-                      let ys1 = sn_binders env ys  in
-                      let zs = intersect_vars xs1 ys1  in
+                     (let xs1 = sn_binders env xs in
+                      let ys1 = sn_binders env ys in
+                      let zs = intersect_vars xs1 ys1 in
                       (let uu____15905 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env)
-                           (FStar_Options.Other "Rel")
-                          in
+                           (FStar_Options.Other "Rel") in
                        if uu____15905
                        then
                          let uu____15906 =
-                           FStar_Syntax_Print.binders_to_string ", " xs1  in
+                           FStar_Syntax_Print.binders_to_string ", " xs1 in
                          let uu____15907 =
-                           FStar_Syntax_Print.binders_to_string ", " ys1  in
+                           FStar_Syntax_Print.binders_to_string ", " ys1 in
                          let uu____15908 =
-                           FStar_Syntax_Print.binders_to_string ", " zs  in
+                           FStar_Syntax_Print.binders_to_string ", " zs in
                          let uu____15909 =
-                           FStar_Syntax_Print.term_to_string k1  in
+                           FStar_Syntax_Print.term_to_string k1 in
                          let uu____15910 =
-                           FStar_Syntax_Print.term_to_string k2  in
+                           FStar_Syntax_Print.term_to_string k2 in
                          FStar_Util.print5
                            "Flex-flex patterns: intersected %s and %s; got %s\n\tk1=%s\n\tk2=%s\n"
                            uu____15906 uu____15907 uu____15908 uu____15909
                            uu____15910
                        else ());
                       (let subst_k k xs2 args =
-                         let xs_len = FStar_List.length xs2  in
-                         let args_len = FStar_List.length args  in
+                         let xs_len = FStar_List.length xs2 in
+                         let args_len = FStar_List.length args in
                          if xs_len = args_len
                          then
                            let uu____15970 =
-                             FStar_Syntax_Util.subst_of_list xs2 args  in
+                             FStar_Syntax_Util.subst_of_list xs2 args in
                            FStar_Syntax_Subst.subst uu____15970 k
                          else
                            if args_len < xs_len
                            then
                              (let uu____15984 =
-                                FStar_Util.first_N args_len xs2  in
+                                FStar_Util.first_N args_len xs2 in
                               match uu____15984 with
                               | (xs3,xs_rest) ->
                                   let k3 =
                                     let uu____16038 =
-                                      FStar_Syntax_Syntax.mk_GTotal k  in
+                                      FStar_Syntax_Syntax.mk_GTotal k in
                                     FStar_Syntax_Util.arrow xs_rest
-                                      uu____16038
-                                     in
+                                      uu____16038 in
                                   let uu____16041 =
-                                    FStar_Syntax_Util.subst_of_list xs3 args
-                                     in
+                                    FStar_Syntax_Util.subst_of_list xs3 args in
                                   FStar_Syntax_Subst.subst uu____16041 k3)
                            else
                              (let uu____16045 =
                                 let uu____16046 =
-                                  FStar_Syntax_Print.term_to_string k  in
+                                  FStar_Syntax_Print.term_to_string k in
                                 let uu____16047 =
                                   FStar_Syntax_Print.binders_to_string ", "
-                                    xs2
-                                   in
+                                    xs2 in
                                 let uu____16048 =
-                                  FStar_Syntax_Print.args_to_string args  in
+                                  FStar_Syntax_Print.args_to_string args in
                                 FStar_Util.format3
                                   "k=%s\nxs=%s\nargs=%s\nIll-formed substitutution"
-                                  uu____16046 uu____16047 uu____16048
-                                 in
-                              failwith uu____16045)
-                          in
+                                  uu____16046 uu____16047 uu____16048 in
+                              failwith uu____16045) in
                        let uu____16049 =
                          let uu____16056 =
                            let uu____16069 =
                              FStar_TypeChecker_Normalize.normalize
-                               [FStar_TypeChecker_Normalize.Beta] env k1
-                              in
-                           FStar_Syntax_Util.arrow_formals uu____16069  in
+                               [FStar_TypeChecker_Normalize.Beta] env k1 in
+                           FStar_Syntax_Util.arrow_formals uu____16069 in
                          match uu____16056 with
                          | (bs,k1') ->
                              let uu____16094 =
                                let uu____16107 =
                                  FStar_TypeChecker_Normalize.normalize
-                                   [FStar_TypeChecker_Normalize.Beta] env k2
-                                  in
-                               FStar_Syntax_Util.arrow_formals uu____16107
-                                in
+                                   [FStar_TypeChecker_Normalize.Beta] env k2 in
+                               FStar_Syntax_Util.arrow_formals uu____16107 in
                              (match uu____16094 with
                               | (cs,k2') ->
-                                  let k1'_xs = subst_k k1' bs args1  in
-                                  let k2'_ys = subst_k k2' cs args2  in
+                                  let k1'_xs = subst_k k1' bs args1 in
+                                  let k2'_ys = subst_k k2' cs args2 in
                                   let sub_prob =
                                     let uu____16135 =
                                       mk_problem (p_scope orig) orig k1'_xs
                                         FStar_TypeChecker_Common.EQ k2'_ys
                                         FStar_Pervasives_Native.None
-                                        "flex-flex kinding"
-                                       in
+                                        "flex-flex kinding" in
                                     FStar_All.pipe_left
                                       (fun _0_63  ->
                                          FStar_TypeChecker_Common.TProb _0_63)
-                                      uu____16135
-                                     in
+                                      uu____16135 in
                                   let uu____16144 =
                                     let uu____16149 =
                                       let uu____16150 =
-                                        FStar_Syntax_Subst.compress k1'  in
-                                      uu____16150.FStar_Syntax_Syntax.n  in
+                                        FStar_Syntax_Subst.compress k1' in
+                                      uu____16150.FStar_Syntax_Syntax.n in
                                     let uu____16153 =
                                       let uu____16154 =
-                                        FStar_Syntax_Subst.compress k2'  in
-                                      uu____16154.FStar_Syntax_Syntax.n  in
-                                    (uu____16149, uu____16153)  in
+                                        FStar_Syntax_Subst.compress k2' in
+                                      uu____16154.FStar_Syntax_Syntax.n in
+                                    (uu____16149, uu____16153) in
                                   (match uu____16144 with
                                    | (FStar_Syntax_Syntax.Tm_type
                                       uu____16163,uu____16164) ->
@@ -5767,11 +5247,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                       uu____16168) -> (k2'_ys, [sub_prob])
                                    | uu____16171 ->
                                        let uu____16176 =
-                                         FStar_Syntax_Util.type_u ()  in
+                                         FStar_Syntax_Util.type_u () in
                                        (match uu____16176 with
                                         | (t,uu____16188) ->
-                                            let uu____16189 = new_uvar r zs t
-                                               in
+                                            let uu____16189 = new_uvar r zs t in
                                             (match uu____16189 with
                                              | (k_zs,uu____16201) ->
                                                  let kprob =
@@ -5782,37 +5261,33 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                        FStar_TypeChecker_Common.EQ
                                                        k_zs
                                                        FStar_Pervasives_Native.None
-                                                       "flex-flex kinding"
-                                                      in
+                                                       "flex-flex kinding" in
                                                    FStar_All.pipe_left
                                                      (fun _0_64  ->
                                                         FStar_TypeChecker_Common.TProb
-                                                          _0_64) uu____16203
-                                                    in
-                                                 (k_zs, [sub_prob; kprob])))))
-                          in
+                                                          _0_64) uu____16203 in
+                                                 (k_zs, [sub_prob; kprob]))))) in
                        match uu____16049 with
                        | (k_u',sub_probs) ->
                            let uu____16220 =
                              let uu____16231 =
-                               let uu____16232 = new_uvar r zs k_u'  in
+                               let uu____16232 = new_uvar r zs k_u' in
                                FStar_All.pipe_left
-                                 FStar_Pervasives_Native.fst uu____16232
-                                in
+                                 FStar_Pervasives_Native.fst uu____16232 in
                              let uu____16241 =
                                let uu____16244 =
-                                 FStar_Syntax_Syntax.mk_Total k_u'  in
-                               FStar_Syntax_Util.arrow xs1 uu____16244  in
+                                 FStar_Syntax_Syntax.mk_Total k_u' in
+                               FStar_Syntax_Util.arrow xs1 uu____16244 in
                              let uu____16247 =
                                let uu____16250 =
-                                 FStar_Syntax_Syntax.mk_Total k_u'  in
-                               FStar_Syntax_Util.arrow ys1 uu____16250  in
-                             (uu____16231, uu____16241, uu____16247)  in
+                                 FStar_Syntax_Syntax.mk_Total k_u' in
+                               FStar_Syntax_Util.arrow ys1 uu____16250 in
+                             (uu____16231, uu____16241, uu____16247) in
                            (match uu____16220 with
                             | (u_zs,knew1,knew2) ->
-                                let sub1 = u_abs knew1 xs1 u_zs  in
+                                let sub1 = u_abs knew1 xs1 u_zs in
                                 let uu____16269 =
-                                  occurs_check env wl1 (u1, k1) sub1  in
+                                  occurs_check env wl1 (u1, k1) sub1 in
                                 (match uu____16269 with
                                  | (occurs_ok,msg) ->
                                      if Prims.op_Negation occurs_ok
@@ -5820,25 +5295,21 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                        giveup_or_defer1 orig
                                          "flex-flex: failed occcurs check"
                                      else
-                                       (let sol1 = TERM ((u1, k1), sub1)  in
+                                       (let sol1 = TERM ((u1, k1), sub1) in
                                         let uu____16288 =
-                                          FStar_Syntax_Unionfind.equiv u1 u2
-                                           in
+                                          FStar_Syntax_Unionfind.equiv u1 u2 in
                                         if uu____16288
                                         then
                                           let wl2 =
                                             solve_prob orig
                                               FStar_Pervasives_Native.None
-                                              [sol1] wl1
-                                             in
+                                              [sol1] wl1 in
                                           solve env wl2
                                         else
-                                          (let sub2 = u_abs knew2 ys1 u_zs
-                                              in
+                                          (let sub2 = u_abs knew2 ys1 u_zs in
                                            let uu____16292 =
                                              occurs_check env wl1 (u2, k2)
-                                               sub2
-                                              in
+                                               sub2 in
                                            match uu____16292 with
                                            | (occurs_ok1,msg1) ->
                                                if
@@ -5848,33 +5319,28 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                    "flex-flex: failed occurs check"
                                                else
                                                  (let sol2 =
-                                                    TERM ((u2, k2), sub2)  in
+                                                    TERM ((u2, k2), sub2) in
                                                   let wl2 =
                                                     solve_prob orig
                                                       FStar_Pervasives_Native.None
-                                                      [sol1; sol2] wl1
-                                                     in
+                                                      [sol1; sol2] wl1 in
                                                   solve env
-                                                    (attempt sub_probs wl2))))))))
-                in
+                                                    (attempt sub_probs wl2)))))))) in
              let solve_one_pat uu____16345 uu____16346 =
                match (uu____16345, uu____16346) with
                | ((t1,u1,k1,xs),(t2,u2,k2,args2)) ->
                    ((let uu____16464 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                         (FStar_Options.Other "Rel")
-                        in
+                         (FStar_Options.Other "Rel") in
                      if uu____16464
                      then
-                       let uu____16465 = FStar_Syntax_Print.term_to_string t1
-                          in
-                       let uu____16466 = FStar_Syntax_Print.term_to_string t2
-                          in
+                       let uu____16465 = FStar_Syntax_Print.term_to_string t1 in
+                       let uu____16466 = FStar_Syntax_Print.term_to_string t2 in
                        FStar_Util.print2
                          "Trying flex-flex one pattern (%s) with %s\n"
                          uu____16465 uu____16466
                      else ());
-                    (let uu____16468 = FStar_Syntax_Unionfind.equiv u1 u2  in
+                    (let uu____16468 = FStar_Syntax_Unionfind.equiv u1 u2 in
                      if uu____16468
                      then
                        let sub_probs =
@@ -5885,70 +5351,61 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                 | ((a,uu____16506),(t21,uu____16508)) ->
                                     let uu____16517 =
                                       let uu____16522 =
-                                        FStar_Syntax_Syntax.bv_to_name a  in
+                                        FStar_Syntax_Syntax.bv_to_name a in
                                       mk_problem (p_scope orig) orig
                                         uu____16522
                                         FStar_TypeChecker_Common.EQ t21
                                         FStar_Pervasives_Native.None
-                                        "flex-flex index"
-                                       in
+                                        "flex-flex index" in
                                     FStar_All.pipe_right uu____16517
                                       (fun _0_65  ->
                                          FStar_TypeChecker_Common.TProb _0_65))
-                           xs args2
-                          in
+                           xs args2 in
                        let guard =
                          let uu____16528 =
                            FStar_List.map
                              (fun p  ->
                                 FStar_All.pipe_right (p_guard p)
-                                  FStar_Pervasives_Native.fst) sub_probs
-                            in
-                         FStar_Syntax_Util.mk_conj_l uu____16528  in
+                                  FStar_Pervasives_Native.fst) sub_probs in
+                         FStar_Syntax_Util.mk_conj_l uu____16528 in
                        let wl1 =
                          solve_prob orig (FStar_Pervasives_Native.Some guard)
-                           [] wl
-                          in
+                           [] wl in
                        solve env (attempt sub_probs wl1)
                      else
-                       (let t21 = sn env t2  in
-                        let rhs_vars = FStar_Syntax_Free.names t21  in
-                        let uu____16543 = occurs_check env wl (u1, k1) t21
-                           in
+                       (let t21 = sn env t2 in
+                        let rhs_vars = FStar_Syntax_Free.names t21 in
+                        let uu____16543 = occurs_check env wl (u1, k1) t21 in
                         match uu____16543 with
                         | (occurs_ok,uu____16551) ->
                             let lhs_vars =
-                              FStar_Syntax_Free.names_of_binders xs  in
+                              FStar_Syntax_Free.names_of_binders xs in
                             let uu____16559 =
                               occurs_ok &&
                                 (FStar_Util.set_is_subset_of rhs_vars
-                                   lhs_vars)
-                               in
+                                   lhs_vars) in
                             if uu____16559
                             then
                               let sol =
                                 let uu____16561 =
-                                  let uu____16570 = u_abs k1 xs t21  in
-                                  ((u1, k1), uu____16570)  in
-                                TERM uu____16561  in
+                                  let uu____16570 = u_abs k1 xs t21 in
+                                  ((u1, k1), uu____16570) in
+                                TERM uu____16561 in
                               let wl1 =
                                 solve_prob orig FStar_Pervasives_Native.None
-                                  [sol] wl
-                                 in
+                                  [sol] wl in
                               solve env wl1
                             else
                               (let uu____16577 =
                                  occurs_ok &&
                                    (FStar_All.pipe_left Prims.op_Negation
-                                      wl.defer_ok)
-                                  in
+                                      wl.defer_ok) in
                                if uu____16577
                                then
                                  let uu____16578 =
                                    force_quasi_pattern
                                      (FStar_Pervasives_Native.Some xs)
-                                     (t21, u2, k2, args2)
-                                    in
+                                     (t21, u2, k2, args2) in
                                  match uu____16578 with
                                  | FStar_Pervasives_Native.None  ->
                                      giveup_or_defer1 orig
@@ -5956,18 +5413,16 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                  | FStar_Pervasives_Native.Some
                                      (sol,(uu____16602,u21,k21,ys)) ->
                                      let wl1 =
-                                       extend_solution (p_pid orig) [sol] wl
-                                        in
+                                       extend_solution (p_pid orig) [sol] wl in
                                      ((let uu____16628 =
                                          FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.debug env)
                                            (FStar_Options.Other
-                                              "QuasiPattern")
-                                          in
+                                              "QuasiPattern") in
                                        if uu____16628
                                        then
                                          let uu____16629 =
-                                           uvi_to_string env sol  in
+                                           uvi_to_string env sol in
                                          FStar_Util.print1
                                            "flex-flex quasi pattern (2): %s\n"
                                            uu____16629
@@ -5978,17 +5433,16 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                        | uu____16636 ->
                                            giveup env "impossible" orig))
                                else
-                                 giveup_or_defer1 orig "flex-flex constraint"))))
-                in
-             let uu____16638 = lhs  in
+                                 giveup_or_defer1 orig "flex-flex constraint")))) in
+             let uu____16638 = lhs in
              match uu____16638 with
              | (t1,u1,k1,args1) ->
-                 let uu____16643 = rhs  in
+                 let uu____16643 = rhs in
                  (match uu____16643 with
                   | (t2,u2,k2,args2) ->
-                      let maybe_pat_vars1 = pat_vars env [] args1  in
-                      let maybe_pat_vars2 = pat_vars env [] args2  in
-                      let r = t2.FStar_Syntax_Syntax.pos  in
+                      let maybe_pat_vars1 = pat_vars env [] args1 in
+                      let maybe_pat_vars2 = pat_vars env [] args2 in
+                      let r = t2.FStar_Syntax_Syntax.pos in
                       (match (maybe_pat_vars1, maybe_pat_vars2) with
                        | (FStar_Pervasives_Native.Some
                           xs,FStar_Pervasives_Native.Some ys) ->
@@ -6009,8 +5463,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              (let uu____16693 =
                                 force_quasi_pattern
                                   FStar_Pervasives_Native.None
-                                  (t1, u1, k1, args1)
-                                 in
+                                  (t1, u1, k1, args1) in
                               match uu____16693 with
                               | FStar_Pervasives_Native.None  ->
                                   giveup env
@@ -6019,16 +5472,14 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                               | FStar_Pervasives_Native.Some
                                   (sol,uu____16711) ->
                                   let wl1 =
-                                    extend_solution (p_pid orig) [sol] wl  in
+                                    extend_solution (p_pid orig) [sol] wl in
                                   ((let uu____16718 =
                                       FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env)
-                                        (FStar_Options.Other "QuasiPattern")
-                                       in
+                                        (FStar_Options.Other "QuasiPattern") in
                                     if uu____16718
                                     then
-                                      let uu____16719 = uvi_to_string env sol
-                                         in
+                                      let uu____16719 = uvi_to_string env sol in
                                       FStar_Util.print1
                                         "flex-flex quasi pattern (1): %s\n"
                                         uu____16719
@@ -6037,41 +5488,37 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                     | FStar_TypeChecker_Common.TProb p ->
                                         solve_t env p wl1
                                     | uu____16726 ->
-                                        giveup env "impossible" orig))))))
-           in
-        let orig = FStar_TypeChecker_Common.TProb problem  in
+                                        giveup env "impossible" orig)))))) in
+        let orig = FStar_TypeChecker_Common.TProb problem in
         let uu____16728 =
           FStar_Util.physical_equality problem.FStar_TypeChecker_Common.lhs
-            problem.FStar_TypeChecker_Common.rhs
-           in
+            problem.FStar_TypeChecker_Common.rhs in
         if uu____16728
         then
           let uu____16729 =
-            solve_prob orig FStar_Pervasives_Native.None [] wl  in
+            solve_prob orig FStar_Pervasives_Native.None [] wl in
           solve env uu____16729
         else
-          (let t1 = problem.FStar_TypeChecker_Common.lhs  in
-           let t2 = problem.FStar_TypeChecker_Common.rhs  in
-           let uu____16733 = FStar_Util.physical_equality t1 t2  in
+          (let t1 = problem.FStar_TypeChecker_Common.lhs in
+           let t2 = problem.FStar_TypeChecker_Common.rhs in
+           let uu____16733 = FStar_Util.physical_equality t1 t2 in
            if uu____16733
            then
              let uu____16734 =
-               solve_prob orig FStar_Pervasives_Native.None [] wl  in
+               solve_prob orig FStar_Pervasives_Native.None [] wl in
              solve env uu____16734
            else
              ((let uu____16737 =
                  FStar_TypeChecker_Env.debug env
-                   (FStar_Options.Other "RelCheck")
-                  in
+                   (FStar_Options.Other "RelCheck") in
                if uu____16737
                then
                  let uu____16738 =
                    FStar_Util.string_of_int
-                     problem.FStar_TypeChecker_Common.pid
-                    in
+                     problem.FStar_TypeChecker_Common.pid in
                  FStar_Util.print1 "Attempting %s\n" uu____16738
                else ());
-              (let r = FStar_TypeChecker_Env.get_range env  in
+              (let r = FStar_TypeChecker_Env.get_range env in
                match ((t1.FStar_Syntax_Syntax.n), (t2.FStar_Syntax_Syntax.n))
                with
                | (FStar_Syntax_Syntax.Tm_delayed uu____16741,uu____16742) ->
@@ -6080,8 +5527,8 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                    failwith "Impossible: terms were not compressed"
                | (FStar_Syntax_Syntax.Tm_ascribed uu____16793,uu____16794) ->
                    let uu____16821 =
-                     let uu___146_16822 = problem  in
-                     let uu____16823 = FStar_Syntax_Util.unmeta t1  in
+                     let uu___146_16822 = problem in
+                     let uu____16823 = FStar_Syntax_Util.unmeta t1 in
                      {
                        FStar_TypeChecker_Common.pid =
                          (uu___146_16822.FStar_TypeChecker_Common.pid);
@@ -6102,12 +5549,12 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          (uu___146_16822.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
                          (uu___146_16822.FStar_TypeChecker_Common.rank)
-                     }  in
+                     } in
                    solve_t' env uu____16821 wl
                | (FStar_Syntax_Syntax.Tm_meta uu____16824,uu____16825) ->
                    let uu____16832 =
-                     let uu___146_16833 = problem  in
-                     let uu____16834 = FStar_Syntax_Util.unmeta t1  in
+                     let uu___146_16833 = problem in
+                     let uu____16834 = FStar_Syntax_Util.unmeta t1 in
                      {
                        FStar_TypeChecker_Common.pid =
                          (uu___146_16833.FStar_TypeChecker_Common.pid);
@@ -6128,12 +5575,12 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          (uu___146_16833.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
                          (uu___146_16833.FStar_TypeChecker_Common.rank)
-                     }  in
+                     } in
                    solve_t' env uu____16832 wl
                | (uu____16835,FStar_Syntax_Syntax.Tm_ascribed uu____16836) ->
                    let uu____16863 =
-                     let uu___147_16864 = problem  in
-                     let uu____16865 = FStar_Syntax_Util.unmeta t2  in
+                     let uu___147_16864 = problem in
+                     let uu____16865 = FStar_Syntax_Util.unmeta t2 in
                      {
                        FStar_TypeChecker_Common.pid =
                          (uu___147_16864.FStar_TypeChecker_Common.pid);
@@ -6154,12 +5601,12 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          (uu___147_16864.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
                          (uu___147_16864.FStar_TypeChecker_Common.rank)
-                     }  in
+                     } in
                    solve_t' env uu____16863 wl
                | (uu____16866,FStar_Syntax_Syntax.Tm_meta uu____16867) ->
                    let uu____16874 =
-                     let uu___147_16875 = problem  in
-                     let uu____16876 = FStar_Syntax_Util.unmeta t2  in
+                     let uu___147_16875 = problem in
+                     let uu____16876 = FStar_Syntax_Util.unmeta t2 in
                      {
                        FStar_TypeChecker_Common.pid =
                          (uu___147_16875.FStar_TypeChecker_Common.pid);
@@ -6180,7 +5627,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          (uu___147_16875.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
                          (uu___147_16875.FStar_TypeChecker_Common.rank)
-                     }  in
+                     } in
                    solve_t' env uu____16874 wl
                | (FStar_Syntax_Syntax.Tm_bvar uu____16877,uu____16878) ->
                    failwith
@@ -6200,12 +5647,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                            FStar_Syntax_Syntax.mk
                              (FStar_Syntax_Syntax.Tm_arrow (bs, c))
                              FStar_Pervasives_Native.None
-                             c.FStar_Syntax_Syntax.pos
-                            in
-                         FStar_Syntax_Syntax.mk_Total uu____16957
-                      in
+                             c.FStar_Syntax_Syntax.pos in
+                         FStar_Syntax_Syntax.mk_Total uu____16957 in
                    let uu____16966 =
-                     match_num_binders (bs1, (mk_c c1)) (bs2, (mk_c c2))  in
+                     match_num_binders (bs1, (mk_c c1)) (bs2, (mk_c c2)) in
                    (match uu____16966 with
                     | ((bs11,c11),(bs21,c21)) ->
                         solve_binders env bs11 bs21 orig wl
@@ -6213,25 +5658,20 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              fun env1  ->
                                fun subst1  ->
                                  let c12 =
-                                   FStar_Syntax_Subst.subst_comp subst1 c11
-                                    in
+                                   FStar_Syntax_Subst.subst_comp subst1 c11 in
                                  let c22 =
-                                   FStar_Syntax_Subst.subst_comp subst1 c21
-                                    in
+                                   FStar_Syntax_Subst.subst_comp subst1 c21 in
                                  let rel =
                                    let uu____17108 =
-                                     FStar_Options.use_eq_at_higher_order ()
-                                      in
+                                     FStar_Options.use_eq_at_higher_order () in
                                    if uu____17108
                                    then FStar_TypeChecker_Common.EQ
                                    else
-                                     problem.FStar_TypeChecker_Common.relation
-                                    in
+                                     problem.FStar_TypeChecker_Common.relation in
                                  let uu____17110 =
                                    mk_problem scope orig c12 rel c22
                                      FStar_Pervasives_Native.None
-                                     "function co-domain"
-                                    in
+                                     "function co-domain" in
                                  FStar_All.pipe_left
                                    (fun _0_66  ->
                                       FStar_TypeChecker_Common.CProb _0_66)
@@ -6246,12 +5686,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          FStar_Syntax_Syntax.mk
                            (FStar_Syntax_Syntax.Tm_abs (bs, t, l))
                            FStar_Pervasives_Native.None
-                           t.FStar_Syntax_Syntax.pos
-                      in
+                           t.FStar_Syntax_Syntax.pos in
                    let uu____17220 =
                      match_num_binders (bs1, (mk_t tbody1 lopt1))
-                       (bs2, (mk_t tbody2 lopt2))
-                      in
+                       (bs2, (mk_t tbody2 lopt2)) in
                    (match uu____17220 with
                     | ((bs11,tbody11),(bs21,tbody21)) ->
                         solve_binders env bs11 bs21 orig wl
@@ -6260,16 +5698,13 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                fun subst1  ->
                                  let uu____17356 =
                                    let uu____17361 =
-                                     FStar_Syntax_Subst.subst subst1 tbody11
-                                      in
+                                     FStar_Syntax_Subst.subst subst1 tbody11 in
                                    let uu____17362 =
-                                     FStar_Syntax_Subst.subst subst1 tbody21
-                                      in
+                                     FStar_Syntax_Subst.subst subst1 tbody21 in
                                    mk_problem scope orig uu____17361
                                      problem.FStar_TypeChecker_Common.relation
                                      uu____17362 FStar_Pervasives_Native.None
-                                     "lambda co-domain"
-                                    in
+                                     "lambda co-domain" in
                                  FStar_All.pipe_left
                                    (fun _0_67  ->
                                       FStar_TypeChecker_Common.TProb _0_67)
@@ -6278,25 +5713,23 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                    let is_abs t =
                      match t.FStar_Syntax_Syntax.n with
                      | FStar_Syntax_Syntax.Tm_abs uu____17393 -> true
-                     | uu____17410 -> false  in
+                     | uu____17410 -> false in
                    let maybe_eta t =
                      if is_abs t
                      then FStar_Util.Inl t
                      else
                        (let t3 =
-                          FStar_TypeChecker_Normalize.eta_expand wl.tcenv t
-                           in
+                          FStar_TypeChecker_Normalize.eta_expand wl.tcenv t in
                         if is_abs t3
                         then FStar_Util.Inl t3
-                        else FStar_Util.Inr t3)
-                      in
+                        else FStar_Util.Inr t3) in
                    let force_eta t =
                      if is_abs t
                      then t
                      else
                        (let uu____17457 =
                           env.FStar_TypeChecker_Env.type_of
-                            (let uu___148_17465 = env  in
+                            (let uu___148_17465 = env in
                              {
                                FStar_TypeChecker_Env.solver =
                                  (uu___148_17465.FStar_TypeChecker_Env.solver);
@@ -6366,24 +5799,21 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                  (uu___148_17465.FStar_TypeChecker_Env.dsenv);
                                FStar_TypeChecker_Env.dep_graph =
                                  (uu___148_17465.FStar_TypeChecker_Env.dep_graph)
-                             }) t
-                           in
+                             }) t in
                         match uu____17457 with
                         | (uu____17468,ty,uu____17470) ->
                             let uu____17471 =
-                              FStar_TypeChecker_Normalize.unfold_whnf env ty
-                               in
+                              FStar_TypeChecker_Normalize.unfold_whnf env ty in
                             FStar_TypeChecker_Normalize.eta_expand_with_type
-                              env t uu____17471)
-                      in
+                              env t uu____17471) in
                    let uu____17472 =
-                     let uu____17489 = maybe_eta t1  in
-                     let uu____17496 = maybe_eta t2  in
-                     (uu____17489, uu____17496)  in
+                     let uu____17489 = maybe_eta t1 in
+                     let uu____17496 = maybe_eta t2 in
+                     (uu____17489, uu____17496) in
                    (match uu____17472 with
                     | (FStar_Util.Inl t11,FStar_Util.Inl t21) ->
                         solve_t env
-                          (let uu___149_17538 = problem  in
+                          (let uu___149_17538 = problem in
                            {
                              FStar_TypeChecker_Common.pid =
                                (uu___149_17538.FStar_TypeChecker_Common.pid);
@@ -6407,20 +5837,18 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     | (FStar_Util.Inl t_abs,FStar_Util.Inr not_abs) ->
                         let uu____17561 =
                           (is_flex not_abs) &&
-                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
-                           in
+                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
                         if uu____17561
                         then
-                          let uu____17562 = destruct_flex_pattern env not_abs
-                             in
+                          let uu____17562 = destruct_flex_pattern env not_abs in
                           solve_t_flex_rigid true orig uu____17562 t_abs wl
                         else
-                          (let t11 = force_eta t1  in
-                           let t21 = force_eta t2  in
+                          (let t11 = force_eta t1 in
+                           let t21 = force_eta t2 in
                            if (is_abs t11) && (is_abs t21)
                            then
                              solve_t env
-                               (let uu___150_17577 = problem  in
+                               (let uu___150_17577 = problem in
                                 {
                                   FStar_TypeChecker_Common.pid =
                                     (uu___150_17577.FStar_TypeChecker_Common.pid);
@@ -6448,20 +5876,18 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     | (FStar_Util.Inr not_abs,FStar_Util.Inl t_abs) ->
                         let uu____17601 =
                           (is_flex not_abs) &&
-                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
-                           in
+                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
                         if uu____17601
                         then
-                          let uu____17602 = destruct_flex_pattern env not_abs
-                             in
+                          let uu____17602 = destruct_flex_pattern env not_abs in
                           solve_t_flex_rigid true orig uu____17602 t_abs wl
                         else
-                          (let t11 = force_eta t1  in
-                           let t21 = force_eta t2  in
+                          (let t11 = force_eta t1 in
+                           let t21 = force_eta t2 in
                            if (is_abs t11) && (is_abs t21)
                            then
                              solve_t env
-                               (let uu___150_17617 = problem  in
+                               (let uu___150_17617 = problem in
                                 {
                                   FStar_TypeChecker_Common.pid =
                                     (uu___150_17617.FStar_TypeChecker_Common.pid);
@@ -6493,25 +5919,23 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                    let is_abs t =
                      match t.FStar_Syntax_Syntax.n with
                      | FStar_Syntax_Syntax.Tm_abs uu____17664 -> true
-                     | uu____17681 -> false  in
+                     | uu____17681 -> false in
                    let maybe_eta t =
                      if is_abs t
                      then FStar_Util.Inl t
                      else
                        (let t3 =
-                          FStar_TypeChecker_Normalize.eta_expand wl.tcenv t
-                           in
+                          FStar_TypeChecker_Normalize.eta_expand wl.tcenv t in
                         if is_abs t3
                         then FStar_Util.Inl t3
-                        else FStar_Util.Inr t3)
-                      in
+                        else FStar_Util.Inr t3) in
                    let force_eta t =
                      if is_abs t
                      then t
                      else
                        (let uu____17728 =
                           env.FStar_TypeChecker_Env.type_of
-                            (let uu___148_17736 = env  in
+                            (let uu___148_17736 = env in
                              {
                                FStar_TypeChecker_Env.solver =
                                  (uu___148_17736.FStar_TypeChecker_Env.solver);
@@ -6581,24 +6005,21 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                  (uu___148_17736.FStar_TypeChecker_Env.dsenv);
                                FStar_TypeChecker_Env.dep_graph =
                                  (uu___148_17736.FStar_TypeChecker_Env.dep_graph)
-                             }) t
-                           in
+                             }) t in
                         match uu____17728 with
                         | (uu____17739,ty,uu____17741) ->
                             let uu____17742 =
-                              FStar_TypeChecker_Normalize.unfold_whnf env ty
-                               in
+                              FStar_TypeChecker_Normalize.unfold_whnf env ty in
                             FStar_TypeChecker_Normalize.eta_expand_with_type
-                              env t uu____17742)
-                      in
+                              env t uu____17742) in
                    let uu____17743 =
-                     let uu____17760 = maybe_eta t1  in
-                     let uu____17767 = maybe_eta t2  in
-                     (uu____17760, uu____17767)  in
+                     let uu____17760 = maybe_eta t1 in
+                     let uu____17767 = maybe_eta t2 in
+                     (uu____17760, uu____17767) in
                    (match uu____17743 with
                     | (FStar_Util.Inl t11,FStar_Util.Inl t21) ->
                         solve_t env
-                          (let uu___149_17809 = problem  in
+                          (let uu___149_17809 = problem in
                            {
                              FStar_TypeChecker_Common.pid =
                                (uu___149_17809.FStar_TypeChecker_Common.pid);
@@ -6622,20 +6043,18 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     | (FStar_Util.Inl t_abs,FStar_Util.Inr not_abs) ->
                         let uu____17832 =
                           (is_flex not_abs) &&
-                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
-                           in
+                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
                         if uu____17832
                         then
-                          let uu____17833 = destruct_flex_pattern env not_abs
-                             in
+                          let uu____17833 = destruct_flex_pattern env not_abs in
                           solve_t_flex_rigid true orig uu____17833 t_abs wl
                         else
-                          (let t11 = force_eta t1  in
-                           let t21 = force_eta t2  in
+                          (let t11 = force_eta t1 in
+                           let t21 = force_eta t2 in
                            if (is_abs t11) && (is_abs t21)
                            then
                              solve_t env
-                               (let uu___150_17848 = problem  in
+                               (let uu___150_17848 = problem in
                                 {
                                   FStar_TypeChecker_Common.pid =
                                     (uu___150_17848.FStar_TypeChecker_Common.pid);
@@ -6663,20 +6082,18 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     | (FStar_Util.Inr not_abs,FStar_Util.Inl t_abs) ->
                         let uu____17872 =
                           (is_flex not_abs) &&
-                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
-                           in
+                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
                         if uu____17872
                         then
-                          let uu____17873 = destruct_flex_pattern env not_abs
-                             in
+                          let uu____17873 = destruct_flex_pattern env not_abs in
                           solve_t_flex_rigid true orig uu____17873 t_abs wl
                         else
-                          (let t11 = force_eta t1  in
-                           let t21 = force_eta t2  in
+                          (let t11 = force_eta t1 in
+                           let t21 = force_eta t2 in
                            if (is_abs t11) && (is_abs t21)
                            then
                              solve_t env
-                               (let uu___150_17888 = problem  in
+                               (let uu___150_17888 = problem in
                                 {
                                   FStar_TypeChecker_Common.pid =
                                     (uu___150_17888.FStar_TypeChecker_Common.pid);
@@ -6707,15 +6124,14 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                | (FStar_Syntax_Syntax.Tm_refine
                   (x1,ph1),FStar_Syntax_Syntax.Tm_refine (x2,phi2)) ->
                    let should_delta =
-                     ((let uu____17924 = FStar_Syntax_Free.uvars t1  in
+                     ((let uu____17924 = FStar_Syntax_Free.uvars t1 in
                        FStar_Util.set_is_empty uu____17924) &&
-                        (let uu____17936 = FStar_Syntax_Free.uvars t2  in
+                        (let uu____17936 = FStar_Syntax_Free.uvars t2 in
                          FStar_Util.set_is_empty uu____17936))
                        &&
                        (let uu____17951 =
                           head_matches env x1.FStar_Syntax_Syntax.sort
-                            x2.FStar_Syntax_Syntax.sort
-                           in
+                            x2.FStar_Syntax_Syntax.sort in
                         match uu____17951 with
                         | MisMatch
                             (FStar_Pervasives_Native.Some
@@ -6726,15 +6142,14 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                               | FStar_Syntax_Syntax.Delta_constant  -> true
                               | FStar_Syntax_Syntax.Delta_defined_at_level
                                   uu____17962 -> true
-                              | uu____17963 -> false  in
+                              | uu____17963 -> false in
                             (is_unfoldable d1) && (is_unfoldable d2)
-                        | uu____17964 -> false)
-                      in
-                   let uu____17965 = as_refinement should_delta env wl t1  in
+                        | uu____17964 -> false) in
+                   let uu____17965 = as_refinement should_delta env wl t1 in
                    (match uu____17965 with
                     | (x11,phi1) ->
                         let uu____17972 =
-                          as_refinement should_delta env wl t2  in
+                          as_refinement should_delta env wl t2 in
                         (match uu____17972 with
                          | (x21,phi21) ->
                              let base_prob =
@@ -6744,29 +6159,23 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                    problem.FStar_TypeChecker_Common.relation
                                    x21.FStar_Syntax_Syntax.sort
                                    problem.FStar_TypeChecker_Common.element
-                                   "refinement base type"
-                                  in
+                                   "refinement base type" in
                                FStar_All.pipe_left
                                  (fun _0_68  ->
                                     FStar_TypeChecker_Common.TProb _0_68)
-                                 uu____17980
-                                in
-                             let x12 = FStar_Syntax_Syntax.freshen_bv x11  in
+                                 uu____17980 in
+                             let x12 = FStar_Syntax_Syntax.freshen_bv x11 in
                              let subst1 =
                                [FStar_Syntax_Syntax.DB
-                                  ((Prims.parse_int "0"), x12)]
-                                in
-                             let phi11 = FStar_Syntax_Subst.subst subst1 phi1
-                                in
+                                  ((Prims.parse_int "0"), x12)] in
+                             let phi11 = FStar_Syntax_Subst.subst subst1 phi1 in
                              let phi22 =
-                               FStar_Syntax_Subst.subst subst1 phi21  in
-                             let env1 = FStar_TypeChecker_Env.push_bv env x12
-                                in
+                               FStar_Syntax_Subst.subst subst1 phi21 in
+                             let env1 = FStar_TypeChecker_Env.push_bv env x12 in
                              let mk_imp1 imp phi12 phi23 =
-                               let uu____18018 = imp phi12 phi23  in
+                               let uu____18018 = imp phi12 phi23 in
                                FStar_All.pipe_right uu____18018
-                                 (guard_on_element wl problem x12)
-                                in
+                                 (guard_on_element wl problem x12) in
                              let fallback uu____18022 =
                                let impl =
                                  if
@@ -6777,20 +6186,16 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                      phi22
                                  else
                                    mk_imp1 FStar_Syntax_Util.mk_imp phi11
-                                     phi22
-                                  in
+                                     phi22 in
                                let guard =
                                  let uu____18028 =
                                    FStar_All.pipe_right (p_guard base_prob)
-                                     FStar_Pervasives_Native.fst
-                                    in
-                                 FStar_Syntax_Util.mk_conj uu____18028 impl
-                                  in
+                                     FStar_Pervasives_Native.fst in
+                                 FStar_Syntax_Util.mk_conj uu____18028 impl in
                                let wl1 =
                                  solve_prob orig
-                                   (FStar_Pervasives_Native.Some guard) [] wl
-                                  in
-                               solve env1 (attempt [base_prob] wl1)  in
+                                   (FStar_Pervasives_Native.Some guard) [] wl in
+                               solve env1 (attempt [base_prob] wl1) in
                              if
                                problem.FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ
@@ -6800,25 +6205,21 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                    let uu____18042 =
                                      let uu____18043 =
                                        let uu____18050 =
-                                         FStar_Syntax_Syntax.mk_binder x12
-                                          in
-                                       [uu____18050]  in
+                                         FStar_Syntax_Syntax.mk_binder x12 in
+                                       [uu____18050] in
                                      FStar_List.append (p_scope orig)
-                                       uu____18043
-                                      in
+                                       uu____18043 in
                                    mk_problem uu____18042 orig phi11
                                      FStar_TypeChecker_Common.EQ phi22
                                      FStar_Pervasives_Native.None
-                                     "refinement formula"
-                                    in
+                                     "refinement formula" in
                                  FStar_All.pipe_left
                                    (fun _0_69  ->
                                       FStar_TypeChecker_Common.TProb _0_69)
-                                   uu____18037
-                                  in
+                                   uu____18037 in
                                let uu____18059 =
                                  solve env1
-                                   (let uu___151_18061 = wl  in
+                                   (let uu___151_18061 = wl in
                                     {
                                       attempting = [ref_prob];
                                       wl_deferred = [];
@@ -6826,8 +6227,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                       defer_ok = false;
                                       smt_ok = (uu___151_18061.smt_ok);
                                       tcenv = (uu___151_18061.tcenv)
-                                    })
-                                  in
+                                    }) in
                                (match uu____18059 with
                                 | Failed uu____18068 -> fallback ()
                                 | Success uu____18073 ->
@@ -6835,27 +6235,22 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                       let uu____18077 =
                                         FStar_All.pipe_right
                                           (p_guard base_prob)
-                                          FStar_Pervasives_Native.fst
-                                         in
+                                          FStar_Pervasives_Native.fst in
                                       let uu____18082 =
                                         let uu____18083 =
                                           FStar_All.pipe_right
                                             (p_guard ref_prob)
-                                            FStar_Pervasives_Native.fst
-                                           in
+                                            FStar_Pervasives_Native.fst in
                                         FStar_All.pipe_right uu____18083
-                                          (guard_on_element wl problem x12)
-                                         in
+                                          (guard_on_element wl problem x12) in
                                       FStar_Syntax_Util.mk_conj uu____18077
-                                        uu____18082
-                                       in
+                                        uu____18082 in
                                     let wl1 =
                                       solve_prob orig
                                         (FStar_Pervasives_Native.Some guard)
-                                        [] wl
-                                       in
+                                        [] wl in
                                     let wl2 =
-                                      let uu___152_18092 = wl1  in
+                                      let uu___152_18092 = wl1 in
                                       {
                                         attempting =
                                           (uu___152_18092.attempting);
@@ -6866,13 +6261,13 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                         defer_ok = (uu___152_18092.defer_ok);
                                         smt_ok = (uu___152_18092.smt_ok);
                                         tcenv = (uu___152_18092.tcenv)
-                                      }  in
+                                      } in
                                     solve env1 (attempt [base_prob] wl2))
                              else fallback ()))
                | (FStar_Syntax_Syntax.Tm_uvar
                   uu____18094,FStar_Syntax_Syntax.Tm_uvar uu____18095) ->
-                   let uu____18128 = destruct_flex_t t1  in
-                   let uu____18129 = destruct_flex_t t2  in
+                   let uu____18128 = destruct_flex_t t1 in
+                   let uu____18129 = destruct_flex_t t2 in
                    flex_flex1 orig uu____18128 uu____18129
                | (FStar_Syntax_Syntax.Tm_app
                   ({
@@ -6881,8 +6276,8 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      FStar_Syntax_Syntax.pos = uu____18131;
                      FStar_Syntax_Syntax.vars = uu____18132;_},uu____18133),FStar_Syntax_Syntax.Tm_uvar
                   uu____18134) ->
-                   let uu____18187 = destruct_flex_t t1  in
-                   let uu____18188 = destruct_flex_t t2  in
+                   let uu____18187 = destruct_flex_t t1 in
+                   let uu____18188 = destruct_flex_t t2 in
                    flex_flex1 orig uu____18187 uu____18188
                | (FStar_Syntax_Syntax.Tm_uvar
                   uu____18189,FStar_Syntax_Syntax.Tm_app
@@ -6892,8 +6287,8 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      FStar_Syntax_Syntax.pos = uu____18191;
                      FStar_Syntax_Syntax.vars = uu____18192;_},uu____18193))
                    ->
-                   let uu____18246 = destruct_flex_t t1  in
-                   let uu____18247 = destruct_flex_t t2  in
+                   let uu____18246 = destruct_flex_t t1 in
+                   let uu____18247 = destruct_flex_t t2 in
                    flex_flex1 orig uu____18246 uu____18247
                | (FStar_Syntax_Syntax.Tm_app
                   ({
@@ -6907,14 +6302,14 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      FStar_Syntax_Syntax.pos = uu____18253;
                      FStar_Syntax_Syntax.vars = uu____18254;_},uu____18255))
                    ->
-                   let uu____18328 = destruct_flex_t t1  in
-                   let uu____18329 = destruct_flex_t t2  in
+                   let uu____18328 = destruct_flex_t t1 in
+                   let uu____18329 = destruct_flex_t t2 in
                    flex_flex1 orig uu____18328 uu____18329
                | (FStar_Syntax_Syntax.Tm_uvar uu____18330,uu____18331) when
                    problem.FStar_TypeChecker_Common.relation =
                      FStar_TypeChecker_Common.EQ
                    ->
-                   let uu____18348 = destruct_flex_pattern env t1  in
+                   let uu____18348 = destruct_flex_pattern env t1 in
                    solve_t_flex_rigid false orig uu____18348 t2 wl
                | (FStar_Syntax_Syntax.Tm_app
                   ({
@@ -6926,7 +6321,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                    problem.FStar_TypeChecker_Common.relation =
                      FStar_TypeChecker_Common.EQ
                    ->
-                   let uu____18396 = destruct_flex_pattern env t1  in
+                   let uu____18396 = destruct_flex_pattern env t1 in
                    solve_t_flex_rigid false orig uu____18396 t2 wl
                | (uu____18403,FStar_Syntax_Syntax.Tm_uvar uu____18404) when
                    problem.FStar_TypeChecker_Common.relation =
@@ -6945,7 +6340,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                | (FStar_Syntax_Syntax.Tm_uvar
                   uu____18462,FStar_Syntax_Syntax.Tm_type uu____18463) ->
                    solve_t' env
-                     (let uu___153_18481 = problem  in
+                     (let uu___153_18481 = problem in
                       {
                         FStar_TypeChecker_Common.pid =
                           (uu___153_18481.FStar_TypeChecker_Common.pid);
@@ -6976,7 +6371,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      FStar_Syntax_Syntax.vars = uu____18484;_},uu____18485),FStar_Syntax_Syntax.Tm_type
                   uu____18486) ->
                    solve_t' env
-                     (let uu___153_18524 = problem  in
+                     (let uu___153_18524 = problem in
                       {
                         FStar_TypeChecker_Common.pid =
                           (uu___153_18524.FStar_TypeChecker_Common.pid);
@@ -7002,7 +6397,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                | (FStar_Syntax_Syntax.Tm_uvar
                   uu____18525,FStar_Syntax_Syntax.Tm_arrow uu____18526) ->
                    solve_t' env
-                     (let uu___153_18556 = problem  in
+                     (let uu___153_18556 = problem in
                       {
                         FStar_TypeChecker_Common.pid =
                           (uu___153_18556.FStar_TypeChecker_Common.pid);
@@ -7033,7 +6428,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      FStar_Syntax_Syntax.vars = uu____18559;_},uu____18560),FStar_Syntax_Syntax.Tm_arrow
                   uu____18561) ->
                    solve_t' env
-                     (let uu___153_18611 = problem  in
+                     (let uu___153_18611 = problem in
                       {
                         FStar_TypeChecker_Common.pid =
                           (uu___153_18611.FStar_TypeChecker_Common.pid);
@@ -7062,18 +6457,17 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      solve env
                        (defer "flex-rigid subtyping deferred" orig wl)
                    else
-                     (let new_rel = problem.FStar_TypeChecker_Common.relation
-                         in
+                     (let new_rel = problem.FStar_TypeChecker_Common.relation in
                       let uu____18632 =
-                        let uu____18633 = is_top_level_prob orig  in
-                        FStar_All.pipe_left Prims.op_Negation uu____18633  in
+                        let uu____18633 = is_top_level_prob orig in
+                        FStar_All.pipe_left Prims.op_Negation uu____18633 in
                       if uu____18632
                       then
                         let uu____18634 =
                           FStar_All.pipe_left
                             (fun _0_70  ->
                                FStar_TypeChecker_Common.TProb _0_70)
-                            (let uu___154_18640 = problem  in
+                            (let uu___154_18640 = problem in
                              {
                                FStar_TypeChecker_Common.pid =
                                  (uu___154_18640.FStar_TypeChecker_Common.pid);
@@ -7094,13 +6488,12 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                  (uu___154_18640.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
                                  (uu___154_18640.FStar_TypeChecker_Common.rank)
-                             })
-                           in
-                        let uu____18641 = destruct_flex_pattern env t1  in
+                             }) in
+                        let uu____18641 = destruct_flex_pattern env t1 in
                         solve_t_flex_rigid false uu____18634 uu____18641 t2
                           wl
                       else
-                        (let uu____18649 = base_and_refinement env t2  in
+                        (let uu____18649 = base_and_refinement env t2 in
                          match uu____18649 with
                          | (t_base,ref_opt) ->
                              (match ref_opt with
@@ -7109,7 +6502,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                     FStar_All.pipe_left
                                       (fun _0_71  ->
                                          FStar_TypeChecker_Common.TProb _0_71)
-                                      (let uu___155_18684 = problem  in
+                                      (let uu___155_18684 = problem in
                                        {
                                          FStar_TypeChecker_Common.pid =
                                            (uu___155_18684.FStar_TypeChecker_Common.pid);
@@ -7132,24 +6525,23 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                            (uu___155_18684.FStar_TypeChecker_Common.loc);
                                          FStar_TypeChecker_Common.rank =
                                            (uu___155_18684.FStar_TypeChecker_Common.rank)
-                                       })
-                                     in
+                                       }) in
                                   let uu____18685 =
-                                    destruct_flex_pattern env t1  in
+                                    destruct_flex_pattern env t1 in
                                   solve_t_flex_rigid false uu____18678
                                     uu____18685 t_base wl
                               | FStar_Pervasives_Native.Some (y,phi) ->
                                   let y' =
-                                    let uu___156_18699 = y  in
+                                    let uu___156_18699 = y in
                                     {
                                       FStar_Syntax_Syntax.ppname =
                                         (uu___156_18699.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
                                         (uu___156_18699.FStar_Syntax_Syntax.index);
                                       FStar_Syntax_Syntax.sort = t1
-                                    }  in
+                                    } in
                                   let impl =
-                                    guard_on_element wl problem y' phi  in
+                                    guard_on_element wl problem y' phi in
                                   let base_prob =
                                     let uu____18702 =
                                       mk_problem
@@ -7157,27 +6549,22 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                         orig t1 new_rel
                                         y.FStar_Syntax_Syntax.sort
                                         problem.FStar_TypeChecker_Common.element
-                                        "flex-rigid: base type"
-                                       in
+                                        "flex-rigid: base type" in
                                     FStar_All.pipe_left
                                       (fun _0_72  ->
                                          FStar_TypeChecker_Common.TProb _0_72)
-                                      uu____18702
-                                     in
+                                      uu____18702 in
                                   let guard =
                                     let uu____18714 =
                                       FStar_All.pipe_right
                                         (p_guard base_prob)
-                                        FStar_Pervasives_Native.fst
-                                       in
+                                        FStar_Pervasives_Native.fst in
                                     FStar_Syntax_Util.mk_conj uu____18714
-                                      impl
-                                     in
+                                      impl in
                                   let wl1 =
                                     solve_prob orig
                                       (FStar_Pervasives_Native.Some guard) []
-                                      wl
-                                     in
+                                      wl in
                                   solve env (attempt [base_prob] wl1))))
                | (FStar_Syntax_Syntax.Tm_app
                   ({
@@ -7191,18 +6578,17 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      solve env
                        (defer "flex-rigid subtyping deferred" orig wl)
                    else
-                     (let new_rel = problem.FStar_TypeChecker_Common.relation
-                         in
+                     (let new_rel = problem.FStar_TypeChecker_Common.relation in
                       let uu____18765 =
-                        let uu____18766 = is_top_level_prob orig  in
-                        FStar_All.pipe_left Prims.op_Negation uu____18766  in
+                        let uu____18766 = is_top_level_prob orig in
+                        FStar_All.pipe_left Prims.op_Negation uu____18766 in
                       if uu____18765
                       then
                         let uu____18767 =
                           FStar_All.pipe_left
                             (fun _0_73  ->
                                FStar_TypeChecker_Common.TProb _0_73)
-                            (let uu___154_18773 = problem  in
+                            (let uu___154_18773 = problem in
                              {
                                FStar_TypeChecker_Common.pid =
                                  (uu___154_18773.FStar_TypeChecker_Common.pid);
@@ -7223,13 +6609,12 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                  (uu___154_18773.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
                                  (uu___154_18773.FStar_TypeChecker_Common.rank)
-                             })
-                           in
-                        let uu____18774 = destruct_flex_pattern env t1  in
+                             }) in
+                        let uu____18774 = destruct_flex_pattern env t1 in
                         solve_t_flex_rigid false uu____18767 uu____18774 t2
                           wl
                       else
-                        (let uu____18782 = base_and_refinement env t2  in
+                        (let uu____18782 = base_and_refinement env t2 in
                          match uu____18782 with
                          | (t_base,ref_opt) ->
                              (match ref_opt with
@@ -7238,7 +6623,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                     FStar_All.pipe_left
                                       (fun _0_74  ->
                                          FStar_TypeChecker_Common.TProb _0_74)
-                                      (let uu___155_18817 = problem  in
+                                      (let uu___155_18817 = problem in
                                        {
                                          FStar_TypeChecker_Common.pid =
                                            (uu___155_18817.FStar_TypeChecker_Common.pid);
@@ -7261,24 +6646,23 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                            (uu___155_18817.FStar_TypeChecker_Common.loc);
                                          FStar_TypeChecker_Common.rank =
                                            (uu___155_18817.FStar_TypeChecker_Common.rank)
-                                       })
-                                     in
+                                       }) in
                                   let uu____18818 =
-                                    destruct_flex_pattern env t1  in
+                                    destruct_flex_pattern env t1 in
                                   solve_t_flex_rigid false uu____18811
                                     uu____18818 t_base wl
                               | FStar_Pervasives_Native.Some (y,phi) ->
                                   let y' =
-                                    let uu___156_18832 = y  in
+                                    let uu___156_18832 = y in
                                     {
                                       FStar_Syntax_Syntax.ppname =
                                         (uu___156_18832.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
                                         (uu___156_18832.FStar_Syntax_Syntax.index);
                                       FStar_Syntax_Syntax.sort = t1
-                                    }  in
+                                    } in
                                   let impl =
-                                    guard_on_element wl problem y' phi  in
+                                    guard_on_element wl problem y' phi in
                                   let base_prob =
                                     let uu____18835 =
                                       mk_problem
@@ -7286,27 +6670,22 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                         orig t1 new_rel
                                         y.FStar_Syntax_Syntax.sort
                                         problem.FStar_TypeChecker_Common.element
-                                        "flex-rigid: base type"
-                                       in
+                                        "flex-rigid: base type" in
                                     FStar_All.pipe_left
                                       (fun _0_75  ->
                                          FStar_TypeChecker_Common.TProb _0_75)
-                                      uu____18835
-                                     in
+                                      uu____18835 in
                                   let guard =
                                     let uu____18847 =
                                       FStar_All.pipe_right
                                         (p_guard base_prob)
-                                        FStar_Pervasives_Native.fst
-                                       in
+                                        FStar_Pervasives_Native.fst in
                                     FStar_Syntax_Util.mk_conj uu____18847
-                                      impl
-                                     in
+                                      impl in
                                   let wl1 =
                                     solve_prob orig
                                       (FStar_Pervasives_Native.Some guard) []
-                                      wl
-                                     in
+                                      wl in
                                   solve env (attempt [base_prob] wl1))))
                | (uu____18855,FStar_Syntax_Syntax.Tm_uvar uu____18856) ->
                    if wl.defer_ok
@@ -7314,11 +6693,11 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      solve env
                        (defer "rigid-flex subtyping deferred" orig wl)
                    else
-                     (let uu____18874 = base_and_refinement env t1  in
+                     (let uu____18874 = base_and_refinement env t1 in
                       match uu____18874 with
                       | (t_base,uu____18886) ->
                           solve_t env
-                            (let uu___157_18900 = problem  in
+                            (let uu___157_18900 = problem in
                              {
                                FStar_TypeChecker_Common.pid =
                                  (uu___157_18900.FStar_TypeChecker_Common.pid);
@@ -7352,11 +6731,11 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      solve env
                        (defer "rigid-flex subtyping deferred" orig wl)
                    else
-                     (let uu____18943 = base_and_refinement env t1  in
+                     (let uu____18943 = base_and_refinement env t1 in
                       match uu____18943 with
                       | (t_base,uu____18955) ->
                           solve_t env
-                            (let uu___157_18969 = problem  in
+                            (let uu___157_18969 = problem in
                              {
                                FStar_TypeChecker_Common.pid =
                                  (uu___157_18969.FStar_TypeChecker_Common.pid);
@@ -7380,10 +6759,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              }) wl)
                | (FStar_Syntax_Syntax.Tm_refine uu____18970,uu____18971) ->
                    let t21 =
-                     let uu____18981 = base_and_refinement env t2  in
-                     FStar_All.pipe_left force_refinement uu____18981  in
+                     let uu____18981 = base_and_refinement env t2 in
+                     FStar_All.pipe_left force_refinement uu____18981 in
                    solve_t env
-                     (let uu___158_19005 = problem  in
+                     (let uu___158_19005 = problem in
                       {
                         FStar_TypeChecker_Common.pid =
                           (uu___158_19005.FStar_TypeChecker_Common.pid);
@@ -7407,10 +6786,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                       }) wl
                | (uu____19006,FStar_Syntax_Syntax.Tm_refine uu____19007) ->
                    let t11 =
-                     let uu____19017 = base_and_refinement env t1  in
-                     FStar_All.pipe_left force_refinement uu____19017  in
+                     let uu____19017 = base_and_refinement env t1 in
+                     FStar_All.pipe_left force_refinement uu____19017 in
                    solve_t env
-                     (let uu___159_19041 = problem  in
+                     (let uu___159_19041 = problem in
                       {
                         FStar_TypeChecker_Common.pid =
                           (uu___159_19041.FStar_TypeChecker_Common.pid);
@@ -7434,639 +6813,552 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                       }) wl
                | (FStar_Syntax_Syntax.Tm_match uu____19044,uu____19045) ->
                    let head1 =
-                     let uu____19071 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____19071 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____19071
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____19115 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____19115 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____19115
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____19156 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____19156
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____19171 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____19171
                       then
                         let guard =
                           let uu____19183 =
-                            let uu____19184 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____19184 = FStar_Syntax_Util.Equal  in
+                            let uu____19184 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____19184 = FStar_Syntax_Util.Equal in
                           if uu____19183
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____19188 = mk_eq2 env t1 t2  in
+                            (let uu____19188 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_76  ->
                                   FStar_Pervasives_Native.Some _0_76)
-                               uu____19188)
-                           in
-                        let uu____19191 = solve_prob orig guard [] wl  in
+                               uu____19188) in
+                        let uu____19191 = solve_prob orig guard [] wl in
                         solve env uu____19191
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (FStar_Syntax_Syntax.Tm_uinst uu____19194,uu____19195) ->
                    let head1 =
-                     let uu____19205 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____19205 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____19205
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____19249 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____19249 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____19249
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____19290 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____19290
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____19305 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____19305
                       then
                         let guard =
                           let uu____19317 =
-                            let uu____19318 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____19318 = FStar_Syntax_Util.Equal  in
+                            let uu____19318 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____19318 = FStar_Syntax_Util.Equal in
                           if uu____19317
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____19322 = mk_eq2 env t1 t2  in
+                            (let uu____19322 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_77  ->
                                   FStar_Pervasives_Native.Some _0_77)
-                               uu____19322)
-                           in
-                        let uu____19325 = solve_prob orig guard [] wl  in
+                               uu____19322) in
+                        let uu____19325 = solve_prob orig guard [] wl in
                         solve env uu____19325
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (FStar_Syntax_Syntax.Tm_name uu____19328,uu____19329) ->
                    let head1 =
-                     let uu____19333 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____19333 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____19333
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____19377 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____19377 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____19377
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____19418 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____19418
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____19433 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____19433
                       then
                         let guard =
                           let uu____19445 =
-                            let uu____19446 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____19446 = FStar_Syntax_Util.Equal  in
+                            let uu____19446 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____19446 = FStar_Syntax_Util.Equal in
                           if uu____19445
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____19450 = mk_eq2 env t1 t2  in
+                            (let uu____19450 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_78  ->
                                   FStar_Pervasives_Native.Some _0_78)
-                               uu____19450)
-                           in
-                        let uu____19453 = solve_prob orig guard [] wl  in
+                               uu____19450) in
+                        let uu____19453 = solve_prob orig guard [] wl in
                         solve env uu____19453
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (FStar_Syntax_Syntax.Tm_constant uu____19456,uu____19457) ->
                    let head1 =
-                     let uu____19461 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____19461 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____19461
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____19505 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____19505 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____19505
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____19546 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____19546
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____19561 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____19561
                       then
                         let guard =
                           let uu____19573 =
-                            let uu____19574 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____19574 = FStar_Syntax_Util.Equal  in
+                            let uu____19574 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____19574 = FStar_Syntax_Util.Equal in
                           if uu____19573
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____19578 = mk_eq2 env t1 t2  in
+                            (let uu____19578 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_79  ->
                                   FStar_Pervasives_Native.Some _0_79)
-                               uu____19578)
-                           in
-                        let uu____19581 = solve_prob orig guard [] wl  in
+                               uu____19578) in
+                        let uu____19581 = solve_prob orig guard [] wl in
                         solve env uu____19581
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (FStar_Syntax_Syntax.Tm_fvar uu____19584,uu____19585) ->
                    let head1 =
-                     let uu____19589 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____19589 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____19589
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____19633 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____19633 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____19633
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____19674 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____19674
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____19689 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____19689
                       then
                         let guard =
                           let uu____19701 =
-                            let uu____19702 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____19702 = FStar_Syntax_Util.Equal  in
+                            let uu____19702 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____19702 = FStar_Syntax_Util.Equal in
                           if uu____19701
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____19706 = mk_eq2 env t1 t2  in
+                            (let uu____19706 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_80  ->
                                   FStar_Pervasives_Native.Some _0_80)
-                               uu____19706)
-                           in
-                        let uu____19709 = solve_prob orig guard [] wl  in
+                               uu____19706) in
+                        let uu____19709 = solve_prob orig guard [] wl in
                         solve env uu____19709
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (FStar_Syntax_Syntax.Tm_app uu____19712,uu____19713) ->
                    let head1 =
-                     let uu____19731 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____19731 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____19731
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____19775 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____19775 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____19775
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____19816 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____19816
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____19831 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____19831
                       then
                         let guard =
                           let uu____19843 =
-                            let uu____19844 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____19844 = FStar_Syntax_Util.Equal  in
+                            let uu____19844 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____19844 = FStar_Syntax_Util.Equal in
                           if uu____19843
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____19848 = mk_eq2 env t1 t2  in
+                            (let uu____19848 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_81  ->
                                   FStar_Pervasives_Native.Some _0_81)
-                               uu____19848)
-                           in
-                        let uu____19851 = solve_prob orig guard [] wl  in
+                               uu____19848) in
+                        let uu____19851 = solve_prob orig guard [] wl in
                         solve env uu____19851
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (uu____19854,FStar_Syntax_Syntax.Tm_match uu____19855) ->
                    let head1 =
-                     let uu____19881 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____19881 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____19881
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____19925 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____19925 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____19925
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____19966 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____19966
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____19981 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____19981
                       then
                         let guard =
                           let uu____19993 =
-                            let uu____19994 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____19994 = FStar_Syntax_Util.Equal  in
+                            let uu____19994 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____19994 = FStar_Syntax_Util.Equal in
                           if uu____19993
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____19998 = mk_eq2 env t1 t2  in
+                            (let uu____19998 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_82  ->
                                   FStar_Pervasives_Native.Some _0_82)
-                               uu____19998)
-                           in
-                        let uu____20001 = solve_prob orig guard [] wl  in
+                               uu____19998) in
+                        let uu____20001 = solve_prob orig guard [] wl in
                         solve env uu____20001
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (uu____20004,FStar_Syntax_Syntax.Tm_uinst uu____20005) ->
                    let head1 =
-                     let uu____20015 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____20015 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____20015
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____20059 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____20059 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____20059
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____20100 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____20100
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____20115 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____20115
                       then
                         let guard =
                           let uu____20127 =
-                            let uu____20128 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____20128 = FStar_Syntax_Util.Equal  in
+                            let uu____20128 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____20128 = FStar_Syntax_Util.Equal in
                           if uu____20127
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____20132 = mk_eq2 env t1 t2  in
+                            (let uu____20132 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_83  ->
                                   FStar_Pervasives_Native.Some _0_83)
-                               uu____20132)
-                           in
-                        let uu____20135 = solve_prob orig guard [] wl  in
+                               uu____20132) in
+                        let uu____20135 = solve_prob orig guard [] wl in
                         solve env uu____20135
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (uu____20138,FStar_Syntax_Syntax.Tm_name uu____20139) ->
                    let head1 =
-                     let uu____20143 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____20143 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____20143
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____20187 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____20187 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____20187
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____20228 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____20228
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____20243 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____20243
                       then
                         let guard =
                           let uu____20255 =
-                            let uu____20256 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____20256 = FStar_Syntax_Util.Equal  in
+                            let uu____20256 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____20256 = FStar_Syntax_Util.Equal in
                           if uu____20255
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____20260 = mk_eq2 env t1 t2  in
+                            (let uu____20260 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_84  ->
                                   FStar_Pervasives_Native.Some _0_84)
-                               uu____20260)
-                           in
-                        let uu____20263 = solve_prob orig guard [] wl  in
+                               uu____20260) in
+                        let uu____20263 = solve_prob orig guard [] wl in
                         solve env uu____20263
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (uu____20266,FStar_Syntax_Syntax.Tm_constant uu____20267) ->
                    let head1 =
-                     let uu____20271 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____20271 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____20271
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____20315 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____20315 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____20315
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____20356 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____20356
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____20371 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____20371
                       then
                         let guard =
                           let uu____20383 =
-                            let uu____20384 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____20384 = FStar_Syntax_Util.Equal  in
+                            let uu____20384 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____20384 = FStar_Syntax_Util.Equal in
                           if uu____20383
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____20388 = mk_eq2 env t1 t2  in
+                            (let uu____20388 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_85  ->
                                   FStar_Pervasives_Native.Some _0_85)
-                               uu____20388)
-                           in
-                        let uu____20391 = solve_prob orig guard [] wl  in
+                               uu____20388) in
+                        let uu____20391 = solve_prob orig guard [] wl in
                         solve env uu____20391
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (uu____20394,FStar_Syntax_Syntax.Tm_fvar uu____20395) ->
                    let head1 =
-                     let uu____20399 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____20399 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____20399
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____20443 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____20443 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____20443
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____20484 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____20484
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____20499 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____20499
                       then
                         let guard =
                           let uu____20511 =
-                            let uu____20512 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____20512 = FStar_Syntax_Util.Equal  in
+                            let uu____20512 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____20512 = FStar_Syntax_Util.Equal in
                           if uu____20511
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____20516 = mk_eq2 env t1 t2  in
+                            (let uu____20516 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_86  ->
                                   FStar_Pervasives_Native.Some _0_86)
-                               uu____20516)
-                           in
-                        let uu____20519 = solve_prob orig guard [] wl  in
+                               uu____20516) in
+                        let uu____20519 = solve_prob orig guard [] wl in
                         solve env uu____20519
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (uu____20522,FStar_Syntax_Syntax.Tm_app uu____20523) ->
                    let head1 =
-                     let uu____20541 = FStar_Syntax_Util.head_and_args t1  in
+                     let uu____20541 = FStar_Syntax_Util.head_and_args t1 in
                      FStar_All.pipe_right uu____20541
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let head2 =
-                     let uu____20585 = FStar_Syntax_Util.head_and_args t2  in
+                     let uu____20585 = FStar_Syntax_Util.head_and_args t2 in
                      FStar_All.pipe_right uu____20585
-                       FStar_Pervasives_Native.fst
-                      in
+                       FStar_Pervasives_Native.fst in
                    let uu____20626 =
                      (((FStar_TypeChecker_Env.is_interpreted env head1) ||
                          (FStar_TypeChecker_Env.is_interpreted env head2))
                         && wl.smt_ok)
                        &&
                        (problem.FStar_TypeChecker_Common.relation =
-                          FStar_TypeChecker_Common.EQ)
-                      in
+                          FStar_TypeChecker_Common.EQ) in
                    if uu____20626
                    then
-                     let uv1 = FStar_Syntax_Free.uvars t1  in
-                     let uv2 = FStar_Syntax_Free.uvars t2  in
+                     let uv1 = FStar_Syntax_Free.uvars t1 in
+                     let uv2 = FStar_Syntax_Free.uvars t2 in
                      let uu____20641 =
                        (FStar_Util.set_is_empty uv1) &&
-                         (FStar_Util.set_is_empty uv2)
-                        in
+                         (FStar_Util.set_is_empty uv2) in
                      (if uu____20641
                       then
                         let guard =
                           let uu____20653 =
-                            let uu____20654 = FStar_Syntax_Util.eq_tm t1 t2
-                               in
-                            uu____20654 = FStar_Syntax_Util.Equal  in
+                            let uu____20654 = FStar_Syntax_Util.eq_tm t1 t2 in
+                            uu____20654 = FStar_Syntax_Util.Equal in
                           if uu____20653
                           then FStar_Pervasives_Native.None
                           else
-                            (let uu____20658 = mk_eq2 env t1 t2  in
+                            (let uu____20658 = mk_eq2 env t1 t2 in
                              FStar_All.pipe_left
                                (fun _0_87  ->
                                   FStar_Pervasives_Native.Some _0_87)
-                               uu____20658)
-                           in
-                        let uu____20661 = solve_prob orig guard [] wl  in
+                               uu____20658) in
+                        let uu____20661 = solve_prob orig guard [] wl in
                         solve env uu____20661
                       else rigid_rigid_delta env orig wl head1 head2 t1 t2)
                    else rigid_rigid_delta env orig wl head1 head2 t1 t2
                | (FStar_Syntax_Syntax.Tm_let
                   uu____20664,FStar_Syntax_Syntax.Tm_let uu____20665) ->
-                   let uu____20690 = FStar_Syntax_Util.term_eq t1 t2  in
+                   let uu____20690 = FStar_Syntax_Util.term_eq t1 t2 in
                    if uu____20690
                    then
                      let uu____20691 =
-                       solve_prob orig FStar_Pervasives_Native.None [] wl  in
+                       solve_prob orig FStar_Pervasives_Native.None [] wl in
                      solve env uu____20691
                    else giveup env "Tm_let mismatch (%s-%s vs %s-%s)" orig
                | (FStar_Syntax_Syntax.Tm_let uu____20693,uu____20694) ->
                    let uu____20707 =
                      let uu____20712 =
-                       let uu____20713 = FStar_Syntax_Print.tag_of_term t1
-                          in
-                       let uu____20714 = FStar_Syntax_Print.tag_of_term t2
-                          in
-                       let uu____20715 = FStar_Syntax_Print.term_to_string t1
-                          in
-                       let uu____20716 = FStar_Syntax_Print.term_to_string t2
-                          in
+                       let uu____20713 = FStar_Syntax_Print.tag_of_term t1 in
+                       let uu____20714 = FStar_Syntax_Print.tag_of_term t2 in
+                       let uu____20715 = FStar_Syntax_Print.term_to_string t1 in
+                       let uu____20716 = FStar_Syntax_Print.term_to_string t2 in
                        FStar_Util.format4
                          "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                         uu____20713 uu____20714 uu____20715 uu____20716
-                        in
+                         uu____20713 uu____20714 uu____20715 uu____20716 in
                      (FStar_Errors.Fatal_UnificationNotWellFormed,
-                       uu____20712)
-                      in
+                       uu____20712) in
                    FStar_Errors.raise_error uu____20707
                      t1.FStar_Syntax_Syntax.pos
                | (uu____20717,FStar_Syntax_Syntax.Tm_let uu____20718) ->
                    let uu____20731 =
                      let uu____20736 =
-                       let uu____20737 = FStar_Syntax_Print.tag_of_term t1
-                          in
-                       let uu____20738 = FStar_Syntax_Print.tag_of_term t2
-                          in
-                       let uu____20739 = FStar_Syntax_Print.term_to_string t1
-                          in
-                       let uu____20740 = FStar_Syntax_Print.term_to_string t2
-                          in
+                       let uu____20737 = FStar_Syntax_Print.tag_of_term t1 in
+                       let uu____20738 = FStar_Syntax_Print.tag_of_term t2 in
+                       let uu____20739 = FStar_Syntax_Print.term_to_string t1 in
+                       let uu____20740 = FStar_Syntax_Print.term_to_string t2 in
                        FStar_Util.format4
                          "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                         uu____20737 uu____20738 uu____20739 uu____20740
-                        in
+                         uu____20737 uu____20738 uu____20739 uu____20740 in
                      (FStar_Errors.Fatal_UnificationNotWellFormed,
-                       uu____20736)
-                      in
+                       uu____20736) in
                    FStar_Errors.raise_error uu____20731
                      t1.FStar_Syntax_Syntax.pos
                | uu____20741 -> giveup env "head tag mismatch" orig)))
-
-and (solve_c :
+and solve_c:
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.comp,Prims.unit) FStar_TypeChecker_Common.problem ->
-      worklist -> solution)
+      worklist -> solution
   =
   fun env  ->
     fun problem  ->
       fun wl  ->
-        let c1 = problem.FStar_TypeChecker_Common.lhs  in
-        let c2 = problem.FStar_TypeChecker_Common.rhs  in
-        let orig = FStar_TypeChecker_Common.CProb problem  in
+        let c1 = problem.FStar_TypeChecker_Common.lhs in
+        let c2 = problem.FStar_TypeChecker_Common.rhs in
+        let orig = FStar_TypeChecker_Common.CProb problem in
         let sub_prob t1 rel t2 reason =
           mk_problem (p_scope orig) orig t1 rel t2
-            FStar_Pervasives_Native.None reason
-           in
+            FStar_Pervasives_Native.None reason in
         let solve_eq c1_comp c2_comp =
           (let uu____20777 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-               (FStar_Options.Other "EQ")
-              in
+               (FStar_Options.Other "EQ") in
            if uu____20777
            then
              FStar_Util.print_string
@@ -8080,15 +7372,12 @@ and (solve_c :
             (let uu____20779 =
                let uu____20780 =
                  FStar_Syntax_Print.lid_to_string
-                   c1_comp.FStar_Syntax_Syntax.effect_name
-                  in
+                   c1_comp.FStar_Syntax_Syntax.effect_name in
                let uu____20781 =
                  FStar_Syntax_Print.lid_to_string
-                   c2_comp.FStar_Syntax_Syntax.effect_name
-                  in
+                   c2_comp.FStar_Syntax_Syntax.effect_name in
                FStar_Util.format2 "incompatible effects: %s <> %s"
-                 uu____20780 uu____20781
-                in
+                 uu____20780 uu____20781 in
              giveup env uu____20779 orig)
           else
             (let sub_probs =
@@ -8099,29 +7388,25 @@ and (solve_c :
                       | ((a1,uu____20820),(a2,uu____20822)) ->
                           let uu____20831 =
                             sub_prob a1 FStar_TypeChecker_Common.EQ a2
-                              "effect arg"
-                             in
+                              "effect arg" in
                           FStar_All.pipe_left
                             (fun _0_88  ->
                                FStar_TypeChecker_Common.TProb _0_88)
                             uu____20831)
                  c1_comp.FStar_Syntax_Syntax.effect_args
-                 c2_comp.FStar_Syntax_Syntax.effect_args
-                in
+                 c2_comp.FStar_Syntax_Syntax.effect_args in
              let guard =
                let uu____20841 =
                  FStar_List.map
                    (fun p  ->
                       FStar_All.pipe_right (p_guard p)
-                        FStar_Pervasives_Native.fst) sub_probs
-                  in
-               FStar_Syntax_Util.mk_conj_l uu____20841  in
+                        FStar_Pervasives_Native.fst) sub_probs in
+               FStar_Syntax_Util.mk_conj_l uu____20841 in
              let wl1 =
-               solve_prob orig (FStar_Pervasives_Native.Some guard) [] wl  in
-             solve env (attempt sub_probs wl1))
-           in
+               solve_prob orig (FStar_Pervasives_Native.Some guard) [] wl in
+             solve env (attempt sub_probs wl1)) in
         let solve_sub c11 edge c21 =
-          let r = FStar_TypeChecker_Env.get_range env  in
+          let r = FStar_TypeChecker_Env.get_range env in
           let lift_c1 uu____20865 =
             let wp =
               match c11.FStar_Syntax_Syntax.effect_args with
@@ -8131,32 +7416,27 @@ and (solve_c :
                     let uu____20899 =
                       FStar_Range.string_of_range
                         (FStar_Ident.range_of_lid
-                           c11.FStar_Syntax_Syntax.effect_name)
-                       in
+                           c11.FStar_Syntax_Syntax.effect_name) in
                     FStar_Util.format1
                       "Unexpected number of indices on a normalized effect (%s)"
-                      uu____20899
-                     in
-                  failwith uu____20898
-               in
+                      uu____20899 in
+                  failwith uu____20898 in
             let univs1 =
               match c11.FStar_Syntax_Syntax.comp_univs with
               | [] ->
                   let uu____20907 =
                     env.FStar_TypeChecker_Env.universe_of env
-                      c11.FStar_Syntax_Syntax.result_typ
-                     in
+                      c11.FStar_Syntax_Syntax.result_typ in
                   [uu____20907]
-              | x -> x  in
+              | x -> x in
             let uu____20909 =
               let uu____20918 =
                 let uu____20919 =
-                  let uu____20920 = FStar_List.hd univs1  in
+                  let uu____20920 = FStar_List.hd univs1 in
                   (edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
-                    uu____20920 c11.FStar_Syntax_Syntax.result_typ wp
-                   in
-                FStar_Syntax_Syntax.as_arg uu____20919  in
-              [uu____20918]  in
+                    uu____20920 c11.FStar_Syntax_Syntax.result_typ wp in
+                FStar_Syntax_Syntax.as_arg uu____20919 in
+              [uu____20918] in
             {
               FStar_Syntax_Syntax.comp_univs = univs1;
               FStar_Syntax_Syntax.effect_name =
@@ -8165,11 +7445,11 @@ and (solve_c :
                 (c11.FStar_Syntax_Syntax.result_typ);
               FStar_Syntax_Syntax.effect_args = uu____20909;
               FStar_Syntax_Syntax.flags = (c11.FStar_Syntax_Syntax.flags)
-            }  in
+            } in
           if
             problem.FStar_TypeChecker_Common.relation =
               FStar_TypeChecker_Common.EQ
-          then let uu____20921 = lift_c1 ()  in solve_eq uu____20921 c21
+          then let uu____20921 = lift_c1 () in solve_eq uu____20921 c21
           else
             (let is_null_wp_2 =
                FStar_All.pipe_right c21.FStar_Syntax_Syntax.flags
@@ -8179,8 +7459,7 @@ and (solve_c :
                        | FStar_Syntax_Syntax.TOTAL  -> true
                        | FStar_Syntax_Syntax.MLEFFECT  -> true
                        | FStar_Syntax_Syntax.SOMETRIVIAL  -> true
-                       | uu____20928 -> false))
-                in
+                       | uu____20928 -> false)) in
              let uu____20929 =
                match ((c11.FStar_Syntax_Syntax.effect_args),
                        (c21.FStar_Syntax_Syntax.effect_args))
@@ -8192,24 +7471,19 @@ and (solve_c :
                      let uu____21050 =
                        let uu____21051 =
                          FStar_Syntax_Print.lid_to_string
-                           c11.FStar_Syntax_Syntax.effect_name
-                          in
+                           c11.FStar_Syntax_Syntax.effect_name in
                        let uu____21052 =
                          FStar_Syntax_Print.lid_to_string
-                           c21.FStar_Syntax_Syntax.effect_name
-                          in
+                           c21.FStar_Syntax_Syntax.effect_name in
                        FStar_Util.format2
                          "Got effects %s and %s, expected normalized effects"
-                         uu____21051 uu____21052
-                        in
-                     (FStar_Errors.Fatal_ExpectNormalizedEffect, uu____21050)
-                      in
+                         uu____21051 uu____21052 in
+                     (FStar_Errors.Fatal_ExpectNormalizedEffect, uu____21050) in
                    FStar_Errors.raise_error uu____21045
-                     env.FStar_TypeChecker_Env.range
-                in
+                     env.FStar_TypeChecker_Env.range in
              match uu____20929 with
              | (wpc1,wpc2) ->
-                 let uu____21071 = FStar_Util.physical_equality wpc1 wpc2  in
+                 let uu____21071 = FStar_Util.physical_equality wpc1 wpc2 in
                  if uu____21071
                  then
                    let uu____21074 =
@@ -8217,88 +7491,74 @@ and (solve_c :
                        c11.FStar_Syntax_Syntax.result_typ
                        problem.FStar_TypeChecker_Common.relation
                        c21.FStar_Syntax_Syntax.result_typ
-                       FStar_Pervasives_Native.None "result type"
-                      in
+                       FStar_Pervasives_Native.None "result type" in
                    solve_t env uu____21074 wl
                  else
                    (let uu____21078 =
                       let uu____21085 =
                         FStar_TypeChecker_Env.effect_decl_opt env
-                          c21.FStar_Syntax_Syntax.effect_name
-                         in
-                      FStar_Util.must uu____21085  in
+                          c21.FStar_Syntax_Syntax.effect_name in
+                      FStar_Util.must uu____21085 in
                     match uu____21078 with
                     | (c2_decl,qualifiers) ->
                         let uu____21106 =
                           FStar_All.pipe_right qualifiers
                             (FStar_List.contains
-                               FStar_Syntax_Syntax.Reifiable)
-                           in
+                               FStar_Syntax_Syntax.Reifiable) in
                         if uu____21106
                         then
                           let c1_repr =
                             let uu____21110 =
                               let uu____21111 =
-                                let uu____21112 = lift_c1 ()  in
-                                FStar_Syntax_Syntax.mk_Comp uu____21112  in
+                                let uu____21112 = lift_c1 () in
+                                FStar_Syntax_Syntax.mk_Comp uu____21112 in
                               let uu____21113 =
                                 env.FStar_TypeChecker_Env.universe_of env
-                                  c11.FStar_Syntax_Syntax.result_typ
-                                 in
+                                  c11.FStar_Syntax_Syntax.result_typ in
                               FStar_TypeChecker_Env.reify_comp env
-                                uu____21111 uu____21113
-                               in
+                                uu____21111 uu____21113 in
                             FStar_TypeChecker_Normalize.normalize
                               [FStar_TypeChecker_Normalize.UnfoldUntil
                                  FStar_Syntax_Syntax.Delta_constant;
                               FStar_TypeChecker_Normalize.Weak;
                               FStar_TypeChecker_Normalize.HNF] env
-                              uu____21110
-                             in
+                              uu____21110 in
                           let c2_repr =
                             let uu____21115 =
                               let uu____21116 =
-                                FStar_Syntax_Syntax.mk_Comp c21  in
+                                FStar_Syntax_Syntax.mk_Comp c21 in
                               let uu____21117 =
                                 env.FStar_TypeChecker_Env.universe_of env
-                                  c21.FStar_Syntax_Syntax.result_typ
-                                 in
+                                  c21.FStar_Syntax_Syntax.result_typ in
                               FStar_TypeChecker_Env.reify_comp env
-                                uu____21116 uu____21117
-                               in
+                                uu____21116 uu____21117 in
                             FStar_TypeChecker_Normalize.normalize
                               [FStar_TypeChecker_Normalize.UnfoldUntil
                                  FStar_Syntax_Syntax.Delta_constant;
                               FStar_TypeChecker_Normalize.Weak;
                               FStar_TypeChecker_Normalize.HNF] env
-                              uu____21115
-                             in
+                              uu____21115 in
                           let prob =
                             let uu____21119 =
                               let uu____21124 =
                                 let uu____21125 =
-                                  FStar_Syntax_Print.term_to_string c1_repr
-                                   in
+                                  FStar_Syntax_Print.term_to_string c1_repr in
                                 let uu____21126 =
-                                  FStar_Syntax_Print.term_to_string c2_repr
-                                   in
+                                  FStar_Syntax_Print.term_to_string c2_repr in
                                 FStar_Util.format2
                                   "sub effect repr: %s <: %s" uu____21125
-                                  uu____21126
-                                 in
+                                  uu____21126 in
                               sub_prob c1_repr
                                 problem.FStar_TypeChecker_Common.relation
-                                c2_repr uu____21124
-                               in
-                            FStar_TypeChecker_Common.TProb uu____21119  in
+                                c2_repr uu____21124 in
+                            FStar_TypeChecker_Common.TProb uu____21119 in
                           let wl1 =
                             let uu____21128 =
                               let uu____21131 =
                                 FStar_All.pipe_right (p_guard prob)
-                                  FStar_Pervasives_Native.fst
-                                 in
-                              FStar_Pervasives_Native.Some uu____21131  in
-                            solve_prob orig uu____21128 [] wl  in
+                                  FStar_Pervasives_Native.fst in
+                              FStar_Pervasives_Native.Some uu____21131 in
+                            solve_prob orig uu____21128 [] wl in
                           solve env (attempt [prob] wl1)
                         else
                           (let g =
@@ -8310,8 +7570,7 @@ and (solve_c :
                                  ((let uu____21140 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env)
-                                       (FStar_Options.Other "Rel")
-                                      in
+                                       (FStar_Options.Other "Rel") in
                                    if uu____21140
                                    then
                                      FStar_Util.print_string
@@ -8319,140 +7578,119 @@ and (solve_c :
                                    else ());
                                   (let c1_univ =
                                      env.FStar_TypeChecker_Env.universe_of
-                                       env c11.FStar_Syntax_Syntax.result_typ
-                                      in
+                                       env c11.FStar_Syntax_Syntax.result_typ in
                                    let uu____21143 =
                                      let uu____21146 =
                                        let uu____21147 =
                                          let uu____21162 =
                                            FStar_TypeChecker_Env.inst_effect_fun_with
                                              [c1_univ] env c2_decl
-                                             c2_decl.FStar_Syntax_Syntax.trivial
-                                            in
+                                             c2_decl.FStar_Syntax_Syntax.trivial in
                                          let uu____21163 =
                                            let uu____21166 =
                                              FStar_Syntax_Syntax.as_arg
-                                               c11.FStar_Syntax_Syntax.result_typ
-                                              in
+                                               c11.FStar_Syntax_Syntax.result_typ in
                                            let uu____21167 =
                                              let uu____21170 =
                                                let uu____21171 =
                                                  (edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                                                    c1_univ
                                                    c11.FStar_Syntax_Syntax.result_typ
-                                                   wpc1
-                                                  in
+                                                   wpc1 in
                                                FStar_All.pipe_left
                                                  FStar_Syntax_Syntax.as_arg
-                                                 uu____21171
-                                                in
-                                             [uu____21170]  in
-                                           uu____21166 :: uu____21167  in
-                                         (uu____21162, uu____21163)  in
-                                       FStar_Syntax_Syntax.Tm_app uu____21147
-                                        in
-                                     FStar_Syntax_Syntax.mk uu____21146  in
+                                                 uu____21171 in
+                                             [uu____21170] in
+                                           uu____21166 :: uu____21167 in
+                                         (uu____21162, uu____21163) in
+                                       FStar_Syntax_Syntax.Tm_app uu____21147 in
+                                     FStar_Syntax_Syntax.mk uu____21146 in
                                    uu____21143 FStar_Pervasives_Native.None r))
                                else
                                  (let c1_univ =
                                     env.FStar_TypeChecker_Env.universe_of env
-                                      c11.FStar_Syntax_Syntax.result_typ
-                                     in
+                                      c11.FStar_Syntax_Syntax.result_typ in
                                   let c2_univ =
                                     env.FStar_TypeChecker_Env.universe_of env
-                                      c21.FStar_Syntax_Syntax.result_typ
-                                     in
+                                      c21.FStar_Syntax_Syntax.result_typ in
                                   let uu____21180 =
                                     let uu____21183 =
                                       let uu____21184 =
                                         let uu____21199 =
                                           FStar_TypeChecker_Env.inst_effect_fun_with
                                             [c2_univ] env c2_decl
-                                            c2_decl.FStar_Syntax_Syntax.stronger
-                                           in
+                                            c2_decl.FStar_Syntax_Syntax.stronger in
                                         let uu____21200 =
                                           let uu____21203 =
                                             FStar_Syntax_Syntax.as_arg
-                                              c21.FStar_Syntax_Syntax.result_typ
-                                             in
+                                              c21.FStar_Syntax_Syntax.result_typ in
                                           let uu____21204 =
                                             let uu____21207 =
-                                              FStar_Syntax_Syntax.as_arg wpc2
-                                               in
+                                              FStar_Syntax_Syntax.as_arg wpc2 in
                                             let uu____21208 =
                                               let uu____21211 =
                                                 let uu____21212 =
                                                   (edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                                                     c1_univ
                                                     c11.FStar_Syntax_Syntax.result_typ
-                                                    wpc1
-                                                   in
+                                                    wpc1 in
                                                 FStar_All.pipe_left
                                                   FStar_Syntax_Syntax.as_arg
-                                                  uu____21212
-                                                 in
-                                              [uu____21211]  in
-                                            uu____21207 :: uu____21208  in
-                                          uu____21203 :: uu____21204  in
-                                        (uu____21199, uu____21200)  in
-                                      FStar_Syntax_Syntax.Tm_app uu____21184
-                                       in
-                                    FStar_Syntax_Syntax.mk uu____21183  in
-                                  uu____21180 FStar_Pervasives_Native.None r)
-                              in
+                                                  uu____21212 in
+                                              [uu____21211] in
+                                            uu____21207 :: uu____21208 in
+                                          uu____21203 :: uu____21204 in
+                                        (uu____21199, uu____21200) in
+                                      FStar_Syntax_Syntax.Tm_app uu____21184 in
+                                    FStar_Syntax_Syntax.mk uu____21183 in
+                                  uu____21180 FStar_Pervasives_Native.None r) in
                            let base_prob =
                              let uu____21219 =
                                sub_prob c11.FStar_Syntax_Syntax.result_typ
                                  problem.FStar_TypeChecker_Common.relation
                                  c21.FStar_Syntax_Syntax.result_typ
-                                 "result type"
-                                in
+                                 "result type" in
                              FStar_All.pipe_left
                                (fun _0_89  ->
                                   FStar_TypeChecker_Common.TProb _0_89)
-                               uu____21219
-                              in
+                               uu____21219 in
                            let wl1 =
                              let uu____21229 =
                                let uu____21232 =
                                  let uu____21235 =
                                    FStar_All.pipe_right (p_guard base_prob)
-                                     FStar_Pervasives_Native.fst
-                                    in
-                                 FStar_Syntax_Util.mk_conj uu____21235 g  in
+                                     FStar_Pervasives_Native.fst in
+                                 FStar_Syntax_Util.mk_conj uu____21235 g in
                                FStar_All.pipe_left
                                  (fun _0_90  ->
                                     FStar_Pervasives_Native.Some _0_90)
-                                 uu____21232
-                                in
-                             solve_prob orig uu____21229 [] wl  in
-                           solve env (attempt [base_prob] wl1))))
-           in
-        let uu____21248 = FStar_Util.physical_equality c1 c2  in
+                                 uu____21232 in
+                             solve_prob orig uu____21229 [] wl in
+                           solve env (attempt [base_prob] wl1)))) in
+        let uu____21248 = FStar_Util.physical_equality c1 c2 in
         if uu____21248
         then
           let uu____21249 =
-            solve_prob orig FStar_Pervasives_Native.None [] wl  in
+            solve_prob orig FStar_Pervasives_Native.None [] wl in
           solve env uu____21249
         else
           ((let uu____21252 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                (FStar_Options.Other "Rel")
-               in
+                (FStar_Options.Other "Rel") in
             if uu____21252
             then
-              let uu____21253 = FStar_Syntax_Print.comp_to_string c1  in
-              let uu____21254 = FStar_Syntax_Print.comp_to_string c2  in
+              let uu____21253 = FStar_Syntax_Print.comp_to_string c1 in
+              let uu____21254 = FStar_Syntax_Print.comp_to_string c2 in
               FStar_Util.print3 "solve_c %s %s %s\n" uu____21253
                 (rel_to_string problem.FStar_TypeChecker_Common.relation)
                 uu____21254
             else ());
            (let uu____21256 =
               let uu____21261 =
-                FStar_TypeChecker_Normalize.ghost_to_pure env c1  in
+                FStar_TypeChecker_Normalize.ghost_to_pure env c1 in
               let uu____21262 =
-                FStar_TypeChecker_Normalize.ghost_to_pure env c2  in
-              (uu____21261, uu____21262)  in
+                FStar_TypeChecker_Normalize.ghost_to_pure env c2 in
+              (uu____21261, uu____21262) in
             match uu____21256 with
             | (c11,c21) ->
                 (match ((c11.FStar_Syntax_Syntax.n),
@@ -8465,8 +7703,7 @@ and (solve_c :
                      let uu____21285 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
-                         FStar_Pervasives_Native.None "result type"
-                        in
+                         FStar_Pervasives_Native.None "result type" in
                      solve_t env uu____21285 wl
                  | (FStar_Syntax_Syntax.GTotal
                     uu____21288,FStar_Syntax_Syntax.Total uu____21289) ->
@@ -8478,8 +7715,7 @@ and (solve_c :
                      let uu____21326 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
-                         FStar_Pervasives_Native.None "result type"
-                        in
+                         FStar_Pervasives_Native.None "result type" in
                      solve_t env uu____21326 wl
                  | (FStar_Syntax_Syntax.GTotal
                     (t1,uu____21330),FStar_Syntax_Syntax.GTotal
@@ -8487,8 +7723,7 @@ and (solve_c :
                      let uu____21349 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
-                         FStar_Pervasives_Native.None "result type"
-                        in
+                         FStar_Pervasives_Native.None "result type" in
                      solve_t env uu____21349 wl
                  | (FStar_Syntax_Syntax.Total
                     (t1,uu____21353),FStar_Syntax_Syntax.GTotal
@@ -8496,19 +7731,17 @@ and (solve_c :
                      let uu____21372 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
-                         FStar_Pervasives_Native.None "result type"
-                        in
+                         FStar_Pervasives_Native.None "result type" in
                      solve_t env uu____21372 wl
                  | (FStar_Syntax_Syntax.GTotal
                     uu____21375,FStar_Syntax_Syntax.Comp uu____21376) ->
                      let uu____21385 =
-                       let uu___160_21390 = problem  in
+                       let uu___160_21390 = problem in
                        let uu____21395 =
                          let uu____21396 =
-                           FStar_TypeChecker_Env.comp_to_comp_typ env c11  in
+                           FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____21396
-                          in
+                           uu____21396 in
                        {
                          FStar_TypeChecker_Common.pid =
                            (uu___160_21390.FStar_TypeChecker_Common.pid);
@@ -8529,18 +7762,17 @@ and (solve_c :
                            (uu___160_21390.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
                            (uu___160_21390.FStar_TypeChecker_Common.rank)
-                       }  in
+                       } in
                      solve_c env uu____21385 wl
                  | (FStar_Syntax_Syntax.Total
                     uu____21397,FStar_Syntax_Syntax.Comp uu____21398) ->
                      let uu____21407 =
-                       let uu___160_21412 = problem  in
+                       let uu___160_21412 = problem in
                        let uu____21417 =
                          let uu____21418 =
-                           FStar_TypeChecker_Env.comp_to_comp_typ env c11  in
+                           FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____21418
-                          in
+                           uu____21418 in
                        {
                          FStar_TypeChecker_Common.pid =
                            (uu___160_21412.FStar_TypeChecker_Common.pid);
@@ -8561,18 +7793,17 @@ and (solve_c :
                            (uu___160_21412.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
                            (uu___160_21412.FStar_TypeChecker_Common.rank)
-                       }  in
+                       } in
                      solve_c env uu____21407 wl
                  | (FStar_Syntax_Syntax.Comp
                     uu____21419,FStar_Syntax_Syntax.GTotal uu____21420) ->
                      let uu____21429 =
-                       let uu___161_21434 = problem  in
+                       let uu___161_21434 = problem in
                        let uu____21439 =
                          let uu____21440 =
-                           FStar_TypeChecker_Env.comp_to_comp_typ env c21  in
+                           FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____21440
-                          in
+                           uu____21440 in
                        {
                          FStar_TypeChecker_Common.pid =
                            (uu___161_21434.FStar_TypeChecker_Common.pid);
@@ -8593,18 +7824,17 @@ and (solve_c :
                            (uu___161_21434.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
                            (uu___161_21434.FStar_TypeChecker_Common.rank)
-                       }  in
+                       } in
                      solve_c env uu____21429 wl
                  | (FStar_Syntax_Syntax.Comp
                     uu____21441,FStar_Syntax_Syntax.Total uu____21442) ->
                      let uu____21451 =
-                       let uu___161_21456 = problem  in
+                       let uu___161_21456 = problem in
                        let uu____21461 =
                          let uu____21462 =
-                           FStar_TypeChecker_Env.comp_to_comp_typ env c21  in
+                           FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____21462
-                          in
+                           uu____21462 in
                        {
                          FStar_TypeChecker_Common.pid =
                            (uu___161_21456.FStar_TypeChecker_Common.pid);
@@ -8625,7 +7855,7 @@ and (solve_c :
                            (uu___161_21456.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
                            (uu___161_21456.FStar_TypeChecker_Common.rank)
-                       }  in
+                       } in
                      solve_c env uu____21451 wl
                  | (FStar_Syntax_Syntax.Comp
                     uu____21463,FStar_Syntax_Syntax.Comp uu____21464) ->
@@ -8640,8 +7870,7 @@ and (solve_c :
                              (FStar_Syntax_Util.is_ml_comp c21))
                             &&
                             (problem.FStar_TypeChecker_Common.relation =
-                               FStar_TypeChecker_Common.SUB))
-                        in
+                               FStar_TypeChecker_Common.SUB)) in
                      if uu____21465
                      then
                        let uu____21466 =
@@ -8649,14 +7878,13 @@ and (solve_c :
                            (FStar_Syntax_Util.comp_result c11)
                            problem.FStar_TypeChecker_Common.relation
                            (FStar_Syntax_Util.comp_result c21)
-                           FStar_Pervasives_Native.None "result type"
-                          in
+                           FStar_Pervasives_Native.None "result type" in
                        solve_t env uu____21466 wl
                      else
                        (let c1_comp =
-                          FStar_TypeChecker_Env.comp_to_comp_typ env c11  in
+                          FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
                         let c2_comp =
-                          FStar_TypeChecker_Env.comp_to_comp_typ env c21  in
+                          FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
                         if
                           problem.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
@@ -8670,30 +7898,24 @@ and (solve_c :
                             else
                               (let uu____21482 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
-                                   env c11
-                                  in
+                                   env c11 in
                                let uu____21483 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
-                                   env c21
-                                  in
-                               (uu____21482, uu____21483))
-                             in
+                                   env c21 in
+                               (uu____21482, uu____21483)) in
                           match uu____21472 with
                           | (c1_comp1,c2_comp1) -> solve_eq c1_comp1 c2_comp1
                         else
                           (let c12 =
                              FStar_TypeChecker_Env.unfold_effect_abbrev env
-                               c11
-                              in
+                               c11 in
                            let c22 =
                              FStar_TypeChecker_Env.unfold_effect_abbrev env
-                               c21
-                              in
+                               c21 in
                            (let uu____21490 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
-                                (FStar_Options.Other "Rel")
-                               in
+                                (FStar_Options.Other "Rel") in
                             if uu____21490
                             then
                               FStar_Util.print2 "solve_c for %s and %s\n"
@@ -8703,29 +7925,23 @@ and (solve_c :
                            (let uu____21492 =
                               FStar_TypeChecker_Env.monad_leq env
                                 c12.FStar_Syntax_Syntax.effect_name
-                                c22.FStar_Syntax_Syntax.effect_name
-                               in
+                                c22.FStar_Syntax_Syntax.effect_name in
                             match uu____21492 with
                             | FStar_Pervasives_Native.None  ->
                                 let uu____21495 =
                                   let uu____21496 =
                                     FStar_Syntax_Print.lid_to_string
-                                      c12.FStar_Syntax_Syntax.effect_name
-                                     in
+                                      c12.FStar_Syntax_Syntax.effect_name in
                                   let uu____21497 =
                                     FStar_Syntax_Print.lid_to_string
-                                      c22.FStar_Syntax_Syntax.effect_name
-                                     in
+                                      c22.FStar_Syntax_Syntax.effect_name in
                                   FStar_Util.format2
                                     "incompatible monad ordering: %s </: %s"
-                                    uu____21496 uu____21497
-                                   in
+                                    uu____21496 uu____21497 in
                                 giveup env uu____21495 orig
                             | FStar_Pervasives_Native.Some edge ->
                                 solve_sub c12 edge c22))))))
-
-let (print_pending_implicits : FStar_TypeChecker_Env.guard_t -> Prims.string)
-  =
+let print_pending_implicits: FStar_TypeChecker_Env.guard_t -> Prims.string =
   fun g  ->
     let uu____21502 =
       FStar_All.pipe_right g.FStar_TypeChecker_Env.implicits
@@ -8733,24 +7949,21 @@ let (print_pending_implicits : FStar_TypeChecker_Env.guard_t -> Prims.string)
            (fun uu____21540  ->
               match uu____21540 with
               | (uu____21553,uu____21554,u,uu____21556,uu____21557,uu____21558)
-                  -> FStar_Syntax_Print.uvar_to_string u))
-       in
+                  -> FStar_Syntax_Print.uvar_to_string u)) in
     FStar_All.pipe_right uu____21502 (FStar_String.concat ", ")
-  
-let (ineqs_to_string :
+let ineqs_to_string:
   (FStar_Syntax_Syntax.universe Prims.list,(FStar_Syntax_Syntax.universe,
                                              FStar_Syntax_Syntax.universe)
                                              FStar_Pervasives_Native.tuple2
                                              Prims.list)
-    FStar_Pervasives_Native.tuple2 -> Prims.string)
+    FStar_Pervasives_Native.tuple2 -> Prims.string
   =
   fun ineqs  ->
     let vars =
       let uu____21589 =
         FStar_All.pipe_right (FStar_Pervasives_Native.fst ineqs)
-          (FStar_List.map FStar_Syntax_Print.univ_to_string)
-         in
-      FStar_All.pipe_right uu____21589 (FStar_String.concat ", ")  in
+          (FStar_List.map FStar_Syntax_Print.univ_to_string) in
+      FStar_All.pipe_right uu____21589 (FStar_String.concat ", ") in
     let ineqs1 =
       let uu____21607 =
         FStar_All.pipe_right (FStar_Pervasives_Native.snd ineqs)
@@ -8758,17 +7971,13 @@ let (ineqs_to_string :
              (fun uu____21635  ->
                 match uu____21635 with
                 | (u1,u2) ->
-                    let uu____21642 = FStar_Syntax_Print.univ_to_string u1
-                       in
-                    let uu____21643 = FStar_Syntax_Print.univ_to_string u2
-                       in
-                    FStar_Util.format2 "%s < %s" uu____21642 uu____21643))
-         in
-      FStar_All.pipe_right uu____21607 (FStar_String.concat ", ")  in
+                    let uu____21642 = FStar_Syntax_Print.univ_to_string u1 in
+                    let uu____21643 = FStar_Syntax_Print.univ_to_string u2 in
+                    FStar_Util.format2 "%s < %s" uu____21642 uu____21643)) in
+      FStar_All.pipe_right uu____21607 (FStar_String.concat ", ") in
     FStar_Util.format2 "Solving for {%s}; inequalities are {%s}" vars ineqs1
-  
-let (guard_to_string :
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.string)
+let guard_to_string:
+  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.string
   =
   fun env  ->
     fun g  ->
@@ -8790,29 +7999,25 @@ let (guard_to_string :
                         (FStar_Options.Other "Implicits")))
                     ||
                     (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                       FStar_Options.Extreme)
-                   in
+                       FStar_Options.Extreme) in
                 if uu____21702
                 then FStar_TypeChecker_Normalize.term_to_string env f
-                else "non-trivial"
-             in
+                else "non-trivial" in
           let carry =
             let uu____21705 =
               FStar_List.map
                 (fun uu____21715  ->
                    match uu____21715 with
                    | (uu____21720,x) -> prob_to_string env x)
-                g.FStar_TypeChecker_Env.deferred
-               in
-            FStar_All.pipe_right uu____21705 (FStar_String.concat ",\n")  in
-          let imps = print_pending_implicits g  in
+                g.FStar_TypeChecker_Env.deferred in
+            FStar_All.pipe_right uu____21705 (FStar_String.concat ",\n") in
+          let imps = print_pending_implicits g in
           let uu____21725 =
-            ineqs_to_string g.FStar_TypeChecker_Env.univ_ineqs  in
+            ineqs_to_string g.FStar_TypeChecker_Env.univ_ineqs in
           FStar_Util.format4
             "\n\t{guard_f=%s;\n\t deferred={\n%s};\n\t univ_ineqs={%s};\n\t implicits={%s}}\n"
             form carry uu____21725 imps
-  
-let new_t_problem :
+let new_t_problem:
   'Auu____21733 .
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term ->
@@ -8832,26 +8037,24 @@ let new_t_problem :
               let reason =
                 let uu____21767 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                    (FStar_Options.Other "ExplainRel")
-                   in
+                    (FStar_Options.Other "ExplainRel") in
                 if uu____21767
                 then
                   let uu____21768 =
-                    FStar_TypeChecker_Normalize.term_to_string env lhs  in
+                    FStar_TypeChecker_Normalize.term_to_string env lhs in
                   let uu____21769 =
-                    FStar_TypeChecker_Normalize.term_to_string env rhs  in
+                    FStar_TypeChecker_Normalize.term_to_string env rhs in
                   FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____21768
                     (rel_to_string rel) uu____21769
-                else "TOP"  in
-              let p = new_problem env lhs rel rhs elt loc reason  in p
-  
-let (new_t_prob :
+                else "TOP" in
+              let p = new_problem env lhs rel rhs elt loc reason in p
+let new_t_prob:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
       FStar_TypeChecker_Common.rel ->
         FStar_Syntax_Syntax.term ->
           (FStar_TypeChecker_Common.prob,FStar_Syntax_Syntax.bv)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun t1  ->
@@ -8859,40 +8062,37 @@ let (new_t_prob :
         fun t2  ->
           let x =
             let uu____21793 =
-              let uu____21796 = FStar_TypeChecker_Env.get_range env  in
+              let uu____21796 = FStar_TypeChecker_Env.get_range env in
               FStar_All.pipe_left
                 (fun _0_91  -> FStar_Pervasives_Native.Some _0_91)
-                uu____21796
-               in
-            FStar_Syntax_Syntax.new_bv uu____21793 t1  in
-          let env1 = FStar_TypeChecker_Env.push_bv env x  in
+                uu____21796 in
+            FStar_Syntax_Syntax.new_bv uu____21793 t1 in
+          let env1 = FStar_TypeChecker_Env.push_bv env x in
           let p =
             let uu____21805 =
-              let uu____21808 = FStar_Syntax_Syntax.bv_to_name x  in
+              let uu____21808 = FStar_Syntax_Syntax.bv_to_name x in
               FStar_All.pipe_left
                 (fun _0_92  -> FStar_Pervasives_Native.Some _0_92)
-                uu____21808
-               in
-            let uu____21811 = FStar_TypeChecker_Env.get_range env1  in
-            new_t_problem env1 t1 rel t2 uu____21805 uu____21811  in
+                uu____21808 in
+            let uu____21811 = FStar_TypeChecker_Env.get_range env1 in
+            new_t_problem env1 t1 rel t2 uu____21805 uu____21811 in
           ((FStar_TypeChecker_Common.TProb p), x)
-  
-let (solve_and_commit :
+let solve_and_commit:
   FStar_TypeChecker_Env.env ->
     worklist ->
       ((FStar_TypeChecker_Common.prob,Prims.string)
          FStar_Pervasives_Native.tuple2 ->
          FStar_TypeChecker_Common.deferred FStar_Pervasives_Native.option)
-        -> FStar_TypeChecker_Common.deferred FStar_Pervasives_Native.option)
+        -> FStar_TypeChecker_Common.deferred FStar_Pervasives_Native.option
   =
   fun env  ->
     fun probs  ->
       fun err  ->
         let probs1 =
-          let uu____21841 = FStar_Options.eager_inference ()  in
+          let uu____21841 = FStar_Options.eager_inference () in
           if uu____21841
           then
-            let uu___162_21842 = probs  in
+            let uu___162_21842 = probs in
             {
               attempting = (uu___162_21842.attempting);
               wl_deferred = (uu___162_21842.wl_deferred);
@@ -8901,9 +8101,9 @@ let (solve_and_commit :
               smt_ok = (uu___162_21842.smt_ok);
               tcenv = (uu___162_21842.tcenv)
             }
-          else probs  in
-        let tx = FStar_Syntax_Unionfind.new_transaction ()  in
-        let sol = solve env probs1  in
+          else probs in
+        let tx = FStar_Syntax_Unionfind.new_transaction () in
+        let sol = solve env probs1 in
         match sol with
         | Success deferred ->
             (FStar_Syntax_Unionfind.commit tx;
@@ -8911,19 +8111,17 @@ let (solve_and_commit :
         | Failed (d,s) ->
             ((let uu____21853 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "ExplainRel")
-                 in
+                  (FStar_Options.Other "ExplainRel") in
               if uu____21853
               then
-                let uu____21854 = explain env d s  in
+                let uu____21854 = explain env d s in
                 FStar_All.pipe_left FStar_Util.print_string uu____21854
               else ());
-             (let result = err (d, s)  in
+             (let result = err (d, s) in
               FStar_Syntax_Unionfind.rollback tx; result))
-  
-let (simplify_guard :
+let simplify_guard:
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun env  ->
     fun g  ->
@@ -8932,11 +8130,10 @@ let (simplify_guard :
       | FStar_TypeChecker_Common.NonTrivial f ->
           ((let uu____21868 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                (FStar_Options.Other "Simplification")
-               in
+                (FStar_Options.Other "Simplification") in
             if uu____21868
             then
-              let uu____21869 = FStar_Syntax_Print.term_to_string f  in
+              let uu____21869 = FStar_Syntax_Print.term_to_string f in
               FStar_Util.print1 "Simplifying guard %s\n" uu____21869
             else ());
            (let f1 =
@@ -8945,28 +8142,26 @@ let (simplify_guard :
                 FStar_TypeChecker_Normalize.Eager_unfolding;
                 FStar_TypeChecker_Normalize.Simplify;
                 FStar_TypeChecker_Normalize.Primops;
-                FStar_TypeChecker_Normalize.NoFullNorm] env f
-               in
+                FStar_TypeChecker_Normalize.NoFullNorm] env f in
             (let uu____21873 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                 (FStar_Options.Other "Simplification")
-                in
+                 (FStar_Options.Other "Simplification") in
              if uu____21873
              then
-               let uu____21874 = FStar_Syntax_Print.term_to_string f1  in
+               let uu____21874 = FStar_Syntax_Print.term_to_string f1 in
                FStar_Util.print1 "Simplified guard to %s\n" uu____21874
              else ());
             (let f2 =
                let uu____21877 =
-                 let uu____21878 = FStar_Syntax_Util.unmeta f1  in
-                 uu____21878.FStar_Syntax_Syntax.n  in
+                 let uu____21878 = FStar_Syntax_Util.unmeta f1 in
+                 uu____21878.FStar_Syntax_Syntax.n in
                match uu____21877 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.true_lid
                    -> FStar_TypeChecker_Common.Trivial
-               | uu____21882 -> FStar_TypeChecker_Common.NonTrivial f1  in
-             let uu___163_21883 = g  in
+               | uu____21882 -> FStar_TypeChecker_Common.NonTrivial f1 in
+             let uu___163_21883 = g in
              {
                FStar_TypeChecker_Env.guard_f = f2;
                FStar_TypeChecker_Env.deferred =
@@ -8976,12 +8171,11 @@ let (simplify_guard :
                FStar_TypeChecker_Env.implicits =
                  (uu___163_21883.FStar_TypeChecker_Env.implicits)
              })))
-  
-let (with_guard :
+let with_guard:
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
       FStar_TypeChecker_Common.deferred FStar_Pervasives_Native.option ->
-        FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option)
+        FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option
   =
   fun env  ->
     fun prob  ->
@@ -8994,22 +8188,19 @@ let (with_guard :
                 let uu____21904 =
                   let uu____21905 =
                     FStar_All.pipe_right (p_guard prob)
-                      FStar_Pervasives_Native.fst
-                     in
+                      FStar_Pervasives_Native.fst in
                   FStar_All.pipe_right uu____21905
-                    (fun _0_93  -> FStar_TypeChecker_Common.NonTrivial _0_93)
-                   in
+                    (fun _0_93  -> FStar_TypeChecker_Common.NonTrivial _0_93) in
                 {
                   FStar_TypeChecker_Env.guard_f = uu____21904;
                   FStar_TypeChecker_Env.deferred = d;
                   FStar_TypeChecker_Env.univ_ineqs = ([], []);
                   FStar_TypeChecker_Env.implicits = []
-                }  in
-              simplify_guard env uu____21903  in
+                } in
+              simplify_guard env uu____21903 in
             FStar_All.pipe_left
               (fun _0_94  -> FStar_Pervasives_Native.Some _0_94) uu____21902
-  
-let with_guard_no_simp :
+let with_guard_no_simp:
   'Auu____21932 .
     'Auu____21932 ->
       FStar_TypeChecker_Common.prob ->
@@ -9026,25 +8217,22 @@ let with_guard_no_simp :
               let uu____21953 =
                 let uu____21954 =
                   FStar_All.pipe_right (p_guard prob)
-                    FStar_Pervasives_Native.fst
-                   in
+                    FStar_Pervasives_Native.fst in
                 FStar_All.pipe_right uu____21954
-                  (fun _0_95  -> FStar_TypeChecker_Common.NonTrivial _0_95)
-                 in
+                  (fun _0_95  -> FStar_TypeChecker_Common.NonTrivial _0_95) in
               {
                 FStar_TypeChecker_Env.guard_f = uu____21953;
                 FStar_TypeChecker_Env.deferred = d;
                 FStar_TypeChecker_Env.univ_ineqs = ([], []);
                 FStar_TypeChecker_Env.implicits = []
-              }  in
+              } in
             FStar_Pervasives_Native.Some uu____21952
-  
-let (try_teq :
+let try_teq:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.typ ->
         FStar_Syntax_Syntax.typ ->
-          FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option)
+          FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option
   =
   fun smt_ok  ->
     fun env  ->
@@ -9052,132 +8240,117 @@ let (try_teq :
         fun t2  ->
           (let uu____21992 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-               (FStar_Options.Other "Rel")
-              in
+               (FStar_Options.Other "Rel") in
            if uu____21992
            then
-             let uu____21993 = FStar_Syntax_Print.term_to_string t1  in
-             let uu____21994 = FStar_Syntax_Print.term_to_string t2  in
+             let uu____21993 = FStar_Syntax_Print.term_to_string t1 in
+             let uu____21994 = FStar_Syntax_Print.term_to_string t2 in
              FStar_Util.print2 "try_teq of %s and %s\n" uu____21993
                uu____21994
            else ());
           (let prob =
              let uu____21997 =
-               let uu____22002 = FStar_TypeChecker_Env.get_range env  in
+               let uu____22002 = FStar_TypeChecker_Env.get_range env in
                new_t_problem env t1 FStar_TypeChecker_Common.EQ t2
-                 FStar_Pervasives_Native.None uu____22002
-                in
+                 FStar_Pervasives_Native.None uu____22002 in
              FStar_All.pipe_left
                (fun _0_96  -> FStar_TypeChecker_Common.TProb _0_96)
-               uu____21997
-              in
+               uu____21997 in
            let g =
              let uu____22010 =
-               let uu____22013 = singleton' env prob smt_ok  in
+               let uu____22013 = singleton' env prob smt_ok in
                solve_and_commit env uu____22013
-                 (fun uu____22015  -> FStar_Pervasives_Native.None)
-                in
-             FStar_All.pipe_left (with_guard env prob) uu____22010  in
+                 (fun uu____22015  -> FStar_Pervasives_Native.None) in
+             FStar_All.pipe_left (with_guard env prob) uu____22010 in
            g)
-  
-let (teq :
+let teq:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.typ -> FStar_TypeChecker_Env.guard_t)
+      FStar_Syntax_Syntax.typ -> FStar_TypeChecker_Env.guard_t
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____22033 = try_teq true env t1 t2  in
+        let uu____22033 = try_teq true env t1 t2 in
         match uu____22033 with
         | FStar_Pervasives_Native.None  ->
-            ((let uu____22037 = FStar_TypeChecker_Env.get_range env  in
+            ((let uu____22037 = FStar_TypeChecker_Env.get_range env in
               let uu____22038 =
                 FStar_TypeChecker_Err.basic_type_error env
-                  FStar_Pervasives_Native.None t2 t1
-                 in
+                  FStar_Pervasives_Native.None t2 t1 in
               FStar_Errors.log_issue uu____22037 uu____22038);
              trivial_guard)
         | FStar_Pervasives_Native.Some g ->
             ((let uu____22045 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "Rel")
-                 in
+                  (FStar_Options.Other "Rel") in
               if uu____22045
               then
-                let uu____22046 = FStar_Syntax_Print.term_to_string t1  in
-                let uu____22047 = FStar_Syntax_Print.term_to_string t2  in
-                let uu____22048 = guard_to_string env g  in
+                let uu____22046 = FStar_Syntax_Print.term_to_string t1 in
+                let uu____22047 = FStar_Syntax_Print.term_to_string t2 in
+                let uu____22048 = guard_to_string env g in
                 FStar_Util.print3
                   "teq of %s and %s succeeded with guard %s\n" uu____22046
                   uu____22047 uu____22048
               else ());
              g)
-  
-let (subtype_fail :
+let subtype_fail:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.unit)
+      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.unit
   =
   fun env  ->
     fun e  ->
       fun t1  ->
         fun t2  ->
-          let uu____22062 = FStar_TypeChecker_Env.get_range env  in
+          let uu____22062 = FStar_TypeChecker_Env.get_range env in
           let uu____22063 =
             FStar_TypeChecker_Err.basic_type_error env
-              (FStar_Pervasives_Native.Some e) t2 t1
-             in
+              (FStar_Pervasives_Native.Some e) t2 t1 in
           FStar_Errors.log_issue uu____22062 uu____22063
-  
-let (sub_comp :
+let sub_comp:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp ->
       FStar_Syntax_Syntax.comp ->
-        FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option)
+        FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option
   =
   fun env  ->
     fun c1  ->
       fun c2  ->
         (let uu____22080 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "Rel")
-            in
+             (FStar_Options.Other "Rel") in
          if uu____22080
          then
-           let uu____22081 = FStar_Syntax_Print.comp_to_string c1  in
-           let uu____22082 = FStar_Syntax_Print.comp_to_string c2  in
+           let uu____22081 = FStar_Syntax_Print.comp_to_string c1 in
+           let uu____22082 = FStar_Syntax_Print.comp_to_string c2 in
            FStar_Util.print2 "sub_comp of %s and %s\n" uu____22081
              uu____22082
          else ());
         (let rel =
            if env.FStar_TypeChecker_Env.use_eq
            then FStar_TypeChecker_Common.EQ
-           else FStar_TypeChecker_Common.SUB  in
+           else FStar_TypeChecker_Common.SUB in
          let prob =
            let uu____22087 =
-             let uu____22092 = FStar_TypeChecker_Env.get_range env  in
+             let uu____22092 = FStar_TypeChecker_Env.get_range env in
              new_problem env c1 rel c2 FStar_Pervasives_Native.None
-               uu____22092 "sub_comp"
-              in
+               uu____22092 "sub_comp" in
            FStar_All.pipe_left
-             (fun _0_97  -> FStar_TypeChecker_Common.CProb _0_97) uu____22087
-            in
+             (fun _0_97  -> FStar_TypeChecker_Common.CProb _0_97) uu____22087 in
          let uu____22097 =
-           let uu____22100 = singleton env prob  in
+           let uu____22100 = singleton env prob in
            solve_and_commit env uu____22100
-             (fun uu____22102  -> FStar_Pervasives_Native.None)
-            in
+             (fun uu____22102  -> FStar_Pervasives_Native.None) in
          FStar_All.pipe_left (with_guard env prob) uu____22097)
-  
-let (solve_universe_inequalities' :
+let solve_universe_inequalities':
   FStar_Syntax_Unionfind.tx ->
     FStar_TypeChecker_Env.env ->
       (FStar_Syntax_Syntax.universe Prims.list,(FStar_Syntax_Syntax.universe,
                                                  FStar_Syntax_Syntax.universe)
                                                  FStar_Pervasives_Native.tuple2
                                                  Prims.list)
-        FStar_Pervasives_Native.tuple2 -> Prims.unit)
+        FStar_Pervasives_Native.tuple2 -> Prims.unit
   =
   fun tx  ->
     fun env  ->
@@ -9188,30 +8361,27 @@ let (solve_universe_inequalities' :
               FStar_Syntax_Unionfind.rollback tx;
               (let uu____22170 =
                  let uu____22175 =
-                   let uu____22176 = FStar_Syntax_Print.univ_to_string u1  in
-                   let uu____22177 = FStar_Syntax_Print.univ_to_string u2  in
+                   let uu____22176 = FStar_Syntax_Print.univ_to_string u1 in
+                   let uu____22177 = FStar_Syntax_Print.univ_to_string u2 in
                    FStar_Util.format2 "Universe %s and %s are incompatible"
-                     uu____22176 uu____22177
-                    in
-                 (FStar_Errors.Fatal_IncompatibleUniverse, uu____22175)  in
-               let uu____22178 = FStar_TypeChecker_Env.get_range env  in
-               FStar_Errors.raise_error uu____22170 uu____22178)
-               in
+                     uu____22176 uu____22177 in
+                 (FStar_Errors.Fatal_IncompatibleUniverse, uu____22175) in
+               let uu____22178 = FStar_TypeChecker_Env.get_range env in
+               FStar_Errors.raise_error uu____22170 uu____22178) in
             let equiv1 v1 v' =
               let uu____22186 =
-                let uu____22191 = FStar_Syntax_Subst.compress_univ v1  in
-                let uu____22192 = FStar_Syntax_Subst.compress_univ v'  in
-                (uu____22191, uu____22192)  in
+                let uu____22191 = FStar_Syntax_Subst.compress_univ v1 in
+                let uu____22192 = FStar_Syntax_Subst.compress_univ v' in
+                (uu____22191, uu____22192) in
               match uu____22186 with
               | (FStar_Syntax_Syntax.U_unif v0,FStar_Syntax_Syntax.U_unif
                  v0') -> FStar_Syntax_Unionfind.univ_equiv v0 v0'
-              | uu____22211 -> false  in
+              | uu____22211 -> false in
             let sols =
               FStar_All.pipe_right variables
                 (FStar_List.collect
                    (fun v1  ->
-                      let uu____22241 = FStar_Syntax_Subst.compress_univ v1
-                         in
+                      let uu____22241 = FStar_Syntax_Subst.compress_univ v1 in
                       match uu____22241 with
                       | FStar_Syntax_Syntax.U_unif uu____22248 ->
                           let lower_bounds_of_v =
@@ -9220,27 +8390,23 @@ let (solve_universe_inequalities' :
                                  (fun uu____22277  ->
                                     match uu____22277 with
                                     | (u,v') ->
-                                        let uu____22286 = equiv1 v1 v'  in
+                                        let uu____22286 = equiv1 v1 v' in
                                         if uu____22286
                                         then
                                           let uu____22289 =
                                             FStar_All.pipe_right variables
-                                              (FStar_Util.for_some (equiv1 u))
-                                             in
+                                              (FStar_Util.for_some (equiv1 u)) in
                                           (if uu____22289 then [] else [u])
-                                        else []))
-                             in
+                                        else [])) in
                           let lb =
                             FStar_TypeChecker_Normalize.normalize_universe
                               env
-                              (FStar_Syntax_Syntax.U_max lower_bounds_of_v)
-                             in
+                              (FStar_Syntax_Syntax.U_max lower_bounds_of_v) in
                           [(lb, v1)]
-                      | uu____22305 -> []))
-               in
+                      | uu____22305 -> [])) in
             let uu____22310 =
               let wl =
-                let uu___164_22314 = empty_worklist env  in
+                let uu___164_22314 = empty_worklist env in
                 {
                   attempting = (uu___164_22314.attempting);
                   wl_deferred = (uu___164_22314.wl_deferred);
@@ -9248,27 +8414,25 @@ let (solve_universe_inequalities' :
                   defer_ok = false;
                   smt_ok = (uu___164_22314.smt_ok);
                   tcenv = (uu___164_22314.tcenv)
-                }  in
+                } in
               FStar_All.pipe_right sols
                 (FStar_List.map
                    (fun uu____22332  ->
                       match uu____22332 with
                       | (lb,v1) ->
                           let uu____22339 =
-                            solve_universe_eq (~- (Prims.parse_int "1")) wl
-                              lb v1
-                             in
+                            solve_universe_eq (- (Prims.parse_int "1")) wl lb
+                              v1 in
                           (match uu____22339 with
                            | USolved wl1 -> ()
-                           | uu____22341 -> fail lb v1)))
-               in
+                           | uu____22341 -> fail lb v1))) in
             let rec check_ineq uu____22349 =
               match uu____22349 with
               | (u,v1) ->
                   let u1 =
-                    FStar_TypeChecker_Normalize.normalize_universe env u  in
+                    FStar_TypeChecker_Normalize.normalize_universe env u in
                   let v2 =
-                    FStar_TypeChecker_Normalize.normalize_universe env v1  in
+                    FStar_TypeChecker_Normalize.normalize_universe env v1 in
                   (match (u1, v2) with
                    | (FStar_Syntax_Syntax.U_zero ,uu____22358) -> true
                    | (FStar_Syntax_Syntax.U_succ
@@ -9293,108 +8457,99 @@ let (solve_universe_inequalities' :
                        FStar_All.pipe_right vs
                          (FStar_Util.for_some
                             (fun v3  -> check_ineq (u1, v3)))
-                   | uu____22409 -> false)
-               in
+                   | uu____22409 -> false) in
             let uu____22414 =
               FStar_All.pipe_right ineqs
                 (FStar_Util.for_all
                    (fun uu____22429  ->
                       match uu____22429 with
                       | (u,v1) ->
-                          let uu____22436 = check_ineq (u, v1)  in
+                          let uu____22436 = check_ineq (u, v1) in
                           if uu____22436
                           then true
                           else
                             ((let uu____22439 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
-                                  (FStar_Options.Other "GenUniverses")
-                                 in
+                                  (FStar_Options.Other "GenUniverses") in
                               if uu____22439
                               then
                                 let uu____22440 =
-                                  FStar_Syntax_Print.univ_to_string u  in
+                                  FStar_Syntax_Print.univ_to_string u in
                                 let uu____22441 =
-                                  FStar_Syntax_Print.univ_to_string v1  in
+                                  FStar_Syntax_Print.univ_to_string v1 in
                                 FStar_Util.print2 "%s </= %s" uu____22440
                                   uu____22441
                               else ());
-                             false)))
-               in
+                             false))) in
             if uu____22414
             then ()
             else
               ((let uu____22445 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                    (FStar_Options.Other "GenUniverses")
-                   in
+                    (FStar_Options.Other "GenUniverses") in
                 if uu____22445
                 then
-                  ((let uu____22447 = ineqs_to_string (variables, ineqs)  in
+                  ((let uu____22447 = ineqs_to_string (variables, ineqs) in
                     FStar_Util.print1
                       "Partially solved inequality constraints are: %s\n"
                       uu____22447);
                    FStar_Syntax_Unionfind.rollback tx;
-                   (let uu____22457 = ineqs_to_string (variables, ineqs)  in
+                   (let uu____22457 = ineqs_to_string (variables, ineqs) in
                     FStar_Util.print1
                       "Original solved inequality constraints are: %s\n"
                       uu____22457))
                 else ());
-               (let uu____22467 = FStar_TypeChecker_Env.get_range env  in
+               (let uu____22467 = FStar_TypeChecker_Env.get_range env in
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_FailToSolveUniverseInEquality,
                     "Failed to solve universe inequalities for inductives")
                   uu____22467))
-  
-let (solve_universe_inequalities :
+let solve_universe_inequalities:
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.universe Prims.list,(FStar_Syntax_Syntax.universe,
                                                FStar_Syntax_Syntax.universe)
                                                FStar_Pervasives_Native.tuple2
                                                Prims.list)
-      FStar_Pervasives_Native.tuple2 -> Prims.unit)
+      FStar_Pervasives_Native.tuple2 -> Prims.unit
   =
   fun env  ->
     fun ineqs  ->
-      let tx = FStar_Syntax_Unionfind.new_transaction ()  in
+      let tx = FStar_Syntax_Unionfind.new_transaction () in
       solve_universe_inequalities' tx env ineqs;
       FStar_Syntax_Unionfind.commit tx
-  
-let rec (solve_deferred_constraints :
+let rec solve_deferred_constraints:
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun env  ->
     fun g  ->
       let fail uu____22515 =
         match uu____22515 with
         | (d,s) ->
-            let msg = explain env d s  in
+            let msg = explain env d s in
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_ErrorInSolveDeferredConstraints, msg)
-              (p_loc d)
-         in
-      let wl = wl_of_guard env g.FStar_TypeChecker_Env.deferred  in
+              (p_loc d) in
+      let wl = wl_of_guard env g.FStar_TypeChecker_Env.deferred in
       (let uu____22529 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "RelCheck")
-          in
+           (FStar_Options.Other "RelCheck") in
        if uu____22529
        then
-         let uu____22530 = wl_to_string wl  in
+         let uu____22530 = wl_to_string wl in
          let uu____22531 =
            FStar_Util.string_of_int
-             (FStar_List.length g.FStar_TypeChecker_Env.implicits)
-            in
+             (FStar_List.length g.FStar_TypeChecker_Env.implicits) in
          FStar_Util.print2
            "Trying to solve carried problems: begin\n\t%s\nend\n and %s implicits\n"
            uu____22530 uu____22531
        else ());
       (let g1 =
-         let uu____22546 = solve_and_commit env wl fail  in
+         let uu____22546 = solve_and_commit env wl fail in
          match uu____22546 with
          | FStar_Pervasives_Native.Some [] ->
-             let uu___165_22559 = g  in
+             let uu___165_22559 = g in
              {
                FStar_TypeChecker_Env.guard_f =
                  (uu___165_22559.FStar_TypeChecker_Env.guard_f);
@@ -9405,10 +8560,9 @@ let rec (solve_deferred_constraints :
                  (uu___165_22559.FStar_TypeChecker_Env.implicits)
              }
          | uu____22564 ->
-             failwith "impossible: Unexpected deferred constraints remain"
-          in
+             failwith "impossible: Unexpected deferred constraints remain" in
        solve_universe_inequalities env g1.FStar_TypeChecker_Env.univ_ineqs;
-       (let uu___166_22568 = g1  in
+       (let uu___166_22568 = g1 in
         {
           FStar_TypeChecker_Env.guard_f =
             (uu___166_22568.FStar_TypeChecker_Env.guard_f);
@@ -9418,15 +8572,14 @@ let rec (solve_deferred_constraints :
           FStar_TypeChecker_Env.implicits =
             (uu___166_22568.FStar_TypeChecker_Env.implicits)
         }))
-  
-let (last_proof_ns :
+let last_proof_ns:
   FStar_TypeChecker_Env.proof_namespace FStar_Pervasives_Native.option
-    FStar_ST.ref)
-  = FStar_Util.mk_ref FStar_Pervasives_Native.None 
-let (maybe_update_proof_ns : FStar_TypeChecker_Env.env -> Prims.unit) =
+    FStar_ST.ref
+  = FStar_Util.mk_ref FStar_Pervasives_Native.None
+let maybe_update_proof_ns: FStar_TypeChecker_Env.env -> Prims.unit =
   fun env  ->
-    let pns = env.FStar_TypeChecker_Env.proof_ns  in
-    let uu____22594 = FStar_ST.op_Bang last_proof_ns  in
+    let pns = env.FStar_TypeChecker_Env.proof_ns in
+    let uu____22594 = FStar_ST.op_Bang last_proof_ns in
     match uu____22594 with
     | FStar_Pervasives_Native.None  ->
         FStar_ST.op_Colon_Equals last_proof_ns
@@ -9439,13 +8592,12 @@ let (maybe_update_proof_ns : FStar_TypeChecker_Env.env -> Prims.unit) =
              ();
            FStar_ST.op_Colon_Equals last_proof_ns
              (FStar_Pervasives_Native.Some pns))
-  
-let (discharge_guard' :
+let discharge_guard':
   (Prims.unit -> Prims.string) FStar_Pervasives_Native.option ->
     FStar_TypeChecker_Env.env ->
       FStar_TypeChecker_Env.guard_t ->
         Prims.bool ->
-          FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option)
+          FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option
   =
   fun use_env_range_msg  ->
     fun env  ->
@@ -9459,11 +8611,10 @@ let (discharge_guard' :
                   (FStar_Options.Other "SMTQuery")))
               ||
               (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                 (FStar_Options.Other "Tac"))
-             in
-          let g1 = solve_deferred_constraints env g  in
+                 (FStar_Options.Other "Tac")) in
+          let g1 = solve_deferred_constraints env g in
           let ret_g =
-            let uu___167_22697 = g1  in
+            let uu___167_22697 = g1 in
             {
               FStar_TypeChecker_Env.guard_f =
                 FStar_TypeChecker_Common.Trivial;
@@ -9473,10 +8624,10 @@ let (discharge_guard' :
                 (uu___167_22697.FStar_TypeChecker_Env.univ_ineqs);
               FStar_TypeChecker_Env.implicits =
                 (uu___167_22697.FStar_TypeChecker_Env.implicits)
-            }  in
+            } in
           let uu____22698 =
-            let uu____22699 = FStar_TypeChecker_Env.should_verify env  in
-            Prims.op_Negation uu____22699  in
+            let uu____22699 = FStar_TypeChecker_Env.should_verify env in
+            Prims.op_Negation uu____22699 in
           if uu____22698
           then FStar_Pervasives_Native.Some ret_g
           else
@@ -9486,35 +8637,29 @@ let (discharge_guard' :
              | FStar_TypeChecker_Common.NonTrivial vc ->
                  (if debug1
                   then
-                    (let uu____22707 = FStar_TypeChecker_Env.get_range env
-                        in
+                    (let uu____22707 = FStar_TypeChecker_Env.get_range env in
                      let uu____22708 =
-                       let uu____22709 = FStar_Syntax_Print.term_to_string vc
-                          in
+                       let uu____22709 = FStar_Syntax_Print.term_to_string vc in
                        FStar_Util.format1 "Before normalization VC=\n%s\n"
-                         uu____22709
-                        in
+                         uu____22709 in
                      FStar_Errors.diag uu____22707 uu____22708)
                   else ();
                   (let vc1 =
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Normalize.Eager_unfolding;
                        FStar_TypeChecker_Normalize.Simplify;
-                       FStar_TypeChecker_Normalize.Primops] env vc
-                      in
+                       FStar_TypeChecker_Normalize.Primops] env vc in
                    if debug1
                    then
-                     (let uu____22713 = FStar_TypeChecker_Env.get_range env
-                         in
+                     (let uu____22713 = FStar_TypeChecker_Env.get_range env in
                       let uu____22714 =
                         let uu____22715 =
-                          FStar_Syntax_Print.term_to_string vc1  in
+                          FStar_Syntax_Print.term_to_string vc1 in
                         FStar_Util.format1 "After normalization VC=\n%s\n"
-                          uu____22715
-                         in
+                          uu____22715 in
                       FStar_Errors.diag uu____22713 uu____22714)
                    else ();
-                   (let uu____22717 = check_trivial vc1  in
+                   (let uu____22717 = check_trivial vc1 in
                     match uu____22717 with
                     | FStar_TypeChecker_Common.Trivial  ->
                         FStar_Pervasives_Native.Some ret_g
@@ -9524,14 +8669,13 @@ let (discharge_guard' :
                           (if debug1
                            then
                              (let uu____22724 =
-                                FStar_TypeChecker_Env.get_range env  in
+                                FStar_TypeChecker_Env.get_range env in
                               let uu____22725 =
                                 let uu____22726 =
-                                  FStar_Syntax_Print.term_to_string vc2  in
+                                  FStar_Syntax_Print.term_to_string vc2 in
                                 FStar_Util.format1
                                   "Cannot solve without SMT : %s\n"
-                                  uu____22726
-                                 in
+                                  uu____22726 in
                               FStar_Errors.diag uu____22724 uu____22725)
                            else ();
                            FStar_Pervasives_Native.None)
@@ -9539,37 +8683,32 @@ let (discharge_guard' :
                           (if debug1
                            then
                              (let uu____22731 =
-                                FStar_TypeChecker_Env.get_range env  in
+                                FStar_TypeChecker_Env.get_range env in
                               let uu____22732 =
                                 let uu____22733 =
-                                  FStar_Syntax_Print.term_to_string vc2  in
+                                  FStar_Syntax_Print.term_to_string vc2 in
                                 FStar_Util.format1 "Checking VC=\n%s\n"
-                                  uu____22733
-                                 in
+                                  uu____22733 in
                               FStar_Errors.diag uu____22731 uu____22732)
                            else ();
                            (let vcs =
-                              let uu____22744 = FStar_Options.use_tactics ()
-                                 in
+                              let uu____22744 = FStar_Options.use_tactics () in
                               if uu____22744
                               then
                                 FStar_Options.with_saved_options
                                   (fun uu____22763  ->
                                      (let uu____22765 =
                                         FStar_Options.set_options
-                                          FStar_Options.Set "--no_tactics"
-                                         in
+                                          FStar_Options.Set "--no_tactics" in
                                       FStar_All.pipe_left
                                         FStar_Pervasives.ignore uu____22765);
                                      (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.preprocess
                                        env vc2)
                               else
                                 (let uu____22767 =
-                                   let uu____22774 = FStar_Options.peek ()
-                                      in
-                                   (env, vc2, uu____22774)  in
-                                 [uu____22767])
-                               in
+                                   let uu____22774 = FStar_Options.peek () in
+                                   (env, vc2, uu____22774) in
+                                 [uu____22767]) in
                             FStar_All.pipe_right vcs
                               (FStar_List.iter
                                  (fun uu____22808  ->
@@ -9579,10 +8718,8 @@ let (discharge_guard' :
                                           FStar_TypeChecker_Normalize.normalize
                                             [FStar_TypeChecker_Normalize.Simplify;
                                             FStar_TypeChecker_Normalize.Primops]
-                                            env1 goal
-                                           in
-                                        let uu____22819 = check_trivial goal1
-                                           in
+                                            env1 goal in
+                                        let uu____22819 = check_trivial goal1 in
                                         (match uu____22819 with
                                          | FStar_TypeChecker_Common.Trivial 
                                              ->
@@ -9600,21 +8737,17 @@ let (discharge_guard' :
                                               then
                                                 (let uu____22827 =
                                                    FStar_TypeChecker_Env.get_range
-                                                     env1
-                                                    in
+                                                     env1 in
                                                  let uu____22828 =
                                                    let uu____22829 =
                                                      FStar_Syntax_Print.term_to_string
-                                                       goal2
-                                                      in
+                                                       goal2 in
                                                    let uu____22830 =
                                                      FStar_TypeChecker_Env.string_of_proof_ns
-                                                       env1
-                                                      in
+                                                       env1 in
                                                    FStar_Util.format2
                                                      "Trying to solve:\n> %s\nWith proof_ns:\n %s\n"
-                                                     uu____22829 uu____22830
-                                                    in
+                                                     uu____22829 uu____22830 in
                                                  FStar_Errors.diag
                                                    uu____22827 uu____22828)
                                               else ();
@@ -9622,17 +8755,14 @@ let (discharge_guard' :
                                               then
                                                 (let uu____22833 =
                                                    FStar_TypeChecker_Env.get_range
-                                                     env1
-                                                    in
+                                                     env1 in
                                                  let uu____22834 =
                                                    let uu____22835 =
                                                      FStar_Syntax_Print.term_to_string
-                                                       goal2
-                                                      in
+                                                       goal2 in
                                                    FStar_Util.format1
                                                      "Before calling solver VC=\n%s\n"
-                                                     uu____22835
-                                                    in
+                                                     uu____22835 in
                                                  FStar_Errors.diag
                                                    uu____22833 uu____22834)
                                               else ();
@@ -9640,52 +8770,49 @@ let (discharge_guard' :
                                                 use_env_range_msg env1 goal2;
                                               FStar_Options.pop ())))));
                            FStar_Pervasives_Native.Some ret_g)))))
-  
-let (discharge_guard_no_smt :
+let discharge_guard_no_smt:
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun env  ->
     fun g  ->
       let uu____22845 =
-        discharge_guard' FStar_Pervasives_Native.None env g false  in
+        discharge_guard' FStar_Pervasives_Native.None env g false in
       match uu____22845 with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None  ->
-          let uu____22851 = FStar_TypeChecker_Env.get_range env  in
+          let uu____22851 = FStar_TypeChecker_Env.get_range env in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExpectTrivialPreCondition,
               "Expected a trivial pre-condition") uu____22851
-  
-let (discharge_guard :
+let discharge_guard:
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+    FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun env  ->
     fun g  ->
       let uu____22858 =
-        discharge_guard' FStar_Pervasives_Native.None env g true  in
+        discharge_guard' FStar_Pervasives_Native.None env g true in
       match uu____22858 with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None  ->
           failwith
             "Impossible, with use_smt = true, discharge_guard' should never have returned None"
-  
-let (resolve_implicits' :
+let resolve_implicits':
   Prims.bool ->
     Prims.bool ->
-      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun must_total  ->
     fun forcelax  ->
       fun g  ->
         let unresolved u =
-          let uu____22877 = FStar_Syntax_Unionfind.find u  in
+          let uu____22877 = FStar_Syntax_Unionfind.find u in
           match uu____22877 with
           | FStar_Pervasives_Native.None  -> true
-          | uu____22880 -> false  in
+          | uu____22880 -> false in
         let rec until_fixpoint acc implicits =
-          let uu____22898 = acc  in
+          let uu____22898 = acc in
           match uu____22898 with
           | (out,changed) ->
               (match implicits with
@@ -9694,21 +8821,20 @@ let (resolve_implicits' :
                    then out
                    else until_fixpoint ([], false) out
                | hd1::tl1 ->
-                   let uu____22984 = hd1  in
+                   let uu____22984 = hd1 in
                    (match uu____22984 with
                     | (uu____22997,env,u,tm,k,r) ->
-                        let uu____23003 = unresolved u  in
+                        let uu____23003 = unresolved u in
                         if uu____23003
                         then until_fixpoint ((hd1 :: out), changed) tl1
                         else
                           (let tm1 =
                              FStar_TypeChecker_Normalize.normalize
-                               [FStar_TypeChecker_Normalize.Beta] env tm
-                              in
+                               [FStar_TypeChecker_Normalize.Beta] env tm in
                            let env1 =
                              if forcelax
                              then
-                               let uu___168_23033 = env  in
+                               let uu___168_23033 = env in
                                {
                                  FStar_TypeChecker_Env.solver =
                                    (uu___168_23033.FStar_TypeChecker_Env.solver);
@@ -9780,20 +8906,19 @@ let (resolve_implicits' :
                                  FStar_TypeChecker_Env.dep_graph =
                                    (uu___168_23033.FStar_TypeChecker_Env.dep_graph)
                                }
-                             else env  in
+                             else env in
                            (let uu____23036 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
-                                (FStar_Options.Other "RelCheck")
-                               in
+                                (FStar_Options.Other "RelCheck") in
                             if uu____23036
                             then
                               let uu____23037 =
-                                FStar_Syntax_Print.uvar_to_string u  in
+                                FStar_Syntax_Print.uvar_to_string u in
                               let uu____23038 =
-                                FStar_Syntax_Print.term_to_string tm1  in
+                                FStar_Syntax_Print.term_to_string tm1 in
                               let uu____23039 =
-                                FStar_Syntax_Print.term_to_string k  in
+                                FStar_Syntax_Print.term_to_string k in
                               FStar_Util.print3
                                 "Checking uvar %s resolved to %s at type %s\n"
                                 uu____23037 uu____23038 uu____23039
@@ -9809,27 +8934,22 @@ let (resolve_implicits' :
                                         let uu____23066 =
                                           let uu____23067 =
                                             FStar_Syntax_Print.uvar_to_string
-                                              u
-                                             in
+                                              u in
                                           let uu____23068 =
                                             FStar_TypeChecker_Normalize.term_to_string
-                                              env1 tm1
-                                             in
+                                              env1 tm1 in
                                           FStar_Util.format2
                                             "Failed while checking implicit %s set to %s"
-                                            uu____23067 uu____23068
-                                           in
+                                            uu____23067 uu____23068 in
                                         (FStar_Errors.Error_BadImplicit,
-                                          uu____23066, r)
-                                         in
-                                      [uu____23059]  in
+                                          uu____23066, r) in
+                                      [uu____23059] in
                                     FStar_Errors.add_errors uu____23050);
-                                   FStar_Exn.raise e)
-                               in
+                                   FStar_Exn.raise e) in
                             let g2 =
                               if env1.FStar_TypeChecker_Env.is_pattern
                               then
-                                let uu___171_23082 = g1  in
+                                let uu___171_23082 = g1 in
                                 {
                                   FStar_TypeChecker_Env.guard_f =
                                     FStar_TypeChecker_Common.Trivial;
@@ -9840,29 +8960,26 @@ let (resolve_implicits' :
                                   FStar_TypeChecker_Env.implicits =
                                     (uu___171_23082.FStar_TypeChecker_Env.implicits)
                                 }
-                              else g1  in
+                              else g1 in
                             let g' =
                               let uu____23085 =
                                 discharge_guard'
                                   (FStar_Pervasives_Native.Some
                                      (fun uu____23091  ->
                                         FStar_Syntax_Print.term_to_string tm1))
-                                  env1 g2 true
-                                 in
+                                  env1 g2 true in
                               match uu____23085 with
                               | FStar_Pervasives_Native.Some g3 -> g3
                               | FStar_Pervasives_Native.None  ->
                                   failwith
-                                    "Impossible, with use_smt = true, discharge_guard' should never have returned None"
-                               in
+                                    "Impossible, with use_smt = true, discharge_guard' should never have returned None" in
                             until_fixpoint
                               ((FStar_List.append
                                   g'.FStar_TypeChecker_Env.implicits out),
-                                true) tl1))))
-           in
-        let uu___172_23119 = g  in
+                                true) tl1)))) in
+        let uu___172_23119 = g in
         let uu____23120 =
-          until_fixpoint ([], false) g.FStar_TypeChecker_Env.implicits  in
+          until_fixpoint ([], false) g.FStar_TypeChecker_Env.implicits in
         {
           FStar_TypeChecker_Env.guard_f =
             (uu___172_23119.FStar_TypeChecker_Env.guard_f);
@@ -9872,44 +8989,40 @@ let (resolve_implicits' :
             (uu___172_23119.FStar_TypeChecker_Env.univ_ineqs);
           FStar_TypeChecker_Env.implicits = uu____23120
         }
-  
-let (resolve_implicits :
-  FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t) =
-  fun g  -> resolve_implicits' true false g 
-let (resolve_implicits_tac :
-  FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t) =
-  fun g  -> resolve_implicits' false true g 
-let (force_trivial_guard :
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.unit) =
+let resolve_implicits:
+  FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t =
+  fun g  -> resolve_implicits' true false g
+let resolve_implicits_tac:
+  FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t =
+  fun g  -> resolve_implicits' false true g
+let force_trivial_guard:
+  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.unit =
   fun env  ->
     fun g  ->
       let g1 =
-        let uu____23174 = solve_deferred_constraints env g  in
-        FStar_All.pipe_right uu____23174 resolve_implicits  in
+        let uu____23174 = solve_deferred_constraints env g in
+        FStar_All.pipe_right uu____23174 resolve_implicits in
       match g1.FStar_TypeChecker_Env.implicits with
       | [] ->
-          let uu____23187 = discharge_guard env g1  in
+          let uu____23187 = discharge_guard env g1 in
           FStar_All.pipe_left FStar_Pervasives.ignore uu____23187
       | (reason,uu____23189,uu____23190,e,t,r)::uu____23194 ->
           let uu____23221 =
             let uu____23226 =
-              let uu____23227 = FStar_Syntax_Print.term_to_string t  in
-              let uu____23228 = FStar_Syntax_Print.term_to_string e  in
+              let uu____23227 = FStar_Syntax_Print.term_to_string t in
+              let uu____23228 = FStar_Syntax_Print.term_to_string e in
               FStar_Util.format2
                 "Failed to resolve implicit argument of type '%s' introduced in %s"
-                uu____23227 uu____23228
-               in
-            (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu____23226)
-             in
+                uu____23227 uu____23228 in
+            (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu____23226) in
           FStar_Errors.raise_error uu____23221 r
-  
-let (universe_inequality :
+let universe_inequality:
   FStar_Syntax_Syntax.universe ->
-    FStar_Syntax_Syntax.universe -> FStar_TypeChecker_Env.guard_t)
+    FStar_Syntax_Syntax.universe -> FStar_TypeChecker_Env.guard_t
   =
   fun u1  ->
     fun u2  ->
-      let uu___173_23235 = trivial_guard  in
+      let uu___173_23235 = trivial_guard in
       {
         FStar_TypeChecker_Env.guard_f =
           (uu___173_23235.FStar_TypeChecker_Env.guard_f);
@@ -9919,77 +9032,70 @@ let (universe_inequality :
         FStar_TypeChecker_Env.implicits =
           (uu___173_23235.FStar_TypeChecker_Env.implicits)
       }
-  
-let (discharge_guard_nosmt :
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.bool) =
+let discharge_guard_nosmt:
+  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.guard_t -> Prims.bool =
   fun env  ->
     fun g  ->
       let uu____23258 =
-        discharge_guard' FStar_Pervasives_Native.None env g false  in
+        discharge_guard' FStar_Pervasives_Native.None env g false in
       match uu____23258 with
       | FStar_Pervasives_Native.Some uu____23263 -> true
       | FStar_Pervasives_Native.None  -> false
-  
-let (teq_nosmt :
+let teq_nosmt:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.bool)
+    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.bool
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____23273 = try_teq false env t1 t2  in
+        let uu____23273 = try_teq false env t1 t2 in
         match uu____23273 with
         | FStar_Pervasives_Native.None  -> false
         | FStar_Pervasives_Native.Some g -> discharge_guard_nosmt env g
-  
-let (check_subtyping :
+let check_subtyping:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.term ->
         (FStar_Syntax_Syntax.bv,FStar_TypeChecker_Env.guard_t)
-          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
         (let uu____23293 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "Rel")
-            in
+             (FStar_Options.Other "Rel") in
          if uu____23293
          then
            let uu____23294 =
-             FStar_TypeChecker_Normalize.term_to_string env t1  in
+             FStar_TypeChecker_Normalize.term_to_string env t1 in
            let uu____23295 =
-             FStar_TypeChecker_Normalize.term_to_string env t2  in
+             FStar_TypeChecker_Normalize.term_to_string env t2 in
            FStar_Util.print2 "check_subtyping of %s and %s\n" uu____23294
              uu____23295
          else ());
-        (let uu____23297 = new_t_prob env t1 FStar_TypeChecker_Common.SUB t2
-            in
+        (let uu____23297 = new_t_prob env t1 FStar_TypeChecker_Common.SUB t2 in
          match uu____23297 with
          | (prob,x) ->
              let g =
                let uu____23313 =
-                 let uu____23316 = singleton' env prob true  in
+                 let uu____23316 = singleton' env prob true in
                  solve_and_commit env uu____23316
-                   (fun uu____23318  -> FStar_Pervasives_Native.None)
-                  in
-               FStar_All.pipe_left (with_guard env prob) uu____23313  in
+                   (fun uu____23318  -> FStar_Pervasives_Native.None) in
+               FStar_All.pipe_left (with_guard env prob) uu____23313 in
              ((let uu____23328 =
                  (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                     (FStar_Options.Other "Rel"))
-                   && (FStar_Util.is_some g)
-                  in
+                   && (FStar_Util.is_some g) in
                if uu____23328
                then
                  let uu____23329 =
-                   FStar_TypeChecker_Normalize.term_to_string env t1  in
+                   FStar_TypeChecker_Normalize.term_to_string env t1 in
                  let uu____23330 =
-                   FStar_TypeChecker_Normalize.term_to_string env t2  in
+                   FStar_TypeChecker_Normalize.term_to_string env t2 in
                  let uu____23331 =
-                   let uu____23332 = FStar_Util.must g  in
-                   guard_to_string env uu____23332  in
+                   let uu____23332 = FStar_Util.must g in
+                   guard_to_string env uu____23332 in
                  FStar_Util.print3
                    "check_subtyping succeeded: %s <: %s\n\tguard is %s\n"
                    uu____23329 uu____23330 uu____23331
@@ -9999,83 +9105,76 @@ let (check_subtyping :
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some g1 ->
                    FStar_Pervasives_Native.Some (x, g1))))
-  
-let (get_subtyping_predicate :
+let get_subtyping_predicate:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
       FStar_Syntax_Syntax.typ ->
-        FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option)
+        FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____23360 = check_subtyping env t1 t2  in
+        let uu____23360 = check_subtyping env t1 t2 in
         match uu____23360 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x,g) ->
             let uu____23379 =
-              let uu____23380 = FStar_Syntax_Syntax.mk_binder x  in
-              abstract_guard uu____23380 g  in
+              let uu____23380 = FStar_Syntax_Syntax.mk_binder x in
+              abstract_guard uu____23380 g in
             FStar_Pervasives_Native.Some uu____23379
-  
-let (get_subtyping_prop :
+let get_subtyping_prop:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
       FStar_Syntax_Syntax.typ ->
-        FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option)
+        FStar_TypeChecker_Env.guard_t FStar_Pervasives_Native.option
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____23392 = check_subtyping env t1 t2  in
+        let uu____23392 = check_subtyping env t1 t2 in
         match uu____23392 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x,g) ->
             let uu____23411 =
               let uu____23412 =
-                let uu____23413 = FStar_Syntax_Syntax.mk_binder x  in
-                [uu____23413]  in
-              close_guard env uu____23412 g  in
+                let uu____23413 = FStar_Syntax_Syntax.mk_binder x in
+                [uu____23413] in
+              close_guard env uu____23412 g in
             FStar_Pervasives_Native.Some uu____23411
-  
-let (subtype_nosmt :
+let subtype_nosmt:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.bool)
+    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.bool
   =
   fun env  ->
     fun t1  ->
       fun t2  ->
         (let uu____23424 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "Rel")
-            in
+             (FStar_Options.Other "Rel") in
          if uu____23424
          then
            let uu____23425 =
-             FStar_TypeChecker_Normalize.term_to_string env t1  in
+             FStar_TypeChecker_Normalize.term_to_string env t1 in
            let uu____23426 =
-             FStar_TypeChecker_Normalize.term_to_string env t2  in
+             FStar_TypeChecker_Normalize.term_to_string env t2 in
            FStar_Util.print2 "try_subtype_no_smt of %s and %s\n" uu____23425
              uu____23426
          else ());
-        (let uu____23428 = new_t_prob env t1 FStar_TypeChecker_Common.SUB t2
-            in
+        (let uu____23428 = new_t_prob env t1 FStar_TypeChecker_Common.SUB t2 in
          match uu____23428 with
          | (prob,x) ->
              let g =
                let uu____23438 =
-                 let uu____23441 = singleton' env prob false  in
+                 let uu____23441 = singleton' env prob false in
                  solve_and_commit env uu____23441
-                   (fun uu____23443  -> FStar_Pervasives_Native.None)
-                  in
-               FStar_All.pipe_left (with_guard env prob) uu____23438  in
+                   (fun uu____23443  -> FStar_Pervasives_Native.None) in
+               FStar_All.pipe_left (with_guard env prob) uu____23438 in
              (match g with
               | FStar_Pervasives_Native.None  -> false
               | FStar_Pervasives_Native.Some g1 ->
                   let g2 =
                     let uu____23454 =
-                      let uu____23455 = FStar_Syntax_Syntax.mk_binder x  in
-                      [uu____23455]  in
-                    close_guard env uu____23454 g1  in
+                      let uu____23455 = FStar_Syntax_Syntax.mk_binder x in
+                      [uu____23455] in
+                    close_guard env uu____23454 g1 in
                   discharge_guard_nosmt env g2))
-  

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -1,17 +1,17 @@
 open Prims
-let (set_hint_correlator :
+let set_hint_correlator:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.sigelt -> FStar_TypeChecker_Env.env)
+    FStar_Syntax_Syntax.sigelt -> FStar_TypeChecker_Env.env
   =
   fun env  ->
     fun se  ->
-      let uu____7 = FStar_Options.reuse_hint_for ()  in
+      let uu____7 = FStar_Options.reuse_hint_for () in
       match uu____7 with
       | FStar_Pervasives_Native.Some l ->
           let lid =
-            let uu____12 = FStar_TypeChecker_Env.current_module env  in
-            FStar_Ident.lid_add_suffix uu____12 l  in
-          let uu___61_13 = env  in
+            let uu____12 = FStar_TypeChecker_Env.current_module env in
+            FStar_Ident.lid_add_suffix uu____12 l in
+          let uu___61_13 = env in
           {
             FStar_TypeChecker_Env.solver =
               (uu___61_13.FStar_TypeChecker_Env.solver);
@@ -85,17 +85,17 @@ let (set_hint_correlator :
               (uu___61_13.FStar_TypeChecker_Env.dep_graph)
           }
       | FStar_Pervasives_Native.None  ->
-          let lids = FStar_Syntax_Util.lids_of_sigelt se  in
+          let lids = FStar_Syntax_Util.lids_of_sigelt se in
           let lid =
             match lids with
             | [] ->
-                let uu____22 = FStar_TypeChecker_Env.current_module env  in
+                let uu____22 = FStar_TypeChecker_Env.current_module env in
                 let uu____23 =
-                  let uu____24 = FStar_Syntax_Syntax.next_id ()  in
-                  FStar_All.pipe_right uu____24 FStar_Util.string_of_int  in
+                  let uu____24 = FStar_Syntax_Syntax.next_id () in
+                  FStar_All.pipe_right uu____24 FStar_Util.string_of_int in
                 FStar_Ident.lid_add_suffix uu____22 uu____23
-            | l::uu____26 -> l  in
-          let uu___62_29 = env  in
+            | l::uu____26 -> l in
+          let uu___62_29 = env in
           {
             FStar_TypeChecker_Env.solver =
               (uu___62_29.FStar_TypeChecker_Env.solver);
@@ -168,16 +168,14 @@ let (set_hint_correlator :
             FStar_TypeChecker_Env.dep_graph =
               (uu___62_29.FStar_TypeChecker_Env.dep_graph)
           }
-  
-let (log : FStar_TypeChecker_Env.env -> Prims.bool) =
+let log: FStar_TypeChecker_Env.env -> Prims.bool =
   fun env  ->
     (FStar_Options.log_types ()) &&
       (let uu____38 =
-         let uu____39 = FStar_TypeChecker_Env.current_module env  in
-         FStar_Ident.lid_equals FStar_Parser_Const.prims_lid uu____39  in
+         let uu____39 = FStar_TypeChecker_Env.current_module env in
+         FStar_Ident.lid_equals FStar_Parser_Const.prims_lid uu____39 in
        Prims.op_Negation uu____38)
-  
-let get_tactic_fv :
+let get_tactic_fv:
   'Auu____44 .
     'Auu____44 ->
       FStar_Ident.lident ->
@@ -190,8 +188,8 @@ let get_tactic_fv :
         match h.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_uinst (h',uu____60) ->
             let uu____65 =
-              let uu____66 = FStar_Syntax_Subst.compress h'  in
-              uu____66.FStar_Syntax_Syntax.n  in
+              let uu____66 = FStar_Syntax_Subst.compress h' in
+              uu____66.FStar_Syntax_Syntax.n in
             (match uu____65 with
              | FStar_Syntax_Syntax.Tm_fvar fv when
                  FStar_Syntax_Syntax.fv_eq_lid fv
@@ -199,64 +197,59 @@ let get_tactic_fv :
                  -> FStar_Pervasives_Native.Some fv
              | uu____72 -> FStar_Pervasives_Native.None)
         | uu____73 -> FStar_Pervasives_Native.None
-  
-let (user_tactics_modules : Prims.string Prims.list FStar_ST.ref) =
-  FStar_Util.mk_ref [] 
-let (tc_check_trivial_guard :
+let user_tactics_modules: Prims.string Prims.list FStar_ST.ref =
+  FStar_Util.mk_ref []
+let tc_check_trivial_guard:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  ->
       fun k  ->
         let uu____115 =
-          FStar_TypeChecker_TcTerm.tc_check_tot_or_gtot_term env t k  in
+          FStar_TypeChecker_TcTerm.tc_check_tot_or_gtot_term env t k in
         match uu____115 with
         | (t1,c,g) -> (FStar_TypeChecker_Rel.force_trivial_guard env g; t1)
-  
-let (recheck_debug :
+let recheck_debug:
   Prims.string ->
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun s  ->
     fun env  ->
       fun t  ->
         (let uu____136 =
-           FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED")  in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
          if uu____136
          then
-           let uu____137 = FStar_Syntax_Print.term_to_string t  in
+           let uu____137 = FStar_Syntax_Print.term_to_string t in
            FStar_Util.print2
              "Term has been %s-transformed to:\n%s\n----------\n" s uu____137
          else ());
-        (let uu____139 = FStar_TypeChecker_TcTerm.tc_term env t  in
+        (let uu____139 = FStar_TypeChecker_TcTerm.tc_term env t in
          match uu____139 with
          | (t',uu____147,uu____148) ->
              ((let uu____150 =
-                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED")
-                  in
+                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
                if uu____150
                then
-                 let uu____151 = FStar_Syntax_Print.term_to_string t'  in
+                 let uu____151 = FStar_Syntax_Print.term_to_string t' in
                  FStar_Util.print1 "Re-checked; got:\n%s\n----------\n"
                    uu____151
                else ());
               t))
-  
-let (check_and_gen :
+let check_and_gen:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.tscheme)
+      FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.tscheme
   =
   fun env  ->
     fun t  ->
       fun k  ->
-        let uu____162 = tc_check_trivial_guard env t k  in
+        let uu____162 = tc_check_trivial_guard env t k in
         FStar_TypeChecker_Util.generalize_universes env uu____162
-  
-let check_nogen :
+let check_nogen:
   'Auu____167 .
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term ->
@@ -267,83 +260,75 @@ let check_nogen :
   fun env  ->
     fun t  ->
       fun k  ->
-        let t1 = tc_check_trivial_guard env t k  in
+        let t1 = tc_check_trivial_guard env t k in
         let uu____187 =
           FStar_TypeChecker_Normalize.normalize
-            [FStar_TypeChecker_Normalize.Beta] env t1
-           in
+            [FStar_TypeChecker_Normalize.Beta] env t1 in
         ([], uu____187)
-  
-let (monad_signature :
+let monad_signature:
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
       FStar_Syntax_Syntax.term ->
         (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.term'
                                   FStar_Syntax_Syntax.syntax)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun m  ->
       fun s  ->
         let fail uu____214 =
           let uu____215 =
-            FStar_TypeChecker_Err.unexpected_signature_for_monad env m s  in
-          FStar_Errors.raise_error uu____215 (FStar_Ident.range_of_lid m)  in
-        let s1 = FStar_Syntax_Subst.compress s  in
+            FStar_TypeChecker_Err.unexpected_signature_for_monad env m s in
+          FStar_Errors.raise_error uu____215 (FStar_Ident.range_of_lid m) in
+        let s1 = FStar_Syntax_Subst.compress s in
         match s1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-            let bs1 = FStar_Syntax_Subst.open_binders bs  in
+            let bs1 = FStar_Syntax_Subst.open_binders bs in
             (match bs1 with
              | (a,uu____259)::(wp,uu____261)::[] ->
                  (a, (wp.FStar_Syntax_Syntax.sort))
              | uu____276 -> fail ())
         | uu____277 -> fail ()
-  
-let (tc_eff_decl :
+let tc_eff_decl:
   FStar_TypeChecker_Env.env_t ->
-    FStar_Syntax_Syntax.eff_decl -> FStar_Syntax_Syntax.eff_decl)
+    FStar_Syntax_Syntax.eff_decl -> FStar_Syntax_Syntax.eff_decl
   =
   fun env0  ->
     fun ed  ->
       let uu____284 =
-        FStar_Syntax_Subst.univ_var_opening ed.FStar_Syntax_Syntax.univs  in
+        FStar_Syntax_Subst.univ_var_opening ed.FStar_Syntax_Syntax.univs in
       match uu____284 with
       | (open_annotated_univs,annotated_univ_names) ->
           let open_univs n_binders t =
             let uu____310 =
-              FStar_Syntax_Subst.shift_subst n_binders open_annotated_univs
-               in
-            FStar_Syntax_Subst.subst uu____310 t  in
+              FStar_Syntax_Subst.shift_subst n_binders open_annotated_univs in
+            FStar_Syntax_Subst.subst uu____310 t in
           let open_univs_binders n_binders bs =
             let uu____320 =
-              FStar_Syntax_Subst.shift_subst n_binders open_annotated_univs
-               in
-            FStar_Syntax_Subst.subst_binders uu____320 bs  in
+              FStar_Syntax_Subst.shift_subst n_binders open_annotated_univs in
+            FStar_Syntax_Subst.subst_binders uu____320 bs in
           let n_effect_params =
-            FStar_List.length ed.FStar_Syntax_Syntax.binders  in
+            FStar_List.length ed.FStar_Syntax_Syntax.binders in
           let uu____328 =
             let uu____335 =
               open_univs_binders (Prims.parse_int "0")
-                ed.FStar_Syntax_Syntax.binders
-               in
+                ed.FStar_Syntax_Syntax.binders in
             let uu____336 =
-              open_univs n_effect_params ed.FStar_Syntax_Syntax.signature  in
-            FStar_Syntax_Subst.open_term' uu____335 uu____336  in
+              open_univs n_effect_params ed.FStar_Syntax_Syntax.signature in
+            FStar_Syntax_Subst.open_term' uu____335 uu____336 in
           (match uu____328 with
            | (effect_params_un,signature_un,opening) ->
                let uu____346 =
-                 FStar_TypeChecker_TcTerm.tc_tparams env0 effect_params_un
-                  in
+                 FStar_TypeChecker_TcTerm.tc_tparams env0 effect_params_un in
                (match uu____346 with
                 | (effect_params,env,uu____355) ->
                     let uu____356 =
                       FStar_TypeChecker_TcTerm.tc_trivial_guard env
-                        signature_un
-                       in
+                        signature_un in
                     (match uu____356 with
                      | (signature,uu____362) ->
                          let ed1 =
-                           let uu___63_364 = ed  in
+                           let uu___63_364 = ed in
                            {
                              FStar_Syntax_Syntax.cattributes =
                                (uu___63_364.FStar_Syntax_Syntax.cattributes);
@@ -381,7 +366,7 @@ let (tc_eff_decl :
                                (uu___63_364.FStar_Syntax_Syntax.bind_repr);
                              FStar_Syntax_Syntax.actions =
                                (uu___63_364.FStar_Syntax_Syntax.actions)
-                           }  in
+                           } in
                          let ed2 =
                            match (effect_params, annotated_univ_names) with
                            | ([],[]) -> ed1
@@ -389,71 +374,62 @@ let (tc_eff_decl :
                                let op uu____402 =
                                  match uu____402 with
                                  | (us,t) ->
-                                     let n_us = FStar_List.length us  in
+                                     let n_us = FStar_List.length us in
                                      let uu____422 =
                                        let uu____423 =
                                          FStar_Syntax_Subst.shift_subst n_us
-                                           opening
-                                          in
+                                           opening in
                                        let uu____432 =
                                          open_univs (n_effect_params + n_us)
-                                           t
-                                          in
+                                           t in
                                        FStar_Syntax_Subst.subst uu____423
-                                         uu____432
-                                        in
-                                     (us, uu____422)
-                                  in
-                               let uu___64_445 = ed1  in
+                                         uu____432 in
+                                     (us, uu____422) in
+                               let uu___64_445 = ed1 in
                                let uu____446 =
-                                 op ed1.FStar_Syntax_Syntax.ret_wp  in
+                                 op ed1.FStar_Syntax_Syntax.ret_wp in
                                let uu____447 =
-                                 op ed1.FStar_Syntax_Syntax.bind_wp  in
+                                 op ed1.FStar_Syntax_Syntax.bind_wp in
                                let uu____448 =
-                                 op ed1.FStar_Syntax_Syntax.if_then_else  in
+                                 op ed1.FStar_Syntax_Syntax.if_then_else in
                                let uu____449 =
-                                 op ed1.FStar_Syntax_Syntax.ite_wp  in
+                                 op ed1.FStar_Syntax_Syntax.ite_wp in
                                let uu____450 =
-                                 op ed1.FStar_Syntax_Syntax.stronger  in
+                                 op ed1.FStar_Syntax_Syntax.stronger in
                                let uu____451 =
-                                 op ed1.FStar_Syntax_Syntax.close_wp  in
+                                 op ed1.FStar_Syntax_Syntax.close_wp in
                                let uu____452 =
-                                 op ed1.FStar_Syntax_Syntax.assert_p  in
+                                 op ed1.FStar_Syntax_Syntax.assert_p in
                                let uu____453 =
-                                 op ed1.FStar_Syntax_Syntax.assume_p  in
+                                 op ed1.FStar_Syntax_Syntax.assume_p in
                                let uu____454 =
-                                 op ed1.FStar_Syntax_Syntax.null_wp  in
+                                 op ed1.FStar_Syntax_Syntax.null_wp in
                                let uu____455 =
-                                 op ed1.FStar_Syntax_Syntax.trivial  in
+                                 op ed1.FStar_Syntax_Syntax.trivial in
                                let uu____456 =
                                  let uu____457 =
-                                   op ([], (ed1.FStar_Syntax_Syntax.repr))
-                                    in
-                                 FStar_Pervasives_Native.snd uu____457  in
+                                   op ([], (ed1.FStar_Syntax_Syntax.repr)) in
+                                 FStar_Pervasives_Native.snd uu____457 in
                                let uu____468 =
-                                 op ed1.FStar_Syntax_Syntax.return_repr  in
+                                 op ed1.FStar_Syntax_Syntax.return_repr in
                                let uu____469 =
-                                 op ed1.FStar_Syntax_Syntax.bind_repr  in
+                                 op ed1.FStar_Syntax_Syntax.bind_repr in
                                let uu____470 =
                                  FStar_List.map
                                    (fun a  ->
-                                      let uu___65_478 = a  in
+                                      let uu___65_478 = a in
                                       let uu____479 =
                                         let uu____480 =
                                           op
                                             ([],
-                                              (a.FStar_Syntax_Syntax.action_defn))
-                                           in
-                                        FStar_Pervasives_Native.snd uu____480
-                                         in
+                                              (a.FStar_Syntax_Syntax.action_defn)) in
+                                        FStar_Pervasives_Native.snd uu____480 in
                                       let uu____491 =
                                         let uu____492 =
                                           op
                                             ([],
-                                              (a.FStar_Syntax_Syntax.action_typ))
-                                           in
-                                        FStar_Pervasives_Native.snd uu____492
-                                         in
+                                              (a.FStar_Syntax_Syntax.action_typ)) in
+                                        FStar_Pervasives_Native.snd uu____492 in
                                       {
                                         FStar_Syntax_Syntax.action_name =
                                           (uu___65_478.FStar_Syntax_Syntax.action_name);
@@ -468,8 +444,7 @@ let (tc_eff_decl :
                                           uu____479;
                                         FStar_Syntax_Syntax.action_typ =
                                           uu____491
-                                      }) ed1.FStar_Syntax_Syntax.actions
-                                  in
+                                      }) ed1.FStar_Syntax_Syntax.actions in
                                {
                                  FStar_Syntax_Syntax.cattributes =
                                    (uu___64_445.FStar_Syntax_Syntax.cattributes);
@@ -495,36 +470,31 @@ let (tc_eff_decl :
                                  FStar_Syntax_Syntax.return_repr = uu____468;
                                  FStar_Syntax_Syntax.bind_repr = uu____469;
                                  FStar_Syntax_Syntax.actions = uu____470
-                               }
-                            in
+                               } in
                          let wp_with_fresh_result_type env1 mname signature1
                            =
                            let fail t =
                              let uu____529 =
                                FStar_TypeChecker_Err.unexpected_signature_for_monad
-                                 env1 mname t
-                                in
+                                 env1 mname t in
                              FStar_Errors.raise_error uu____529
-                               (FStar_Ident.range_of_lid mname)
-                              in
+                               (FStar_Ident.range_of_lid mname) in
                            let uu____540 =
                              let uu____541 =
-                               FStar_Syntax_Subst.compress signature1  in
-                             uu____541.FStar_Syntax_Syntax.n  in
+                               FStar_Syntax_Subst.compress signature1 in
+                             uu____541.FStar_Syntax_Syntax.n in
                            match uu____540 with
                            | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                               let bs1 = FStar_Syntax_Subst.open_binders bs
-                                  in
+                               let bs1 = FStar_Syntax_Subst.open_binders bs in
                                (match bs1 with
                                 | (a,uu____576)::(wp,uu____578)::[] ->
                                     (a, (wp.FStar_Syntax_Syntax.sort))
                                 | uu____593 -> fail signature1)
-                           | uu____594 -> fail signature1  in
+                           | uu____594 -> fail signature1 in
                          let uu____595 =
                            wp_with_fresh_result_type env
                              ed2.FStar_Syntax_Syntax.mname
-                             ed2.FStar_Syntax_Syntax.signature
-                            in
+                             ed2.FStar_Syntax_Syntax.signature in
                          (match uu____595 with
                           | (a,wp_a) ->
                               let fresh_effect_signature uu____617 =
@@ -532,8 +502,7 @@ let (tc_eff_decl :
                                 | [] ->
                                     let uu____624 =
                                       FStar_TypeChecker_TcTerm.tc_trivial_guard
-                                        env signature_un
-                                       in
+                                        env signature_un in
                                     (match uu____624 with
                                      | (signature1,uu____636) ->
                                          wp_with_fresh_result_type env
@@ -544,55 +513,44 @@ let (tc_eff_decl :
                                       let uu____645 =
                                         let uu____646 =
                                           FStar_Syntax_Subst.close_univ_vars
-                                            annotated_univ_names signature
-                                           in
-                                        (annotated_univ_names, uu____646)  in
+                                            annotated_univ_names signature in
+                                        (annotated_univ_names, uu____646) in
                                       FStar_TypeChecker_Env.inst_tscheme
-                                        uu____645
-                                       in
+                                        uu____645 in
                                     (match uu____640 with
                                      | (uu____655,signature1) ->
                                          wp_with_fresh_result_type env
                                            ed2.FStar_Syntax_Syntax.mname
-                                           signature1)
-                                 in
+                                           signature1) in
                               let env1 =
                                 let uu____658 =
                                   FStar_Syntax_Syntax.new_bv
                                     FStar_Pervasives_Native.None
-                                    ed2.FStar_Syntax_Syntax.signature
-                                   in
-                                FStar_TypeChecker_Env.push_bv env uu____658
-                                 in
+                                    ed2.FStar_Syntax_Syntax.signature in
+                                FStar_TypeChecker_Env.push_bv env uu____658 in
                               ((let uu____660 =
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.debug env0)
-                                    (FStar_Options.Other "ED")
-                                   in
+                                    (FStar_Options.Other "ED") in
                                 if uu____660
                                 then
                                   let uu____661 =
                                     FStar_Syntax_Print.lid_to_string
-                                      ed2.FStar_Syntax_Syntax.mname
-                                     in
+                                      ed2.FStar_Syntax_Syntax.mname in
                                   let uu____662 =
                                     FStar_Syntax_Print.binders_to_string " "
-                                      ed2.FStar_Syntax_Syntax.binders
-                                     in
+                                      ed2.FStar_Syntax_Syntax.binders in
                                   let uu____663 =
                                     FStar_Syntax_Print.term_to_string
-                                      ed2.FStar_Syntax_Syntax.signature
-                                     in
+                                      ed2.FStar_Syntax_Syntax.signature in
                                   let uu____664 =
                                     let uu____665 =
-                                      FStar_Syntax_Syntax.bv_to_name a  in
+                                      FStar_Syntax_Syntax.bv_to_name a in
                                     FStar_Syntax_Print.term_to_string
-                                      uu____665
-                                     in
+                                      uu____665 in
                                   let uu____666 =
                                     FStar_Syntax_Print.term_to_string
-                                      a.FStar_Syntax_Syntax.sort
-                                     in
+                                      a.FStar_Syntax_Syntax.sort in
                                   FStar_Util.print5
                                     "Checking effect signature: %s %s : %s\n(a is %s:%s)\n"
                                     uu____661 uu____662 uu____663 uu____664
@@ -606,52 +564,42 @@ let (tc_eff_decl :
                                        | uu____696::uu____697 ->
                                            let uu____700 =
                                              FStar_Syntax_Subst.subst_tscheme
-                                               open_annotated_univs (us, t)
-                                              in
+                                               open_annotated_univs (us, t) in
                                            (match uu____700 with
                                             | (us1,t1) ->
                                                 let uu____709 =
                                                   FStar_Syntax_Subst.open_univ_vars
-                                                    us1 t1
-                                                   in
+                                                    us1 t1 in
                                                 (match uu____709 with
                                                  | (us2,t2) ->
                                                      let uu____716 =
                                                        tc_check_trivial_guard
-                                                         env2 t2 k
-                                                        in
+                                                         env2 t2 k in
                                                      let uu____717 =
                                                        FStar_Syntax_Subst.close_univ_vars
-                                                         us2 t2
-                                                        in
-                                                     (us2, uu____717))))
-                                   in
+                                                         us2 t2 in
+                                                     (us2, uu____717)))) in
                                 let return_wp =
                                   let expected_k =
                                     let uu____722 =
                                       let uu____729 =
-                                        FStar_Syntax_Syntax.mk_binder a  in
+                                        FStar_Syntax_Syntax.mk_binder a in
                                       let uu____730 =
                                         let uu____733 =
                                           let uu____734 =
-                                            FStar_Syntax_Syntax.bv_to_name a
-                                             in
+                                            FStar_Syntax_Syntax.bv_to_name a in
                                           FStar_Syntax_Syntax.null_binder
-                                            uu____734
-                                           in
-                                        [uu____733]  in
-                                      uu____729 :: uu____730  in
+                                            uu____734 in
+                                        [uu____733] in
+                                      uu____729 :: uu____730 in
                                     let uu____735 =
-                                      FStar_Syntax_Syntax.mk_GTotal wp_a  in
+                                      FStar_Syntax_Syntax.mk_GTotal wp_a in
                                     FStar_Syntax_Util.arrow uu____722
-                                      uu____735
-                                     in
+                                      uu____735 in
                                   check_and_gen' env1
-                                    ed2.FStar_Syntax_Syntax.ret_wp expected_k
-                                   in
+                                    ed2.FStar_Syntax_Syntax.ret_wp expected_k in
                                 let bind_wp =
-                                  let uu____739 = fresh_effect_signature ()
-                                     in
+                                  let uu____739 = fresh_effect_signature () in
                                   match uu____739 with
                                   | (b,wp_b) ->
                                       let a_wp_b =
@@ -659,321 +607,269 @@ let (tc_eff_decl :
                                           let uu____762 =
                                             let uu____763 =
                                               FStar_Syntax_Syntax.bv_to_name
-                                                a
-                                               in
+                                                a in
                                             FStar_Syntax_Syntax.null_binder
-                                              uu____763
-                                             in
-                                          [uu____762]  in
+                                              uu____763 in
+                                          [uu____762] in
                                         let uu____764 =
-                                          FStar_Syntax_Syntax.mk_Total wp_b
-                                           in
+                                          FStar_Syntax_Syntax.mk_Total wp_b in
                                         FStar_Syntax_Util.arrow uu____755
-                                          uu____764
-                                         in
+                                          uu____764 in
                                       let expected_k =
                                         let uu____770 =
                                           let uu____777 =
                                             FStar_Syntax_Syntax.null_binder
-                                              FStar_Syntax_Syntax.t_range
-                                             in
+                                              FStar_Syntax_Syntax.t_range in
                                           let uu____778 =
                                             let uu____781 =
-                                              FStar_Syntax_Syntax.mk_binder a
-                                               in
+                                              FStar_Syntax_Syntax.mk_binder a in
                                             let uu____782 =
                                               let uu____785 =
                                                 FStar_Syntax_Syntax.mk_binder
-                                                  b
-                                                 in
+                                                  b in
                                               let uu____786 =
                                                 let uu____789 =
                                                   FStar_Syntax_Syntax.null_binder
-                                                    wp_a
-                                                   in
+                                                    wp_a in
                                                 let uu____790 =
                                                   let uu____793 =
                                                     FStar_Syntax_Syntax.null_binder
-                                                      a_wp_b
-                                                     in
-                                                  [uu____793]  in
-                                                uu____789 :: uu____790  in
-                                              uu____785 :: uu____786  in
-                                            uu____781 :: uu____782  in
-                                          uu____777 :: uu____778  in
+                                                      a_wp_b in
+                                                  [uu____793] in
+                                                uu____789 :: uu____790 in
+                                              uu____785 :: uu____786 in
+                                            uu____781 :: uu____782 in
+                                          uu____777 :: uu____778 in
                                         let uu____794 =
-                                          FStar_Syntax_Syntax.mk_Total wp_b
-                                           in
+                                          FStar_Syntax_Syntax.mk_Total wp_b in
                                         FStar_Syntax_Util.arrow uu____770
-                                          uu____794
-                                         in
+                                          uu____794 in
                                       check_and_gen' env1
                                         ed2.FStar_Syntax_Syntax.bind_wp
-                                        expected_k
-                                   in
+                                        expected_k in
                                 let if_then_else1 =
                                   let p =
                                     let uu____799 =
                                       let uu____800 =
-                                        FStar_Syntax_Util.type_u ()  in
+                                        FStar_Syntax_Util.type_u () in
                                       FStar_All.pipe_right uu____800
-                                        FStar_Pervasives_Native.fst
-                                       in
+                                        FStar_Pervasives_Native.fst in
                                     FStar_Syntax_Syntax.new_bv
                                       (FStar_Pervasives_Native.Some
                                          (FStar_Ident.range_of_lid
                                             ed2.FStar_Syntax_Syntax.mname))
-                                      uu____799
-                                     in
+                                      uu____799 in
                                   let expected_k =
                                     let uu____812 =
                                       let uu____819 =
-                                        FStar_Syntax_Syntax.mk_binder a  in
+                                        FStar_Syntax_Syntax.mk_binder a in
                                       let uu____820 =
                                         let uu____823 =
-                                          FStar_Syntax_Syntax.mk_binder p  in
+                                          FStar_Syntax_Syntax.mk_binder p in
                                         let uu____824 =
                                           let uu____827 =
                                             FStar_Syntax_Syntax.null_binder
-                                              wp_a
-                                             in
+                                              wp_a in
                                           let uu____828 =
                                             let uu____831 =
                                               FStar_Syntax_Syntax.null_binder
-                                                wp_a
-                                               in
-                                            [uu____831]  in
-                                          uu____827 :: uu____828  in
-                                        uu____823 :: uu____824  in
-                                      uu____819 :: uu____820  in
+                                                wp_a in
+                                            [uu____831] in
+                                          uu____827 :: uu____828 in
+                                        uu____823 :: uu____824 in
+                                      uu____819 :: uu____820 in
                                     let uu____832 =
-                                      FStar_Syntax_Syntax.mk_Total wp_a  in
+                                      FStar_Syntax_Syntax.mk_Total wp_a in
                                     FStar_Syntax_Util.arrow uu____812
-                                      uu____832
-                                     in
+                                      uu____832 in
                                   check_and_gen' env1
                                     ed2.FStar_Syntax_Syntax.if_then_else
-                                    expected_k
-                                   in
+                                    expected_k in
                                 let ite_wp =
                                   let expected_k =
                                     let uu____839 =
                                       let uu____846 =
-                                        FStar_Syntax_Syntax.mk_binder a  in
+                                        FStar_Syntax_Syntax.mk_binder a in
                                       let uu____847 =
                                         let uu____850 =
                                           FStar_Syntax_Syntax.null_binder
-                                            wp_a
-                                           in
-                                        [uu____850]  in
-                                      uu____846 :: uu____847  in
+                                            wp_a in
+                                        [uu____850] in
+                                      uu____846 :: uu____847 in
                                     let uu____851 =
-                                      FStar_Syntax_Syntax.mk_Total wp_a  in
+                                      FStar_Syntax_Syntax.mk_Total wp_a in
                                     FStar_Syntax_Util.arrow uu____839
-                                      uu____851
-                                     in
+                                      uu____851 in
                                   check_and_gen' env1
-                                    ed2.FStar_Syntax_Syntax.ite_wp expected_k
-                                   in
+                                    ed2.FStar_Syntax_Syntax.ite_wp expected_k in
                                 let stronger =
-                                  let uu____855 = FStar_Syntax_Util.type_u ()
-                                     in
+                                  let uu____855 = FStar_Syntax_Util.type_u () in
                                   match uu____855 with
                                   | (t,uu____861) ->
                                       let expected_k =
                                         let uu____865 =
                                           let uu____872 =
-                                            FStar_Syntax_Syntax.mk_binder a
-                                             in
+                                            FStar_Syntax_Syntax.mk_binder a in
                                           let uu____873 =
                                             let uu____876 =
                                               FStar_Syntax_Syntax.null_binder
-                                                wp_a
-                                               in
+                                                wp_a in
                                             let uu____877 =
                                               let uu____880 =
                                                 FStar_Syntax_Syntax.null_binder
-                                                  wp_a
-                                                 in
-                                              [uu____880]  in
-                                            uu____876 :: uu____877  in
-                                          uu____872 :: uu____873  in
+                                                  wp_a in
+                                              [uu____880] in
+                                            uu____876 :: uu____877 in
+                                          uu____872 :: uu____873 in
                                         let uu____881 =
-                                          FStar_Syntax_Syntax.mk_Total t  in
+                                          FStar_Syntax_Syntax.mk_Total t in
                                         FStar_Syntax_Util.arrow uu____865
-                                          uu____881
-                                         in
+                                          uu____881 in
                                       check_and_gen' env1
                                         ed2.FStar_Syntax_Syntax.stronger
-                                        expected_k
-                                   in
+                                        expected_k in
                                 let close_wp =
                                   let b =
                                     let uu____886 =
                                       let uu____887 =
-                                        FStar_Syntax_Util.type_u ()  in
+                                        FStar_Syntax_Util.type_u () in
                                       FStar_All.pipe_right uu____887
-                                        FStar_Pervasives_Native.fst
-                                       in
+                                        FStar_Pervasives_Native.fst in
                                     FStar_Syntax_Syntax.new_bv
                                       (FStar_Pervasives_Native.Some
                                          (FStar_Ident.range_of_lid
                                             ed2.FStar_Syntax_Syntax.mname))
-                                      uu____886
-                                     in
+                                      uu____886 in
                                   let b_wp_a =
                                     let uu____899 =
                                       let uu____906 =
                                         let uu____907 =
-                                          FStar_Syntax_Syntax.bv_to_name b
-                                           in
+                                          FStar_Syntax_Syntax.bv_to_name b in
                                         FStar_Syntax_Syntax.null_binder
-                                          uu____907
-                                         in
-                                      [uu____906]  in
+                                          uu____907 in
+                                      [uu____906] in
                                     let uu____908 =
-                                      FStar_Syntax_Syntax.mk_Total wp_a  in
+                                      FStar_Syntax_Syntax.mk_Total wp_a in
                                     FStar_Syntax_Util.arrow uu____899
-                                      uu____908
-                                     in
+                                      uu____908 in
                                   let expected_k =
                                     let uu____914 =
                                       let uu____921 =
-                                        FStar_Syntax_Syntax.mk_binder a  in
+                                        FStar_Syntax_Syntax.mk_binder a in
                                       let uu____922 =
                                         let uu____925 =
-                                          FStar_Syntax_Syntax.mk_binder b  in
+                                          FStar_Syntax_Syntax.mk_binder b in
                                         let uu____926 =
                                           let uu____929 =
                                             FStar_Syntax_Syntax.null_binder
-                                              b_wp_a
-                                             in
-                                          [uu____929]  in
-                                        uu____925 :: uu____926  in
-                                      uu____921 :: uu____922  in
+                                              b_wp_a in
+                                          [uu____929] in
+                                        uu____925 :: uu____926 in
+                                      uu____921 :: uu____922 in
                                     let uu____930 =
-                                      FStar_Syntax_Syntax.mk_Total wp_a  in
+                                      FStar_Syntax_Syntax.mk_Total wp_a in
                                     FStar_Syntax_Util.arrow uu____914
-                                      uu____930
-                                     in
+                                      uu____930 in
                                   check_and_gen' env1
                                     ed2.FStar_Syntax_Syntax.close_wp
-                                    expected_k
-                                   in
+                                    expected_k in
                                 let assert_p =
                                   let expected_k =
                                     let uu____937 =
                                       let uu____944 =
-                                        FStar_Syntax_Syntax.mk_binder a  in
+                                        FStar_Syntax_Syntax.mk_binder a in
                                       let uu____945 =
                                         let uu____948 =
                                           let uu____949 =
                                             let uu____950 =
-                                              FStar_Syntax_Util.type_u ()  in
+                                              FStar_Syntax_Util.type_u () in
                                             FStar_All.pipe_right uu____950
-                                              FStar_Pervasives_Native.fst
-                                             in
+                                              FStar_Pervasives_Native.fst in
                                           FStar_Syntax_Syntax.null_binder
-                                            uu____949
-                                           in
+                                            uu____949 in
                                         let uu____959 =
                                           let uu____962 =
                                             FStar_Syntax_Syntax.null_binder
-                                              wp_a
-                                             in
-                                          [uu____962]  in
-                                        uu____948 :: uu____959  in
-                                      uu____944 :: uu____945  in
+                                              wp_a in
+                                          [uu____962] in
+                                        uu____948 :: uu____959 in
+                                      uu____944 :: uu____945 in
                                     let uu____963 =
-                                      FStar_Syntax_Syntax.mk_Total wp_a  in
+                                      FStar_Syntax_Syntax.mk_Total wp_a in
                                     FStar_Syntax_Util.arrow uu____937
-                                      uu____963
-                                     in
+                                      uu____963 in
                                   check_and_gen' env1
                                     ed2.FStar_Syntax_Syntax.assert_p
-                                    expected_k
-                                   in
+                                    expected_k in
                                 let assume_p =
                                   let expected_k =
                                     let uu____970 =
                                       let uu____977 =
-                                        FStar_Syntax_Syntax.mk_binder a  in
+                                        FStar_Syntax_Syntax.mk_binder a in
                                       let uu____978 =
                                         let uu____981 =
                                           let uu____982 =
                                             let uu____983 =
-                                              FStar_Syntax_Util.type_u ()  in
+                                              FStar_Syntax_Util.type_u () in
                                             FStar_All.pipe_right uu____983
-                                              FStar_Pervasives_Native.fst
-                                             in
+                                              FStar_Pervasives_Native.fst in
                                           FStar_Syntax_Syntax.null_binder
-                                            uu____982
-                                           in
+                                            uu____982 in
                                         let uu____992 =
                                           let uu____995 =
                                             FStar_Syntax_Syntax.null_binder
-                                              wp_a
-                                             in
-                                          [uu____995]  in
-                                        uu____981 :: uu____992  in
-                                      uu____977 :: uu____978  in
+                                              wp_a in
+                                          [uu____995] in
+                                        uu____981 :: uu____992 in
+                                      uu____977 :: uu____978 in
                                     let uu____996 =
-                                      FStar_Syntax_Syntax.mk_Total wp_a  in
+                                      FStar_Syntax_Syntax.mk_Total wp_a in
                                     FStar_Syntax_Util.arrow uu____970
-                                      uu____996
-                                     in
+                                      uu____996 in
                                   check_and_gen' env1
                                     ed2.FStar_Syntax_Syntax.assume_p
-                                    expected_k
-                                   in
+                                    expected_k in
                                 let null_wp =
                                   let expected_k =
                                     let uu____1003 =
                                       let uu____1010 =
-                                        FStar_Syntax_Syntax.mk_binder a  in
-                                      [uu____1010]  in
+                                        FStar_Syntax_Syntax.mk_binder a in
+                                      [uu____1010] in
                                     let uu____1011 =
-                                      FStar_Syntax_Syntax.mk_Total wp_a  in
+                                      FStar_Syntax_Syntax.mk_Total wp_a in
                                     FStar_Syntax_Util.arrow uu____1003
-                                      uu____1011
-                                     in
+                                      uu____1011 in
                                   check_and_gen' env1
                                     ed2.FStar_Syntax_Syntax.null_wp
-                                    expected_k
-                                   in
+                                    expected_k in
                                 let trivial_wp =
                                   let uu____1015 =
-                                    FStar_Syntax_Util.type_u ()  in
+                                    FStar_Syntax_Util.type_u () in
                                   match uu____1015 with
                                   | (t,uu____1021) ->
                                       let expected_k =
                                         let uu____1025 =
                                           let uu____1032 =
-                                            FStar_Syntax_Syntax.mk_binder a
-                                             in
+                                            FStar_Syntax_Syntax.mk_binder a in
                                           let uu____1033 =
                                             let uu____1036 =
                                               FStar_Syntax_Syntax.null_binder
-                                                wp_a
-                                               in
-                                            [uu____1036]  in
-                                          uu____1032 :: uu____1033  in
+                                                wp_a in
+                                            [uu____1036] in
+                                          uu____1032 :: uu____1033 in
                                         let uu____1037 =
-                                          FStar_Syntax_Syntax.mk_GTotal t  in
+                                          FStar_Syntax_Syntax.mk_GTotal t in
                                         FStar_Syntax_Util.arrow uu____1025
-                                          uu____1037
-                                         in
+                                          uu____1037 in
                                       check_and_gen' env1
                                         ed2.FStar_Syntax_Syntax.trivial
-                                        expected_k
-                                   in
+                                        expected_k in
                                 let uu____1040 =
                                   let uu____1051 =
                                     let uu____1052 =
                                       FStar_Syntax_Subst.compress
-                                        ed2.FStar_Syntax_Syntax.repr
-                                       in
-                                    uu____1052.FStar_Syntax_Syntax.n  in
+                                        ed2.FStar_Syntax_Syntax.repr in
+                                    uu____1052.FStar_Syntax_Syntax.n in
                                   match uu____1051 with
                                   | FStar_Syntax_Syntax.Tm_unknown  ->
                                       ((ed2.FStar_Syntax_Syntax.repr),
@@ -983,97 +879,81 @@ let (tc_eff_decl :
                                   | uu____1067 ->
                                       let repr =
                                         let uu____1069 =
-                                          FStar_Syntax_Util.type_u ()  in
+                                          FStar_Syntax_Util.type_u () in
                                         match uu____1069 with
                                         | (t,uu____1075) ->
                                             let expected_k =
                                               let uu____1079 =
                                                 let uu____1086 =
                                                   FStar_Syntax_Syntax.mk_binder
-                                                    a
-                                                   in
+                                                    a in
                                                 let uu____1087 =
                                                   let uu____1090 =
                                                     FStar_Syntax_Syntax.null_binder
-                                                      wp_a
-                                                     in
-                                                  [uu____1090]  in
-                                                uu____1086 :: uu____1087  in
+                                                      wp_a in
+                                                  [uu____1090] in
+                                                uu____1086 :: uu____1087 in
                                               let uu____1091 =
                                                 FStar_Syntax_Syntax.mk_GTotal
-                                                  t
-                                                 in
+                                                  t in
                                               FStar_Syntax_Util.arrow
-                                                uu____1079 uu____1091
-                                               in
+                                                uu____1079 uu____1091 in
                                             tc_check_trivial_guard env1
                                               ed2.FStar_Syntax_Syntax.repr
-                                              expected_k
-                                         in
+                                              expected_k in
                                       let mk_repr' t wp =
                                         let repr1 =
                                           FStar_TypeChecker_Normalize.normalize
                                             [FStar_TypeChecker_Normalize.EraseUniverses;
                                             FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                                            env1 repr
-                                           in
+                                            env1 repr in
                                         let uu____1104 =
                                           let uu____1107 =
                                             let uu____1108 =
                                               let uu____1123 =
                                                 let uu____1126 =
                                                   FStar_Syntax_Syntax.as_arg
-                                                    t
-                                                   in
+                                                    t in
                                                 let uu____1127 =
                                                   let uu____1130 =
                                                     FStar_Syntax_Syntax.as_arg
-                                                      wp
-                                                     in
-                                                  [uu____1130]  in
-                                                uu____1126 :: uu____1127  in
-                                              (repr1, uu____1123)  in
+                                                      wp in
+                                                  [uu____1130] in
+                                                uu____1126 :: uu____1127 in
+                                              (repr1, uu____1123) in
                                             FStar_Syntax_Syntax.Tm_app
-                                              uu____1108
-                                             in
-                                          FStar_Syntax_Syntax.mk uu____1107
-                                           in
+                                              uu____1108 in
+                                          FStar_Syntax_Syntax.mk uu____1107 in
                                         uu____1104
                                           FStar_Pervasives_Native.None
-                                          FStar_Range.dummyRange
-                                         in
+                                          FStar_Range.dummyRange in
                                       let mk_repr a1 wp =
                                         let uu____1145 =
-                                          FStar_Syntax_Syntax.bv_to_name a1
-                                           in
-                                        mk_repr' uu____1145 wp  in
+                                          FStar_Syntax_Syntax.bv_to_name a1 in
+                                        mk_repr' uu____1145 wp in
                                       let destruct_repr t =
                                         let uu____1158 =
                                           let uu____1159 =
-                                            FStar_Syntax_Subst.compress t  in
-                                          uu____1159.FStar_Syntax_Syntax.n
-                                           in
+                                            FStar_Syntax_Subst.compress t in
+                                          uu____1159.FStar_Syntax_Syntax.n in
                                         match uu____1158 with
                                         | FStar_Syntax_Syntax.Tm_app
                                             (uu____1170,(t1,uu____1172)::
                                              (wp,uu____1174)::[])
                                             -> (t1, wp)
                                         | uu____1217 ->
-                                            failwith "Unexpected repr type"
-                                         in
+                                            failwith "Unexpected repr type" in
                                       let bind_repr =
                                         let r =
                                           let uu____1228 =
                                             FStar_Syntax_Syntax.lid_as_fv
                                               FStar_Parser_Const.range_0
                                               FStar_Syntax_Syntax.Delta_constant
-                                              FStar_Pervasives_Native.None
-                                             in
+                                              FStar_Pervasives_Native.None in
                                           FStar_All.pipe_right uu____1228
-                                            FStar_Syntax_Syntax.fv_to_tm
-                                           in
+                                            FStar_Syntax_Syntax.fv_to_tm in
                                         let uu____1229 =
-                                          fresh_effect_signature ()  in
+                                          fresh_effect_signature () in
                                         match uu____1229 with
                                         | (b,wp_b) ->
                                             let a_wp_b =
@@ -1081,158 +961,125 @@ let (tc_eff_decl :
                                                 let uu____1252 =
                                                   let uu____1253 =
                                                     FStar_Syntax_Syntax.bv_to_name
-                                                      a
-                                                     in
+                                                      a in
                                                   FStar_Syntax_Syntax.null_binder
-                                                    uu____1253
-                                                   in
-                                                [uu____1252]  in
+                                                    uu____1253 in
+                                                [uu____1252] in
                                               let uu____1254 =
                                                 FStar_Syntax_Syntax.mk_Total
-                                                  wp_b
-                                                 in
+                                                  wp_b in
                                               FStar_Syntax_Util.arrow
-                                                uu____1245 uu____1254
-                                               in
+                                                uu____1245 uu____1254 in
                                             let wp_f =
                                               FStar_Syntax_Syntax.gen_bv
                                                 "wp_f"
                                                 FStar_Pervasives_Native.None
-                                                wp_a
-                                               in
+                                                wp_a in
                                             let wp_g =
                                               FStar_Syntax_Syntax.gen_bv
                                                 "wp_g"
                                                 FStar_Pervasives_Native.None
-                                                a_wp_b
-                                               in
+                                                a_wp_b in
                                             let x_a =
                                               let uu____1260 =
                                                 FStar_Syntax_Syntax.bv_to_name
-                                                  a
-                                                 in
+                                                  a in
                                               FStar_Syntax_Syntax.gen_bv
                                                 "x_a"
                                                 FStar_Pervasives_Native.None
-                                                uu____1260
-                                               in
+                                                uu____1260 in
                                             let wp_g_x =
                                               let uu____1264 =
                                                 let uu____1265 =
                                                   FStar_Syntax_Syntax.bv_to_name
-                                                    wp_g
-                                                   in
+                                                    wp_g in
                                                 let uu____1266 =
                                                   let uu____1267 =
                                                     let uu____1268 =
                                                       FStar_Syntax_Syntax.bv_to_name
-                                                        x_a
-                                                       in
+                                                        x_a in
                                                     FStar_All.pipe_left
                                                       FStar_Syntax_Syntax.as_arg
-                                                      uu____1268
-                                                     in
-                                                  [uu____1267]  in
+                                                      uu____1268 in
+                                                  [uu____1267] in
                                                 FStar_Syntax_Syntax.mk_Tm_app
-                                                  uu____1265 uu____1266
-                                                 in
+                                                  uu____1265 uu____1266 in
                                               uu____1264
                                                 FStar_Pervasives_Native.None
-                                                FStar_Range.dummyRange
-                                               in
+                                                FStar_Range.dummyRange in
                                             let res =
                                               let wp =
                                                 let uu____1277 =
                                                   let uu____1278 =
                                                     let uu____1279 =
                                                       FStar_TypeChecker_Env.inst_tscheme
-                                                        bind_wp
-                                                       in
+                                                        bind_wp in
                                                     FStar_All.pipe_right
                                                       uu____1279
-                                                      FStar_Pervasives_Native.snd
-                                                     in
+                                                      FStar_Pervasives_Native.snd in
                                                   let uu____1288 =
                                                     let uu____1289 =
                                                       let uu____1292 =
                                                         let uu____1295 =
                                                           FStar_Syntax_Syntax.bv_to_name
-                                                            a
-                                                           in
+                                                            a in
                                                         let uu____1296 =
                                                           let uu____1299 =
                                                             FStar_Syntax_Syntax.bv_to_name
-                                                              b
-                                                             in
+                                                              b in
                                                           let uu____1300 =
                                                             let uu____1303 =
                                                               FStar_Syntax_Syntax.bv_to_name
-                                                                wp_f
-                                                               in
+                                                                wp_f in
                                                             let uu____1304 =
                                                               let uu____1307
                                                                 =
                                                                 FStar_Syntax_Syntax.bv_to_name
-                                                                  wp_g
-                                                                 in
-                                                              [uu____1307]
-                                                               in
+                                                                  wp_g in
+                                                              [uu____1307] in
                                                             uu____1303 ::
-                                                              uu____1304
-                                                             in
+                                                              uu____1304 in
                                                           uu____1299 ::
-                                                            uu____1300
-                                                           in
+                                                            uu____1300 in
                                                         uu____1295 ::
-                                                          uu____1296
-                                                         in
-                                                      r :: uu____1292  in
+                                                          uu____1296 in
+                                                      r :: uu____1292 in
                                                     FStar_List.map
                                                       FStar_Syntax_Syntax.as_arg
-                                                      uu____1289
-                                                     in
+                                                      uu____1289 in
                                                   FStar_Syntax_Syntax.mk_Tm_app
-                                                    uu____1278 uu____1288
-                                                   in
+                                                    uu____1278 uu____1288 in
                                                 uu____1277
                                                   FStar_Pervasives_Native.None
-                                                  FStar_Range.dummyRange
-                                                 in
-                                              mk_repr b wp  in
+                                                  FStar_Range.dummyRange in
+                                              mk_repr b wp in
                                             let expected_k =
                                               let uu____1313 =
                                                 let uu____1320 =
                                                   FStar_Syntax_Syntax.mk_binder
-                                                    a
-                                                   in
+                                                    a in
                                                 let uu____1321 =
                                                   let uu____1324 =
                                                     FStar_Syntax_Syntax.mk_binder
-                                                      b
-                                                     in
+                                                      b in
                                                   let uu____1325 =
                                                     let uu____1328 =
                                                       FStar_Syntax_Syntax.mk_binder
-                                                        wp_f
-                                                       in
+                                                        wp_f in
                                                     let uu____1329 =
                                                       let uu____1332 =
                                                         let uu____1333 =
                                                           let uu____1334 =
                                                             FStar_Syntax_Syntax.bv_to_name
-                                                              wp_f
-                                                             in
+                                                              wp_f in
                                                           mk_repr a
-                                                            uu____1334
-                                                           in
+                                                            uu____1334 in
                                                         FStar_Syntax_Syntax.null_binder
-                                                          uu____1333
-                                                         in
+                                                          uu____1333 in
                                                       let uu____1335 =
                                                         let uu____1338 =
                                                           FStar_Syntax_Syntax.mk_binder
-                                                            wp_g
-                                                           in
+                                                            wp_g in
                                                         let uu____1339 =
                                                           let uu____1342 =
                                                             let uu____1343 =
@@ -1241,51 +1088,38 @@ let (tc_eff_decl :
                                                                 let uu____1351
                                                                   =
                                                                   FStar_Syntax_Syntax.mk_binder
-                                                                    x_a
-                                                                   in
-                                                                [uu____1351]
-                                                                 in
+                                                                    x_a in
+                                                                [uu____1351] in
                                                               let uu____1352
                                                                 =
                                                                 let uu____1355
                                                                   =
                                                                   mk_repr b
-                                                                    wp_g_x
-                                                                   in
+                                                                    wp_g_x in
                                                                 FStar_All.pipe_left
                                                                   FStar_Syntax_Syntax.mk_Total
-                                                                  uu____1355
-                                                                 in
+                                                                  uu____1355 in
                                                               FStar_Syntax_Util.arrow
                                                                 uu____1344
-                                                                uu____1352
-                                                               in
+                                                                uu____1352 in
                                                             FStar_Syntax_Syntax.null_binder
-                                                              uu____1343
-                                                             in
-                                                          [uu____1342]  in
+                                                              uu____1343 in
+                                                          [uu____1342] in
                                                         uu____1338 ::
-                                                          uu____1339
-                                                         in
+                                                          uu____1339 in
                                                       uu____1332 ::
-                                                        uu____1335
-                                                       in
-                                                    uu____1328 :: uu____1329
-                                                     in
-                                                  uu____1324 :: uu____1325
-                                                   in
-                                                uu____1320 :: uu____1321  in
+                                                        uu____1335 in
+                                                    uu____1328 :: uu____1329 in
+                                                  uu____1324 :: uu____1325 in
+                                                uu____1320 :: uu____1321 in
                                               let uu____1356 =
                                                 FStar_Syntax_Syntax.mk_Total
-                                                  res
-                                                 in
+                                                  res in
                                               FStar_Syntax_Util.arrow
-                                                uu____1313 uu____1356
-                                               in
+                                                uu____1313 uu____1356 in
                                             let uu____1359 =
                                               FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                                env1 expected_k
-                                               in
+                                                env1 expected_k in
                                             (match uu____1359 with
                                              | (expected_k1,uu____1367,uu____1368)
                                                  ->
@@ -1293,11 +1127,9 @@ let (tc_eff_decl :
                                                    FStar_TypeChecker_Env.set_range
                                                      env1
                                                      (FStar_Pervasives_Native.snd
-                                                        ed2.FStar_Syntax_Syntax.bind_repr).FStar_Syntax_Syntax.pos
-                                                    in
+                                                        ed2.FStar_Syntax_Syntax.bind_repr).FStar_Syntax_Syntax.pos in
                                                  let env3 =
-                                                   let uu___66_1373 = env2
-                                                      in
+                                                   let uu___66_1373 = env2 in
                                                    {
                                                      FStar_TypeChecker_Env.solver
                                                        =
@@ -1403,83 +1235,66 @@ let (tc_eff_decl :
                                                      FStar_TypeChecker_Env.dep_graph
                                                        =
                                                        (uu___66_1373.FStar_TypeChecker_Env.dep_graph)
-                                                   }  in
+                                                   } in
                                                  let br =
                                                    check_and_gen' env3
                                                      ed2.FStar_Syntax_Syntax.bind_repr
-                                                     expected_k1
-                                                    in
-                                                 br)
-                                         in
+                                                     expected_k1 in
+                                                 br) in
                                       let return_repr =
                                         let x_a =
                                           let uu____1383 =
-                                            FStar_Syntax_Syntax.bv_to_name a
-                                             in
+                                            FStar_Syntax_Syntax.bv_to_name a in
                                           FStar_Syntax_Syntax.gen_bv "x_a"
                                             FStar_Pervasives_Native.None
-                                            uu____1383
-                                           in
+                                            uu____1383 in
                                         let res =
                                           let wp =
                                             let uu____1390 =
                                               let uu____1391 =
                                                 let uu____1392 =
                                                   FStar_TypeChecker_Env.inst_tscheme
-                                                    return_wp
-                                                   in
+                                                    return_wp in
                                                 FStar_All.pipe_right
                                                   uu____1392
-                                                  FStar_Pervasives_Native.snd
-                                                 in
+                                                  FStar_Pervasives_Native.snd in
                                               let uu____1401 =
                                                 let uu____1402 =
                                                   let uu____1405 =
                                                     FStar_Syntax_Syntax.bv_to_name
-                                                      a
-                                                     in
+                                                      a in
                                                   let uu____1406 =
                                                     let uu____1409 =
                                                       FStar_Syntax_Syntax.bv_to_name
-                                                        x_a
-                                                       in
-                                                    [uu____1409]  in
-                                                  uu____1405 :: uu____1406
-                                                   in
+                                                        x_a in
+                                                    [uu____1409] in
+                                                  uu____1405 :: uu____1406 in
                                                 FStar_List.map
                                                   FStar_Syntax_Syntax.as_arg
-                                                  uu____1402
-                                                 in
+                                                  uu____1402 in
                                               FStar_Syntax_Syntax.mk_Tm_app
-                                                uu____1391 uu____1401
-                                               in
+                                                uu____1391 uu____1401 in
                                             uu____1390
                                               FStar_Pervasives_Native.None
-                                              FStar_Range.dummyRange
-                                             in
-                                          mk_repr a wp  in
+                                              FStar_Range.dummyRange in
+                                          mk_repr a wp in
                                         let expected_k =
                                           let uu____1415 =
                                             let uu____1422 =
-                                              FStar_Syntax_Syntax.mk_binder a
-                                               in
+                                              FStar_Syntax_Syntax.mk_binder a in
                                             let uu____1423 =
                                               let uu____1426 =
                                                 FStar_Syntax_Syntax.mk_binder
-                                                  x_a
-                                                 in
-                                              [uu____1426]  in
-                                            uu____1422 :: uu____1423  in
+                                                  x_a in
+                                              [uu____1426] in
+                                            uu____1422 :: uu____1423 in
                                           let uu____1427 =
-                                            FStar_Syntax_Syntax.mk_Total res
-                                             in
+                                            FStar_Syntax_Syntax.mk_Total res in
                                           FStar_Syntax_Util.arrow uu____1415
-                                            uu____1427
-                                           in
+                                            uu____1427 in
                                         let uu____1430 =
                                           FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                            env1 expected_k
-                                           in
+                                            env1 expected_k in
                                         match uu____1430 with
                                         | (expected_k1,uu____1444,uu____1445)
                                             ->
@@ -1487,13 +1302,11 @@ let (tc_eff_decl :
                                               FStar_TypeChecker_Env.set_range
                                                 env1
                                                 (FStar_Pervasives_Native.snd
-                                                   ed2.FStar_Syntax_Syntax.return_repr).FStar_Syntax_Syntax.pos
-                                               in
+                                                   ed2.FStar_Syntax_Syntax.return_repr).FStar_Syntax_Syntax.pos in
                                             let uu____1449 =
                                               check_and_gen' env2
                                                 ed2.FStar_Syntax_Syntax.return_repr
-                                                expected_k1
-                                               in
+                                                expected_k1 in
                                             (match uu____1449 with
                                              | (univs1,repr1) ->
                                                  (match univs1 with
@@ -1502,22 +1315,19 @@ let (tc_eff_decl :
                                                       FStar_Errors.raise_error
                                                         (FStar_Errors.Fatal_UnexpectedUniversePolymorphicReturn,
                                                           "Unexpected universe-polymorphic return for effect")
-                                                        repr1.FStar_Syntax_Syntax.pos))
-                                         in
+                                                        repr1.FStar_Syntax_Syntax.pos)) in
                                       let actions =
                                         let check_action act =
                                           let uu____1495 =
                                             FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                               env1
-                                              act.FStar_Syntax_Syntax.action_typ
-                                             in
+                                              act.FStar_Syntax_Syntax.action_typ in
                                           match uu____1495 with
                                           | (act_typ,uu____1503,g_t) ->
                                               let env' =
                                                 let uu___67_1506 =
                                                   FStar_TypeChecker_Env.set_expected_typ
-                                                    env1 act_typ
-                                                   in
+                                                    env1 act_typ in
                                                 {
                                                   FStar_TypeChecker_Env.solver
                                                     =
@@ -1622,22 +1432,19 @@ let (tc_eff_decl :
                                                   FStar_TypeChecker_Env.dep_graph
                                                     =
                                                     (uu___67_1506.FStar_TypeChecker_Env.dep_graph)
-                                                }  in
+                                                } in
                                               ((let uu____1508 =
                                                   FStar_TypeChecker_Env.debug
                                                     env1
-                                                    (FStar_Options.Other "ED")
-                                                   in
+                                                    (FStar_Options.Other "ED") in
                                                 if uu____1508
                                                 then
                                                   let uu____1509 =
                                                     FStar_Syntax_Print.term_to_string
-                                                      act.FStar_Syntax_Syntax.action_defn
-                                                     in
+                                                      act.FStar_Syntax_Syntax.action_defn in
                                                   let uu____1510 =
                                                     FStar_Syntax_Print.term_to_string
-                                                      act_typ
-                                                     in
+                                                      act_typ in
                                                   FStar_Util.print3
                                                     "Checking action %s:\n[definition]: %s\n[cps'd type]: %s\n"
                                                     (FStar_Ident.text_of_lid
@@ -1647,8 +1454,7 @@ let (tc_eff_decl :
                                                (let uu____1512 =
                                                   FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                     env'
-                                                    act.FStar_Syntax_Syntax.action_defn
-                                                   in
+                                                    act.FStar_Syntax_Syntax.action_defn in
                                                 match uu____1512 with
                                                 | (act_defn,uu____1520,g_a)
                                                     ->
@@ -1656,29 +1462,25 @@ let (tc_eff_decl :
                                                       FStar_TypeChecker_Normalize.normalize
                                                         [FStar_TypeChecker_Normalize.UnfoldUntil
                                                            FStar_Syntax_Syntax.Delta_constant]
-                                                        env1 act_defn
-                                                       in
+                                                        env1 act_defn in
                                                     let act_typ1 =
                                                       FStar_TypeChecker_Normalize.normalize
                                                         [FStar_TypeChecker_Normalize.UnfoldUntil
                                                            FStar_Syntax_Syntax.Delta_constant;
                                                         FStar_TypeChecker_Normalize.Eager_unfolding;
                                                         FStar_TypeChecker_Normalize.Beta]
-                                                        env1 act_typ
-                                                       in
+                                                        env1 act_typ in
                                                     let uu____1524 =
                                                       let act_typ2 =
                                                         FStar_Syntax_Subst.compress
-                                                          act_typ1
-                                                         in
+                                                          act_typ1 in
                                                       match act_typ2.FStar_Syntax_Syntax.n
                                                       with
                                                       | FStar_Syntax_Syntax.Tm_arrow
                                                           (bs,c) ->
                                                           let uu____1552 =
                                                             FStar_Syntax_Subst.open_comp
-                                                              bs c
-                                                             in
+                                                              bs c in
                                                           (match uu____1552
                                                            with
                                                            | (bs1,uu____1562)
@@ -1686,23 +1488,19 @@ let (tc_eff_decl :
                                                                let res =
                                                                  mk_repr'
                                                                    FStar_Syntax_Syntax.tun
-                                                                   FStar_Syntax_Syntax.tun
-                                                                  in
+                                                                   FStar_Syntax_Syntax.tun in
                                                                let k =
                                                                  let uu____1569
                                                                    =
                                                                    FStar_Syntax_Syntax.mk_Total
-                                                                    res
-                                                                    in
+                                                                    res in
                                                                  FStar_Syntax_Util.arrow
                                                                    bs1
-                                                                   uu____1569
-                                                                  in
+                                                                   uu____1569 in
                                                                let uu____1572
                                                                  =
                                                                  FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                                                   env1 k
-                                                                  in
+                                                                   env1 k in
                                                                (match uu____1572
                                                                 with
                                                                 | (k1,uu____1584,g)
@@ -1714,46 +1512,37 @@ let (tc_eff_decl :
                                                               let uu____1593
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
-                                                                  act_typ2
-                                                                 in
+                                                                  act_typ2 in
                                                               let uu____1594
                                                                 =
                                                                 FStar_Syntax_Print.tag_of_term
-                                                                  act_typ2
-                                                                 in
+                                                                  act_typ2 in
                                                               FStar_Util.format2
                                                                 "Actions must have function types (not: %s, a.k.a. %s)"
                                                                 uu____1593
-                                                                uu____1594
-                                                               in
+                                                                uu____1594 in
                                                             (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                              uu____1592)
-                                                             in
+                                                              uu____1592) in
                                                           FStar_Errors.raise_error
                                                             uu____1587
-                                                            act_defn1.FStar_Syntax_Syntax.pos
-                                                       in
+                                                            act_defn1.FStar_Syntax_Syntax.pos in
                                                     (match uu____1524 with
                                                      | (expected_k,g_k) ->
                                                          let g =
                                                            FStar_TypeChecker_Rel.teq
                                                              env1 act_typ1
-                                                             expected_k
-                                                            in
+                                                             expected_k in
                                                          ((let uu____1603 =
                                                              let uu____1604 =
                                                                let uu____1605
                                                                  =
                                                                  FStar_TypeChecker_Rel.conj_guard
-                                                                   g_t g
-                                                                  in
+                                                                   g_t g in
                                                                FStar_TypeChecker_Rel.conj_guard
                                                                  g_k
-                                                                 uu____1605
-                                                                in
+                                                                 uu____1605 in
                                                              FStar_TypeChecker_Rel.conj_guard
-                                                               g_a uu____1604
-                                                              in
+                                                               g_a uu____1604 in
                                                            FStar_TypeChecker_Rel.force_trivial_guard
                                                              env1 uu____1603);
                                                           (let act_typ2 =
@@ -1761,10 +1550,8 @@ let (tc_eff_decl :
                                                                let uu____1610
                                                                  =
                                                                  FStar_Syntax_Subst.compress
-                                                                   expected_k
-                                                                  in
-                                                               uu____1610.FStar_Syntax_Syntax.n
-                                                                in
+                                                                   expected_k in
+                                                               uu____1610.FStar_Syntax_Syntax.n in
                                                              match uu____1609
                                                              with
                                                              | FStar_Syntax_Syntax.Tm_arrow
@@ -1772,8 +1559,7 @@ let (tc_eff_decl :
                                                                  let uu____1633
                                                                    =
                                                                    FStar_Syntax_Subst.open_comp
-                                                                    bs c
-                                                                    in
+                                                                    bs c in
                                                                  (match uu____1633
                                                                   with
                                                                   | (bs1,c1)
@@ -1782,7 +1568,7 @@ let (tc_eff_decl :
                                                                     =
                                                                     destruct_repr
                                                                     (FStar_Syntax_Util.comp_result
-                                                                    c1)  in
+                                                                    c1) in
                                                                     (match uu____1642
                                                                     with
                                                                     | 
@@ -1794,18 +1580,15 @@ let (tc_eff_decl :
                                                                     let uu____1665
                                                                     =
                                                                     env1.FStar_TypeChecker_Env.universe_of
-                                                                    env1 a1
-                                                                     in
-                                                                    [uu____1665]
-                                                                     in
+                                                                    env1 a1 in
+                                                                    [uu____1665] in
                                                                     let uu____1666
                                                                     =
                                                                     let uu____1675
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    wp  in
-                                                                    [uu____1675]
-                                                                     in
+                                                                    wp in
+                                                                    [uu____1675] in
                                                                     {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
@@ -1820,22 +1603,20 @@ let (tc_eff_decl :
                                                                     uu____1666;
                                                                     FStar_Syntax_Syntax.flags
                                                                     = []
-                                                                    }  in
+                                                                    } in
                                                                     let uu____1676
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Comp
-                                                                    c2  in
+                                                                    c2 in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs1
                                                                     uu____1676))
                                                              | uu____1679 ->
                                                                  failwith
-                                                                   "Impossible (expected_k is an arrow)"
-                                                              in
+                                                                   "Impossible (expected_k is an arrow)" in
                                                            let uu____1682 =
                                                              FStar_TypeChecker_Util.generalize_universes
-                                                               env1 act_defn1
-                                                              in
+                                                               env1 act_defn1 in
                                                            match uu____1682
                                                            with
                                                            | (univs1,act_defn2)
@@ -1844,15 +1625,13 @@ let (tc_eff_decl :
                                                                  FStar_TypeChecker_Normalize.normalize
                                                                    [FStar_TypeChecker_Normalize.Beta]
                                                                    env1
-                                                                   act_typ2
-                                                                  in
+                                                                   act_typ2 in
                                                                let act_typ4 =
                                                                  FStar_Syntax_Subst.close_univ_vars
                                                                    univs1
-                                                                   act_typ3
-                                                                  in
+                                                                   act_typ3 in
                                                                let uu___68_1691
-                                                                 = act  in
+                                                                 = act in
                                                                {
                                                                  FStar_Syntax_Syntax.action_name
                                                                    =
@@ -1870,30 +1649,24 @@ let (tc_eff_decl :
                                                                    act_defn2;
                                                                  FStar_Syntax_Syntax.action_typ
                                                                    = act_typ4
-                                                               })))))
-                                           in
+                                                               }))))) in
                                         FStar_All.pipe_right
                                           ed2.FStar_Syntax_Syntax.actions
-                                          (FStar_List.map check_action)
-                                         in
-                                      (repr, bind_repr, return_repr, actions)
-                                   in
+                                          (FStar_List.map check_action) in
+                                      (repr, bind_repr, return_repr, actions) in
                                 match uu____1040 with
                                 | (repr,bind_repr,return_repr,actions) ->
                                     let t0 =
                                       let uu____1715 =
                                         FStar_Syntax_Syntax.mk_Total
-                                          ed2.FStar_Syntax_Syntax.signature
-                                         in
+                                          ed2.FStar_Syntax_Syntax.signature in
                                       FStar_Syntax_Util.arrow
                                         ed2.FStar_Syntax_Syntax.binders
-                                        uu____1715
-                                       in
+                                        uu____1715 in
                                     let uu____1718 =
                                       let uu____1725 =
                                         FStar_TypeChecker_Util.generalize_universes
-                                          env0 t0
-                                         in
+                                          env0 t0 in
                                       match uu____1725 with
                                       | (gen_univs,t) ->
                                           (match annotated_univ_names with
@@ -1912,10 +1685,10 @@ let (tc_eff_decl :
                                                            (FStar_Syntax_Syntax.order_univ_name
                                                               u1 u2)
                                                              =
-                                                             (Prims.parse_int "0"))
+                                                             (Prims.parse_int
+                                                                "0"))
                                                       gen_univs
-                                                      annotated_univ_names)
-                                                  in
+                                                      annotated_univ_names) in
                                                if uu____1749
                                                then (gen_univs, t)
                                                else
@@ -1924,24 +1697,19 @@ let (tc_eff_decl :
                                                       let uu____1769 =
                                                         FStar_Util.string_of_int
                                                           (FStar_List.length
-                                                             annotated_univ_names)
-                                                         in
+                                                             annotated_univ_names) in
                                                       let uu____1770 =
                                                         FStar_Util.string_of_int
                                                           (FStar_List.length
-                                                             gen_univs)
-                                                         in
+                                                             gen_univs) in
                                                       FStar_Util.format2
                                                         "Expected an effect definition with %s universes; but found %s"
-                                                        uu____1769 uu____1770
-                                                       in
+                                                        uu____1769 uu____1770 in
                                                     (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                      uu____1768)
-                                                     in
+                                                      uu____1768) in
                                                   FStar_Errors.raise_error
                                                     uu____1763
-                                                    (ed2.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos))
-                                       in
+                                                    (ed2.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos)) in
                                     (match uu____1718 with
                                      | (univs1,t) ->
                                          let signature1 =
@@ -1949,11 +1717,9 @@ let (tc_eff_decl :
                                              let uu____1789 =
                                                let uu____1790 =
                                                  FStar_Syntax_Subst.compress
-                                                   t
-                                                  in
-                                               uu____1790.FStar_Syntax_Syntax.n
-                                                in
-                                             (effect_params, uu____1789)  in
+                                                   t in
+                                               uu____1790.FStar_Syntax_Syntax.n in
+                                             (effect_params, uu____1789) in
                                            match uu____1784 with
                                            | ([],uu____1793) -> t
                                            | (uu____1804,FStar_Syntax_Syntax.Tm_arrow
@@ -1962,34 +1728,28 @@ let (tc_eff_decl :
                                                  c
                                            | uu____1823 ->
                                                failwith
-                                                 "Impossible : t is an arrow"
-                                            in
+                                                 "Impossible : t is an arrow" in
                                          let close1 n1 ts =
                                            let ts1 =
                                              let uu____1836 =
                                                FStar_Syntax_Subst.close_tscheme
-                                                 effect_params ts
-                                                in
+                                                 effect_params ts in
                                              FStar_Syntax_Subst.close_univ_vars_tscheme
-                                               univs1 uu____1836
-                                              in
+                                               univs1 uu____1836 in
                                            let m =
                                              FStar_List.length
                                                (FStar_Pervasives_Native.fst
-                                                  ts1)
-                                              in
+                                                  ts1) in
                                            (let uu____1841 =
                                               ((n1 >= (Prims.parse_int "0"))
                                                  &&
                                                  (let uu____1843 =
                                                     FStar_Syntax_Util.is_unknown
                                                       (FStar_Pervasives_Native.snd
-                                                         ts1)
-                                                     in
+                                                         ts1) in
                                                   Prims.op_Negation
                                                     uu____1843))
-                                                && (m <> n1)
-                                               in
+                                                && (m <> n1) in
                                             if uu____1841
                                             then
                                               let error =
@@ -1997,50 +1757,41 @@ let (tc_eff_decl :
                                                 then
                                                   "not universe-polymorphic enough"
                                                 else
-                                                  "too universe-polymorphic"
-                                                 in
+                                                  "too universe-polymorphic" in
                                               let err_msg =
                                                 let uu____1859 =
-                                                  FStar_Util.string_of_int m
-                                                   in
+                                                  FStar_Util.string_of_int m in
                                                 let uu____1866 =
-                                                  FStar_Util.string_of_int n1
-                                                   in
+                                                  FStar_Util.string_of_int n1 in
                                                 let uu____1867 =
                                                   FStar_Syntax_Print.tscheme_to_string
-                                                    ts1
-                                                   in
+                                                    ts1 in
                                                 FStar_Util.format4
                                                   "The effect combinator is %s (m,n=%s,%s) (%s)"
                                                   error uu____1859 uu____1866
-                                                  uu____1867
-                                                 in
+                                                  uu____1867 in
                                               FStar_Errors.raise_error
                                                 (FStar_Errors.Fatal_MismatchUniversePolymorphic,
                                                   err_msg)
                                                 (FStar_Pervasives_Native.snd
                                                    ts1).FStar_Syntax_Syntax.pos
                                             else ());
-                                           ts1  in
+                                           ts1 in
                                          let close_action act =
                                            let uu____1875 =
-                                             close1
-                                               (~- (Prims.parse_int "1"))
+                                             close1 (- (Prims.parse_int "1"))
                                                ((act.FStar_Syntax_Syntax.action_univs),
-                                                 (act.FStar_Syntax_Syntax.action_defn))
-                                              in
+                                                 (act.FStar_Syntax_Syntax.action_defn)) in
                                            match uu____1875 with
                                            | (univs2,defn) ->
                                                let uu____1882 =
                                                  close1
-                                                   (~- (Prims.parse_int "1"))
+                                                   (- (Prims.parse_int "1"))
                                                    ((act.FStar_Syntax_Syntax.action_univs),
-                                                     (act.FStar_Syntax_Syntax.action_typ))
-                                                  in
+                                                     (act.FStar_Syntax_Syntax.action_typ)) in
                                                (match uu____1882 with
                                                 | (univs',typ) ->
-                                                    let uu___69_1892 = act
-                                                       in
+                                                    let uu___69_1892 = act in
                                                     {
                                                       FStar_Syntax_Syntax.action_name
                                                         =
@@ -2057,70 +1808,54 @@ let (tc_eff_decl :
                                                         = defn;
                                                       FStar_Syntax_Syntax.action_typ
                                                         = typ
-                                                    })
-                                            in
+                                                    }) in
                                          let ed3 =
-                                           let uu___70_1897 = ed2  in
+                                           let uu___70_1897 = ed2 in
                                            let uu____1898 =
                                              close1 (Prims.parse_int "0")
-                                               return_wp
-                                              in
+                                               return_wp in
                                            let uu____1899 =
                                              close1 (Prims.parse_int "1")
-                                               bind_wp
-                                              in
+                                               bind_wp in
                                            let uu____1900 =
                                              close1 (Prims.parse_int "0")
-                                               if_then_else1
-                                              in
+                                               if_then_else1 in
                                            let uu____1901 =
                                              close1 (Prims.parse_int "0")
-                                               ite_wp
-                                              in
+                                               ite_wp in
                                            let uu____1902 =
                                              close1 (Prims.parse_int "0")
-                                               stronger
-                                              in
+                                               stronger in
                                            let uu____1903 =
                                              close1 (Prims.parse_int "1")
-                                               close_wp
-                                              in
+                                               close_wp in
                                            let uu____1904 =
                                              close1 (Prims.parse_int "0")
-                                               assert_p
-                                              in
+                                               assert_p in
                                            let uu____1905 =
                                              close1 (Prims.parse_int "0")
-                                               assume_p
-                                              in
+                                               assume_p in
                                            let uu____1906 =
                                              close1 (Prims.parse_int "0")
-                                               null_wp
-                                              in
+                                               null_wp in
                                            let uu____1907 =
                                              close1 (Prims.parse_int "0")
-                                               trivial_wp
-                                              in
+                                               trivial_wp in
                                            let uu____1908 =
                                              let uu____1909 =
                                                close1 (Prims.parse_int "0")
-                                                 ([], repr)
-                                                in
+                                                 ([], repr) in
                                              FStar_Pervasives_Native.snd
-                                               uu____1909
-                                              in
+                                               uu____1909 in
                                            let uu____1920 =
                                              close1 (Prims.parse_int "0")
-                                               return_repr
-                                              in
+                                               return_repr in
                                            let uu____1921 =
                                              close1 (Prims.parse_int "1")
-                                               bind_repr
-                                              in
+                                               bind_repr in
                                            let uu____1922 =
                                              FStar_List.map close_action
-                                               actions
-                                              in
+                                               actions in
                                            {
                                              FStar_Syntax_Syntax.cattributes
                                                =
@@ -2161,7 +1896,7 @@ let (tc_eff_decl :
                                                uu____1921;
                                              FStar_Syntax_Syntax.actions =
                                                uu____1922
-                                           }  in
+                                           } in
                                          ((let uu____1926 =
                                              (FStar_TypeChecker_Env.debug
                                                 env1 FStar_Options.Low)
@@ -2169,75 +1904,67 @@ let (tc_eff_decl :
                                                (FStar_All.pipe_left
                                                   (FStar_TypeChecker_Env.debug
                                                      env1)
-                                                  (FStar_Options.Other "ED"))
-                                              in
+                                                  (FStar_Options.Other "ED")) in
                                            if uu____1926
                                            then
                                              let uu____1927 =
                                                FStar_Syntax_Print.eff_decl_to_string
-                                                 false ed3
-                                                in
+                                                 false ed3 in
                                              FStar_Util.print_string
                                                uu____1927
                                            else ());
                                           ed3))))))))
-  
-let (cps_and_elaborate :
+let cps_and_elaborate:
   FStar_TypeChecker_Env.env_t ->
     FStar_Syntax_Syntax.eff_decl ->
       (FStar_Syntax_Syntax.sigelt Prims.list,FStar_Syntax_Syntax.eff_decl,
         FStar_Syntax_Syntax.sigelt FStar_Pervasives_Native.option)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun ed  ->
       let uu____1945 =
         FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders
-          ed.FStar_Syntax_Syntax.signature
-         in
+          ed.FStar_Syntax_Syntax.signature in
       match uu____1945 with
       | (effect_binders_un,signature_un) ->
           let uu____1962 =
-            FStar_TypeChecker_TcTerm.tc_tparams env effect_binders_un  in
+            FStar_TypeChecker_TcTerm.tc_tparams env effect_binders_un in
           (match uu____1962 with
            | (effect_binders,env1,uu____1981) ->
                let uu____1982 =
-                 FStar_TypeChecker_TcTerm.tc_trivial_guard env1 signature_un
-                  in
+                 FStar_TypeChecker_TcTerm.tc_trivial_guard env1 signature_un in
                (match uu____1982 with
                 | (signature,uu____1998) ->
                     let raise_error1 a uu____2009 =
                       match uu____2009 with
                       | (e,err_msg) ->
                           FStar_Errors.raise_error (e, err_msg)
-                            signature.FStar_Syntax_Syntax.pos
-                       in
+                            signature.FStar_Syntax_Syntax.pos in
                     let effect_binders1 =
                       FStar_List.map
                         (fun uu____2035  ->
                            match uu____2035 with
                            | (bv,qual) ->
                                let uu____2046 =
-                                 let uu___71_2047 = bv  in
+                                 let uu___71_2047 = bv in
                                  let uu____2048 =
                                    FStar_TypeChecker_Normalize.normalize
                                      [FStar_TypeChecker_Normalize.EraseUniverses]
-                                     env1 bv.FStar_Syntax_Syntax.sort
-                                    in
+                                     env1 bv.FStar_Syntax_Syntax.sort in
                                  {
                                    FStar_Syntax_Syntax.ppname =
                                      (uu___71_2047.FStar_Syntax_Syntax.ppname);
                                    FStar_Syntax_Syntax.index =
                                      (uu___71_2047.FStar_Syntax_Syntax.index);
                                    FStar_Syntax_Syntax.sort = uu____2048
-                                 }  in
-                               (uu____2046, qual)) effect_binders
-                       in
+                                 } in
+                               (uu____2046, qual)) effect_binders in
                     let uu____2051 =
                       let uu____2058 =
                         let uu____2059 =
-                          FStar_Syntax_Subst.compress signature_un  in
-                        uu____2059.FStar_Syntax_Syntax.n  in
+                          FStar_Syntax_Subst.compress signature_un in
+                        uu____2059.FStar_Syntax_Syntax.n in
                       Obj.magic
                         (match uu____2058 with
                          | FStar_Syntax_Syntax.Tm_arrow
@@ -2247,66 +1974,56 @@ let (cps_and_elaborate :
                              Obj.repr
                                (raise_error1 ()
                                   (FStar_Errors.Fatal_BadSignatureShape,
-                                    "bad shape for effect-for-free signature")))
-                       in
+                                    "bad shape for effect-for-free signature"))) in
                     (match uu____2051 with
                      | (a,effect_marker) ->
                          let a1 =
-                           let uu____2109 = FStar_Syntax_Syntax.is_null_bv a
-                              in
+                           let uu____2109 = FStar_Syntax_Syntax.is_null_bv a in
                            if uu____2109
                            then
                              let uu____2110 =
                                let uu____2113 =
-                                 FStar_Syntax_Syntax.range_of_bv a  in
-                               FStar_Pervasives_Native.Some uu____2113  in
+                                 FStar_Syntax_Syntax.range_of_bv a in
+                               FStar_Pervasives_Native.Some uu____2113 in
                              FStar_Syntax_Syntax.gen_bv "a" uu____2110
                                a.FStar_Syntax_Syntax.sort
-                           else a  in
+                           else a in
                          let open_and_check env2 other_binders t =
                            let subst1 =
                              FStar_Syntax_Subst.opening_of_binders
                                (FStar_List.append effect_binders1
-                                  other_binders)
-                              in
-                           let t1 = FStar_Syntax_Subst.subst subst1 t  in
+                                  other_binders) in
+                           let t1 = FStar_Syntax_Subst.subst subst1 t in
                            let uu____2147 =
-                             FStar_TypeChecker_TcTerm.tc_term env2 t1  in
+                             FStar_TypeChecker_TcTerm.tc_term env2 t1 in
                            match uu____2147 with
-                           | (t2,comp,uu____2160) -> (t2, comp)  in
+                           | (t2,comp,uu____2160) -> (t2, comp) in
                          let mk1 x =
                            FStar_Syntax_Syntax.mk x
                              FStar_Pervasives_Native.None
-                             signature.FStar_Syntax_Syntax.pos
-                            in
+                             signature.FStar_Syntax_Syntax.pos in
                          let uu____2167 =
-                           open_and_check env1 [] ed.FStar_Syntax_Syntax.repr
-                            in
+                           open_and_check env1 [] ed.FStar_Syntax_Syntax.repr in
                          (match uu____2167 with
                           | (repr,_comp) ->
                               ((let uu____2189 =
                                   FStar_TypeChecker_Env.debug env1
-                                    (FStar_Options.Other "ED")
-                                   in
+                                    (FStar_Options.Other "ED") in
                                 if uu____2189
                                 then
                                   let uu____2190 =
-                                    FStar_Syntax_Print.term_to_string repr
-                                     in
+                                    FStar_Syntax_Print.term_to_string repr in
                                   FStar_Util.print1 "Representation is: %s\n"
                                     uu____2190
                                 else ());
                                (let dmff_env =
                                   FStar_TypeChecker_DMFF.empty env1
                                     (FStar_TypeChecker_TcTerm.tc_constant
-                                       env1 FStar_Range.dummyRange)
-                                   in
+                                       env1 FStar_Range.dummyRange) in
                                 let wp_type =
                                   FStar_TypeChecker_DMFF.star_type dmff_env
-                                    repr
-                                   in
-                                let wp_type1 = recheck_debug "*" env1 wp_type
-                                   in
+                                    repr in
+                                let wp_type1 = recheck_debug "*" env1 wp_type in
                                 let wp_a =
                                   let uu____2196 =
                                     let uu____2197 =
@@ -2315,126 +2032,102 @@ let (cps_and_elaborate :
                                           let uu____2220 =
                                             let uu____2225 =
                                               FStar_Syntax_Syntax.bv_to_name
-                                                a1
-                                               in
+                                                a1 in
                                             let uu____2226 =
                                               FStar_Syntax_Syntax.as_implicit
-                                                false
-                                               in
-                                            (uu____2225, uu____2226)  in
-                                          [uu____2220]  in
-                                        (wp_type1, uu____2213)  in
-                                      FStar_Syntax_Syntax.Tm_app uu____2198
-                                       in
-                                    mk1 uu____2197  in
+                                                false in
+                                            (uu____2225, uu____2226) in
+                                          [uu____2220] in
+                                        (wp_type1, uu____2213) in
+                                      FStar_Syntax_Syntax.Tm_app uu____2198 in
+                                    mk1 uu____2197 in
                                   FStar_TypeChecker_Normalize.normalize
                                     [FStar_TypeChecker_Normalize.Beta] env1
-                                    uu____2196
-                                   in
+                                    uu____2196 in
                                 let effect_signature =
                                   let binders =
                                     let uu____2251 =
                                       let uu____2256 =
-                                        FStar_Syntax_Syntax.as_implicit false
-                                         in
-                                      (a1, uu____2256)  in
+                                        FStar_Syntax_Syntax.as_implicit false in
+                                      (a1, uu____2256) in
                                     let uu____2257 =
                                       let uu____2264 =
                                         let uu____2265 =
                                           FStar_Syntax_Syntax.gen_bv
                                             "dijkstra_wp"
-                                            FStar_Pervasives_Native.None wp_a
-                                           in
+                                            FStar_Pervasives_Native.None wp_a in
                                         FStar_All.pipe_right uu____2265
-                                          FStar_Syntax_Syntax.mk_binder
-                                         in
-                                      [uu____2264]  in
-                                    uu____2251 :: uu____2257  in
+                                          FStar_Syntax_Syntax.mk_binder in
+                                      [uu____2264] in
+                                    uu____2251 :: uu____2257 in
                                   let binders1 =
-                                    FStar_Syntax_Subst.close_binders binders
-                                     in
+                                    FStar_Syntax_Subst.close_binders binders in
                                   mk1
                                     (FStar_Syntax_Syntax.Tm_arrow
-                                       (binders1, effect_marker))
-                                   in
+                                       (binders1, effect_marker)) in
                                 let effect_signature1 =
                                   recheck_debug
                                     "turned into the effect signature" env1
-                                    effect_signature
-                                   in
-                                let sigelts = FStar_Util.mk_ref []  in
+                                    effect_signature in
+                                let sigelts = FStar_Util.mk_ref [] in
                                 let mk_lid name =
-                                  FStar_Syntax_Util.dm4f_lid ed name  in
+                                  FStar_Syntax_Util.dm4f_lid ed name in
                                 let elaborate_and_star dmff_env1
                                   other_binders item =
                                   let env2 =
-                                    FStar_TypeChecker_DMFF.get_env dmff_env1
-                                     in
-                                  let uu____2328 = item  in
+                                    FStar_TypeChecker_DMFF.get_env dmff_env1 in
+                                  let uu____2328 = item in
                                   match uu____2328 with
                                   | (u_item,item1) ->
                                       let uu____2349 =
                                         open_and_check env2 other_binders
-                                          item1
-                                         in
+                                          item1 in
                                       (match uu____2349 with
                                        | (item2,item_comp) ->
                                            ((let uu____2365 =
                                                let uu____2366 =
                                                  FStar_Syntax_Util.is_total_lcomp
-                                                   item_comp
-                                                  in
-                                               Prims.op_Negation uu____2366
-                                                in
+                                                   item_comp in
+                                               Prims.op_Negation uu____2366 in
                                              if uu____2365
                                              then
                                                let uu____2367 =
                                                  let uu____2372 =
                                                    let uu____2373 =
                                                      FStar_Syntax_Print.term_to_string
-                                                       item2
-                                                      in
+                                                       item2 in
                                                    let uu____2374 =
                                                      FStar_Syntax_Print.lcomp_to_string
-                                                       item_comp
-                                                      in
+                                                       item_comp in
                                                    FStar_Util.format2
                                                      "Computation for [%s] is not total : %s !"
-                                                     uu____2373 uu____2374
-                                                    in
+                                                     uu____2373 uu____2374 in
                                                  (FStar_Errors.Fatal_ComputationNotTotal,
-                                                   uu____2372)
-                                                  in
+                                                   uu____2372) in
                                                FStar_Errors.raise_err
                                                  uu____2367
                                              else ());
                                             (let uu____2376 =
                                                FStar_TypeChecker_DMFF.star_expr
-                                                 dmff_env1 item2
-                                                in
+                                                 dmff_env1 item2 in
                                              match uu____2376 with
                                              | (item_t,item_wp,item_elab) ->
                                                  let item_wp1 =
                                                    recheck_debug "*" env2
-                                                     item_wp
-                                                    in
+                                                     item_wp in
                                                  let item_elab1 =
                                                    recheck_debug "_" env2
-                                                     item_elab
-                                                    in
+                                                     item_elab in
                                                  (dmff_env1, item_t,
-                                                   item_wp1, item_elab1))))
-                                   in
+                                                   item_wp1, item_elab1)))) in
                                 let uu____2396 =
                                   elaborate_and_star dmff_env []
-                                    ed.FStar_Syntax_Syntax.bind_repr
-                                   in
+                                    ed.FStar_Syntax_Syntax.bind_repr in
                                 match uu____2396 with
                                 | (dmff_env1,uu____2420,bind_wp,bind_elab) ->
                                     let uu____2423 =
                                       elaborate_and_star dmff_env1 []
-                                        ed.FStar_Syntax_Syntax.return_repr
-                                       in
+                                        ed.FStar_Syntax_Syntax.return_repr in
                                     (match uu____2423 with
                                      | (dmff_env2,uu____2447,return_wp,return_elab)
                                          ->
@@ -2447,15 +2140,13 @@ let (cps_and_elaborate :
                                                = FStar_Pervasives_Native.None;
                                              FStar_Syntax_Syntax.residual_flags
                                                = []
-                                           }  in
+                                           } in
                                          let lift_from_pure_wp =
                                            let uu____2454 =
                                              let uu____2455 =
                                                FStar_Syntax_Subst.compress
-                                                 return_wp
-                                                in
-                                             uu____2455.FStar_Syntax_Syntax.n
-                                              in
+                                                 return_wp in
+                                             uu____2455.FStar_Syntax_Syntax.n in
                                            Obj.magic
                                              (match uu____2454 with
                                               | FStar_Syntax_Syntax.Tm_abs
@@ -2466,31 +2157,26 @@ let (cps_and_elaborate :
                                                          let uu____2519 =
                                                            FStar_Syntax_Util.abs
                                                              bs body
-                                                             FStar_Pervasives_Native.None
-                                                            in
+                                                             FStar_Pervasives_Native.None in
                                                          FStar_Syntax_Subst.open_term
                                                            [b1; b2]
-                                                           uu____2519
-                                                          in
+                                                           uu____2519 in
                                                        match uu____2514 with
                                                        | (b11::b21::[],body1)
                                                            ->
                                                            (b11, b21, body1)
                                                        | uu____2583 ->
                                                            failwith
-                                                             "Impossible : open_term not preserving binders arity"
-                                                        in
+                                                             "Impossible : open_term not preserving binders arity" in
                                                      match uu____2499 with
                                                      | (b11,b21,body1) ->
                                                          let env0 =
                                                            let uu____2622 =
                                                              FStar_TypeChecker_DMFF.get_env
-                                                               dmff_env2
-                                                              in
+                                                               dmff_env2 in
                                                            FStar_TypeChecker_Env.push_binders
                                                              uu____2622
-                                                             [b11; b21]
-                                                            in
+                                                             [b11; b21] in
                                                          let wp_b1 =
                                                            let raw_wp_b1 =
                                                              let uu____2639 =
@@ -2504,42 +2190,33 @@ let (cps_and_elaborate :
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     (FStar_Pervasives_Native.fst
-                                                                    b11)  in
+                                                                    b11) in
                                                                     let uu____2668
                                                                     =
                                                                     FStar_Syntax_Syntax.as_implicit
-                                                                    false  in
+                                                                    false in
                                                                     (uu____2667,
-                                                                    uu____2668)
-                                                                     in
-                                                                   [uu____2662]
-                                                                    in
+                                                                    uu____2668) in
+                                                                   [uu____2662] in
                                                                  (wp_type1,
-                                                                   uu____2655)
-                                                                  in
+                                                                   uu____2655) in
                                                                FStar_Syntax_Syntax.Tm_app
-                                                                 uu____2640
-                                                                in
-                                                             mk1 uu____2639
-                                                              in
+                                                                 uu____2640 in
+                                                             mk1 uu____2639 in
                                                            FStar_TypeChecker_Normalize.normalize
                                                              [FStar_TypeChecker_Normalize.Beta]
-                                                             env0 raw_wp_b1
-                                                            in
+                                                             env0 raw_wp_b1 in
                                                          let uu____2683 =
                                                            let uu____2692 =
                                                              let uu____2693 =
                                                                FStar_Syntax_Util.unascribe
-                                                                 wp_b1
-                                                                in
+                                                                 wp_b1 in
                                                              FStar_TypeChecker_Normalize.eta_expand_with_type
                                                                env0 body1
-                                                               uu____2693
-                                                              in
+                                                               uu____2693 in
                                                            FStar_All.pipe_left
                                                              FStar_Syntax_Util.abs_formals
-                                                             uu____2692
-                                                            in
+                                                             uu____2692 in
                                                          (match uu____2683
                                                           with
                                                           | (bs1,body2,what')
@@ -2554,7 +2231,7 @@ let (cps_and_elaborate :
                                                                     let uu____2714
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
-                                                                    body2  in
+                                                                    body2 in
                                                                     FStar_Util.format2
                                                                     "The body of return_wp (%s) should be of type Type0 but is of type %s"
                                                                     uu____2714
@@ -2568,14 +2245,12 @@ let (cps_and_elaborate :
                                                                     FStar_Pervasives_Native.Some
                                                                     rc ->
                                                                     FStar_Ident.text_of_lid
-                                                                    rc.FStar_Syntax_Syntax.residual_effect)
-                                                                     in
+                                                                    rc.FStar_Syntax_Syntax.residual_effect) in
                                                                     raise_error1
                                                                     ()
                                                                     (FStar_Errors.Fatal_WrongBodyTypeForReturnWP,
                                                                     error_msg)))
-                                                                  a415
-                                                                 in
+                                                                  a415 in
                                                               ((match what'
                                                                 with
                                                                 | FStar_Pervasives_Native.None
@@ -2603,8 +2278,7 @@ let (cps_and_elaborate :
                                                                     FStar_TypeChecker_Rel.try_teq
                                                                     true env1
                                                                     rt
-                                                                    FStar_Syntax_Util.ktype0
-                                                                     in
+                                                                    FStar_Syntax_Util.ktype0 in
                                                                     match g_opt
                                                                     with
                                                                     | 
@@ -2615,32 +2289,29 @@ let (cps_and_elaborate :
                                                                     | 
                                                                     FStar_Pervasives_Native.None
                                                                      ->
-                                                                    fail ())
-                                                                     in
+                                                                    fail ()) in
                                                                     FStar_All.pipe_right
                                                                     uu____2720
                                                                     FStar_Pervasives.ignore)));
                                                                (let wp =
                                                                   let t2 =
                                                                     (FStar_Pervasives_Native.fst
-                                                                    b21).FStar_Syntax_Syntax.sort
-                                                                     in
+                                                                    b21).FStar_Syntax_Syntax.sort in
                                                                   let pure_wp_type
                                                                     =
                                                                     FStar_TypeChecker_DMFF.double_star
-                                                                    t2  in
+                                                                    t2 in
                                                                   FStar_Syntax_Syntax.gen_bv
                                                                     "wp"
                                                                     FStar_Pervasives_Native.None
-                                                                    pure_wp_type
-                                                                   in
+                                                                    pure_wp_type in
                                                                 let body3 =
                                                                   let uu____2747
                                                                     =
                                                                     let uu____2748
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
-                                                                    wp  in
+                                                                    wp in
                                                                     let uu____2749
                                                                     =
                                                                     let uu____2750
@@ -2650,20 +2321,16 @@ let (cps_and_elaborate :
                                                                     FStar_Syntax_Util.abs
                                                                     [b21]
                                                                     body2
-                                                                    what'  in
+                                                                    what' in
                                                                     (uu____2757,
-                                                                    FStar_Pervasives_Native.None)
-                                                                     in
-                                                                    [uu____2750]
-                                                                     in
+                                                                    FStar_Pervasives_Native.None) in
+                                                                    [uu____2750] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     uu____2748
-                                                                    uu____2749
-                                                                     in
+                                                                    uu____2749 in
                                                                   uu____2747
                                                                     FStar_Pervasives_Native.None
-                                                                    FStar_Range.dummyRange
-                                                                   in
+                                                                    FStar_Range.dummyRange in
                                                                 let uu____2782
                                                                   =
                                                                   let uu____2783
@@ -2671,18 +2338,15 @@ let (cps_and_elaborate :
                                                                     let uu____2790
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
-                                                                    wp  in
-                                                                    [uu____2790]
-                                                                     in
+                                                                    wp in
+                                                                    [uu____2790] in
                                                                   b11 ::
-                                                                    uu____2783
-                                                                   in
+                                                                    uu____2783 in
                                                                 let uu____2795
                                                                   =
                                                                   FStar_Syntax_Util.abs
                                                                     bs1 body3
-                                                                    what
-                                                                   in
+                                                                    what in
                                                                 FStar_Syntax_Util.abs
                                                                   uu____2782
                                                                   uu____2795
@@ -2692,16 +2356,13 @@ let (cps_and_elaborate :
                                                   Obj.repr
                                                     (raise_error1 ()
                                                        (FStar_Errors.Fatal_UnexpectedReturnShape,
-                                                         "unexpected shape for return")))
-                                            in
+                                                         "unexpected shape for return"))) in
                                          let return_wp1 =
                                            let uu____2798 =
                                              let uu____2799 =
                                                FStar_Syntax_Subst.compress
-                                                 return_wp
-                                                in
-                                             uu____2799.FStar_Syntax_Syntax.n
-                                              in
+                                                 return_wp in
+                                             uu____2799.FStar_Syntax_Syntax.n in
                                            Obj.magic
                                              (match uu____2798 with
                                               | FStar_Syntax_Syntax.Tm_abs
@@ -2709,8 +2370,7 @@ let (cps_and_elaborate :
                                                   Obj.repr
                                                     (let uu____2843 =
                                                        FStar_Syntax_Util.abs
-                                                         bs body what
-                                                        in
+                                                         bs body what in
                                                      FStar_Syntax_Util.abs
                                                        [b1; b2] uu____2843
                                                        (FStar_Pervasives_Native.Some
@@ -2719,16 +2379,13 @@ let (cps_and_elaborate :
                                                   Obj.repr
                                                     (raise_error1 ()
                                                        (FStar_Errors.Fatal_UnexpectedReturnShape,
-                                                         "unexpected shape for return")))
-                                            in
+                                                         "unexpected shape for return"))) in
                                          let bind_wp1 =
                                            let uu____2858 =
                                              let uu____2859 =
                                                FStar_Syntax_Subst.compress
-                                                 bind_wp
-                                                in
-                                             uu____2859.FStar_Syntax_Syntax.n
-                                              in
+                                                 bind_wp in
+                                             uu____2859.FStar_Syntax_Syntax.n in
                                            Obj.magic
                                              (match uu____2858 with
                                               | FStar_Syntax_Syntax.Tm_abs
@@ -2738,32 +2395,28 @@ let (cps_and_elaborate :
                                                        FStar_Syntax_Syntax.lid_as_fv
                                                          FStar_Parser_Const.range_lid
                                                          (FStar_Syntax_Syntax.Delta_defined_at_level
-                                                            (Prims.parse_int "1"))
-                                                         FStar_Pervasives_Native.None
-                                                        in
+                                                            (Prims.parse_int
+                                                               "1"))
+                                                         FStar_Pervasives_Native.None in
                                                      let uu____2886 =
                                                        let uu____2887 =
                                                          let uu____2890 =
                                                            let uu____2891 =
                                                              mk1
                                                                (FStar_Syntax_Syntax.Tm_fvar
-                                                                  r)
-                                                              in
+                                                                  r) in
                                                            FStar_Syntax_Syntax.null_binder
-                                                             uu____2891
-                                                            in
-                                                         [uu____2890]  in
+                                                             uu____2891 in
+                                                         [uu____2890] in
                                                        FStar_List.append
-                                                         uu____2887 binders
-                                                        in
+                                                         uu____2887 binders in
                                                      FStar_Syntax_Util.abs
                                                        uu____2886 body what)
                                               | uu____2892 ->
                                                   Obj.repr
                                                     (raise_error1 ()
                                                        (FStar_Errors.Fatal_UnexpectedBindShape,
-                                                         "unexpected shape for bind")))
-                                            in
+                                                         "unexpected shape for bind"))) in
                                          let apply_close t =
                                            if
                                              (FStar_List.length
@@ -2777,35 +2430,29 @@ let (cps_and_elaborate :
                                                     let uu____2927 =
                                                       let uu____2928 =
                                                         FStar_Syntax_Util.args_of_binders
-                                                          effect_binders1
-                                                         in
+                                                          effect_binders1 in
                                                       FStar_Pervasives_Native.snd
-                                                        uu____2928
-                                                       in
-                                                    (t, uu____2927)  in
+                                                        uu____2928 in
+                                                    (t, uu____2927) in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____2912
-                                                   in
-                                                mk1 uu____2911  in
+                                                    uu____2912 in
+                                                mk1 uu____2911 in
                                               FStar_Syntax_Subst.close
-                                                effect_binders1 uu____2910)
-                                            in
+                                                effect_binders1 uu____2910) in
                                          let rec apply_last1 f l =
                                            match l with
                                            | [] -> failwith "empty path.."
                                            | a2::[] ->
-                                               let uu____2958 = f a2  in
+                                               let uu____2958 = f a2 in
                                                [uu____2958]
                                            | x::xs ->
                                                let uu____2963 =
-                                                 apply_last1 f xs  in
-                                               x :: uu____2963
-                                            in
+                                                 apply_last1 f xs in
+                                               x :: uu____2963 in
                                          let register name item =
                                            let p =
                                              FStar_Ident.path_of_lid
-                                               ed.FStar_Syntax_Syntax.mname
-                                              in
+                                               ed.FStar_Syntax_Syntax.mname in
                                            let p' =
                                              apply_last1
                                                (fun s  ->
@@ -2813,28 +2460,23 @@ let (cps_and_elaborate :
                                                     (Prims.strcat s
                                                        (Prims.strcat
                                                           "_eff_override_"
-                                                          name))) p
-                                              in
+                                                          name))) p in
                                            let l' =
                                              FStar_Ident.lid_of_path p'
-                                               FStar_Range.dummyRange
-                                              in
+                                               FStar_Range.dummyRange in
                                            let uu____2983 =
                                              FStar_TypeChecker_Env.try_lookup_lid
-                                               env1 l'
-                                              in
+                                               env1 l' in
                                            match uu____2983 with
                                            | FStar_Pervasives_Native.Some
                                                (_us,_t) ->
                                                ((let uu____3013 =
-                                                   FStar_Options.debug_any ()
-                                                    in
+                                                   FStar_Options.debug_any () in
                                                  if uu____3013
                                                  then
                                                    let uu____3014 =
                                                      FStar_Ident.string_of_lid
-                                                       l'
-                                                      in
+                                                       l' in
                                                    FStar_Util.print1
                                                      "DM4F: Applying override %s\n"
                                                      uu____3014
@@ -2843,78 +2485,65 @@ let (cps_and_elaborate :
                                                    FStar_Syntax_Syntax.lid_as_fv
                                                      l'
                                                      FStar_Syntax_Syntax.Delta_equational
-                                                     FStar_Pervasives_Native.None
-                                                    in
+                                                     FStar_Pervasives_Native.None in
                                                  FStar_Syntax_Syntax.fv_to_tm
                                                    uu____3016))
                                            | FStar_Pervasives_Native.None  ->
                                                let uu____3025 =
-                                                 let uu____3030 = mk_lid name
-                                                    in
+                                                 let uu____3030 = mk_lid name in
                                                  let uu____3031 =
                                                    FStar_Syntax_Util.abs
                                                      effect_binders1 item
-                                                     FStar_Pervasives_Native.None
-                                                    in
+                                                     FStar_Pervasives_Native.None in
                                                  FStar_TypeChecker_Util.mk_toplevel_definition
-                                                   env1 uu____3030 uu____3031
-                                                  in
+                                                   env1 uu____3030 uu____3031 in
                                                (match uu____3025 with
                                                 | (sigelt,fv) ->
                                                     ((let uu____3035 =
                                                         let uu____3038 =
                                                           FStar_ST.op_Bang
-                                                            sigelts
-                                                           in
-                                                        sigelt :: uu____3038
-                                                         in
+                                                            sigelts in
+                                                        sigelt :: uu____3038 in
                                                       FStar_ST.op_Colon_Equals
                                                         sigelts uu____3035);
-                                                     fv))
-                                            in
+                                                     fv)) in
                                          let lift_from_pure_wp1 =
                                            register "lift_from_pure"
-                                             lift_from_pure_wp
-                                            in
+                                             lift_from_pure_wp in
                                          let return_wp2 =
-                                           register "return_wp" return_wp1
-                                            in
+                                           register "return_wp" return_wp1 in
                                          (FStar_Options.push ();
                                           (let uu____3135 =
                                              let uu____3138 =
                                                FStar_Syntax_Syntax.mk_sigelt
                                                  (FStar_Syntax_Syntax.Sig_pragma
                                                     (FStar_Syntax_Syntax.SetOptions
-                                                       "--admit_smt_queries true"))
-                                                in
+                                                       "--admit_smt_queries true")) in
                                              let uu____3139 =
-                                               FStar_ST.op_Bang sigelts  in
-                                             uu____3138 :: uu____3139  in
+                                               FStar_ST.op_Bang sigelts in
+                                             uu____3138 :: uu____3139 in
                                            FStar_ST.op_Colon_Equals sigelts
                                              uu____3135);
                                           (let return_elab1 =
                                              register "return_elab"
-                                               return_elab
-                                              in
+                                               return_elab in
                                            FStar_Options.pop ();
                                            (let bind_wp2 =
-                                              register "bind_wp" bind_wp1  in
+                                              register "bind_wp" bind_wp1 in
                                             FStar_Options.push ();
                                             (let uu____3237 =
                                                let uu____3240 =
                                                  FStar_Syntax_Syntax.mk_sigelt
                                                    (FStar_Syntax_Syntax.Sig_pragma
                                                       (FStar_Syntax_Syntax.SetOptions
-                                                         "--admit_smt_queries true"))
-                                                  in
+                                                         "--admit_smt_queries true")) in
                                                let uu____3241 =
-                                                 FStar_ST.op_Bang sigelts  in
-                                               uu____3240 :: uu____3241  in
+                                                 FStar_ST.op_Bang sigelts in
+                                               uu____3240 :: uu____3241 in
                                              FStar_ST.op_Colon_Equals sigelts
                                                uu____3237);
                                             (let bind_elab1 =
-                                               register "bind_elab" bind_elab
-                                                in
+                                               register "bind_elab" bind_elab in
                                              FStar_Options.pop ();
                                              (let uu____3336 =
                                                 FStar_List.fold_left
@@ -2925,17 +2554,14 @@ let (cps_and_elaborate :
                                                            ->
                                                            let params_un =
                                                              FStar_Syntax_Subst.open_binders
-                                                               action.FStar_Syntax_Syntax.action_params
-                                                              in
+                                                               action.FStar_Syntax_Syntax.action_params in
                                                            let uu____3397 =
                                                              let uu____3404 =
                                                                FStar_TypeChecker_DMFF.get_env
-                                                                 dmff_env3
-                                                                in
+                                                                 dmff_env3 in
                                                              FStar_TypeChecker_TcTerm.tc_tparams
                                                                uu____3404
-                                                               params_un
-                                                              in
+                                                               params_un in
                                                            (match uu____3397
                                                             with
                                                             | (action_params,env',uu____3413)
@@ -2955,14 +2581,13 @@ let (cps_and_elaborate :
                                                                     let uu____3444
                                                                     =
                                                                     let uu___72_3445
-                                                                    = bv  in
+                                                                    = bv in
                                                                     let uu____3446
                                                                     =
                                                                     FStar_TypeChecker_Normalize.normalize
                                                                     [FStar_TypeChecker_Normalize.EraseUniverses]
                                                                     env'
-                                                                    bv.FStar_Syntax_Syntax.sort
-                                                                     in
+                                                                    bv.FStar_Syntax_Syntax.sort in
                                                                     {
                                                                     FStar_Syntax_Syntax.ppname
                                                                     =
@@ -2973,64 +2598,55 @@ let (cps_and_elaborate :
                                                                     FStar_Syntax_Syntax.sort
                                                                     =
                                                                     uu____3446
-                                                                    }  in
+                                                                    } in
                                                                     (uu____3444,
                                                                     qual))
-                                                                    action_params
-                                                                   in
+                                                                    action_params in
                                                                 let dmff_env'
                                                                   =
                                                                   FStar_TypeChecker_DMFF.set_env
                                                                     dmff_env3
-                                                                    env'
-                                                                   in
+                                                                    env' in
                                                                 let uu____3450
                                                                   =
                                                                   elaborate_and_star
                                                                     dmff_env'
                                                                     action_params1
                                                                     ((action.FStar_Syntax_Syntax.action_univs),
-                                                                    (action.FStar_Syntax_Syntax.action_defn))
-                                                                   in
+                                                                    (action.FStar_Syntax_Syntax.action_defn)) in
                                                                 (match uu____3450
                                                                  with
                                                                  | (dmff_env4,action_t,action_wp,action_elab)
                                                                     ->
                                                                     let name
                                                                     =
-                                                                    ((action.FStar_Syntax_Syntax.action_name).FStar_Ident.ident).FStar_Ident.idText
-                                                                     in
+                                                                    ((action.FStar_Syntax_Syntax.action_name).FStar_Ident.ident).FStar_Ident.idText in
                                                                     let action_typ_with_wp
                                                                     =
                                                                     FStar_TypeChecker_DMFF.trans_F
                                                                     dmff_env'
                                                                     action_t
-                                                                    action_wp
-                                                                     in
+                                                                    action_wp in
                                                                     let action_params2
                                                                     =
                                                                     FStar_Syntax_Subst.close_binders
-                                                                    action_params1
-                                                                     in
+                                                                    action_params1 in
                                                                     let action_elab1
                                                                     =
                                                                     FStar_Syntax_Subst.close
                                                                     action_params2
-                                                                    action_elab
-                                                                     in
+                                                                    action_elab in
                                                                     let action_typ_with_wp1
                                                                     =
                                                                     FStar_Syntax_Subst.close
                                                                     action_params2
-                                                                    action_typ_with_wp
-                                                                     in
+                                                                    action_typ_with_wp in
                                                                     let action_elab2
                                                                     =
                                                                     FStar_Syntax_Util.abs
                                                                     action_params2
                                                                     action_elab1
-                                                                    FStar_Pervasives_Native.None
-                                                                     in
+                                                                    FStar_Pervasives_Native.None in
                                                                     let action_typ_with_wp2
                                                                     =
                                                                     match action_params2
@@ -3044,12 +2660,10 @@ let (cps_and_elaborate :
                                                                     let uu____3481
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
-                                                                    action_typ_with_wp1
-                                                                     in
+                                                                    action_typ_with_wp1 in
                                                                     FStar_Syntax_Util.flat_arrow
                                                                     action_params2
-                                                                    uu____3481
-                                                                     in
+                                                                    uu____3481 in
                                                                     ((
                                                                     let uu____3485
                                                                     =
@@ -3057,7 +2671,7 @@ let (cps_and_elaborate :
                                                                     (FStar_TypeChecker_Env.debug
                                                                     env1)
                                                                     (FStar_Options.Other
-                                                                    "ED")  in
+                                                                    "ED") in
                                                                     if
                                                                     uu____3485
                                                                     then
@@ -3065,24 +2679,20 @@ let (cps_and_elaborate :
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ","
-                                                                    params_un
-                                                                     in
+                                                                    params_un in
                                                                     let uu____3487
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ","
-                                                                    action_params2
-                                                                     in
+                                                                    action_params2 in
                                                                     let uu____3488
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
-                                                                    action_typ_with_wp2
-                                                                     in
+                                                                    action_typ_with_wp2 in
                                                                     let uu____3489
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
-                                                                    action_elab2
-                                                                     in
+                                                                    action_elab2 in
                                                                     FStar_Util.print4
                                                                     "original action_params %s, end action_params %s, type %s, term %s\n"
                                                                     uu____3486
@@ -3096,33 +2706,28 @@ let (cps_and_elaborate :
                                                                     (Prims.strcat
                                                                     name
                                                                     "_elab")
-                                                                    action_elab2
-                                                                     in
+                                                                    action_elab2 in
                                                                     let action_typ_with_wp3
                                                                     =
                                                                     register
                                                                     (Prims.strcat
                                                                     name
                                                                     "_complete_type")
-                                                                    action_typ_with_wp2
-                                                                     in
+                                                                    action_typ_with_wp2 in
                                                                     let uu____3493
                                                                     =
                                                                     let uu____3496
                                                                     =
                                                                     let uu___73_3497
-                                                                    = action
-                                                                     in
+                                                                    = action in
                                                                     let uu____3498
                                                                     =
                                                                     apply_close
-                                                                    action_elab3
-                                                                     in
+                                                                    action_elab3 in
                                                                     let uu____3499
                                                                     =
                                                                     apply_close
-                                                                    action_typ_with_wp3
-                                                                     in
+                                                                    action_typ_with_wp3 in
                                                                     {
                                                                     FStar_Syntax_Syntax.action_name
                                                                     =
@@ -3141,42 +2746,35 @@ let (cps_and_elaborate :
                                                                     FStar_Syntax_Syntax.action_typ
                                                                     =
                                                                     uu____3499
-                                                                    }  in
+                                                                    } in
                                                                     uu____3496
                                                                     ::
-                                                                    actions
-                                                                     in
+                                                                    actions in
                                                                     (dmff_env4,
                                                                     uu____3493))))))
                                                   (dmff_env2, [])
-                                                  ed.FStar_Syntax_Syntax.actions
-                                                 in
+                                                  ed.FStar_Syntax_Syntax.actions in
                                               match uu____3336 with
                                               | (dmff_env3,actions) ->
                                                   let actions1 =
-                                                    FStar_List.rev actions
-                                                     in
+                                                    FStar_List.rev actions in
                                                   let repr1 =
                                                     let wp =
                                                       FStar_Syntax_Syntax.gen_bv
                                                         "wp_a"
                                                         FStar_Pervasives_Native.None
-                                                        wp_a
-                                                       in
+                                                        wp_a in
                                                     let binders =
                                                       let uu____3532 =
                                                         FStar_Syntax_Syntax.mk_binder
-                                                          a1
-                                                         in
+                                                          a1 in
                                                       let uu____3533 =
                                                         let uu____3536 =
                                                           FStar_Syntax_Syntax.mk_binder
-                                                            wp
-                                                           in
-                                                        [uu____3536]  in
+                                                            wp in
+                                                        [uu____3536] in
                                                       uu____3532 ::
-                                                        uu____3533
-                                                       in
+                                                        uu____3533 in
                                                     let uu____3537 =
                                                       let uu____3538 =
                                                         let uu____3539 =
@@ -3187,56 +2785,43 @@ let (cps_and_elaborate :
                                                                 let uu____3567
                                                                   =
                                                                   FStar_Syntax_Syntax.bv_to_name
-                                                                    a1
-                                                                   in
+                                                                    a1 in
                                                                 let uu____3568
                                                                   =
                                                                   FStar_Syntax_Syntax.as_implicit
-                                                                    false
-                                                                   in
+                                                                    false in
                                                                 (uu____3567,
-                                                                  uu____3568)
-                                                                 in
-                                                              [uu____3562]
-                                                               in
+                                                                  uu____3568) in
+                                                              [uu____3562] in
                                                             (repr,
-                                                              uu____3555)
-                                                             in
+                                                              uu____3555) in
                                                           FStar_Syntax_Syntax.Tm_app
-                                                            uu____3540
-                                                           in
-                                                        mk1 uu____3539  in
+                                                            uu____3540 in
+                                                        mk1 uu____3539 in
                                                       let uu____3583 =
                                                         FStar_Syntax_Syntax.bv_to_name
-                                                          wp
-                                                         in
+                                                          wp in
                                                       FStar_TypeChecker_DMFF.trans_F
                                                         dmff_env3 uu____3538
-                                                        uu____3583
-                                                       in
+                                                        uu____3583 in
                                                     FStar_Syntax_Util.abs
                                                       binders uu____3537
-                                                      FStar_Pervasives_Native.None
-                                                     in
+                                                      FStar_Pervasives_Native.None in
                                                   let repr2 =
                                                     recheck_debug "FC" env1
-                                                      repr1
-                                                     in
+                                                      repr1 in
                                                   let repr3 =
-                                                    register "repr" repr2  in
+                                                    register "repr" repr2 in
                                                   let uu____3586 =
                                                     let uu____3593 =
                                                       let uu____3594 =
                                                         let uu____3597 =
                                                           FStar_Syntax_Subst.compress
-                                                            wp_type1
-                                                           in
+                                                            wp_type1 in
                                                         FStar_All.pipe_left
                                                           FStar_Syntax_Util.unascribe
-                                                          uu____3597
-                                                         in
-                                                      uu____3594.FStar_Syntax_Syntax.n
-                                                       in
+                                                          uu____3597 in
+                                                      uu____3594.FStar_Syntax_Syntax.n in
                                                     Obj.magic
                                                       (match uu____3593 with
                                                        | FStar_Syntax_Syntax.Tm_abs
@@ -3251,8 +2836,7 @@ let (cps_and_elaborate :
                                                                     (type_param
                                                                     ::
                                                                     effect_param)
-                                                                    arrow1
-                                                                   in
+                                                                    arrow1 in
                                                                 match uu____3653
                                                                 with
                                                                 | (b::bs,body)
@@ -3262,8 +2846,7 @@ let (cps_and_elaborate :
                                                                 | uu____3711
                                                                     ->
                                                                     failwith
-                                                                    "Impossible : open_term nt preserving binders arity"
-                                                                 in
+                                                                    "Impossible : open_term nt preserving binders arity" in
                                                               match uu____3636
                                                               with
                                                               | (type_param1,effect_param1,arrow2)
@@ -3275,14 +2858,11 @@ let (cps_and_elaborate :
                                                                     let uu____3765
                                                                     =
                                                                     FStar_Syntax_Subst.compress
-                                                                    arrow2
-                                                                     in
+                                                                    arrow2 in
                                                                     FStar_All.pipe_left
                                                                     FStar_Syntax_Util.unascribe
-                                                                    uu____3765
-                                                                     in
-                                                                    uu____3762.FStar_Syntax_Syntax.n
-                                                                     in
+                                                                    uu____3765 in
+                                                                    uu____3762.FStar_Syntax_Syntax.n in
                                                                   Obj.magic
                                                                     (
                                                                     match uu____3761
@@ -3296,7 +2876,7 @@ let (cps_and_elaborate :
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     wp_binders
-                                                                    c  in
+                                                                    c in
                                                                     match uu____3790
                                                                     with
                                                                     | 
@@ -3318,19 +2898,16 @@ let (cps_and_elaborate :
                                                                     let uu____3836
                                                                     =
                                                                     FStar_Syntax_Free.names
-                                                                    bv.FStar_Syntax_Syntax.sort
-                                                                     in
+                                                                    bv.FStar_Syntax_Syntax.sort in
                                                                     FStar_All.pipe_right
                                                                     uu____3836
                                                                     (FStar_Util.set_mem
                                                                     (FStar_Pervasives_Native.fst
-                                                                    type_param1))
-                                                                     in
+                                                                    type_param1)) in
                                                                     FStar_All.pipe_right
                                                                     uu____3835
                                                                     Prims.op_Negation)
-                                                                    wp_binders1
-                                                                     in
+                                                                    wp_binders1 in
                                                                     (match uu____3803
                                                                     with
                                                                     | 
@@ -3350,12 +2927,10 @@ let (cps_and_elaborate :
                                                                     let uu____3900
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
-                                                                    arrow2
-                                                                     in
+                                                                    arrow2 in
                                                                     FStar_Util.format1
                                                                     "Impossible to generate DM effect: no post candidate %s (Type variable does not appear)"
-                                                                    uu____3900
-                                                                     in
+                                                                    uu____3900 in
                                                                     FStar_Errors.raise_err
                                                                     (FStar_Errors.Fatal_ImpossibleToGenerateDMEffect,
                                                                     err_msg)
@@ -3367,21 +2942,18 @@ let (cps_and_elaborate :
                                                                     let uu____3913
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
-                                                                    arrow2
-                                                                     in
+                                                                    arrow2 in
                                                                     FStar_Util.format1
                                                                     "Impossible to generate DM effect: multiple post candidates %s"
-                                                                    uu____3913
-                                                                     in
+                                                                    uu____3913 in
                                                                     FStar_Errors.raise_err
                                                                     (FStar_Errors.Fatal_ImpossibleToGenerateDMEffect,
-                                                                    err_msg)
-                                                                     in
+                                                                    err_msg) in
                                                                     let uu____3918
                                                                     =
                                                                     FStar_Syntax_Util.arrow
                                                                     pre_args
-                                                                    c1  in
+                                                                    c1 in
                                                                     let uu____3921
                                                                     =
                                                                     FStar_Syntax_Util.abs
@@ -3390,8 +2962,7 @@ let (cps_and_elaborate :
                                                                     effect_param1)
                                                                     (FStar_Pervasives_Native.fst
                                                                     post).FStar_Syntax_Syntax.sort
-                                                                    FStar_Pervasives_Native.None
-                                                                     in
+                                                                    FStar_Pervasives_Native.None in
                                                                     (uu____3918,
                                                                     uu____3921)))
                                                                     | 
@@ -3405,15 +2976,12 @@ let (cps_and_elaborate :
                                                                     let uu____3935
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
-                                                                    arrow2
-                                                                     in
+                                                                    arrow2 in
                                                                     FStar_Util.format1
                                                                     "Impossible: pre/post arrow %s"
-                                                                    uu____3935
-                                                                     in
+                                                                    uu____3935 in
                                                                     (FStar_Errors.Fatal_ImpossiblePrePostArrow,
-                                                                    uu____3934)
-                                                                     in
+                                                                    uu____3934) in
                                                                     raise_error1
                                                                     ()
                                                                     uu____3929)))
@@ -3426,78 +2994,60 @@ let (cps_and_elaborate :
                                                                   let uu____3943
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
-                                                                    wp_type1
-                                                                     in
+                                                                    wp_type1 in
                                                                   FStar_Util.format1
                                                                     "Impossible: pre/post abs %s"
-                                                                    uu____3943
-                                                                   in
+                                                                    uu____3943 in
                                                                 (FStar_Errors.Fatal_ImpossiblePrePostAbs,
-                                                                  uu____3942)
-                                                                 in
+                                                                  uu____3942) in
                                                               raise_error1 ()
-                                                                uu____3937))
-                                                     in
+                                                                uu____3937)) in
                                                   (match uu____3586 with
                                                    | (pre,post) ->
                                                        ((let uu____3961 =
-                                                           register "pre" pre
-                                                            in
+                                                           register "pre" pre in
                                                          ());
                                                         (let uu____3963 =
                                                            register "post"
-                                                             post
-                                                            in
+                                                             post in
                                                          ());
                                                         (let uu____3965 =
                                                            register "wp"
-                                                             wp_type1
-                                                            in
+                                                             wp_type1 in
                                                          ());
                                                         (let ed1 =
                                                            let uu___74_3967 =
-                                                             ed  in
+                                                             ed in
                                                            let uu____3968 =
                                                              FStar_Syntax_Subst.close_binders
-                                                               effect_binders1
-                                                              in
+                                                               effect_binders1 in
                                                            let uu____3969 =
                                                              FStar_Syntax_Subst.close
                                                                effect_binders1
-                                                               effect_signature1
-                                                              in
+                                                               effect_signature1 in
                                                            let uu____3970 =
                                                              let uu____3971 =
                                                                apply_close
-                                                                 return_wp2
-                                                                in
-                                                             ([], uu____3971)
-                                                              in
+                                                                 return_wp2 in
+                                                             ([], uu____3971) in
                                                            let uu____3978 =
                                                              let uu____3979 =
                                                                apply_close
-                                                                 bind_wp2
-                                                                in
-                                                             ([], uu____3979)
-                                                              in
+                                                                 bind_wp2 in
+                                                             ([], uu____3979) in
                                                            let uu____3986 =
                                                              apply_close
-                                                               repr3
-                                                              in
+                                                               repr3 in
                                                            let uu____3987 =
                                                              let uu____3988 =
                                                                apply_close
-                                                                 return_elab1
-                                                                in
-                                                             ([], uu____3988)
-                                                              in
+                                                                 return_elab1 in
+                                                             ([], uu____3988) in
                                                            let uu____3995 =
                                                              let uu____3996 =
                                                                apply_close
-                                                                 bind_elab1
-                                                                in
-                                                             ([], uu____3996)
-                                                              in
+                                                                 bind_elab1 in
+                                                             ([], uu____3996) in
                                                            {
                                                              FStar_Syntax_Syntax.cattributes
                                                                =
@@ -3548,13 +3098,12 @@ let (cps_and_elaborate :
                                                                = uu____3995;
                                                              FStar_Syntax_Syntax.actions
                                                                = actions1
-                                                           }  in
+                                                           } in
                                                          let uu____4003 =
                                                            FStar_TypeChecker_DMFF.gen_wps_for_free
                                                              env1
                                                              effect_binders1
-                                                             a1 wp_a ed1
-                                                            in
+                                                             a1 wp_a ed1 in
                                                          match uu____4003
                                                          with
                                                          | (sigelts',ed2) ->
@@ -3563,15 +3112,13 @@ let (cps_and_elaborate :
                                                                  FStar_TypeChecker_Env.debug
                                                                    env1
                                                                    (FStar_Options.Other
-                                                                    "ED")
-                                                                  in
+                                                                    "ED") in
                                                                if uu____4021
                                                                then
                                                                  let uu____4022
                                                                    =
                                                                    FStar_Syntax_Print.eff_decl_to_string
-                                                                    true ed2
-                                                                    in
+                                                                    true ed2 in
                                                                  FStar_Util.print_string
                                                                    uu____4022
                                                                else ());
@@ -3581,7 +3128,8 @@ let (cps_and_elaborate :
                                                                    (FStar_List.length
                                                                     effect_binders1)
                                                                     =
-                                                                    (Prims.parse_int "0")
+                                                                    (Prims.parse_int
+                                                                    "0")
                                                                  then
                                                                    let lift_from_pure
                                                                     =
@@ -3592,14 +3140,11 @@ let (cps_and_elaborate :
                                                                     let uu____4046
                                                                     =
                                                                     apply_close
-                                                                    lift_from_pure_wp1
-                                                                     in
+                                                                    lift_from_pure_wp1 in
                                                                     ([],
-                                                                    uu____4046)
-                                                                     in
+                                                                    uu____4046) in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____4037
-                                                                     in
+                                                                    uu____4037 in
                                                                     {
                                                                     FStar_Syntax_Syntax.source
                                                                     =
@@ -3613,18 +3158,16 @@ let (cps_and_elaborate :
                                                                     FStar_Syntax_Syntax.lift
                                                                     =
                                                                     FStar_Pervasives_Native.None
-                                                                    }  in
+                                                                    } in
                                                                    let uu____4061
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_sigelt
                                                                     (FStar_Syntax_Syntax.Sig_sub_effect
-                                                                    lift_from_pure)
-                                                                     in
+                                                                    lift_from_pure) in
                                                                    FStar_Pervasives_Native.Some
                                                                     uu____4061
                                                                  else
-                                                                   FStar_Pervasives_Native.None
-                                                                  in
+                                                                   FStar_Pervasives_Native.None in
                                                                let uu____4063
                                                                  =
                                                                  let uu____4066
@@ -3632,20 +3175,16 @@ let (cps_and_elaborate :
                                                                    let uu____4069
                                                                     =
                                                                     FStar_ST.op_Bang
-                                                                    sigelts
-                                                                     in
+                                                                    sigelts in
                                                                    FStar_List.rev
-                                                                    uu____4069
-                                                                    in
+                                                                    uu____4069 in
                                                                  FStar_List.append
                                                                    uu____4066
-                                                                   sigelts'
-                                                                  in
+                                                                   sigelts' in
                                                                (uu____4063,
                                                                  ed2,
                                                                  lift_from_pure_opt))))))))))))))))))
-  
-let tc_lex_t :
+let tc_lex_t:
   'Auu____4126 .
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -3657,8 +3196,8 @@ let tc_lex_t :
       fun quals  ->
         fun lids  ->
           let err_range =
-            let uu____4159 = FStar_List.hd ses  in
-            uu____4159.FStar_Syntax_Syntax.sigrng  in
+            let uu____4159 = FStar_List.hd ses in
+            uu____4159.FStar_Syntax_Syntax.sigrng in
           (match lids with
            | lex_t1::lex_top1::lex_cons::[] when
                ((FStar_Ident.lid_equals lex_t1 FStar_Parser_Const.lex_t_lid)
@@ -3716,15 +3255,13 @@ let tc_lex_t :
                ->
                let u =
                  FStar_Syntax_Syntax.new_univ_name
-                   (FStar_Pervasives_Native.Some r)
-                  in
+                   (FStar_Pervasives_Native.Some r) in
                let t1 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_type
                       (FStar_Syntax_Syntax.U_name u))
-                   FStar_Pervasives_Native.None r
-                  in
-               let t2 = FStar_Syntax_Subst.close_univ_vars [u] t1  in
+                   FStar_Pervasives_Native.None r in
+               let t2 = FStar_Syntax_Subst.close_univ_vars [u] t1 in
                let tc =
                  {
                    FStar_Syntax_Syntax.sigel =
@@ -3737,11 +3274,10 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
                    FStar_Syntax_Syntax.sigattrs = []
-                 }  in
+                 } in
                let utop =
                  FStar_Syntax_Syntax.new_univ_name
-                   (FStar_Pervasives_Native.Some r1)
-                  in
+                   (FStar_Pervasives_Native.Some r1) in
                let lex_top_t =
                  let uu____4252 =
                    let uu____4255 =
@@ -3751,14 +3287,13 @@ let tc_lex_t :
                            (FStar_Ident.set_lid_range
                               FStar_Parser_Const.lex_t_lid r1)
                            FStar_Syntax_Syntax.Delta_constant
-                           FStar_Pervasives_Native.None
-                          in
-                       (uu____4263, [FStar_Syntax_Syntax.U_name utop])  in
-                     FStar_Syntax_Syntax.Tm_uinst uu____4256  in
-                   FStar_Syntax_Syntax.mk uu____4255  in
-                 uu____4252 FStar_Pervasives_Native.None r1  in
+                           FStar_Pervasives_Native.None in
+                       (uu____4263, [FStar_Syntax_Syntax.U_name utop]) in
+                     FStar_Syntax_Syntax.Tm_uinst uu____4256 in
+                   FStar_Syntax_Syntax.mk uu____4255 in
+                 uu____4252 FStar_Pervasives_Native.None r1 in
                let lex_top_t1 =
-                 FStar_Syntax_Subst.close_univ_vars [utop] lex_top_t  in
+                 FStar_Syntax_Subst.close_univ_vars [utop] lex_top_t in
                let dc_lextop =
                  {
                    FStar_Syntax_Syntax.sigel =
@@ -3771,31 +3306,26 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
                    FStar_Syntax_Syntax.sigattrs = []
-                 }  in
+                 } in
                let ucons1 =
                  FStar_Syntax_Syntax.new_univ_name
-                   (FStar_Pervasives_Native.Some r2)
-                  in
+                   (FStar_Pervasives_Native.Some r2) in
                let ucons2 =
                  FStar_Syntax_Syntax.new_univ_name
-                   (FStar_Pervasives_Native.Some r2)
-                  in
+                   (FStar_Pervasives_Native.Some r2) in
                let lex_cons_t =
                  let a =
                    let uu____4281 =
                      FStar_Syntax_Syntax.mk
                        (FStar_Syntax_Syntax.Tm_type
                           (FStar_Syntax_Syntax.U_name ucons1))
-                       FStar_Pervasives_Native.None r2
-                      in
+                       FStar_Pervasives_Native.None r2 in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____4281
-                    in
+                     (FStar_Pervasives_Native.Some r2) uu____4281 in
                  let hd1 =
-                   let uu____4283 = FStar_Syntax_Syntax.bv_to_name a  in
+                   let uu____4283 = FStar_Syntax_Syntax.bv_to_name a in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____4283
-                    in
+                     (FStar_Pervasives_Native.Some r2) uu____4283 in
                  let tl1 =
                    let uu____4285 =
                      let uu____4286 =
@@ -3806,16 +3336,13 @@ let tc_lex_t :
                                (FStar_Ident.set_lid_range
                                   FStar_Parser_Const.lex_t_lid r2)
                                FStar_Syntax_Syntax.Delta_constant
-                               FStar_Pervasives_Native.None
-                              in
-                           (uu____4297, [FStar_Syntax_Syntax.U_name ucons2])
-                            in
-                         FStar_Syntax_Syntax.Tm_uinst uu____4290  in
-                       FStar_Syntax_Syntax.mk uu____4289  in
-                     uu____4286 FStar_Pervasives_Native.None r2  in
+                               FStar_Pervasives_Native.None in
+                           (uu____4297, [FStar_Syntax_Syntax.U_name ucons2]) in
+                         FStar_Syntax_Syntax.Tm_uinst uu____4290 in
+                       FStar_Syntax_Syntax.mk uu____4289 in
+                     uu____4286 FStar_Pervasives_Native.None r2 in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____4285
-                    in
+                     (FStar_Pervasives_Native.Some r2) uu____4285 in
                  let res =
                    let uu____4306 =
                      let uu____4309 =
@@ -3825,28 +3352,24 @@ let tc_lex_t :
                              (FStar_Ident.set_lid_range
                                 FStar_Parser_Const.lex_t_lid r2)
                              FStar_Syntax_Syntax.Delta_constant
-                             FStar_Pervasives_Native.None
-                            in
+                             FStar_Pervasives_Native.None in
                          (uu____4317,
                            [FStar_Syntax_Syntax.U_max
                               [FStar_Syntax_Syntax.U_name ucons1;
-                              FStar_Syntax_Syntax.U_name ucons2]])
-                          in
-                       FStar_Syntax_Syntax.Tm_uinst uu____4310  in
-                     FStar_Syntax_Syntax.mk uu____4309  in
-                   uu____4306 FStar_Pervasives_Native.None r2  in
-                 let uu____4323 = FStar_Syntax_Syntax.mk_Total res  in
+                              FStar_Syntax_Syntax.U_name ucons2]]) in
+                       FStar_Syntax_Syntax.Tm_uinst uu____4310 in
+                     FStar_Syntax_Syntax.mk uu____4309 in
+                   uu____4306 FStar_Pervasives_Native.None r2 in
+                 let uu____4323 = FStar_Syntax_Syntax.mk_Total res in
                  FStar_Syntax_Util.arrow
                    [(a,
                       (FStar_Pervasives_Native.Some
                          FStar_Syntax_Syntax.imp_tag));
                    (hd1, FStar_Pervasives_Native.None);
-                   (tl1, FStar_Pervasives_Native.None)] uu____4323
-                  in
+                   (tl1, FStar_Pervasives_Native.None)] uu____4323 in
                let lex_cons_t1 =
                  FStar_Syntax_Subst.close_univ_vars [ucons1; ucons2]
-                   lex_cons_t
-                  in
+                   lex_cons_t in
                let dc_lexcons =
                  {
                    FStar_Syntax_Syntax.sigel =
@@ -3859,8 +3382,8 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigmeta =
                      FStar_Syntax_Syntax.default_sigmeta;
                    FStar_Syntax_Syntax.sigattrs = []
-                 }  in
-               let uu____4362 = FStar_TypeChecker_Env.get_range env  in
+                 } in
+               let uu____4362 = FStar_TypeChecker_Env.get_range env in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_bundle
@@ -3876,42 +3399,38 @@ let tc_lex_t :
                  let uu____4371 =
                    let uu____4372 =
                      FStar_Syntax_Syntax.mk_sigelt
-                       (FStar_Syntax_Syntax.Sig_bundle (ses, lids))
-                      in
-                   FStar_Syntax_Print.sigelt_to_string uu____4372  in
+                       (FStar_Syntax_Syntax.Sig_bundle (ses, lids)) in
+                   FStar_Syntax_Print.sigelt_to_string uu____4372 in
                  FStar_Util.format1 "Invalid (re)definition of lex_t: %s\n"
-                   uu____4371
-                  in
+                   uu____4371 in
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_InvalidRedefinitionOfLexT, err_msg)
                  err_range)
-  
-let (tc_assume :
+let tc_assume:
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
       FStar_Syntax_Syntax.formula ->
         FStar_Syntax_Syntax.qualifier Prims.list ->
-          FStar_Range.range -> FStar_Syntax_Syntax.sigelt)
+          FStar_Range.range -> FStar_Syntax_Syntax.sigelt
   =
   fun env  ->
     fun lid  ->
       fun phi  ->
         fun quals  ->
           fun r  ->
-            let env1 = FStar_TypeChecker_Env.set_range env r  in
-            let uu____4397 = FStar_Syntax_Util.type_u ()  in
+            let env1 = FStar_TypeChecker_Env.set_range env r in
+            let uu____4397 = FStar_Syntax_Util.type_u () in
             match uu____4397 with
             | (k,uu____4403) ->
                 let phi1 =
-                  let uu____4405 = tc_check_trivial_guard env1 phi k  in
+                  let uu____4405 = tc_check_trivial_guard env1 phi k in
                   FStar_All.pipe_right uu____4405
                     (FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Normalize.Beta;
-                       FStar_TypeChecker_Normalize.Eager_unfolding] env1)
-                   in
+                       FStar_TypeChecker_Normalize.Eager_unfolding] env1) in
                 (FStar_TypeChecker_Util.check_uvars r phi1;
                  (let uu____4407 =
-                    FStar_TypeChecker_Util.generalize_universes env1 phi1  in
+                    FStar_TypeChecker_Util.generalize_universes env1 phi1 in
                   match uu____4407 with
                   | (us,phi2) ->
                       {
@@ -3923,48 +3442,43 @@ let (tc_assume :
                           FStar_Syntax_Syntax.default_sigmeta;
                         FStar_Syntax_Syntax.sigattrs = []
                       }))
-  
-let (tc_inductive :
+let tc_inductive:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
         FStar_Ident.lident Prims.list ->
           (FStar_Syntax_Syntax.sigelt Prims.list,FStar_Syntax_Syntax.sigelt
                                                    Prims.list)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun ses  ->
       fun quals  ->
         fun lids  ->
-          let env1 = FStar_TypeChecker_Env.push env "tc_inductive"  in
+          let env1 = FStar_TypeChecker_Env.push env "tc_inductive" in
           let uu____4449 =
             FStar_TypeChecker_TcInductive.check_inductive_well_typedness env1
-              ses quals lids
-             in
+              ses quals lids in
           match uu____4449 with
           | (sig_bndle,tcs,datas) ->
               let data_ops_ses =
                 let uu____4482 =
                   FStar_List.map
                     (FStar_TypeChecker_Util.mk_data_operations quals env1 tcs)
-                    datas
-                   in
-                FStar_All.pipe_right uu____4482 FStar_List.flatten  in
+                    datas in
+                FStar_All.pipe_right uu____4482 FStar_List.flatten in
               ((let uu____4496 =
-                  (FStar_Options.no_positivity ()) || (FStar_Options.lax ())
-                   in
+                  (FStar_Options.no_positivity ()) || (FStar_Options.lax ()) in
                 if uu____4496
                 then ()
                 else
                   (let env2 =
-                     FStar_TypeChecker_Env.push_sigelt env1 sig_bndle  in
+                     FStar_TypeChecker_Env.push_sigelt env1 sig_bndle in
                    FStar_List.iter
                      (fun ty  ->
                         let b =
                           FStar_TypeChecker_TcInductive.check_positivity ty
-                            env2
-                           in
+                            env2 in
                         if Prims.op_Negation b
                         then
                           let uu____4507 =
@@ -3972,7 +3486,7 @@ let (tc_inductive :
                             | FStar_Syntax_Syntax.Sig_inductive_typ
                                 (lid,uu____4517,uu____4518,uu____4519,uu____4520,uu____4521)
                                 -> (lid, (ty.FStar_Syntax_Syntax.sigrng))
-                            | uu____4530 -> failwith "Impossible!"  in
+                            | uu____4530 -> failwith "Impossible!" in
                           match uu____4507 with
                           | (lid,r) ->
                               FStar_Errors.log_issue r
@@ -3983,27 +3497,25 @@ let (tc_inductive :
                         else ()) tcs));
                (let skip_prims_type uu____4541 =
                   let lid =
-                    let ty = FStar_List.hd tcs  in
+                    let ty = FStar_List.hd tcs in
                     match ty.FStar_Syntax_Syntax.sigel with
                     | FStar_Syntax_Syntax.Sig_inductive_typ
                         (lid,uu____4545,uu____4546,uu____4547,uu____4548,uu____4549)
                         -> lid
-                    | uu____4558 -> failwith "Impossible"  in
+                    | uu____4558 -> failwith "Impossible" in
                   let types_to_skip =
                     ["c_False";
                     "c_True";
                     "equals";
                     "h_equals";
                     "c_and";
-                    "c_or"]  in
+                    "c_or"] in
                   FStar_List.existsb
                     (fun s  -> s = (lid.FStar_Ident.ident).FStar_Ident.idText)
-                    types_to_skip
-                   in
+                    types_to_skip in
                 let is_noeq =
                   FStar_List.existsb (fun q  -> q = FStar_Syntax_Syntax.Noeq)
-                    quals
-                   in
+                    quals in
                 let res =
                   let uu____4576 =
                     (((FStar_List.length tcs) = (Prims.parse_int "0")) ||
@@ -4011,15 +3523,13 @@ let (tc_inductive :
                            env1.FStar_TypeChecker_Env.curmodule
                            FStar_Parser_Const.prims_lid)
                           && (skip_prims_type ())))
-                      || is_noeq
-                     in
+                      || is_noeq in
                   if uu____4576
                   then ([sig_bndle], data_ops_ses)
                   else
                     (let is_unopteq =
                        FStar_List.existsb
-                         (fun q  -> q = FStar_Syntax_Syntax.Unopteq) quals
-                        in
+                         (fun q  -> q = FStar_Syntax_Syntax.Unopteq) quals in
                      let ses1 =
                        if is_unopteq
                        then
@@ -4027,12 +3537,11 @@ let (tc_inductive :
                            sig_bndle tcs datas env1 tc_assume
                        else
                          FStar_TypeChecker_TcInductive.optimized_haseq_scheme
-                           sig_bndle tcs datas env1 tc_assume
-                        in
+                           sig_bndle tcs datas env1 tc_assume in
                      let uu____4599 =
                        let uu____4602 =
                          let uu____4603 =
-                           FStar_TypeChecker_Env.get_range env1  in
+                           FStar_TypeChecker_Env.get_range env1 in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_bundle
@@ -4042,27 +3551,25 @@ let (tc_inductive :
                            FStar_Syntax_Syntax.sigmeta =
                              FStar_Syntax_Syntax.default_sigmeta;
                            FStar_Syntax_Syntax.sigattrs = []
-                         }  in
-                       uu____4602 :: ses1  in
-                     (uu____4599, data_ops_ses))
-                   in
+                         } in
+                       uu____4602 :: ses1 in
+                     (uu____4599, data_ops_ses)) in
                 (let uu____4613 =
-                   FStar_TypeChecker_Env.pop env1 "tc_inductive"  in
+                   FStar_TypeChecker_Env.pop env1 "tc_inductive" in
                  ());
                 res))
-  
-let (tc_decl :
+let tc_decl:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt ->
       (FStar_Syntax_Syntax.sigelt Prims.list,FStar_Syntax_Syntax.sigelt
                                                Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun se  ->
-      let env1 = set_hint_correlator env se  in
+      let env1 = set_hint_correlator env se in
       FStar_TypeChecker_Util.check_sigelt_quals env1 se;
-      (let r = se.FStar_Syntax_Syntax.sigrng  in
+      (let r = se.FStar_Syntax_Syntax.sigrng in
        match se.FStar_Syntax_Syntax.sigel with
        | FStar_Syntax_Syntax.Sig_inductive_typ uu____4647 ->
            failwith "Impossible bare data-constructor"
@@ -4073,26 +3580,25 @@ let (tc_decl :
              (FStar_Util.for_some
                 (FStar_Ident.lid_equals FStar_Parser_Const.lex_t_lid))
            ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r  in
-           let se1 = tc_lex_t env2 ses se.FStar_Syntax_Syntax.sigquals lids
-              in
+           let env2 = FStar_TypeChecker_Env.set_range env1 r in
+           let se1 = tc_lex_t env2 ses se.FStar_Syntax_Syntax.sigquals lids in
            ([se1], [])
        | FStar_Syntax_Syntax.Sig_bundle (ses,lids) ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r  in
+           let env2 = FStar_TypeChecker_Env.set_range env1 r in
            let uu____4724 =
-             tc_inductive env2 ses se.FStar_Syntax_Syntax.sigquals lids  in
+             tc_inductive env2 ses se.FStar_Syntax_Syntax.sigquals lids in
            (match uu____4724 with
             | (ses1,projectors_ses) -> (ses1, projectors_ses))
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p r; ([se], []))
        | FStar_Syntax_Syntax.Sig_new_effect_for_free ne ->
-           let uu____4762 = cps_and_elaborate env1 ne  in
+           let uu____4762 = cps_and_elaborate env1 ne in
            (match uu____4762 with
             | (ses,ne1,lift_from_pure_opt) ->
                 let effect_and_lift_ses =
                   match lift_from_pure_opt with
                   | FStar_Pervasives_Native.Some lift ->
-                      [(let uu___75_4799 = se  in
+                      [(let uu___75_4799 = se in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_new_effect ne1);
@@ -4107,7 +3613,7 @@ let (tc_decl :
                         });
                       lift]
                   | FStar_Pervasives_Native.None  ->
-                      [(let uu___76_4801 = se  in
+                      [(let uu___76_4801 = se in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_new_effect ne1);
@@ -4119,13 +3625,12 @@ let (tc_decl :
                             (uu___76_4801.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
                             (uu___76_4801.FStar_Syntax_Syntax.sigattrs)
-                        })]
-                   in
+                        })] in
                 ([], (FStar_List.append ses effect_and_lift_ses)))
        | FStar_Syntax_Syntax.Sig_new_effect ne ->
-           let ne1 = tc_eff_decl env1 ne  in
+           let ne1 = tc_eff_decl env1 ne in
            let se1 =
-             let uu___77_4809 = se  in
+             let uu___77_4809 = se in
              {
                FStar_Syntax_Syntax.sigel =
                  (FStar_Syntax_Syntax.Sig_new_effect ne1);
@@ -4137,34 +3642,28 @@ let (tc_decl :
                  (uu___77_4809.FStar_Syntax_Syntax.sigmeta);
                FStar_Syntax_Syntax.sigattrs =
                  (uu___77_4809.FStar_Syntax_Syntax.sigattrs)
-             }  in
+             } in
            ([se1], [])
        | FStar_Syntax_Syntax.Sig_sub_effect sub1 ->
            let ed_src =
              FStar_TypeChecker_Env.get_effect_decl env1
-               sub1.FStar_Syntax_Syntax.source
-              in
+               sub1.FStar_Syntax_Syntax.source in
            let ed_tgt =
              FStar_TypeChecker_Env.get_effect_decl env1
-               sub1.FStar_Syntax_Syntax.target
-              in
+               sub1.FStar_Syntax_Syntax.target in
            let uu____4817 =
              let uu____4824 =
                FStar_TypeChecker_Env.lookup_effect_lid env1
-                 sub1.FStar_Syntax_Syntax.source
-                in
-             monad_signature env1 sub1.FStar_Syntax_Syntax.source uu____4824
-              in
+                 sub1.FStar_Syntax_Syntax.source in
+             monad_signature env1 sub1.FStar_Syntax_Syntax.source uu____4824 in
            (match uu____4817 with
             | (a,wp_a_src) ->
                 let uu____4839 =
                   let uu____4846 =
                     FStar_TypeChecker_Env.lookup_effect_lid env1
-                      sub1.FStar_Syntax_Syntax.target
-                     in
+                      sub1.FStar_Syntax_Syntax.target in
                   monad_signature env1 sub1.FStar_Syntax_Syntax.target
-                    uu____4846
-                   in
+                    uu____4846 in
                 (match uu____4839 with
                  | (b,wp_b_tgt) ->
                      let wp_a_tgt =
@@ -4172,75 +3671,68 @@ let (tc_decl :
                          let uu____4865 =
                            let uu____4866 =
                              let uu____4873 =
-                               FStar_Syntax_Syntax.bv_to_name a  in
-                             (b, uu____4873)  in
-                           FStar_Syntax_Syntax.NT uu____4866  in
-                         [uu____4865]  in
-                       FStar_Syntax_Subst.subst uu____4862 wp_b_tgt  in
+                               FStar_Syntax_Syntax.bv_to_name a in
+                             (b, uu____4873) in
+                           FStar_Syntax_Syntax.NT uu____4866 in
+                         [uu____4865] in
+                       FStar_Syntax_Subst.subst uu____4862 wp_b_tgt in
                      let expected_k =
                        let uu____4877 =
-                         let uu____4884 = FStar_Syntax_Syntax.mk_binder a  in
+                         let uu____4884 = FStar_Syntax_Syntax.mk_binder a in
                          let uu____4885 =
                            let uu____4888 =
-                             FStar_Syntax_Syntax.null_binder wp_a_src  in
-                           [uu____4888]  in
-                         uu____4884 :: uu____4885  in
-                       let uu____4889 = FStar_Syntax_Syntax.mk_Total wp_a_tgt
-                          in
-                       FStar_Syntax_Util.arrow uu____4877 uu____4889  in
+                             FStar_Syntax_Syntax.null_binder wp_a_src in
+                           [uu____4888] in
+                         uu____4884 :: uu____4885 in
+                       let uu____4889 = FStar_Syntax_Syntax.mk_Total wp_a_tgt in
+                       FStar_Syntax_Util.arrow uu____4877 uu____4889 in
                      let repr_type eff_name a1 wp =
                        let no_reify l =
                          let uu____4910 =
                            let uu____4915 =
                              FStar_Util.format1 "Effect %s cannot be reified"
-                               l.FStar_Ident.str
-                              in
+                               l.FStar_Ident.str in
                            (FStar_Errors.Fatal_EffectCannotBeReified,
-                             uu____4915)
-                            in
+                             uu____4915) in
                          let uu____4916 =
-                           FStar_TypeChecker_Env.get_range env1  in
-                         FStar_Errors.raise_error uu____4910 uu____4916  in
+                           FStar_TypeChecker_Env.get_range env1 in
+                         FStar_Errors.raise_error uu____4910 uu____4916 in
                        let uu____4919 =
-                         FStar_TypeChecker_Env.effect_decl_opt env1 eff_name
-                          in
+                         FStar_TypeChecker_Env.effect_decl_opt env1 eff_name in
                        match uu____4919 with
                        | FStar_Pervasives_Native.None  -> no_reify eff_name
                        | FStar_Pervasives_Native.Some (ed,qualifiers) ->
                            let repr =
                              FStar_TypeChecker_Env.inst_effect_fun_with
                                [FStar_Syntax_Syntax.U_unknown] env1 ed
-                               ([], (ed.FStar_Syntax_Syntax.repr))
-                              in
+                               ([], (ed.FStar_Syntax_Syntax.repr)) in
                            let uu____4951 =
                              let uu____4952 =
                                FStar_All.pipe_right qualifiers
                                  (FStar_List.contains
-                                    FStar_Syntax_Syntax.Reifiable)
-                                in
-                             Prims.op_Negation uu____4952  in
+                                    FStar_Syntax_Syntax.Reifiable) in
+                             Prims.op_Negation uu____4952 in
                            if uu____4951
                            then no_reify eff_name
                            else
                              (let uu____4958 =
-                                FStar_TypeChecker_Env.get_range env1  in
+                                FStar_TypeChecker_Env.get_range env1 in
                               let uu____4959 =
                                 let uu____4962 =
                                   let uu____4963 =
                                     let uu____4978 =
                                       let uu____4981 =
-                                        FStar_Syntax_Syntax.as_arg a1  in
+                                        FStar_Syntax_Syntax.as_arg a1 in
                                       let uu____4982 =
                                         let uu____4985 =
-                                          FStar_Syntax_Syntax.as_arg wp  in
-                                        [uu____4985]  in
-                                      uu____4981 :: uu____4982  in
-                                    (repr, uu____4978)  in
-                                  FStar_Syntax_Syntax.Tm_app uu____4963  in
-                                FStar_Syntax_Syntax.mk uu____4962  in
+                                          FStar_Syntax_Syntax.as_arg wp in
+                                        [uu____4985] in
+                                      uu____4981 :: uu____4982 in
+                                    (repr, uu____4978) in
+                                  FStar_Syntax_Syntax.Tm_app uu____4963 in
+                                FStar_Syntax_Syntax.mk uu____4962 in
                               uu____4959 FStar_Pervasives_Native.None
-                                uu____4958)
-                        in
+                                uu____4958) in
                      let uu____4991 =
                        match ((sub1.FStar_Syntax_Syntax.lift),
                                (sub1.FStar_Syntax_Syntax.lift_wp))
@@ -4251,51 +3743,45 @@ let (tc_decl :
                        | (lift,FStar_Pervasives_Native.Some
                           (uu____5019,lift_wp)) ->
                            let uu____5043 =
-                             check_and_gen env1 lift_wp expected_k  in
+                             check_and_gen env1 lift_wp expected_k in
                            (lift, uu____5043)
                        | (FStar_Pervasives_Native.Some
                           (what,lift),FStar_Pervasives_Native.None ) ->
                            ((let uu____5069 =
                                FStar_TypeChecker_Env.debug env1
-                                 (FStar_Options.Other "ED")
-                                in
+                                 (FStar_Options.Other "ED") in
                              if uu____5069
                              then
                                let uu____5070 =
-                                 FStar_Syntax_Print.term_to_string lift  in
+                                 FStar_Syntax_Print.term_to_string lift in
                                FStar_Util.print1 "Lift for free : %s\n"
                                  uu____5070
                              else ());
                             (let dmff_env =
                                FStar_TypeChecker_DMFF.empty env1
                                  (FStar_TypeChecker_TcTerm.tc_constant env1
-                                    FStar_Range.dummyRange)
-                                in
+                                    FStar_Range.dummyRange) in
                              let uu____5073 =
-                               FStar_TypeChecker_TcTerm.tc_term env1 lift  in
+                               FStar_TypeChecker_TcTerm.tc_term env1 lift in
                              match uu____5073 with
                              | (lift1,comp,uu____5088) ->
                                  let uu____5089 =
                                    FStar_TypeChecker_DMFF.star_expr dmff_env
-                                     lift1
-                                    in
+                                     lift1 in
                                  (match uu____5089 with
                                   | (uu____5102,lift_wp,lift_elab) ->
                                       let uu____5105 =
-                                        recheck_debug "lift-wp" env1 lift_wp
-                                         in
+                                        recheck_debug "lift-wp" env1 lift_wp in
                                       let uu____5106 =
                                         recheck_debug "lift-elab" env1
-                                          lift_elab
-                                         in
+                                          lift_elab in
                                       ((FStar_Pervasives_Native.Some
-                                          ([], lift_elab)), ([], lift_wp)))))
-                        in
+                                          ([], lift_elab)), ([], lift_wp))))) in
                      (match uu____4991 with
                       | (lift,lift_wp) ->
-                          let lax1 = env1.FStar_TypeChecker_Env.lax  in
+                          let lax1 = env1.FStar_TypeChecker_Env.lax in
                           let env2 =
-                            let uu___78_5147 = env1  in
+                            let uu___78_5147 = env1 in
                             {
                               FStar_TypeChecker_Env.solver =
                                 (uu___78_5147.FStar_TypeChecker_Env.solver);
@@ -4366,7 +3852,7 @@ let (tc_decl :
                                 (uu___78_5147.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.dep_graph =
                                 (uu___78_5147.FStar_TypeChecker_Env.dep_graph)
-                            }  in
+                            } in
                           let lift1 =
                             match lift with
                             | FStar_Pervasives_Native.None  ->
@@ -4376,29 +3862,24 @@ let (tc_decl :
                                 let uu____5165 =
                                   let uu____5172 =
                                     FStar_TypeChecker_Env.lookup_effect_lid
-                                      env2 sub1.FStar_Syntax_Syntax.source
-                                     in
+                                      env2 sub1.FStar_Syntax_Syntax.source in
                                   monad_signature env2
                                     sub1.FStar_Syntax_Syntax.source
-                                    uu____5172
-                                   in
+                                    uu____5172 in
                                 (match uu____5165 with
                                  | (a1,wp_a_src1) ->
                                      let wp_a =
                                        FStar_Syntax_Syntax.new_bv
                                          FStar_Pervasives_Native.None
-                                         wp_a_src1
-                                        in
+                                         wp_a_src1 in
                                      let a_typ =
-                                       FStar_Syntax_Syntax.bv_to_name a1  in
+                                       FStar_Syntax_Syntax.bv_to_name a1 in
                                      let wp_a_typ =
-                                       FStar_Syntax_Syntax.bv_to_name wp_a
-                                        in
+                                       FStar_Syntax_Syntax.bv_to_name wp_a in
                                      let repr_f =
                                        repr_type
                                          sub1.FStar_Syntax_Syntax.source
-                                         a_typ wp_a_typ
-                                        in
+                                         a_typ wp_a_typ in
                                      let repr_result =
                                        let lift_wp1 =
                                          FStar_TypeChecker_Normalize.normalize
@@ -4406,82 +3887,66 @@ let (tc_decl :
                                            FStar_TypeChecker_Normalize.AllowUnboundUniverses]
                                            env2
                                            (FStar_Pervasives_Native.snd
-                                              lift_wp)
-                                          in
+                                              lift_wp) in
                                        let lift_wp_a =
                                          let uu____5196 =
                                            FStar_TypeChecker_Env.get_range
-                                             env2
-                                            in
+                                             env2 in
                                          let uu____5197 =
                                            let uu____5200 =
                                              let uu____5201 =
                                                let uu____5216 =
                                                  let uu____5219 =
                                                    FStar_Syntax_Syntax.as_arg
-                                                     a_typ
-                                                    in
+                                                     a_typ in
                                                  let uu____5220 =
                                                    let uu____5223 =
                                                      FStar_Syntax_Syntax.as_arg
-                                                       wp_a_typ
-                                                      in
-                                                   [uu____5223]  in
-                                                 uu____5219 :: uu____5220  in
-                                               (lift_wp1, uu____5216)  in
+                                                       wp_a_typ in
+                                                   [uu____5223] in
+                                                 uu____5219 :: uu____5220 in
+                                               (lift_wp1, uu____5216) in
                                              FStar_Syntax_Syntax.Tm_app
-                                               uu____5201
-                                              in
-                                           FStar_Syntax_Syntax.mk uu____5200
-                                            in
+                                               uu____5201 in
+                                           FStar_Syntax_Syntax.mk uu____5200 in
                                          uu____5197
                                            FStar_Pervasives_Native.None
-                                           uu____5196
-                                          in
+                                           uu____5196 in
                                        repr_type
                                          sub1.FStar_Syntax_Syntax.target
-                                         a_typ lift_wp_a
-                                        in
+                                         a_typ lift_wp_a in
                                      let expected_k1 =
                                        let uu____5232 =
                                          let uu____5239 =
-                                           FStar_Syntax_Syntax.mk_binder a1
-                                            in
+                                           FStar_Syntax_Syntax.mk_binder a1 in
                                          let uu____5240 =
                                            let uu____5243 =
                                              FStar_Syntax_Syntax.mk_binder
-                                               wp_a
-                                              in
+                                               wp_a in
                                            let uu____5244 =
                                              let uu____5247 =
                                                FStar_Syntax_Syntax.null_binder
-                                                 repr_f
-                                                in
-                                             [uu____5247]  in
-                                           uu____5243 :: uu____5244  in
-                                         uu____5239 :: uu____5240  in
+                                                 repr_f in
+                                             [uu____5247] in
+                                           uu____5243 :: uu____5244 in
+                                         uu____5239 :: uu____5240 in
                                        let uu____5248 =
                                          FStar_Syntax_Syntax.mk_Total
-                                           repr_result
-                                          in
+                                           repr_result in
                                        FStar_Syntax_Util.arrow uu____5232
-                                         uu____5248
-                                        in
+                                         uu____5248 in
                                      let uu____5251 =
                                        FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                         env2 expected_k1
-                                        in
+                                         env2 expected_k1 in
                                      (match uu____5251 with
                                       | (expected_k2,uu____5261,uu____5262)
                                           ->
                                           let lift2 =
                                             check_and_gen env2 lift1
-                                              expected_k2
-                                             in
-                                          FStar_Pervasives_Native.Some lift2))
-                             in
+                                              expected_k2 in
+                                          FStar_Pervasives_Native.Some lift2)) in
                           let sub2 =
-                            let uu___79_5265 = sub1  in
+                            let uu___79_5265 = sub1 in
                             {
                               FStar_Syntax_Syntax.source =
                                 (uu___79_5265.FStar_Syntax_Syntax.source);
@@ -4490,9 +3955,9 @@ let (tc_decl :
                               FStar_Syntax_Syntax.lift_wp =
                                 (FStar_Pervasives_Native.Some lift_wp);
                               FStar_Syntax_Syntax.lift = lift1
-                            }  in
+                            } in
                           let se1 =
-                            let uu___80_5267 = se  in
+                            let uu___80_5267 = se in
                             {
                               FStar_Syntax_Syntax.sigel =
                                 (FStar_Syntax_Syntax.Sig_sub_effect sub2);
@@ -4504,53 +3969,48 @@ let (tc_decl :
                                 (uu___80_5267.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
                                 (uu___80_5267.FStar_Syntax_Syntax.sigattrs)
-                            }  in
+                            } in
                           ([se1], []))))
        | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uvs,tps,c,flags1) ->
-           let env0 = env1  in
-           let env2 = FStar_TypeChecker_Env.set_range env1 r  in
-           let uu____5286 = FStar_Syntax_Subst.open_comp tps c  in
+           let env0 = env1 in
+           let env2 = FStar_TypeChecker_Env.set_range env1 r in
+           let uu____5286 = FStar_Syntax_Subst.open_comp tps c in
            (match uu____5286 with
             | (tps1,c1) ->
                 let uu____5301 =
-                  FStar_TypeChecker_TcTerm.tc_tparams env2 tps1  in
+                  FStar_TypeChecker_TcTerm.tc_tparams env2 tps1 in
                 (match uu____5301 with
                  | (tps2,env3,us) ->
                      let uu____5319 =
-                       FStar_TypeChecker_TcTerm.tc_comp env3 c1  in
+                       FStar_TypeChecker_TcTerm.tc_comp env3 c1 in
                      (match uu____5319 with
                       | (c2,u,g) ->
                           (FStar_TypeChecker_Rel.force_trivial_guard env3 g;
-                           (let tps3 = FStar_Syntax_Subst.close_binders tps2
-                               in
-                            let c3 = FStar_Syntax_Subst.close_comp tps3 c2
-                               in
+                           (let tps3 = FStar_Syntax_Subst.close_binders tps2 in
+                            let c3 = FStar_Syntax_Subst.close_comp tps3 c2 in
                             let uu____5340 =
                               let uu____5341 =
                                 FStar_Syntax_Syntax.mk
                                   (FStar_Syntax_Syntax.Tm_arrow (tps3, c3))
-                                  FStar_Pervasives_Native.None r
-                                 in
+                                  FStar_Pervasives_Native.None r in
                               FStar_TypeChecker_Util.generalize_universes
-                                env0 uu____5341
-                               in
+                                env0 uu____5341 in
                             match uu____5340 with
                             | (uvs1,t) ->
                                 let uu____5356 =
                                   let uu____5369 =
                                     let uu____5374 =
                                       let uu____5375 =
-                                        FStar_Syntax_Subst.compress t  in
-                                      uu____5375.FStar_Syntax_Syntax.n  in
-                                    (tps3, uu____5374)  in
+                                        FStar_Syntax_Subst.compress t in
+                                      uu____5375.FStar_Syntax_Syntax.n in
+                                    (tps3, uu____5374) in
                                   match uu____5369 with
                                   | ([],FStar_Syntax_Syntax.Tm_arrow
                                      (uu____5390,c4)) -> ([], c4)
                                   | (uu____5430,FStar_Syntax_Syntax.Tm_arrow
                                      (tps4,c4)) -> (tps4, c4)
                                   | uu____5457 ->
-                                      failwith "Impossible (t is an arrow)"
-                                   in
+                                      failwith "Impossible (t is an arrow)" in
                                 (match uu____5356 with
                                  | (tps4,c4) ->
                                      (if
@@ -4559,38 +4019,32 @@ let (tc_decl :
                                       then
                                         (let uu____5501 =
                                            FStar_Syntax_Subst.open_univ_vars
-                                             uvs1 t
-                                            in
+                                             uvs1 t in
                                          match uu____5501 with
                                          | (uu____5506,t1) ->
                                              let uu____5508 =
                                                let uu____5513 =
                                                  let uu____5514 =
                                                    FStar_Syntax_Print.lid_to_string
-                                                     lid
-                                                    in
+                                                     lid in
                                                  let uu____5515 =
                                                    FStar_All.pipe_right
                                                      (FStar_List.length uvs1)
-                                                     FStar_Util.string_of_int
-                                                    in
+                                                     FStar_Util.string_of_int in
                                                  let uu____5516 =
                                                    FStar_Syntax_Print.term_to_string
-                                                     t1
-                                                    in
+                                                     t1 in
                                                  FStar_Util.format3
                                                    "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
                                                    uu____5514 uu____5515
-                                                   uu____5516
-                                                  in
+                                                   uu____5516 in
                                                (FStar_Errors.Fatal_TooManyUniverse,
-                                                 uu____5513)
-                                                in
+                                                 uu____5513) in
                                              FStar_Errors.raise_error
                                                uu____5508 r)
                                       else ();
                                       (let se1 =
-                                         let uu___81_5519 = se  in
+                                         let uu___81_5519 = se in
                                          {
                                            FStar_Syntax_Syntax.sigel =
                                              (FStar_Syntax_Syntax.Sig_effect_abbrev
@@ -4603,7 +4057,7 @@ let (tc_decl :
                                              (uu___81_5519.FStar_Syntax_Syntax.sigmeta);
                                            FStar_Syntax_Syntax.sigattrs =
                                              (uu___81_5519.FStar_Syntax_Syntax.sigattrs)
-                                         }  in
+                                         } in
                                        ([se1], [])))))))))
        | FStar_Syntax_Syntax.Sig_declare_typ
            (uu____5536,uu____5537,uu____5538) when
@@ -4623,51 +4077,46 @@ let (tc_decl :
                    | uu____5558 -> false))
            -> ([], [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r  in
-           ((let uu____5568 = FStar_TypeChecker_Env.lid_exists env2 lid  in
+           let env2 = FStar_TypeChecker_Env.set_range env1 r in
+           ((let uu____5568 = FStar_TypeChecker_Env.lid_exists env2 lid in
              if uu____5568
              then
                let uu____5569 =
                  let uu____5574 =
                    FStar_Util.format1
                      "Top-level declaration %s for a name that is already used in this module; top-level declarations must be unique in their module"
-                     (FStar_Ident.text_of_lid lid)
-                    in
+                     (FStar_Ident.text_of_lid lid) in
                  (FStar_Errors.Fatal_AlreadyDefinedTopLevelDeclaration,
-                   uu____5574)
-                  in
+                   uu____5574) in
                FStar_Errors.raise_error uu____5569 r
              else ());
             (let uu____5576 =
                if uvs = []
                then
                  let uu____5577 =
-                   let uu____5578 = FStar_Syntax_Util.type_u ()  in
-                   FStar_Pervasives_Native.fst uu____5578  in
+                   let uu____5578 = FStar_Syntax_Util.type_u () in
+                   FStar_Pervasives_Native.fst uu____5578 in
                  check_and_gen env2 t uu____5577
                else
-                 (let uu____5584 = FStar_Syntax_Subst.open_univ_vars uvs t
-                     in
+                 (let uu____5584 = FStar_Syntax_Subst.open_univ_vars uvs t in
                   match uu____5584 with
                   | (uvs1,t1) ->
                       let t2 =
                         let uu____5592 =
-                          let uu____5593 = FStar_Syntax_Util.type_u ()  in
-                          FStar_Pervasives_Native.fst uu____5593  in
-                        tc_check_trivial_guard env2 t1 uu____5592  in
+                          let uu____5593 = FStar_Syntax_Util.type_u () in
+                          FStar_Pervasives_Native.fst uu____5593 in
+                        tc_check_trivial_guard env2 t1 uu____5592 in
                       let t3 =
                         FStar_TypeChecker_Normalize.normalize
                           [FStar_TypeChecker_Normalize.NoFullNorm;
-                          FStar_TypeChecker_Normalize.Beta] env2 t2
-                         in
+                          FStar_TypeChecker_Normalize.Beta] env2 t2 in
                       let uu____5599 =
-                        FStar_Syntax_Subst.close_univ_vars uvs1 t3  in
-                      (uvs1, uu____5599))
-                in
+                        FStar_Syntax_Subst.close_univ_vars uvs1 t3 in
+                      (uvs1, uu____5599)) in
              match uu____5576 with
              | (uvs1,t1) ->
                  let se1 =
-                   let uu___82_5615 = se  in
+                   let uu___82_5615 = se in
                    {
                      FStar_Syntax_Syntax.sigel =
                        (FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs1, t1));
@@ -4679,45 +4128,40 @@ let (tc_decl :
                        (uu___82_5615.FStar_Syntax_Syntax.sigmeta);
                      FStar_Syntax_Syntax.sigattrs =
                        (uu___82_5615.FStar_Syntax_Syntax.sigattrs)
-                   }  in
+                   } in
                  ([se1], [])))
        | FStar_Syntax_Syntax.Sig_assume (lid,us,phi) ->
-           let uu____5625 = FStar_Syntax_Subst.open_univ_vars us phi  in
+           let uu____5625 = FStar_Syntax_Subst.open_univ_vars us phi in
            (match uu____5625 with
             | (uu____5638,phi1) ->
                 let se1 =
-                  tc_assume env1 lid phi1 se.FStar_Syntax_Syntax.sigquals r
-                   in
+                  tc_assume env1 lid phi1 se.FStar_Syntax_Syntax.sigquals r in
                 ([se1], []))
        | FStar_Syntax_Syntax.Sig_main e ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r  in
+           let env2 = FStar_TypeChecker_Env.set_range env1 r in
            let env3 =
              FStar_TypeChecker_Env.set_expected_typ env2
-               FStar_Syntax_Syntax.t_unit
-              in
-           let uu____5648 = FStar_TypeChecker_TcTerm.tc_term env3 e  in
+               FStar_Syntax_Syntax.t_unit in
+           let uu____5648 = FStar_TypeChecker_TcTerm.tc_term env3 e in
            (match uu____5648 with
             | (e1,c,g1) ->
                 let uu____5666 =
                   let uu____5673 =
                     let uu____5676 =
-                      FStar_Syntax_Util.ml_comp FStar_Syntax_Syntax.t_unit r
-                       in
-                    FStar_Pervasives_Native.Some uu____5676  in
+                      FStar_Syntax_Util.ml_comp FStar_Syntax_Syntax.t_unit r in
+                    FStar_Pervasives_Native.Some uu____5676 in
                   let uu____5677 =
-                    let uu____5682 = FStar_Syntax_Syntax.lcomp_comp c  in
-                    (e1, uu____5682)  in
+                    let uu____5682 = FStar_Syntax_Syntax.lcomp_comp c in
+                    (e1, uu____5682) in
                   FStar_TypeChecker_TcTerm.check_expected_effect env3
-                    uu____5673 uu____5677
-                   in
+                    uu____5673 uu____5677 in
                 (match uu____5666 with
                  | (e2,uu____5692,g) ->
-                     ((let uu____5695 = FStar_TypeChecker_Rel.conj_guard g1 g
-                          in
+                     ((let uu____5695 = FStar_TypeChecker_Rel.conj_guard g1 g in
                        FStar_TypeChecker_Rel.force_trivial_guard env3
                          uu____5695);
                       (let se1 =
-                         let uu___83_5697 = se  in
+                         let uu___83_5697 = se in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_main e2);
@@ -4729,10 +4173,10 @@ let (tc_decl :
                              (uu___83_5697.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
                              (uu___83_5697.FStar_Syntax_Syntax.sigattrs)
-                         }  in
+                         } in
                        ([se1], [])))))
        | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
-           let env2 = FStar_TypeChecker_Env.set_range env1 r  in
+           let env2 = FStar_TypeChecker_Env.set_range env1 r in
            let check_quals_eq l qopt q =
              match qopt with
              | FStar_Pervasives_Native.None  ->
@@ -4741,39 +4185,33 @@ let (tc_decl :
                  let uu____5748 =
                    ((FStar_List.length q) = (FStar_List.length q')) &&
                      (FStar_List.forall2 FStar_Syntax_Util.qualifier_equal q
-                        q')
-                    in
+                        q') in
                  if uu____5748
                  then FStar_Pervasives_Native.Some q
                  else
                    (let uu____5756 =
                       let uu____5761 =
-                        let uu____5762 = FStar_Syntax_Print.lid_to_string l
-                           in
-                        let uu____5763 = FStar_Syntax_Print.quals_to_string q
-                           in
+                        let uu____5762 = FStar_Syntax_Print.lid_to_string l in
+                        let uu____5763 = FStar_Syntax_Print.quals_to_string q in
                         let uu____5764 =
-                          FStar_Syntax_Print.quals_to_string q'  in
+                          FStar_Syntax_Print.quals_to_string q' in
                         FStar_Util.format3
                           "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}"
-                          uu____5762 uu____5763 uu____5764
-                         in
+                          uu____5762 uu____5763 uu____5764 in
                       (FStar_Errors.Fatal_InconsistentQualifierAnnotation,
-                        uu____5761)
-                       in
-                    FStar_Errors.raise_error uu____5756 r)
-              in
+                        uu____5761) in
+                    FStar_Errors.raise_error uu____5756 r) in
            let rename_parameters lb =
              let rename_in_typ def typ =
-               let typ1 = FStar_Syntax_Subst.compress typ  in
+               let typ1 = FStar_Syntax_Subst.compress typ in
                let def_bs =
                  let uu____5790 =
-                   let uu____5791 = FStar_Syntax_Subst.compress def  in
-                   uu____5791.FStar_Syntax_Syntax.n  in
+                   let uu____5791 = FStar_Syntax_Subst.compress def in
+                   uu____5791.FStar_Syntax_Syntax.n in
                  match uu____5790 with
                  | FStar_Syntax_Syntax.Tm_abs (binders,uu____5801,uu____5802)
                      -> binders
-                 | uu____5823 -> []  in
+                 | uu____5823 -> [] in
                match typ1 with
                | {
                    FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_arrow
@@ -4783,24 +4221,23 @@ let (tc_decl :
                    let has_auto_name bv =
                      FStar_Util.starts_with
                        (bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                       FStar_Ident.reserved_prefix
-                      in
+                       FStar_Ident.reserved_prefix in
                    let rec rename_binders1 def_bs1 val_bs1 =
                      match (def_bs1, val_bs1) with
                      | ([],uu____5911) -> val_bs1
                      | (uu____5934,[]) -> val_bs1
                      | ((body_bv,uu____5958)::bt,(val_bv,aqual)::vt) ->
-                         let uu____5995 = rename_binders1 bt vt  in
+                         let uu____5995 = rename_binders1 bt vt in
                          ((match ((has_auto_name body_bv),
                                    (has_auto_name val_bv))
                            with
                            | (true ,uu____6011) -> (val_bv, aqual)
                            | (false ,true ) ->
-                               ((let uu___84_6013 = val_bv  in
+                               ((let uu___84_6013 = val_bv in
                                  {
                                    FStar_Syntax_Syntax.ppname =
                                      (let uu___85_6016 =
-                                        val_bv.FStar_Syntax_Syntax.ppname  in
+                                        val_bv.FStar_Syntax_Syntax.ppname in
                                       {
                                         FStar_Ident.idText =
                                           ((body_bv.FStar_Syntax_Syntax.ppname).FStar_Ident.idText);
@@ -4813,22 +4250,20 @@ let (tc_decl :
                                      (uu___84_6013.FStar_Syntax_Syntax.sort)
                                  }), aqual)
                            | (false ,false ) -> (val_bv, aqual))) ::
-                           uu____5995
-                      in
+                           uu____5995 in
                    let uu____6017 =
                      let uu____6020 =
                        let uu____6021 =
-                         let uu____6034 = rename_binders1 def_bs val_bs  in
-                         (uu____6034, c)  in
-                       FStar_Syntax_Syntax.Tm_arrow uu____6021  in
-                     FStar_Syntax_Syntax.mk uu____6020  in
+                         let uu____6034 = rename_binders1 def_bs val_bs in
+                         (uu____6034, c) in
+                       FStar_Syntax_Syntax.Tm_arrow uu____6021 in
+                     FStar_Syntax_Syntax.mk uu____6020 in
                    uu____6017 FStar_Pervasives_Native.None r1
-               | uu____6052 -> typ1  in
-             let uu___86_6053 = lb  in
+               | uu____6052 -> typ1 in
+             let uu___86_6053 = lb in
              let uu____6054 =
                rename_in_typ lb.FStar_Syntax_Syntax.lbdef
-                 lb.FStar_Syntax_Syntax.lbtyp
-                in
+                 lb.FStar_Syntax_Syntax.lbtyp in
              {
                FStar_Syntax_Syntax.lbname =
                  (uu___86_6053.FStar_Syntax_Syntax.lbname);
@@ -4841,7 +4276,7 @@ let (tc_decl :
                  (uu___86_6053.FStar_Syntax_Syntax.lbdef);
                FStar_Syntax_Syntax.lbattrs =
                  (uu___86_6053.FStar_Syntax_Syntax.lbattrs)
-             }  in
+             } in
            let uu____6057 =
              FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                (FStar_List.fold_left
@@ -4850,13 +4285,11 @@ let (tc_decl :
                        match uu____6108 with
                        | (gen1,lbs1,quals_opt) ->
                            let lbname =
-                             FStar_Util.right lb.FStar_Syntax_Syntax.lbname
-                              in
+                             FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
                            let uu____6150 =
                              let uu____6161 =
                                FStar_TypeChecker_Env.try_lookup_val_decl env2
-                                 (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                in
+                                 (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                              match uu____6161 with
                              | FStar_Pervasives_Native.None  ->
                                  if lb.FStar_Syntax_Syntax.lbunivs <> []
@@ -4867,8 +4300,7 @@ let (tc_decl :
                                  let quals_opt1 =
                                    check_quals_eq
                                      (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                     quals_opt quals
-                                    in
+                                     quals_opt quals in
                                  let def =
                                    match (lb.FStar_Syntax_Syntax.lbtyp).FStar_Syntax_Syntax.n
                                    with
@@ -4883,8 +4315,7 @@ let (tc_decl :
                                                 FStar_Pervasives_Native.None),
                                               FStar_Pervasives_Native.None))
                                          FStar_Pervasives_Native.None
-                                         (lb.FStar_Syntax_Syntax.lbdef).FStar_Syntax_Syntax.pos
-                                    in
+                                         (lb.FStar_Syntax_Syntax.lbdef).FStar_Syntax_Syntax.pos in
                                  (if
                                     (lb.FStar_Syntax_Syntax.lbunivs <> []) &&
                                       ((FStar_List.length
@@ -4900,10 +4331,8 @@ let (tc_decl :
                                      FStar_Syntax_Syntax.mk_lb
                                        ((FStar_Util.Inr lbname), uvs,
                                          FStar_Parser_Const.effect_ALL_lid,
-                                         tval, def)
-                                      in
-                                   (false, uu____6289, quals_opt1)))
-                              in
+                                         tval, def) in
+                                   (false, uu____6289, quals_opt1))) in
                            (match uu____6150 with
                             | (gen2,lb1,quals_opt1) ->
                                 (gen2, (lb1 :: lbs1), quals_opt1)))
@@ -4912,8 +4341,7 @@ let (tc_decl :
                      then FStar_Pervasives_Native.None
                      else
                        FStar_Pervasives_Native.Some
-                         (se.FStar_Syntax_Syntax.sigquals))))
-              in
+                         (se.FStar_Syntax_Syntax.sigquals)))) in
            (match uu____6057 with
             | (should_generalize,lbs',quals_opt) ->
                 let quals =
@@ -4931,13 +4359,11 @@ let (tc_decl :
                                     true
                                 | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
                                      -> true
-                                | uu____6388 -> false))
-                         in
+                                | uu____6388 -> false)) in
                       if uu____6383
                       then q
-                      else FStar_Syntax_Syntax.Visible_default :: q
-                   in
-                let lbs'1 = FStar_List.rev lbs'  in
+                      else FStar_Syntax_Syntax.Visible_default :: q in
+                let lbs'1 = FStar_List.rev lbs' in
                 let e =
                   let uu____6398 =
                     let uu____6401 =
@@ -4946,18 +4372,16 @@ let (tc_decl :
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_constant
                                FStar_Const.Const_unit)
-                            FStar_Pervasives_Native.None r
-                           in
+                            FStar_Pervasives_Native.None r in
                         (((FStar_Pervasives_Native.fst lbs), lbs'1),
-                          uu____6415)
-                         in
-                      FStar_Syntax_Syntax.Tm_let uu____6402  in
-                    FStar_Syntax_Syntax.mk uu____6401  in
-                  uu____6398 FStar_Pervasives_Native.None r  in
+                          uu____6415) in
+                      FStar_Syntax_Syntax.Tm_let uu____6402 in
+                    FStar_Syntax_Syntax.mk uu____6401 in
+                  uu____6398 FStar_Pervasives_Native.None r in
                 let uu____6433 =
                   let uu____6444 =
                     FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
-                      (let uu___87_6453 = env2  in
+                      (let uu___87_6453 = env2 in
                        {
                          FStar_TypeChecker_Env.solver =
                            (uu___87_6453.FStar_TypeChecker_Env.solver);
@@ -5027,8 +4451,7 @@ let (tc_decl :
                            (uu___87_6453.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.dep_graph =
                            (uu___87_6453.FStar_TypeChecker_Env.dep_graph)
-                       }) e
-                     in
+                       }) e in
                   match uu____6444 with
                   | ({
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_let
@@ -5040,17 +4463,16 @@ let (tc_decl :
                         let uu____6497 =
                           FStar_All.pipe_right
                             (FStar_Pervasives_Native.snd lbs1)
-                            (FStar_List.map rename_parameters)
-                           in
-                        ((FStar_Pervasives_Native.fst lbs1), uu____6497)  in
+                            (FStar_List.map rename_parameters) in
+                        ((FStar_Pervasives_Native.fst lbs1), uu____6497) in
                       let quals1 =
                         match e1.FStar_Syntax_Syntax.n with
                         | FStar_Syntax_Syntax.Tm_meta
                             (uu____6515,FStar_Syntax_Syntax.Meta_desugared
                              (FStar_Syntax_Syntax.Masked_effect ))
                             -> FStar_Syntax_Syntax.HasMaskedEffect :: quals
-                        | uu____6520 -> quals  in
-                      ((let uu___88_6528 = se  in
+                        | uu____6520 -> quals in
+                      ((let uu___88_6528 = se in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_let (lbs2, lids));
@@ -5064,8 +4486,7 @@ let (tc_decl :
                         }), lbs2)
                   | uu____6537 ->
                       failwith
-                        "impossible (typechecking should preserve Tm_let)"
-                   in
+                        "impossible (typechecking should preserve Tm_let)" in
                 (match uu____6433 with
                  | (se1,lbs1) ->
                      (FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs1)
@@ -5073,11 +4494,10 @@ let (tc_decl :
                            (fun lb  ->
                               let fv =
                                 FStar_Util.right
-                                  lb.FStar_Syntax_Syntax.lbname
-                                 in
+                                  lb.FStar_Syntax_Syntax.lbname in
                               FStar_TypeChecker_Env.insert_fv_info env2 fv
                                 lb.FStar_Syntax_Syntax.lbtyp));
-                      (let uu____6586 = log env2  in
+                      (let uu____6586 = log env2 in
                        if uu____6586
                        then
                          let uu____6587 =
@@ -5092,48 +4512,40 @@ let (tc_decl :
                                            let uu____6613 =
                                              let uu____6616 =
                                                FStar_Util.right
-                                                 lb.FStar_Syntax_Syntax.lbname
-                                                in
-                                             uu____6616.FStar_Syntax_Syntax.fv_name
-                                              in
-                                           uu____6613.FStar_Syntax_Syntax.v
-                                            in
+                                                 lb.FStar_Syntax_Syntax.lbname in
+                                             uu____6616.FStar_Syntax_Syntax.fv_name in
+                                           uu____6613.FStar_Syntax_Syntax.v in
                                          FStar_TypeChecker_Env.try_lookup_val_decl
-                                           env2 uu____6612
-                                          in
+                                           env2 uu____6612 in
                                        match uu____6603 with
                                        | FStar_Pervasives_Native.None  ->
                                            true
-                                       | uu____6623 -> false  in
+                                       | uu____6623 -> false in
                                      if should_log
                                      then
                                        let uu____6632 =
                                          FStar_Syntax_Print.lbname_to_string
-                                           lb.FStar_Syntax_Syntax.lbname
-                                          in
+                                           lb.FStar_Syntax_Syntax.lbname in
                                        let uu____6633 =
                                          FStar_Syntax_Print.term_to_string
-                                           lb.FStar_Syntax_Syntax.lbtyp
-                                          in
+                                           lb.FStar_Syntax_Syntax.lbtyp in
                                        FStar_Util.format2 "let %s : %s"
                                          uu____6632 uu____6633
-                                     else ""))
-                              in
+                                     else "")) in
                            FStar_All.pipe_right uu____6588
-                             (FStar_String.concat "\n")
-                            in
+                             (FStar_String.concat "\n") in
                          FStar_Util.print1 "%s\n" uu____6587
                        else ());
                       (let reified_tactic_type l t =
-                         let t1 = FStar_Syntax_Subst.compress t  in
+                         let t1 = FStar_Syntax_Subst.compress t in
                          match t1.FStar_Syntax_Syntax.n with
                          | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                              let uu____6664 =
-                               FStar_Syntax_Subst.open_comp bs c  in
+                               FStar_Syntax_Subst.open_comp bs c in
                              (match uu____6664 with
                               | (bs1,c1) ->
                                   let uu____6671 =
-                                    FStar_Syntax_Util.is_total_comp c1  in
+                                    FStar_Syntax_Util.is_total_comp c1 in
                                   if uu____6671
                                   then
                                     let c' =
@@ -5141,20 +4553,16 @@ let (tc_decl :
                                       | FStar_Syntax_Syntax.Total (t',u) ->
                                           let uu____6683 =
                                             let uu____6684 =
-                                              FStar_Syntax_Subst.compress t'
-                                               in
-                                            uu____6684.FStar_Syntax_Syntax.n
-                                             in
+                                              FStar_Syntax_Subst.compress t' in
+                                            uu____6684.FStar_Syntax_Syntax.n in
                                           (match uu____6683 with
                                            | FStar_Syntax_Syntax.Tm_app
                                                (h,args) ->
                                                let uu____6709 =
                                                  let uu____6710 =
                                                    FStar_Syntax_Subst.compress
-                                                     h
-                                                    in
-                                                 uu____6710.FStar_Syntax_Syntax.n
-                                                  in
+                                                     h in
+                                                 uu____6710.FStar_Syntax_Syntax.n in
                                                (match uu____6709 with
                                                 | FStar_Syntax_Syntax.Tm_uinst
                                                     (h',u') ->
@@ -5163,40 +4571,33 @@ let (tc_decl :
                                                         FStar_Syntax_Syntax.lid_as_fv
                                                           FStar_Parser_Const.u_tac_lid
                                                           FStar_Syntax_Syntax.Delta_constant
-                                                          FStar_Pervasives_Native.None
-                                                         in
+                                                          FStar_Pervasives_Native.None in
                                                       FStar_All.pipe_left
                                                         FStar_Syntax_Syntax.fv_to_tm
-                                                        uu____6720
-                                                       in
+                                                        uu____6720 in
                                                     let uu____6721 =
                                                       let uu____6722 =
                                                         let uu____6723 =
                                                           FStar_Syntax_Syntax.mk_Tm_uinst
-                                                            h'' u'
-                                                           in
+                                                            h'' u' in
                                                         FStar_Syntax_Syntax.mk_Tm_app
-                                                          uu____6723 args
-                                                         in
+                                                          uu____6723 args in
                                                       uu____6722
                                                         FStar_Pervasives_Native.None
-                                                        t'.FStar_Syntax_Syntax.pos
-                                                       in
+                                                        t'.FStar_Syntax_Syntax.pos in
                                                     FStar_Syntax_Syntax.mk_Total'
                                                       uu____6721 u
                                                 | uu____6726 -> c1)
                                            | uu____6727 -> c1)
-                                      | uu____6728 -> c1  in
-                                    let uu___89_6729 = t1  in
+                                      | uu____6728 -> c1 in
+                                    let uu___89_6729 = t1 in
                                     let uu____6730 =
                                       let uu____6731 =
                                         let uu____6744 =
                                           FStar_Syntax_Subst.close_comp bs1
-                                            c'
-                                           in
-                                        (bs1, uu____6744)  in
-                                      FStar_Syntax_Syntax.Tm_arrow uu____6731
-                                       in
+                                            c' in
+                                        (bs1, uu____6744) in
+                                      FStar_Syntax_Syntax.Tm_arrow uu____6731 in
                                     {
                                       FStar_Syntax_Syntax.n = uu____6730;
                                       FStar_Syntax_Syntax.pos =
@@ -5207,9 +4608,8 @@ let (tc_decl :
                                   else t1)
                          | FStar_Syntax_Syntax.Tm_app (h,args) ->
                              let uu____6768 =
-                               let uu____6769 = FStar_Syntax_Subst.compress h
-                                  in
-                               uu____6769.FStar_Syntax_Syntax.n  in
+                               let uu____6769 = FStar_Syntax_Subst.compress h in
+                               uu____6769.FStar_Syntax_Syntax.n in
                              (match uu____6768 with
                               | FStar_Syntax_Syntax.Tm_uinst (h',u') ->
                                   let h'' =
@@ -5217,27 +4617,22 @@ let (tc_decl :
                                       FStar_Syntax_Syntax.lid_as_fv
                                         FStar_Parser_Const.u_tac_lid
                                         FStar_Syntax_Syntax.Delta_constant
-                                        FStar_Pervasives_Native.None
-                                       in
+                                        FStar_Pervasives_Native.None in
                                     FStar_All.pipe_left
-                                      FStar_Syntax_Syntax.fv_to_tm uu____6779
-                                     in
+                                      FStar_Syntax_Syntax.fv_to_tm uu____6779 in
                                   let uu____6780 =
                                     let uu____6781 =
-                                      FStar_Syntax_Syntax.mk_Tm_uinst h'' u'
-                                       in
+                                      FStar_Syntax_Syntax.mk_Tm_uinst h'' u' in
                                     FStar_Syntax_Syntax.mk_Tm_app uu____6781
-                                      args
-                                     in
+                                      args in
                                   uu____6780 FStar_Pervasives_Native.None
                                     t1.FStar_Syntax_Syntax.pos
                               | uu____6784 -> t1)
-                         | uu____6785 -> t1  in
+                         | uu____6785 -> t1 in
                        let reified_tactic_decl assm_lid lb =
                          let t =
                            reified_tactic_type assm_lid
-                             lb.FStar_Syntax_Syntax.lbtyp
-                            in
+                             lb.FStar_Syntax_Syntax.lbtyp in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_declare_typ
@@ -5250,73 +4645,62 @@ let (tc_decl :
                            FStar_Syntax_Syntax.sigmeta =
                              FStar_Syntax_Syntax.default_sigmeta;
                            FStar_Syntax_Syntax.sigattrs = []
-                         }  in
+                         } in
                        let reflected_tactic_decl b lb bs assm_lid comp =
                          let reified_tac =
                            let uu____6813 =
                              FStar_Syntax_Syntax.lid_as_fv assm_lid
                                FStar_Syntax_Syntax.Delta_constant
-                               FStar_Pervasives_Native.None
-                              in
+                               FStar_Pervasives_Native.None in
                            FStar_All.pipe_left FStar_Syntax_Syntax.fv_to_tm
-                             uu____6813
-                            in
+                             uu____6813 in
                          let tac_args =
                            FStar_List.map
                              (fun x  ->
                                 let uu____6830 =
                                   FStar_Syntax_Syntax.bv_to_name
-                                    (FStar_Pervasives_Native.fst x)
-                                   in
+                                    (FStar_Pervasives_Native.fst x) in
                                 (uu____6830, (FStar_Pervasives_Native.snd x)))
-                             bs
-                            in
+                             bs in
                          let reflect_head =
                            FStar_Syntax_Syntax.mk
                              (FStar_Syntax_Syntax.Tm_constant
                                 (FStar_Const.Const_reflect
                                    FStar_Parser_Const.tac_effect_lid))
                              FStar_Pervasives_Native.None
-                             FStar_Range.dummyRange
-                            in
+                             FStar_Range.dummyRange in
                          let refl_arg =
                            FStar_Syntax_Syntax.mk_Tm_app reified_tac tac_args
                              FStar_Pervasives_Native.None
-                             FStar_Range.dummyRange
-                            in
+                             FStar_Range.dummyRange in
                          let app =
                            FStar_Syntax_Syntax.mk_Tm_app reflect_head
                              [(refl_arg, FStar_Pervasives_Native.None)]
                              FStar_Pervasives_Native.None
-                             FStar_Range.dummyRange
-                            in
+                             FStar_Range.dummyRange in
                          let unit_binder =
                            let uu____6861 =
                              FStar_Syntax_Syntax.new_bv
                                FStar_Pervasives_Native.None
-                               FStar_Syntax_Syntax.t_unit
-                              in
+                               FStar_Syntax_Syntax.t_unit in
                            FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder
-                             uu____6861
-                            in
+                             uu____6861 in
                          let body =
                            FStar_All.pipe_left
                              (FStar_Syntax_Util.abs [unit_binder] app)
                              (FStar_Pervasives_Native.Some
-                                (FStar_Syntax_Util.residual_comp_of_comp comp))
-                            in
+                                (FStar_Syntax_Util.residual_comp_of_comp comp)) in
                          let func =
                            FStar_All.pipe_left
                              (FStar_Syntax_Util.abs bs body)
                              (FStar_Pervasives_Native.Some
-                                (FStar_Syntax_Util.residual_comp_of_comp comp))
-                            in
-                         let uu___90_6868 = se1  in
+                                (FStar_Syntax_Util.residual_comp_of_comp comp)) in
+                         let uu___90_6868 = se1 in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_let
                                 ((b,
-                                   [(let uu___91_6880 = lb  in
+                                   [(let uu___91_6880 = lb in
                                      {
                                        FStar_Syntax_Syntax.lbname =
                                          (uu___91_6880.FStar_Syntax_Syntax.lbname);
@@ -5338,81 +4722,67 @@ let (tc_decl :
                              (uu___90_6868.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
                              (uu___90_6868.FStar_Syntax_Syntax.sigattrs)
-                         }  in
+                         } in
                        let tactic_decls =
                          match FStar_Pervasives_Native.snd lbs1 with
                          | hd1::[] ->
                              let uu____6897 =
                                FStar_Syntax_Util.arrow_formals_comp
-                                 hd1.FStar_Syntax_Syntax.lbtyp
-                                in
+                                 hd1.FStar_Syntax_Syntax.lbtyp in
                              (match uu____6897 with
                               | (bs,comp) ->
-                                  let t = FStar_Syntax_Util.comp_result comp
-                                     in
+                                  let t = FStar_Syntax_Util.comp_result comp in
                                   let uu____6931 =
                                     let uu____6932 =
-                                      FStar_Syntax_Subst.compress t  in
-                                    uu____6932.FStar_Syntax_Syntax.n  in
+                                      FStar_Syntax_Subst.compress t in
+                                    uu____6932.FStar_Syntax_Syntax.n in
                                   (match uu____6931 with
                                    | FStar_Syntax_Syntax.Tm_app (h,args) ->
-                                       let h1 = FStar_Syntax_Subst.compress h
-                                          in
+                                       let h1 = FStar_Syntax_Subst.compress h in
                                        let tac_lid =
                                          let uu____6965 =
                                            let uu____6968 =
                                              FStar_Util.right
-                                               hd1.FStar_Syntax_Syntax.lbname
-                                              in
-                                           uu____6968.FStar_Syntax_Syntax.fv_name
-                                            in
-                                         uu____6965.FStar_Syntax_Syntax.v  in
+                                               hd1.FStar_Syntax_Syntax.lbname in
+                                           uu____6968.FStar_Syntax_Syntax.fv_name in
+                                         uu____6965.FStar_Syntax_Syntax.v in
                                        let assm_lid =
                                          let uu____6970 =
                                            FStar_All.pipe_left
                                              FStar_Ident.id_of_text
                                              (Prims.strcat "__"
-                                                (tac_lid.FStar_Ident.ident).FStar_Ident.idText)
-                                            in
+                                                (tac_lid.FStar_Ident.ident).FStar_Ident.idText) in
                                          FStar_Ident.lid_of_ns_and_id
-                                           tac_lid.FStar_Ident.ns uu____6970
-                                          in
+                                           tac_lid.FStar_Ident.ns uu____6970 in
                                        let uu____6971 =
-                                         get_tactic_fv env2 assm_lid h1  in
+                                         get_tactic_fv env2 assm_lid h1 in
                                        (match uu____6971 with
                                         | FStar_Pervasives_Native.Some fv ->
                                             let uu____6981 =
                                               let uu____6982 =
                                                 let uu____6983 =
                                                   FStar_TypeChecker_Env.try_lookup_val_decl
-                                                    env2 tac_lid
-                                                   in
+                                                    env2 tac_lid in
                                                 FStar_All.pipe_left
                                                   FStar_Util.is_some
-                                                  uu____6983
-                                                 in
-                                              Prims.op_Negation uu____6982
-                                               in
+                                                  uu____6983 in
+                                              Prims.op_Negation uu____6982 in
                                             if uu____6981
                                             then
                                               ((let uu____7013 =
                                                   let uu____7014 =
                                                     FStar_Syntax_Util.is_builtin_tactic
-                                                      env2.FStar_TypeChecker_Env.curmodule
-                                                     in
+                                                      env2.FStar_TypeChecker_Env.curmodule in
                                                   Prims.op_Negation
-                                                    uu____7014
-                                                   in
+                                                    uu____7014 in
                                                 if uu____7013
                                                 then
                                                   let added_modules =
                                                     FStar_ST.op_Bang
-                                                      user_tactics_modules
-                                                     in
+                                                      user_tactics_modules in
                                                   let module_name =
                                                     FStar_Ident.ml_path_of_lid
-                                                      env2.FStar_TypeChecker_Env.curmodule
-                                                     in
+                                                      env2.FStar_TypeChecker_Env.curmodule in
                                                   (if
                                                      Prims.op_Negation
                                                        (FStar_List.contains
@@ -5428,20 +4798,17 @@ let (tc_decl :
                                                 else ());
                                                (let uu____7067 =
                                                   env2.FStar_TypeChecker_Env.is_native_tactic
-                                                    assm_lid
-                                                   in
+                                                    assm_lid in
                                                 if uu____7067
                                                 then
                                                   let se_assm =
                                                     reified_tactic_decl
-                                                      assm_lid hd1
-                                                     in
+                                                      assm_lid hd1 in
                                                   let se_refl =
                                                     reflected_tactic_decl
                                                       (FStar_Pervasives_Native.fst
                                                          lbs1) hd1 bs
-                                                      assm_lid comp
-                                                     in
+                                                      assm_lid comp in
                                                   FStar_Pervasives_Native.Some
                                                     (se_assm, se_refl)
                                                 else
@@ -5451,33 +4818,29 @@ let (tc_decl :
                                             FStar_Pervasives_Native.None)
                                    | uu____7096 ->
                                        FStar_Pervasives_Native.None))
-                         | uu____7101 -> FStar_Pervasives_Native.None  in
+                         | uu____7101 -> FStar_Pervasives_Native.None in
                        match tactic_decls with
                        | FStar_Pervasives_Native.Some (se_assm,se_refl) ->
                            ((let uu____7123 =
                                FStar_TypeChecker_Env.debug env2
-                                 (FStar_Options.Other "NativeTactics")
-                                in
+                                 (FStar_Options.Other "NativeTactics") in
                              if uu____7123
                              then
                                let uu____7124 =
-                                 FStar_Syntax_Print.sigelt_to_string se_assm
-                                  in
+                                 FStar_Syntax_Print.sigelt_to_string se_assm in
                                let uu____7125 =
-                                 FStar_Syntax_Print.sigelt_to_string se_refl
-                                  in
+                                 FStar_Syntax_Print.sigelt_to_string se_refl in
                                FStar_Util.print2
                                  "Native tactic declarations: \n%s\n%s\n"
                                  uu____7124 uu____7125
                              else ());
                             ([se_assm; se_refl], []))
                        | FStar_Pervasives_Native.None  -> ([se1], []))))))
-  
-let (for_export :
+let for_export:
   FStar_Ident.lident Prims.list ->
     FStar_Syntax_Syntax.sigelt ->
       (FStar_Syntax_Syntax.sigelt Prims.list,FStar_Ident.lident Prims.list)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun hidden  ->
     fun se  ->
@@ -5487,8 +4850,7 @@ let (for_export :
              (fun uu___58_7176  ->
                 match uu___58_7176 with
                 | FStar_Syntax_Syntax.Abstract  -> true
-                | uu____7177 -> false))
-         in
+                | uu____7177 -> false)) in
       let is_hidden_proj_or_disc q =
         match q with
         | FStar_Syntax_Syntax.Projector (l,uu____7183) ->
@@ -5497,7 +4859,7 @@ let (for_export :
         | FStar_Syntax_Syntax.Discriminator l ->
             FStar_All.pipe_right hidden
               (FStar_Util.for_some (FStar_Ident.lid_equals l))
-        | uu____7189 -> false  in
+        | uu____7189 -> false in
       match se.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_pragma uu____7198 -> ([], hidden)
       | FStar_Syntax_Syntax.Sig_inductive_typ uu____7203 ->
@@ -5505,7 +4867,7 @@ let (for_export :
       | FStar_Syntax_Syntax.Sig_datacon uu____7228 ->
           failwith "Impossible (Already handled)"
       | FStar_Syntax_Syntax.Sig_bundle (ses,uu____7252) ->
-          let uu____7261 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+          let uu____7261 = is_abstract se.FStar_Syntax_Syntax.sigquals in
           if uu____7261
           then
             let for_export_bundle se1 uu____7292 =
@@ -5515,15 +4877,15 @@ let (for_export :
                    | FStar_Syntax_Syntax.Sig_inductive_typ
                        (l,us,bs,t,uu____7331,uu____7332) ->
                        let dec =
-                         let uu___92_7342 = se1  in
+                         let uu___92_7342 = se1 in
                          let uu____7343 =
                            let uu____7344 =
                              let uu____7351 =
                                let uu____7354 =
-                                 FStar_Syntax_Syntax.mk_Total t  in
-                               FStar_Syntax_Util.arrow bs uu____7354  in
-                             (l, us, uu____7351)  in
-                           FStar_Syntax_Syntax.Sig_declare_typ uu____7344  in
+                                 FStar_Syntax_Syntax.mk_Total t in
+                               FStar_Syntax_Util.arrow bs uu____7354 in
+                             (l, us, uu____7351) in
+                           FStar_Syntax_Syntax.Sig_declare_typ uu____7344 in
                          {
                            FStar_Syntax_Syntax.sigel = uu____7343;
                            FStar_Syntax_Syntax.sigrng =
@@ -5536,12 +4898,12 @@ let (for_export :
                              (uu___92_7342.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
                              (uu___92_7342.FStar_Syntax_Syntax.sigattrs)
-                         }  in
+                         } in
                        ((dec :: out), hidden1)
                    | FStar_Syntax_Syntax.Sig_datacon
                        (l,us,t,uu____7366,uu____7367,uu____7368) ->
                        let dec =
-                         let uu___93_7374 = se1  in
+                         let uu___93_7374 = se1 in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_declare_typ (l, us, t));
@@ -5553,23 +4915,21 @@ let (for_export :
                              (uu___93_7374.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
                              (uu___93_7374.FStar_Syntax_Syntax.sigattrs)
-                         }  in
+                         } in
                        ((dec :: out), (l :: hidden1))
-                   | uu____7379 -> (out, hidden1))
-               in
+                   | uu____7379 -> (out, hidden1)) in
             FStar_List.fold_right for_export_bundle ses ([], hidden)
           else ([se], hidden)
       | FStar_Syntax_Syntax.Sig_assume (uu____7401,uu____7402,uu____7403) ->
-          let uu____7404 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+          let uu____7404 = is_abstract se.FStar_Syntax_Syntax.sigquals in
           if uu____7404 then ([], hidden) else ([se], hidden)
       | FStar_Syntax_Syntax.Sig_declare_typ (l,us,t) ->
           let uu____7425 =
             FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
-              (FStar_Util.for_some is_hidden_proj_or_disc)
-             in
+              (FStar_Util.for_some is_hidden_proj_or_disc) in
           if uu____7425
           then
-            ([(let uu___94_7441 = se  in
+            ([(let uu___94_7441 = se in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_declare_typ (l, us, t));
@@ -5591,8 +4951,7 @@ let (for_export :
                        | FStar_Syntax_Syntax.Assumption  -> true
                        | FStar_Syntax_Syntax.Projector uu____7448 -> true
                        | FStar_Syntax_Syntax.Discriminator uu____7453 -> true
-                       | uu____7454 -> false))
-                in
+                       | uu____7454 -> false)) in
              if uu____7443 then ([se], hidden) else ([], hidden))
       | FStar_Syntax_Syntax.Sig_main uu____7472 -> ([], hidden)
       | FStar_Syntax_Syntax.Sig_new_effect uu____7477 -> ([se], hidden)
@@ -5604,13 +4963,11 @@ let (for_export :
           FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
             (FStar_Util.for_some is_hidden_proj_or_disc)
           ->
-          let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-          let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+          let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
+          let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           let uu____7527 =
             FStar_All.pipe_right hidden
-              (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv))
-             in
+              (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv)) in
           if uu____7527
           then ([], hidden)
           else
@@ -5627,31 +4984,29 @@ let (for_export :
                  FStar_Syntax_Syntax.sigmeta =
                    FStar_Syntax_Syntax.default_sigmeta;
                  FStar_Syntax_Syntax.sigattrs = []
-               }  in
+               } in
              ([dec], (lid :: hidden)))
       | FStar_Syntax_Syntax.Sig_let (lbs,l) ->
-          let uu____7558 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+          let uu____7558 = is_abstract se.FStar_Syntax_Syntax.sigquals in
           if uu____7558
           then
             let uu____7567 =
               FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                 (FStar_List.map
                    (fun lb  ->
-                      let uu___95_7580 = se  in
+                      let uu___95_7580 = se in
                       let uu____7581 =
                         let uu____7582 =
                           let uu____7589 =
                             let uu____7590 =
                               let uu____7593 =
                                 FStar_Util.right
-                                  lb.FStar_Syntax_Syntax.lbname
-                                 in
-                              uu____7593.FStar_Syntax_Syntax.fv_name  in
-                            uu____7590.FStar_Syntax_Syntax.v  in
+                                  lb.FStar_Syntax_Syntax.lbname in
+                              uu____7593.FStar_Syntax_Syntax.fv_name in
+                            uu____7590.FStar_Syntax_Syntax.v in
                           (uu____7589, (lb.FStar_Syntax_Syntax.lbunivs),
-                            (lb.FStar_Syntax_Syntax.lbtyp))
-                           in
-                        FStar_Syntax_Syntax.Sig_declare_typ uu____7582  in
+                            (lb.FStar_Syntax_Syntax.lbtyp)) in
+                        FStar_Syntax_Syntax.Sig_declare_typ uu____7582 in
                       {
                         FStar_Syntax_Syntax.sigel = uu____7581;
                         FStar_Syntax_Syntax.sigrng =
@@ -5663,14 +5018,12 @@ let (for_export :
                           (uu___95_7580.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
                           (uu___95_7580.FStar_Syntax_Syntax.sigattrs)
-                      }))
-               in
+                      })) in
             (uu____7567, hidden)
           else ([se], hidden)
-  
-let (add_sigelt_to_env :
+let add_sigelt_to_env:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.sigelt -> FStar_TypeChecker_Env.env)
+    FStar_Syntax_Syntax.sigelt -> FStar_TypeChecker_Env.env
   =
   fun env  ->
     fun se  ->
@@ -5682,23 +5035,22 @@ let (add_sigelt_to_env :
       | FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.ResetOptions
           uu____7645) ->
           let env1 =
-            let uu____7649 = FStar_Options.using_facts_from ()  in
-            FStar_TypeChecker_Env.set_proof_ns uu____7649 env  in
+            let uu____7649 = FStar_Options.using_facts_from () in
+            FStar_TypeChecker_Env.set_proof_ns uu____7649 env in
           ((env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh
              ();
            env1)
       | FStar_Syntax_Syntax.Sig_pragma uu____7651 -> env
       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____7652 -> env
       | FStar_Syntax_Syntax.Sig_new_effect ne ->
-          let env1 = FStar_TypeChecker_Env.push_sigelt env se  in
+          let env1 = FStar_TypeChecker_Env.push_sigelt env se in
           FStar_All.pipe_right ne.FStar_Syntax_Syntax.actions
             (FStar_List.fold_left
                (fun env2  ->
                   fun a  ->
                     let uu____7662 =
                       FStar_Syntax_Util.action_as_lb
-                        ne.FStar_Syntax_Syntax.mname a
-                       in
+                        ne.FStar_Syntax_Syntax.mname a in
                     FStar_TypeChecker_Env.push_sigelt env2 uu____7662) env1)
       | FStar_Syntax_Syntax.Sig_declare_typ
           (uu____7663,uu____7664,uu____7665) when
@@ -5718,17 +5070,15 @@ let (add_sigelt_to_env :
                   | uu____7681 -> false))
           -> env
       | uu____7682 -> FStar_TypeChecker_Env.push_sigelt env se
-  
-let (dont_use_exports : Prims.bool) =
+let dont_use_exports: Prims.bool =
   (FStar_Options.use_extracted_interfaces ()) ||
     (FStar_Options.check_interface ())
-  
-let (tc_decls :
+let tc_decls:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
       (FStar_Syntax_Syntax.sigelt Prims.list,FStar_Syntax_Syntax.sigelt
                                                Prims.list,FStar_TypeChecker_Env.env)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun ses  ->
@@ -5736,14 +5086,14 @@ let (tc_decls :
         match uu____7742 with
         | (ses1,exports,env1,hidden) ->
             ((let uu____7795 =
-                FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
+                FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
               if uu____7795
               then
-                let uu____7796 = FStar_Syntax_Print.sigelt_to_string se  in
+                let uu____7796 = FStar_Syntax_Print.sigelt_to_string se in
                 FStar_Util.print1
                   ">>>>>>>>>>>>>>Checking top-level decl %s\n" uu____7796
               else ());
-             (let uu____7798 = tc_decl env1 se  in
+             (let uu____7798 = tc_decl env1 se in
               match uu____7798 with
               | (ses',ses_elaborated) ->
                   let ses'1 =
@@ -5752,23 +5102,20 @@ let (tc_decls :
                          (fun se1  ->
                             (let uu____7848 =
                                FStar_TypeChecker_Env.debug env1
-                                 (FStar_Options.Other "UF")
-                                in
+                                 (FStar_Options.Other "UF") in
                              if uu____7848
                              then
                                let uu____7849 =
-                                 FStar_Syntax_Print.sigelt_to_string se1  in
+                                 FStar_Syntax_Print.sigelt_to_string se1 in
                                FStar_Util.print1 "About to elim vars from %s"
                                  uu____7849
                              else ());
-                            FStar_TypeChecker_Normalize.elim_uvars env1 se1))
-                     in
+                            FStar_TypeChecker_Normalize.elim_uvars env1 se1)) in
                   let ses_elaborated1 =
                     FStar_All.pipe_right ses_elaborated
                       (FStar_List.map
                          (fun se1  ->
-                            FStar_TypeChecker_Normalize.elim_uvars env1 se1))
-                     in
+                            FStar_TypeChecker_Normalize.elim_uvars env1 se1)) in
                   (FStar_TypeChecker_Env.promote_id_info env1
                      (fun t  ->
                         FStar_TypeChecker_Normalize.normalize
@@ -5786,15 +5133,13 @@ let (tc_decls :
                       FStar_All.pipe_right ses'1
                         (FStar_List.fold_left
                            (fun env2  ->
-                              fun se1  -> add_sigelt_to_env env2 se1) env1)
-                       in
+                              fun se1  -> add_sigelt_to_env env2 se1) env1) in
                     FStar_Syntax_Unionfind.reset ();
                     (let uu____7872 =
                        (FStar_Options.log_types ()) ||
                          (FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env2)
-                            (FStar_Options.Other "LogTypes"))
-                        in
+                            (FStar_Options.Other "LogTypes")) in
                      if uu____7872
                      then
                        let uu____7873 =
@@ -5803,11 +5148,9 @@ let (tc_decls :
                               fun se1  ->
                                 let uu____7879 =
                                   let uu____7880 =
-                                    FStar_Syntax_Print.sigelt_to_string se1
-                                     in
-                                  Prims.strcat uu____7880 "\n"  in
-                                Prims.strcat s uu____7879) "" ses'1
-                          in
+                                    FStar_Syntax_Print.sigelt_to_string se1 in
+                                  Prims.strcat uu____7880 "\n" in
+                                Prims.strcat s uu____7879) "" ses'1 in
                        FStar_Util.print1 "Checked: %s\n" uu____7873
                      else ());
                     FStar_List.iter
@@ -5821,21 +5164,19 @@ let (tc_decls :
                          (let accum_exports_hidden uu____7928 se1 =
                             match uu____7928 with
                             | (exports1,hidden1) ->
-                                let uu____7956 = for_export hidden1 se1  in
+                                let uu____7956 = for_export hidden1 se1 in
                                 (match uu____7956 with
                                  | (se_exported,hidden2) ->
                                      ((FStar_List.rev_append se_exported
-                                         exports1), hidden2))
-                             in
+                                         exports1), hidden2)) in
                           FStar_List.fold_left accum_exports_hidden
-                            (exports, hidden) ses'1)
-                        in
+                            (exports, hidden) ses'1) in
                      match uu____7885 with
                      | (exports1,hidden1) ->
                          let ses'2 =
                            FStar_List.map
                              (fun s  ->
-                                let uu___96_8035 = s  in
+                                let uu___96_8035 = s in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (uu___96_8035.FStar_Syntax_Syntax.sigel);
@@ -5847,63 +5188,55 @@ let (tc_decls :
                                     (uu___96_8035.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
                                     (se.FStar_Syntax_Syntax.sigattrs)
-                                }) ses'1
-                            in
+                                }) ses'1 in
                          (((FStar_List.rev_append ses'2 ses1), exports1,
-                            env2, hidden1), ses_elaborated1))))))
-         in
+                            env2, hidden1), ses_elaborated1)))))) in
       let process_one_decl_timed acc se =
-        let uu____8113 = acc  in
+        let uu____8113 = acc in
         match uu____8113 with
         | (uu____8148,uu____8149,env1,uu____8151) ->
             let uu____8164 =
               FStar_Util.record_time
-                (fun uu____8210  -> process_one_decl acc se)
-               in
+                (fun uu____8210  -> process_one_decl acc se) in
             (match uu____8164 with
              | (r,ms_elapsed) ->
                  ((let uu____8274 =
                      FStar_TypeChecker_Env.debug env1
-                       (FStar_Options.Other "TCDeclTime")
-                      in
+                       (FStar_Options.Other "TCDeclTime") in
                    if uu____8274
                    then
                      let uu____8275 =
-                       FStar_Syntax_Print.sigelt_to_string_short se  in
-                     let uu____8276 = FStar_Util.string_of_int ms_elapsed  in
+                       FStar_Syntax_Print.sigelt_to_string_short se in
+                     let uu____8276 = FStar_Util.string_of_int ms_elapsed in
                      FStar_Util.print2 "Checked %s in %s milliseconds\n"
                        uu____8275 uu____8276
                    else ());
-                  r))
-         in
+                  r)) in
       let uu____8278 =
-        FStar_Util.fold_flatten process_one_decl_timed ([], [], env, []) ses
-         in
+        FStar_Util.fold_flatten process_one_decl_timed ([], [], env, []) ses in
       match uu____8278 with
       | (ses1,exports,env1,uu____8326) ->
           ((FStar_List.rev_append ses1 []),
             (FStar_List.rev_append exports []), env1)
-  
-let (tc_partial_modul :
+let tc_partial_modul:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul ->
       Prims.bool ->
         (FStar_Syntax_Syntax.modul,FStar_Syntax_Syntax.sigelt Prims.list,
-          FStar_TypeChecker_Env.env) FStar_Pervasives_Native.tuple3)
+          FStar_TypeChecker_Env.env) FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun modul  ->
       fun push_before_typechecking  ->
         let verify =
           FStar_Options.should_verify
-            (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
-           in
-        let action = if verify then "Verifying" else "Lax-checking"  in
+            (modul.FStar_Syntax_Syntax.name).FStar_Ident.str in
+        let action = if verify then "Verifying" else "Lax-checking" in
         let label1 =
           if modul.FStar_Syntax_Syntax.is_interface
           then "interface"
-          else "implementation"  in
-        (let uu____8366 = FStar_Options.debug_any ()  in
+          else "implementation" in
+        (let uu____8366 = FStar_Options.debug_any () in
          if uu____8366
          then
            FStar_Util.print3 "%s %s of %s\n" action label1
@@ -5913,11 +5246,10 @@ let (tc_partial_modul :
            FStar_Util.format2 "%s %s"
              (if modul.FStar_Syntax_Syntax.is_interface
               then "interface"
-              else "module") (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
-            in
-         let msg = Prims.strcat "Internals for " name  in
+              else "module") (modul.FStar_Syntax_Syntax.name).FStar_Ident.str in
+         let msg = Prims.strcat "Internals for " name in
          let env1 =
-           let uu___97_8372 = env  in
+           let uu___97_8372 = env in
            {
              FStar_TypeChecker_Env.solver =
                (uu___97_8372.FStar_TypeChecker_Env.solver);
@@ -5988,20 +5320,19 @@ let (tc_partial_modul :
                (uu___97_8372.FStar_TypeChecker_Env.dsenv);
              FStar_TypeChecker_Env.dep_graph =
                (uu___97_8372.FStar_TypeChecker_Env.dep_graph)
-           }  in
+           } in
          if push_before_typechecking
          then
            (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.push msg
          else ();
          (let env2 =
             FStar_TypeChecker_Env.set_current_module env1
-              modul.FStar_Syntax_Syntax.name
-             in
+              modul.FStar_Syntax_Syntax.name in
           let uu____8376 =
-            tc_decls env2 modul.FStar_Syntax_Syntax.declarations  in
+            tc_decls env2 modul.FStar_Syntax_Syntax.declarations in
           match uu____8376 with
           | (ses,exports,env3) ->
-              ((let uu___98_8409 = modul  in
+              ((let uu___98_8409 = modul in
                 {
                   FStar_Syntax_Syntax.name =
                     (uu___98_8409.FStar_Syntax_Syntax.name);
@@ -6011,22 +5342,21 @@ let (tc_partial_modul :
                   FStar_Syntax_Syntax.is_interface =
                     (uu___98_8409.FStar_Syntax_Syntax.is_interface)
                 }), exports, env3)))
-  
-let (tc_more_partial_modul :
+let tc_more_partial_modul:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul ->
       FStar_Syntax_Syntax.sigelt Prims.list ->
         (FStar_Syntax_Syntax.modul,FStar_Syntax_Syntax.sigelt Prims.list,
-          FStar_TypeChecker_Env.env) FStar_Pervasives_Native.tuple3)
+          FStar_TypeChecker_Env.env) FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun modul  ->
       fun decls  ->
-        let uu____8431 = tc_decls env decls  in
+        let uu____8431 = tc_decls env decls in
         match uu____8431 with
         | (ses,exports,env1) ->
             let modul1 =
-              let uu___99_8462 = modul  in
+              let uu___99_8462 = modul in
               {
                 FStar_Syntax_Syntax.name =
                   (uu___99_8462.FStar_Syntax_Syntax.name);
@@ -6037,19 +5367,18 @@ let (tc_more_partial_modul :
                   (uu___99_8462.FStar_Syntax_Syntax.exports);
                 FStar_Syntax_Syntax.is_interface =
                   (uu___99_8462.FStar_Syntax_Syntax.is_interface)
-              }  in
+              } in
             (modul1, exports, env1)
-  
-let (check_exports :
+let check_exports:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul ->
-      FStar_Syntax_Syntax.sigelt Prims.list -> Prims.unit)
+      FStar_Syntax_Syntax.sigelt Prims.list -> Prims.unit
   =
   fun env  ->
     fun modul  ->
       fun exports  ->
         let env1 =
-          let uu___100_8479 = env  in
+          let uu___100_8479 = env in
           {
             FStar_TypeChecker_Env.solver =
               (uu___100_8479.FStar_TypeChecker_Env.solver);
@@ -6118,68 +5447,59 @@ let (check_exports :
               (uu___100_8479.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.dep_graph =
               (uu___100_8479.FStar_TypeChecker_Env.dep_graph)
-          }  in
+          } in
         let check_term1 lid univs1 t =
-          let uu____8490 = FStar_Syntax_Subst.open_univ_vars univs1 t  in
+          let uu____8490 = FStar_Syntax_Subst.open_univ_vars univs1 t in
           match uu____8490 with
           | (univs2,t1) ->
               ((let uu____8498 =
                   let uu____8499 =
                     let uu____8502 =
                       FStar_TypeChecker_Env.set_current_module env1
-                        modul.FStar_Syntax_Syntax.name
-                       in
-                    FStar_TypeChecker_Env.debug uu____8502  in
+                        modul.FStar_Syntax_Syntax.name in
+                    FStar_TypeChecker_Env.debug uu____8502 in
                   FStar_All.pipe_left uu____8499
-                    (FStar_Options.Other "Exports")
-                   in
+                    (FStar_Options.Other "Exports") in
                 if uu____8498
                 then
-                  let uu____8503 = FStar_Syntax_Print.lid_to_string lid  in
+                  let uu____8503 = FStar_Syntax_Print.lid_to_string lid in
                   let uu____8504 =
                     let uu____8505 =
                       FStar_All.pipe_right univs2
                         (FStar_List.map
                            (fun x  ->
                               FStar_Syntax_Print.univ_to_string
-                                (FStar_Syntax_Syntax.U_name x)))
-                       in
+                                (FStar_Syntax_Syntax.U_name x))) in
                     FStar_All.pipe_right uu____8505
-                      (FStar_String.concat ", ")
-                     in
-                  let uu____8514 = FStar_Syntax_Print.term_to_string t1  in
+                      (FStar_String.concat ", ") in
+                  let uu____8514 = FStar_Syntax_Print.term_to_string t1 in
                   FStar_Util.print3 "Checking for export %s <%s> : %s\n"
                     uu____8503 uu____8504 uu____8514
                 else ());
-               (let env2 = FStar_TypeChecker_Env.push_univ_vars env1 univs2
-                   in
+               (let env2 = FStar_TypeChecker_Env.push_univ_vars env1 univs2 in
                 let uu____8517 =
-                  FStar_TypeChecker_TcTerm.tc_trivial_guard env2 t1  in
-                FStar_All.pipe_right uu____8517 FStar_Pervasives.ignore))
-           in
+                  FStar_TypeChecker_TcTerm.tc_trivial_guard env2 t1 in
+                FStar_All.pipe_right uu____8517 FStar_Pervasives.ignore)) in
         let check_term2 lid univs1 t =
           (let uu____8541 =
              let uu____8542 =
                FStar_Syntax_Print.lid_to_string
-                 modul.FStar_Syntax_Syntax.name
-                in
-             let uu____8543 = FStar_Syntax_Print.lid_to_string lid  in
+                 modul.FStar_Syntax_Syntax.name in
+             let uu____8543 = FStar_Syntax_Print.lid_to_string lid in
              FStar_Util.format2
                "Interface of %s violates its abstraction (add a 'private' qualifier to '%s'?)"
-               uu____8542 uu____8543
-              in
+               uu____8542 uu____8543 in
            FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____8541);
           check_term1 lid univs1 t;
-          FStar_Errors.message_prefix.FStar_Errors.clear_prefix ()  in
+          FStar_Errors.message_prefix.FStar_Errors.clear_prefix () in
         let rec check_sigelt se =
           match se.FStar_Syntax_Syntax.sigel with
           | FStar_Syntax_Syntax.Sig_bundle (ses,uu____8550) ->
               let uu____8559 =
                 let uu____8560 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
-                    (FStar_List.contains FStar_Syntax_Syntax.Private)
-                   in
-                Prims.op_Negation uu____8560  in
+                    (FStar_List.contains FStar_Syntax_Syntax.Private) in
+                Prims.op_Negation uu____8560 in
               if uu____8559
               then FStar_All.pipe_right ses (FStar_List.iter check_sigelt)
               else ()
@@ -6189,13 +5509,12 @@ let (check_exports :
                 let uu____8583 =
                   let uu____8586 =
                     let uu____8587 =
-                      let uu____8600 = FStar_Syntax_Syntax.mk_Total typ  in
-                      (binders, uu____8600)  in
-                    FStar_Syntax_Syntax.Tm_arrow uu____8587  in
-                  FStar_Syntax_Syntax.mk uu____8586  in
+                      let uu____8600 = FStar_Syntax_Syntax.mk_Total typ in
+                      (binders, uu____8600) in
+                    FStar_Syntax_Syntax.Tm_arrow uu____8587 in
+                  FStar_Syntax_Syntax.mk uu____8586 in
                 uu____8583 FStar_Pervasives_Native.None
-                  se.FStar_Syntax_Syntax.sigrng
-                 in
+                  se.FStar_Syntax_Syntax.sigrng in
               check_term2 l univs1 t
           | FStar_Syntax_Syntax.Sig_datacon
               (l,univs1,t,uu____8607,uu____8608,uu____8609) ->
@@ -6204,24 +5523,22 @@ let (check_exports :
               let uu____8617 =
                 let uu____8618 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
-                    (FStar_List.contains FStar_Syntax_Syntax.Private)
-                   in
-                Prims.op_Negation uu____8618  in
+                    (FStar_List.contains FStar_Syntax_Syntax.Private) in
+                Prims.op_Negation uu____8618 in
               if uu____8617 then check_term2 l univs1 t else ()
           | FStar_Syntax_Syntax.Sig_let ((uu____8622,lbs),uu____8624) ->
               let uu____8639 =
                 let uu____8640 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
-                    (FStar_List.contains FStar_Syntax_Syntax.Private)
-                   in
-                Prims.op_Negation uu____8640  in
+                    (FStar_List.contains FStar_Syntax_Syntax.Private) in
+                Prims.op_Negation uu____8640 in
               if uu____8639
               then
                 FStar_All.pipe_right lbs
                   (FStar_List.iter
                      (fun lb  ->
                         let fv =
-                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
+                          FStar_Util.right lb.FStar_Syntax_Syntax.lbname in
                         check_term2
                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                           lb.FStar_Syntax_Syntax.lbunivs
@@ -6232,17 +5549,15 @@ let (check_exports :
               let uu____8659 =
                 let uu____8660 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
-                    (FStar_List.contains FStar_Syntax_Syntax.Private)
-                   in
-                Prims.op_Negation uu____8660  in
+                    (FStar_List.contains FStar_Syntax_Syntax.Private) in
+                Prims.op_Negation uu____8660 in
               if uu____8659
               then
                 let arrow1 =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_arrow (binders, comp))
                     FStar_Pervasives_Native.None
-                    se.FStar_Syntax_Syntax.sigrng
-                   in
+                    se.FStar_Syntax_Syntax.sigrng in
                 check_term2 l univs1 arrow1
               else ()
           | FStar_Syntax_Syntax.Sig_main uu____8667 -> ()
@@ -6250,20 +5565,19 @@ let (check_exports :
           | FStar_Syntax_Syntax.Sig_new_effect uu____8675 -> ()
           | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____8676 -> ()
           | FStar_Syntax_Syntax.Sig_sub_effect uu____8677 -> ()
-          | FStar_Syntax_Syntax.Sig_pragma uu____8678 -> ()  in
+          | FStar_Syntax_Syntax.Sig_pragma uu____8678 -> () in
         if
           FStar_Ident.lid_equals modul.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
         then ()
         else FStar_List.iter check_sigelt exports
-  
-let (finish_partial_modul :
+let finish_partial_modul:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.modul ->
         FStar_Syntax_Syntax.sigelts ->
           (FStar_Syntax_Syntax.modul,FStar_TypeChecker_Env.env)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun must_check_exports  ->
     fun env  ->
@@ -6272,7 +5586,7 @@ let (finish_partial_modul :
           let modul1 =
             if dont_use_exports
             then
-              let uu___101_8697 = modul  in
+              let uu___101_8697 = modul in
               {
                 FStar_Syntax_Syntax.name =
                   (uu___101_8697.FStar_Syntax_Syntax.name);
@@ -6284,7 +5598,7 @@ let (finish_partial_modul :
                   (uu___101_8697.FStar_Syntax_Syntax.is_interface)
               }
             else
-              (let uu___102_8699 = modul  in
+              (let uu___102_8699 = modul in
                {
                  FStar_Syntax_Syntax.name =
                    (uu___102_8699.FStar_Syntax_Syntax.name);
@@ -6293,15 +5607,13 @@ let (finish_partial_modul :
                  FStar_Syntax_Syntax.exports = exports;
                  FStar_Syntax_Syntax.is_interface =
                    (uu___102_8699.FStar_Syntax_Syntax.is_interface)
-               })
-             in
-          let env1 = FStar_TypeChecker_Env.finish_module env modul1  in
+               }) in
+          let env1 = FStar_TypeChecker_Env.finish_module env modul1 in
           (let uu____8702 =
-             ((let uu____8705 = FStar_Options.lax ()  in
+             ((let uu____8705 = FStar_Options.lax () in
                Prims.op_Negation uu____8705) &&
                 (Prims.op_Negation dont_use_exports))
-               && must_check_exports
-              in
+               && must_check_exports in
            if uu____8702 then check_exports env1 modul1 exports else ());
           (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.pop
             (Prims.strcat "Ending modul "
@@ -6311,87 +5623,79 @@ let (finish_partial_modul :
           (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh
             ();
           (let uu____8711 =
-             let uu____8712 = FStar_Options.interactive ()  in
-             Prims.op_Negation uu____8712  in
+             let uu____8712 = FStar_Options.interactive () in
+             Prims.op_Negation uu____8712 in
            if uu____8711
            then
-             let uu____8713 = FStar_Options.restore_cmd_line_options true  in
+             let uu____8713 = FStar_Options.restore_cmd_line_options true in
              FStar_All.pipe_right uu____8713 FStar_Pervasives.ignore
            else ());
           (modul1, env1)
-  
-let (load_checked_module :
+let load_checked_module:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.modul -> FStar_TypeChecker_Env.env)
+    FStar_Syntax_Syntax.modul -> FStar_TypeChecker_Env.env
   =
   fun env  ->
     fun modul  ->
       let env1 =
         FStar_TypeChecker_Env.set_current_module env
-          modul.FStar_Syntax_Syntax.name
-         in
+          modul.FStar_Syntax_Syntax.name in
       (let uu____8723 =
          let uu____8724 =
-           FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
-         Prims.strcat "Internals for " uu____8724  in
+           FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
+         Prims.strcat "Internals for " uu____8724 in
        (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.push
          uu____8723);
       (let env2 =
          FStar_List.fold_left
            (fun env2  ->
               fun se  ->
-                let env3 = FStar_TypeChecker_Env.push_sigelt env2 se  in
-                let lids = FStar_Syntax_Util.lids_of_sigelt se  in
+                let env3 = FStar_TypeChecker_Env.push_sigelt env2 se in
+                let lids = FStar_Syntax_Util.lids_of_sigelt se in
                 FStar_All.pipe_right lids
                   (FStar_List.iter
                      (fun lid  ->
                         let uu____8743 =
-                          FStar_TypeChecker_Env.try_lookup_lid env3 lid  in
+                          FStar_TypeChecker_Env.try_lookup_lid env3 lid in
                         ()));
-                env3) env1 modul.FStar_Syntax_Syntax.declarations
-          in
+                env3) env1 modul.FStar_Syntax_Syntax.declarations in
        let uu____8764 =
          finish_partial_modul false env2 modul
-           modul.FStar_Syntax_Syntax.exports
-          in
+           modul.FStar_Syntax_Syntax.exports in
        FStar_Pervasives_Native.snd uu____8764)
-  
-let (tc_modul :
+let tc_modul:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul ->
       (FStar_Syntax_Syntax.modul,FStar_TypeChecker_Env.env)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun modul  ->
-      let uu____8779 = tc_partial_modul env modul true  in
+      let uu____8779 = tc_partial_modul env modul true in
       match uu____8779 with
       | (modul1,non_private_decls,env1) ->
           finish_partial_modul true env1 modul1 non_private_decls
-  
-let (extract_interface :
+let extract_interface:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.modul -> FStar_Syntax_Syntax.modul)
+    FStar_Syntax_Syntax.modul -> FStar_Syntax_Syntax.modul
   =
   fun env  ->
     fun m  ->
-      let is_abstract = FStar_List.contains FStar_Syntax_Syntax.Abstract  in
+      let is_abstract = FStar_List.contains FStar_Syntax_Syntax.Abstract in
       let is_irreducible1 =
-        FStar_List.contains FStar_Syntax_Syntax.Irreducible  in
-      let is_assume = FStar_List.contains FStar_Syntax_Syntax.Assumption  in
+        FStar_List.contains FStar_Syntax_Syntax.Irreducible in
+      let is_assume = FStar_List.contains FStar_Syntax_Syntax.Assumption in
       let is_noeq_or_unopteq =
         FStar_List.existsb
           (fun q  ->
              (q = FStar_Syntax_Syntax.Noeq) ||
-               (q = FStar_Syntax_Syntax.Unopteq))
-         in
+               (q = FStar_Syntax_Syntax.Unopteq)) in
       let filter_out_abstract =
         FStar_List.filter
           (fun q  ->
              Prims.op_Negation
                ((q = FStar_Syntax_Syntax.Abstract) ||
-                  (q = FStar_Syntax_Syntax.Irreducible)))
-         in
+                  (q = FStar_Syntax_Syntax.Irreducible))) in
       let filter_out_abstract_and_noeq =
         FStar_List.filter
           (fun q  ->
@@ -6399,8 +5703,7 @@ let (extract_interface :
                ((((q = FStar_Syntax_Syntax.Abstract) ||
                     (q = FStar_Syntax_Syntax.Noeq))
                    || (q = FStar_Syntax_Syntax.Unopteq))
-                  || (q = FStar_Syntax_Syntax.Irreducible)))
-         in
+                  || (q = FStar_Syntax_Syntax.Irreducible))) in
       let filter_out_abstract_and_inline =
         FStar_List.filter
           (fun q  ->
@@ -6409,30 +5712,28 @@ let (extract_interface :
                     (q = FStar_Syntax_Syntax.Irreducible))
                    || (q = FStar_Syntax_Syntax.Inline_for_extraction))
                   ||
-                  (q = FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)))
-         in
+                  (q = FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen))) in
       let add_assume_if_needed quals =
         if is_assume quals
         then quals
-        else FStar_Syntax_Syntax.Assumption :: quals  in
-      let val_typs = FStar_Util.mk_ref []  in
-      let abstract_inductive_datacons = FStar_Util.mk_ref []  in
+        else FStar_Syntax_Syntax.Assumption :: quals in
+      let val_typs = FStar_Util.mk_ref [] in
+      let abstract_inductive_datacons = FStar_Util.mk_ref [] in
       let is_projector_or_discriminator_of_an_abstract_inductive quals =
         FStar_List.existsML
           (fun q  ->
              match q with
              | FStar_Syntax_Syntax.Discriminator l ->
                  let uu____8924 =
-                   FStar_ST.op_Bang abstract_inductive_datacons  in
+                   FStar_ST.op_Bang abstract_inductive_datacons in
                  FStar_List.existsb (fun l'  -> FStar_Ident.lid_equals l l')
                    uu____8924
              | FStar_Syntax_Syntax.Projector (l,uu____8975) ->
                  let uu____8976 =
-                   FStar_ST.op_Bang abstract_inductive_datacons  in
+                   FStar_ST.op_Bang abstract_inductive_datacons in
                  FStar_List.existsb (fun l'  -> FStar_Ident.lid_equals l l')
                    uu____8976
-             | uu____9026 -> false) quals
-         in
+             | uu____9026 -> false) quals in
       let vals_of_abstract_inductive s =
         let mk_typ_for_abstract_inductive bs t r =
           match bs with
@@ -6448,30 +5749,27 @@ let (extract_interface :
                    let uu____9077 =
                      let uu____9080 =
                        let uu____9081 =
-                         let uu____9094 = FStar_Syntax_Syntax.mk_Total t  in
-                         (bs, uu____9094)  in
-                       FStar_Syntax_Syntax.Tm_arrow uu____9081  in
-                     FStar_Syntax_Syntax.mk uu____9080  in
-                   uu____9077 FStar_Pervasives_Native.None r)
-           in
+                         let uu____9094 = FStar_Syntax_Syntax.mk_Total t in
+                         (bs, uu____9094) in
+                       FStar_Syntax_Syntax.Tm_arrow uu____9081 in
+                     FStar_Syntax_Syntax.mk uu____9080 in
+                   uu____9077 FStar_Pervasives_Native.None r) in
         match s.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
             (lid,uvs,bs,t,uu____9102,uu____9103) ->
             let s1 =
-              let uu___103_9113 = s  in
+              let uu___103_9113 = s in
               let uu____9114 =
                 let uu____9115 =
                   let uu____9122 =
                     mk_typ_for_abstract_inductive bs t
-                      s.FStar_Syntax_Syntax.sigrng
-                     in
-                  (lid, uvs, uu____9122)  in
-                FStar_Syntax_Syntax.Sig_declare_typ uu____9115  in
+                      s.FStar_Syntax_Syntax.sigrng in
+                  (lid, uvs, uu____9122) in
+                FStar_Syntax_Syntax.Sig_declare_typ uu____9115 in
               let uu____9123 =
                 let uu____9126 =
-                  filter_out_abstract_and_noeq s.FStar_Syntax_Syntax.sigquals
-                   in
-                FStar_Syntax_Syntax.Assumption :: uu____9126  in
+                  filter_out_abstract_and_noeq s.FStar_Syntax_Syntax.sigquals in
+                FStar_Syntax_Syntax.Assumption :: uu____9126 in
               {
                 FStar_Syntax_Syntax.sigel = uu____9114;
                 FStar_Syntax_Syntax.sigrng =
@@ -6481,37 +5779,32 @@ let (extract_interface :
                   (uu___103_9113.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs =
                   (uu___103_9113.FStar_Syntax_Syntax.sigattrs)
-              }  in
+              } in
             if
               Prims.op_Negation
                 (is_noeq_or_unopteq s.FStar_Syntax_Syntax.sigquals)
             then
-              let uu____9129 = FStar_Syntax_Subst.univ_var_opening uvs  in
+              let uu____9129 = FStar_Syntax_Subst.univ_var_opening uvs in
               (match uu____9129 with
                | (usubst,uvs1) ->
-                   let env1 = FStar_TypeChecker_Env.push_univ_vars env uvs1
-                      in
+                   let env1 = FStar_TypeChecker_Env.push_univ_vars env uvs1 in
                    let uu____9149 =
                      FStar_TypeChecker_Util.get_optimized_haseq_axiom env1 s
-                       usubst uvs1
-                      in
+                       usubst uvs1 in
                    (match uu____9149 with
                     | (axiom_lid,fml,uu____9162,uu____9163,uu____9164) ->
                         let uu____9165 =
                           FStar_TypeChecker_Util.generalize_universes env1
-                            fml
-                           in
+                            fml in
                         (match uu____9165 with
                          | (uvs2,fml1) ->
                              let s2 =
-                               let uu___104_9173 = s  in
+                               let uu___104_9173 = s in
                                let uu____9174 =
                                  let uu____9177 =
                                    filter_out_abstract
-                                     s.FStar_Syntax_Syntax.sigquals
-                                    in
-                                 FStar_Syntax_Syntax.Assumption :: uu____9177
-                                  in
+                                     s.FStar_Syntax_Syntax.sigquals in
+                                 FStar_Syntax_Syntax.Assumption :: uu____9177 in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_assume
@@ -6523,28 +5816,25 @@ let (extract_interface :
                                    (uu___104_9173.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
                                    (uu___104_9173.FStar_Syntax_Syntax.sigattrs)
-                               }  in
+                               } in
                              [s1; s2])))
             else [s1]
-        | uu____9183 -> failwith "Impossible!"  in
+        | uu____9183 -> failwith "Impossible!" in
       let val_of_lb s lid uu____9201 =
         match uu____9201 with
         | (uvs,c_or_t) ->
             let t =
-              let uu____9223 = FStar_All.pipe_right c_or_t FStar_Util.is_left
-                 in
+              let uu____9223 = FStar_All.pipe_right c_or_t FStar_Util.is_left in
               if uu____9223
               then
-                let uu____9230 = FStar_All.pipe_right c_or_t FStar_Util.left
-                   in
+                let uu____9230 = FStar_All.pipe_right c_or_t FStar_Util.left in
                 FStar_All.pipe_right uu____9230 FStar_Syntax_Util.comp_result
-              else FStar_All.pipe_right c_or_t FStar_Util.right  in
-            let uu___105_9242 = s  in
+              else FStar_All.pipe_right c_or_t FStar_Util.right in
+            let uu___105_9242 = s in
             let uu____9243 =
               let uu____9246 =
-                filter_out_abstract_and_inline s.FStar_Syntax_Syntax.sigquals
-                 in
-              FStar_Syntax_Syntax.Assumption :: uu____9246  in
+                filter_out_abstract_and_inline s.FStar_Syntax_Syntax.sigquals in
+              FStar_Syntax_Syntax.Assumption :: uu____9246 in
             {
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs, t));
@@ -6555,28 +5845,25 @@ let (extract_interface :
                 (uu___105_9242.FStar_Syntax_Syntax.sigmeta);
               FStar_Syntax_Syntax.sigattrs =
                 (uu___105_9242.FStar_Syntax_Syntax.sigattrs)
-            }
-         in
+            } in
       let extract_lb_annotation lb lid r =
         let opt =
-          let uu____9302 = FStar_ST.op_Bang val_typs  in
+          let uu____9302 = FStar_ST.op_Bang val_typs in
           FStar_List.tryFind
             (fun uu____9394  ->
                match uu____9394 with
                | (l,uu____9406,uu____9407) -> FStar_Ident.lid_equals lid l)
-            uu____9302
-           in
+            uu____9302 in
         if FStar_Util.is_some opt
         then
-          let uu____9440 = FStar_All.pipe_right opt FStar_Util.must  in
+          let uu____9440 = FStar_All.pipe_right opt FStar_Util.must in
           match uu____9440 with
           | (uu____9497,uvs,t) ->
               let uu____9508 =
-                let uu___106_9509 = lb  in
+                let uu___106_9509 = lb in
                 let uu____9510 =
                   FStar_Syntax_Util.ascribe lb.FStar_Syntax_Syntax.lbdef
-                    ((FStar_Util.Inl t), FStar_Pervasives_Native.None)
-                   in
+                    ((FStar_Util.Inl t), FStar_Pervasives_Native.None) in
                 {
                   FStar_Syntax_Syntax.lbname =
                     (uu___106_9509.FStar_Syntax_Syntax.lbname);
@@ -6588,21 +5875,20 @@ let (extract_interface :
                   FStar_Syntax_Syntax.lbdef = uu____9510;
                   FStar_Syntax_Syntax.lbattrs =
                     (uu___106_9509.FStar_Syntax_Syntax.lbattrs)
-                }  in
+                } in
               (uu____9508,
                 (FStar_Pervasives_Native.Some (uvs, (FStar_Util.Inr t))))
         else
           (let uu____9568 =
              let uu____9569 =
-               FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp  in
-             uu____9569.FStar_Syntax_Syntax.n  in
+               FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp in
+             uu____9569.FStar_Syntax_Syntax.n in
            match uu____9568 with
            | FStar_Syntax_Syntax.Tm_unknown  ->
                let uu____9586 =
                  let uu____9587 =
-                   FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbdef
-                    in
-                 uu____9587.FStar_Syntax_Syntax.n  in
+                   FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbdef in
+                 uu____9587.FStar_Syntax_Syntax.n in
                (match uu____9586 with
                 | FStar_Syntax_Syntax.Tm_ascribed
                     (uu____9604,(FStar_Util.Inr c,uu____9606),uu____9607) ->
@@ -6618,8 +5904,8 @@ let (extract_interface :
                            (FStar_Util.Inr t))))
                 | FStar_Syntax_Syntax.Tm_abs (bs,e,uu____9778) ->
                     let uu____9799 =
-                      let uu____9800 = FStar_Syntax_Subst.compress e  in
-                      uu____9800.FStar_Syntax_Syntax.n  in
+                      let uu____9800 = FStar_Syntax_Subst.compress e in
+                      uu____9800.FStar_Syntax_Syntax.n in
                     (match uu____9799 with
                      | FStar_Syntax_Syntax.Tm_ascribed
                          (uu____9817,(FStar_Util.Inr c,uu____9819),uu____9820)
@@ -6630,33 +5916,29 @@ let (extract_interface :
                                let uu____9902 =
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_arrow (bs, c))
-                                   FStar_Pervasives_Native.None r
-                                  in
-                               FStar_Util.Inr uu____9902  in
-                             ((lb.FStar_Syntax_Syntax.lbunivs), uu____9895)
-                              in
-                           FStar_Pervasives_Native.Some uu____9882  in
+                                   FStar_Pervasives_Native.None r in
+                               FStar_Util.Inr uu____9902 in
+                             ((lb.FStar_Syntax_Syntax.lbunivs), uu____9895) in
+                           FStar_Pervasives_Native.Some uu____9882 in
                          (lb, uu____9867)
                      | FStar_Syntax_Syntax.Tm_ascribed
                          (uu____9949,(FStar_Util.Inl t,uu____9951),uu____9952)
                          ->
                          let c =
-                           let uu____10000 = FStar_Options.ml_ish ()  in
+                           let uu____10000 = FStar_Options.ml_ish () in
                            if uu____10000
                            then FStar_Syntax_Util.ml_comp t r
-                           else FStar_Syntax_Syntax.mk_Total t  in
+                           else FStar_Syntax_Syntax.mk_Total t in
                          let uu____10002 =
                            let uu____10017 =
                              let uu____10030 =
                                let uu____10037 =
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_arrow (bs, c))
-                                   FStar_Pervasives_Native.None r
-                                  in
-                               FStar_Util.Inr uu____10037  in
-                             ((lb.FStar_Syntax_Syntax.lbunivs), uu____10030)
-                              in
-                           FStar_Pervasives_Native.Some uu____10017  in
+                                   FStar_Pervasives_Native.None r in
+                               FStar_Util.Inr uu____10037 in
+                             ((lb.FStar_Syntax_Syntax.lbunivs), uu____10030) in
+                           FStar_Pervasives_Native.Some uu____10017 in
                          (lb, uu____10002)
                      | uu____10082 -> (lb, FStar_Pervasives_Native.None))
                 | uu____10101 -> (lb, FStar_Pervasives_Native.None))
@@ -6664,48 +5946,44 @@ let (extract_interface :
                (lb,
                  (FStar_Pervasives_Native.Some
                     ((lb.FStar_Syntax_Syntax.lbunivs),
-                      (FStar_Util.Inr (lb.FStar_Syntax_Syntax.lbtyp))))))
-         in
+                      (FStar_Util.Inr (lb.FStar_Syntax_Syntax.lbtyp)))))) in
       let should_keep_lbdef c_or_t =
         let comp_effect_name1 c =
           match c.FStar_Syntax_Syntax.n with
           | FStar_Syntax_Syntax.Comp c1 -> c1.FStar_Syntax_Syntax.effect_name
-          | uu____10174 -> failwith "Impossible!"  in
+          | uu____10174 -> failwith "Impossible!" in
         let c_opt =
-          let uu____10178 = FStar_Util.is_left c_or_t  in
+          let uu____10178 = FStar_Util.is_left c_or_t in
           if uu____10178
           then
-            let uu____10181 = FStar_All.pipe_right c_or_t FStar_Util.left  in
+            let uu____10181 = FStar_All.pipe_right c_or_t FStar_Util.left in
             FStar_Pervasives_Native.Some uu____10181
           else
-            (let t = FStar_All.pipe_right c_or_t FStar_Util.right  in
-             let uu____10192 = FStar_Syntax_Util.is_unit t  in
+            (let t = FStar_All.pipe_right c_or_t FStar_Util.right in
+             let uu____10192 = FStar_Syntax_Util.is_unit t in
              if uu____10192
              then
-               let uu____10195 = FStar_Syntax_Syntax.mk_Total t  in
+               let uu____10195 = FStar_Syntax_Syntax.mk_Total t in
                FStar_Pervasives_Native.Some uu____10195
              else
                (let uu____10197 =
-                  let uu____10198 = FStar_Syntax_Subst.compress t  in
-                  uu____10198.FStar_Syntax_Syntax.n  in
+                  let uu____10198 = FStar_Syntax_Subst.compress t in
+                  uu____10198.FStar_Syntax_Syntax.n in
                 match uu____10197 with
                 | FStar_Syntax_Syntax.Tm_arrow (uu____10203,c) ->
                     FStar_Pervasives_Native.Some c
-                | uu____10223 -> FStar_Pervasives_Native.None))
-           in
+                | uu____10223 -> FStar_Pervasives_Native.None)) in
         (c_opt = FStar_Pervasives_Native.None) ||
-          (let c = FStar_All.pipe_right c_opt FStar_Util.must  in
+          (let c = FStar_All.pipe_right c_opt FStar_Util.must in
            ((FStar_Syntax_Util.is_pure_or_ghost_comp c) ||
-              (let uu____10231 = comp_effect_name1 c  in
+              (let uu____10231 = comp_effect_name1 c in
                FStar_TypeChecker_Util.is_reifiable env uu____10231))
              &&
              (let uu____10233 =
                 let uu____10234 =
-                  FStar_All.pipe_right c FStar_Syntax_Util.comp_result  in
-                FStar_All.pipe_right uu____10234 FStar_Syntax_Util.is_unit
-                 in
-              Prims.op_Negation uu____10233))
-         in
+                  FStar_All.pipe_right c FStar_Syntax_Util.comp_result in
+                FStar_All.pipe_right uu____10234 FStar_Syntax_Util.is_unit in
+              Prims.op_Negation uu____10233)) in
       let extract_sigelt s =
         match s.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ uu____10249 ->
@@ -6722,16 +6000,15 @@ let (extract_interface :
                      | FStar_Syntax_Syntax.Sig_inductive_typ
                          (uu____10314,uu____10315,uu____10316,uu____10317,uu____10318,uu____10319)
                          ->
-                         let uu____10328 = vals_of_abstract_inductive s1  in
+                         let uu____10328 = vals_of_abstract_inductive s1 in
                          FStar_List.append uu____10328 sigelts1
                      | FStar_Syntax_Syntax.Sig_datacon
                          (lid,uu____10332,uu____10333,uu____10334,uu____10335,uu____10336)
                          ->
                          ((let uu____10342 =
                              let uu____10345 =
-                               FStar_ST.op_Bang abstract_inductive_datacons
-                                in
-                             lid :: uu____10345  in
+                               FStar_ST.op_Bang abstract_inductive_datacons in
+                             lid :: uu____10345 in
                            FStar_ST.op_Colon_Equals
                              abstract_inductive_datacons uu____10342);
                           sigelts1)
@@ -6743,17 +6020,16 @@ let (extract_interface :
         | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
             let uu____10445 =
               is_projector_or_discriminator_of_an_abstract_inductive
-                s.FStar_Syntax_Syntax.sigquals
-               in
+                s.FStar_Syntax_Syntax.sigquals in
             if uu____10445
             then []
             else
               if is_assume s.FStar_Syntax_Syntax.sigquals
               then
                 (let uu____10451 =
-                   let uu___107_10452 = s  in
+                   let uu___107_10452 = s in
                    let uu____10453 =
-                     filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
+                     filter_out_abstract s.FStar_Syntax_Syntax.sigquals in
                    {
                      FStar_Syntax_Syntax.sigel =
                        (uu___107_10452.FStar_Syntax_Syntax.sigel);
@@ -6764,23 +6040,22 @@ let (extract_interface :
                        (uu___107_10452.FStar_Syntax_Syntax.sigmeta);
                      FStar_Syntax_Syntax.sigattrs =
                        (uu___107_10452.FStar_Syntax_Syntax.sigattrs)
-                   }  in
+                   } in
                  [uu____10451])
               else
                 ((let uu____10458 =
-                    let uu____10471 = FStar_ST.op_Bang val_typs  in
-                    (lid, uvs, t) :: uu____10471  in
+                    let uu____10471 = FStar_ST.op_Bang val_typs in
+                    (lid, uvs, t) :: uu____10471 in
                   FStar_ST.op_Colon_Equals val_typs uu____10458);
                  [])
         | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
             let uu____10622 =
               is_projector_or_discriminator_of_an_abstract_inductive
-                s.FStar_Syntax_Syntax.sigquals
-               in
+                s.FStar_Syntax_Syntax.sigquals in
             if uu____10622
             then []
             else
-              (let uu____10626 = lbs  in
+              (let uu____10626 = lbs in
                match uu____10626 with
                | (flbs,slbs) ->
                    let uu____10635 =
@@ -6792,24 +6067,21 @@ let (extract_interface :
                               | (b,lbs1,typs) ->
                                   let uu____10759 =
                                     extract_lb_annotation lb lid
-                                      s.FStar_Syntax_Syntax.sigrng
-                                     in
+                                      s.FStar_Syntax_Syntax.sigrng in
                                   (match uu____10759 with
                                    | (lb1,t) ->
                                        (((FStar_Util.is_some t) && b), (lb1
                                          :: lbs1), (t :: typs))))
-                       (true, [], []) slbs lids
-                      in
+                       (true, [], []) slbs lids in
                    (match uu____10635 with
                     | (b,lbs1,typs) ->
                         let uu____10905 =
                           ((FStar_List.rev_append lbs1 []),
-                            (FStar_List.rev_append typs []))
-                           in
+                            (FStar_List.rev_append typs [])) in
                         (match uu____10905 with
                          | (lbs2,typs1) ->
                              let s1 =
-                               let uu___108_10991 = s  in
+                               let uu___108_10991 = s in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_let
@@ -6822,7 +6094,7 @@ let (extract_interface :
                                    (uu___108_10991.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
                                    (uu___108_10991.FStar_Syntax_Syntax.sigattrs)
-                               }  in
+                               } in
                              if Prims.op_Negation b
                              then
                                (if
@@ -6835,16 +6107,13 @@ let (extract_interface :
                                   let uu____11006 =
                                     let uu____11011 =
                                       let uu____11012 =
-                                        let uu____11013 = FStar_List.hd lids
-                                           in
-                                        uu____11013.FStar_Ident.str  in
+                                        let uu____11013 = FStar_List.hd lids in
+                                        uu____11013.FStar_Ident.str in
                                       Prims.strcat
                                         "For extracting interfaces, abstract and irreducible defns must be annotated at the top-level: "
-                                        uu____11012
-                                       in
+                                        uu____11012 in
                                     (FStar_Errors.Fatal_IllTyped,
-                                      uu____11011)
-                                     in
+                                      uu____11011) in
                                   FStar_Errors.raise_error uu____11006
                                     s1.FStar_Syntax_Syntax.sigrng
                                 else [s1])
@@ -6854,31 +6123,26 @@ let (extract_interface :
                                     (fun opt  ->
                                        let uu____11044 =
                                          FStar_All.pipe_right opt
-                                           FStar_Util.must
-                                          in
+                                           FStar_Util.must in
                                        match uu____11044 with
                                        | (uu____11079,c_or_t) ->
                                            (FStar_Util.is_right c_or_t) &&
                                              (let uu____11090 =
                                                 FStar_All.pipe_right c_or_t
-                                                  FStar_Util.right
-                                                 in
+                                                  FStar_Util.right in
                                               FStar_All.pipe_right
                                                 uu____11090
                                                 FStar_Syntax_Util.is_lemma))
-                                    typs1
-                                   in
+                                    typs1 in
                                 let vals =
                                   FStar_List.map2
                                     (fun lid  ->
                                        fun opt  ->
                                          let uu____11123 =
                                            FStar_All.pipe_right opt
-                                             FStar_Util.must
-                                            in
+                                             FStar_Util.must in
                                          val_of_lb s1 lid uu____11123) lids
-                                    typs1
-                                   in
+                                    typs1 in
                                 if
                                   ((is_abstract
                                       s1.FStar_Syntax_Syntax.sigquals)
@@ -6894,23 +6158,20 @@ let (extract_interface :
                                           let uu____11185 =
                                             let uu____11190 =
                                               FStar_All.pipe_right opt
-                                                FStar_Util.must
-                                               in
+                                                FStar_Util.must in
                                             FStar_All.pipe_right uu____11190
-                                              FStar_Pervasives_Native.snd
-                                             in
+                                              FStar_Pervasives_Native.snd in
                                           should_keep_lbdef uu____11185)
-                                       typs1
-                                      in
+                                       typs1 in
                                    if should_keep_defs then [s1] else vals)))))
         | FStar_Syntax_Syntax.Sig_main t ->
             failwith
               "Did not anticipate main would arise when extracting interfaces!"
         | FStar_Syntax_Syntax.Sig_assume (lids,uvs,t) ->
             let uu____11250 =
-              let uu___109_11251 = s  in
+              let uu___109_11251 = s in
               let uu____11252 =
-                filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
+                filter_out_abstract s.FStar_Syntax_Syntax.sigquals in
               {
                 FStar_Syntax_Syntax.sigel =
                   (uu___109_11251.FStar_Syntax_Syntax.sigel);
@@ -6921,19 +6182,18 @@ let (extract_interface :
                   (uu___109_11251.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs =
                   (uu___109_11251.FStar_Syntax_Syntax.sigattrs)
-              }  in
+              } in
             [uu____11250]
         | FStar_Syntax_Syntax.Sig_new_effect uu____11255 -> [s]
         | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____11256 -> [s]
         | FStar_Syntax_Syntax.Sig_sub_effect uu____11257 -> [s]
         | FStar_Syntax_Syntax.Sig_effect_abbrev uu____11258 -> [s]
-        | FStar_Syntax_Syntax.Sig_pragma uu____11271 -> [s]  in
-      let uu___110_11272 = m  in
+        | FStar_Syntax_Syntax.Sig_pragma uu____11271 -> [s] in
+      let uu___110_11272 = m in
       let uu____11273 =
         let uu____11274 =
-          FStar_List.map extract_sigelt m.FStar_Syntax_Syntax.declarations
-           in
-        FStar_List.flatten uu____11274  in
+          FStar_List.map extract_sigelt m.FStar_Syntax_Syntax.declarations in
+        FStar_List.flatten uu____11274 in
       {
         FStar_Syntax_Syntax.name = (uu___110_11272.FStar_Syntax_Syntax.name);
         FStar_Syntax_Syntax.declarations = uu____11273;
@@ -6941,32 +6201,30 @@ let (extract_interface :
           (uu___110_11272.FStar_Syntax_Syntax.exports);
         FStar_Syntax_Syntax.is_interface = true
       }
-  
-let (check_module :
+let check_module:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul ->
       (FStar_Syntax_Syntax.modul,FStar_TypeChecker_Env.env)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun m  ->
-      (let uu____11292 = FStar_Options.debug_any ()  in
+      (let uu____11292 = FStar_Options.debug_any () in
        if uu____11292
        then
          let uu____11293 =
-           FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name  in
+           FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name in
          FStar_Util.print2 "Checking %s: %s\n"
            (if m.FStar_Syntax_Syntax.is_interface then "i'face" else "module")
            uu____11293
        else ());
       (let env1 =
-         let uu___111_11297 = env  in
+         let uu___111_11297 = env in
          let uu____11298 =
            let uu____11299 =
              FStar_Options.should_verify
-               (m.FStar_Syntax_Syntax.name).FStar_Ident.str
-              in
-           Prims.op_Negation uu____11299  in
+               (m.FStar_Syntax_Syntax.name).FStar_Ident.str in
+           Prims.op_Negation uu____11299 in
          {
            FStar_TypeChecker_Env.solver =
              (uu___111_11297.FStar_TypeChecker_Env.solver);
@@ -7037,17 +6295,16 @@ let (check_module :
              (uu___111_11297.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.dep_graph =
              (uu___111_11297.FStar_TypeChecker_Env.dep_graph)
-         }  in
-       let uu____11300 = tc_modul env1 m  in
+         } in
+       let uu____11300 = tc_modul env1 m in
        match uu____11300 with
        | (m1,env2) ->
            ((let uu____11312 =
                FStar_Options.dump_module
-                 (m1.FStar_Syntax_Syntax.name).FStar_Ident.str
-                in
+                 (m1.FStar_Syntax_Syntax.name).FStar_Ident.str in
              if uu____11312
              then
-               let uu____11313 = FStar_Syntax_Print.modul_to_string m1  in
+               let uu____11313 = FStar_Syntax_Print.modul_to_string m1 in
                FStar_Util.print1 "Module after type checking:\n%s\n"
                  uu____11313
              else ());
@@ -7057,8 +6314,7 @@ let (check_module :
                  &&
                  (FStar_Options.debug_at_level
                     (m1.FStar_Syntax_Syntax.name).FStar_Ident.str
-                    (FStar_Options.Other "Normalize"))
-                in
+                    (FStar_Options.Other "Normalize")) in
              if uu____11316
              then
                let normalize_toplevel_lets se =
@@ -7073,23 +6329,20 @@ let (check_module :
                          FStar_TypeChecker_Normalize.Primops;
                          FStar_TypeChecker_Normalize.UnfoldUntil
                            FStar_Syntax_Syntax.Delta_constant;
-                         FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                        in
+                         FStar_TypeChecker_Normalize.AllowUnboundUniverses] in
                      let update lb =
                        let uu____11347 =
                          FStar_Syntax_Subst.open_univ_vars
                            lb.FStar_Syntax_Syntax.lbunivs
-                           lb.FStar_Syntax_Syntax.lbdef
-                          in
+                           lb.FStar_Syntax_Syntax.lbdef in
                        match uu____11347 with
                        | (univnames1,e) ->
-                           let uu___112_11354 = lb  in
+                           let uu___112_11354 = lb in
                            let uu____11355 =
                              let uu____11358 =
                                FStar_TypeChecker_Env.push_univ_vars env2
-                                 univnames1
-                                in
-                             n1 uu____11358 e  in
+                                 univnames1 in
+                             n1 uu____11358 e in
                            {
                              FStar_Syntax_Syntax.lbname =
                                (uu___112_11354.FStar_Syntax_Syntax.lbname);
@@ -7102,16 +6355,15 @@ let (check_module :
                              FStar_Syntax_Syntax.lbdef = uu____11355;
                              FStar_Syntax_Syntax.lbattrs =
                                (uu___112_11354.FStar_Syntax_Syntax.lbattrs)
-                           }
-                        in
-                     let uu___113_11359 = se  in
+                           } in
+                     let uu___113_11359 = se in
                      let uu____11360 =
                        let uu____11361 =
                          let uu____11368 =
-                           let uu____11375 = FStar_List.map update lbs  in
-                           (b, uu____11375)  in
-                         (uu____11368, ids)  in
-                       FStar_Syntax_Syntax.Sig_let uu____11361  in
+                           let uu____11375 = FStar_List.map update lbs in
+                           (b, uu____11375) in
+                         (uu____11368, ids) in
+                       FStar_Syntax_Syntax.Sig_let uu____11361 in
                      {
                        FStar_Syntax_Syntax.sigel = uu____11360;
                        FStar_Syntax_Syntax.sigrng =
@@ -7123,13 +6375,12 @@ let (check_module :
                        FStar_Syntax_Syntax.sigattrs =
                          (uu___113_11359.FStar_Syntax_Syntax.sigattrs)
                      }
-                 | uu____11388 -> se  in
+                 | uu____11388 -> se in
                let normalized_module =
-                 let uu___114_11390 = m1  in
+                 let uu___114_11390 = m1 in
                  let uu____11391 =
                    FStar_List.map normalize_toplevel_lets
-                     m1.FStar_Syntax_Syntax.declarations
-                    in
+                     m1.FStar_Syntax_Syntax.declarations in
                  {
                    FStar_Syntax_Syntax.name =
                      (uu___114_11390.FStar_Syntax_Syntax.name);
@@ -7138,10 +6389,9 @@ let (check_module :
                      (uu___114_11390.FStar_Syntax_Syntax.exports);
                    FStar_Syntax_Syntax.is_interface =
                      (uu___114_11390.FStar_Syntax_Syntax.is_interface)
-                 }  in
+                 } in
                let uu____11392 =
-                 FStar_Syntax_Print.modul_to_string normalized_module  in
+                 FStar_Syntax_Print.modul_to_string normalized_module in
                FStar_Util.print1 "%s\n" uu____11392
              else ());
             (m1, env2)))
-  

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -1,98 +1,82 @@
 open Prims
-let (tc_tycon :
+let tc_tycon:
   FStar_TypeChecker_Env.env_t ->
     FStar_Syntax_Syntax.sigelt ->
       (FStar_TypeChecker_Env.env_t,FStar_Syntax_Syntax.sigelt,FStar_Syntax_Syntax.universe,
-        FStar_TypeChecker_Env.guard_t) FStar_Pervasives_Native.tuple4)
+        FStar_TypeChecker_Env.guard_t) FStar_Pervasives_Native.tuple4
   =
   fun env  ->
     fun s  ->
       match s.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_inductive_typ (tc,uvs,tps,k,mutuals,data) ->
-          let uu____40 = FStar_Syntax_Subst.open_term tps k  in
+          let uu____40 = FStar_Syntax_Subst.open_term tps k in
           (match uu____40 with
            | (tps1,k1) ->
-               let uu____55 = FStar_TypeChecker_TcTerm.tc_binders env tps1
-                  in
+               let uu____55 = FStar_TypeChecker_TcTerm.tc_binders env tps1 in
                (match uu____55 with
                 | (tps2,env_tps,guard_params,us) ->
-                    let k2 = FStar_TypeChecker_Normalize.unfold_whnf env k1
-                       in
-                    let uu____77 = FStar_Syntax_Util.arrow_formals k2  in
+                    let k2 = FStar_TypeChecker_Normalize.unfold_whnf env k1 in
+                    let uu____77 = FStar_Syntax_Util.arrow_formals k2 in
                     (match uu____77 with
                      | (indices,t) ->
                          let uu____116 =
                            FStar_TypeChecker_TcTerm.tc_binders env_tps
-                             indices
-                            in
+                             indices in
                          (match uu____116 with
                           | (indices1,env',guard_indices,us') ->
                               let uu____137 =
                                 let uu____142 =
                                   FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                    env' t
-                                   in
+                                    env' t in
                                 match uu____142 with
                                 | (t1,uu____154,g) ->
                                     let uu____156 =
                                       let uu____157 =
                                         let uu____158 =
                                           FStar_TypeChecker_Rel.conj_guard
-                                            guard_indices g
-                                           in
+                                            guard_indices g in
                                         FStar_TypeChecker_Rel.conj_guard
-                                          guard_params uu____158
-                                         in
+                                          guard_params uu____158 in
                                       FStar_TypeChecker_Rel.discharge_guard
-                                        env' uu____157
-                                       in
-                                    (t1, uu____156)
-                                 in
+                                        env' uu____157 in
+                                    (t1, uu____156) in
                               (match uu____137 with
                                | (t1,guard) ->
                                    let k3 =
                                      let uu____172 =
-                                       FStar_Syntax_Syntax.mk_Total t1  in
+                                       FStar_Syntax_Syntax.mk_Total t1 in
                                      FStar_Syntax_Util.arrow indices1
-                                       uu____172
-                                      in
+                                       uu____172 in
                                    let uu____175 =
-                                     FStar_Syntax_Util.type_u ()  in
+                                     FStar_Syntax_Util.type_u () in
                                    (match uu____175 with
                                     | (t_type,u) ->
                                         ((let uu____191 =
                                             FStar_TypeChecker_Rel.teq env' t1
-                                              t_type
-                                             in
+                                              t_type in
                                           FStar_TypeChecker_Rel.force_trivial_guard
                                             env' uu____191);
                                          (let t_tc =
                                             let uu____195 =
-                                              FStar_Syntax_Syntax.mk_Total t1
-                                               in
+                                              FStar_Syntax_Syntax.mk_Total t1 in
                                             FStar_Syntax_Util.arrow
                                               (FStar_List.append tps2
-                                                 indices1) uu____195
-                                             in
+                                                 indices1) uu____195 in
                                           let tps3 =
                                             FStar_Syntax_Subst.close_binders
-                                              tps2
-                                             in
+                                              tps2 in
                                           let k4 =
-                                            FStar_Syntax_Subst.close tps3 k3
-                                             in
+                                            FStar_Syntax_Subst.close tps3 k3 in
                                           let fv_tc =
                                             FStar_Syntax_Syntax.lid_as_fv tc
                                               FStar_Syntax_Syntax.Delta_constant
-                                              FStar_Pervasives_Native.None
-                                             in
+                                              FStar_Pervasives_Native.None in
                                           let uu____205 =
                                             FStar_TypeChecker_Env.push_let_binding
                                               env (FStar_Util.Inr fv_tc)
-                                              ([], t_tc)
-                                             in
+                                              ([], t_tc) in
                                           (uu____205,
-                                            (let uu___59_211 = s  in
+                                            (let uu___59_211 = s in
                                              {
                                                FStar_Syntax_Syntax.sigel =
                                                  (FStar_Syntax_Syntax.Sig_inductive_typ
@@ -108,14 +92,13 @@ let (tc_tycon :
                                                  (uu___59_211.FStar_Syntax_Syntax.sigattrs)
                                              }), u, guard)))))))))
       | uu____218 -> failwith "impossible"
-  
-let (tc_data :
+let tc_data:
   FStar_TypeChecker_Env.env_t ->
     (FStar_Syntax_Syntax.sigelt,FStar_Syntax_Syntax.universe)
       FStar_Pervasives_Native.tuple2 Prims.list ->
       FStar_Syntax_Syntax.sigelt ->
         (FStar_Syntax_Syntax.sigelt,FStar_TypeChecker_Env.guard_t)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun tcs  ->
@@ -132,9 +115,9 @@ let (tc_data :
                          let uu____329 =
                            let uu____330 =
                              let uu____331 =
-                               FStar_Syntax_Util.lid_of_sigelt se1  in
-                             FStar_Util.must uu____331  in
-                           FStar_Ident.lid_equals tc_lid uu____330  in
+                               FStar_Syntax_Util.lid_of_sigelt se1 in
+                             FStar_Util.must uu____331 in
+                           FStar_Ident.lid_equals tc_lid uu____330 in
                          if uu____329
                          then
                            (match se1.FStar_Syntax_Syntax.sigel with
@@ -149,20 +132,17 @@ let (tc_data :
                                           | (x,uu____406) ->
                                               (x,
                                                 (FStar_Pervasives_Native.Some
-                                                   FStar_Syntax_Syntax.imp_tag))))
-                                   in
+                                                   FStar_Syntax_Syntax.imp_tag)))) in
                                 let tps2 =
-                                  FStar_Syntax_Subst.open_binders tps1  in
+                                  FStar_Syntax_Subst.open_binders tps1 in
                                 let uu____410 =
                                   let uu____417 =
                                     FStar_TypeChecker_Env.push_binders env
-                                      tps2
-                                     in
-                                  (uu____417, tps2, u_tc)  in
+                                      tps2 in
+                                  (uu____417, tps2, u_tc) in
                                 FStar_Pervasives_Native.Some uu____410
                             | uu____424 -> failwith "Impossible")
-                         else FStar_Pervasives_Native.None)
-                 in
+                         else FStar_Pervasives_Native.None) in
               match tps_u_opt with
               | FStar_Pervasives_Native.Some x -> x
               | FStar_Pervasives_Native.None  ->
@@ -172,27 +152,24 @@ let (tc_data :
                     FStar_Errors.raise_error
                       (FStar_Errors.Fatal_UnexpectedDataConstructor,
                         "Unexpected data constructor")
-                      se.FStar_Syntax_Syntax.sigrng
-               in
+                      se.FStar_Syntax_Syntax.sigrng in
             (match uu____275 with
              | (env1,tps,u_tc) ->
                  let uu____495 =
-                   let t1 = FStar_TypeChecker_Normalize.unfold_whnf env1 t
-                      in
+                   let t1 = FStar_TypeChecker_Normalize.unfold_whnf env1 t in
                    let uu____509 =
-                     let uu____510 = FStar_Syntax_Subst.compress t1  in
-                     uu____510.FStar_Syntax_Syntax.n  in
+                     let uu____510 = FStar_Syntax_Subst.compress t1 in
+                     uu____510.FStar_Syntax_Syntax.n in
                    match uu____509 with
                    | FStar_Syntax_Syntax.Tm_arrow (bs,res) ->
-                       let uu____543 = FStar_Util.first_N ntps bs  in
+                       let uu____543 = FStar_Util.first_N ntps bs in
                        (match uu____543 with
                         | (uu____576,bs') ->
                             let t2 =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_arrow (bs', res))
                                 FStar_Pervasives_Native.None
-                                t1.FStar_Syntax_Syntax.pos
-                               in
+                                t1.FStar_Syntax_Syntax.pos in
                             let subst1 =
                               FStar_All.pipe_right tps
                                 (FStar_List.mapi
@@ -203,48 +180,41 @@ let (tc_data :
                                             FStar_Syntax_Syntax.DB
                                               ((ntps -
                                                   ((Prims.parse_int "1") + i)),
-                                                x)))
-                               in
+                                                x))) in
                             let uu____634 =
-                              FStar_Syntax_Subst.subst subst1 t2  in
+                              FStar_Syntax_Subst.subst subst1 t2 in
                             FStar_Syntax_Util.arrow_formals uu____634)
-                   | uu____635 -> ([], t1)  in
+                   | uu____635 -> ([], t1) in
                  (match uu____495 with
                   | (arguments,result) ->
                       ((let uu____669 =
-                          FStar_TypeChecker_Env.debug env1 FStar_Options.Low
-                           in
+                          FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
                         if uu____669
                         then
-                          let uu____670 = FStar_Syntax_Print.lid_to_string c
-                             in
+                          let uu____670 = FStar_Syntax_Print.lid_to_string c in
                           let uu____671 =
                             FStar_Syntax_Print.binders_to_string "->"
-                              arguments
-                             in
+                              arguments in
                           let uu____672 =
-                            FStar_Syntax_Print.term_to_string result  in
+                            FStar_Syntax_Print.term_to_string result in
                           FStar_Util.print3
                             "Checking datacon  %s : %s -> %s \n" uu____670
                             uu____671 uu____672
                         else ());
                        (let uu____674 =
-                          FStar_TypeChecker_TcTerm.tc_tparams env1 arguments
-                           in
+                          FStar_TypeChecker_TcTerm.tc_tparams env1 arguments in
                         match uu____674 with
                         | (arguments1,env',us) ->
                             let uu____688 =
                               FStar_TypeChecker_TcTerm.tc_trivial_guard env'
-                                result
-                               in
+                                result in
                             (match uu____688 with
                              | (result1,res_lcomp) ->
                                  ((let uu____700 =
                                      let uu____701 =
                                        FStar_Syntax_Subst.compress
-                                         res_lcomp.FStar_Syntax_Syntax.res_typ
-                                        in
-                                     uu____701.FStar_Syntax_Syntax.n  in
+                                         res_lcomp.FStar_Syntax_Syntax.res_typ in
+                                     uu____701.FStar_Syntax_Syntax.n in
                                    match uu____700 with
                                    | FStar_Syntax_Syntax.Tm_type uu____704 ->
                                        ()
@@ -253,33 +223,26 @@ let (tc_data :
                                          let uu____711 =
                                            let uu____712 =
                                              FStar_Syntax_Print.term_to_string
-                                               result1
-                                              in
+                                               result1 in
                                            let uu____713 =
                                              FStar_Syntax_Print.term_to_string
-                                               res_lcomp.FStar_Syntax_Syntax.res_typ
-                                              in
+                                               res_lcomp.FStar_Syntax_Syntax.res_typ in
                                            FStar_Util.format2
                                              "The type of %s is %s, but since this is the result type of a constructor its type should be Type"
-                                             uu____712 uu____713
-                                            in
+                                             uu____712 uu____713 in
                                          (FStar_Errors.Fatal_WrongResultTypeAfterConstrutor,
-                                           uu____711)
-                                          in
+                                           uu____711) in
                                        FStar_Errors.raise_error uu____706
                                          se.FStar_Syntax_Syntax.sigrng);
                                   (let uu____714 =
-                                     FStar_Syntax_Util.head_and_args result1
-                                      in
+                                     FStar_Syntax_Util.head_and_args result1 in
                                    match uu____714 with
                                    | (head1,uu____734) ->
                                        ((let uu____756 =
                                            let uu____757 =
                                              FStar_Syntax_Subst.compress
-                                               head1
-                                              in
-                                           uu____757.FStar_Syntax_Syntax.n
-                                            in
+                                               head1 in
+                                           uu____757.FStar_Syntax_Syntax.n in
                                          match uu____756 with
                                          | FStar_Syntax_Syntax.Tm_fvar fv
                                              when
@@ -291,19 +254,15 @@ let (tc_data :
                                                let uu____767 =
                                                  let uu____768 =
                                                    FStar_Syntax_Print.lid_to_string
-                                                     tc_lid
-                                                    in
+                                                     tc_lid in
                                                  let uu____769 =
                                                    FStar_Syntax_Print.term_to_string
-                                                     head1
-                                                    in
+                                                     head1 in
                                                  FStar_Util.format2
                                                    "Expected a constructor of type %s; got %s"
-                                                   uu____768 uu____769
-                                                  in
+                                                   uu____768 uu____769 in
                                                (FStar_Errors.Fatal_UnexpectedConstructorType,
-                                                 uu____767)
-                                                in
+                                                 uu____767) in
                                              FStar_Errors.raise_error
                                                uu____762
                                                se.FStar_Syntax_Syntax.sigrng);
@@ -316,13 +275,11 @@ let (tc_data :
                                                     | (x,uu____789) ->
                                                         let uu____790 =
                                                           FStar_TypeChecker_Rel.universe_inequality
-                                                            u_x u_tc
-                                                           in
+                                                            u_x u_tc in
                                                         FStar_TypeChecker_Rel.conj_guard
                                                           g uu____790)
                                              FStar_TypeChecker_Rel.trivial_guard
-                                             arguments1 us
-                                            in
+                                             arguments1 us in
                                          let t1 =
                                            let uu____794 =
                                              let uu____801 =
@@ -334,19 +291,15 @@ let (tc_data :
                                                            (x,
                                                              (FStar_Pervasives_Native.Some
                                                                 (FStar_Syntax_Syntax.Implicit
-                                                                   true)))))
-                                                in
+                                                                   true))))) in
                                              FStar_List.append uu____801
-                                               arguments1
-                                              in
+                                               arguments1 in
                                            let uu____852 =
                                              FStar_Syntax_Syntax.mk_Total
-                                               result1
-                                              in
+                                               result1 in
                                            FStar_Syntax_Util.arrow uu____794
-                                             uu____852
-                                            in
-                                         ((let uu___60_856 = se  in
+                                             uu____852 in
+                                         ((let uu___60_856 = se in
                                            {
                                              FStar_Syntax_Syntax.sigel =
                                                (FStar_Syntax_Syntax.Sig_datacon
@@ -362,8 +315,7 @@ let (tc_data :
                                                (uu___60_856.FStar_Syntax_Syntax.sigattrs)
                                            }), g))))))))))
         | uu____863 -> failwith "impossible"
-  
-let (generalize_and_inst_within :
+let generalize_and_inst_within:
   FStar_TypeChecker_Env.env_t ->
     FStar_TypeChecker_Env.guard_t ->
       (FStar_Syntax_Syntax.sigelt,FStar_Syntax_Syntax.universe)
@@ -371,16 +323,16 @@ let (generalize_and_inst_within :
         FStar_Syntax_Syntax.sigelt Prims.list ->
           (FStar_Syntax_Syntax.sigelt Prims.list,FStar_Syntax_Syntax.sigelt
                                                    Prims.list)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun g  ->
       fun tcs  ->
         fun datas  ->
           let tc_universe_vars =
-            FStar_List.map FStar_Pervasives_Native.snd tcs  in
+            FStar_List.map FStar_Pervasives_Native.snd tcs in
           let g1 =
-            let uu___61_920 = g  in
+            let uu___61_920 = g in
             {
               FStar_TypeChecker_Env.guard_f =
                 (uu___61_920.FStar_TypeChecker_Env.guard_f);
@@ -392,14 +344,13 @@ let (generalize_and_inst_within :
                      g.FStar_TypeChecker_Env.univ_ineqs));
               FStar_TypeChecker_Env.implicits =
                 (uu___61_920.FStar_TypeChecker_Env.implicits)
-            }  in
+            } in
           (let uu____930 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-               (FStar_Options.Other "GenUniverses")
-              in
+               (FStar_Options.Other "GenUniverses") in
            if uu____930
            then
-             let uu____931 = FStar_TypeChecker_Rel.guard_to_string env g1  in
+             let uu____931 = FStar_TypeChecker_Rel.guard_to_string env g1 in
              FStar_Util.print1 "@@@@@@Guard before generalization: %s\n"
                uu____931
            else ());
@@ -416,13 +367,11 @@ let (generalize_and_inst_within :
                               ->
                               let uu____980 =
                                 let uu____981 =
-                                  FStar_Syntax_Syntax.mk_Total k  in
+                                  FStar_Syntax_Syntax.mk_Total k in
                                 FStar_All.pipe_left
-                                  (FStar_Syntax_Util.arrow tps) uu____981
-                                 in
+                                  (FStar_Syntax_Util.arrow tps) uu____981 in
                               FStar_Syntax_Syntax.null_binder uu____980
-                          | uu____988 -> failwith "Impossible")))
-              in
+                          | uu____988 -> failwith "Impossible"))) in
            let binders' =
              FStar_All.pipe_right datas
                (FStar_List.map
@@ -431,58 +380,50 @@ let (generalize_and_inst_within :
                      | FStar_Syntax_Syntax.Sig_datacon
                          (uu____1004,uu____1005,t,uu____1007,uu____1008,uu____1009)
                          -> FStar_Syntax_Syntax.null_binder t
-                     | uu____1014 -> failwith "Impossible"))
-              in
+                     | uu____1014 -> failwith "Impossible")) in
            let t =
              let uu____1018 =
-               FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.t_unit  in
+               FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.t_unit in
              FStar_Syntax_Util.arrow (FStar_List.append binders binders')
-               uu____1018
-              in
+               uu____1018 in
            (let uu____1022 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                (FStar_Options.Other "GenUniverses")
-               in
+                (FStar_Options.Other "GenUniverses") in
             if uu____1022
             then
               let uu____1023 =
-                FStar_TypeChecker_Normalize.term_to_string env t  in
+                FStar_TypeChecker_Normalize.term_to_string env t in
               FStar_Util.print1
                 "@@@@@@Trying to generalize universes in %s\n" uu____1023
             else ());
            (let uu____1025 =
-              FStar_TypeChecker_Util.generalize_universes env t  in
+              FStar_TypeChecker_Util.generalize_universes env t in
             match uu____1025 with
             | (uvs,t1) ->
                 ((let uu____1041 =
                     FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                      (FStar_Options.Other "GenUniverses")
-                     in
+                      (FStar_Options.Other "GenUniverses") in
                   if uu____1041
                   then
                     let uu____1042 =
                       let uu____1043 =
                         FStar_All.pipe_right uvs
-                          (FStar_List.map (fun u  -> u.FStar_Ident.idText))
-                         in
+                          (FStar_List.map (fun u  -> u.FStar_Ident.idText)) in
                       FStar_All.pipe_right uu____1043
-                        (FStar_String.concat ", ")
-                       in
-                    let uu____1054 = FStar_Syntax_Print.term_to_string t1  in
+                        (FStar_String.concat ", ") in
+                    let uu____1054 = FStar_Syntax_Print.term_to_string t1 in
                     FStar_Util.print2 "@@@@@@Generalized to (%s, %s)\n"
                       uu____1042 uu____1054
                   else ());
-                 (let uu____1056 = FStar_Syntax_Subst.open_univ_vars uvs t1
-                     in
+                 (let uu____1056 = FStar_Syntax_Subst.open_univ_vars uvs t1 in
                   match uu____1056 with
                   | (uvs1,t2) ->
-                      let uu____1071 = FStar_Syntax_Util.arrow_formals t2  in
+                      let uu____1071 = FStar_Syntax_Util.arrow_formals t2 in
                       (match uu____1071 with
                        | (args,uu____1093) ->
                            let uu____1110 =
                              FStar_Util.first_N (FStar_List.length binders)
-                               args
-                              in
+                               args in
                            (match uu____1110 with
                             | (tc_types,data_types) ->
                                 let tcs1 =
@@ -500,24 +441,20 @@ let (generalize_and_inst_within :
                                                   let ty =
                                                     FStar_Syntax_Subst.close_univ_vars
                                                       uvs1
-                                                      x.FStar_Syntax_Syntax.sort
-                                                     in
+                                                      x.FStar_Syntax_Syntax.sort in
                                                   let uu____1238 =
                                                     let uu____1251 =
                                                       let uu____1252 =
                                                         FStar_Syntax_Subst.compress
-                                                          ty
-                                                         in
-                                                      uu____1252.FStar_Syntax_Syntax.n
-                                                       in
+                                                          ty in
+                                                      uu____1252.FStar_Syntax_Syntax.n in
                                                     match uu____1251 with
                                                     | FStar_Syntax_Syntax.Tm_arrow
                                                         (binders1,c) ->
                                                         let uu____1285 =
                                                           FStar_Util.first_N
                                                             (FStar_List.length
-                                                               tps) binders1
-                                                           in
+                                                               tps) binders1 in
                                                         (match uu____1285
                                                          with
                                                          | (tps1,rest) ->
@@ -533,15 +470,12 @@ let (generalize_and_inst_within :
                                                                     (FStar_Syntax_Syntax.Tm_arrow
                                                                     (rest, c))
                                                                     FStar_Pervasives_Native.None
-                                                                    (x.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos
-                                                                in
+                                                                    (x.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos in
                                                              (tps1, t3))
-                                                    | uu____1380 -> ([], ty)
-                                                     in
+                                                    | uu____1380 -> ([], ty) in
                                                   (match uu____1238 with
                                                    | (tps1,t3) ->
-                                                       let uu___62_1409 = se
-                                                          in
+                                                       let uu___62_1409 = se in
                                                        {
                                                          FStar_Syntax_Syntax.sigel
                                                            =
@@ -565,8 +499,7 @@ let (generalize_and_inst_within :
                                                        })
                                               | uu____1422 ->
                                                   failwith "Impossible"))
-                                    tc_types tcs
-                                   in
+                                    tc_types tcs in
                                 let datas1 =
                                   match uvs1 with
                                   | [] -> datas
@@ -576,8 +509,7 @@ let (generalize_and_inst_within :
                                           (FStar_List.map
                                              (fun _0_40  ->
                                                 FStar_Syntax_Syntax.U_name
-                                                  _0_40))
-                                         in
+                                                  _0_40)) in
                                       let tc_insts =
                                         FStar_All.pipe_right tcs1
                                           (FStar_List.map
@@ -598,8 +530,7 @@ let (generalize_and_inst_within :
                                                       = uu____1486;_}
                                                     -> (tc, uvs_universes)
                                                 | uu____1501 ->
-                                                    failwith "Impossible"))
-                                         in
+                                                    failwith "Impossible")) in
                                       FStar_List.map2
                                         (fun uu____1524  ->
                                            fun d  ->
@@ -614,15 +545,12 @@ let (generalize_and_inst_within :
                                                         let uu____1543 =
                                                           FStar_Syntax_InstFV.instantiate
                                                             tc_insts
-                                                            t3.FStar_Syntax_Syntax.sort
-                                                           in
+                                                            t3.FStar_Syntax_Syntax.sort in
                                                         FStar_All.pipe_right
                                                           uu____1543
                                                           (FStar_Syntax_Subst.close_univ_vars
-                                                             uvs1)
-                                                         in
-                                                      let uu___63_1544 = d
-                                                         in
+                                                             uvs1) in
+                                                      let uu___63_1544 = d in
                                                       {
                                                         FStar_Syntax_Syntax.sigel
                                                           =
@@ -645,39 +573,34 @@ let (generalize_and_inst_within :
                                                       }
                                                   | uu____1547 ->
                                                       failwith "Impossible"))
-                                        data_types datas
-                                   in
+                                        data_types datas in
                                 (tcs1, datas1)))))))
-  
-let (debug_log : FStar_TypeChecker_Env.env_t -> Prims.string -> Prims.unit) =
+let debug_log: FStar_TypeChecker_Env.env_t -> Prims.string -> Prims.unit =
   fun env  ->
     fun s  ->
       let uu____1558 =
         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-          (FStar_Options.Other "Positivity")
-         in
+          (FStar_Options.Other "Positivity") in
       if uu____1558
       then
         FStar_Util.print_string
           (Prims.strcat "Positivity::" (Prims.strcat s "\n"))
       else ()
-  
-let (ty_occurs_in :
-  FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool) =
+let ty_occurs_in:
+  FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool =
   fun ty_lid  ->
     fun t  ->
-      let uu____1566 = FStar_Syntax_Free.fvars t  in
+      let uu____1566 = FStar_Syntax_Free.fvars t in
       FStar_Util.set_mem ty_lid uu____1566
-  
-let (try_get_fv :
+let try_get_fv:
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.fv,FStar_Syntax_Syntax.universes)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun t  ->
     let uu____1580 =
-      let uu____1581 = FStar_Syntax_Subst.compress t  in
-      uu____1581.FStar_Syntax_Syntax.n  in
+      let uu____1581 = FStar_Syntax_Subst.compress t in
+      uu____1581.FStar_Syntax_Syntax.n in
     match uu____1580 with
     | FStar_Syntax_Syntax.Tm_fvar fv -> (fv, [])
     | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
@@ -686,21 +609,20 @@ let (try_get_fv :
          | uu____1602 ->
              failwith "Node is a Tm_uinst, but Tm_uinst is not an fvar")
     | uu____1607 -> failwith "Node is not an fvar or a Tm_uinst"
-  
 type unfolded_memo_elt =
   (FStar_Ident.lident,FStar_Syntax_Syntax.args)
     FStar_Pervasives_Native.tuple2 Prims.list[@@deriving show]
 type unfolded_memo_t = unfolded_memo_elt FStar_ST.ref[@@deriving show]
-let (already_unfolded :
+let already_unfolded:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.args ->
-      unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool)
+      unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
   =
   fun ilid  ->
     fun arrghs  ->
       fun unfolded  ->
         fun env  ->
-          let uu____1652 = FStar_ST.op_Bang unfolded  in
+          let uu____1652 = FStar_ST.op_Bang unfolded in
           FStar_List.existsML
             (fun uu____1717  ->
                match uu____1717 with
@@ -708,8 +630,8 @@ let (already_unfolded :
                    (FStar_Ident.lid_equals lid ilid) &&
                      (let args =
                         let uu____1752 =
-                          FStar_List.splitAt (FStar_List.length l) arrghs  in
-                        FStar_Pervasives_Native.fst uu____1752  in
+                          FStar_List.splitAt (FStar_List.length l) arrghs in
+                        FStar_Pervasives_Native.fst uu____1752 in
                       FStar_List.fold_left2
                         (fun b  ->
                            fun a  ->
@@ -719,20 +641,18 @@ let (already_unfolded :
                                     (FStar_Pervasives_Native.fst a)
                                     (FStar_Pervasives_Native.fst a'))) true
                         args l)) uu____1652
-  
-let rec (ty_strictly_positive_in_type :
+let rec ty_strictly_positive_in_type:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.term ->
-      unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool)
+      unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
   =
   fun ty_lid  ->
     fun btype  ->
       fun unfolded  ->
         fun env  ->
           (let uu____1924 =
-             let uu____1925 = FStar_Syntax_Print.term_to_string btype  in
-             Prims.strcat "Checking strict positivity in type: " uu____1925
-              in
+             let uu____1925 = FStar_Syntax_Print.term_to_string btype in
+             Prims.strcat "Checking strict positivity in type: " uu____1925 in
            debug_log env uu____1924);
           (let btype1 =
              FStar_TypeChecker_Normalize.normalize
@@ -742,24 +662,22 @@ let rec (ty_strictly_positive_in_type :
                  FStar_Syntax_Syntax.Delta_constant;
                FStar_TypeChecker_Normalize.Iota;
                FStar_TypeChecker_Normalize.Zeta;
-               FStar_TypeChecker_Normalize.AllowUnboundUniverses] env btype
-              in
+               FStar_TypeChecker_Normalize.AllowUnboundUniverses] env btype in
            (let uu____1928 =
-              let uu____1929 = FStar_Syntax_Print.term_to_string btype1  in
+              let uu____1929 = FStar_Syntax_Print.term_to_string btype1 in
               Prims.strcat
                 "Checking strict positivity in type, after normalization: "
-                uu____1929
-               in
+                uu____1929 in
             debug_log env uu____1928);
-           (let uu____1932 = ty_occurs_in ty_lid btype1  in
+           (let uu____1932 = ty_occurs_in ty_lid btype1 in
             Prims.op_Negation uu____1932) ||
              ((debug_log env "ty does occur in this type, pressing ahead";
                (let uu____1942 =
-                  let uu____1943 = FStar_Syntax_Subst.compress btype1  in
-                  uu____1943.FStar_Syntax_Syntax.n  in
+                  let uu____1943 = FStar_Syntax_Subst.compress btype1 in
+                  uu____1943.FStar_Syntax_Syntax.n in
                 match uu____1942 with
                 | FStar_Syntax_Syntax.Tm_app (t,args) ->
-                    let uu____1968 = try_get_fv t  in
+                    let uu____1968 = try_get_fv t in
                     (match uu____1968 with
                      | (fv,us) ->
                          if
@@ -773,8 +691,7 @@ let rec (ty_strictly_positive_in_type :
                               (fun uu____1984  ->
                                  match uu____1984 with
                                  | (t1,uu____1990) ->
-                                     let uu____1991 = ty_occurs_in ty_lid t1
-                                        in
+                                     let uu____1991 = ty_occurs_in ty_lid t1 in
                                      Prims.op_Negation uu____1991) args)
                          else
                            (debug_log env
@@ -786,8 +703,8 @@ let rec (ty_strictly_positive_in_type :
                     (debug_log env "Checking strict positivity in Tm_arrow";
                      (let uu____2033 =
                         let uu____2034 =
-                          FStar_Syntax_Util.is_pure_or_ghost_comp c  in
-                        Prims.op_Negation uu____2034  in
+                          FStar_Syntax_Util.is_pure_or_ghost_comp c in
+                        Prims.op_Negation uu____2034 in
                       if uu____2033
                       then
                         (debug_log env
@@ -802,19 +719,16 @@ let rec (ty_strictly_positive_in_type :
                                | (b,uu____2052) ->
                                    let uu____2053 =
                                      ty_occurs_in ty_lid
-                                       b.FStar_Syntax_Syntax.sort
-                                      in
+                                       b.FStar_Syntax_Syntax.sort in
                                    Prims.op_Negation uu____2053) sbs)
                            &&
                            ((let uu____2058 =
                                FStar_Syntax_Subst.open_term sbs
-                                 (FStar_Syntax_Util.comp_result c)
-                                in
+                                 (FStar_Syntax_Util.comp_result c) in
                              match uu____2058 with
                              | (uu____2063,return_type) ->
                                  let uu____2065 =
-                                   FStar_TypeChecker_Env.push_binders env sbs
-                                    in
+                                   FStar_TypeChecker_Env.push_binders env sbs in
                                  ty_strictly_positive_in_type ty_lid
                                    return_type unfolded uu____2065)))))
                 | FStar_Syntax_Syntax.Tm_fvar uu____2086 ->
@@ -843,18 +757,16 @@ let rec (ty_strictly_positive_in_type :
                           | (p,uu____2214,t) ->
                               let bs =
                                 let uu____2227 =
-                                  FStar_Syntax_Syntax.pat_bvs p  in
+                                  FStar_Syntax_Syntax.pat_bvs p in
                                 FStar_List.map FStar_Syntax_Syntax.mk_binder
-                                  uu____2227
-                                 in
+                                  uu____2227 in
                               let uu____2230 =
-                                FStar_Syntax_Subst.open_term bs t  in
+                                FStar_Syntax_Subst.open_term bs t in
                               (match uu____2230 with
                                | (bs1,t1) ->
                                    let uu____2237 =
                                      FStar_TypeChecker_Env.push_binders env
-                                       bs1
-                                      in
+                                       bs1 in
                                    ty_strictly_positive_in_type ty_lid t1
                                      unfolded uu____2237)) branches)
                 | FStar_Syntax_Syntax.Tm_ascribed (t,uu____2259,uu____2260)
@@ -866,25 +778,23 @@ let rec (ty_strictly_positive_in_type :
                     ((let uu____2324 =
                         let uu____2325 =
                           let uu____2326 =
-                            FStar_Syntax_Print.tag_of_term btype1  in
+                            FStar_Syntax_Print.tag_of_term btype1 in
                           let uu____2327 =
                             let uu____2328 =
-                              FStar_Syntax_Print.term_to_string btype1  in
-                            Prims.strcat " and term: " uu____2328  in
-                          Prims.strcat uu____2326 uu____2327  in
+                              FStar_Syntax_Print.term_to_string btype1 in
+                            Prims.strcat " and term: " uu____2328 in
+                          Prims.strcat uu____2326 uu____2327 in
                         Prims.strcat
                           "Checking strict positivity, unexpected tag: "
-                          uu____2325
-                         in
+                          uu____2325 in
                       debug_log env uu____2324);
                      false)))))
-
-and (ty_nested_positive_in_inductive :
+and ty_nested_positive_in_inductive:
   FStar_Ident.lident ->
     FStar_Ident.lident ->
       FStar_Syntax_Syntax.universes ->
         FStar_Syntax_Syntax.args ->
-          unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool)
+          unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
   =
   fun ty_lid  ->
     fun ilid  ->
@@ -895,16 +805,14 @@ and (ty_nested_positive_in_inductive :
               (let uu____2346 =
                  let uu____2347 =
                    let uu____2348 =
-                     let uu____2349 = FStar_Syntax_Print.args_to_string args
-                        in
-                     Prims.strcat " applied to arguments: " uu____2349  in
-                   Prims.strcat ilid.FStar_Ident.str uu____2348  in
+                     let uu____2349 = FStar_Syntax_Print.args_to_string args in
+                     Prims.strcat " applied to arguments: " uu____2349 in
+                   Prims.strcat ilid.FStar_Ident.str uu____2348 in
                  Prims.strcat "Checking nested positivity in the inductive "
-                   uu____2347
-                  in
+                   uu____2347 in
                debug_log env uu____2346);
               (let uu____2350 =
-                 FStar_TypeChecker_Env.datacons_of_typ env ilid  in
+                 FStar_TypeChecker_Env.datacons_of_typ env ilid in
                match uu____2350 with
                | (b,idatas) ->
                    if Prims.op_Negation b
@@ -914,7 +822,7 @@ and (ty_nested_positive_in_inductive :
                       false)
                    else
                      (let uu____2365 =
-                        already_unfolded ilid args unfolded env  in
+                        already_unfolded ilid args unfolded env in
                       if uu____2365
                       then
                         (debug_log env
@@ -923,45 +831,41 @@ and (ty_nested_positive_in_inductive :
                       else
                         (let num_ibs =
                            FStar_TypeChecker_Env.num_inductive_ty_params env
-                             ilid
-                            in
+                             ilid in
                          (let uu____2390 =
                             let uu____2391 =
                               let uu____2392 =
-                                FStar_Util.string_of_int num_ibs  in
+                                FStar_Util.string_of_int num_ibs in
                               Prims.strcat uu____2392
-                                ", also adding to the memo table"
-                               in
+                                ", also adding to the memo table" in
                             Prims.strcat
                               "Checking nested positivity, number of type parameters is "
-                              uu____2391
-                             in
+                              uu____2391 in
                           debug_log env uu____2390);
                          (let uu____2394 =
-                            let uu____2395 = FStar_ST.op_Bang unfolded  in
+                            let uu____2395 = FStar_ST.op_Bang unfolded in
                             let uu____2441 =
                               let uu____2448 =
                                 let uu____2461 =
                                   let uu____2470 =
-                                    FStar_List.splitAt num_ibs args  in
-                                  FStar_Pervasives_Native.fst uu____2470  in
-                                (ilid, uu____2461)  in
-                              [uu____2448]  in
-                            FStar_List.append uu____2395 uu____2441  in
+                                    FStar_List.splitAt num_ibs args in
+                                  FStar_Pervasives_Native.fst uu____2470 in
+                                (ilid, uu____2461) in
+                              [uu____2448] in
+                            FStar_List.append uu____2395 uu____2441 in
                           FStar_ST.op_Colon_Equals unfolded uu____2394);
                          FStar_List.for_all
                            (fun d  ->
                               ty_nested_positive_in_dlid ty_lid d ilid us
                                 args num_ibs unfolded env) idatas)))
-
-and (ty_nested_positive_in_dlid :
+and ty_nested_positive_in_dlid:
   FStar_Ident.lident ->
     FStar_Ident.lident ->
       FStar_Ident.lident ->
         FStar_Syntax_Syntax.universes ->
           FStar_Syntax_Syntax.args ->
             Prims.int ->
-              unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool)
+              unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
   =
   fun ty_lid  ->
     fun dlid  ->
@@ -978,7 +882,7 @@ and (ty_nested_positive_in_dlid :
                           (Prims.strcat " of the inductive "
                              ilid.FStar_Ident.str)));
                   (let uu____2629 =
-                     FStar_TypeChecker_Env.lookup_datacon env dlid  in
+                     FStar_TypeChecker_Env.lookup_datacon env dlid in
                    match uu____2629 with
                    | (univ_unif_vars,dt) ->
                        (FStar_List.iter2
@@ -1000,48 +904,41 @@ and (ty_nested_positive_in_dlid :
                              FStar_TypeChecker_Normalize.Iota;
                              FStar_TypeChecker_Normalize.Zeta;
                              FStar_TypeChecker_Normalize.AllowUnboundUniverses]
-                             env dt
-                            in
+                             env dt in
                          (let uu____2654 =
                             let uu____2655 =
-                              FStar_Syntax_Print.term_to_string dt1  in
+                              FStar_Syntax_Print.term_to_string dt1 in
                             Prims.strcat
                               "Checking nested positivity in the data constructor type: "
-                              uu____2655
-                             in
+                              uu____2655 in
                           debug_log env uu____2654);
                          (let uu____2656 =
-                            let uu____2657 = FStar_Syntax_Subst.compress dt1
-                               in
-                            uu____2657.FStar_Syntax_Syntax.n  in
+                            let uu____2657 = FStar_Syntax_Subst.compress dt1 in
+                            uu____2657.FStar_Syntax_Syntax.n in
                           match uu____2656 with
                           | FStar_Syntax_Syntax.Tm_arrow (dbs,c) ->
                               (debug_log env
                                  "Checked nested positivity in Tm_arrow data constructor type";
                                (let uu____2679 =
-                                  FStar_List.splitAt num_ibs dbs  in
+                                  FStar_List.splitAt num_ibs dbs in
                                 match uu____2679 with
                                 | (ibs,dbs1) ->
                                     let ibs1 =
-                                      FStar_Syntax_Subst.open_binders ibs  in
+                                      FStar_Syntax_Subst.open_binders ibs in
                                     let dbs2 =
                                       let uu____2728 =
                                         FStar_Syntax_Subst.opening_of_binders
-                                          ibs1
-                                         in
+                                          ibs1 in
                                       FStar_Syntax_Subst.subst_binders
-                                        uu____2728 dbs1
-                                       in
+                                        uu____2728 dbs1 in
                                     let c1 =
                                       let uu____2732 =
                                         FStar_Syntax_Subst.opening_of_binders
-                                          ibs1
-                                         in
+                                          ibs1 in
                                       FStar_Syntax_Subst.subst_comp
-                                        uu____2732 c
-                                       in
+                                        uu____2732 c in
                                     let uu____2735 =
-                                      FStar_List.splitAt num_ibs args  in
+                                      FStar_List.splitAt num_ibs args in
                                     (match uu____2735 with
                                      | (args1,uu____2763) ->
                                          let subst1 =
@@ -1055,42 +952,33 @@ and (ty_nested_positive_in_dlid :
                                                              ib),
                                                            (FStar_Pervasives_Native.fst
                                                               arg))]) [] ibs1
-                                             args1
-                                            in
+                                             args1 in
                                          let dbs3 =
                                            FStar_Syntax_Subst.subst_binders
-                                             subst1 dbs2
-                                            in
+                                             subst1 dbs2 in
                                          let c2 =
                                            let uu____2835 =
                                              FStar_Syntax_Subst.shift_subst
                                                (FStar_List.length dbs3)
-                                               subst1
-                                              in
+                                               subst1 in
                                            FStar_Syntax_Subst.subst_comp
-                                             uu____2835 c1
-                                            in
+                                             uu____2835 c1 in
                                          ((let uu____2843 =
                                              let uu____2844 =
                                                let uu____2845 =
                                                  FStar_Syntax_Print.binders_to_string
-                                                   "; " dbs3
-                                                  in
+                                                   "; " dbs3 in
                                                let uu____2846 =
                                                  let uu____2847 =
                                                    FStar_Syntax_Print.comp_to_string
-                                                     c2
-                                                    in
+                                                     c2 in
                                                  Prims.strcat ", and c: "
-                                                   uu____2847
-                                                  in
+                                                   uu____2847 in
                                                Prims.strcat uu____2845
-                                                 uu____2846
-                                                in
+                                                 uu____2846 in
                                              Prims.strcat
                                                "Checking nested positivity in the unfolded data constructor binders as: "
-                                               uu____2844
-                                              in
+                                               uu____2844 in
                                            debug_log env uu____2843);
                                           ty_nested_positive_in_type ty_lid
                                             (FStar_Syntax_Syntax.Tm_arrow
@@ -1101,17 +989,16 @@ and (ty_nested_positive_in_dlid :
                                  "Checking nested positivity in the data constructor type that is not an arrow";
                                (let uu____2870 =
                                   let uu____2871 =
-                                    FStar_Syntax_Subst.compress dt1  in
-                                  uu____2871.FStar_Syntax_Syntax.n  in
+                                    FStar_Syntax_Subst.compress dt1 in
+                                  uu____2871.FStar_Syntax_Syntax.n in
                                 ty_nested_positive_in_type ty_lid uu____2870
                                   ilid num_ibs unfolded env))))))
-
-and (ty_nested_positive_in_type :
+and ty_nested_positive_in_type:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.term' ->
       FStar_Ident.lident ->
         Prims.int ->
-          unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool)
+          unfolded_memo_t -> FStar_TypeChecker_Env.env_t -> Prims.bool
   =
   fun ty_lid  ->
     fun t  ->
@@ -1123,7 +1010,7 @@ and (ty_nested_positive_in_type :
               | FStar_Syntax_Syntax.Tm_app (t1,args) ->
                   (debug_log env
                      "Checking nested positivity in an Tm_app node, which is expected to be the ilid itself";
-                   (let uu____2933 = try_get_fv t1  in
+                   (let uu____2933 = try_get_fv t1 in
                     match uu____2933 with
                     | (fv,uu____2939) ->
                         if
@@ -1136,13 +1023,12 @@ and (ty_nested_positive_in_type :
               | FStar_Syntax_Syntax.Tm_arrow (sbs,c) ->
                   ((let uu____2960 =
                       let uu____2961 =
-                        FStar_Syntax_Print.binders_to_string "; " sbs  in
+                        FStar_Syntax_Print.binders_to_string "; " sbs in
                       Prims.strcat
                         "Checking nested positivity in an Tm_arrow node, with binders as: "
-                        uu____2961
-                       in
+                        uu____2961 in
                     debug_log env uu____2960);
-                   (let sbs1 = FStar_Syntax_Subst.open_binders sbs  in
+                   (let sbs1 = FStar_Syntax_Subst.open_binders sbs in
                     let uu____2963 =
                       FStar_List.fold_left
                         (fun uu____2980  ->
@@ -1155,25 +1041,21 @@ and (ty_nested_positive_in_type :
                                    (let uu____3001 =
                                       ty_strictly_positive_in_type ty_lid
                                         (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                                        unfolded env1
-                                       in
+                                        unfolded env1 in
                                     let uu____3022 =
                                       FStar_TypeChecker_Env.push_binders env1
-                                        [b]
-                                       in
+                                        [b] in
                                     (uu____3001, uu____3022))) (true, env)
-                        sbs1
-                       in
+                        sbs1 in
                     match uu____2963 with | (b,uu____3032) -> b))
               | uu____3033 ->
                   failwith "Nested positive check, unhandled case"
-
-let (ty_positive_in_datacon :
+let ty_positive_in_datacon:
   FStar_Ident.lident ->
     FStar_Ident.lident ->
       FStar_Syntax_Syntax.binders ->
         FStar_Syntax_Syntax.universes ->
-          unfolded_memo_t -> FStar_TypeChecker_Env.env -> Prims.bool)
+          unfolded_memo_t -> FStar_TypeChecker_Env.env -> Prims.bool
   =
   fun ty_lid  ->
     fun dlid  ->
@@ -1181,8 +1063,7 @@ let (ty_positive_in_datacon :
         fun us  ->
           fun unfolded  ->
             fun env  ->
-              let uu____3072 = FStar_TypeChecker_Env.lookup_datacon env dlid
-                 in
+              let uu____3072 = FStar_TypeChecker_Env.lookup_datacon env dlid in
               match uu____3072 with
               | (univ_unif_vars,dt) ->
                   (FStar_List.iter2
@@ -1196,15 +1077,13 @@ let (ty_positive_in_datacon :
                                 "Impossible! Expected universe unification variables")
                      univ_unif_vars us;
                    (let uu____3096 =
-                      let uu____3097 = FStar_Syntax_Print.term_to_string dt
-                         in
+                      let uu____3097 = FStar_Syntax_Print.term_to_string dt in
                       Prims.strcat "Checking data constructor type: "
-                        uu____3097
-                       in
+                        uu____3097 in
                     debug_log env uu____3096);
                    (let uu____3098 =
-                      let uu____3099 = FStar_Syntax_Subst.compress dt  in
-                      uu____3099.FStar_Syntax_Syntax.n  in
+                      let uu____3099 = FStar_Syntax_Subst.compress dt in
+                      uu____3099.FStar_Syntax_Syntax.n in
                     match uu____3098 with
                     | FStar_Syntax_Syntax.Tm_fvar uu____3102 ->
                         (debug_log env
@@ -1213,26 +1092,22 @@ let (ty_positive_in_datacon :
                     | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____3105) ->
                         let dbs1 =
                           let uu____3129 =
-                            FStar_List.splitAt (FStar_List.length ty_bs) dbs
-                             in
-                          FStar_Pervasives_Native.snd uu____3129  in
+                            FStar_List.splitAt (FStar_List.length ty_bs) dbs in
+                          FStar_Pervasives_Native.snd uu____3129 in
                         let dbs2 =
                           let uu____3167 =
-                            FStar_Syntax_Subst.opening_of_binders ty_bs  in
-                          FStar_Syntax_Subst.subst_binders uu____3167 dbs1
-                           in
-                        let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
+                            FStar_Syntax_Subst.opening_of_binders ty_bs in
+                          FStar_Syntax_Subst.subst_binders uu____3167 dbs1 in
+                        let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
                         ((let uu____3172 =
                             let uu____3173 =
                               let uu____3174 =
                                 FStar_Util.string_of_int
-                                  (FStar_List.length dbs3)
-                                 in
-                              Prims.strcat uu____3174 " binders"  in
+                                  (FStar_List.length dbs3) in
+                              Prims.strcat uu____3174 " binders" in
                             Prims.strcat
                               "Data constructor type is an arrow type, so checking strict positivity in "
-                              uu____3173
-                             in
+                              uu____3173 in
                           debug_log env uu____3172);
                          (let uu____3179 =
                             FStar_List.fold_left
@@ -1247,15 +1122,12 @@ let (ty_positive_in_datacon :
                                             ty_strictly_positive_in_type
                                               ty_lid
                                               (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                                              unfolded env1
-                                             in
+                                              unfolded env1 in
                                           let uu____3238 =
                                             FStar_TypeChecker_Env.push_binders
-                                              env1 [b]
-                                             in
+                                              env1 [b] in
                                           (uu____3217, uu____3238)))
-                              (true, env) dbs3
-                             in
+                              (true, env) dbs3 in
                           match uu____3179 with | (b,uu____3248) -> b))
                     | FStar_Syntax_Syntax.Tm_app (uu____3249,uu____3250) ->
                         (debug_log env
@@ -1268,72 +1140,67 @@ let (ty_positive_in_datacon :
                     | uu____3299 ->
                         failwith
                           "Unexpected data constructor type when checking positivity"))
-  
-let (check_positivity :
-  FStar_Syntax_Syntax.sigelt -> FStar_TypeChecker_Env.env -> Prims.bool) =
+let check_positivity:
+  FStar_Syntax_Syntax.sigelt -> FStar_TypeChecker_Env.env -> Prims.bool =
   fun ty  ->
     fun env  ->
-      let unfolded_inductives = FStar_Util.mk_ref []  in
+      let unfolded_inductives = FStar_Util.mk_ref [] in
       let uu____3325 =
         match ty.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
             (lid,us,bs,uu____3341,uu____3342,uu____3343) -> (lid, us, bs)
-        | uu____3352 -> failwith "Impossible!"  in
+        | uu____3352 -> failwith "Impossible!" in
       match uu____3325 with
       | (ty_lid,ty_us,ty_bs) ->
-          let uu____3362 = FStar_Syntax_Subst.univ_var_opening ty_us  in
+          let uu____3362 = FStar_Syntax_Subst.univ_var_opening ty_us in
           (match uu____3362 with
            | (ty_usubst,ty_us1) ->
-               let env1 = FStar_TypeChecker_Env.push_univ_vars env ty_us1  in
-               let env2 = FStar_TypeChecker_Env.push_binders env1 ty_bs  in
-               let ty_bs1 = FStar_Syntax_Subst.subst_binders ty_usubst ty_bs
-                  in
-               let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1  in
+               let env1 = FStar_TypeChecker_Env.push_univ_vars env ty_us1 in
+               let env2 = FStar_TypeChecker_Env.push_binders env1 ty_bs in
+               let ty_bs1 = FStar_Syntax_Subst.subst_binders ty_usubst ty_bs in
+               let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1 in
                let uu____3385 =
                  let uu____3388 =
-                   FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid  in
-                 FStar_Pervasives_Native.snd uu____3388  in
+                   FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid in
+                 FStar_Pervasives_Native.snd uu____3388 in
                FStar_List.for_all
                  (fun d  ->
                     let uu____3400 =
                       FStar_List.map (fun s  -> FStar_Syntax_Syntax.U_name s)
-                        ty_us1
-                       in
+                        ty_us1 in
                     ty_positive_in_datacon ty_lid d ty_bs2 uu____3400
                       unfolded_inductives env2) uu____3385)
-  
-let (datacon_typ : FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.term) =
+let datacon_typ: FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.term =
   fun data  ->
     match data.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_datacon
         (uu____3428,uu____3429,t,uu____3431,uu____3432,uu____3433) -> t
     | uu____3438 -> failwith "Impossible!"
-  
-let (optimized_haseq_soundness_for_data :
+let optimized_haseq_soundness_for_data:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.sigelt ->
       FStar_Syntax_Syntax.subst_elt Prims.list ->
-        FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.term)
+        FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.term
   =
   fun ty_lid  ->
     fun data  ->
       fun usubst  ->
         fun bs  ->
-          let dt = datacon_typ data  in
-          let dt1 = FStar_Syntax_Subst.subst usubst dt  in
+          let dt = datacon_typ data in
+          let dt1 = FStar_Syntax_Subst.subst usubst dt in
           let uu____3457 =
-            let uu____3458 = FStar_Syntax_Subst.compress dt1  in
-            uu____3458.FStar_Syntax_Syntax.n  in
+            let uu____3458 = FStar_Syntax_Subst.compress dt1 in
+            uu____3458.FStar_Syntax_Syntax.n in
           match uu____3457 with
           | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____3462) ->
               let dbs1 =
                 let uu____3486 =
-                  FStar_List.splitAt (FStar_List.length bs) dbs  in
-                FStar_Pervasives_Native.snd uu____3486  in
+                  FStar_List.splitAt (FStar_List.length bs) dbs in
+                FStar_Pervasives_Native.snd uu____3486 in
               let dbs2 =
-                let uu____3524 = FStar_Syntax_Subst.opening_of_binders bs  in
-                FStar_Syntax_Subst.subst_binders uu____3524 dbs1  in
-              let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
+                let uu____3524 = FStar_Syntax_Subst.opening_of_binders bs in
+                FStar_Syntax_Subst.subst_binders uu____3524 dbs1 in
+              let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
               let cond =
                 FStar_List.fold_left
                   (fun t  ->
@@ -1343,30 +1210,23 @@ let (optimized_haseq_soundness_for_data :
                            let uu____3540 =
                              let uu____3541 =
                                FStar_Syntax_Syntax.as_arg
-                                 (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                                in
-                             [uu____3541]  in
+                                 (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
+                             [uu____3541] in
                            FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.t_haseq uu____3540
-                            in
+                             FStar_Syntax_Util.t_haseq uu____3540 in
                          uu____3539 FStar_Pervasives_Native.None
-                           FStar_Range.dummyRange
-                          in
+                           FStar_Range.dummyRange in
                        let sort_range =
-                         ((FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos
-                          in
+                         ((FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos in
                        let haseq_b1 =
                          let uu____3546 =
                            FStar_Util.format1
                              "Failed to prove that the type '%s' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier"
-                             ty_lid.FStar_Ident.str
-                            in
+                             ty_lid.FStar_Ident.str in
                          FStar_TypeChecker_Util.label uu____3546 sort_range
-                           haseq_b
-                          in
+                           haseq_b in
                        FStar_Syntax_Util.mk_conj t haseq_b1)
-                  FStar_Syntax_Util.t_true dbs3
-                 in
+                  FStar_Syntax_Util.t_true dbs3 in
               FStar_List.fold_right
                 (fun b  ->
                    fun t  ->
@@ -1374,23 +1234,19 @@ let (optimized_haseq_soundness_for_data :
                        let uu____3555 =
                          let uu____3556 =
                            let uu____3557 =
-                             let uu____3558 = FStar_Syntax_Subst.close [b] t
-                                in
+                             let uu____3558 = FStar_Syntax_Subst.close [b] t in
                              FStar_Syntax_Util.abs
                                [((FStar_Pervasives_Native.fst b),
                                   FStar_Pervasives_Native.None)] uu____3558
-                               FStar_Pervasives_Native.None
-                              in
-                           FStar_Syntax_Syntax.as_arg uu____3557  in
-                         [uu____3556]  in
+                               FStar_Pervasives_Native.None in
+                           FStar_Syntax_Syntax.as_arg uu____3557 in
+                         [uu____3556] in
                        FStar_Syntax_Syntax.mk_Tm_app
-                         FStar_Syntax_Util.tforall uu____3555
-                        in
+                         FStar_Syntax_Util.tforall uu____3555 in
                      uu____3554 FStar_Pervasives_Native.None
                        FStar_Range.dummyRange) dbs3 cond
           | uu____3575 -> FStar_Syntax_Util.t_true
-  
-let (optimized_haseq_ty :
+let optimized_haseq_ty:
   FStar_Syntax_Syntax.sigelts ->
     FStar_Syntax_Syntax.subst_elt Prims.list ->
       FStar_Syntax_Syntax.univ_name Prims.list ->
@@ -1403,7 +1259,7 @@ let (optimized_haseq_ty :
                FStar_Pervasives_Native.tuple2 Prims.list,FStar_TypeChecker_Env.env,
               FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.term'
                                                                     FStar_Syntax_Syntax.syntax)
-              FStar_Pervasives_Native.tuple4)
+              FStar_Pervasives_Native.tuple4
   =
   fun all_datas_in_the_bundle  ->
     fun usubst  ->
@@ -1415,24 +1271,23 @@ let (optimized_haseq_ty :
               | FStar_Syntax_Syntax.Sig_inductive_typ
                   (lid,uu____3647,uu____3648,uu____3649,uu____3650,uu____3651)
                   -> lid
-              | uu____3660 -> failwith "Impossible!"  in
-            let uu____3661 = acc  in
+              | uu____3660 -> failwith "Impossible!" in
+            let uu____3661 = acc in
             match uu____3661 with
             | (uu____3694,en,uu____3696,uu____3697) ->
                 let uu____3710 =
                   FStar_TypeChecker_Util.get_optimized_haseq_axiom en ty
-                    usubst us
-                   in
+                    usubst us in
                 (match uu____3710 with
                  | (axiom_lid,fml,bs,ibs,haseq_bs) ->
-                     let guard = FStar_Syntax_Util.mk_conj haseq_bs fml  in
-                     let uu____3747 = acc  in
+                     let guard = FStar_Syntax_Util.mk_conj haseq_bs fml in
+                     let uu____3747 = acc in
                      (match uu____3747 with
                       | (l_axioms,env,guard',cond') ->
                           let env1 =
-                            FStar_TypeChecker_Env.push_binders env bs  in
+                            FStar_TypeChecker_Env.push_binders env bs in
                           let env2 =
-                            FStar_TypeChecker_Env.push_binders env1 ibs  in
+                            FStar_TypeChecker_Env.push_binders env1 ibs in
                           let t_datas =
                             FStar_List.filter
                               (fun s  ->
@@ -1441,27 +1296,23 @@ let (optimized_haseq_ty :
                                      (uu____3809,uu____3810,uu____3811,t_lid,uu____3813,uu____3814)
                                      -> t_lid = lid
                                  | uu____3819 -> failwith "Impossible")
-                              all_datas_in_the_bundle
-                             in
+                              all_datas_in_the_bundle in
                           let cond =
                             FStar_List.fold_left
                               (fun acc1  ->
                                  fun d  ->
                                    let uu____3826 =
                                      optimized_haseq_soundness_for_data lid d
-                                       usubst bs
-                                      in
+                                       usubst bs in
                                    FStar_Syntax_Util.mk_conj acc1 uu____3826)
-                              FStar_Syntax_Util.t_true t_datas
-                             in
+                              FStar_Syntax_Util.t_true t_datas in
                           let uu____3827 =
-                            FStar_Syntax_Util.mk_conj guard' guard  in
+                            FStar_Syntax_Util.mk_conj guard' guard in
                           let uu____3830 =
-                            FStar_Syntax_Util.mk_conj cond' cond  in
+                            FStar_Syntax_Util.mk_conj cond' cond in
                           ((FStar_List.append l_axioms [(axiom_lid, fml)]),
                             env2, uu____3827, uu____3830)))
-  
-let (optimized_haseq_scheme :
+let optimized_haseq_scheme:
   FStar_Syntax_Syntax.sigelt ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
       FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -1471,7 +1322,7 @@ let (optimized_haseq_scheme :
                FStar_Syntax_Syntax.formula ->
                  FStar_Syntax_Syntax.qualifier Prims.list ->
                    FStar_Range.range -> FStar_Syntax_Syntax.sigelt)
-            -> FStar_Syntax_Syntax.sigelt Prims.list)
+            -> FStar_Syntax_Syntax.sigelt Prims.list
   =
   fun sig_bndle  ->
     fun tcs  ->
@@ -1479,44 +1330,40 @@ let (optimized_haseq_scheme :
         fun env0  ->
           fun tc_assume  ->
             let us =
-              let ty = FStar_List.hd tcs  in
+              let ty = FStar_List.hd tcs in
               match ty.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_inductive_typ
                   (uu____3913,us,uu____3915,uu____3916,uu____3917,uu____3918)
                   -> us
-              | uu____3927 -> failwith "Impossible!"  in
-            let uu____3928 = FStar_Syntax_Subst.univ_var_opening us  in
+              | uu____3927 -> failwith "Impossible!" in
+            let uu____3928 = FStar_Syntax_Subst.univ_var_opening us in
             match uu____3928 with
             | (usubst,us1) ->
-                let env = FStar_TypeChecker_Env.push_sigelt env0 sig_bndle
-                   in
+                let env = FStar_TypeChecker_Env.push_sigelt env0 sig_bndle in
                 ((env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.push
                    "haseq";
                  (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
                    env sig_bndle;
-                 (let env1 = FStar_TypeChecker_Env.push_univ_vars env us1  in
+                 (let env1 = FStar_TypeChecker_Env.push_univ_vars env us1 in
                   let uu____3953 =
                     FStar_List.fold_left
                       (optimized_haseq_ty datas usubst us1)
                       ([], env1, FStar_Syntax_Util.t_true,
-                        FStar_Syntax_Util.t_true) tcs
-                     in
+                        FStar_Syntax_Util.t_true) tcs in
                   match uu____3953 with
                   | (axioms,env2,guard,cond) ->
-                      let phi = FStar_Syntax_Util.mk_imp guard cond  in
+                      let phi = FStar_Syntax_Util.mk_imp guard cond in
                       let uu____4011 =
-                        FStar_TypeChecker_TcTerm.tc_trivial_guard env2 phi
-                         in
+                        FStar_TypeChecker_TcTerm.tc_trivial_guard env2 phi in
                       (match uu____4011 with
                        | (phi1,uu____4019) ->
                            ((let uu____4021 =
-                               FStar_TypeChecker_Env.should_verify env2  in
+                               FStar_TypeChecker_Env.should_verify env2 in
                              if uu____4021
                              then
                                let uu____4022 =
                                  FStar_TypeChecker_Rel.guard_of_guard_formula
-                                   (FStar_TypeChecker_Common.NonTrivial phi1)
-                                  in
+                                   (FStar_TypeChecker_Common.NonTrivial phi1) in
                                FStar_TypeChecker_Rel.force_trivial_guard env2
                                  uu____4022
                              else ());
@@ -1528,22 +1375,19 @@ let (optimized_haseq_scheme :
                                       | (lid,fml) ->
                                           let se =
                                             tc_assume env2 lid fml []
-                                              FStar_Range.dummyRange
-                                             in
-                                          FStar_List.append l [se]) [] axioms
-                                in
+                                              FStar_Range.dummyRange in
+                                          FStar_List.append l [se]) [] axioms in
                              (env2.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.pop
                                "haseq";
                              ses)))))
-  
-let (unoptimized_haseq_data :
+let unoptimized_haseq_data:
   FStar_Syntax_Syntax.subst_elt Prims.list ->
     FStar_Syntax_Syntax.binders ->
       FStar_Syntax_Syntax.term ->
         FStar_Ident.lident Prims.list ->
           FStar_Syntax_Syntax.term ->
             FStar_Syntax_Syntax.sigelt ->
-              FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+              FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun usubst  ->
     fun bs  ->
@@ -1553,8 +1397,8 @@ let (unoptimized_haseq_data :
             fun data  ->
               let rec is_mutual t =
                 let uu____4091 =
-                  let uu____4092 = FStar_Syntax_Subst.compress t  in
-                  uu____4092.FStar_Syntax_Syntax.n  in
+                  let uu____4092 = FStar_Syntax_Subst.compress t in
+                  uu____4092.FStar_Syntax_Syntax.n in
                 match uu____4091 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_List.existsb
@@ -1567,67 +1411,59 @@ let (unoptimized_haseq_data :
                 | FStar_Syntax_Syntax.Tm_refine (bv,t') ->
                     is_mutual bv.FStar_Syntax_Syntax.sort
                 | FStar_Syntax_Syntax.Tm_app (t',args) ->
-                    let uu____4132 = is_mutual t'  in
+                    let uu____4132 = is_mutual t' in
                     if uu____4132
                     then true
                     else
                       (let uu____4134 =
-                         FStar_List.map FStar_Pervasives_Native.fst args  in
+                         FStar_List.map FStar_Pervasives_Native.fst args in
                        exists_mutual uu____4134)
                 | FStar_Syntax_Syntax.Tm_meta (t',uu____4150) -> is_mutual t'
                 | uu____4155 -> false
-              
               and exists_mutual uu___56_4156 =
                 match uu___56_4156 with
                 | [] -> false
-                | hd1::tl1 -> (is_mutual hd1) || (exists_mutual tl1)
-               in
-              let dt = datacon_typ data  in
-              let dt1 = FStar_Syntax_Subst.subst usubst dt  in
+                | hd1::tl1 -> (is_mutual hd1) || (exists_mutual tl1) in
+              let dt = datacon_typ data in
+              let dt1 = FStar_Syntax_Subst.subst usubst dt in
               let uu____4175 =
-                let uu____4176 = FStar_Syntax_Subst.compress dt1  in
-                uu____4176.FStar_Syntax_Syntax.n  in
+                let uu____4176 = FStar_Syntax_Subst.compress dt1 in
+                uu____4176.FStar_Syntax_Syntax.n in
               match uu____4175 with
               | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____4182) ->
                   let dbs1 =
                     let uu____4206 =
-                      FStar_List.splitAt (FStar_List.length bs) dbs  in
-                    FStar_Pervasives_Native.snd uu____4206  in
+                      FStar_List.splitAt (FStar_List.length bs) dbs in
+                    FStar_Pervasives_Native.snd uu____4206 in
                   let dbs2 =
-                    let uu____4244 = FStar_Syntax_Subst.opening_of_binders bs
-                       in
-                    FStar_Syntax_Subst.subst_binders uu____4244 dbs1  in
-                  let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
+                    let uu____4244 = FStar_Syntax_Subst.opening_of_binders bs in
+                    FStar_Syntax_Subst.subst_binders uu____4244 dbs1 in
+                  let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
                   let cond =
                     FStar_List.fold_left
                       (fun t  ->
                          fun b  ->
                            let sort =
-                             (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                              in
+                             (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
                            let haseq_sort =
                              let uu____4262 =
                                let uu____4263 =
                                  let uu____4264 =
                                    FStar_Syntax_Syntax.as_arg
-                                     (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                                    in
-                                 [uu____4264]  in
+                                     (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
+                                 [uu____4264] in
                                FStar_Syntax_Syntax.mk_Tm_app
-                                 FStar_Syntax_Util.t_haseq uu____4263
-                                in
+                                 FStar_Syntax_Util.t_haseq uu____4263 in
                              uu____4262 FStar_Pervasives_Native.None
-                               FStar_Range.dummyRange
-                              in
+                               FStar_Range.dummyRange in
                            let haseq_sort1 =
-                             let uu____4268 = is_mutual sort  in
+                             let uu____4268 = is_mutual sort in
                              if uu____4268
                              then
                                FStar_Syntax_Util.mk_imp haseq_ind haseq_sort
-                             else haseq_sort  in
+                             else haseq_sort in
                            FStar_Syntax_Util.mk_conj t haseq_sort1)
-                      FStar_Syntax_Util.t_true dbs3
-                     in
+                      FStar_Syntax_Util.t_true dbs3 in
                   let cond1 =
                     FStar_List.fold_right
                       (fun b  ->
@@ -1637,31 +1473,27 @@ let (unoptimized_haseq_data :
                                let uu____4280 =
                                  let uu____4281 =
                                    let uu____4282 =
-                                     FStar_Syntax_Subst.close [b] t  in
+                                     FStar_Syntax_Subst.close [b] t in
                                    FStar_Syntax_Util.abs
                                      [((FStar_Pervasives_Native.fst b),
                                         FStar_Pervasives_Native.None)]
-                                     uu____4282 FStar_Pervasives_Native.None
-                                    in
-                                 FStar_Syntax_Syntax.as_arg uu____4281  in
-                               [uu____4280]  in
+                                     uu____4282 FStar_Pervasives_Native.None in
+                                 FStar_Syntax_Syntax.as_arg uu____4281 in
+                               [uu____4280] in
                              FStar_Syntax_Syntax.mk_Tm_app
-                               FStar_Syntax_Util.tforall uu____4279
-                              in
+                               FStar_Syntax_Util.tforall uu____4279 in
                            uu____4278 FStar_Pervasives_Native.None
-                             FStar_Range.dummyRange) dbs3 cond
-                     in
+                             FStar_Range.dummyRange) dbs3 cond in
                   FStar_Syntax_Util.mk_conj acc cond1
               | uu____4299 -> acc
-  
-let (unoptimized_haseq_ty :
+let unoptimized_haseq_ty:
   FStar_Syntax_Syntax.sigelt Prims.list ->
     FStar_Ident.lident Prims.list ->
       FStar_Syntax_Syntax.subst_elt Prims.list ->
         FStar_Syntax_Syntax.univ_name Prims.list ->
           FStar_Syntax_Syntax.term ->
             FStar_Syntax_Syntax.sigelt ->
-              FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+              FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun all_datas_in_the_bundle  ->
     fun mutuals  ->
@@ -1674,42 +1506,37 @@ let (unoptimized_haseq_ty :
                 | FStar_Syntax_Syntax.Sig_inductive_typ
                     (lid,uu____4358,bs,t,uu____4361,d_lids) ->
                     (lid, bs, t, d_lids)
-                | uu____4373 -> failwith "Impossible!"  in
+                | uu____4373 -> failwith "Impossible!" in
               match uu____4336 with
               | (lid,bs,t,d_lids) ->
-                  let bs1 = FStar_Syntax_Subst.subst_binders usubst bs  in
+                  let bs1 = FStar_Syntax_Subst.subst_binders usubst bs in
                   let t1 =
                     let uu____4396 =
                       FStar_Syntax_Subst.shift_subst (FStar_List.length bs1)
-                        usubst
-                       in
-                    FStar_Syntax_Subst.subst uu____4396 t  in
-                  let uu____4403 = FStar_Syntax_Subst.open_term bs1 t1  in
+                        usubst in
+                    FStar_Syntax_Subst.subst uu____4396 t in
+                  let uu____4403 = FStar_Syntax_Subst.open_term bs1 t1 in
                   (match uu____4403 with
                    | (bs2,t2) ->
                        let ibs =
                          let uu____4419 =
-                           let uu____4420 = FStar_Syntax_Subst.compress t2
-                              in
-                           uu____4420.FStar_Syntax_Syntax.n  in
+                           let uu____4420 = FStar_Syntax_Subst.compress t2 in
+                           uu____4420.FStar_Syntax_Syntax.n in
                          match uu____4419 with
                          | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____4430) ->
                              ibs
-                         | uu____4447 -> []  in
-                       let ibs1 = FStar_Syntax_Subst.open_binders ibs  in
+                         | uu____4447 -> [] in
+                       let ibs1 = FStar_Syntax_Subst.open_binders ibs in
                        let ind =
                          let uu____4454 =
                            FStar_Syntax_Syntax.fvar lid
                              FStar_Syntax_Syntax.Delta_constant
-                             FStar_Pervasives_Native.None
-                            in
+                             FStar_Pervasives_Native.None in
                          let uu____4455 =
                            FStar_List.map
-                             (fun u  -> FStar_Syntax_Syntax.U_name u) us
-                            in
+                             (fun u  -> FStar_Syntax_Syntax.U_name u) us in
                          FStar_Syntax_Syntax.mk_Tm_uinst uu____4454
-                           uu____4455
-                          in
+                           uu____4455 in
                        let ind1 =
                          let uu____4461 =
                            let uu____4462 =
@@ -1718,13 +1545,11 @@ let (unoptimized_haseq_ty :
                                   match uu____4475 with
                                   | (bv,aq) ->
                                       let uu____4486 =
-                                        FStar_Syntax_Syntax.bv_to_name bv  in
-                                      (uu____4486, aq)) bs2
-                              in
-                           FStar_Syntax_Syntax.mk_Tm_app ind uu____4462  in
+                                        FStar_Syntax_Syntax.bv_to_name bv in
+                                      (uu____4486, aq)) bs2 in
+                           FStar_Syntax_Syntax.mk_Tm_app ind uu____4462 in
                          uu____4461 FStar_Pervasives_Native.None
-                           FStar_Range.dummyRange
-                          in
+                           FStar_Range.dummyRange in
                        let ind2 =
                          let uu____4492 =
                            let uu____4493 =
@@ -1733,25 +1558,20 @@ let (unoptimized_haseq_ty :
                                   match uu____4506 with
                                   | (bv,aq) ->
                                       let uu____4517 =
-                                        FStar_Syntax_Syntax.bv_to_name bv  in
-                                      (uu____4517, aq)) ibs1
-                              in
-                           FStar_Syntax_Syntax.mk_Tm_app ind1 uu____4493  in
+                                        FStar_Syntax_Syntax.bv_to_name bv in
+                                      (uu____4517, aq)) ibs1 in
+                           FStar_Syntax_Syntax.mk_Tm_app ind1 uu____4493 in
                          uu____4492 FStar_Pervasives_Native.None
-                           FStar_Range.dummyRange
-                          in
+                           FStar_Range.dummyRange in
                        let haseq_ind =
                          let uu____4523 =
                            let uu____4524 =
-                             let uu____4525 = FStar_Syntax_Syntax.as_arg ind2
-                                in
-                             [uu____4525]  in
+                             let uu____4525 = FStar_Syntax_Syntax.as_arg ind2 in
+                             [uu____4525] in
                            FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.t_haseq uu____4524
-                            in
+                             FStar_Syntax_Util.t_haseq uu____4524 in
                          uu____4523 FStar_Pervasives_Native.None
-                           FStar_Range.dummyRange
-                          in
+                           FStar_Range.dummyRange in
                        let t_datas =
                          FStar_List.filter
                            (fun s  ->
@@ -1760,37 +1580,33 @@ let (unoptimized_haseq_ty :
                                   (uu____4539,uu____4540,uu____4541,t_lid,uu____4543,uu____4544)
                                   -> t_lid = lid
                               | uu____4549 -> failwith "Impossible")
-                           all_datas_in_the_bundle
-                          in
+                           all_datas_in_the_bundle in
                        let data_cond =
                          FStar_List.fold_left
                            (unoptimized_haseq_data usubst bs2 haseq_ind
-                              mutuals) FStar_Syntax_Util.t_true t_datas
-                          in
-                       let fml = FStar_Syntax_Util.mk_imp data_cond haseq_ind
-                          in
+                              mutuals) FStar_Syntax_Util.t_true t_datas in
+                       let fml = FStar_Syntax_Util.mk_imp data_cond haseq_ind in
                        let fml1 =
-                         let uu___64_4555 = fml  in
+                         let uu___64_4555 = fml in
                          let uu____4556 =
                            let uu____4557 =
                              let uu____4564 =
                                let uu____4565 =
                                  let uu____4576 =
                                    let uu____4579 =
-                                     FStar_Syntax_Syntax.as_arg haseq_ind  in
-                                   [uu____4579]  in
-                                 [uu____4576]  in
-                               FStar_Syntax_Syntax.Meta_pattern uu____4565
-                                in
-                             (fml, uu____4564)  in
-                           FStar_Syntax_Syntax.Tm_meta uu____4557  in
+                                     FStar_Syntax_Syntax.as_arg haseq_ind in
+                                   [uu____4579] in
+                                 [uu____4576] in
+                               FStar_Syntax_Syntax.Meta_pattern uu____4565 in
+                             (fml, uu____4564) in
+                           FStar_Syntax_Syntax.Tm_meta uu____4557 in
                          {
                            FStar_Syntax_Syntax.n = uu____4556;
                            FStar_Syntax_Syntax.pos =
                              (uu___64_4555.FStar_Syntax_Syntax.pos);
                            FStar_Syntax_Syntax.vars =
                              (uu___64_4555.FStar_Syntax_Syntax.vars)
-                         }  in
+                         } in
                        let fml2 =
                          FStar_List.fold_right
                            (fun b  ->
@@ -1800,22 +1616,18 @@ let (unoptimized_haseq_ty :
                                     let uu____4594 =
                                       let uu____4595 =
                                         let uu____4596 =
-                                          FStar_Syntax_Subst.close [b] t3  in
+                                          FStar_Syntax_Subst.close [b] t3 in
                                         FStar_Syntax_Util.abs
                                           [((FStar_Pervasives_Native.fst b),
                                              FStar_Pervasives_Native.None)]
                                           uu____4596
-                                          FStar_Pervasives_Native.None
-                                         in
-                                      FStar_Syntax_Syntax.as_arg uu____4595
-                                       in
-                                    [uu____4594]  in
+                                          FStar_Pervasives_Native.None in
+                                      FStar_Syntax_Syntax.as_arg uu____4595 in
+                                    [uu____4594] in
                                   FStar_Syntax_Syntax.mk_Tm_app
-                                    FStar_Syntax_Util.tforall uu____4593
-                                   in
+                                    FStar_Syntax_Util.tforall uu____4593 in
                                 uu____4592 FStar_Pervasives_Native.None
-                                  FStar_Range.dummyRange) ibs1 fml1
-                          in
+                                  FStar_Range.dummyRange) ibs1 fml1 in
                        let fml3 =
                          FStar_List.fold_right
                            (fun b  ->
@@ -1825,25 +1637,20 @@ let (unoptimized_haseq_ty :
                                     let uu____4623 =
                                       let uu____4624 =
                                         let uu____4625 =
-                                          FStar_Syntax_Subst.close [b] t3  in
+                                          FStar_Syntax_Subst.close [b] t3 in
                                         FStar_Syntax_Util.abs
                                           [((FStar_Pervasives_Native.fst b),
                                              FStar_Pervasives_Native.None)]
                                           uu____4625
-                                          FStar_Pervasives_Native.None
-                                         in
-                                      FStar_Syntax_Syntax.as_arg uu____4624
-                                       in
-                                    [uu____4623]  in
+                                          FStar_Pervasives_Native.None in
+                                      FStar_Syntax_Syntax.as_arg uu____4624 in
+                                    [uu____4623] in
                                   FStar_Syntax_Syntax.mk_Tm_app
-                                    FStar_Syntax_Util.tforall uu____4622
-                                   in
+                                    FStar_Syntax_Util.tforall uu____4622 in
                                 uu____4621 FStar_Pervasives_Native.None
-                                  FStar_Range.dummyRange) bs2 fml2
-                          in
+                                  FStar_Range.dummyRange) bs2 fml2 in
                        FStar_Syntax_Util.mk_conj acc fml3)
-  
-let (unoptimized_haseq_scheme :
+let unoptimized_haseq_scheme:
   FStar_Syntax_Syntax.sigelt ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
       FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -1853,7 +1660,7 @@ let (unoptimized_haseq_scheme :
                FStar_Syntax_Syntax.formula ->
                  FStar_Syntax_Syntax.qualifier Prims.list ->
                    FStar_Range.range -> FStar_Syntax_Syntax.sigelt)
-            -> FStar_Syntax_Syntax.sigelt Prims.list)
+            -> FStar_Syntax_Syntax.sigelt Prims.list
   =
   fun sig_bndle  ->
     fun tcs  ->
@@ -1867,33 +1674,31 @@ let (unoptimized_haseq_scheme :
                    | FStar_Syntax_Syntax.Sig_inductive_typ
                        (lid,uu____4710,uu____4711,uu____4712,uu____4713,uu____4714)
                        -> lid
-                   | uu____4723 -> failwith "Impossible!") tcs
-               in
+                   | uu____4723 -> failwith "Impossible!") tcs in
             let uu____4724 =
-              let ty = FStar_List.hd tcs  in
+              let ty = FStar_List.hd tcs in
               match ty.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_inductive_typ
                   (lid,us,uu____4736,uu____4737,uu____4738,uu____4739) ->
                   (lid, us)
-              | uu____4748 -> failwith "Impossible!"  in
+              | uu____4748 -> failwith "Impossible!" in
             match uu____4724 with
             | (lid,us) ->
-                let uu____4757 = FStar_Syntax_Subst.univ_var_opening us  in
+                let uu____4757 = FStar_Syntax_Subst.univ_var_opening us in
                 (match uu____4757 with
                  | (usubst,us1) ->
                      let fml =
                        FStar_List.fold_left
                          (unoptimized_haseq_ty datas mutuals usubst us1)
-                         FStar_Syntax_Util.t_true tcs
-                        in
+                         FStar_Syntax_Util.t_true tcs in
                      let env =
-                       FStar_TypeChecker_Env.push_sigelt env0 sig_bndle  in
+                       FStar_TypeChecker_Env.push_sigelt env0 sig_bndle in
                      ((env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.push
                         "haseq";
                       (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
                         env sig_bndle;
                       (let env1 =
-                         FStar_TypeChecker_Env.push_univ_vars env us1  in
+                         FStar_TypeChecker_Env.push_univ_vars env us1 in
                        let se =
                          let uu____4784 =
                            FStar_Ident.lid_of_ids
@@ -1901,23 +1706,20 @@ let (unoptimized_haseq_scheme :
                                 [FStar_Ident.id_of_text
                                    (Prims.strcat
                                       (lid.FStar_Ident.ident).FStar_Ident.idText
-                                      "_haseq")])
-                            in
+                                      "_haseq")]) in
                          tc_assume env1 uu____4784 fml []
-                           FStar_Range.dummyRange
-                          in
+                           FStar_Range.dummyRange in
                        (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.pop
                          "haseq";
                        [se])))
-  
-let (check_inductive_well_typedness :
+let check_inductive_well_typedness:
   FStar_TypeChecker_Env.env_t ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
         FStar_Ident.lident Prims.list ->
           (FStar_Syntax_Syntax.sigelt,FStar_Syntax_Syntax.sigelt Prims.list,
             FStar_Syntax_Syntax.sigelt Prims.list)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun ses  ->
@@ -1935,8 +1737,7 @@ let (check_inductive_well_typedness :
                         FStar_Syntax_Syntax.sigquals = uu____4858;
                         FStar_Syntax_Syntax.sigmeta = uu____4859;
                         FStar_Syntax_Syntax.sigattrs = uu____4860;_} -> true
-                    | uu____4881 -> false))
-             in
+                    | uu____4881 -> false)) in
           match uu____4830 with
           | (tys,datas) ->
               ((let uu____4903 =
@@ -1952,55 +1753,48 @@ let (check_inductive_well_typedness :
                               FStar_Syntax_Syntax.sigmeta = uu____4916;
                               FStar_Syntax_Syntax.sigattrs = uu____4917;_} ->
                               false
-                          | uu____4936 -> true))
-                   in
+                          | uu____4936 -> true)) in
                 if uu____4903
                 then
-                  let uu____4937 = FStar_TypeChecker_Env.get_range env  in
+                  let uu____4937 = FStar_TypeChecker_Env.get_range env in
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                       "Mutually defined type contains a non-inductive element")
                     uu____4937
                 else ());
-               (let env0 = env  in
+               (let env0 = env in
                 let uu____4940 =
                   FStar_List.fold_right
                     (fun tc  ->
                        fun uu____4979  ->
                          match uu____4979 with
                          | (env1,all_tcs,g) ->
-                             let uu____5019 = tc_tycon env1 tc  in
+                             let uu____5019 = tc_tycon env1 tc in
                              (match uu____5019 with
                               | (env2,tc1,tc_u,guard) ->
                                   let g' =
                                     FStar_TypeChecker_Rel.universe_inequality
-                                      FStar_Syntax_Syntax.U_zero tc_u
-                                     in
+                                      FStar_Syntax_Syntax.U_zero tc_u in
                                   ((let uu____5046 =
                                       FStar_TypeChecker_Env.debug env2
-                                        FStar_Options.Low
-                                       in
+                                        FStar_Options.Low in
                                     if uu____5046
                                     then
                                       let uu____5047 =
                                         FStar_Syntax_Print.sigelt_to_string
-                                          tc1
-                                         in
+                                          tc1 in
                                       FStar_Util.print1
                                         "Checked inductive: %s\n" uu____5047
                                     else ());
                                    (let uu____5049 =
                                       let uu____5050 =
                                         FStar_TypeChecker_Rel.conj_guard
-                                          guard g'
-                                         in
+                                          guard g' in
                                       FStar_TypeChecker_Rel.conj_guard g
-                                        uu____5050
-                                       in
+                                        uu____5050 in
                                     (env2, ((tc1, tc_u) :: all_tcs),
                                       uu____5049))))) tys
-                    (env, [], FStar_TypeChecker_Rel.trivial_guard)
-                   in
+                    (env, [], FStar_TypeChecker_Rel.trivial_guard) in
                 match uu____4940 with
                 | (env1,tcs,g) ->
                     let uu____5096 =
@@ -2010,31 +1804,28 @@ let (check_inductive_well_typedness :
                              match uu____5118 with
                              | (datas1,g1) ->
                                  let uu____5137 =
-                                   let uu____5142 = tc_data env1 tcs  in
-                                   uu____5142 se  in
+                                   let uu____5142 = tc_data env1 tcs in
+                                   uu____5142 se in
                                  (match uu____5137 with
                                   | (data,g') ->
                                       let uu____5157 =
                                         FStar_TypeChecker_Rel.conj_guard g1
-                                          g'
-                                         in
+                                          g' in
                                       ((data :: datas1), uu____5157))) datas
-                        ([], g)
-                       in
+                        ([], g) in
                     (match uu____5096 with
                      | (datas1,g1) ->
                          let uu____5178 =
-                           generalize_and_inst_within env0 g1 tcs datas1  in
+                           generalize_and_inst_within env0 g1 tcs datas1 in
                          (match uu____5178 with
                           | (tcs1,datas2) ->
                               let sig_bndle =
                                 let uu____5208 =
-                                  FStar_TypeChecker_Env.get_range env0  in
+                                  FStar_TypeChecker_Env.get_range env0 in
                                 let uu____5209 =
                                   FStar_List.collect
                                     (fun s  -> s.FStar_Syntax_Syntax.sigattrs)
-                                    ses
-                                   in
+                                    ses in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_bundle
@@ -2045,7 +1836,7 @@ let (check_inductive_well_typedness :
                                   FStar_Syntax_Syntax.sigmeta =
                                     FStar_Syntax_Syntax.default_sigmeta;
                                   FStar_Syntax_Syntax.sigattrs = uu____5209
-                                }  in
+                                } in
                               (FStar_All.pipe_right tcs1
                                  (FStar_List.iter
                                     (fun se  ->
@@ -2059,27 +1850,21 @@ let (check_inductive_well_typedness :
                                                let uu____5257 =
                                                  let uu____5258 =
                                                    FStar_Syntax_Print.tscheme_to_string
-                                                     expected
-                                                    in
+                                                     expected in
                                                  let uu____5259 =
                                                    FStar_Syntax_Print.tscheme_to_string
-                                                     inferred
-                                                    in
+                                                     inferred in
                                                  FStar_Util.format2
                                                    "Expected an inductive with type %s; got %s"
-                                                   uu____5258 uu____5259
-                                                  in
+                                                   uu____5258 uu____5259 in
                                                (FStar_Errors.Fatal_UnexpectedInductivetype,
-                                                 uu____5257)
-                                                in
+                                                 uu____5257) in
                                              FStar_Errors.raise_error
                                                uu____5252
-                                               se.FStar_Syntax_Syntax.sigrng
-                                              in
+                                               se.FStar_Syntax_Syntax.sigrng in
                                            let uu____5260 =
                                              FStar_TypeChecker_Env.try_lookup_val_decl
-                                               env0 l
-                                              in
+                                               env0 l in
                                            (match uu____5260 with
                                             | FStar_Pervasives_Native.None 
                                                 -> ()
@@ -2096,22 +1881,17 @@ let (check_inductive_well_typedness :
                                                               let uu____5315
                                                                 =
                                                                 FStar_Syntax_Syntax.mk_Total
-                                                                  typ
-                                                                 in
+                                                                  typ in
                                                               (binders,
-                                                                uu____5315)
-                                                               in
+                                                                uu____5315) in
                                                             FStar_Syntax_Syntax.Tm_arrow
-                                                              uu____5302
-                                                             in
+                                                              uu____5302 in
                                                           FStar_Syntax_Syntax.mk
-                                                            uu____5301
-                                                           in
+                                                            uu____5301 in
                                                         uu____5298
                                                           FStar_Pervasives_Native.None
-                                                          se.FStar_Syntax_Syntax.sigrng
-                                                     in
-                                                  (univs1, body)  in
+                                                          se.FStar_Syntax_Syntax.sigrng in
+                                                  (univs1, body) in
                                                 if
                                                   (FStar_List.length univs1)
                                                     =
@@ -2121,22 +1901,19 @@ let (check_inductive_well_typedness :
                                                 then
                                                   let uu____5321 =
                                                     FStar_TypeChecker_Env.inst_tscheme
-                                                      inferred_typ
-                                                     in
+                                                      inferred_typ in
                                                   (match uu____5321 with
                                                    | (uu____5326,inferred) ->
                                                        let uu____5328 =
                                                          FStar_TypeChecker_Env.inst_tscheme
-                                                           expected_typ1
-                                                          in
+                                                           expected_typ1 in
                                                        (match uu____5328 with
                                                         | (uu____5333,expected)
                                                             ->
                                                             let uu____5335 =
                                                               FStar_TypeChecker_Rel.teq_nosmt
                                                                 env0 inferred
-                                                                expected
-                                                               in
+                                                                expected in
                                                             if uu____5335
                                                             then ()
                                                             else
@@ -2148,4 +1925,3 @@ let (check_inductive_well_typedness :
                                                     inferred_typ)
                                        | uu____5338 -> ()));
                                (sig_bndle, tcs1, datas2))))))
-  

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -1,8 +1,8 @@
 open Prims
-let (instantiate_both :
-  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
+let instantiate_both: FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env
+  =
   fun env  ->
-    let uu___66_4 = env  in
+    let uu___66_4 = env in
     {
       FStar_TypeChecker_Env.solver = (uu___66_4.FStar_TypeChecker_Env.solver);
       FStar_TypeChecker_Env.range = (uu___66_4.FStar_TypeChecker_Env.range);
@@ -65,10 +65,9 @@ let (instantiate_both :
       FStar_TypeChecker_Env.dep_graph =
         (uu___66_4.FStar_TypeChecker_Env.dep_graph)
     }
-  
-let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
+let no_inst: FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env =
   fun env  ->
-    let uu___67_8 = env  in
+    let uu___67_8 = env in
     {
       FStar_TypeChecker_Env.solver = (uu___67_8.FStar_TypeChecker_Env.solver);
       FStar_TypeChecker_Env.range = (uu___67_8.FStar_TypeChecker_Env.range);
@@ -131,10 +130,9 @@ let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
       FStar_TypeChecker_Env.dep_graph =
         (uu___67_8.FStar_TypeChecker_Env.dep_graph)
     }
-  
-let (mk_lex_list :
+let mk_lex_list:
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun vs  ->
     FStar_List.fold_right
@@ -145,55 +143,47 @@ let (mk_lex_list :
              then v1.FStar_Syntax_Syntax.pos
              else
                FStar_Range.union_ranges v1.FStar_Syntax_Syntax.pos
-                 tl1.FStar_Syntax_Syntax.pos
-              in
+                 tl1.FStar_Syntax_Syntax.pos in
            let uu____40 =
              let uu____41 =
-               let uu____42 = FStar_Syntax_Syntax.as_arg v1  in
+               let uu____42 = FStar_Syntax_Syntax.as_arg v1 in
                let uu____43 =
-                 let uu____46 = FStar_Syntax_Syntax.as_arg tl1  in [uu____46]
-                  in
-               uu____42 :: uu____43  in
+                 let uu____46 = FStar_Syntax_Syntax.as_arg tl1 in [uu____46] in
+               uu____42 :: uu____43 in
              FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.lex_pair
-               uu____41
-              in
+               uu____41 in
            uu____40 FStar_Pervasives_Native.None r) vs
       FStar_Syntax_Util.lex_top
-  
-let (is_eq :
+let is_eq:
   FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option ->
-    Prims.bool)
+    Prims.bool
   =
   fun uu___61_53  ->
     match uu___61_53 with
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality ) -> true
     | uu____56 -> false
-  
-let steps :
+let steps:
   'Auu____61 . 'Auu____61 -> FStar_TypeChecker_Normalize.step Prims.list =
   fun env  ->
     [FStar_TypeChecker_Normalize.Beta;
     FStar_TypeChecker_Normalize.Eager_unfolding]
-  
-let (norm :
+let norm:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  -> FStar_TypeChecker_Normalize.normalize (steps env) env t
-  
-let (norm_c :
+let norm_c:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
+    FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
   =
   fun env  ->
     fun c  -> FStar_TypeChecker_Normalize.normalize_comp (steps env) env c
-  
-let (check_no_escape :
+let check_no_escape:
   FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.bv Prims.list ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun head_opt  ->
     fun env  ->
@@ -203,12 +193,11 @@ let (check_no_escape :
             match fvs with
             | [] -> t
             | uu____107 ->
-                let t1 = if try_norm then norm env t else t  in
-                let fvs' = FStar_Syntax_Free.names t1  in
+                let t1 = if try_norm then norm env t else t in
+                let fvs' = FStar_Syntax_Free.names t1 in
                 let uu____115 =
                   FStar_List.tryFind (fun x  -> FStar_Util.set_mem x fvs')
-                    fvs
-                   in
+                    fvs in
                 (match uu____115 with
                  | FStar_Pervasives_Native.None  -> t1
                  | FStar_Pervasives_Native.Some x ->
@@ -220,45 +209,38 @@ let (check_no_escape :
                             match head_opt with
                             | FStar_Pervasives_Native.None  ->
                                 let uu____127 =
-                                  FStar_Syntax_Print.bv_to_string x  in
+                                  FStar_Syntax_Print.bv_to_string x in
                                 FStar_Util.format1
                                   "Bound variables '%s' escapes; add a type annotation"
                                   uu____127
                             | FStar_Pervasives_Native.Some head1 ->
                                 let uu____129 =
-                                  FStar_Syntax_Print.bv_to_string x  in
+                                  FStar_Syntax_Print.bv_to_string x in
                                 let uu____130 =
                                   FStar_TypeChecker_Normalize.term_to_string
-                                    env head1
-                                   in
+                                    env head1 in
                                 FStar_Util.format2
                                   "Bound variables '%s' in the type of '%s' escape because of impure applications; add explicit let-bindings"
-                                  uu____129 uu____130
-                             in
-                          let uu____131 = FStar_TypeChecker_Env.get_range env
-                             in
+                                  uu____129 uu____130 in
+                          let uu____131 = FStar_TypeChecker_Env.get_range env in
                           FStar_Errors.raise_error
                             (FStar_Errors.Fatal_EscapedBoundVar, msg)
-                            uu____131
-                           in
+                            uu____131 in
                         let s =
                           let uu____133 =
-                            let uu____134 = FStar_Syntax_Util.type_u ()  in
+                            let uu____134 = FStar_Syntax_Util.type_u () in
                             FStar_All.pipe_left FStar_Pervasives_Native.fst
-                              uu____134
-                             in
-                          FStar_TypeChecker_Util.new_uvar env uu____133  in
+                              uu____134 in
+                          FStar_TypeChecker_Util.new_uvar env uu____133 in
                         let uu____143 =
-                          FStar_TypeChecker_Rel.try_teq true env t1 s  in
+                          FStar_TypeChecker_Rel.try_teq true env t1 s in
                         match uu____143 with
                         | FStar_Pervasives_Native.Some g ->
                             (FStar_TypeChecker_Rel.force_trivial_guard env g;
                              s)
-                        | uu____148 -> fail ()))
-             in
+                        | uu____148 -> fail ())) in
           aux false kt
-  
-let push_binding :
+let push_binding:
   'Auu____154 .
     FStar_TypeChecker_Env.env ->
       (FStar_Syntax_Syntax.bv,'Auu____154) FStar_Pervasives_Native.tuple2 ->
@@ -267,46 +249,43 @@ let push_binding :
   fun env  ->
     fun b  ->
       FStar_TypeChecker_Env.push_bv env (FStar_Pervasives_Native.fst b)
-  
-let (maybe_extend_subst :
+let maybe_extend_subst:
   FStar_Syntax_Syntax.subst_t ->
     FStar_Syntax_Syntax.binder ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.subst_t)
+        FStar_Syntax_Syntax.subst_t
   =
   fun s  ->
     fun b  ->
       fun v1  ->
-        let uu____184 = FStar_Syntax_Syntax.is_null_binder b  in
+        let uu____184 = FStar_Syntax_Syntax.is_null_binder b in
         if uu____184
         then s
         else (FStar_Syntax_Syntax.NT ((FStar_Pervasives_Native.fst b), v1))
           :: s
-  
-let (set_lcomp_result :
+let set_lcomp_result:
   FStar_Syntax_Syntax.lcomp ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.lcomp)
+    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.lcomp
   =
   fun lc  ->
     fun t  ->
       FStar_Syntax_Syntax.mk_lcomp lc.FStar_Syntax_Syntax.eff_name t
         lc.FStar_Syntax_Syntax.cflags
         (fun uu____196  ->
-           let uu____197 = FStar_Syntax_Syntax.lcomp_comp lc  in
+           let uu____197 = FStar_Syntax_Syntax.lcomp_comp lc in
            FStar_Syntax_Util.set_result_typ uu____197 t)
-  
-let (memo_tk :
+let memo_tk:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term)
-  = fun e  -> fun t  -> e 
-let (value_check_expected_typ :
+    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
+  = fun e  -> fun t  -> e
+let value_check_expected_typ:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.lcomp) FStar_Util.either
         ->
         FStar_TypeChecker_Env.guard_t ->
           (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
@@ -315,51 +294,46 @@ let (value_check_expected_typ :
           let lc =
             match tlc with
             | FStar_Util.Inl t ->
-                let uu____240 = FStar_Syntax_Syntax.mk_Total t  in
+                let uu____240 = FStar_Syntax_Syntax.mk_Total t in
                 FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____240
-            | FStar_Util.Inr lc -> lc  in
-          let t = lc.FStar_Syntax_Syntax.res_typ  in
+            | FStar_Util.Inr lc -> lc in
+          let t = lc.FStar_Syntax_Syntax.res_typ in
           let uu____249 =
-            let uu____256 = FStar_TypeChecker_Env.expected_typ env  in
+            let uu____256 = FStar_TypeChecker_Env.expected_typ env in
             match uu____256 with
             | FStar_Pervasives_Native.None  -> ((memo_tk e t), lc, guard)
             | FStar_Pervasives_Native.Some t' ->
                 let uu____266 =
                   FStar_TypeChecker_Util.maybe_coerce_bool_to_type env e lc
-                    t'
-                   in
+                    t' in
                 (match uu____266 with
                  | (e1,lc1) ->
-                     let t1 = lc1.FStar_Syntax_Syntax.res_typ  in
+                     let t1 = lc1.FStar_Syntax_Syntax.res_typ in
                      let uu____282 =
-                       FStar_TypeChecker_Util.check_and_ascribe env e1 t1 t'
-                        in
+                       FStar_TypeChecker_Util.check_and_ascribe env e1 t1 t' in
                      (match uu____282 with
                       | (e2,g) ->
                           ((let uu____296 =
                               FStar_TypeChecker_Env.debug env
-                                FStar_Options.High
-                               in
+                                FStar_Options.High in
                             if uu____296
                             then
                               let uu____297 =
-                                FStar_Syntax_Print.term_to_string t1  in
+                                FStar_Syntax_Print.term_to_string t1 in
                               let uu____298 =
-                                FStar_Syntax_Print.term_to_string t'  in
+                                FStar_Syntax_Print.term_to_string t' in
                               let uu____299 =
-                                FStar_TypeChecker_Rel.guard_to_string env g
-                                 in
+                                FStar_TypeChecker_Rel.guard_to_string env g in
                               let uu____300 =
                                 FStar_TypeChecker_Rel.guard_to_string env
-                                  guard
-                                 in
+                                  guard in
                               FStar_Util.print4
                                 "check_and_ascribe: type is %s<:%s \tguard is %s, %s\n"
                                 uu____297 uu____298 uu____299 uu____300
                             else ());
                            (let msg =
                               let uu____307 =
-                                FStar_TypeChecker_Rel.is_trivial g  in
+                                FStar_TypeChecker_Rel.is_trivial g in
                               if uu____307
                               then FStar_Pervasives_Native.None
                               else
@@ -367,49 +341,43 @@ let (value_check_expected_typ :
                                   (fun _0_40  ->
                                      FStar_Pervasives_Native.Some _0_40)
                                   (FStar_TypeChecker_Err.subtyping_failed env
-                                     t1 t')
-                               in
-                            let g1 = FStar_TypeChecker_Rel.conj_guard g guard
-                               in
+                                     t1 t') in
+                            let g1 = FStar_TypeChecker_Rel.conj_guard g guard in
                             let uu____324 =
                               FStar_TypeChecker_Util.strengthen_precondition
-                                msg env e2 lc1 g1
-                               in
+                                msg env e2 lc1 g1 in
                             match uu____324 with
                             | (lc2,g2) ->
-                                let uu____337 = set_lcomp_result lc2 t'  in
-                                ((memo_tk e2 t'), uu____337, g2)))))
-             in
+                                let uu____337 = set_lcomp_result lc2 t' in
+                                ((memo_tk e2 t'), uu____337, g2))))) in
           match uu____249 with | (e1,lc1,g) -> (e1, lc1, g)
-  
-let (comp_check_expected_typ :
+let comp_check_expected_typ:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.lcomp ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       fun lc  ->
-        let uu____368 = FStar_TypeChecker_Env.expected_typ env  in
+        let uu____368 = FStar_TypeChecker_Env.expected_typ env in
         match uu____368 with
         | FStar_Pervasives_Native.None  ->
             (e, lc, FStar_TypeChecker_Rel.trivial_guard)
         | FStar_Pervasives_Native.Some t ->
             let uu____378 =
-              FStar_TypeChecker_Util.maybe_coerce_bool_to_type env e lc t  in
+              FStar_TypeChecker_Util.maybe_coerce_bool_to_type env e lc t in
             (match uu____378 with
              | (e1,lc1) ->
                  FStar_TypeChecker_Util.weaken_result_typ env e1 lc1 t)
-  
-let (check_expected_effect :
+let check_expected_effect:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp FStar_Pervasives_Native.option ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.comp)
         FStar_Pervasives_Native.tuple2 ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.comp,FStar_TypeChecker_Env.guard_t)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun copt  ->
@@ -417,20 +385,18 @@ let (check_expected_effect :
         match uu____411 with
         | (e,c) ->
             let tot_or_gtot c1 =
-              let uu____440 = FStar_Syntax_Util.is_pure_comp c1  in
+              let uu____440 = FStar_Syntax_Util.is_pure_comp c1 in
               if uu____440
               then
                 FStar_Syntax_Syntax.mk_Total
                   (FStar_Syntax_Util.comp_result c1)
               else
-                (let uu____442 = FStar_Syntax_Util.is_pure_or_ghost_comp c1
-                    in
+                (let uu____442 = FStar_Syntax_Util.is_pure_or_ghost_comp c1 in
                  if uu____442
                  then
                    FStar_Syntax_Syntax.mk_GTotal
                      (FStar_Syntax_Util.comp_result c1)
-                 else failwith "Impossible: Expected pure_or_ghost comp")
-               in
+                 else failwith "Impossible: Expected pure_or_ghost comp") in
             let uu____444 =
               match copt with
               | FStar_Pervasives_Native.Some uu____457 -> (copt, c)
@@ -445,75 +411,64 @@ let (check_expected_effect :
                           env.FStar_TypeChecker_Env.lax)
                          &&
                          (let uu____462 =
-                            FStar_Syntax_Util.is_pure_or_ghost_comp c  in
-                          Prims.op_Negation uu____462))
-                     in
+                            FStar_Syntax_Util.is_pure_or_ghost_comp c in
+                          Prims.op_Negation uu____462)) in
                   if uu____460
                   then
                     let uu____469 =
                       let uu____472 =
                         FStar_Syntax_Util.ml_comp
                           (FStar_Syntax_Util.comp_result c)
-                          e.FStar_Syntax_Syntax.pos
-                         in
-                      FStar_Pervasives_Native.Some uu____472  in
+                          e.FStar_Syntax_Syntax.pos in
+                      FStar_Pervasives_Native.Some uu____472 in
                     (uu____469, c)
                   else
-                    (let uu____476 = FStar_Syntax_Util.is_tot_or_gtot_comp c
-                        in
+                    (let uu____476 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
                      if uu____476
                      then
-                       let uu____483 = tot_or_gtot c  in
+                       let uu____483 = tot_or_gtot c in
                        (FStar_Pervasives_Native.None, uu____483)
                      else
                        (let uu____487 =
-                          FStar_Syntax_Util.is_pure_or_ghost_comp c  in
+                          FStar_Syntax_Util.is_pure_or_ghost_comp c in
                         if uu____487
                         then
                           let uu____494 =
-                            let uu____497 = tot_or_gtot c  in
-                            FStar_Pervasives_Native.Some uu____497  in
+                            let uu____497 = tot_or_gtot c in
+                            FStar_Pervasives_Native.Some uu____497 in
                           (uu____494, c)
-                        else (FStar_Pervasives_Native.None, c)))
-               in
+                        else (FStar_Pervasives_Native.None, c))) in
             (match uu____444 with
              | (expected_c_opt,c1) ->
-                 let c2 = norm_c env c1  in
+                 let c2 = norm_c env c1 in
                  (match expected_c_opt with
                   | FStar_Pervasives_Native.None  ->
                       (e, c2, FStar_TypeChecker_Rel.trivial_guard)
                   | FStar_Pervasives_Native.Some expected_c ->
                       let c3 =
-                        let uu____524 = FStar_Syntax_Util.lcomp_of_comp c2
-                           in
+                        let uu____524 = FStar_Syntax_Util.lcomp_of_comp c2 in
                         FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
-                          env e uu____524
-                         in
-                      let c4 = FStar_Syntax_Syntax.lcomp_comp c3  in
+                          env e uu____524 in
+                      let c4 = FStar_Syntax_Syntax.lcomp_comp c3 in
                       let uu____526 =
-                        FStar_TypeChecker_Util.check_comp env e c4 expected_c
-                         in
+                        FStar_TypeChecker_Util.check_comp env e c4 expected_c in
                       (match uu____526 with
                        | (e1,uu____540,g) ->
                            let g1 =
                              let uu____543 =
-                               FStar_TypeChecker_Env.get_range env  in
+                               FStar_TypeChecker_Env.get_range env in
                              FStar_TypeChecker_Util.label_guard uu____543
-                               "could not prove post-condition" g
-                              in
+                               "could not prove post-condition" g in
                            ((let uu____545 =
                                FStar_TypeChecker_Env.debug env
-                                 FStar_Options.Low
-                                in
+                                 FStar_Options.Low in
                              if uu____545
                              then
                                let uu____546 =
                                  FStar_Range.string_of_range
-                                   e1.FStar_Syntax_Syntax.pos
-                                  in
+                                   e1.FStar_Syntax_Syntax.pos in
                                let uu____547 =
-                                 FStar_TypeChecker_Rel.guard_to_string env g1
-                                  in
+                                 FStar_TypeChecker_Rel.guard_to_string env g1 in
                                FStar_Util.print2
                                  "(%s) DONE check_expected_effect; guard is: %s\n"
                                  uu____546 uu____547
@@ -523,11 +478,9 @@ let (check_expected_effect :
                                  (FStar_Syntax_Util.comp_effect_name c4)
                                  (FStar_Syntax_Util.comp_effect_name
                                     expected_c)
-                                 (FStar_Syntax_Util.comp_result c4)
-                                in
+                                 (FStar_Syntax_Util.comp_result c4) in
                              (e2, expected_c, g1))))))
-  
-let no_logical_guard :
+let no_logical_guard:
   'Auu____554 'Auu____555 .
     FStar_TypeChecker_Env.env ->
       ('Auu____555,'Auu____554,FStar_TypeChecker_Env.guard_t)
@@ -539,41 +492,38 @@ let no_logical_guard :
     fun uu____575  ->
       match uu____575 with
       | (te,kt,f) ->
-          let uu____585 = FStar_TypeChecker_Rel.guard_form f  in
+          let uu____585 = FStar_TypeChecker_Rel.guard_form f in
           (match uu____585 with
            | FStar_TypeChecker_Common.Trivial  -> (te, kt, f)
            | FStar_TypeChecker_Common.NonTrivial f1 ->
                let uu____593 =
                  FStar_TypeChecker_Err.unexpected_non_trivial_precondition_on_term
-                   env f1
-                  in
-               let uu____598 = FStar_TypeChecker_Env.get_range env  in
+                   env f1 in
+               let uu____598 = FStar_TypeChecker_Env.get_range env in
                FStar_Errors.raise_error uu____593 uu____598)
-  
-let (print_expected_ty : FStar_TypeChecker_Env.env -> Prims.unit) =
+let print_expected_ty: FStar_TypeChecker_Env.env -> Prims.unit =
   fun env  ->
-    let uu____608 = FStar_TypeChecker_Env.expected_typ env  in
+    let uu____608 = FStar_TypeChecker_Env.expected_typ env in
     match uu____608 with
     | FStar_Pervasives_Native.None  ->
         FStar_Util.print_string "Expected type is None\n"
     | FStar_Pervasives_Native.Some t ->
-        let uu____612 = FStar_Syntax_Print.term_to_string t  in
+        let uu____612 = FStar_Syntax_Print.term_to_string t in
         FStar_Util.print1 "Expected type is %s" uu____612
-  
-let rec (get_pat_vars :
+let rec get_pat_vars:
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.bv FStar_Util.set ->
-      FStar_Syntax_Syntax.bv FStar_Util.set)
+      FStar_Syntax_Syntax.bv FStar_Util.set
   =
   fun pats  ->
     fun acc  ->
-      let pats1 = FStar_Syntax_Util.unmeta pats  in
-      let uu____636 = FStar_Syntax_Util.head_and_args pats1  in
+      let pats1 = FStar_Syntax_Util.unmeta pats in
+      let uu____636 = FStar_Syntax_Util.head_and_args pats1 in
       match uu____636 with
       | (head1,args) ->
           let uu____675 =
-            let uu____676 = FStar_Syntax_Util.un_uinst head1  in
-            uu____676.FStar_Syntax_Syntax.n  in
+            let uu____676 = FStar_Syntax_Util.un_uinst head1 in
+            uu____676.FStar_Syntax_Syntax.n in
           (match uu____675 with
            | FStar_Syntax_Syntax.Tm_fvar fv when
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid ->
@@ -581,7 +531,7 @@ let rec (get_pat_vars :
            | FStar_Syntax_Syntax.Tm_fvar fv when
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.smtpat_lid
                ->
-               let uu____683 = FStar_List.tl args  in
+               let uu____683 = FStar_List.tl args in
                get_pat_vars_args uu____683 acc
            | FStar_Syntax_Syntax.Tm_fvar fv when
                FStar_Syntax_Syntax.fv_eq_lid fv
@@ -591,13 +541,12 @@ let rec (get_pat_vars :
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid
                -> get_pat_vars_args args acc
            | uu____692 ->
-               let uu____693 = FStar_Syntax_Free.names pats1  in
+               let uu____693 = FStar_Syntax_Free.names pats1 in
                FStar_Util.set_union acc uu____693)
-
-and (get_pat_vars_args :
+and get_pat_vars_args:
   FStar_Syntax_Syntax.args ->
     FStar_Syntax_Syntax.bv FStar_Util.set ->
-      FStar_Syntax_Syntax.bv FStar_Util.set)
+      FStar_Syntax_Syntax.bv FStar_Util.set
   =
   fun args  ->
     fun acc  ->
@@ -605,8 +554,7 @@ and (get_pat_vars_args :
         (fun s  ->
            fun arg  -> get_pat_vars (FStar_Pervasives_Native.fst arg) s) acc
         args
-
-let check_smt_pat :
+let check_smt_pat:
   'Auu____723 .
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term ->
@@ -618,7 +566,7 @@ let check_smt_pat :
     fun t  ->
       fun bs  ->
         fun c  ->
-          let uu____756 = FStar_Syntax_Util.is_smt_lemma t  in
+          let uu____756 = FStar_Syntax_Util.is_smt_lemma t in
           if uu____756
           then
             match c.FStar_Syntax_Syntax.n with
@@ -633,46 +581,39 @@ let check_smt_pat :
                 let pat_vars =
                   let uu____812 =
                     FStar_TypeChecker_Normalize.normalize
-                      [FStar_TypeChecker_Normalize.Beta] env pats
-                     in
+                      [FStar_TypeChecker_Normalize.Beta] env pats in
                   let uu____813 =
-                    FStar_Util.new_set FStar_Syntax_Syntax.order_bv  in
-                  get_pat_vars uu____812 uu____813  in
+                    FStar_Util.new_set FStar_Syntax_Syntax.order_bv in
+                  get_pat_vars uu____812 uu____813 in
                 let uu____816 =
                   FStar_All.pipe_right bs
                     (FStar_Util.find_opt
                        (fun uu____843  ->
                           match uu____843 with
                           | (b,uu____849) ->
-                              let uu____850 = FStar_Util.set_mem b pat_vars
-                                 in
-                              Prims.op_Negation uu____850))
-                   in
+                              let uu____850 = FStar_Util.set_mem b pat_vars in
+                              Prims.op_Negation uu____850)) in
                 (match uu____816 with
                  | FStar_Pervasives_Native.None  -> ()
                  | FStar_Pervasives_Native.Some (x,uu____856) ->
                      let uu____861 =
                        let uu____866 =
-                         let uu____867 = FStar_Syntax_Print.bv_to_string x
-                            in
+                         let uu____867 = FStar_Syntax_Print.bv_to_string x in
                          FStar_Util.format1
                            "Pattern misses at least one bound variable: %s"
-                           uu____867
-                          in
+                           uu____867 in
                        (FStar_Errors.Warning_PatternMissingBoundVar,
-                         uu____866)
-                        in
+                         uu____866) in
                      FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos
                        uu____861)
             | uu____868 -> failwith "Impossible"
           else ()
-  
-let (guard_letrecs :
+let guard_letrecs:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
       FStar_Syntax_Syntax.comp ->
         (FStar_Syntax_Syntax.lbname,FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.univ_names)
-          FStar_Pervasives_Native.tuple3 Prims.list)
+          FStar_Pervasives_Native.tuple3 Prims.list
   =
   fun env  ->
     fun actuals  ->
@@ -680,9 +621,9 @@ let (guard_letrecs :
         match env.FStar_TypeChecker_Env.letrecs with
         | [] -> []
         | letrecs ->
-            let r = FStar_TypeChecker_Env.get_range env  in
+            let r = FStar_TypeChecker_Env.get_range env in
             let env1 =
-              let uu___68_918 = env  in
+              let uu___68_918 = env in
               {
                 FStar_TypeChecker_Env.solver =
                   (uu___68_918.FStar_TypeChecker_Env.solver);
@@ -753,19 +694,17 @@ let (guard_letrecs :
                   (uu___68_918.FStar_TypeChecker_Env.dsenv);
                 FStar_TypeChecker_Env.dep_graph =
                   (uu___68_918.FStar_TypeChecker_Env.dep_graph)
-              }  in
+              } in
             let precedes =
               FStar_TypeChecker_Util.fvar_const env1
-                FStar_Parser_Const.precedes_lid
-               in
+                FStar_Parser_Const.precedes_lid in
             let decreases_clause bs c =
               (let uu____934 =
-                 FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
+                 FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
                if uu____934
                then
-                 let uu____935 = FStar_Syntax_Print.binders_to_string ", " bs
-                    in
-                 let uu____936 = FStar_Syntax_Print.comp_to_string c  in
+                 let uu____935 = FStar_Syntax_Print.binders_to_string ", " bs in
+                 let uu____936 = FStar_Syntax_Print.comp_to_string c in
                  FStar_Util.print2
                    "Building a decreases clause over (%s) and %s\n" uu____935
                    uu____936
@@ -779,21 +718,18 @@ let (guard_letrecs :
                              let t =
                                let uu____965 =
                                  FStar_Syntax_Util.unrefine
-                                   b.FStar_Syntax_Syntax.sort
-                                  in
+                                   b.FStar_Syntax_Syntax.sort in
                                FStar_TypeChecker_Normalize.unfold_whnf env1
-                                 uu____965
-                                in
+                                 uu____965 in
                              (match t.FStar_Syntax_Syntax.n with
                               | FStar_Syntax_Syntax.Tm_type uu____968 -> []
                               | FStar_Syntax_Syntax.Tm_arrow uu____969 -> []
                               | uu____982 ->
                                   let uu____983 =
-                                    FStar_Syntax_Syntax.bv_to_name b  in
-                                  [uu____983])))
-                  in
+                                    FStar_Syntax_Syntax.bv_to_name b in
+                                  [uu____983]))) in
                let as_lex_list dec =
-                 let uu____988 = FStar_Syntax_Util.head_and_args dec  in
+                 let uu____988 = FStar_Syntax_Util.head_and_args dec in
                  match uu____988 with
                  | (head1,uu____1004) ->
                      (match head1.FStar_Syntax_Syntax.n with
@@ -801,32 +737,29 @@ let (guard_letrecs :
                           FStar_Syntax_Syntax.fv_eq_lid fv
                             FStar_Parser_Const.lexcons_lid
                           -> dec
-                      | uu____1026 -> mk_lex_list [dec])
-                  in
-               let cflags = FStar_Syntax_Util.comp_flags c  in
+                      | uu____1026 -> mk_lex_list [dec]) in
+               let cflags = FStar_Syntax_Util.comp_flags c in
                let uu____1030 =
                  FStar_All.pipe_right cflags
                    (FStar_List.tryFind
                       (fun uu___62_1039  ->
                          match uu___62_1039 with
                          | FStar_Syntax_Syntax.DECREASES uu____1040 -> true
-                         | uu____1043 -> false))
-                  in
+                         | uu____1043 -> false)) in
                match uu____1030 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                    dec) -> as_lex_list dec
                | uu____1047 ->
                    let xs =
-                     FStar_All.pipe_right bs filter_types_and_functions  in
-                   (match xs with | x::[] -> x | uu____1056 -> mk_lex_list xs))
-               in
-            let previous_dec = decreases_clause actuals expected_c  in
+                     FStar_All.pipe_right bs filter_types_and_functions in
+                   (match xs with | x::[] -> x | uu____1056 -> mk_lex_list xs)) in
+            let previous_dec = decreases_clause actuals expected_c in
             let guard_one_letrec uu____1077 =
               match uu____1077 with
               | (l,t,u_names) ->
                   let uu____1095 =
-                    let uu____1096 = FStar_Syntax_Subst.compress t  in
-                    uu____1096.FStar_Syntax_Syntax.n  in
+                    let uu____1096 = FStar_Syntax_Subst.compress t in
+                    uu____1096.FStar_Syntax_Syntax.n in
                   (match uu____1095 with
                    | FStar_Syntax_Syntax.Tm_arrow (formals,c) ->
                        let formals1 =
@@ -836,80 +769,68 @@ let (guard_letrecs :
                                  match uu____1157 with
                                  | (x,imp) ->
                                      let uu____1168 =
-                                       FStar_Syntax_Syntax.is_null_bv x  in
+                                       FStar_Syntax_Syntax.is_null_bv x in
                                      if uu____1168
                                      then
                                        let uu____1173 =
                                          let uu____1174 =
                                            let uu____1177 =
                                              FStar_Syntax_Syntax.range_of_bv
-                                               x
-                                              in
+                                               x in
                                            FStar_Pervasives_Native.Some
-                                             uu____1177
-                                            in
+                                             uu____1177 in
                                          FStar_Syntax_Syntax.new_bv
                                            uu____1174
-                                           x.FStar_Syntax_Syntax.sort
-                                          in
+                                           x.FStar_Syntax_Syntax.sort in
                                        (uu____1173, imp)
-                                     else (x, imp)))
-                          in
+                                     else (x, imp))) in
                        let uu____1179 =
-                         FStar_Syntax_Subst.open_comp formals1 c  in
+                         FStar_Syntax_Subst.open_comp formals1 c in
                        (match uu____1179 with
                         | (formals2,c1) ->
-                            let dec = decreases_clause formals2 c1  in
+                            let dec = decreases_clause formals2 c1 in
                             let precedes1 =
                               let uu____1198 =
                                 let uu____1199 =
                                   let uu____1200 =
-                                    FStar_Syntax_Syntax.as_arg dec  in
+                                    FStar_Syntax_Syntax.as_arg dec in
                                   let uu____1201 =
                                     let uu____1204 =
-                                      FStar_Syntax_Syntax.as_arg previous_dec
-                                       in
-                                    [uu____1204]  in
-                                  uu____1200 :: uu____1201  in
+                                      FStar_Syntax_Syntax.as_arg previous_dec in
+                                    [uu____1204] in
+                                  uu____1200 :: uu____1201 in
                                 FStar_Syntax_Syntax.mk_Tm_app precedes
-                                  uu____1199
-                                 in
-                              uu____1198 FStar_Pervasives_Native.None r  in
-                            let uu____1207 = FStar_Util.prefix formals2  in
+                                  uu____1199 in
+                              uu____1198 FStar_Pervasives_Native.None r in
+                            let uu____1207 = FStar_Util.prefix formals2 in
                             (match uu____1207 with
                              | (bs,(last1,imp)) ->
                                  let last2 =
-                                   let uu___69_1254 = last1  in
+                                   let uu___69_1254 = last1 in
                                    let uu____1255 =
-                                     FStar_Syntax_Util.refine last1 precedes1
-                                      in
+                                     FStar_Syntax_Util.refine last1 precedes1 in
                                    {
                                      FStar_Syntax_Syntax.ppname =
                                        (uu___69_1254.FStar_Syntax_Syntax.ppname);
                                      FStar_Syntax_Syntax.index =
                                        (uu___69_1254.FStar_Syntax_Syntax.index);
                                      FStar_Syntax_Syntax.sort = uu____1255
-                                   }  in
+                                   } in
                                  let refined_formals =
-                                   FStar_List.append bs [(last2, imp)]  in
+                                   FStar_List.append bs [(last2, imp)] in
                                  let t' =
-                                   FStar_Syntax_Util.arrow refined_formals c1
-                                    in
+                                   FStar_Syntax_Util.arrow refined_formals c1 in
                                  ((let uu____1281 =
                                      FStar_TypeChecker_Env.debug env1
-                                       FStar_Options.Low
-                                      in
+                                       FStar_Options.Low in
                                    if uu____1281
                                    then
                                      let uu____1282 =
-                                       FStar_Syntax_Print.lbname_to_string l
-                                        in
+                                       FStar_Syntax_Print.lbname_to_string l in
                                      let uu____1283 =
-                                       FStar_Syntax_Print.term_to_string t
-                                        in
+                                       FStar_Syntax_Print.term_to_string t in
                                      let uu____1284 =
-                                       FStar_Syntax_Print.term_to_string t'
-                                        in
+                                       FStar_Syntax_Print.term_to_string t' in
                                      FStar_Util.print3
                                        "Refined let rec %s\n\tfrom type %s\n\tto type %s\n"
                                        uu____1282 uu____1283 uu____1284
@@ -919,20 +840,18 @@ let (guard_letrecs :
                        FStar_Errors.raise_error
                          (FStar_Errors.Fatal_ExpectedArrowAnnotatedType,
                            "Annotated type of 'let rec' must be an arrow")
-                         t.FStar_Syntax_Syntax.pos)
-               in
+                         t.FStar_Syntax_Syntax.pos) in
             FStar_All.pipe_right letrecs (FStar_List.map guard_one_letrec)
-  
-let rec (tc_term :
+let rec tc_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       tc_maybe_toplevel_term
-        (let uu___70_1739 = env  in
+        (let uu___70_1739 = env in
          {
            FStar_TypeChecker_Env.solver =
              (uu___70_1739.FStar_TypeChecker_Env.solver);
@@ -1004,31 +923,28 @@ let rec (tc_term :
            FStar_TypeChecker_Env.dep_graph =
              (uu___70_1739.FStar_TypeChecker_Env.dep_graph)
          }) e
-
-and (tc_maybe_toplevel_term :
+and tc_maybe_toplevel_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       let env1 =
         if e.FStar_Syntax_Syntax.pos = FStar_Range.dummyRange
         then env
-        else FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos
-         in
-      (let uu____1751 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low
-          in
+        else FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos in
+      (let uu____1751 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
        if uu____1751
        then
          let uu____1752 =
-           let uu____1753 = FStar_TypeChecker_Env.get_range env1  in
-           FStar_All.pipe_left FStar_Range.string_of_range uu____1753  in
-         let uu____1754 = FStar_Syntax_Print.tag_of_term e  in
+           let uu____1753 = FStar_TypeChecker_Env.get_range env1 in
+           FStar_All.pipe_left FStar_Range.string_of_range uu____1753 in
+         let uu____1754 = FStar_Syntax_Print.tag_of_term e in
          FStar_Util.print2 "%s (%s)\n" uu____1752 uu____1754
        else ());
-      (let top = FStar_Syntax_Subst.compress e  in
+      (let top = FStar_Syntax_Subst.compress e in
        match top.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Tm_delayed uu____1763 -> failwith "Impossible"
        | FStar_Syntax_Syntax.Tm_uinst uu____1794 -> tc_value env1 e
@@ -1049,19 +965,18 @@ and (tc_maybe_toplevel_term :
             (uu____1862,uu____1863,ty))
            ->
            let uu____1873 =
-             let uu____1874 = FStar_Syntax_Syntax.mk_Total ty  in
-             FStar_All.pipe_right uu____1874 FStar_Syntax_Util.lcomp_of_comp
-              in
+             let uu____1874 = FStar_Syntax_Syntax.mk_Total ty in
+             FStar_All.pipe_right uu____1874 FStar_Syntax_Util.lcomp_of_comp in
            (top, uu____1873, FStar_TypeChecker_Rel.trivial_guard)
        | FStar_Syntax_Syntax.Tm_meta
            (e1,FStar_Syntax_Syntax.Meta_desugared
             (FStar_Syntax_Syntax.Meta_smt_pat ))
            ->
-           let uu____1880 = tc_tot_or_gtot_term env1 e1  in
+           let uu____1880 = tc_tot_or_gtot_term env1 e1 in
            (match uu____1880 with
             | (e2,c,g) ->
                 let g1 =
-                  let uu___71_1897 = g  in
+                  let uu___71_1897 = g in
                   {
                     FStar_TypeChecker_Env.guard_f =
                       FStar_TypeChecker_Common.Trivial;
@@ -1071,33 +986,32 @@ and (tc_maybe_toplevel_term :
                       (uu___71_1897.FStar_TypeChecker_Env.univ_ineqs);
                     FStar_TypeChecker_Env.implicits =
                       (uu___71_1897.FStar_TypeChecker_Env.implicits)
-                  }  in
+                  } in
                 let uu____1898 =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_meta
                        (e2,
                          (FStar_Syntax_Syntax.Meta_desugared
                             FStar_Syntax_Syntax.Meta_smt_pat)))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
-                   in
+                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos in
                 (uu____1898, c, g1))
        | FStar_Syntax_Syntax.Tm_meta
            (e1,FStar_Syntax_Syntax.Meta_pattern pats) ->
-           let uu____1919 = FStar_Syntax_Util.type_u ()  in
+           let uu____1919 = FStar_Syntax_Util.type_u () in
            (match uu____1919 with
             | (t,u) ->
-                let uu____1932 = tc_check_tot_or_gtot_term env1 e1 t  in
+                let uu____1932 = tc_check_tot_or_gtot_term env1 e1 t in
                 (match uu____1932 with
                  | (e2,c,g) ->
                      let uu____1948 =
                        let uu____1963 =
-                         FStar_TypeChecker_Env.clear_expected_typ env1  in
+                         FStar_TypeChecker_Env.clear_expected_typ env1 in
                        match uu____1963 with
-                       | (env2,uu____1985) -> tc_pats env2 pats  in
+                       | (env2,uu____1985) -> tc_pats env2 pats in
                      (match uu____1948 with
                       | (pats1,g') ->
                           let g'1 =
-                            let uu___72_2019 = g'  in
+                            let uu___72_2019 = g' in
                             {
                               FStar_TypeChecker_Env.guard_f =
                                 FStar_TypeChecker_Common.Trivial;
@@ -1107,25 +1021,24 @@ and (tc_maybe_toplevel_term :
                                 (uu___72_2019.FStar_TypeChecker_Env.univ_ineqs);
                               FStar_TypeChecker_Env.implicits =
                                 (uu___72_2019.FStar_TypeChecker_Env.implicits)
-                            }  in
+                            } in
                           let uu____2020 =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_meta
                                  (e2,
                                    (FStar_Syntax_Syntax.Meta_pattern pats1)))
                               FStar_Pervasives_Native.None
-                              top.FStar_Syntax_Syntax.pos
-                             in
+                              top.FStar_Syntax_Syntax.pos in
                           let uu____2023 =
-                            FStar_TypeChecker_Rel.conj_guard g g'1  in
+                            FStar_TypeChecker_Rel.conj_guard g g'1 in
                           (uu____2020, c, uu____2023))))
        | FStar_Syntax_Syntax.Tm_meta
            (e1,FStar_Syntax_Syntax.Meta_desugared
             (FStar_Syntax_Syntax.Sequence ))
            ->
            let uu____2031 =
-             let uu____2032 = FStar_Syntax_Subst.compress e1  in
-             uu____2032.FStar_Syntax_Syntax.n  in
+             let uu____2032 = FStar_Syntax_Subst.compress e1 in
+             uu____2032.FStar_Syntax_Syntax.n in
            (match uu____2031 with
             | FStar_Syntax_Syntax.Tm_let
                 ((uu____2041,{ FStar_Syntax_Syntax.lbname = x;
@@ -1138,32 +1051,28 @@ and (tc_maybe_toplevel_term :
                 let uu____2075 =
                   let uu____2082 =
                     FStar_TypeChecker_Env.set_expected_typ env1
-                      FStar_Syntax_Syntax.t_unit
-                     in
-                  tc_term uu____2082 e11  in
+                      FStar_Syntax_Syntax.t_unit in
+                  tc_term uu____2082 e11 in
                 (match uu____2075 with
                  | (e12,c1,g1) ->
-                     let uu____2092 = tc_term env1 e2  in
+                     let uu____2092 = tc_term env1 e2 in
                      (match uu____2092 with
                       | (e21,c2,g2) ->
                           let c =
                             FStar_TypeChecker_Util.maybe_return_e2_and_bind
                               e12.FStar_Syntax_Syntax.pos env1
                               (FStar_Pervasives_Native.Some e12) c1 e21
-                              (FStar_Pervasives_Native.None, c2)
-                             in
+                              (FStar_Pervasives_Native.None, c2) in
                           let e13 =
                             FStar_TypeChecker_Util.maybe_lift env1 e12
                               c1.FStar_Syntax_Syntax.eff_name
                               c.FStar_Syntax_Syntax.eff_name
-                              c1.FStar_Syntax_Syntax.res_typ
-                             in
+                              c1.FStar_Syntax_Syntax.res_typ in
                           let e22 =
                             FStar_TypeChecker_Util.maybe_lift env1 e21
                               c2.FStar_Syntax_Syntax.eff_name
                               c.FStar_Syntax_Syntax.eff_name
-                              c2.FStar_Syntax_Syntax.res_typ
-                             in
+                              c2.FStar_Syntax_Syntax.res_typ in
                           let e3 =
                             let uu____2116 =
                               let uu____2119 =
@@ -1174,21 +1083,18 @@ and (tc_maybe_toplevel_term :
                                         FStar_Syntax_Syntax.mk_lb
                                           (x, [],
                                             (c1.FStar_Syntax_Syntax.eff_name),
-                                            FStar_Syntax_Syntax.t_unit, e13)
-                                         in
-                                      [uu____2143]  in
-                                    (false, uu____2140)  in
-                                  (uu____2133, e22)  in
-                                FStar_Syntax_Syntax.Tm_let uu____2120  in
-                              FStar_Syntax_Syntax.mk uu____2119  in
+                                            FStar_Syntax_Syntax.t_unit, e13) in
+                                      [uu____2143] in
+                                    (false, uu____2140) in
+                                  (uu____2133, e22) in
+                                FStar_Syntax_Syntax.Tm_let uu____2120 in
+                              FStar_Syntax_Syntax.mk uu____2119 in
                             uu____2116 FStar_Pervasives_Native.None
-                              e1.FStar_Syntax_Syntax.pos
-                             in
+                              e1.FStar_Syntax_Syntax.pos in
                           let e4 =
                             FStar_TypeChecker_Util.maybe_monadic env1 e3
                               c.FStar_Syntax_Syntax.eff_name
-                              c.FStar_Syntax_Syntax.res_typ
-                             in
+                              c.FStar_Syntax_Syntax.res_typ in
                           let e5 =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_meta
@@ -1196,13 +1102,12 @@ and (tc_maybe_toplevel_term :
                                    (FStar_Syntax_Syntax.Meta_desugared
                                       FStar_Syntax_Syntax.Sequence)))
                               FStar_Pervasives_Native.None
-                              top.FStar_Syntax_Syntax.pos
-                             in
+                              top.FStar_Syntax_Syntax.pos in
                           let uu____2165 =
-                            FStar_TypeChecker_Rel.conj_guard g1 g2  in
+                            FStar_TypeChecker_Rel.conj_guard g1 g2 in
                           (e5, c, uu____2165)))
             | uu____2168 ->
-                let uu____2169 = tc_term env1 e1  in
+                let uu____2169 = tc_term env1 e1 in
                 (match uu____2169 with
                  | (e2,c,g) ->
                      let e3 =
@@ -1212,8 +1117,7 @@ and (tc_maybe_toplevel_term :
                               (FStar_Syntax_Syntax.Meta_desugared
                                  FStar_Syntax_Syntax.Sequence)))
                          FStar_Pervasives_Native.None
-                         top.FStar_Syntax_Syntax.pos
-                        in
+                         top.FStar_Syntax_Syntax.pos in
                      (e3, c, g)))
        | FStar_Syntax_Syntax.Tm_meta
            (e1,FStar_Syntax_Syntax.Meta_monadic uu____2191) ->
@@ -1222,41 +1126,37 @@ and (tc_maybe_toplevel_term :
            (e1,FStar_Syntax_Syntax.Meta_monadic_lift uu____2203) ->
            tc_term env1 e1
        | FStar_Syntax_Syntax.Tm_meta (e1,m) ->
-           let uu____2222 = tc_term env1 e1  in
+           let uu____2222 = tc_term env1 e1 in
            (match uu____2222 with
             | (e2,c,g) ->
                 let e3 =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_meta (e2, m))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
-                   in
+                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos in
                 (e3, c, g))
        | FStar_Syntax_Syntax.Tm_ascribed
            (e1,(FStar_Util.Inr expected_c,topt),uu____2246) ->
-           let uu____2293 = FStar_TypeChecker_Env.clear_expected_typ env1  in
+           let uu____2293 = FStar_TypeChecker_Env.clear_expected_typ env1 in
            (match uu____2293 with
             | (env0,uu____2307) ->
-                let uu____2312 = tc_comp env0 expected_c  in
+                let uu____2312 = tc_comp env0 expected_c in
                 (match uu____2312 with
                  | (expected_c1,uu____2326,g) ->
-                     let t_res = FStar_Syntax_Util.comp_result expected_c1
-                        in
+                     let t_res = FStar_Syntax_Util.comp_result expected_c1 in
                      let uu____2331 =
                        let uu____2338 =
-                         FStar_TypeChecker_Env.set_expected_typ env0 t_res
-                          in
-                       tc_term uu____2338 e1  in
+                         FStar_TypeChecker_Env.set_expected_typ env0 t_res in
+                       tc_term uu____2338 e1 in
                      (match uu____2331 with
                       | (e2,c',g') ->
                           let uu____2348 =
                             let uu____2355 =
                               let uu____2360 =
-                                FStar_Syntax_Syntax.lcomp_comp c'  in
-                              (e2, uu____2360)  in
+                                FStar_Syntax_Syntax.lcomp_comp c' in
+                              (e2, uu____2360) in
                             check_expected_effect env0
                               (FStar_Pervasives_Native.Some expected_c1)
-                              uu____2355
-                             in
+                              uu____2355 in
                           (match uu____2348 with
                            | (e3,expected_c2,g'') ->
                                let e4 =
@@ -1269,19 +1169,15 @@ and (tc_maybe_toplevel_term :
                                            (FStar_Syntax_Util.comp_effect_name
                                               expected_c2))))
                                    FStar_Pervasives_Native.None
-                                   top.FStar_Syntax_Syntax.pos
-                                  in
+                                   top.FStar_Syntax_Syntax.pos in
                                let lc =
-                                 FStar_Syntax_Util.lcomp_of_comp expected_c2
-                                  in
+                                 FStar_Syntax_Util.lcomp_of_comp expected_c2 in
                                let f =
                                  let uu____2405 =
-                                   FStar_TypeChecker_Rel.conj_guard g' g''
-                                    in
+                                   FStar_TypeChecker_Rel.conj_guard g' g'' in
                                  FStar_TypeChecker_Rel.conj_guard g
-                                   uu____2405
-                                  in
-                               let topt1 = tc_tactic_opt env0 topt  in
+                                   uu____2405 in
+                               let topt1 = tc_tactic_opt env0 topt in
                                let f1 =
                                  match topt1 with
                                  | FStar_Pervasives_Native.None  -> f
@@ -1290,45 +1186,40 @@ and (tc_maybe_toplevel_term :
                                        (fun f1  ->
                                           let uu____2414 =
                                             FStar_Syntax_Util.mk_squash
-                                              FStar_Syntax_Syntax.U_zero f1
-                                             in
+                                              FStar_Syntax_Syntax.U_zero f1 in
                                           FStar_TypeChecker_Common.mk_by_tactic
-                                            tactic uu____2414)
-                                  in
+                                            tactic uu____2414) in
                                let uu____2415 =
-                                 comp_check_expected_typ env1 e4 lc  in
+                                 comp_check_expected_typ env1 e4 lc in
                                (match uu____2415 with
                                 | (e5,c,f2) ->
                                     let final_guard =
-                                      FStar_TypeChecker_Rel.conj_guard f1 f2
-                                       in
+                                      FStar_TypeChecker_Rel.conj_guard f1 f2 in
                                     (e5, c, final_guard))))))
        | FStar_Syntax_Syntax.Tm_ascribed
            (e1,(FStar_Util.Inl t,topt),uu____2435) ->
-           let uu____2482 = FStar_Syntax_Util.type_u ()  in
+           let uu____2482 = FStar_Syntax_Util.type_u () in
            (match uu____2482 with
             | (k,u) ->
-                let uu____2495 = tc_check_tot_or_gtot_term env1 t k  in
+                let uu____2495 = tc_check_tot_or_gtot_term env1 t k in
                 (match uu____2495 with
                  | (t1,uu____2509,f) ->
                      let uu____2511 =
                        let uu____2518 =
-                         FStar_TypeChecker_Env.set_expected_typ env1 t1  in
-                       tc_term uu____2518 e1  in
+                         FStar_TypeChecker_Env.set_expected_typ env1 t1 in
+                       tc_term uu____2518 e1 in
                      (match uu____2511 with
                       | (e2,c,g) ->
                           let uu____2528 =
                             let uu____2533 =
                               FStar_TypeChecker_Env.set_range env1
-                                t1.FStar_Syntax_Syntax.pos
-                               in
+                                t1.FStar_Syntax_Syntax.pos in
                             FStar_TypeChecker_Util.strengthen_precondition
                               (FStar_Pervasives_Native.Some
                                  (fun uu____2537  ->
                                     FStar_Util.return_all
                                       FStar_TypeChecker_Err.ill_kinded_type))
-                              uu____2533 e2 c f
-                             in
+                              uu____2533 e2 c f in
                           (match uu____2528 with
                            | (c1,f1) ->
                                let uu____2546 =
@@ -1341,19 +1232,15 @@ and (tc_maybe_toplevel_term :
                                           (FStar_Pervasives_Native.Some
                                              (c1.FStar_Syntax_Syntax.eff_name))))
                                      FStar_Pervasives_Native.None
-                                     top.FStar_Syntax_Syntax.pos
-                                    in
-                                 comp_check_expected_typ env1 uu____2553 c1
-                                  in
+                                     top.FStar_Syntax_Syntax.pos in
+                                 comp_check_expected_typ env1 uu____2553 c1 in
                                (match uu____2546 with
                                 | (e3,c2,f2) ->
                                     let uu____2593 =
                                       let uu____2594 =
-                                        FStar_TypeChecker_Rel.conj_guard g f2
-                                         in
+                                        FStar_TypeChecker_Rel.conj_guard g f2 in
                                       FStar_TypeChecker_Rel.conj_guard f1
-                                        uu____2594
-                                       in
+                                        uu____2594 in
                                     (e3, c2, uu____2593))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1362,24 +1249,21 @@ and (tc_maybe_toplevel_term :
               FStar_Syntax_Syntax.pos = uu____2595;
               FStar_Syntax_Syntax.vars = uu____2596;_},a::hd1::rest)
            ->
-           let rest1 = hd1 :: rest  in
-           let uu____2659 = FStar_Syntax_Util.head_and_args top  in
+           let rest1 = hd1 :: rest in
+           let uu____2659 = FStar_Syntax_Util.head_and_args top in
            (match uu____2659 with
             | (unary_op,uu____2681) ->
                 let head1 =
                   let uu____2705 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
-                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
-                     in
+                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                    FStar_Pervasives_Native.None uu____2705
-                   in
+                    FStar_Pervasives_Native.None uu____2705 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head1, rest1))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
-                   in
+                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos in
                 tc_term env1 t)
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1388,24 +1272,21 @@ and (tc_maybe_toplevel_term :
               FStar_Syntax_Syntax.pos = uu____2743;
               FStar_Syntax_Syntax.vars = uu____2744;_},a::hd1::rest)
            ->
-           let rest1 = hd1 :: rest  in
-           let uu____2807 = FStar_Syntax_Util.head_and_args top  in
+           let rest1 = hd1 :: rest in
+           let uu____2807 = FStar_Syntax_Util.head_and_args top in
            (match uu____2807 with
             | (unary_op,uu____2829) ->
                 let head1 =
                   let uu____2853 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
-                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
-                     in
+                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                    FStar_Pervasives_Native.None uu____2853
-                   in
+                    FStar_Pervasives_Native.None uu____2853 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head1, rest1))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
-                   in
+                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos in
                 tc_term env1 t)
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1414,24 +1295,21 @@ and (tc_maybe_toplevel_term :
               FStar_Syntax_Syntax.pos = uu____2892;
               FStar_Syntax_Syntax.vars = uu____2893;_},a::hd1::rest)
            ->
-           let rest1 = hd1 :: rest  in
-           let uu____2956 = FStar_Syntax_Util.head_and_args top  in
+           let rest1 = hd1 :: rest in
+           let uu____2956 = FStar_Syntax_Util.head_and_args top in
            (match uu____2956 with
             | (unary_op,uu____2978) ->
                 let head1 =
                   let uu____3002 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
-                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
-                     in
+                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                    FStar_Pervasives_Native.None uu____3002
-                   in
+                    FStar_Pervasives_Native.None uu____3002 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head1, rest1))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
-                   in
+                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos in
                 tc_term env1 t)
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1440,24 +1318,21 @@ and (tc_maybe_toplevel_term :
               FStar_Syntax_Syntax.pos = uu____3040;
               FStar_Syntax_Syntax.vars = uu____3041;_},a1::a2::hd1::rest)
            ->
-           let rest1 = hd1 :: rest  in
-           let uu____3117 = FStar_Syntax_Util.head_and_args top  in
+           let rest1 = hd1 :: rest in
+           let uu____3117 = FStar_Syntax_Util.head_and_args top in
            (match uu____3117 with
             | (unary_op,uu____3139) ->
                 let head1 =
                   let uu____3163 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
-                      (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos
-                     in
+                      (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))
-                    FStar_Pervasives_Native.None uu____3163
-                   in
+                    FStar_Pervasives_Native.None uu____3163 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head1, rest1))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
-                   in
+                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos in
                 tc_term env1 t)
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1469,13 +1344,12 @@ and (tc_maybe_toplevel_term :
            ->
            let uu____3246 =
              let uu____3253 =
-               let uu____3254 = FStar_TypeChecker_Env.clear_expected_typ env1
-                  in
-               FStar_All.pipe_left FStar_Pervasives_Native.fst uu____3254  in
-             tc_term uu____3253 e1  in
+               let uu____3254 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               FStar_All.pipe_left FStar_Pervasives_Native.fst uu____3254 in
+             tc_term uu____3253 e1 in
            (match uu____3246 with
             | (e2,c,g) ->
-                let uu____3278 = FStar_Syntax_Util.head_and_args top  in
+                let uu____3278 = FStar_Syntax_Util.head_and_args top in
                 (match uu____3278 with
                  | (head1,uu____3300) ->
                      let uu____3321 =
@@ -1483,18 +1357,15 @@ and (tc_maybe_toplevel_term :
                          (FStar_Syntax_Syntax.Tm_app
                             (head1, [(e2, FStar_Pervasives_Native.None)]))
                          FStar_Pervasives_Native.None
-                         top.FStar_Syntax_Syntax.pos
-                        in
+                         top.FStar_Syntax_Syntax.pos in
                      let uu____3348 =
                        let uu____3349 =
                          let uu____3352 =
                            FStar_Syntax_Syntax.tabbrev
-                             FStar_Parser_Const.range_lid
-                            in
-                         FStar_Syntax_Syntax.mk_Total uu____3352  in
+                             FStar_Parser_Const.range_lid in
+                         FStar_Syntax_Syntax.mk_Total uu____3352 in
                        FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                         uu____3349
-                        in
+                         uu____3349 in
                      (uu____3321, uu____3348, g)))
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1505,36 +1376,33 @@ and (tc_maybe_toplevel_term :
                                                         )::(r,FStar_Pervasives_Native.None
                                                             )::[])
            ->
-           let uu____3411 = FStar_Syntax_Util.head_and_args top  in
+           let uu____3411 = FStar_Syntax_Util.head_and_args top in
            (match uu____3411 with
             | (head1,uu____3433) ->
                 let env' =
                   let uu____3455 =
-                    FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid
-                     in
-                  FStar_TypeChecker_Env.set_expected_typ env1 uu____3455  in
-                let uu____3456 = tc_term env' r  in
+                    FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid in
+                  FStar_TypeChecker_Env.set_expected_typ env1 uu____3455 in
+                let uu____3456 = tc_term env' r in
                 (match uu____3456 with
                  | (er,uu____3470,gr) ->
-                     let uu____3472 = tc_term env1 t  in
+                     let uu____3472 = tc_term env1 t in
                      (match uu____3472 with
                       | (t1,tt,gt1) ->
-                          let g = FStar_TypeChecker_Rel.conj_guard gr gt1  in
+                          let g = FStar_TypeChecker_Rel.conj_guard gr gt1 in
                           let uu____3489 =
                             let uu____3492 =
                               let uu____3493 =
                                 let uu____3494 =
-                                  FStar_Syntax_Syntax.as_arg t1  in
+                                  FStar_Syntax_Syntax.as_arg t1 in
                                 let uu____3495 =
                                   let uu____3498 =
-                                    FStar_Syntax_Syntax.as_arg r  in
-                                  [uu____3498]  in
-                                uu____3494 :: uu____3495  in
-                              FStar_Syntax_Syntax.mk_Tm_app head1 uu____3493
-                               in
+                                    FStar_Syntax_Syntax.as_arg r in
+                                  [uu____3498] in
+                                uu____3494 :: uu____3495 in
+                              FStar_Syntax_Syntax.mk_Tm_app head1 uu____3493 in
                             uu____3492 FStar_Pervasives_Native.None
-                              top.FStar_Syntax_Syntax.pos
-                             in
+                              top.FStar_Syntax_Syntax.pos in
                           (uu____3489, tt, g))))
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1545,9 +1413,9 @@ and (tc_maybe_toplevel_term :
            ->
            let uu____3526 =
              let uu____3531 =
-               let uu____3532 = FStar_Syntax_Print.term_to_string top  in
-               FStar_Util.format1 "Ill-applied constant %s" uu____3532  in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu____3531)  in
+               let uu____3532 = FStar_Syntax_Print.term_to_string top in
+               FStar_Util.format1 "Ill-applied constant %s" uu____3532 in
+             (FStar_Errors.Fatal_IllAppliedConstant, uu____3531) in
            FStar_Errors.raise_error uu____3526 e.FStar_Syntax_Syntax.pos
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1558,9 +1426,9 @@ and (tc_maybe_toplevel_term :
            ->
            let uu____3562 =
              let uu____3567 =
-               let uu____3568 = FStar_Syntax_Print.term_to_string top  in
-               FStar_Util.format1 "Ill-applied constant %s" uu____3568  in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu____3567)  in
+               let uu____3568 = FStar_Syntax_Print.term_to_string top in
+               FStar_Util.format1 "Ill-applied constant %s" uu____3568 in
+             (FStar_Errors.Fatal_IllAppliedConstant, uu____3567) in
            FStar_Errors.raise_error uu____3562 e.FStar_Syntax_Syntax.pos
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1575,41 +1443,37 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReify,
                   "Qualifier on argument to reify is irrelevant and will be ignored")
             else ();
-            (let uu____3609 = FStar_TypeChecker_Env.clear_expected_typ env1
-                in
+            (let uu____3609 = FStar_TypeChecker_Env.clear_expected_typ env1 in
              match uu____3609 with
              | (env0,uu____3623) ->
-                 let uu____3628 = tc_term env0 e1  in
+                 let uu____3628 = tc_term env0 e1 in
                  (match uu____3628 with
                   | (e2,c,g) ->
-                      let uu____3644 = FStar_Syntax_Util.head_and_args top
-                         in
+                      let uu____3644 = FStar_Syntax_Util.head_and_args top in
                       (match uu____3644 with
                        | (reify_op,uu____3666) ->
                            let u_c =
                              let uu____3688 =
-                               tc_term env0 c.FStar_Syntax_Syntax.res_typ  in
+                               tc_term env0 c.FStar_Syntax_Syntax.res_typ in
                              match uu____3688 with
                              | (uu____3695,c',uu____3697) ->
                                  let uu____3698 =
                                    let uu____3699 =
                                      FStar_Syntax_Subst.compress
-                                       c'.FStar_Syntax_Syntax.res_typ
-                                      in
-                                   uu____3699.FStar_Syntax_Syntax.n  in
+                                       c'.FStar_Syntax_Syntax.res_typ in
+                                   uu____3699.FStar_Syntax_Syntax.n in
                                  (match uu____3698 with
                                   | FStar_Syntax_Syntax.Tm_type u -> u
                                   | uu____3703 ->
                                       let uu____3704 =
-                                        FStar_Syntax_Util.type_u ()  in
+                                        FStar_Syntax_Util.type_u () in
                                       (match uu____3704 with
                                        | (t,u) ->
                                            let g_opt =
                                              FStar_TypeChecker_Rel.try_teq
                                                true env1
                                                c'.FStar_Syntax_Syntax.res_typ
-                                               t
-                                              in
+                                               t in
                                            ((match g_opt with
                                              | FStar_Pervasives_Native.Some
                                                  g' ->
@@ -1620,49 +1484,41 @@ and (tc_maybe_toplevel_term :
                                                  let uu____3716 =
                                                    let uu____3717 =
                                                      FStar_Syntax_Print.lcomp_to_string
-                                                       c'
-                                                      in
+                                                       c' in
                                                    let uu____3718 =
                                                      FStar_Syntax_Print.term_to_string
-                                                       c.FStar_Syntax_Syntax.res_typ
-                                                      in
+                                                       c.FStar_Syntax_Syntax.res_typ in
                                                    let uu____3719 =
                                                      FStar_Syntax_Print.term_to_string
-                                                       c'.FStar_Syntax_Syntax.res_typ
-                                                      in
+                                                       c'.FStar_Syntax_Syntax.res_typ in
                                                    FStar_Util.format3
                                                      "Unexpected result type of computation. The computation type %s of the term %s should have type Type n for some level n but has type %s"
                                                      uu____3717 uu____3718
-                                                     uu____3719
-                                                    in
+                                                     uu____3719 in
                                                  failwith uu____3716);
-                                            u)))
-                              in
+                                            u))) in
                            let repr =
                              let uu____3721 =
-                               FStar_Syntax_Syntax.lcomp_comp c  in
+                               FStar_Syntax_Syntax.lcomp_comp c in
                              FStar_TypeChecker_Env.reify_comp env1 uu____3721
-                               u_c
-                              in
+                               u_c in
                            let e3 =
                              FStar_Syntax_Syntax.mk
                                (FStar_Syntax_Syntax.Tm_app
                                   (reify_op, [(e2, aqual)]))
                                FStar_Pervasives_Native.None
-                               top.FStar_Syntax_Syntax.pos
-                              in
+                               top.FStar_Syntax_Syntax.pos in
                            let c1 =
                              let uu____3742 =
-                               FStar_Syntax_Syntax.mk_Total repr  in
+                               FStar_Syntax_Syntax.mk_Total repr in
                              FStar_All.pipe_right uu____3742
-                               FStar_Syntax_Util.lcomp_of_comp
-                              in
+                               FStar_Syntax_Util.lcomp_of_comp in
                            let uu____3743 =
-                             comp_check_expected_typ env1 e3 c1  in
+                             comp_check_expected_typ env1 e3 c1 in
                            (match uu____3743 with
                             | (e4,c2,g') ->
                                 let uu____3759 =
-                                  FStar_TypeChecker_Rel.conj_guard g g'  in
+                                  FStar_TypeChecker_Rel.conj_guard g g' in
                                 (e4, c2, uu____3759))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
@@ -1681,40 +1537,35 @@ and (tc_maybe_toplevel_term :
                let uu____3805 =
                  let uu____3810 =
                    FStar_Util.format1 "Effect %s cannot be reified"
-                     l.FStar_Ident.str
-                    in
-                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____3810)  in
-               FStar_Errors.raise_error uu____3805 e1.FStar_Syntax_Syntax.pos
-                in
-             let uu____3817 = FStar_Syntax_Util.head_and_args top  in
+                     l.FStar_Ident.str in
+                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____3810) in
+               FStar_Errors.raise_error uu____3805 e1.FStar_Syntax_Syntax.pos in
+             let uu____3817 = FStar_Syntax_Util.head_and_args top in
              match uu____3817 with
              | (reflect_op,uu____3839) ->
                  let uu____3860 =
-                   FStar_TypeChecker_Env.effect_decl_opt env1 l  in
+                   FStar_TypeChecker_Env.effect_decl_opt env1 l in
                  (match uu____3860 with
                   | FStar_Pervasives_Native.None  -> no_reflect ()
                   | FStar_Pervasives_Native.Some (ed,qualifiers) ->
                       let uu____3893 =
                         let uu____3894 =
                           FStar_All.pipe_right qualifiers
-                            FStar_Syntax_Syntax.contains_reflectable
-                           in
-                        Prims.op_Negation uu____3894  in
+                            FStar_Syntax_Syntax.contains_reflectable in
+                        Prims.op_Negation uu____3894 in
                       if uu____3893
                       then no_reflect ()
                       else
                         (let uu____3904 =
-                           FStar_TypeChecker_Env.clear_expected_typ env1  in
+                           FStar_TypeChecker_Env.clear_expected_typ env1 in
                          match uu____3904 with
                          | (env_no_ex,topt) ->
                              let uu____3923 =
-                               let u = FStar_TypeChecker_Env.new_u_univ ()
-                                  in
+                               let u = FStar_TypeChecker_Env.new_u_univ () in
                                let repr =
                                  FStar_TypeChecker_Env.inst_effect_fun_with
                                    [u] env1 ed
-                                   ([], (ed.FStar_Syntax_Syntax.repr))
-                                  in
+                                   ([], (ed.FStar_Syntax_Syntax.repr)) in
                                let t =
                                  let uu____3943 =
                                    let uu____3946 =
@@ -1722,60 +1573,51 @@ and (tc_maybe_toplevel_term :
                                        let uu____3962 =
                                          let uu____3965 =
                                            FStar_Syntax_Syntax.as_arg
-                                             FStar_Syntax_Syntax.tun
-                                            in
+                                             FStar_Syntax_Syntax.tun in
                                          let uu____3966 =
                                            let uu____3969 =
                                              FStar_Syntax_Syntax.as_arg
-                                               FStar_Syntax_Syntax.tun
-                                              in
-                                           [uu____3969]  in
-                                         uu____3965 :: uu____3966  in
-                                       (repr, uu____3962)  in
-                                     FStar_Syntax_Syntax.Tm_app uu____3947
-                                      in
-                                   FStar_Syntax_Syntax.mk uu____3946  in
+                                               FStar_Syntax_Syntax.tun in
+                                           [uu____3969] in
+                                         uu____3965 :: uu____3966 in
+                                       (repr, uu____3962) in
+                                     FStar_Syntax_Syntax.Tm_app uu____3947 in
+                                   FStar_Syntax_Syntax.mk uu____3946 in
                                  uu____3943 FStar_Pervasives_Native.None
-                                   top.FStar_Syntax_Syntax.pos
-                                  in
+                                   top.FStar_Syntax_Syntax.pos in
                                let uu____3975 =
                                  let uu____3982 =
                                    let uu____3983 =
                                      FStar_TypeChecker_Env.clear_expected_typ
-                                       env1
-                                      in
+                                       env1 in
                                    FStar_All.pipe_right uu____3983
-                                     FStar_Pervasives_Native.fst
-                                    in
-                                 tc_tot_or_gtot_term uu____3982 t  in
+                                     FStar_Pervasives_Native.fst in
+                                 tc_tot_or_gtot_term uu____3982 t in
                                match uu____3975 with
                                | (t1,uu____4011,g) ->
                                    let uu____4013 =
                                      let uu____4014 =
-                                       FStar_Syntax_Subst.compress t1  in
-                                     uu____4014.FStar_Syntax_Syntax.n  in
+                                       FStar_Syntax_Subst.compress t1 in
+                                     uu____4014.FStar_Syntax_Syntax.n in
                                    (match uu____4013 with
                                     | FStar_Syntax_Syntax.Tm_app
                                         (uu____4029,(res,uu____4031)::
                                          (wp,uu____4033)::[])
                                         -> (t1, res, wp, g)
-                                    | uu____4076 -> failwith "Impossible")
-                                in
+                                    | uu____4076 -> failwith "Impossible") in
                              (match uu____3923 with
                               | (expected_repr_typ,res_typ,wp,g0) ->
                                   let uu____4107 =
                                     let uu____4112 =
-                                      tc_tot_or_gtot_term env_no_ex e1  in
+                                      tc_tot_or_gtot_term env_no_ex e1 in
                                     match uu____4112 with
                                     | (e2,c,g) ->
                                         ((let uu____4127 =
                                             let uu____4128 =
                                               FStar_Syntax_Util.is_total_lcomp
-                                                c
-                                               in
+                                                c in
                                             FStar_All.pipe_left
-                                              Prims.op_Negation uu____4128
-                                             in
+                                              Prims.op_Negation uu____4128 in
                                           if uu____4127
                                           then
                                             FStar_TypeChecker_Err.add_errors
@@ -1788,8 +1630,7 @@ and (tc_maybe_toplevel_term :
                                             FStar_TypeChecker_Rel.try_teq
                                               true env_no_ex
                                               c.FStar_Syntax_Syntax.res_typ
-                                              expected_repr_typ
-                                             in
+                                              expected_repr_typ in
                                           match uu____4142 with
                                           | FStar_Pervasives_Native.None  ->
                                               ((let uu____4150 =
@@ -1797,40 +1638,32 @@ and (tc_maybe_toplevel_term :
                                                     let uu____4166 =
                                                       let uu____4167 =
                                                         FStar_Syntax_Print.term_to_string
-                                                          ed.FStar_Syntax_Syntax.repr
-                                                         in
+                                                          ed.FStar_Syntax_Syntax.repr in
                                                       let uu____4168 =
                                                         FStar_Syntax_Print.term_to_string
-                                                          c.FStar_Syntax_Syntax.res_typ
-                                                         in
+                                                          c.FStar_Syntax_Syntax.res_typ in
                                                       FStar_Util.format2
                                                         "Expected an instance of %s; got %s"
-                                                        uu____4167 uu____4168
-                                                       in
+                                                        uu____4167 uu____4168 in
                                                     (FStar_Errors.Error_UnexpectedInstance,
                                                       uu____4166,
-                                                      (e2.FStar_Syntax_Syntax.pos))
-                                                     in
-                                                  [uu____4159]  in
+                                                      (e2.FStar_Syntax_Syntax.pos)) in
+                                                  [uu____4159] in
                                                 FStar_TypeChecker_Err.add_errors
                                                   env1 uu____4150);
                                                (let uu____4181 =
                                                   FStar_TypeChecker_Rel.conj_guard
-                                                    g g0
-                                                   in
+                                                    g g0 in
                                                 (e2, uu____4181)))
                                           | FStar_Pervasives_Native.Some g'
                                               ->
                                               let uu____4183 =
                                                 let uu____4184 =
                                                   FStar_TypeChecker_Rel.conj_guard
-                                                    g g0
-                                                   in
+                                                    g g0 in
                                                 FStar_TypeChecker_Rel.conj_guard
-                                                  g' uu____4184
-                                                 in
-                                              (e2, uu____4183)))
-                                     in
+                                                  g' uu____4184 in
+                                              (e2, uu____4183))) in
                                   (match uu____4107 with
                                    | (e2,g) ->
                                        let c =
@@ -1839,15 +1672,13 @@ and (tc_maybe_toplevel_term :
                                              let uu____4196 =
                                                let uu____4197 =
                                                  env1.FStar_TypeChecker_Env.universe_of
-                                                   env1 res_typ
-                                                  in
-                                               [uu____4197]  in
+                                                   env1 res_typ in
+                                               [uu____4197] in
                                              let uu____4198 =
                                                let uu____4207 =
                                                  FStar_Syntax_Syntax.as_arg
-                                                   wp
-                                                  in
-                                               [uu____4207]  in
+                                                   wp in
+                                               [uu____4207] in
                                              {
                                                FStar_Syntax_Syntax.comp_univs
                                                  = uu____4196;
@@ -1859,124 +1690,109 @@ and (tc_maybe_toplevel_term :
                                                FStar_Syntax_Syntax.effect_args
                                                  = uu____4198;
                                                FStar_Syntax_Syntax.flags = []
-                                             }  in
+                                             } in
                                            FStar_Syntax_Syntax.mk_Comp
-                                             uu____4195
-                                            in
+                                             uu____4195 in
                                          FStar_All.pipe_right uu____4194
-                                           FStar_Syntax_Util.lcomp_of_comp
-                                          in
+                                           FStar_Syntax_Util.lcomp_of_comp in
                                        let e3 =
                                          FStar_Syntax_Syntax.mk
                                            (FStar_Syntax_Syntax.Tm_app
                                               (reflect_op, [(e2, aqual)]))
                                            FStar_Pervasives_Native.None
-                                           top.FStar_Syntax_Syntax.pos
-                                          in
+                                           top.FStar_Syntax_Syntax.pos in
                                        let uu____4227 =
-                                         comp_check_expected_typ env1 e3 c
-                                          in
+                                         comp_check_expected_typ env1 e3 c in
                                        (match uu____4227 with
                                         | (e4,c1,g') ->
                                             let uu____4243 =
                                               FStar_TypeChecker_Rel.conj_guard
-                                                g' g
-                                               in
+                                                g' g in
                                             (e4, c1, uu____4243))))))))
        | FStar_Syntax_Syntax.Tm_app (head1,args) when
            FStar_Syntax_Util.is_synth_by_tactic head1 ->
            tc_synth env1 args top.FStar_Syntax_Syntax.pos
        | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-           let env0 = env1  in
+           let env0 = env1 in
            let env2 =
              let uu____4290 =
-               let uu____4291 = FStar_TypeChecker_Env.clear_expected_typ env1
-                  in
-               FStar_All.pipe_right uu____4291 FStar_Pervasives_Native.fst
-                in
-             FStar_All.pipe_right uu____4290 instantiate_both  in
+               let uu____4291 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               FStar_All.pipe_right uu____4291 FStar_Pervasives_Native.fst in
+             FStar_All.pipe_right uu____4290 instantiate_both in
            ((let uu____4307 =
-               FStar_TypeChecker_Env.debug env2 FStar_Options.High  in
+               FStar_TypeChecker_Env.debug env2 FStar_Options.High in
              if uu____4307
              then
                let uu____4308 =
-                 FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos  in
-               let uu____4309 = FStar_Syntax_Print.term_to_string top  in
+                 FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos in
+               let uu____4309 = FStar_Syntax_Print.term_to_string top in
                FStar_Util.print2 "(%s) Checking app %s\n" uu____4308
                  uu____4309
              else ());
             (let isquote =
-               let uu____4312 = FStar_Syntax_Util.head_and_args head1  in
+               let uu____4312 = FStar_Syntax_Util.head_and_args head1 in
                match uu____4312 with
                | (head2,uu____4328) ->
                    let uu____4349 =
-                     let uu____4350 = FStar_Syntax_Util.un_uinst head2  in
-                     uu____4350.FStar_Syntax_Syntax.n  in
+                     let uu____4350 = FStar_Syntax_Util.un_uinst head2 in
+                     uu____4350.FStar_Syntax_Syntax.n in
                    (match uu____4349 with
                     | FStar_Syntax_Syntax.Tm_fvar fv when
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.quote_lid
                         -> true
-                    | uu____4354 -> false)
-                in
-             let uu____4355 = tc_term (no_inst env2) head1  in
+                    | uu____4354 -> false) in
+             let uu____4355 = tc_term (no_inst env2) head1 in
              match uu____4355 with
              | (head2,chead,g_head) ->
                  let uu____4371 =
                    let uu____4378 =
                      (Prims.op_Negation env2.FStar_TypeChecker_Env.lax) &&
-                       (FStar_TypeChecker_Util.short_circuit_head head2)
-                      in
+                       (FStar_TypeChecker_Util.short_circuit_head head2) in
                    if uu____4378
                    then
                      let uu____4385 =
                        let uu____4392 =
-                         FStar_TypeChecker_Env.expected_typ env0  in
+                         FStar_TypeChecker_Env.expected_typ env0 in
                        check_short_circuit_args env2 head2 chead g_head args
-                         uu____4392
-                        in
+                         uu____4392 in
                      match uu____4385 with | (e1,c,g) -> (e1, c, g)
                    else
-                     (let env3 = if isquote then no_inst env2 else env2  in
+                     (let env3 = if isquote then no_inst env2 else env2 in
                       let uu____4407 =
-                        FStar_TypeChecker_Env.expected_typ env0  in
+                        FStar_TypeChecker_Env.expected_typ env0 in
                       check_application_args env3 head2 chead g_head args
-                        uu____4407)
-                    in
+                        uu____4407) in
                  (match uu____4371 with
                   | (e1,c,g) ->
                       ((let uu____4420 =
                           FStar_TypeChecker_Env.debug env2
-                            FStar_Options.Extreme
-                           in
+                            FStar_Options.Extreme in
                         if uu____4420
                         then
                           let uu____4421 =
-                            FStar_TypeChecker_Rel.print_pending_implicits g
-                             in
+                            FStar_TypeChecker_Rel.print_pending_implicits g in
                           FStar_Util.print1
                             "Introduced {%s} implicits in application\n"
                             uu____4421
                         else ());
-                       (let uu____4423 = comp_check_expected_typ env0 e1 c
-                           in
+                       (let uu____4423 = comp_check_expected_typ env0 e1 c in
                         match uu____4423 with
                         | (e2,c1,g') ->
                             let gimp =
                               let uu____4440 =
                                 let uu____4441 =
-                                  FStar_Syntax_Subst.compress head2  in
-                                uu____4441.FStar_Syntax_Syntax.n  in
+                                  FStar_Syntax_Subst.compress head2 in
+                                uu____4441.FStar_Syntax_Syntax.n in
                               match uu____4440 with
                               | FStar_Syntax_Syntax.Tm_uvar (u,uu____4445) ->
                                   let imp =
                                     ("head of application is a uvar", env0,
                                       u, e2,
                                       (c1.FStar_Syntax_Syntax.res_typ),
-                                      (head2.FStar_Syntax_Syntax.pos))
-                                     in
+                                      (head2.FStar_Syntax_Syntax.pos)) in
                                   let uu___73_4507 =
-                                    FStar_TypeChecker_Rel.trivial_guard  in
+                                    FStar_TypeChecker_Rel.trivial_guard in
                                   {
                                     FStar_TypeChecker_Env.guard_f =
                                       (uu___73_4507.FStar_TypeChecker_Env.guard_f);
@@ -1987,63 +1803,56 @@ and (tc_maybe_toplevel_term :
                                     FStar_TypeChecker_Env.implicits = [imp]
                                   }
                               | uu____4556 ->
-                                  FStar_TypeChecker_Rel.trivial_guard
-                               in
+                                  FStar_TypeChecker_Rel.trivial_guard in
                             let gres =
                               let uu____4558 =
-                                FStar_TypeChecker_Rel.conj_guard g' gimp  in
-                              FStar_TypeChecker_Rel.conj_guard g uu____4558
-                               in
+                                FStar_TypeChecker_Rel.conj_guard g' gimp in
+                              FStar_TypeChecker_Rel.conj_guard g uu____4558 in
                             ((let uu____4560 =
                                 FStar_TypeChecker_Env.debug env2
-                                  FStar_Options.Extreme
-                                 in
+                                  FStar_Options.Extreme in
                               if uu____4560
                               then
                                 let uu____4561 =
-                                  FStar_Syntax_Print.term_to_string e2  in
+                                  FStar_Syntax_Print.term_to_string e2 in
                                 let uu____4562 =
                                   FStar_TypeChecker_Rel.guard_to_string env2
-                                    gres
-                                   in
+                                    gres in
                                 FStar_Util.print2
                                   "Guard from application node %s is %s\n"
                                   uu____4561 uu____4562
                               else ());
                              (e2, c1, gres)))))))
        | FStar_Syntax_Syntax.Tm_match (e1,eqns) ->
-           let uu____4602 = FStar_TypeChecker_Env.clear_expected_typ env1  in
+           let uu____4602 = FStar_TypeChecker_Env.clear_expected_typ env1 in
            (match uu____4602 with
             | (env11,topt) ->
-                let env12 = instantiate_both env11  in
-                let uu____4622 = tc_term env12 e1  in
+                let env12 = instantiate_both env11 in
+                let uu____4622 = tc_term env12 e1 in
                 (match uu____4622 with
                  | (e11,c1,g1) ->
                      let uu____4638 =
                        match topt with
                        | FStar_Pervasives_Native.Some t -> (env1, t)
                        | FStar_Pervasives_Native.None  ->
-                           let uu____4648 = FStar_Syntax_Util.type_u ()  in
+                           let uu____4648 = FStar_Syntax_Util.type_u () in
                            (match uu____4648 with
                             | (k,uu____4658) ->
                                 let res_t =
-                                  FStar_TypeChecker_Util.new_uvar env1 k  in
+                                  FStar_TypeChecker_Util.new_uvar env1 k in
                                 let uu____4660 =
                                   FStar_TypeChecker_Env.set_expected_typ env1
-                                    res_t
-                                   in
-                                (uu____4660, res_t))
-                        in
+                                    res_t in
+                                (uu____4660, res_t)) in
                      (match uu____4638 with
                       | (env_branches,res_t) ->
                           ((let uu____4670 =
                               FStar_TypeChecker_Env.debug env1
-                                FStar_Options.Extreme
-                               in
+                                FStar_Options.Extreme in
                             if uu____4670
                             then
                               let uu____4671 =
-                                FStar_Syntax_Print.term_to_string res_t  in
+                                FStar_Syntax_Print.term_to_string res_t in
                               FStar_Util.print1
                                 "Tm_match: expected type of branches is %s\n"
                                 uu____4671
@@ -2052,12 +1861,10 @@ and (tc_maybe_toplevel_term :
                               FStar_Syntax_Syntax.new_bv
                                 (FStar_Pervasives_Native.Some
                                    (e11.FStar_Syntax_Syntax.pos))
-                                c1.FStar_Syntax_Syntax.res_typ
-                               in
+                                c1.FStar_Syntax_Syntax.res_typ in
                             let t_eqns =
                               FStar_All.pipe_right eqns
-                                (FStar_List.map (tc_eqn guard_x env_branches))
-                               in
+                                (FStar_List.map (tc_eqn guard_x env_branches)) in
                             let uu____4781 =
                               let uu____4786 =
                                 FStar_List.fold_right
@@ -2068,20 +1875,16 @@ and (tc_maybe_toplevel_term :
                                           (caccum,gaccum)) ->
                                            let uu____5064 =
                                              FStar_TypeChecker_Rel.conj_guard
-                                               g gaccum
-                                              in
+                                               g gaccum in
                                            (((f, eff_label, cflags, c) ::
                                              caccum), uu____5064)) t_eqns
-                                  ([], FStar_TypeChecker_Rel.trivial_guard)
-                                 in
+                                  ([], FStar_TypeChecker_Rel.trivial_guard) in
                               match uu____4786 with
                               | (cases,g) ->
                                   let uu____5155 =
                                     FStar_TypeChecker_Util.bind_cases env1
-                                      res_t cases
-                                     in
-                                  (uu____5155, g)
-                               in
+                                      res_t cases in
+                                  (uu____5155, g) in
                             match uu____4781 with
                             | (c_branches,g_branches) ->
                                 let cres =
@@ -2089,8 +1892,7 @@ and (tc_maybe_toplevel_term :
                                     e11.FStar_Syntax_Syntax.pos env1
                                     (FStar_Pervasives_Native.Some e11) c1
                                     ((FStar_Pervasives_Native.Some guard_x),
-                                      c_branches)
-                                   in
+                                      c_branches) in
                                 let e2 =
                                   let mk_match scrutinee =
                                     let branches =
@@ -2104,23 +1906,19 @@ and (tc_maybe_toplevel_term :
                                                     FStar_TypeChecker_Util.maybe_lift
                                                       env1 br eff_label
                                                       cres.FStar_Syntax_Syntax.eff_name
-                                                      res_t
-                                                     in
-                                                  (pat, wopt, uu____5330)))
-                                       in
+                                                      res_t in
+                                                  (pat, wopt, uu____5330))) in
                                     let e2 =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_match
                                            (scrutinee, branches))
                                         FStar_Pervasives_Native.None
-                                        top.FStar_Syntax_Syntax.pos
-                                       in
+                                        top.FStar_Syntax_Syntax.pos in
                                     let e3 =
                                       FStar_TypeChecker_Util.maybe_monadic
                                         env1 e2
                                         cres.FStar_Syntax_Syntax.eff_name
-                                        cres.FStar_Syntax_Syntax.res_typ
-                                       in
+                                        cres.FStar_Syntax_Syntax.res_typ in
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_ascribed
                                          (e3,
@@ -2130,27 +1928,23 @@ and (tc_maybe_toplevel_term :
                                            (FStar_Pervasives_Native.Some
                                               (cres.FStar_Syntax_Syntax.eff_name))))
                                       FStar_Pervasives_Native.None
-                                      e3.FStar_Syntax_Syntax.pos
-                                     in
+                                      e3.FStar_Syntax_Syntax.pos in
                                   let uu____5385 =
                                     FStar_TypeChecker_Util.is_pure_or_ghost_effect
-                                      env1 c1.FStar_Syntax_Syntax.eff_name
-                                     in
+                                      env1 c1.FStar_Syntax_Syntax.eff_name in
                                   if uu____5385
                                   then mk_match e11
                                   else
                                     (let e_match =
                                        let uu____5392 =
                                          FStar_Syntax_Syntax.bv_to_name
-                                           guard_x
-                                          in
-                                       mk_match uu____5392  in
+                                           guard_x in
+                                       mk_match uu____5392 in
                                      let lb =
                                        let uu____5396 =
                                          FStar_TypeChecker_Env.norm_eff_name
                                            env1
-                                           c1.FStar_Syntax_Syntax.eff_name
-                                          in
+                                           c1.FStar_Syntax_Syntax.eff_name in
                                        {
                                          FStar_Syntax_Syntax.lbname =
                                            (FStar_Util.Inl guard_x);
@@ -2161,7 +1955,7 @@ and (tc_maybe_toplevel_term :
                                            uu____5396;
                                          FStar_Syntax_Syntax.lbdef = e11;
                                          FStar_Syntax_Syntax.lbattrs = []
-                                       }  in
+                                       } in
                                      let e2 =
                                        let uu____5402 =
                                          let uu____5405 =
@@ -2170,47 +1964,37 @@ and (tc_maybe_toplevel_term :
                                                let uu____5420 =
                                                  let uu____5421 =
                                                    FStar_Syntax_Syntax.mk_binder
-                                                     guard_x
-                                                    in
-                                                 [uu____5421]  in
+                                                     guard_x in
+                                                 [uu____5421] in
                                                FStar_Syntax_Subst.close
-                                                 uu____5420 e_match
-                                                in
-                                             ((false, [lb]), uu____5419)  in
+                                                 uu____5420 e_match in
+                                             ((false, [lb]), uu____5419) in
                                            FStar_Syntax_Syntax.Tm_let
-                                             uu____5406
-                                            in
-                                         FStar_Syntax_Syntax.mk uu____5405
-                                          in
+                                             uu____5406 in
+                                         FStar_Syntax_Syntax.mk uu____5405 in
                                        uu____5402
                                          FStar_Pervasives_Native.None
-                                         top.FStar_Syntax_Syntax.pos
-                                        in
+                                         top.FStar_Syntax_Syntax.pos in
                                      FStar_TypeChecker_Util.maybe_monadic
                                        env1 e2
                                        cres.FStar_Syntax_Syntax.eff_name
-                                       cres.FStar_Syntax_Syntax.res_typ)
-                                   in
+                                       cres.FStar_Syntax_Syntax.res_typ) in
                                 ((let uu____5434 =
                                     FStar_TypeChecker_Env.debug env1
-                                      FStar_Options.Extreme
-                                     in
+                                      FStar_Options.Extreme in
                                   if uu____5434
                                   then
                                     let uu____5435 =
                                       FStar_Range.string_of_range
-                                        top.FStar_Syntax_Syntax.pos
-                                       in
+                                        top.FStar_Syntax_Syntax.pos in
                                     let uu____5436 =
-                                      FStar_Syntax_Print.lcomp_to_string cres
-                                       in
+                                      FStar_Syntax_Print.lcomp_to_string cres in
                                     FStar_Util.print2 "(%s) comp type = %s\n"
                                       uu____5435 uu____5436
                                   else ());
                                  (let uu____5438 =
                                     FStar_TypeChecker_Rel.conj_guard g1
-                                      g_branches
-                                     in
+                                      g_branches in
                                   (e2, cres, uu____5438))))))))
        | FStar_Syntax_Syntax.Tm_let
            ((false
@@ -2222,13 +2006,13 @@ and (tc_maybe_toplevel_term :
                 FStar_Syntax_Syntax.lbattrs = uu____5446;_}::[]),uu____5447)
            ->
            ((let uu____5471 =
-               FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
+               FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
              if uu____5471
              then
-               let uu____5472 = FStar_Syntax_Print.term_to_string top  in
+               let uu____5472 = FStar_Syntax_Print.term_to_string top in
                FStar_Util.print1 "%s\n" uu____5472
              else ());
-            (let uu____5474 = FStar_Options.use_two_phase_tc ()  in
+            (let uu____5474 = FStar_Options.use_two_phase_tc () in
              if uu____5474
              then
                let is_lb_unannotated t =
@@ -2238,27 +2022,25 @@ and (tc_maybe_toplevel_term :
                      let uu____5500 =
                        let uu____5501 =
                          FStar_Syntax_Subst.compress
-                           lb.FStar_Syntax_Syntax.lbtyp
-                          in
-                       uu____5501.FStar_Syntax_Syntax.n  in
+                           lb.FStar_Syntax_Syntax.lbtyp in
+                       uu____5501.FStar_Syntax_Syntax.n in
                      uu____5500 = FStar_Syntax_Syntax.Tm_unknown
-                 | uu____5504 -> failwith "Impossible"  in
+                 | uu____5504 -> failwith "Impossible" in
                let drop_lbtyp t =
                  match t.FStar_Syntax_Syntax.n with
                  | FStar_Syntax_Syntax.Tm_let ((t1,lb::[]),t2) ->
-                     let uu___74_5524 = t  in
+                     let uu___74_5524 = t in
                      let uu____5525 =
                        let uu____5526 =
                          let uu____5539 =
                            let uu____5546 =
                              let uu____5549 =
-                               let uu___75_5550 = lb  in
+                               let uu___75_5550 = lb in
                                let uu____5551 =
                                  FStar_Syntax_Syntax.mk
                                    FStar_Syntax_Syntax.Tm_unknown
                                    FStar_Pervasives_Native.None
-                                   (lb.FStar_Syntax_Syntax.lbtyp).FStar_Syntax_Syntax.pos
-                                  in
+                                   (lb.FStar_Syntax_Syntax.lbtyp).FStar_Syntax_Syntax.pos in
                                {
                                  FStar_Syntax_Syntax.lbname =
                                    (uu___75_5550.FStar_Syntax_Syntax.lbname);
@@ -2271,11 +2053,11 @@ and (tc_maybe_toplevel_term :
                                    (uu___75_5550.FStar_Syntax_Syntax.lbdef);
                                  FStar_Syntax_Syntax.lbattrs =
                                    (uu___75_5550.FStar_Syntax_Syntax.lbattrs)
-                               }  in
-                             [uu____5549]  in
-                           (t1, uu____5546)  in
-                         (uu____5539, t2)  in
-                       FStar_Syntax_Syntax.Tm_let uu____5526  in
+                               } in
+                             [uu____5549] in
+                           (t1, uu____5546) in
+                         (uu____5539, t2) in
+                       FStar_Syntax_Syntax.Tm_let uu____5526 in
                      {
                        FStar_Syntax_Syntax.n = uu____5525;
                        FStar_Syntax_Syntax.pos =
@@ -2283,10 +2065,10 @@ and (tc_maybe_toplevel_term :
                        FStar_Syntax_Syntax.vars =
                          (uu___74_5524.FStar_Syntax_Syntax.vars)
                      }
-                 | uu____5564 -> failwith "Impossible"  in
+                 | uu____5564 -> failwith "Impossible" in
                let uu____5565 =
                  check_top_level_let
-                   (let uu___76_5574 = env1  in
+                   (let uu___76_5574 = env1 in
                     {
                       FStar_TypeChecker_Env.solver =
                         (uu___76_5574.FStar_TypeChecker_Env.solver);
@@ -2357,32 +2139,28 @@ and (tc_maybe_toplevel_term :
                         (uu___76_5574.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.dep_graph =
                         (uu___76_5574.FStar_TypeChecker_Env.dep_graph)
-                    }) top
-                  in
+                    }) top in
                match uu____5565 with
                | (lax_top,l,g) ->
                    let lax_top1 =
                      FStar_TypeChecker_Normalize.remove_uvar_solutions env1
-                       lax_top
-                      in
+                       lax_top in
                    ((let uu____5586 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
-                         (FStar_Options.Other "TwoPhases")
-                        in
+                         (FStar_Options.Other "TwoPhases") in
                      if uu____5586
                      then
                        let uu____5587 =
-                         FStar_Syntax_Print.term_to_string lax_top1  in
+                         FStar_Syntax_Print.term_to_string lax_top1 in
                        FStar_Util.print1 "Phase 1: checked %s\n" uu____5587
                      else ());
                     (let uu____5589 =
-                       FStar_TypeChecker_Env.should_verify env1  in
+                       FStar_TypeChecker_Env.should_verify env1 in
                      if uu____5589
                      then
                        let uu____5596 =
-                         let uu____5597 = is_lb_unannotated top  in
-                         if uu____5597 then drop_lbtyp lax_top1 else lax_top1
-                          in
+                         let uu____5597 = is_lb_unannotated top in
+                         if uu____5597 then drop_lbtyp lax_top1 else lax_top1 in
                        check_top_level_let env1 uu____5596
                      else (lax_top1, l, g)))
              else check_top_level_let env1 top))
@@ -2398,18 +2176,18 @@ and (tc_maybe_toplevel_term :
                 FStar_Syntax_Syntax.lbattrs = uu____5622;_}::uu____5623),uu____5624)
            ->
            ((let uu____5650 =
-               FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
+               FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
              if uu____5650
              then
-               let uu____5651 = FStar_Syntax_Print.term_to_string top  in
+               let uu____5651 = FStar_Syntax_Print.term_to_string top in
                FStar_Util.print1 "%s\n" uu____5651
              else ());
-            (let uu____5653 = FStar_Options.use_two_phase_tc ()  in
+            (let uu____5653 = FStar_Options.use_two_phase_tc () in
              if uu____5653
              then
                let uu____5660 =
                  check_top_level_let_rec
-                   (let uu___77_5669 = env1  in
+                   (let uu___77_5669 = env1 in
                     {
                       FStar_TypeChecker_Env.solver =
                         (uu___77_5669.FStar_TypeChecker_Env.solver);
@@ -2480,40 +2258,36 @@ and (tc_maybe_toplevel_term :
                         (uu___77_5669.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.dep_graph =
                         (uu___77_5669.FStar_TypeChecker_Env.dep_graph)
-                    }) top
-                  in
+                    }) top in
                match uu____5660 with
                | (lax_top,l,g) ->
                    let lax_top1 =
                      FStar_TypeChecker_Normalize.remove_uvar_solutions env1
-                       lax_top
-                      in
+                       lax_top in
                    ((let uu____5681 =
                        FStar_TypeChecker_Env.debug env1
-                         (FStar_Options.Other "TwoPhases")
-                        in
+                         (FStar_Options.Other "TwoPhases") in
                      if uu____5681
                      then
                        let uu____5682 =
-                         FStar_Syntax_Print.term_to_string lax_top1  in
+                         FStar_Syntax_Print.term_to_string lax_top1 in
                        FStar_Util.print1 "Phase 1: checked %s\n" uu____5682
                      else ());
                     (let uu____5684 =
-                       FStar_TypeChecker_Env.should_verify env1  in
+                       FStar_TypeChecker_Env.should_verify env1 in
                      if uu____5684
                      then check_top_level_let_rec env1 lax_top1
                      else (lax_top1, l, g)))
              else check_top_level_let_rec env1 top))
        | FStar_Syntax_Syntax.Tm_let ((true ,uu____5693),uu____5694) ->
            check_inner_let_rec env1 top)
-
-and (tc_synth :
+and tc_synth:
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
       FStar_Pervasives_Native.tuple2 Prims.list ->
       FStar_Range.range ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun args  ->
@@ -2533,33 +2307,30 @@ and (tc_synth :
           | uu____5945 ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_SynthByTacticError,
-                  "synth_by_tactic: bad application") rng
-           in
+                  "synth_by_tactic: bad application") rng in
         match uu____5720 with
         | (tau,atyp,rest) ->
             let typ =
               match atyp with
               | FStar_Pervasives_Native.Some t -> t
               | FStar_Pervasives_Native.None  ->
-                  let uu____6029 = FStar_TypeChecker_Env.expected_typ env  in
+                  let uu____6029 = FStar_TypeChecker_Env.expected_typ env in
                   (match uu____6029 with
                    | FStar_Pervasives_Native.Some t -> t
                    | FStar_Pervasives_Native.None  ->
-                       let uu____6035 = FStar_TypeChecker_Env.get_range env
-                          in
+                       let uu____6035 = FStar_TypeChecker_Env.get_range env in
                        FStar_Errors.raise_error
                          (FStar_Errors.Fatal_SynthByTacticError,
                            "synth_by_tactic: need a type annotation when no expected type is present")
-                         uu____6035)
-               in
-            let uu____6038 = FStar_TypeChecker_Env.clear_expected_typ env  in
+                         uu____6035) in
+            let uu____6038 = FStar_TypeChecker_Env.clear_expected_typ env in
             (match uu____6038 with
              | (env',uu____6052) ->
-                 let uu____6057 = tc_term env' typ  in
+                 let uu____6057 = tc_term env' typ in
                  (match uu____6057 with
                   | (typ1,uu____6071,g1) ->
                       (FStar_TypeChecker_Rel.force_trivial_guard env' g1;
-                       (let uu____6074 = tc_tactic env' tau  in
+                       (let uu____6074 = tc_tactic env' tau in
                         match uu____6074 with
                         | (tau1,uu____6088,g2) ->
                             (FStar_TypeChecker_Rel.force_trivial_guard env'
@@ -2570,55 +2341,46 @@ and (tc_synth :
                                   let uu____6096 =
                                     let uu____6097 =
                                       FStar_TypeChecker_Util.fvar_const env
-                                        FStar_Parser_Const.magic_lid
-                                       in
+                                        FStar_Parser_Const.magic_lid in
                                     let uu____6098 =
                                       let uu____6099 =
                                         FStar_Syntax_Syntax.as_arg
-                                          FStar_Syntax_Util.exp_unit
-                                         in
-                                      [uu____6099]  in
+                                          FStar_Syntax_Util.exp_unit in
+                                      [uu____6099] in
                                     FStar_Syntax_Syntax.mk_Tm_app uu____6097
-                                      uu____6098
-                                     in
+                                      uu____6098 in
                                   uu____6096 FStar_Pervasives_Native.None rng
                                 else
                                   (let t =
                                      env.FStar_TypeChecker_Env.synth env'
-                                       typ1 tau1
-                                      in
+                                       typ1 tau1 in
                                    (let uu____6105 =
                                       FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env)
-                                        (FStar_Options.Other "Tac")
-                                       in
+                                        (FStar_Options.Other "Tac") in
                                     if uu____6105
                                     then
                                       let uu____6106 =
-                                        FStar_Syntax_Print.term_to_string t
-                                         in
+                                        FStar_Syntax_Print.term_to_string t in
                                       FStar_Util.print1 "Got %s\n" uu____6106
                                     else ());
-                                   t)
-                                 in
+                                   t) in
                               FStar_TypeChecker_Util.check_uvars
                                 tau1.FStar_Syntax_Syntax.pos t;
                               (let uu____6109 =
                                  FStar_Syntax_Syntax.mk_Tm_app t rest
-                                   FStar_Pervasives_Native.None rng
-                                  in
+                                   FStar_Pervasives_Native.None rng in
                                tc_term env uu____6109)))))))
-
-and (tc_tactic :
+and tc_tactic:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun tau  ->
       let env1 =
-        let uu___78_6113 = env  in
+        let uu___78_6113 = env in
         {
           FStar_TypeChecker_Env.solver =
             (uu___78_6113.FStar_TypeChecker_Env.solver);
@@ -2689,19 +2451,18 @@ and (tc_tactic :
             (uu___78_6113.FStar_TypeChecker_Env.dsenv);
           FStar_TypeChecker_Env.dep_graph =
             (uu___78_6113.FStar_TypeChecker_Env.dep_graph)
-        }  in
+        } in
       tc_check_tot_or_gtot_term env1 tau FStar_Syntax_Syntax.t_tactic_unit
-
-and (tc_reified_tactic :
+and tc_reified_tactic:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun tau  ->
       let env1 =
-        let uu___79_6117 = env  in
+        let uu___79_6117 = env in
         {
           FStar_TypeChecker_Env.solver =
             (uu___79_6117.FStar_TypeChecker_Env.solver);
@@ -2772,103 +2533,92 @@ and (tc_reified_tactic :
             (uu___79_6117.FStar_TypeChecker_Env.dsenv);
           FStar_TypeChecker_Env.dep_graph =
             (uu___79_6117.FStar_TypeChecker_Env.dep_graph)
-        }  in
+        } in
       tc_check_tot_or_gtot_term env1 tau FStar_Syntax_Syntax.t_tac_unit
-
-and (tc_tactic_opt :
+and tc_tactic_opt:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
       FStar_Pervasives_Native.option ->
-      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
   =
   fun env  ->
     fun topt  ->
       match topt with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some tactic ->
-          let uu____6133 = tc_tactic env tactic  in
+          let uu____6133 = tc_tactic env tactic in
           (match uu____6133 with
            | (tactic1,uu____6143,uu____6144) ->
                FStar_Pervasives_Native.Some tactic1)
-
-and (tc_value :
+and tc_value:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       let check_instantiated_fvar env1 v1 dc e1 t0 =
-        let uu____6183 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t0
-           in
+        let uu____6183 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t0 in
         match uu____6183 with
         | (e2,t,implicits) ->
             let tc =
-              let uu____6204 = FStar_TypeChecker_Env.should_verify env1  in
+              let uu____6204 = FStar_TypeChecker_Env.should_verify env1 in
               if uu____6204
               then FStar_Util.Inl t
               else
                 (let uu____6210 =
-                   let uu____6211 = FStar_Syntax_Syntax.mk_Total t  in
+                   let uu____6211 = FStar_Syntax_Syntax.mk_Total t in
                    FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                     uu____6211
-                    in
-                 FStar_Util.Inr uu____6210)
-               in
+                     uu____6211 in
+                 FStar_Util.Inr uu____6210) in
             let is_data_ctor uu___63_6221 =
               match uu___63_6221 with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor )
                   -> true
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
                   uu____6224) -> true
-              | uu____6231 -> false  in
+              | uu____6231 -> false in
             let uu____6234 =
               (is_data_ctor dc) &&
                 (let uu____6236 =
                    FStar_TypeChecker_Env.is_datacon env1
-                     v1.FStar_Syntax_Syntax.v
-                    in
-                 Prims.op_Negation uu____6236)
-               in
+                     v1.FStar_Syntax_Syntax.v in
+                 Prims.op_Negation uu____6236) in
             if uu____6234
             then
               let uu____6243 =
                 let uu____6248 =
                   FStar_Util.format1 "Expected a data constructor; got %s"
-                    (v1.FStar_Syntax_Syntax.v).FStar_Ident.str
-                   in
-                (FStar_Errors.Fatal_MissingDataConstructor, uu____6248)  in
-              let uu____6249 = FStar_TypeChecker_Env.get_range env1  in
+                    (v1.FStar_Syntax_Syntax.v).FStar_Ident.str in
+                (FStar_Errors.Fatal_MissingDataConstructor, uu____6248) in
+              let uu____6249 = FStar_TypeChecker_Env.get_range env1 in
               FStar_Errors.raise_error uu____6243 uu____6249
-            else value_check_expected_typ env1 e2 tc implicits
-         in
+            else value_check_expected_typ env1 e2 tc implicits in
       let env1 =
-        FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos  in
-      let top = FStar_Syntax_Subst.compress e  in
+        FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos in
+      let top = FStar_Syntax_Subst.compress e in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_bvar x ->
           let uu____6266 =
-            let uu____6267 = FStar_Syntax_Print.term_to_string top  in
+            let uu____6267 = FStar_Syntax_Print.term_to_string top in
             FStar_Util.format1
               "Impossible: Violation of locally nameless convention: %s"
-              uu____6267
-             in
+              uu____6267 in
           failwith uu____6266
       | FStar_Syntax_Syntax.Tm_uvar (u,t1) ->
           let g =
             let uu____6301 =
-              let uu____6302 = FStar_Syntax_Subst.compress t1  in
-              uu____6302.FStar_Syntax_Syntax.n  in
+              let uu____6302 = FStar_Syntax_Subst.compress t1 in
+              uu____6302.FStar_Syntax_Syntax.n in
             match uu____6301 with
             | FStar_Syntax_Syntax.Tm_arrow uu____6305 ->
                 FStar_TypeChecker_Rel.trivial_guard
             | uu____6318 ->
                 let imp =
                   ("uvar in term", env1, u, top, t1,
-                    (top.FStar_Syntax_Syntax.pos))
-                   in
-                let uu___80_6356 = FStar_TypeChecker_Rel.trivial_guard  in
+                    (top.FStar_Syntax_Syntax.pos)) in
+                let uu___80_6356 = FStar_TypeChecker_Rel.trivial_guard in
                 {
                   FStar_TypeChecker_Env.guard_f =
                     (uu___80_6356.FStar_TypeChecker_Env.guard_f);
@@ -2877,79 +2627,70 @@ and (tc_value :
                   FStar_TypeChecker_Env.univ_ineqs =
                     (uu___80_6356.FStar_TypeChecker_Env.univ_ineqs);
                   FStar_TypeChecker_Env.implicits = [imp]
-                }
-             in
+                } in
           value_check_expected_typ env1 e (FStar_Util.Inl t1) g
       | FStar_Syntax_Syntax.Tm_unknown  ->
-          let r = FStar_TypeChecker_Env.get_range env1  in
+          let r = FStar_TypeChecker_Env.get_range env1 in
           let uu____6408 =
-            let uu____6421 = FStar_TypeChecker_Env.expected_typ env1  in
+            let uu____6421 = FStar_TypeChecker_Env.expected_typ env1 in
             match uu____6421 with
             | FStar_Pervasives_Native.None  ->
-                let uu____6436 = FStar_Syntax_Util.type_u ()  in
+                let uu____6436 = FStar_Syntax_Util.type_u () in
                 (match uu____6436 with
                  | (k,u) ->
                      FStar_TypeChecker_Util.new_implicit_var
                        "type of user-provided implicit term" r env1 k)
             | FStar_Pervasives_Native.Some t ->
-                (t, [], FStar_TypeChecker_Rel.trivial_guard)
-             in
+                (t, [], FStar_TypeChecker_Rel.trivial_guard) in
           (match uu____6408 with
            | (t,uu____6473,g0) ->
                let uu____6487 =
                  FStar_TypeChecker_Util.new_implicit_var
-                   "user-provided implicit term" r env1 t
-                  in
+                   "user-provided implicit term" r env1 t in
                (match uu____6487 with
                 | (e1,uu____6507,g1) ->
                     let uu____6521 =
-                      let uu____6522 = FStar_Syntax_Syntax.mk_Total t  in
+                      let uu____6522 = FStar_Syntax_Syntax.mk_Total t in
                       FStar_All.pipe_right uu____6522
-                        FStar_Syntax_Util.lcomp_of_comp
-                       in
-                    let uu____6523 = FStar_TypeChecker_Rel.conj_guard g0 g1
-                       in
+                        FStar_Syntax_Util.lcomp_of_comp in
+                    let uu____6523 = FStar_TypeChecker_Rel.conj_guard g0 g1 in
                     (e1, uu____6521, uu____6523)))
       | FStar_Syntax_Syntax.Tm_name x ->
           let uu____6525 =
             if env1.FStar_TypeChecker_Env.use_bv_sorts
             then
-              let uu____6538 = FStar_Syntax_Syntax.range_of_bv x  in
+              let uu____6538 = FStar_Syntax_Syntax.range_of_bv x in
               ((x.FStar_Syntax_Syntax.sort), uu____6538)
-            else FStar_TypeChecker_Env.lookup_bv env1 x  in
+            else FStar_TypeChecker_Env.lookup_bv env1 x in
           (match uu____6525 with
            | (t,rng) ->
                let x1 =
                  FStar_Syntax_Syntax.set_range_of_bv
-                   (let uu___81_6557 = x  in
+                   (let uu___81_6557 = x in
                     {
                       FStar_Syntax_Syntax.ppname =
                         (uu___81_6557.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
                         (uu___81_6557.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort = t
-                    }) rng
-                  in
+                    }) rng in
                (FStar_TypeChecker_Env.insert_bv_info env1 x1 t;
-                (let e1 = FStar_Syntax_Syntax.bv_to_name x1  in
+                (let e1 = FStar_Syntax_Syntax.bv_to_name x1 in
                  let uu____6560 =
-                   FStar_TypeChecker_Util.maybe_instantiate env1 e1 t  in
+                   FStar_TypeChecker_Util.maybe_instantiate env1 e1 t in
                  match uu____6560 with
                  | (e2,t1,implicits) ->
                      let tc =
                        let uu____6581 =
-                         FStar_TypeChecker_Env.should_verify env1  in
+                         FStar_TypeChecker_Env.should_verify env1 in
                        if uu____6581
                        then FStar_Util.Inl t1
                        else
                          (let uu____6587 =
-                            let uu____6588 = FStar_Syntax_Syntax.mk_Total t1
-                               in
+                            let uu____6588 = FStar_Syntax_Syntax.mk_Total t1 in
                             FStar_All.pipe_left
-                              FStar_Syntax_Util.lcomp_of_comp uu____6588
-                             in
-                          FStar_Util.Inr uu____6587)
-                        in
+                              FStar_Syntax_Util.lcomp_of_comp uu____6588 in
+                          FStar_Util.Inr uu____6587) in
                      value_check_expected_typ env1 e2 tc implicits)))
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
@@ -2957,13 +2698,13 @@ and (tc_value :
              FStar_Syntax_Syntax.vars = uu____6595;_},uu____6596)
           when FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid
           ->
-          let uu____6601 = FStar_TypeChecker_Env.get_range env1  in
+          let uu____6601 = FStar_TypeChecker_Env.get_range env1 in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
               "Badly instantiated synth_by_tactic") uu____6601
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid ->
-          let uu____6609 = FStar_TypeChecker_Env.get_range env1  in
+          let uu____6609 = FStar_TypeChecker_Env.get_range env1 in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
               "Badly instantiated synth_by_tactic") uu____6609
@@ -2972,31 +2713,27 @@ and (tc_value :
              FStar_Syntax_Syntax.pos = uu____6617;
              FStar_Syntax_Syntax.vars = uu____6618;_},us)
           ->
-          let us1 = FStar_List.map (tc_universe env1) us  in
+          let us1 = FStar_List.map (tc_universe env1) us in
           let uu____6627 =
             FStar_TypeChecker_Env.lookup_lid env1
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           (match uu____6627 with
            | ((us',t),range) ->
                (if (FStar_List.length us1) <> (FStar_List.length us')
                 then
                   (let uu____6650 =
                      let uu____6655 =
-                       let uu____6656 = FStar_Syntax_Print.fv_to_string fv
-                          in
+                       let uu____6656 = FStar_Syntax_Print.fv_to_string fv in
                        let uu____6657 =
-                         FStar_Util.string_of_int (FStar_List.length us1)  in
+                         FStar_Util.string_of_int (FStar_List.length us1) in
                        let uu____6658 =
-                         FStar_Util.string_of_int (FStar_List.length us')  in
+                         FStar_Util.string_of_int (FStar_List.length us') in
                        FStar_Util.format3
                          "Unexpected number of universe instantiations for \"%s\" (%s vs %s)"
-                         uu____6656 uu____6657 uu____6658
-                        in
+                         uu____6656 uu____6657 uu____6658 in
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                       uu____6655)
-                      in
-                   let uu____6659 = FStar_TypeChecker_Env.get_range env1  in
+                       uu____6655) in
+                   let uu____6659 = FStar_TypeChecker_Env.get_range env1 in
                    FStar_Errors.raise_error uu____6650 uu____6659)
                 else
                   FStar_List.iter2
@@ -3006,84 +2743,77 @@ and (tc_value :
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
                          | uu____6675 -> failwith "Impossible") us' us1;
-                (let fv' = FStar_Syntax_Syntax.set_range_of_fv fv range  in
+                (let fv' = FStar_Syntax_Syntax.set_range_of_fv fv range in
                  FStar_TypeChecker_Env.insert_fv_info env1 fv' t;
                  (let e1 =
                     let uu____6679 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_fvar fv')
                         FStar_Pervasives_Native.None
-                        e.FStar_Syntax_Syntax.pos
-                       in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____6679 us1  in
+                        e.FStar_Syntax_Syntax.pos in
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu____6679 us1 in
                   check_instantiated_fvar env1
                     fv'.FStar_Syntax_Syntax.fv_name
                     fv'.FStar_Syntax_Syntax.fv_qual e1 t))))
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let uu____6681 =
             FStar_TypeChecker_Env.lookup_lid env1
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           (match uu____6681 with
            | ((us,t),range) ->
                ((let uu____6704 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
-                     (FStar_Options.Other "Range")
-                    in
+                     (FStar_Options.Other "Range") in
                  if uu____6704
                  then
                    let uu____6705 =
-                     let uu____6706 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                     FStar_Syntax_Print.lid_to_string uu____6706  in
+                     let uu____6706 = FStar_Syntax_Syntax.lid_of_fv fv in
+                     FStar_Syntax_Print.lid_to_string uu____6706 in
                    let uu____6707 =
-                     FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos
-                      in
-                   let uu____6708 = FStar_Range.string_of_range range  in
-                   let uu____6709 = FStar_Range.string_of_use_range range  in
-                   let uu____6710 = FStar_Syntax_Print.term_to_string t  in
+                     FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos in
+                   let uu____6708 = FStar_Range.string_of_range range in
+                   let uu____6709 = FStar_Range.string_of_use_range range in
+                   let uu____6710 = FStar_Syntax_Print.term_to_string t in
                    FStar_Util.print5
                      "Lookup up fvar %s at location %s (lid range = defined at %s, used at %s); got universes type %s"
                      uu____6705 uu____6707 uu____6708 uu____6709 uu____6710
                  else ());
-                (let fv' = FStar_Syntax_Syntax.set_range_of_fv fv range  in
+                (let fv' = FStar_Syntax_Syntax.set_range_of_fv fv range in
                  FStar_TypeChecker_Env.insert_fv_info env1 fv' t;
                  (let e1 =
                     let uu____6715 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_fvar fv')
                         FStar_Pervasives_Native.None
-                        e.FStar_Syntax_Syntax.pos
-                       in
-                    FStar_Syntax_Syntax.mk_Tm_uinst uu____6715 us  in
+                        e.FStar_Syntax_Syntax.pos in
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu____6715 us in
                   check_instantiated_fvar env1
                     fv'.FStar_Syntax_Syntax.fv_name
                     fv'.FStar_Syntax_Syntax.fv_qual e1 t))))
       | FStar_Syntax_Syntax.Tm_constant c ->
-          let t = tc_constant env1 top.FStar_Syntax_Syntax.pos c  in
+          let t = tc_constant env1 top.FStar_Syntax_Syntax.pos c in
           let e1 =
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant c)
-              FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-             in
+              FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos in
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Rel.trivial_guard
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____6739 = FStar_Syntax_Subst.open_comp bs c  in
+          let uu____6739 = FStar_Syntax_Subst.open_comp bs c in
           (match uu____6739 with
            | (bs1,c1) ->
-               let env0 = env1  in
-               let uu____6753 = FStar_TypeChecker_Env.clear_expected_typ env1
-                  in
+               let env0 = env1 in
+               let uu____6753 = FStar_TypeChecker_Env.clear_expected_typ env1 in
                (match uu____6753 with
                 | (env2,uu____6767) ->
-                    let uu____6772 = tc_binders env2 bs1  in
+                    let uu____6772 = tc_binders env2 bs1 in
                     (match uu____6772 with
                      | (bs2,env3,g,us) ->
-                         let uu____6791 = tc_comp env3 c1  in
+                         let uu____6791 = tc_comp env3 c1 in
                          (match uu____6791 with
                           | (c2,uc,f) ->
                               let e1 =
                                 let uu___82_6810 =
-                                  FStar_Syntax_Util.arrow bs2 c2  in
+                                  FStar_Syntax_Util.arrow bs2 c2 in
                                 {
                                   FStar_Syntax_Syntax.n =
                                     (uu___82_6810.FStar_Syntax_Syntax.n);
@@ -3091,91 +2821,79 @@ and (tc_value :
                                     (top.FStar_Syntax_Syntax.pos);
                                   FStar_Syntax_Syntax.vars =
                                     (uu___82_6810.FStar_Syntax_Syntax.vars)
-                                }  in
+                                } in
                               (check_smt_pat env3 e1 bs2 c2;
-                               (let u = FStar_Syntax_Syntax.U_max (uc :: us)
-                                   in
+                               (let u = FStar_Syntax_Syntax.U_max (uc :: us) in
                                 let t =
                                   FStar_Syntax_Syntax.mk
                                     (FStar_Syntax_Syntax.Tm_type u)
                                     FStar_Pervasives_Native.None
-                                    top.FStar_Syntax_Syntax.pos
-                                   in
+                                    top.FStar_Syntax_Syntax.pos in
                                 let g1 =
                                   let uu____6819 =
                                     FStar_TypeChecker_Rel.close_guard_univs
-                                      us bs2 f
-                                     in
+                                      us bs2 f in
                                   FStar_TypeChecker_Rel.conj_guard g
-                                    uu____6819
-                                   in
+                                    uu____6819 in
                                 value_check_expected_typ env0 e1
                                   (FStar_Util.Inl t) g1))))))
       | FStar_Syntax_Syntax.Tm_type u ->
-          let u1 = tc_universe env1 u  in
+          let u1 = tc_universe env1 u in
           let t =
             FStar_Syntax_Syntax.mk
               (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u1))
-              FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
-             in
+              FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos in
           let e1 =
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u1)
-              FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
-             in
+              FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos in
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Rel.trivial_guard
       | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
           let uu____6838 =
             let uu____6843 =
-              let uu____6844 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____6844]  in
-            FStar_Syntax_Subst.open_term uu____6843 phi  in
+              let uu____6844 = FStar_Syntax_Syntax.mk_binder x in
+              [uu____6844] in
+            FStar_Syntax_Subst.open_term uu____6843 phi in
           (match uu____6838 with
            | (x1,phi1) ->
-               let env0 = env1  in
-               let uu____6854 = FStar_TypeChecker_Env.clear_expected_typ env1
-                  in
+               let env0 = env1 in
+               let uu____6854 = FStar_TypeChecker_Env.clear_expected_typ env1 in
                (match uu____6854 with
                 | (env2,uu____6868) ->
                     let uu____6873 =
-                      let uu____6886 = FStar_List.hd x1  in
-                      tc_binder env2 uu____6886  in
+                      let uu____6886 = FStar_List.hd x1 in
+                      tc_binder env2 uu____6886 in
                     (match uu____6873 with
                      | (x2,env3,f1,u) ->
                          ((let uu____6914 =
                              FStar_TypeChecker_Env.debug env3
-                               FStar_Options.High
-                              in
+                               FStar_Options.High in
                            if uu____6914
                            then
                              let uu____6915 =
                                FStar_Range.string_of_range
-                                 top.FStar_Syntax_Syntax.pos
-                                in
+                                 top.FStar_Syntax_Syntax.pos in
                              let uu____6916 =
-                               FStar_Syntax_Print.term_to_string phi1  in
+                               FStar_Syntax_Print.term_to_string phi1 in
                              let uu____6917 =
                                FStar_Syntax_Print.bv_to_string
-                                 (FStar_Pervasives_Native.fst x2)
-                                in
+                                 (FStar_Pervasives_Native.fst x2) in
                              FStar_Util.print3
                                "(%s) Checking refinement formula %s; binder is %s\n"
                                uu____6915 uu____6916 uu____6917
                            else ());
-                          (let uu____6919 = FStar_Syntax_Util.type_u ()  in
+                          (let uu____6919 = FStar_Syntax_Util.type_u () in
                            match uu____6919 with
                            | (t_phi,uu____6931) ->
                                let uu____6932 =
-                                 tc_check_tot_or_gtot_term env3 phi1 t_phi
-                                  in
+                                 tc_check_tot_or_gtot_term env3 phi1 t_phi in
                                (match uu____6932 with
                                 | (phi2,uu____6946,f2) ->
                                     let e1 =
                                       let uu___83_6951 =
                                         FStar_Syntax_Util.refine
                                           (FStar_Pervasives_Native.fst x2)
-                                          phi2
-                                         in
+                                          phi2 in
                                       {
                                         FStar_Syntax_Syntax.n =
                                           (uu___83_6951.FStar_Syntax_Syntax.n);
@@ -3183,33 +2901,29 @@ and (tc_value :
                                           (top.FStar_Syntax_Syntax.pos);
                                         FStar_Syntax_Syntax.vars =
                                           (uu___83_6951.FStar_Syntax_Syntax.vars)
-                                      }  in
+                                      } in
                                     let t =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_type u)
                                         FStar_Pervasives_Native.None
-                                        top.FStar_Syntax_Syntax.pos
-                                       in
+                                        top.FStar_Syntax_Syntax.pos in
                                     let g =
                                       let uu____6958 =
                                         FStar_TypeChecker_Rel.close_guard_univs
-                                          [u] [x2] f2
-                                         in
+                                          [u] [x2] f2 in
                                       FStar_TypeChecker_Rel.conj_guard f1
-                                        uu____6958
-                                       in
+                                        uu____6958 in
                                     value_check_expected_typ env0 e1
                                       (FStar_Util.Inl t) g))))))
       | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____6971) ->
-          let bs1 = FStar_TypeChecker_Util.maybe_add_implicit_binders env1 bs
-             in
+          let bs1 = FStar_TypeChecker_Util.maybe_add_implicit_binders env1 bs in
           ((let uu____6994 =
-              FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
+              FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
             if uu____6994
             then
               let uu____6995 =
                 FStar_Syntax_Print.term_to_string
-                  (let uu___84_6998 = top  in
+                  (let uu___84_6998 = top in
                    {
                      FStar_Syntax_Syntax.n =
                        (FStar_Syntax_Syntax.Tm_abs
@@ -3218,24 +2932,21 @@ and (tc_value :
                        (uu___84_6998.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
                        (uu___84_6998.FStar_Syntax_Syntax.vars)
-                   })
-                 in
+                   }) in
               FStar_Util.print1 "Abstraction is: %s\n" uu____6995
             else ());
-           (let uu____7004 = FStar_Syntax_Subst.open_term bs1 body  in
+           (let uu____7004 = FStar_Syntax_Subst.open_term bs1 body in
             match uu____7004 with | (bs2,body1) -> tc_abs env1 top bs2 body1))
       | uu____7017 ->
           let uu____7018 =
-            let uu____7019 = FStar_Syntax_Print.term_to_string top  in
-            let uu____7020 = FStar_Syntax_Print.tag_of_term top  in
+            let uu____7019 = FStar_Syntax_Print.term_to_string top in
+            let uu____7020 = FStar_Syntax_Print.tag_of_term top in
             FStar_Util.format2 "Unexpected value: %s (%s)" uu____7019
-              uu____7020
-             in
+              uu____7020 in
           failwith uu____7018
-
-and (tc_constant :
+and tc_constant:
   FStar_TypeChecker_Env.env ->
-    FStar_Range.range -> FStar_Const.sconst -> FStar_Syntax_Syntax.typ)
+    FStar_Range.range -> FStar_Const.sconst -> FStar_Syntax_Syntax.typ
   =
   fun env  ->
     fun r  ->
@@ -3271,138 +2982,125 @@ and (tc_constant :
             let uu____7065 =
               let uu____7070 =
                 FStar_ToSyntax_Env.try_lookup_lid
-                  env.FStar_TypeChecker_Env.dsenv FStar_Parser_Const.char_lid
-                 in
-              FStar_All.pipe_right uu____7070 FStar_Util.must  in
+                  env.FStar_TypeChecker_Env.dsenv FStar_Parser_Const.char_lid in
+              FStar_All.pipe_right uu____7070 FStar_Util.must in
             FStar_All.pipe_right uu____7065 FStar_Pervasives_Native.fst
         | FStar_Const.Const_effect  -> FStar_Syntax_Util.ktype0
         | FStar_Const.Const_range uu____7095 -> FStar_Syntax_Syntax.t_range
         | FStar_Const.Const_range_of  ->
             let uu____7096 =
               let uu____7101 =
-                let uu____7102 = FStar_Parser_Const.const_to_string c  in
+                let uu____7102 = FStar_Parser_Const.const_to_string c in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____7102
-                 in
-              (FStar_Errors.Fatal_IllTyped, uu____7101)  in
+                  uu____7102 in
+              (FStar_Errors.Fatal_IllTyped, uu____7101) in
             FStar_Errors.raise_error uu____7096 r
         | FStar_Const.Const_set_range_of  ->
             let uu____7103 =
               let uu____7108 =
-                let uu____7109 = FStar_Parser_Const.const_to_string c  in
+                let uu____7109 = FStar_Parser_Const.const_to_string c in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____7109
-                 in
-              (FStar_Errors.Fatal_IllTyped, uu____7108)  in
+                  uu____7109 in
+              (FStar_Errors.Fatal_IllTyped, uu____7108) in
             FStar_Errors.raise_error uu____7103 r
         | FStar_Const.Const_reify  ->
             let uu____7110 =
               let uu____7115 =
-                let uu____7116 = FStar_Parser_Const.const_to_string c  in
+                let uu____7116 = FStar_Parser_Const.const_to_string c in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____7116
-                 in
-              (FStar_Errors.Fatal_IllTyped, uu____7115)  in
+                  uu____7116 in
+              (FStar_Errors.Fatal_IllTyped, uu____7115) in
             FStar_Errors.raise_error uu____7110 r
         | FStar_Const.Const_reflect uu____7117 ->
             let uu____7118 =
               let uu____7123 =
-                let uu____7124 = FStar_Parser_Const.const_to_string c  in
+                let uu____7124 = FStar_Parser_Const.const_to_string c in
                 FStar_Util.format1
                   "Ill-typed %s: this constant must be fully applied"
-                  uu____7124
-                 in
-              (FStar_Errors.Fatal_IllTyped, uu____7123)  in
+                  uu____7124 in
+              (FStar_Errors.Fatal_IllTyped, uu____7123) in
             FStar_Errors.raise_error uu____7118 r
         | uu____7125 ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnsupportedConstant,
                 "Unsupported constant") r
-
-and (tc_comp :
+and tc_comp:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp ->
       (FStar_Syntax_Syntax.comp,FStar_Syntax_Syntax.universe,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun c  ->
-      let c0 = c  in
+      let c0 = c in
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Total (t,uu____7142) ->
-          let uu____7151 = FStar_Syntax_Util.type_u ()  in
+          let uu____7151 = FStar_Syntax_Util.type_u () in
           (match uu____7151 with
            | (k,u) ->
-               let uu____7164 = tc_check_tot_or_gtot_term env t k  in
+               let uu____7164 = tc_check_tot_or_gtot_term env t k in
                (match uu____7164 with
                 | (t1,uu____7178,g) ->
                     let uu____7180 =
                       FStar_Syntax_Syntax.mk_Total' t1
-                        (FStar_Pervasives_Native.Some u)
-                       in
+                        (FStar_Pervasives_Native.Some u) in
                     (uu____7180, u, g)))
       | FStar_Syntax_Syntax.GTotal (t,uu____7182) ->
-          let uu____7191 = FStar_Syntax_Util.type_u ()  in
+          let uu____7191 = FStar_Syntax_Util.type_u () in
           (match uu____7191 with
            | (k,u) ->
-               let uu____7204 = tc_check_tot_or_gtot_term env t k  in
+               let uu____7204 = tc_check_tot_or_gtot_term env t k in
                (match uu____7204 with
                 | (t1,uu____7218,g) ->
                     let uu____7220 =
                       FStar_Syntax_Syntax.mk_GTotal' t1
-                        (FStar_Pervasives_Native.Some u)
-                       in
+                        (FStar_Pervasives_Native.Some u) in
                     (uu____7220, u, g)))
       | FStar_Syntax_Syntax.Comp c1 ->
           let head1 =
             FStar_Syntax_Syntax.fvar c1.FStar_Syntax_Syntax.effect_name
-              FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None
-             in
+              FStar_Syntax_Syntax.Delta_constant FStar_Pervasives_Native.None in
           let head2 =
             match c1.FStar_Syntax_Syntax.comp_univs with
             | [] -> head1
             | us ->
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_uinst (head1, us))
-                  FStar_Pervasives_Native.None c0.FStar_Syntax_Syntax.pos
-             in
+                  FStar_Pervasives_Native.None c0.FStar_Syntax_Syntax.pos in
           let tc =
             let uu____7228 =
               let uu____7229 =
                 let uu____7230 =
                   FStar_Syntax_Syntax.as_arg
-                    c1.FStar_Syntax_Syntax.result_typ
-                   in
-                uu____7230 :: (c1.FStar_Syntax_Syntax.effect_args)  in
-              FStar_Syntax_Syntax.mk_Tm_app head2 uu____7229  in
+                    c1.FStar_Syntax_Syntax.result_typ in
+                uu____7230 :: (c1.FStar_Syntax_Syntax.effect_args) in
+              FStar_Syntax_Syntax.mk_Tm_app head2 uu____7229 in
             uu____7228 FStar_Pervasives_Native.None
-              (c1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
-             in
+              (c1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
           let uu____7233 =
-            tc_check_tot_or_gtot_term env tc FStar_Syntax_Syntax.teff  in
+            tc_check_tot_or_gtot_term env tc FStar_Syntax_Syntax.teff in
           (match uu____7233 with
            | (tc1,uu____7247,f) ->
-               let uu____7249 = FStar_Syntax_Util.head_and_args tc1  in
+               let uu____7249 = FStar_Syntax_Util.head_and_args tc1 in
                (match uu____7249 with
                 | (head3,args) ->
                     let comp_univs =
                       let uu____7293 =
-                        let uu____7294 = FStar_Syntax_Subst.compress head3
-                           in
-                        uu____7294.FStar_Syntax_Syntax.n  in
+                        let uu____7294 = FStar_Syntax_Subst.compress head3 in
+                        uu____7294.FStar_Syntax_Syntax.n in
                       match uu____7293 with
                       | FStar_Syntax_Syntax.Tm_uinst (uu____7297,us) -> us
-                      | uu____7303 -> []  in
-                    let uu____7304 = FStar_Syntax_Util.head_and_args tc1  in
+                      | uu____7303 -> [] in
+                    let uu____7304 = FStar_Syntax_Util.head_and_args tc1 in
                     (match uu____7304 with
                      | (uu____7325,args1) ->
                          let uu____7347 =
-                           let uu____7366 = FStar_List.hd args1  in
-                           let uu____7379 = FStar_List.tl args1  in
-                           (uu____7366, uu____7379)  in
+                           let uu____7366 = FStar_List.hd args1 in
+                           let uu____7379 = FStar_List.tl args1 in
+                           (uu____7366, uu____7379) in
                          (match uu____7347 with
                           | (res,args2) ->
                               let uu____7444 =
@@ -3416,34 +3114,29 @@ and (tc_comp :
                                               ->
                                               let uu____7489 =
                                                 FStar_TypeChecker_Env.clear_expected_typ
-                                                  env
-                                                 in
+                                                  env in
                                               (match uu____7489 with
                                                | (env1,uu____7501) ->
                                                    let uu____7506 =
                                                      tc_tot_or_gtot_term env1
-                                                       e
-                                                      in
+                                                       e in
                                                    (match uu____7506 with
                                                     | (e1,uu____7518,g) ->
                                                         ((FStar_Syntax_Syntax.DECREASES
                                                             e1), g)))
                                           | f1 ->
                                               (f1,
-                                                FStar_TypeChecker_Rel.trivial_guard)))
-                                   in
+                                                FStar_TypeChecker_Rel.trivial_guard))) in
                                 FStar_All.pipe_right uu____7453
-                                  FStar_List.unzip
-                                 in
+                                  FStar_List.unzip in
                               (match uu____7444 with
                                | (flags1,guards) ->
                                    let u =
                                      env.FStar_TypeChecker_Env.universe_of
-                                       env (FStar_Pervasives_Native.fst res)
-                                      in
+                                       env (FStar_Pervasives_Native.fst res) in
                                    let c2 =
                                      FStar_Syntax_Syntax.mk_Comp
-                                       (let uu___85_7557 = c1  in
+                                       (let uu___85_7557 = c1 in
                                         {
                                           FStar_Syntax_Syntax.comp_univs =
                                             comp_univs;
@@ -3455,34 +3148,29 @@ and (tc_comp :
                                             args2;
                                           FStar_Syntax_Syntax.flags =
                                             (uu___85_7557.FStar_Syntax_Syntax.flags)
-                                        })
-                                      in
+                                        }) in
                                    let u_c =
                                      let uu____7561 =
                                        FStar_TypeChecker_Env.effect_repr env
-                                         c2 u
-                                        in
+                                         c2 u in
                                      match uu____7561 with
                                      | FStar_Pervasives_Native.None  -> u
                                      | FStar_Pervasives_Native.Some tm ->
                                          env.FStar_TypeChecker_Env.universe_of
-                                           env tm
-                                      in
+                                           env tm in
                                    let uu____7565 =
                                      FStar_List.fold_left
                                        FStar_TypeChecker_Rel.conj_guard f
-                                       guards
-                                      in
+                                       guards in
                                    (c2, u_c, uu____7565))))))
-
-and (tc_universe :
+and tc_universe:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe)
+    FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe
   =
   fun env  ->
     fun u  ->
       let rec aux u1 =
-        let u2 = FStar_Syntax_Subst.compress_univ u1  in
+        let u2 = FStar_Syntax_Subst.compress_univ u1 in
         match u2 with
         | FStar_Syntax_Syntax.U_bvar uu____7573 ->
             failwith "Impossible: locally nameless"
@@ -3490,27 +3178,26 @@ and (tc_universe :
         | FStar_Syntax_Syntax.U_unif uu____7574 -> u2
         | FStar_Syntax_Syntax.U_zero  -> u2
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____7584 = aux u3  in FStar_Syntax_Syntax.U_succ uu____7584
+            let uu____7584 = aux u3 in FStar_Syntax_Syntax.U_succ uu____7584
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____7588 = FStar_List.map aux us  in
+            let uu____7588 = FStar_List.map aux us in
             FStar_Syntax_Syntax.U_max uu____7588
-        | FStar_Syntax_Syntax.U_name x -> u2  in
+        | FStar_Syntax_Syntax.U_name x -> u2 in
       if env.FStar_TypeChecker_Env.lax_universes
       then FStar_Syntax_Syntax.U_zero
       else
         (match u with
          | FStar_Syntax_Syntax.U_unknown  ->
-             let uu____7593 = FStar_Syntax_Util.type_u ()  in
+             let uu____7593 = FStar_Syntax_Util.type_u () in
              FStar_All.pipe_right uu____7593 FStar_Pervasives_Native.snd
          | uu____7602 -> aux u)
-
-and (tc_abs :
+and tc_abs:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.binders ->
         FStar_Syntax_Syntax.term ->
           (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun top  ->
@@ -3519,10 +3206,8 @@ and (tc_abs :
           let fail a msg t =
             let uu____7623 =
               FStar_TypeChecker_Err.expected_a_term_of_type_t_got_a_function
-                env msg t top
-               in
-            FStar_Errors.raise_error uu____7623 top.FStar_Syntax_Syntax.pos
-             in
+                env msg t top in
+            FStar_Errors.raise_error uu____7623 top.FStar_Syntax_Syntax.pos in
           let check_binders env1 bs1 bs_expected =
             let rec aux uu____7717 bs2 bs_expected1 =
               match uu____7717 with
@@ -3539,16 +3224,14 @@ and (tc_abs :
                              let uu____7890 =
                                let uu____7895 =
                                  let uu____7896 =
-                                   FStar_Syntax_Print.bv_to_string hd1  in
+                                   FStar_Syntax_Print.bv_to_string hd1 in
                                  FStar_Util.format1
                                    "Inconsistent implicit argument annotation on argument %s"
-                                   uu____7896
-                                  in
+                                   uu____7896 in
                                (FStar_Errors.Fatal_InconsistentImplicitArgumentAnnotation,
-                                 uu____7895)
-                                in
+                                 uu____7895) in
                              let uu____7897 =
-                               FStar_Syntax_Syntax.range_of_bv hd1  in
+                               FStar_Syntax_Syntax.range_of_bv hd1 in
                              FStar_Errors.raise_error uu____7890 uu____7897
                          | (FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.Implicit
@@ -3556,118 +3239,102 @@ and (tc_abs :
                              let uu____7903 =
                                let uu____7908 =
                                  let uu____7909 =
-                                   FStar_Syntax_Print.bv_to_string hd1  in
+                                   FStar_Syntax_Print.bv_to_string hd1 in
                                  FStar_Util.format1
                                    "Inconsistent implicit argument annotation on argument %s"
-                                   uu____7909
-                                  in
+                                   uu____7909 in
                                (FStar_Errors.Fatal_InconsistentImplicitArgumentAnnotation,
-                                 uu____7908)
-                                in
+                                 uu____7908) in
                              let uu____7910 =
-                               FStar_Syntax_Syntax.range_of_bv hd1  in
+                               FStar_Syntax_Syntax.range_of_bv hd1 in
                              FStar_Errors.raise_error uu____7903 uu____7910
                          | uu____7911 -> ());
                         (let expected_t =
                            FStar_Syntax_Subst.subst subst1
-                             hd_expected.FStar_Syntax_Syntax.sort
-                            in
+                             hd_expected.FStar_Syntax_Syntax.sort in
                          let uu____7917 =
                            let uu____7922 =
                              let uu____7923 =
                                FStar_Syntax_Util.unmeta
-                                 hd1.FStar_Syntax_Syntax.sort
-                                in
-                             uu____7923.FStar_Syntax_Syntax.n  in
+                                 hd1.FStar_Syntax_Syntax.sort in
+                             uu____7923.FStar_Syntax_Syntax.n in
                            match uu____7922 with
                            | FStar_Syntax_Syntax.Tm_unknown  ->
                                (expected_t, g)
                            | uu____7930 ->
                                ((let uu____7932 =
                                    FStar_TypeChecker_Env.debug env2
-                                     FStar_Options.High
-                                    in
+                                     FStar_Options.High in
                                  if uu____7932
                                  then
                                    let uu____7933 =
-                                     FStar_Syntax_Print.bv_to_string hd1  in
+                                     FStar_Syntax_Print.bv_to_string hd1 in
                                    FStar_Util.print1 "Checking binder %s\n"
                                      uu____7933
                                  else ());
                                 (let uu____7935 =
                                    tc_tot_or_gtot_term env2
-                                     hd1.FStar_Syntax_Syntax.sort
-                                    in
+                                     hd1.FStar_Syntax_Syntax.sort in
                                  match uu____7935 with
                                  | (t,uu____7947,g1) ->
                                      let g2 =
                                        let uu____7950 =
                                          FStar_TypeChecker_Rel.teq_nosmt env2
-                                           t expected_t
-                                          in
+                                           t expected_t in
                                        if uu____7950
                                        then
                                          FStar_TypeChecker_Rel.trivial_guard
                                        else
                                          (let uu____7952 =
                                             FStar_TypeChecker_Rel.get_subtyping_prop
-                                              env2 expected_t t
-                                             in
+                                              env2 expected_t t in
                                           match uu____7952 with
                                           | FStar_Pervasives_Native.None  ->
                                               let uu____7955 =
                                                 FStar_TypeChecker_Err.basic_type_error
                                                   env2
                                                   FStar_Pervasives_Native.None
-                                                  expected_t t
-                                                 in
+                                                  expected_t t in
                                               let uu____7960 =
                                                 FStar_TypeChecker_Env.get_range
-                                                  env2
-                                                 in
+                                                  env2 in
                                               FStar_Errors.raise_error
                                                 uu____7955 uu____7960
                                           | FStar_Pervasives_Native.Some g2
                                               ->
                                               let uu____7962 =
                                                 FStar_TypeChecker_Env.get_range
-                                                  env2
-                                                 in
+                                                  env2 in
                                               FStar_TypeChecker_Util.label_guard
                                                 uu____7962
                                                 "Type annotation on parameter incompatible with the expected type"
-                                                g2)
-                                        in
+                                                g2) in
                                      let g3 =
                                        let uu____7964 =
                                          FStar_TypeChecker_Rel.conj_guard g1
-                                           g2
-                                          in
+                                           g2 in
                                        FStar_TypeChecker_Rel.conj_guard g
-                                         uu____7964
-                                        in
-                                     (t, g3)))
-                            in
+                                         uu____7964 in
+                                     (t, g3))) in
                          match uu____7917 with
                          | (t,g1) ->
                              let hd2 =
-                               let uu___86_7992 = hd1  in
+                               let uu___86_7992 = hd1 in
                                {
                                  FStar_Syntax_Syntax.ppname =
                                    (uu___86_7992.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
                                    (uu___86_7992.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = t
-                               }  in
-                             let b = (hd2, imp)  in
-                             let b_expected = (hd_expected, imp')  in
-                             let env3 = push_binding env2 b  in
+                               } in
+                             let b = (hd2, imp) in
+                             let b_expected = (hd_expected, imp') in
+                             let env3 = push_binding env2 b in
                              let subst2 =
                                let uu____8005 =
-                                 FStar_Syntax_Syntax.bv_to_name hd2  in
+                                 FStar_Syntax_Syntax.bv_to_name hd2 in
                                maybe_extend_subst subst1 b_expected
-                                 uu____8005
-                                in
+                                 uu____8005 in
                              aux (env3, (b :: out), g1, subst2) bs3
                                bs_expected2))
                    | (rest,[]) ->
@@ -3677,11 +3344,9 @@ and (tc_abs :
                    | ([],rest) ->
                        (env2, (FStar_List.rev out),
                          (FStar_Pervasives_Native.Some (FStar_Util.Inr rest)),
-                         g, subst1))
-               in
+                         g, subst1)) in
             aux (env1, [], FStar_TypeChecker_Rel.trivial_guard, []) bs1
-              bs_expected
-             in
+              bs_expected in
           let rec expected_function_typ1 env1 t0 body1 =
             match t0 with
             | FStar_Pervasives_Native.None  ->
@@ -3690,29 +3355,28 @@ and (tc_abs :
                   | uu____8153 ->
                       failwith
                         "Impossible: Can't have a let rec annotation but no expected type");
-                 (let uu____8162 = tc_binders env1 bs  in
+                 (let uu____8162 = tc_binders env1 bs in
                   match uu____8162 with
                   | (bs1,envbody,g,uu____8192) ->
                       (FStar_Pervasives_Native.None, bs1, [],
                         FStar_Pervasives_Native.None, envbody, body1, g)))
             | FStar_Pervasives_Native.Some t ->
-                let t1 = FStar_Syntax_Subst.compress t  in
+                let t1 = FStar_Syntax_Subst.compress t in
                 let rec as_function_typ norm1 t2 =
                   let uu____8236 =
-                    let uu____8237 = FStar_Syntax_Subst.compress t2  in
-                    uu____8237.FStar_Syntax_Syntax.n  in
+                    let uu____8237 = FStar_Syntax_Subst.compress t2 in
+                    uu____8237.FStar_Syntax_Syntax.n in
                   match uu____8236 with
                   | FStar_Syntax_Syntax.Tm_uvar uu____8260 ->
                       ((match env1.FStar_TypeChecker_Env.letrecs with
                         | [] -> ()
                         | uu____8284 -> failwith "Impossible");
-                       (let uu____8293 = tc_binders env1 bs  in
+                       (let uu____8293 = tc_binders env1 bs in
                         match uu____8293 with
                         | (bs1,envbody,g,uu____8325) ->
                             let uu____8326 =
                               FStar_TypeChecker_Env.clear_expected_typ
-                                envbody
-                               in
+                                envbody in
                             (match uu____8326 with
                              | (envbody1,uu____8354) ->
                                  ((FStar_Pervasives_Native.Some t2), bs1, [],
@@ -3728,13 +3392,12 @@ and (tc_abs :
                       ((match env1.FStar_TypeChecker_Env.letrecs with
                         | [] -> ()
                         | uu____8412 -> failwith "Impossible");
-                       (let uu____8421 = tc_binders env1 bs  in
+                       (let uu____8421 = tc_binders env1 bs in
                         match uu____8421 with
                         | (bs1,envbody,g,uu____8453) ->
                             let uu____8454 =
                               FStar_TypeChecker_Env.clear_expected_typ
-                                envbody
-                               in
+                                envbody in
                             (match uu____8454 with
                              | (envbody1,uu____8482) ->
                                  ((FStar_Pervasives_Native.Some t2), bs1, [],
@@ -3742,15 +3405,14 @@ and (tc_abs :
                                    body1, g))))
                   | FStar_Syntax_Syntax.Tm_refine (b,uu____8494) ->
                       let uu____8499 =
-                        as_function_typ norm1 b.FStar_Syntax_Syntax.sort  in
+                        as_function_typ norm1 b.FStar_Syntax_Syntax.sort in
                       (match uu____8499 with
                        | (uu____8540,bs1,bs',copt,env2,body2,g) ->
                            ((FStar_Pervasives_Native.Some t2), bs1, bs',
                              copt, env2, body2, g))
                   | FStar_Syntax_Syntax.Tm_arrow (bs_expected,c_expected) ->
                       let uu____8583 =
-                        FStar_Syntax_Subst.open_comp bs_expected c_expected
-                         in
+                        FStar_Syntax_Subst.open_comp bs_expected c_expected in
                       (match uu____8583 with
                        | (bs_expected1,c_expected1) ->
                            let check_actuals_against_formals env2 bs1
@@ -3763,72 +3425,61 @@ and (tc_abs :
                                     | FStar_Pervasives_Native.None  ->
                                         let uu____8812 =
                                           FStar_Syntax_Subst.subst_comp
-                                            subst1 c_expected2
-                                           in
+                                            subst1 c_expected2 in
                                         (env3, bs2, guard, uu____8812, body3)
                                     | FStar_Pervasives_Native.Some
                                         (FStar_Util.Inr more_bs_expected) ->
                                         let c =
                                           let uu____8843 =
                                             FStar_Syntax_Util.arrow
-                                              more_bs_expected c_expected2
-                                             in
+                                              more_bs_expected c_expected2 in
                                           FStar_Syntax_Syntax.mk_Total
-                                            uu____8843
-                                           in
+                                            uu____8843 in
                                         let uu____8844 =
                                           FStar_Syntax_Subst.subst_comp
-                                            subst1 c
-                                           in
+                                            subst1 c in
                                         (env3, bs2, guard, uu____8844, body3)
                                     | FStar_Pervasives_Native.Some
                                         (FStar_Util.Inl more_bs) ->
                                         let c =
                                           FStar_Syntax_Subst.subst_comp
-                                            subst1 c_expected2
-                                           in
+                                            subst1 c_expected2 in
                                         let uu____8869 =
                                           (FStar_Options.ml_ish ()) ||
-                                            (FStar_Syntax_Util.is_named_tot c)
-                                           in
+                                            (FStar_Syntax_Util.is_named_tot c) in
                                         if uu____8869
                                         then
                                           let t3 =
                                             FStar_TypeChecker_Normalize.unfold_whnf
                                               env3
                                               (FStar_Syntax_Util.comp_result
-                                                 c)
-                                             in
+                                                 c) in
                                           (match t3.FStar_Syntax_Syntax.n
                                            with
                                            | FStar_Syntax_Syntax.Tm_arrow
                                                (bs_expected3,c_expected3) ->
                                                let uu____8921 =
                                                  FStar_Syntax_Subst.open_comp
-                                                   bs_expected3 c_expected3
-                                                  in
+                                                   bs_expected3 c_expected3 in
                                                (match uu____8921 with
                                                 | (bs_expected4,c_expected4)
                                                     ->
                                                     let uu____8944 =
                                                       check_binders env3
-                                                        more_bs bs_expected4
-                                                       in
+                                                        more_bs bs_expected4 in
                                                     (match uu____8944 with
                                                      | (env4,bs',more1,guard',subst2)
                                                          ->
                                                          let uu____8994 =
                                                            let uu____9025 =
                                                              FStar_TypeChecker_Rel.conj_guard
-                                                               guard guard'
-                                                              in
+                                                               guard guard' in
                                                            (env4,
                                                              (FStar_List.append
                                                                 bs2 bs'),
                                                              more1,
                                                              uu____9025,
-                                                             subst2)
-                                                            in
+                                                             subst2) in
                                                          handle_more
                                                            uu____8994
                                                            c_expected4 body3))
@@ -3836,24 +3487,21 @@ and (tc_abs :
                                                let body4 =
                                                  FStar_Syntax_Util.abs
                                                    more_bs body3
-                                                   FStar_Pervasives_Native.None
-                                                  in
+                                                   FStar_Pervasives_Native.None in
                                                (env3, bs2, guard, c, body4))
                                         else
                                           (let body4 =
                                              FStar_Syntax_Util.abs more_bs
                                                body3
-                                               FStar_Pervasives_Native.None
-                                              in
-                                           (env3, bs2, guard, c, body4)))
-                                in
+                                               FStar_Pervasives_Native.None in
+                                           (env3, bs2, guard, c, body4))) in
                              let uu____9058 =
-                               check_binders env2 bs1 bs_expected2  in
-                             handle_more uu____9058 c_expected1 body2  in
+                               check_binders env2 bs1 bs_expected2 in
+                             handle_more uu____9058 c_expected1 body2 in
                            let mk_letrec_env envbody bs1 c =
-                             let letrecs = guard_letrecs envbody bs1 c  in
+                             let letrecs = guard_letrecs envbody bs1 c in
                              let envbody1 =
-                               let uu___87_9115 = envbody  in
+                               let uu___87_9115 = envbody in
                                {
                                  FStar_TypeChecker_Env.solver =
                                    (uu___87_9115.FStar_TypeChecker_Env.solver);
@@ -3924,7 +3572,7 @@ and (tc_abs :
                                    (uu___87_9115.FStar_TypeChecker_Env.dsenv);
                                  FStar_TypeChecker_Env.dep_graph =
                                    (uu___87_9115.FStar_TypeChecker_Env.dep_graph)
-                               }  in
+                               } in
                              FStar_All.pipe_right letrecs
                                (FStar_List.fold_left
                                   (fun uu____9163  ->
@@ -3936,26 +3584,23 @@ and (tc_abs :
                                              let uu____9233 =
                                                let uu____9234 =
                                                  FStar_TypeChecker_Env.clear_expected_typ
-                                                   env2
-                                                  in
+                                                   env2 in
                                                FStar_All.pipe_right
                                                  uu____9234
-                                                 FStar_Pervasives_Native.fst
-                                                in
-                                             tc_term uu____9233 t3  in
+                                                 FStar_Pervasives_Native.fst in
+                                             tc_term uu____9233 t3 in
                                            (match uu____9226 with
                                             | (t4,uu____9256,uu____9257) ->
                                                 let env3 =
                                                   FStar_TypeChecker_Env.push_let_binding
-                                                    env2 l (u_names, t4)
-                                                   in
+                                                    env2 l (u_names, t4) in
                                                 let lb =
                                                   match l with
                                                   | FStar_Util.Inl x ->
                                                       let uu____9267 =
                                                         FStar_Syntax_Syntax.mk_binder
                                                           (let uu___88_9270 =
-                                                             x  in
+                                                             x in
                                                            {
                                                              FStar_Syntax_Syntax.ppname
                                                                =
@@ -3965,30 +3610,24 @@ and (tc_abs :
                                                                (uu___88_9270.FStar_Syntax_Syntax.index);
                                                              FStar_Syntax_Syntax.sort
                                                                = t4
-                                                           })
-                                                         in
+                                                           }) in
                                                       uu____9267 ::
                                                         letrec_binders
                                                   | uu____9271 ->
-                                                      letrec_binders
-                                                   in
-                                                (env3, lb))) (envbody1, []))
-                              in
+                                                      letrec_binders in
+                                                (env3, lb))) (envbody1, [])) in
                            let uu____9276 =
                              check_actuals_against_formals env1 bs
-                               bs_expected1 body1
-                              in
+                               bs_expected1 body1 in
                            (match uu____9276 with
                             | (envbody,bs1,g,c,body2) ->
-                                let uu____9330 = mk_letrec_env envbody bs1 c
-                                   in
+                                let uu____9330 = mk_letrec_env envbody bs1 c in
                                 (match uu____9330 with
                                  | (envbody1,letrecs) ->
                                      let envbody2 =
                                        FStar_TypeChecker_Env.set_expected_typ
                                          envbody1
-                                         (FStar_Syntax_Util.comp_result c)
-                                        in
+                                         (FStar_Syntax_Util.comp_result c) in
                                      ((FStar_Pervasives_Native.Some t2), bs1,
                                        letrecs,
                                        (FStar_Pervasives_Native.Some c),
@@ -3997,35 +3636,31 @@ and (tc_abs :
                       if Prims.op_Negation norm1
                       then
                         let uu____9397 =
-                          FStar_TypeChecker_Normalize.unfold_whnf env1 t2  in
+                          FStar_TypeChecker_Normalize.unfold_whnf env1 t2 in
                         as_function_typ true uu____9397
                       else
                         (let uu____9399 =
                            expected_function_typ1 env1
-                             FStar_Pervasives_Native.None body1
-                            in
+                             FStar_Pervasives_Native.None body1 in
                          match uu____9399 with
                          | (uu____9438,bs1,uu____9440,c_opt,envbody,body2,g)
                              ->
                              ((FStar_Pervasives_Native.Some t2), bs1, [],
-                               c_opt, envbody, body2, g))
-                   in
-                as_function_typ false t1
-             in
-          let use_eq = env.FStar_TypeChecker_Env.use_eq  in
-          let uu____9460 = FStar_TypeChecker_Env.clear_expected_typ env  in
+                               c_opt, envbody, body2, g)) in
+                as_function_typ false t1 in
+          let use_eq = env.FStar_TypeChecker_Env.use_eq in
+          let uu____9460 = FStar_TypeChecker_Env.clear_expected_typ env in
           match uu____9460 with
           | (env1,topt) ->
               ((let uu____9480 =
-                  FStar_TypeChecker_Env.debug env1 FStar_Options.High  in
+                  FStar_TypeChecker_Env.debug env1 FStar_Options.High in
                 if uu____9480
                 then
                   let uu____9481 =
                     match topt with
                     | FStar_Pervasives_Native.None  -> "None"
                     | FStar_Pervasives_Native.Some t ->
-                        FStar_Syntax_Print.term_to_string t
-                     in
+                        FStar_Syntax_Print.term_to_string t in
                   FStar_Util.print2
                     "!!!!!!!!!!!!!!!Expected type is %s, top_level=%s\n"
                     uu____9481
@@ -4033,7 +3668,7 @@ and (tc_abs :
                      then "true"
                      else "false")
                 else ());
-               (let uu____9485 = expected_function_typ1 env1 topt body  in
+               (let uu____9485 = expected_function_typ1 env1 topt body in
                 match uu____9485 with
                 | (tfun_opt,bs1,letrec_binders,c_opt,envbody,body1,g) ->
                     let uu____9525 =
@@ -4041,18 +3676,18 @@ and (tc_abs :
                         let uu____9533 =
                           let uu____9540 =
                             let uu____9541 =
-                              FStar_Syntax_Subst.compress body1  in
-                            uu____9541.FStar_Syntax_Syntax.n  in
-                          (c_opt, uu____9540)  in
+                              FStar_Syntax_Subst.compress body1 in
+                            uu____9541.FStar_Syntax_Syntax.n in
+                          (c_opt, uu____9540) in
                         match uu____9533 with
                         | (FStar_Pervasives_Native.None
                            ,FStar_Syntax_Syntax.Tm_ascribed
                            (uu____9546,(FStar_Util.Inr expected_c,uu____9548),uu____9549))
                             -> false
-                        | uu____9598 -> true  in
+                        | uu____9598 -> true in
                       let uu____9605 =
                         tc_term
-                          (let uu___89_9614 = envbody  in
+                          (let uu___89_9614 = envbody in
                            {
                              FStar_TypeChecker_Env.solver =
                                (uu___89_9614.FStar_TypeChecker_Env.solver);
@@ -4122,23 +3757,21 @@ and (tc_abs :
                                (uu___89_9614.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.dep_graph =
                                (uu___89_9614.FStar_TypeChecker_Env.dep_graph)
-                           }) body1
-                         in
+                           }) body1 in
                       match uu____9605 with
                       | (body2,cbody,guard_body) ->
                           let guard_body1 =
                             FStar_TypeChecker_Rel.solve_deferred_constraints
-                              envbody guard_body
-                             in
+                              envbody guard_body in
                           if should_check_expected_effect
                           then
                             let uu____9631 =
                               let uu____9638 =
                                 let uu____9643 =
-                                  FStar_Syntax_Syntax.lcomp_comp cbody  in
-                                (body2, uu____9643)  in
+                                  FStar_Syntax_Syntax.lcomp_comp cbody in
+                                (body2, uu____9643) in
                               check_expected_effect
-                                (let uu___90_9646 = envbody  in
+                                (let uu___90_9646 = envbody in
                                  {
                                    FStar_TypeChecker_Env.solver =
                                      (uu___90_9646.FStar_TypeChecker_Env.solver);
@@ -4209,91 +3842,77 @@ and (tc_abs :
                                      (uu___90_9646.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.dep_graph =
                                      (uu___90_9646.FStar_TypeChecker_Env.dep_graph)
-                                 }) c_opt uu____9638
-                               in
+                                 }) c_opt uu____9638 in
                             (match uu____9631 with
                              | (body3,cbody1,guard) ->
                                  let uu____9656 =
                                    FStar_TypeChecker_Rel.conj_guard
-                                     guard_body1 guard
-                                    in
+                                     guard_body1 guard in
                                  (body3, cbody1, uu____9656))
                           else
                             (let uu____9658 =
-                               FStar_Syntax_Syntax.lcomp_comp cbody  in
-                             (body2, uu____9658, guard_body1))
-                       in
+                               FStar_Syntax_Syntax.lcomp_comp cbody in
+                             (body2, uu____9658, guard_body1)) in
                     (match uu____9525 with
                      | (body2,cbody,guard) ->
                          let guard1 =
                            let uu____9669 =
                              env1.FStar_TypeChecker_Env.top_level ||
                                (let uu____9671 =
-                                  FStar_TypeChecker_Env.should_verify env1
-                                   in
-                                Prims.op_Negation uu____9671)
-                              in
+                                  FStar_TypeChecker_Env.should_verify env1 in
+                                Prims.op_Negation uu____9671) in
                            if uu____9669
                            then
                              let uu____9672 =
-                               FStar_TypeChecker_Rel.conj_guard g guard  in
+                               FStar_TypeChecker_Rel.conj_guard g guard in
                              FStar_TypeChecker_Rel.discharge_guard envbody
                                uu____9672
                            else
                              (let guard1 =
                                 let uu____9675 =
-                                  FStar_TypeChecker_Rel.conj_guard g guard
-                                   in
+                                  FStar_TypeChecker_Rel.conj_guard g guard in
                                 FStar_TypeChecker_Rel.close_guard env1
                                   (FStar_List.append bs1 letrec_binders)
-                                  uu____9675
-                                 in
-                              guard1)
-                            in
+                                  uu____9675 in
+                              guard1) in
                          let tfun_computed =
-                           FStar_Syntax_Util.arrow bs1 cbody  in
+                           FStar_Syntax_Util.arrow bs1 cbody in
                          let e =
                            FStar_Syntax_Util.abs bs1 body2
                              (FStar_Pervasives_Native.Some
                                 (FStar_Syntax_Util.residual_comp_of_comp
-                                   (FStar_Util.dflt cbody c_opt)))
-                            in
+                                   (FStar_Util.dflt cbody c_opt))) in
                          let uu____9684 =
                            match tfun_opt with
                            | FStar_Pervasives_Native.Some t ->
-                               let t1 = FStar_Syntax_Subst.compress t  in
+                               let t1 = FStar_Syntax_Subst.compress t in
                                (match t1.FStar_Syntax_Syntax.n with
                                 | FStar_Syntax_Syntax.Tm_arrow uu____9705 ->
                                     (e, t1, guard1)
                                 | uu____9718 ->
                                     let uu____9719 =
                                       FStar_TypeChecker_Util.check_and_ascribe
-                                        env1 e tfun_computed t1
-                                       in
+                                        env1 e tfun_computed t1 in
                                     (match uu____9719 with
                                      | (e1,guard') ->
                                          let uu____9732 =
                                            FStar_TypeChecker_Rel.conj_guard
-                                             guard1 guard'
-                                            in
+                                             guard1 guard' in
                                          (e1, t1, uu____9732)))
                            | FStar_Pervasives_Native.None  ->
-                               (e, tfun_computed, guard1)
-                            in
+                               (e, tfun_computed, guard1) in
                          (match uu____9684 with
                           | (e1,tfun,guard2) ->
-                              let c = FStar_Syntax_Syntax.mk_Total tfun  in
+                              let c = FStar_Syntax_Syntax.mk_Total tfun in
                               let uu____9745 =
                                 let uu____9750 =
-                                  FStar_Syntax_Util.lcomp_of_comp c  in
+                                  FStar_Syntax_Util.lcomp_of_comp c in
                                 FStar_TypeChecker_Util.strengthen_precondition
                                   FStar_Pervasives_Native.None env1 e1
-                                  uu____9750 guard2
-                                 in
+                                  uu____9750 guard2 in
                               (match uu____9745 with
                                | (c1,g1) -> (e1, c1, g1))))))
-
-and (check_application_args :
+and check_application_args:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.lcomp ->
@@ -4302,7 +3921,7 @@ and (check_application_args :
             FStar_Pervasives_Native.tuple2 Prims.list ->
             FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option ->
               (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-                FStar_Pervasives_Native.tuple3)
+                FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun head1  ->
@@ -4310,17 +3929,16 @@ and (check_application_args :
         fun ghead  ->
           fun args  ->
             fun expected_topt  ->
-              let n_args = FStar_List.length args  in
-              let r = FStar_TypeChecker_Env.get_range env  in
-              let thead = chead.FStar_Syntax_Syntax.res_typ  in
+              let n_args = FStar_List.length args in
+              let r = FStar_TypeChecker_Env.get_range env in
+              let thead = chead.FStar_Syntax_Syntax.res_typ in
               (let uu____9795 =
-                 FStar_TypeChecker_Env.debug env FStar_Options.High  in
+                 FStar_TypeChecker_Env.debug env FStar_Options.High in
                if uu____9795
                then
                  let uu____9796 =
-                   FStar_Range.string_of_range head1.FStar_Syntax_Syntax.pos
-                    in
-                 let uu____9797 = FStar_Syntax_Print.term_to_string thead  in
+                   FStar_Range.string_of_range head1.FStar_Syntax_Syntax.pos in
+                 let uu____9797 = FStar_Syntax_Print.term_to_string thead in
                  FStar_Util.print2 "(%s) Type of head is %s\n" uu____9796
                    uu____9797
                else ());
@@ -4330,10 +3948,9 @@ and (check_application_args :
                  | (head2,chead1,ghead1,cres) ->
                      let rt =
                        check_no_escape (FStar_Pervasives_Native.Some head2)
-                         env fvs cres.FStar_Syntax_Syntax.res_typ
-                        in
+                         env fvs cres.FStar_Syntax_Syntax.res_typ in
                      let cres1 =
-                       let uu___91_9913 = cres  in
+                       let uu___91_9913 = cres in
                        {
                          FStar_Syntax_Syntax.eff_name =
                            (uu___91_9913.FStar_Syntax_Syntax.eff_name);
@@ -4342,45 +3959,39 @@ and (check_application_args :
                            (uu___91_9913.FStar_Syntax_Syntax.cflags);
                          FStar_Syntax_Syntax.comp_thunk =
                            (uu___91_9913.FStar_Syntax_Syntax.comp_thunk)
-                       }  in
+                       } in
                      let uu____9914 =
                        match bs with
                        | [] ->
                            let g =
-                             FStar_TypeChecker_Rel.conj_guard ghead1 guard
-                              in
+                             FStar_TypeChecker_Rel.conj_guard ghead1 guard in
                            (cres1, g)
                        | uu____9928 ->
                            let g =
                              let uu____9936 =
-                               FStar_TypeChecker_Rel.conj_guard ghead1 guard
-                                in
+                               FStar_TypeChecker_Rel.conj_guard ghead1 guard in
                              FStar_All.pipe_right uu____9936
                                (FStar_TypeChecker_Rel.solve_deferred_constraints
-                                  env)
-                              in
+                                  env) in
                            let uu____9937 =
                              let uu____9938 =
                                let uu____9941 =
                                  let uu____9942 =
-                                   FStar_Syntax_Syntax.lcomp_comp cres1  in
-                                 FStar_Syntax_Util.arrow bs uu____9942  in
-                               FStar_Syntax_Syntax.mk_Total uu____9941  in
+                                   FStar_Syntax_Syntax.lcomp_comp cres1 in
+                                 FStar_Syntax_Util.arrow bs uu____9942 in
+                               FStar_Syntax_Syntax.mk_Total uu____9941 in
                              FStar_All.pipe_left
-                               FStar_Syntax_Util.lcomp_of_comp uu____9938
-                              in
-                           (uu____9937, g)
-                        in
+                               FStar_Syntax_Util.lcomp_of_comp uu____9938 in
+                           (uu____9937, g) in
                      (match uu____9914 with
                       | (cres2,guard1) ->
                           ((let uu____9956 =
                               FStar_TypeChecker_Env.debug env
-                                FStar_Options.Low
-                               in
+                                FStar_Options.Low in
                             if uu____9956
                             then
                               let uu____9957 =
-                                FStar_Syntax_Print.lcomp_to_string cres2  in
+                                FStar_Syntax_Print.lcomp_to_string cres2 in
                               FStar_Util.print1
                                 "\t Type of result cres is %s\n" uu____9957
                             else ());
@@ -4395,34 +4006,28 @@ and (check_application_args :
                                         | (uu____9982,uu____9983,lc) ->
                                             (let uu____9991 =
                                                FStar_Syntax_Util.is_pure_or_ghost_lcomp
-                                                 lc
-                                                in
+                                                 lc in
                                              Prims.op_Negation uu____9991) ||
                                               (FStar_TypeChecker_Util.should_not_inline_lc
-                                                 lc)) arg_comps_rev)
-                                 in
+                                                 lc)) arg_comps_rev) in
                               let term =
                                 FStar_Syntax_Syntax.mk_Tm_app head2
                                   (FStar_List.rev arg_rets_rev)
                                   FStar_Pervasives_Native.None
-                                  head2.FStar_Syntax_Syntax.pos
-                                 in
+                                  head2.FStar_Syntax_Syntax.pos in
                               let uu____10001 =
                                 (FStar_Syntax_Util.is_pure_or_ghost_lcomp
                                    cres2)
-                                  && head_is_pure_and_some_arg_is_effectful
-                                 in
+                                  && head_is_pure_and_some_arg_is_effectful in
                               if uu____10001
                               then
                                 ((let uu____10003 =
                                     FStar_TypeChecker_Env.debug env
-                                      FStar_Options.Extreme
-                                     in
+                                      FStar_Options.Extreme in
                                   if uu____10003
                                   then
                                     let uu____10004 =
-                                      FStar_Syntax_Print.term_to_string term
-                                       in
+                                      FStar_Syntax_Print.term_to_string term in
                                     FStar_Util.print1
                                       "(a) Monadic app: Return inserted in monadic application: %s\n"
                                       uu____10004
@@ -4432,19 +4037,16 @@ and (check_application_args :
                               else
                                 ((let uu____10008 =
                                     FStar_TypeChecker_Env.debug env
-                                      FStar_Options.Extreme
-                                     in
+                                      FStar_Options.Extreme in
                                   if uu____10008
                                   then
                                     let uu____10009 =
-                                      FStar_Syntax_Print.term_to_string term
-                                       in
+                                      FStar_Syntax_Print.term_to_string term in
                                     FStar_Util.print1
                                       "(a) Monadic app: No return inserted in monadic application: %s\n"
                                       uu____10009
                                   else ());
-                                 cres2)
-                               in
+                                 cres2) in
                             let comp =
                               FStar_List.fold_left
                                 (fun out_c  ->
@@ -4453,8 +4055,7 @@ and (check_application_args :
                                      | ((e,q),x,c) ->
                                          ((let uu____10059 =
                                              FStar_TypeChecker_Env.debug env
-                                               FStar_Options.Extreme
-                                              in
+                                               FStar_Options.Extreme in
                                            if uu____10059
                                            then
                                              let uu____10060 =
@@ -4464,20 +4065,17 @@ and (check_application_args :
                                                | FStar_Pervasives_Native.Some
                                                    x1 ->
                                                    FStar_Syntax_Print.bv_to_string
-                                                     x1
-                                                in
+                                                     x1 in
                                              let uu____10062 =
                                                FStar_Syntax_Print.term_to_string
-                                                 e
-                                                in
+                                                 e in
                                              FStar_Util.print2
                                                "(b) Monadic app: Binding argument %s : %s\n"
                                                uu____10060 uu____10062
                                            else ());
                                           (let uu____10064 =
                                              FStar_Syntax_Util.is_pure_or_ghost_lcomp
-                                               c
-                                              in
+                                               c in
                                            if uu____10064
                                            then
                                              FStar_TypeChecker_Util.bind
@@ -4489,26 +4087,22 @@ and (check_application_args :
                                                e.FStar_Syntax_Syntax.pos env
                                                FStar_Pervasives_Native.None c
                                                (x, out_c)))) cres3
-                                arg_comps_rev
-                               in
+                                arg_comps_rev in
                             let comp1 =
                               (let uu____10072 =
                                  FStar_TypeChecker_Env.debug env
-                                   FStar_Options.Extreme
-                                  in
+                                   FStar_Options.Extreme in
                                if uu____10072
                                then
                                  let uu____10073 =
-                                   FStar_Syntax_Print.term_to_string head2
-                                    in
+                                   FStar_Syntax_Print.term_to_string head2 in
                                  FStar_Util.print1
                                    "(c) Monadic app: Binding head %s "
                                    uu____10073
                                else ());
                               (let uu____10075 =
                                  FStar_Syntax_Util.is_pure_or_ghost_lcomp
-                                   chead1
-                                  in
+                                   chead1 in
                                if uu____10075
                                then
                                  FStar_TypeChecker_Util.bind
@@ -4520,16 +4114,14 @@ and (check_application_args :
                                  FStar_TypeChecker_Util.bind
                                    head2.FStar_Syntax_Syntax.pos env
                                    FStar_Pervasives_Native.None chead1
-                                   (FStar_Pervasives_Native.None, comp))
-                               in
+                                   (FStar_Pervasives_Native.None, comp)) in
                             let comp2 =
-                              FStar_TypeChecker_Util.subst_lcomp subst1 comp1
-                               in
+                              FStar_TypeChecker_Util.subst_lcomp subst1 comp1 in
                             let shortcuts_evaluation_order =
                               let uu____10083 =
                                 let uu____10084 =
-                                  FStar_Syntax_Subst.compress head2  in
-                                uu____10084.FStar_Syntax_Syntax.n  in
+                                  FStar_Syntax_Subst.compress head2 in
+                                uu____10084.FStar_Syntax_Syntax.n in
                               match uu____10083 with
                               | FStar_Syntax_Syntax.Tm_fvar fv ->
                                   (FStar_Syntax_Syntax.fv_eq_lid fv
@@ -4537,7 +4129,7 @@ and (check_application_args :
                                     ||
                                     (FStar_Syntax_Syntax.fv_eq_lid fv
                                        FStar_Parser_Const.op_Or)
-                              | uu____10088 -> false  in
+                              | uu____10088 -> false in
                             let app =
                               if shortcuts_evaluation_order
                               then
@@ -4547,18 +4139,15 @@ and (check_application_args :
                                        fun uu____10109  ->
                                          match uu____10109 with
                                          | (arg,uu____10123,uu____10124) ->
-                                             arg :: args1) [] arg_comps_rev
-                                   in
+                                             arg :: args1) [] arg_comps_rev in
                                 let app =
                                   FStar_Syntax_Syntax.mk_Tm_app head2 args1
-                                    FStar_Pervasives_Native.None r
-                                   in
+                                    FStar_Pervasives_Native.None r in
                                 let app1 =
                                   FStar_TypeChecker_Util.maybe_lift env app
                                     cres3.FStar_Syntax_Syntax.eff_name
                                     comp2.FStar_Syntax_Syntax.eff_name
-                                    comp2.FStar_Syntax_Syntax.res_typ
-                                   in
+                                    comp2.FStar_Syntax_Syntax.res_typ in
                                 FStar_TypeChecker_Util.maybe_monadic env app1
                                   comp2.FStar_Syntax_Syntax.eff_name
                                   comp2.FStar_Syntax_Syntax.res_typ
@@ -4569,8 +4158,7 @@ and (check_application_args :
                                      | ((e,q),uu____10231,c) ->
                                          let uu____10241 =
                                            FStar_Syntax_Util.is_pure_or_ghost_lcomp
-                                             c
-                                            in
+                                             c in
                                          if uu____10241
                                          then
                                            (FStar_Pervasives_Native.None,
@@ -4579,77 +4167,65 @@ and (check_application_args :
                                            (let x =
                                               FStar_Syntax_Syntax.new_bv
                                                 FStar_Pervasives_Native.None
-                                                c.FStar_Syntax_Syntax.res_typ
-                                               in
+                                                c.FStar_Syntax_Syntax.res_typ in
                                             let e1 =
                                               FStar_TypeChecker_Util.maybe_lift
                                                 env e
                                                 c.FStar_Syntax_Syntax.eff_name
                                                 comp2.FStar_Syntax_Syntax.eff_name
-                                                c.FStar_Syntax_Syntax.res_typ
-                                               in
+                                                c.FStar_Syntax_Syntax.res_typ in
                                             let uu____10291 =
                                               let uu____10296 =
                                                 FStar_Syntax_Syntax.bv_to_name
-                                                  x
-                                                 in
-                                              (uu____10296, q)  in
+                                                  x in
+                                              (uu____10296, q) in
                                             ((FStar_Pervasives_Native.Some
                                                 (x,
                                                   (c.FStar_Syntax_Syntax.eff_name),
                                                   (c.FStar_Syntax_Syntax.res_typ),
-                                                  e1)), uu____10291))
-                                      in
+                                                  e1)), uu____10291)) in
                                    let uu____10325 =
                                      let uu____10350 =
                                        let uu____10373 =
                                          let uu____10388 =
                                            let uu____10397 =
-                                             FStar_Syntax_Syntax.as_arg head2
-                                              in
+                                             FStar_Syntax_Syntax.as_arg head2 in
                                            (uu____10397,
                                              FStar_Pervasives_Native.None,
-                                             chead1)
-                                            in
-                                         uu____10388 :: arg_comps_rev  in
-                                       FStar_List.map map_fun uu____10373  in
+                                             chead1) in
+                                         uu____10388 :: arg_comps_rev in
+                                       FStar_List.map map_fun uu____10373 in
                                      FStar_All.pipe_left FStar_List.split
-                                       uu____10350
-                                      in
+                                       uu____10350 in
                                    match uu____10325 with
                                    | (lifted_args,reverse_args) ->
                                        let uu____10570 =
                                          let uu____10571 =
-                                           FStar_List.hd reverse_args  in
+                                           FStar_List.hd reverse_args in
                                          FStar_Pervasives_Native.fst
-                                           uu____10571
-                                          in
+                                           uu____10571 in
                                        let uu____10580 =
                                          let uu____10587 =
-                                           FStar_List.tl reverse_args  in
-                                         FStar_List.rev uu____10587  in
+                                           FStar_List.tl reverse_args in
+                                         FStar_List.rev uu____10587 in
                                        (lifted_args, uu____10570,
-                                         uu____10580)
-                                    in
+                                         uu____10580) in
                                  match uu____10134 with
                                  | (lifted_args,head3,args1) ->
                                      let app =
                                        FStar_Syntax_Syntax.mk_Tm_app head3
-                                         args1 FStar_Pervasives_Native.None r
-                                        in
+                                         args1 FStar_Pervasives_Native.None r in
                                      let app1 =
                                        FStar_TypeChecker_Util.maybe_lift env
                                          app
                                          cres3.FStar_Syntax_Syntax.eff_name
                                          comp2.FStar_Syntax_Syntax.eff_name
-                                         comp2.FStar_Syntax_Syntax.res_typ
-                                        in
+                                         comp2.FStar_Syntax_Syntax.res_typ in
                                      let app2 =
                                        FStar_TypeChecker_Util.maybe_monadic
                                          env app1
                                          comp2.FStar_Syntax_Syntax.eff_name
-                                         comp2.FStar_Syntax_Syntax.res_typ
-                                        in
+                                         comp2.FStar_Syntax_Syntax.res_typ in
                                      let bind_lifted_args e uu___65_10690 =
                                        match uu___65_10690 with
                                        | FStar_Pervasives_Native.None  -> e
@@ -4658,8 +4234,7 @@ and (check_application_args :
                                            let lb =
                                              FStar_Syntax_Util.mk_letbinding
                                                (FStar_Util.Inl x) [] t m e1
-                                               []
-                                              in
+                                               [] in
                                            let letbinding =
                                              let uu____10747 =
                                                let uu____10750 =
@@ -4668,25 +4243,19 @@ and (check_application_args :
                                                      let uu____10765 =
                                                        let uu____10766 =
                                                          FStar_Syntax_Syntax.mk_binder
-                                                           x
-                                                          in
-                                                       [uu____10766]  in
+                                                           x in
+                                                       [uu____10766] in
                                                      FStar_Syntax_Subst.close
-                                                       uu____10765 e
-                                                      in
+                                                       uu____10765 e in
                                                    ((false, [lb]),
-                                                     uu____10764)
-                                                    in
+                                                     uu____10764) in
                                                  FStar_Syntax_Syntax.Tm_let
-                                                   uu____10751
-                                                  in
+                                                   uu____10751 in
                                                FStar_Syntax_Syntax.mk
-                                                 uu____10750
-                                                in
+                                                 uu____10750 in
                                              uu____10747
                                                FStar_Pervasives_Native.None
-                                               e.FStar_Syntax_Syntax.pos
-                                              in
+                                               e.FStar_Syntax_Syntax.pos in
                                            FStar_Syntax_Syntax.mk
                                              (FStar_Syntax_Syntax.Tm_meta
                                                 (letbinding,
@@ -4694,37 +4263,30 @@ and (check_application_args :
                                                      (m,
                                                        (comp2.FStar_Syntax_Syntax.res_typ)))))
                                              FStar_Pervasives_Native.None
-                                             e.FStar_Syntax_Syntax.pos
-                                        in
+                                             e.FStar_Syntax_Syntax.pos in
                                      FStar_List.fold_left bind_lifted_args
-                                       app2 lifted_args)
-                               in
+                                       app2 lifted_args) in
                             let uu____10796 =
                               FStar_TypeChecker_Util.strengthen_precondition
                                 FStar_Pervasives_Native.None env app comp2
-                                guard1
-                               in
+                                guard1 in
                             match uu____10796 with
                             | (comp3,g) ->
                                 ((let uu____10812 =
                                     FStar_TypeChecker_Env.debug env
-                                      FStar_Options.Extreme
-                                     in
+                                      FStar_Options.Extreme in
                                   if uu____10812
                                   then
                                     let uu____10813 =
-                                      FStar_Syntax_Print.term_to_string app
-                                       in
+                                      FStar_Syntax_Print.term_to_string app in
                                     let uu____10814 =
                                       FStar_Syntax_Print.lcomp_to_string
-                                        comp3
-                                       in
+                                        comp3 in
                                     FStar_Util.print2
                                       "(d) Monadic app: type of app\n\t(%s)\n\t: %s\n"
                                       uu____10813 uu____10814
                                   else ());
-                                 (app, comp3, g)))))
-                  in
+                                 (app, comp3, g))))) in
                let rec tc_args head_info uu____10890 bs args1 =
                  match uu____10890 with
                  | (subst1,outargs,arg_rets,g,fvs) ->
@@ -4735,46 +4297,38 @@ and (check_application_args :
                           ->
                           let t =
                             FStar_Syntax_Subst.subst subst1
-                              x.FStar_Syntax_Syntax.sort
-                             in
+                              x.FStar_Syntax_Syntax.sort in
                           let t1 =
                             check_no_escape
-                              (FStar_Pervasives_Native.Some head1) env fvs t
-                             in
+                              (FStar_Pervasives_Native.Some head1) env fvs t in
                           let uu____11087 =
                             FStar_TypeChecker_Util.new_implicit_var
                               "Instantiating implicit argument in application"
-                              head1.FStar_Syntax_Syntax.pos env t1
-                             in
+                              head1.FStar_Syntax_Syntax.pos env t1 in
                           (match uu____11087 with
                            | (varg,uu____11107,implicits) ->
                                let subst2 =
-                                 (FStar_Syntax_Syntax.NT (x, varg)) :: subst1
-                                  in
+                                 (FStar_Syntax_Syntax.NT (x, varg)) :: subst1 in
                                let arg =
                                  let uu____11129 =
-                                   FStar_Syntax_Syntax.as_implicit true  in
-                                 (varg, uu____11129)  in
+                                   FStar_Syntax_Syntax.as_implicit true in
+                                 (varg, uu____11129) in
                                let uu____11130 =
                                  let uu____11165 =
                                    let uu____11180 =
                                      let uu____11193 =
                                        let uu____11194 =
-                                         FStar_Syntax_Syntax.mk_Total t1  in
+                                         FStar_Syntax_Syntax.mk_Total t1 in
                                        FStar_All.pipe_right uu____11194
-                                         FStar_Syntax_Util.lcomp_of_comp
-                                        in
+                                         FStar_Syntax_Util.lcomp_of_comp in
                                      (arg, FStar_Pervasives_Native.None,
-                                       uu____11193)
-                                      in
-                                   uu____11180 :: outargs  in
+                                       uu____11193) in
+                                   uu____11180 :: outargs in
                                  let uu____11213 =
                                    FStar_TypeChecker_Rel.conj_guard implicits
-                                     g
-                                    in
+                                     g in
                                  (subst2, uu____11165, (arg :: arg_rets),
-                                   uu____11213, fvs)
-                                  in
+                                   uu____11213, fvs) in
                                tc_args head_info uu____11130 rest args1)
                       | ((x,aqual)::rest,(e,aq)::rest') ->
                           ((match (aqual, aq) with
@@ -4793,46 +4347,40 @@ and (check_application_args :
                                   let uu____11333 =
                                     let uu____11334 =
                                       FStar_Syntax_Print.aqual_to_string
-                                        aqual
-                                       in
+                                        aqual in
                                     let uu____11335 =
-                                      FStar_Syntax_Print.aqual_to_string aq
-                                       in
+                                      FStar_Syntax_Print.aqual_to_string aq in
                                     let uu____11336 =
-                                      FStar_Syntax_Print.bv_to_string x  in
+                                      FStar_Syntax_Print.bv_to_string x in
                                     let uu____11337 =
-                                      FStar_Syntax_Print.term_to_string e  in
+                                      FStar_Syntax_Print.term_to_string e in
                                     FStar_Util.format4
                                       "Inconsistent implicit qualifier; %s vs %s\nfor bvar %s and term %s"
                                       uu____11334 uu____11335 uu____11336
-                                      uu____11337
-                                     in
+                                      uu____11337 in
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
-                                    uu____11333)
-                                   in
+                                    uu____11333) in
                                 FStar_Errors.raise_error uu____11328
                                   e.FStar_Syntax_Syntax.pos);
                            (let targ =
                               FStar_Syntax_Subst.subst subst1
-                                x.FStar_Syntax_Syntax.sort
-                               in
+                                x.FStar_Syntax_Syntax.sort in
                             let x1 =
-                              let uu___92_11340 = x  in
+                              let uu___92_11340 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
                                   (uu___92_11340.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
                                   (uu___92_11340.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = targ
-                              }  in
+                              } in
                             (let uu____11342 =
                                FStar_TypeChecker_Env.debug env
-                                 FStar_Options.Extreme
-                                in
+                                 FStar_Options.Extreme in
                              if uu____11342
                              then
                                let uu____11343 =
-                                 FStar_Syntax_Print.term_to_string targ  in
+                                 FStar_Syntax_Print.term_to_string targ in
                                FStar_Util.print1
                                  "\tType of arg (after subst) = %s\n"
                                  uu____11343
@@ -4840,14 +4388,12 @@ and (check_application_args :
                             (let targ1 =
                                check_no_escape
                                  (FStar_Pervasives_Native.Some head1) env fvs
-                                 targ
-                                in
+                                 targ in
                              let env1 =
                                FStar_TypeChecker_Env.set_expected_typ env
-                                 targ1
-                                in
+                                 targ1 in
                              let env2 =
-                               let uu___93_11348 = env1  in
+                               let uu___93_11348 = env1 in
                                {
                                  FStar_TypeChecker_Env.solver =
                                    (uu___93_11348.FStar_TypeChecker_Env.solver);
@@ -4918,55 +4464,48 @@ and (check_application_args :
                                    (uu___93_11348.FStar_TypeChecker_Env.dsenv);
                                  FStar_TypeChecker_Env.dep_graph =
                                    (uu___93_11348.FStar_TypeChecker_Env.dep_graph)
-                               }  in
+                               } in
                              (let uu____11350 =
                                 FStar_TypeChecker_Env.debug env2
-                                  FStar_Options.High
-                                 in
+                                  FStar_Options.High in
                               if uu____11350
                               then
                                 let uu____11351 =
-                                  FStar_Syntax_Print.tag_of_term e  in
+                                  FStar_Syntax_Print.tag_of_term e in
                                 let uu____11352 =
-                                  FStar_Syntax_Print.term_to_string e  in
+                                  FStar_Syntax_Print.term_to_string e in
                                 let uu____11353 =
-                                  FStar_Syntax_Print.term_to_string targ1  in
+                                  FStar_Syntax_Print.term_to_string targ1 in
                                 FStar_Util.print3
                                   "Checking arg (%s) %s at type %s\n"
                                   uu____11351 uu____11352 uu____11353
                               else ());
-                             (let uu____11355 = tc_term env2 e  in
+                             (let uu____11355 = tc_term env2 e in
                               match uu____11355 with
                               | (e1,c,g_e) ->
                                   let g1 =
-                                    FStar_TypeChecker_Rel.conj_guard g g_e
-                                     in
-                                  let arg = (e1, aq)  in
+                                    FStar_TypeChecker_Rel.conj_guard g g_e in
+                                  let arg = (e1, aq) in
                                   let xterm =
                                     let uu____11390 =
                                       let uu____11393 =
                                         let uu____11400 =
-                                          FStar_Syntax_Syntax.bv_to_name x1
-                                           in
+                                          FStar_Syntax_Syntax.bv_to_name x1 in
                                         FStar_Syntax_Syntax.as_arg
-                                          uu____11400
-                                         in
-                                      FStar_Pervasives_Native.fst uu____11393
-                                       in
-                                    (uu____11390, aq)  in
+                                          uu____11400 in
+                                      FStar_Pervasives_Native.fst uu____11393 in
+                                    (uu____11390, aq) in
                                   let uu____11407 =
                                     (FStar_Syntax_Util.is_tot_or_gtot_lcomp c)
                                       ||
                                       (FStar_TypeChecker_Util.is_pure_or_ghost_effect
-                                         env2 c.FStar_Syntax_Syntax.eff_name)
-                                     in
+                                         env2 c.FStar_Syntax_Syntax.eff_name) in
                                   if uu____11407
                                   then
                                     let subst2 =
-                                      let uu____11415 = FStar_List.hd bs  in
+                                      let uu____11415 = FStar_List.hd bs in
                                       maybe_extend_subst subst1 uu____11415
-                                        e1
-                                       in
+                                        e1 in
                                     tc_args head_info
                                       (subst2,
                                         ((arg,
@@ -4987,37 +4526,31 @@ and (check_application_args :
                       | ([],arg::uu____11573) ->
                           let uu____11616 =
                             monadic_application head_info subst1 outargs
-                              arg_rets g fvs []
-                             in
+                              arg_rets g fvs [] in
                           (match uu____11616 with
                            | (head2,chead1,ghead1) ->
                                let rec aux norm1 tres =
                                  let tres1 =
                                    let uu____11650 =
-                                     FStar_Syntax_Subst.compress tres  in
+                                     FStar_Syntax_Subst.compress tres in
                                    FStar_All.pipe_right uu____11650
-                                     FStar_Syntax_Util.unrefine
-                                    in
+                                     FStar_Syntax_Util.unrefine in
                                  match tres1.FStar_Syntax_Syntax.n with
                                  | FStar_Syntax_Syntax.Tm_arrow (bs1,cres')
                                      ->
                                      let uu____11675 =
-                                       FStar_Syntax_Subst.open_comp bs1 cres'
-                                        in
+                                       FStar_Syntax_Subst.open_comp bs1 cres' in
                                      (match uu____11675 with
                                       | (bs2,cres'1) ->
                                           let head_info1 =
                                             let uu____11697 =
                                               FStar_Syntax_Util.lcomp_of_comp
-                                                cres'1
-                                               in
+                                                cres'1 in
                                             (head2, chead1, ghead1,
-                                              uu____11697)
-                                             in
+                                              uu____11697) in
                                           ((let uu____11699 =
                                               FStar_TypeChecker_Env.debug env
-                                                FStar_Options.Low
-                                               in
+                                                FStar_Options.Low in
                                             if uu____11699
                                             then
                                               FStar_Errors.log_issue
@@ -5034,14 +4567,11 @@ and (check_application_args :
                                      let rec norm_tres tres2 =
                                        let tres3 =
                                          FStar_TypeChecker_Normalize.unfold_whnf
-                                           env tres2
-                                          in
+                                           env tres2 in
                                        let uu____11747 =
                                          let uu____11748 =
-                                           FStar_Syntax_Subst.compress tres3
-                                            in
-                                         uu____11748.FStar_Syntax_Syntax.n
-                                          in
+                                           FStar_Syntax_Subst.compress tres3 in
+                                         uu____11748.FStar_Syntax_Syntax.n in
                                        match uu____11747 with
                                        | FStar_Syntax_Syntax.Tm_refine
                                            ({
@@ -5052,59 +4582,51 @@ and (check_application_args :
                                               FStar_Syntax_Syntax.sort =
                                                 tres4;_},uu____11754)
                                            -> norm_tres tres4
-                                       | uu____11761 -> tres3  in
-                                     let uu____11762 = norm_tres tres1  in
+                                       | uu____11761 -> tres3 in
+                                     let uu____11762 = norm_tres tres1 in
                                      aux true uu____11762
                                  | uu____11763 ->
                                      let uu____11764 =
                                        let uu____11769 =
                                          let uu____11770 =
                                            FStar_TypeChecker_Normalize.term_to_string
-                                             env thead
-                                            in
+                                             env thead in
                                          let uu____11771 =
-                                           FStar_Util.string_of_int n_args
-                                            in
+                                           FStar_Util.string_of_int n_args in
                                          FStar_Util.format2
                                            "Too many arguments to function of type %s; got %s arguments"
-                                           uu____11770 uu____11771
-                                          in
+                                           uu____11770 uu____11771 in
                                        (FStar_Errors.Fatal_ToManyArgumentToFunction,
-                                         uu____11769)
-                                        in
+                                         uu____11769) in
                                      let uu____11778 =
-                                       FStar_Syntax_Syntax.argpos arg  in
+                                       FStar_Syntax_Syntax.argpos arg in
                                      FStar_Errors.raise_error uu____11764
-                                       uu____11778
-                                  in
-                               aux false chead1.FStar_Syntax_Syntax.res_typ))
-                  in
+                                       uu____11778 in
+                               aux false chead1.FStar_Syntax_Syntax.res_typ)) in
                let rec check_function_app tf =
                  let uu____11797 =
                    let uu____11798 =
-                     FStar_TypeChecker_Normalize.unfold_whnf env tf  in
-                   uu____11798.FStar_Syntax_Syntax.n  in
+                     FStar_TypeChecker_Normalize.unfold_whnf env tf in
+                   uu____11798.FStar_Syntax_Syntax.n in
                  match uu____11797 with
                  | FStar_Syntax_Syntax.Tm_uvar uu____11809 ->
                      let rec tc_args1 env1 args1 =
                        match args1 with
                        | [] -> ([], [], FStar_TypeChecker_Rel.trivial_guard)
                        | (e,imp)::tl1 ->
-                           let uu____11910 = tc_term env1 e  in
+                           let uu____11910 = tc_term env1 e in
                            (match uu____11910 with
                             | (e1,c,g_e) ->
-                                let uu____11932 = tc_args1 env1 tl1  in
+                                let uu____11932 = tc_args1 env1 tl1 in
                                 (match uu____11932 with
                                  | (args2,comps,g_rest) ->
                                      let uu____11972 =
                                        FStar_TypeChecker_Rel.conj_guard g_e
-                                         g_rest
-                                        in
+                                         g_rest in
                                      (((e1, imp) :: args2),
                                        (((e1.FStar_Syntax_Syntax.pos), c) ::
-                                       comps), uu____11972)))
-                        in
-                     let uu____11993 = tc_args1 env args  in
+                                       comps), uu____11972))) in
+                     let uu____11993 = tc_args1 env args in
                      (match uu____11993 with
                       | (args1,comps,g_args) ->
                           let bs =
@@ -5115,54 +4637,47 @@ and (check_application_args :
                                       match uu____12068 with
                                       | (uu____12081,c) ->
                                           ((c.FStar_Syntax_Syntax.res_typ),
-                                            FStar_Pervasives_Native.None)))
-                               in
-                            FStar_Syntax_Util.null_binders_of_tks uu____12030
-                             in
+                                            FStar_Pervasives_Native.None))) in
+                            FStar_Syntax_Util.null_binders_of_tks uu____12030 in
                           let ml_or_tot t r1 =
-                            let uu____12098 = FStar_Options.ml_ish ()  in
+                            let uu____12098 = FStar_Options.ml_ish () in
                             if uu____12098
                             then FStar_Syntax_Util.ml_comp t r1
-                            else FStar_Syntax_Syntax.mk_Total t  in
+                            else FStar_Syntax_Syntax.mk_Total t in
                           let cres =
                             let uu____12101 =
                               let uu____12104 =
-                                let uu____12105 = FStar_Syntax_Util.type_u ()
-                                   in
+                                let uu____12105 = FStar_Syntax_Util.type_u () in
                                 FStar_All.pipe_right uu____12105
-                                  FStar_Pervasives_Native.fst
-                                 in
-                              FStar_TypeChecker_Util.new_uvar env uu____12104
-                               in
-                            ml_or_tot uu____12101 r  in
-                          let bs_cres = FStar_Syntax_Util.arrow bs cres  in
+                                  FStar_Pervasives_Native.fst in
+                              FStar_TypeChecker_Util.new_uvar env uu____12104 in
+                            ml_or_tot uu____12101 r in
+                          let bs_cres = FStar_Syntax_Util.arrow bs cres in
                           ((let uu____12118 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
-                                FStar_Options.Extreme
-                               in
+                                FStar_Options.Extreme in
                             if uu____12118
                             then
                               let uu____12119 =
-                                FStar_Syntax_Print.term_to_string head1  in
+                                FStar_Syntax_Print.term_to_string head1 in
                               let uu____12120 =
-                                FStar_Syntax_Print.term_to_string tf  in
+                                FStar_Syntax_Print.term_to_string tf in
                               let uu____12121 =
-                                FStar_Syntax_Print.term_to_string bs_cres  in
+                                FStar_Syntax_Print.term_to_string bs_cres in
                               FStar_Util.print3
                                 "Forcing the type of %s from %s to %s\n"
                                 uu____12119 uu____12120 uu____12121
                             else ());
                            (let uu____12124 =
-                              FStar_TypeChecker_Rel.teq env tf bs_cres  in
+                              FStar_TypeChecker_Rel.teq env tf bs_cres in
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Rel.force_trivial_guard env)
                               uu____12124);
                            (let comp =
                               let uu____12126 =
                                 FStar_All.pipe_left
-                                  FStar_Syntax_Util.lcomp_of_comp cres
-                                 in
+                                  FStar_Syntax_Util.lcomp_of_comp cres in
                               FStar_List.fold_right
                                 (fun uu____12137  ->
                                    fun out  ->
@@ -5173,15 +4688,12 @@ and (check_application_args :
                                            (FStar_Pervasives_Native.None,
                                              out))
                                 (((head1.FStar_Syntax_Syntax.pos), chead) ::
-                                comps) uu____12126
-                               in
+                                comps) uu____12126 in
                             let uu____12151 =
                               FStar_Syntax_Syntax.mk_Tm_app head1 args1
-                                FStar_Pervasives_Native.None r
-                               in
+                                FStar_Pervasives_Native.None r in
                             let uu____12154 =
-                              FStar_TypeChecker_Rel.conj_guard ghead g_args
-                               in
+                              FStar_TypeChecker_Rel.conj_guard ghead g_args in
                             (uu____12151, comp, uu____12154))))
                  | FStar_Syntax_Syntax.Tm_app
                      ({
@@ -5194,21 +4706,19 @@ and (check_application_args :
                        match args1 with
                        | [] -> ([], [], FStar_TypeChecker_Rel.trivial_guard)
                        | (e,imp)::tl1 ->
-                           let uu____12281 = tc_term env1 e  in
+                           let uu____12281 = tc_term env1 e in
                            (match uu____12281 with
                             | (e1,c,g_e) ->
-                                let uu____12303 = tc_args1 env1 tl1  in
+                                let uu____12303 = tc_args1 env1 tl1 in
                                 (match uu____12303 with
                                  | (args2,comps,g_rest) ->
                                      let uu____12343 =
                                        FStar_TypeChecker_Rel.conj_guard g_e
-                                         g_rest
-                                        in
+                                         g_rest in
                                      (((e1, imp) :: args2),
                                        (((e1.FStar_Syntax_Syntax.pos), c) ::
-                                       comps), uu____12343)))
-                        in
-                     let uu____12364 = tc_args1 env args  in
+                                       comps), uu____12343))) in
+                     let uu____12364 = tc_args1 env args in
                      (match uu____12364 with
                       | (args1,comps,g_args) ->
                           let bs =
@@ -5219,54 +4729,47 @@ and (check_application_args :
                                       match uu____12439 with
                                       | (uu____12452,c) ->
                                           ((c.FStar_Syntax_Syntax.res_typ),
-                                            FStar_Pervasives_Native.None)))
-                               in
-                            FStar_Syntax_Util.null_binders_of_tks uu____12401
-                             in
+                                            FStar_Pervasives_Native.None))) in
+                            FStar_Syntax_Util.null_binders_of_tks uu____12401 in
                           let ml_or_tot t r1 =
-                            let uu____12469 = FStar_Options.ml_ish ()  in
+                            let uu____12469 = FStar_Options.ml_ish () in
                             if uu____12469
                             then FStar_Syntax_Util.ml_comp t r1
-                            else FStar_Syntax_Syntax.mk_Total t  in
+                            else FStar_Syntax_Syntax.mk_Total t in
                           let cres =
                             let uu____12472 =
                               let uu____12475 =
-                                let uu____12476 = FStar_Syntax_Util.type_u ()
-                                   in
+                                let uu____12476 = FStar_Syntax_Util.type_u () in
                                 FStar_All.pipe_right uu____12476
-                                  FStar_Pervasives_Native.fst
-                                 in
-                              FStar_TypeChecker_Util.new_uvar env uu____12475
-                               in
-                            ml_or_tot uu____12472 r  in
-                          let bs_cres = FStar_Syntax_Util.arrow bs cres  in
+                                  FStar_Pervasives_Native.fst in
+                              FStar_TypeChecker_Util.new_uvar env uu____12475 in
+                            ml_or_tot uu____12472 r in
+                          let bs_cres = FStar_Syntax_Util.arrow bs cres in
                           ((let uu____12489 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
-                                FStar_Options.Extreme
-                               in
+                                FStar_Options.Extreme in
                             if uu____12489
                             then
                               let uu____12490 =
-                                FStar_Syntax_Print.term_to_string head1  in
+                                FStar_Syntax_Print.term_to_string head1 in
                               let uu____12491 =
-                                FStar_Syntax_Print.term_to_string tf  in
+                                FStar_Syntax_Print.term_to_string tf in
                               let uu____12492 =
-                                FStar_Syntax_Print.term_to_string bs_cres  in
+                                FStar_Syntax_Print.term_to_string bs_cres in
                               FStar_Util.print3
                                 "Forcing the type of %s from %s to %s\n"
                                 uu____12490 uu____12491 uu____12492
                             else ());
                            (let uu____12495 =
-                              FStar_TypeChecker_Rel.teq env tf bs_cres  in
+                              FStar_TypeChecker_Rel.teq env tf bs_cres in
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Rel.force_trivial_guard env)
                               uu____12495);
                            (let comp =
                               let uu____12497 =
                                 FStar_All.pipe_left
-                                  FStar_Syntax_Util.lcomp_of_comp cres
-                                 in
+                                  FStar_Syntax_Util.lcomp_of_comp cres in
                               FStar_List.fold_right
                                 (fun uu____12508  ->
                                    fun out  ->
@@ -5277,24 +4780,21 @@ and (check_application_args :
                                            (FStar_Pervasives_Native.None,
                                              out))
                                 (((head1.FStar_Syntax_Syntax.pos), chead) ::
-                                comps) uu____12497
-                               in
+                                comps) uu____12497 in
                             let uu____12522 =
                               FStar_Syntax_Syntax.mk_Tm_app head1 args1
-                                FStar_Pervasives_Native.None r
-                               in
+                                FStar_Pervasives_Native.None r in
                             let uu____12525 =
-                              FStar_TypeChecker_Rel.conj_guard ghead g_args
-                               in
+                              FStar_TypeChecker_Rel.conj_guard ghead g_args in
                             (uu____12522, comp, uu____12525))))
                  | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                     let uu____12546 = FStar_Syntax_Subst.open_comp bs c  in
+                     let uu____12546 = FStar_Syntax_Subst.open_comp bs c in
                      (match uu____12546 with
                       | (bs1,c1) ->
                           let head_info =
                             let uu____12570 =
-                              FStar_Syntax_Util.lcomp_of_comp c1  in
-                            (head1, chead, ghead, uu____12570)  in
+                              FStar_Syntax_Util.lcomp_of_comp c1 in
+                            (head1, chead, ghead, uu____12570) in
                           tc_args head_info
                             ([], [], [], FStar_TypeChecker_Rel.trivial_guard,
                               []) bs1 args)
@@ -5304,13 +4804,11 @@ and (check_application_args :
                      (t,uu____12618,uu____12619) -> check_function_app t
                  | uu____12660 ->
                      let uu____12661 =
-                       FStar_TypeChecker_Err.expected_function_typ env tf  in
+                       FStar_TypeChecker_Err.expected_function_typ env tf in
                      FStar_Errors.raise_error uu____12661
-                       head1.FStar_Syntax_Syntax.pos
-                  in
+                       head1.FStar_Syntax_Syntax.pos in
                check_function_app thead)
-
-and (check_short_circuit_args :
+and check_short_circuit_args:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.lcomp ->
@@ -5319,7 +4817,7 @@ and (check_short_circuit_args :
             FStar_Pervasives_Native.tuple2 Prims.list ->
             FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option ->
               (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-                FStar_Pervasives_Native.tuple3)
+                FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun head1  ->
@@ -5327,16 +4825,15 @@ and (check_short_circuit_args :
         fun g_head  ->
           fun args  ->
             fun expected_topt  ->
-              let r = FStar_TypeChecker_Env.get_range env  in
+              let r = FStar_TypeChecker_Env.get_range env in
               let tf =
-                FStar_Syntax_Subst.compress chead.FStar_Syntax_Syntax.res_typ
-                 in
+                FStar_Syntax_Subst.compress chead.FStar_Syntax_Syntax.res_typ in
               match tf.FStar_Syntax_Syntax.n with
               | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
                   (FStar_Syntax_Util.is_total_comp c) &&
                     ((FStar_List.length bs) = (FStar_List.length args))
                   ->
-                  let res_t = FStar_Syntax_Util.comp_result c  in
+                  let res_t = FStar_Syntax_Util.comp_result c in
                   let uu____12735 =
                     FStar_List.fold_left2
                       (fun uu____12778  ->
@@ -5354,76 +4851,62 @@ and (check_short_circuit_args :
                                   else ();
                                   (let uu____12848 =
                                      tc_check_tot_or_gtot_term env e
-                                       b.FStar_Syntax_Syntax.sort
-                                      in
+                                       b.FStar_Syntax_Syntax.sort in
                                    match uu____12848 with
                                    | (e1,c1,g) ->
                                        let short =
                                          FStar_TypeChecker_Util.short_circuit
-                                           head1 seen
-                                          in
+                                           head1 seen in
                                        let g1 =
                                          let uu____12866 =
                                            FStar_TypeChecker_Rel.guard_of_guard_formula
-                                             short
-                                            in
+                                             short in
                                          FStar_TypeChecker_Rel.imp_guard
-                                           uu____12866 g
-                                          in
+                                           uu____12866 g in
                                        let ghost1 =
                                          ghost ||
                                            ((let uu____12870 =
                                                FStar_Syntax_Util.is_total_lcomp
-                                                 c1
-                                                in
+                                                 c1 in
                                              Prims.op_Negation uu____12870)
                                               &&
                                               (let uu____12872 =
                                                  FStar_TypeChecker_Util.is_pure_effect
                                                    env
-                                                   c1.FStar_Syntax_Syntax.eff_name
-                                                  in
-                                               Prims.op_Negation uu____12872))
-                                          in
+                                                   c1.FStar_Syntax_Syntax.eff_name in
+                                               Prims.op_Negation uu____12872)) in
                                        let uu____12873 =
                                          let uu____12882 =
                                            let uu____12891 =
-                                             FStar_Syntax_Syntax.as_arg e1
-                                              in
-                                           [uu____12891]  in
-                                         FStar_List.append seen uu____12882
-                                          in
+                                             FStar_Syntax_Syntax.as_arg e1 in
+                                           [uu____12891] in
+                                         FStar_List.append seen uu____12882 in
                                        let uu____12898 =
                                          FStar_TypeChecker_Rel.conj_guard
-                                           guard g1
-                                          in
+                                           guard g1 in
                                        (uu____12873, uu____12898, ghost1))))
-                      ([], g_head, false) args bs
-                     in
+                      ([], g_head, false) args bs in
                   (match uu____12735 with
                    | (args1,guard,ghost) ->
                        let e =
                          FStar_Syntax_Syntax.mk_Tm_app head1 args1
-                           FStar_Pervasives_Native.None r
-                          in
+                           FStar_Pervasives_Native.None r in
                        let c1 =
                          if ghost
                          then
                            let uu____12934 =
-                             FStar_Syntax_Syntax.mk_GTotal res_t  in
+                             FStar_Syntax_Syntax.mk_GTotal res_t in
                            FStar_All.pipe_right uu____12934
                              FStar_Syntax_Util.lcomp_of_comp
-                         else FStar_Syntax_Util.lcomp_of_comp c  in
+                         else FStar_Syntax_Util.lcomp_of_comp c in
                        let uu____12936 =
                          FStar_TypeChecker_Util.strengthen_precondition
-                           FStar_Pervasives_Native.None env e c1 guard
-                          in
+                           FStar_Pervasives_Native.None env e c1 guard in
                        (match uu____12936 with | (c2,g) -> (e, c2, g)))
               | uu____12953 ->
                   check_application_args env head1 chead g_head args
                     expected_topt
-
-and (tc_eqn :
+and tc_eqn:
   FStar_Syntax_Syntax.bv ->
     FStar_TypeChecker_Env.env ->
       (FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t,FStar_Syntax_Syntax.term'
@@ -5436,56 +4919,51 @@ and (tc_eqn :
            FStar_Pervasives_Native.tuple3,FStar_Syntax_Syntax.term,FStar_Ident.lident,
           FStar_Syntax_Syntax.cflags Prims.list,Prims.bool ->
                                                   FStar_Syntax_Syntax.lcomp,
-          FStar_TypeChecker_Env.guard_t) FStar_Pervasives_Native.tuple6)
+          FStar_TypeChecker_Env.guard_t) FStar_Pervasives_Native.tuple6
   =
   fun scrutinee  ->
     fun env  ->
       fun branch1  ->
-        let uu____12995 = FStar_Syntax_Subst.open_branch branch1  in
+        let uu____12995 = FStar_Syntax_Subst.open_branch branch1 in
         match uu____12995 with
         | (pattern,when_clause,branch_exp) ->
-            let uu____13039 = branch1  in
+            let uu____13039 = branch1 in
             (match uu____13039 with
              | (cpat,uu____13079,cbr) ->
                  let tc_pat allow_implicits pat_t p0 =
                    let tc_annot env1 t =
-                     let uu____13146 = FStar_Syntax_Util.type_u ()  in
+                     let uu____13146 = FStar_Syntax_Util.type_u () in
                      match uu____13146 with
                      | (tu,u) ->
                          let uu____13157 =
-                           tc_check_tot_or_gtot_term env1 t tu  in
+                           tc_check_tot_or_gtot_term env1 t tu in
                          (match uu____13157 with
-                          | (t1,uu____13169,g) -> (t1, g))
-                      in
+                          | (t1,uu____13169,g) -> (t1, g)) in
                    let uu____13171 =
                      FStar_TypeChecker_Util.pat_as_exp allow_implicits env p0
-                       tc_annot
-                      in
+                       tc_annot in
                    match uu____13171 with
                    | (pat_bvs1,exp,guard_pat_annots,p) ->
                        ((let uu____13205 =
-                           FStar_TypeChecker_Env.debug env FStar_Options.High
-                            in
+                           FStar_TypeChecker_Env.debug env FStar_Options.High in
                          if uu____13205
                          then
                            let uu____13206 =
-                             FStar_Syntax_Print.pat_to_string p0  in
+                             FStar_Syntax_Print.pat_to_string p0 in
                            let uu____13207 =
-                             FStar_Syntax_Print.pat_to_string p  in
+                             FStar_Syntax_Print.pat_to_string p in
                            FStar_Util.print2 "Pattern %s elaborated to %s\n"
                              uu____13206 uu____13207
                          else ());
                         (let pat_env =
                            FStar_List.fold_left FStar_TypeChecker_Env.push_bv
-                             env pat_bvs1
-                            in
+                             env pat_bvs1 in
                          let uu____13210 =
-                           FStar_TypeChecker_Env.clear_expected_typ pat_env
-                            in
+                           FStar_TypeChecker_Env.clear_expected_typ pat_env in
                          match uu____13210 with
                          | (env1,uu____13232) ->
                              let env11 =
-                               let uu___94_13238 = env1  in
+                               let uu___94_13238 = env1 in
                                {
                                  FStar_TypeChecker_Env.solver =
                                    (uu___94_13238.FStar_TypeChecker_Env.solver);
@@ -5556,34 +5034,31 @@ and (tc_eqn :
                                    (uu___94_13238.FStar_TypeChecker_Env.dsenv);
                                  FStar_TypeChecker_Env.dep_graph =
                                    (uu___94_13238.FStar_TypeChecker_Env.dep_graph)
-                               }  in
+                               } in
                              let expected_pat_t =
-                               FStar_TypeChecker_Rel.unrefine env pat_t  in
+                               FStar_TypeChecker_Rel.unrefine env pat_t in
                              ((let uu____13241 =
                                  FStar_TypeChecker_Env.debug env
-                                   FStar_Options.High
-                                  in
+                                   FStar_Options.High in
                                if uu____13241
                                then
                                  let uu____13242 =
-                                   FStar_Syntax_Print.term_to_string exp  in
+                                   FStar_Syntax_Print.term_to_string exp in
                                  let uu____13243 =
-                                   FStar_Syntax_Print.term_to_string pat_t
-                                    in
+                                   FStar_Syntax_Print.term_to_string pat_t in
                                  FStar_Util.print2
                                    "Checking pattern expression %s against expected type %s\n"
                                    uu____13242 uu____13243
                                else ());
                               (let env12 =
                                  FStar_TypeChecker_Env.set_expected_typ env11
-                                   expected_pat_t
-                                  in
+                                   expected_pat_t in
                                let uu____13246 =
-                                 tc_tot_or_gtot_term env12 exp  in
+                                 tc_tot_or_gtot_term env12 exp in
                                match uu____13246 with
                                | (exp1,lc,g) ->
                                    let g1 =
-                                     let uu___95_13271 = g  in
+                                     let uu___95_13271 = g in
                                      {
                                        FStar_TypeChecker_Env.guard_f =
                                          FStar_TypeChecker_Common.Trivial;
@@ -5593,23 +5068,20 @@ and (tc_eqn :
                                          (uu___95_13271.FStar_TypeChecker_Env.univ_ineqs);
                                        FStar_TypeChecker_Env.implicits =
                                          (uu___95_13271.FStar_TypeChecker_Env.implicits)
-                                     }  in
+                                     } in
                                    let uu____13272 =
                                      let uu____13273 =
                                        FStar_TypeChecker_Rel.teq_nosmt env12
                                          lc.FStar_Syntax_Syntax.res_typ
-                                         expected_pat_t
-                                        in
+                                         expected_pat_t in
                                      if uu____13273
                                      then
                                        let env13 =
                                          FStar_TypeChecker_Env.set_range
-                                           env12 exp1.FStar_Syntax_Syntax.pos
-                                          in
+                                           env12 exp1.FStar_Syntax_Syntax.pos in
                                        let uu____13275 =
                                          FStar_TypeChecker_Rel.discharge_guard_no_smt
-                                           env13 g1
-                                          in
+                                           env13 g1 in
                                        FStar_All.pipe_right uu____13275
                                          FStar_TypeChecker_Rel.resolve_implicits
                                      else
@@ -5617,60 +5089,47 @@ and (tc_eqn :
                                           let uu____13282 =
                                             let uu____13283 =
                                               FStar_Syntax_Print.term_to_string
-                                                lc.FStar_Syntax_Syntax.res_typ
-                                               in
+                                                lc.FStar_Syntax_Syntax.res_typ in
                                             let uu____13284 =
                                               FStar_Syntax_Print.term_to_string
-                                                expected_pat_t
-                                               in
+                                                expected_pat_t in
                                             FStar_Util.format2
                                               "Inferred type of pattern (%s) is incompatible with the type of the scrutinee (%s)"
-                                              uu____13283 uu____13284
-                                             in
+                                              uu____13283 uu____13284 in
                                           (FStar_Errors.Fatal_MismatchedPatternType,
-                                            uu____13282)
-                                           in
+                                            uu____13282) in
                                         FStar_Errors.raise_error uu____13277
-                                          exp1.FStar_Syntax_Syntax.pos)
-                                      in
+                                          exp1.FStar_Syntax_Syntax.pos) in
                                    let norm_exp =
                                      FStar_TypeChecker_Normalize.normalize
                                        [FStar_TypeChecker_Normalize.Beta]
-                                       env12 exp1
-                                      in
+                                       env12 exp1 in
                                    let uvs1 =
-                                     FStar_Syntax_Free.uvars norm_exp  in
+                                     FStar_Syntax_Free.uvars norm_exp in
                                    let uvs2 =
-                                     FStar_Syntax_Free.uvars expected_pat_t
-                                      in
+                                     FStar_Syntax_Free.uvars expected_pat_t in
                                    ((let uu____13301 =
                                        let uu____13302 =
                                          FStar_Util.set_is_subset_of uvs1
-                                           uvs2
-                                          in
+                                           uvs2 in
                                        FStar_All.pipe_left Prims.op_Negation
-                                         uu____13302
-                                        in
+                                         uu____13302 in
                                      if uu____13301
                                      then
                                        let unresolved =
                                          let uu____13314 =
                                            FStar_Util.set_difference uvs1
-                                             uvs2
-                                            in
+                                             uvs2 in
                                          FStar_All.pipe_right uu____13314
-                                           FStar_Util.set_elements
-                                          in
+                                           FStar_Util.set_elements in
                                        let uu____13341 =
                                          let uu____13346 =
                                            let uu____13347 =
                                              FStar_TypeChecker_Normalize.term_to_string
-                                               env norm_exp
-                                              in
+                                               env norm_exp in
                                            let uu____13348 =
                                              FStar_TypeChecker_Normalize.term_to_string
-                                               env expected_pat_t
-                                              in
+                                               env expected_pat_t in
                                            let uu____13349 =
                                              let uu____13350 =
                                                FStar_All.pipe_right
@@ -5680,55 +5139,45 @@ and (tc_eqn :
                                                        match uu____13368 with
                                                        | (u,uu____13374) ->
                                                            FStar_Syntax_Print.uvar_to_string
-                                                             u))
-                                                in
+                                                             u)) in
                                              FStar_All.pipe_right uu____13350
-                                               (FStar_String.concat ", ")
-                                              in
+                                               (FStar_String.concat ", ") in
                                            FStar_Util.format3
                                              "Implicit pattern variables in %s could not be resolved against expected type %s;Variables {%s} were unresolved; please bind them explicitly"
                                              uu____13347 uu____13348
-                                             uu____13349
-                                            in
+                                             uu____13349 in
                                          (FStar_Errors.Fatal_UnresolvedPatternVar,
-                                           uu____13346)
-                                          in
+                                           uu____13346) in
                                        FStar_Errors.raise_error uu____13341
                                          p.FStar_Syntax_Syntax.p
                                      else ());
                                     (let uu____13379 =
                                        FStar_TypeChecker_Env.debug env
-                                         FStar_Options.High
-                                        in
+                                         FStar_Options.High in
                                      if uu____13379
                                      then
                                        let uu____13380 =
                                          FStar_TypeChecker_Normalize.term_to_string
-                                           env exp1
-                                          in
+                                           env exp1 in
                                        FStar_Util.print1
                                          "Done checking pattern expression %s\n"
                                          uu____13380
                                      else ());
                                     (let p1 =
                                        FStar_TypeChecker_Util.decorate_pattern
-                                         env p exp1
-                                        in
+                                         env p exp1 in
                                      (p1, pat_bvs1, pat_env, exp1,
-                                       guard_pat_annots, norm_exp)))))))
-                    in
-                 let pat_t = scrutinee.FStar_Syntax_Syntax.sort  in
-                 let scrutinee_tm = FStar_Syntax_Syntax.bv_to_name scrutinee
-                    in
+                                       guard_pat_annots, norm_exp))))))) in
+                 let pat_t = scrutinee.FStar_Syntax_Syntax.sort in
+                 let scrutinee_tm = FStar_Syntax_Syntax.bv_to_name scrutinee in
                  let uu____13389 =
                    let uu____13396 =
-                     FStar_TypeChecker_Env.push_bv env scrutinee  in
+                     FStar_TypeChecker_Env.push_bv env scrutinee in
                    FStar_All.pipe_right uu____13396
-                     FStar_TypeChecker_Env.clear_expected_typ
-                    in
+                     FStar_TypeChecker_Env.clear_expected_typ in
                  (match uu____13389 with
                   | (scrutinee_env,uu____13428) ->
-                      let uu____13433 = tc_pat true pat_t pattern  in
+                      let uu____13433 = tc_pat true pat_t pattern in
                       (match uu____13433 with
                        | (pattern1,pat_bvs1,pat_env,pat_exp,guard_pat_annots,norm_pat_exp)
                            ->
@@ -5739,8 +5188,7 @@ and (tc_eqn :
                                    FStar_TypeChecker_Rel.trivial_guard)
                              | FStar_Pervasives_Native.Some e ->
                                  let uu____13504 =
-                                   FStar_TypeChecker_Env.should_verify env
-                                    in
+                                   FStar_TypeChecker_Env.should_verify env in
                                  if uu____13504
                                  then
                                    FStar_Errors.raise_error
@@ -5751,24 +5199,20 @@ and (tc_eqn :
                                    (let uu____13518 =
                                       let uu____13525 =
                                         FStar_TypeChecker_Env.set_expected_typ
-                                          pat_env FStar_Syntax_Util.t_bool
-                                         in
-                                      tc_term uu____13525 e  in
+                                          pat_env FStar_Syntax_Util.t_bool in
+                                      tc_term uu____13525 e in
                                     match uu____13518 with
                                     | (e1,c,g) ->
                                         ((FStar_Pervasives_Native.Some e1),
-                                          g))
-                              in
+                                          g)) in
                            (match uu____13482 with
                             | (when_clause1,g_when) ->
-                                let uu____13567 = tc_term pat_env branch_exp
-                                   in
+                                let uu____13567 = tc_term pat_env branch_exp in
                                 (match uu____13567 with
                                  | (branch_exp1,c,g_branch) ->
                                      let g_branch1 =
                                        FStar_TypeChecker_Rel.conj_guard
-                                         guard_pat_annots g_branch
-                                        in
+                                         guard_pat_annots g_branch in
                                      let when_condition =
                                        match when_clause1 with
                                        | FStar_Pervasives_Native.None  ->
@@ -5778,28 +5222,24 @@ and (tc_eqn :
                                              FStar_Syntax_Util.mk_eq2
                                                FStar_Syntax_Syntax.U_zero
                                                FStar_Syntax_Util.t_bool w
-                                               FStar_Syntax_Util.exp_true_bool
-                                              in
+                                               FStar_Syntax_Util.exp_true_bool in
                                            FStar_All.pipe_left
                                              (fun _0_41  ->
                                                 FStar_Pervasives_Native.Some
-                                                  _0_41) uu____13608
-                                        in
+                                                  _0_41) uu____13608 in
                                      let uu____13611 =
                                        let eqs =
                                          let uu____13629 =
                                            let uu____13630 =
                                              FStar_TypeChecker_Env.should_verify
-                                               env
-                                              in
-                                           Prims.op_Negation uu____13630  in
+                                               env in
+                                           Prims.op_Negation uu____13630 in
                                          if uu____13629
                                          then FStar_Pervasives_Native.None
                                          else
                                            (let e =
                                               FStar_Syntax_Subst.compress
-                                                pat_exp
-                                               in
+                                                pat_exp in
                                             match e.FStar_Syntax_Syntax.n
                                             with
                                             | FStar_Syntax_Syntax.Tm_uvar
@@ -5815,20 +5255,16 @@ and (tc_eqn :
                                                 let uu____13657 =
                                                   let uu____13658 =
                                                     env.FStar_TypeChecker_Env.universe_of
-                                                      env pat_t
-                                                     in
+                                                      env pat_t in
                                                   FStar_Syntax_Util.mk_eq2
                                                     uu____13658 pat_t
-                                                    scrutinee_tm e
-                                                   in
+                                                    scrutinee_tm e in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____13657)
-                                          in
+                                                  uu____13657) in
                                        let uu____13659 =
                                          FStar_TypeChecker_Util.strengthen_precondition
                                            FStar_Pervasives_Native.None env
-                                           branch_exp1 c g_branch1
-                                          in
+                                           branch_exp1 c g_branch1 in
                                        match uu____13659 with
                                        | (c1,g_branch2) ->
                                            let uu____13682 =
@@ -5836,8 +5272,7 @@ and (tc_eqn :
                                              | uu____13695 when
                                                  let uu____13704 =
                                                    FStar_TypeChecker_Env.should_verify
-                                                     env
-                                                    in
+                                                     env in
                                                  Prims.op_Negation
                                                    uu____13704
                                                  -> (c1, g_when)
@@ -5849,99 +5284,80 @@ and (tc_eqn :
                                                 ) ->
                                                  let gf =
                                                    FStar_TypeChecker_Common.NonTrivial
-                                                     f
-                                                    in
+                                                     f in
                                                  let g =
                                                    FStar_TypeChecker_Rel.guard_of_guard_formula
-                                                     gf
-                                                    in
+                                                     gf in
                                                  let uu____13716 =
                                                    FStar_TypeChecker_Util.weaken_precondition
-                                                     env c1 gf
-                                                    in
+                                                     env c1 gf in
                                                  let uu____13717 =
                                                    FStar_TypeChecker_Rel.imp_guard
-                                                     g g_when
-                                                    in
+                                                     g g_when in
                                                  (uu____13716, uu____13717)
                                              | (FStar_Pervasives_Native.Some
                                                 f,FStar_Pervasives_Native.Some
                                                 w) ->
                                                  let g_f =
                                                    FStar_TypeChecker_Common.NonTrivial
-                                                     f
-                                                    in
+                                                     f in
                                                  let g_fw =
                                                    let uu____13726 =
                                                      FStar_Syntax_Util.mk_conj
-                                                       f w
-                                                      in
+                                                       f w in
                                                    FStar_TypeChecker_Common.NonTrivial
-                                                     uu____13726
-                                                    in
+                                                     uu____13726 in
                                                  let uu____13727 =
                                                    FStar_TypeChecker_Util.weaken_precondition
-                                                     env c1 g_fw
-                                                    in
+                                                     env c1 g_fw in
                                                  let uu____13728 =
                                                    let uu____13729 =
                                                      FStar_TypeChecker_Rel.guard_of_guard_formula
-                                                       g_f
-                                                      in
+                                                       g_f in
                                                    FStar_TypeChecker_Rel.imp_guard
-                                                     uu____13729 g_when
-                                                    in
+                                                     uu____13729 g_when in
                                                  (uu____13727, uu____13728)
                                              | (FStar_Pervasives_Native.None
                                                 ,FStar_Pervasives_Native.Some
                                                 w) ->
                                                  let g_w =
                                                    FStar_TypeChecker_Common.NonTrivial
-                                                     w
-                                                    in
+                                                     w in
                                                  let g =
                                                    FStar_TypeChecker_Rel.guard_of_guard_formula
-                                                     g_w
-                                                    in
+                                                     g_w in
                                                  let uu____13737 =
                                                    FStar_TypeChecker_Util.weaken_precondition
-                                                     env c1 g_w
-                                                    in
-                                                 (uu____13737, g_when)
-                                              in
+                                                     env c1 g_w in
+                                                 (uu____13737, g_when) in
                                            (match uu____13682 with
                                             | (c_weak,g_when_weak) ->
                                                 let binders =
                                                   FStar_List.map
                                                     FStar_Syntax_Syntax.mk_binder
-                                                    pat_bvs1
-                                                   in
+                                                    pat_bvs1 in
                                                 let maybe_return_c_weak
                                                   should_return =
                                                   let c_weak1 =
                                                     let uu____13762 =
                                                       should_return &&
                                                         (FStar_Syntax_Util.is_pure_or_ghost_lcomp
-                                                           c_weak)
-                                                       in
+                                                           c_weak) in
                                                     if uu____13762
                                                     then
                                                       FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                                         env branch_exp1
                                                         c_weak
-                                                    else c_weak  in
+                                                    else c_weak in
                                                   FStar_TypeChecker_Util.close_lcomp
-                                                    env pat_bvs1 c_weak1
-                                                   in
+                                                    env pat_bvs1 c_weak1 in
                                                 let uu____13764 =
                                                   FStar_TypeChecker_Rel.close_guard
-                                                    env binders g_when_weak
-                                                   in
+                                                    env binders g_when_weak in
                                                 ((c_weak.FStar_Syntax_Syntax.eff_name),
                                                   (c_weak.FStar_Syntax_Syntax.cflags),
                                                   maybe_return_c_weak,
-                                                  uu____13764, g_branch2))
-                                        in
+                                                  uu____13764, g_branch2)) in
                                      (match uu____13611 with
                                       | (effect_label,cflags,maybe_return_c,g_when1,g_branch2)
                                           ->
@@ -5949,10 +5365,8 @@ and (tc_eqn :
                                             let uu____13807 =
                                               let uu____13808 =
                                                 FStar_TypeChecker_Env.should_verify
-                                                  env
-                                                 in
-                                              Prims.op_Negation uu____13808
-                                               in
+                                                  env in
+                                              Prims.op_Negation uu____13808 in
                                             if uu____13807
                                             then FStar_Syntax_Util.t_true
                                             else
@@ -5967,30 +5381,23 @@ and (tc_eqn :
                                                            let uu____13850 =
                                                              FStar_TypeChecker_Env.typ_of_datacon
                                                                env
-                                                               f.FStar_Syntax_Syntax.v
-                                                              in
+                                                               f.FStar_Syntax_Syntax.v in
                                                            FStar_TypeChecker_Env.datacons_of_typ
-                                                             env uu____13850
-                                                            in
+                                                             env uu____13850 in
                                                          FStar_Pervasives_Native.snd
-                                                           uu____13843
-                                                          in
+                                                           uu____13843 in
                                                        FStar_List.length
-                                                         uu____13840
-                                                        in
+                                                         uu____13840 in
                                                      uu____13839 >
-                                                       (Prims.parse_int "1")
-                                                      in
+                                                       (Prims.parse_int "1") in
                                                    if uu____13838
                                                    then
                                                      let discriminator =
                                                        FStar_Syntax_Util.mk_discriminator
-                                                         f.FStar_Syntax_Syntax.v
-                                                        in
+                                                         f.FStar_Syntax_Syntax.v in
                                                      let uu____13856 =
                                                        FStar_TypeChecker_Env.try_lookup_lid
-                                                         env discriminator
-                                                        in
+                                                         env discriminator in
                                                      match uu____13856 with
                                                      | FStar_Pervasives_Native.None
                                                           -> []
@@ -5999,8 +5406,7 @@ and (tc_eqn :
                                                            FStar_Syntax_Syntax.fvar
                                                              discriminator
                                                              FStar_Syntax_Syntax.Delta_equational
-                                                             FStar_Pervasives_Native.None
-                                                            in
+                                                             FStar_Pervasives_Native.None in
                                                          let disc1 =
                                                            let uu____13892 =
                                                              let uu____13893
@@ -6008,48 +5414,39 @@ and (tc_eqn :
                                                                let uu____13894
                                                                  =
                                                                  FStar_Syntax_Syntax.as_arg
-                                                                   scrutinee_tm2
-                                                                  in
-                                                               [uu____13894]
-                                                                in
+                                                                   scrutinee_tm2 in
+                                                               [uu____13894] in
                                                              FStar_Syntax_Syntax.mk_Tm_app
                                                                disc
-                                                               uu____13893
-                                                              in
+                                                               uu____13893 in
                                                            uu____13892
                                                              FStar_Pervasives_Native.None
-                                                             scrutinee_tm2.FStar_Syntax_Syntax.pos
-                                                            in
+                                                             scrutinee_tm2.FStar_Syntax_Syntax.pos in
                                                          let uu____13897 =
                                                            FStar_Syntax_Util.mk_eq2
                                                              FStar_Syntax_Syntax.U_zero
                                                              FStar_Syntax_Util.t_bool
                                                              disc1
-                                                             FStar_Syntax_Util.exp_true_bool
-                                                            in
+                                                             FStar_Syntax_Util.exp_true_bool in
                                                          [uu____13897]
-                                                   else []  in
+                                                   else [] in
                                                  let fail uu____13902 =
                                                    let uu____13903 =
                                                      let uu____13904 =
                                                        FStar_Range.string_of_range
-                                                         pat_exp1.FStar_Syntax_Syntax.pos
-                                                        in
+                                                         pat_exp1.FStar_Syntax_Syntax.pos in
                                                      let uu____13905 =
                                                        FStar_Syntax_Print.term_to_string
-                                                         pat_exp1
-                                                        in
+                                                         pat_exp1 in
                                                      let uu____13906 =
                                                        FStar_Syntax_Print.tag_of_term
-                                                         pat_exp1
-                                                        in
+                                                         pat_exp1 in
                                                      FStar_Util.format3
                                                        "tc_eqn: Impossible (%s) %s (%s)"
                                                        uu____13904
                                                        uu____13905
-                                                       uu____13906
-                                                      in
-                                                   failwith uu____13903  in
+                                                       uu____13906 in
+                                                   failwith uu____13903 in
                                                  let rec head_constructor t =
                                                    match t.FStar_Syntax_Syntax.n
                                                    with
@@ -6059,17 +5456,14 @@ and (tc_eqn :
                                                    | FStar_Syntax_Syntax.Tm_uinst
                                                        (t1,uu____13917) ->
                                                        head_constructor t1
-                                                   | uu____13922 -> fail ()
-                                                    in
+                                                   | uu____13922 -> fail () in
                                                  let pat_exp2 =
                                                    let uu____13924 =
                                                      FStar_Syntax_Subst.compress
-                                                       pat_exp1
-                                                      in
+                                                       pat_exp1 in
                                                    FStar_All.pipe_right
                                                      uu____13924
-                                                     FStar_Syntax_Util.unmeta
-                                                    in
+                                                     FStar_Syntax_Util.unmeta in
                                                  match pat_exp2.FStar_Syntax_Syntax.n
                                                  with
                                                  | FStar_Syntax_Syntax.Tm_uvar
@@ -6096,37 +5490,31 @@ and (tc_eqn :
                                                        let uu____13987 =
                                                          tc_constant env
                                                            pat_exp2.FStar_Syntax_Syntax.pos
-                                                           c1
-                                                          in
+                                                           c1 in
                                                        FStar_Syntax_Util.mk_eq2
                                                          FStar_Syntax_Syntax.U_zero
                                                          uu____13987
                                                          scrutinee_tm1
-                                                         pat_exp2
-                                                        in
+                                                         pat_exp2 in
                                                      [uu____13986]
                                                  | FStar_Syntax_Syntax.Tm_uinst
                                                      uu____13988 ->
                                                      let f =
                                                        head_constructor
-                                                         pat_exp2
-                                                        in
+                                                         pat_exp2 in
                                                      let uu____13996 =
                                                        let uu____13997 =
                                                          FStar_TypeChecker_Env.is_datacon
                                                            env
-                                                           f.FStar_Syntax_Syntax.v
-                                                          in
+                                                           f.FStar_Syntax_Syntax.v in
                                                        Prims.op_Negation
-                                                         uu____13997
-                                                        in
+                                                         uu____13997 in
                                                      if uu____13996
                                                      then []
                                                      else
                                                        (let uu____14001 =
                                                           head_constructor
-                                                            pat_exp2
-                                                           in
+                                                            pat_exp2 in
                                                         discriminate
                                                           scrutinee_tm1
                                                           uu____14001)
@@ -6134,41 +5522,34 @@ and (tc_eqn :
                                                      uu____14004 ->
                                                      let f =
                                                        head_constructor
-                                                         pat_exp2
-                                                        in
+                                                         pat_exp2 in
                                                      let uu____14006 =
                                                        let uu____14007 =
                                                          FStar_TypeChecker_Env.is_datacon
                                                            env
-                                                           f.FStar_Syntax_Syntax.v
-                                                          in
+                                                           f.FStar_Syntax_Syntax.v in
                                                        Prims.op_Negation
-                                                         uu____14007
-                                                        in
+                                                         uu____14007 in
                                                      if uu____14006
                                                      then []
                                                      else
                                                        (let uu____14011 =
                                                           head_constructor
-                                                            pat_exp2
-                                                           in
+                                                            pat_exp2 in
                                                         discriminate
                                                           scrutinee_tm1
                                                           uu____14011)
                                                  | FStar_Syntax_Syntax.Tm_app
                                                      (head1,args) ->
                                                      let f =
-                                                       head_constructor head1
-                                                        in
+                                                       head_constructor head1 in
                                                      let uu____14037 =
                                                        let uu____14038 =
                                                          FStar_TypeChecker_Env.is_datacon
                                                            env
-                                                           f.FStar_Syntax_Syntax.v
-                                                          in
+                                                           f.FStar_Syntax_Syntax.v in
                                                        Prims.op_Negation
-                                                         uu____14038
-                                                        in
+                                                         uu____14038 in
                                                      if uu____14037
                                                      then []
                                                      else
@@ -6191,13 +5572,12 @@ and (tc_eqn :
                                                                     FStar_TypeChecker_Env.lookup_projector
                                                                     env
                                                                     f.FStar_Syntax_Syntax.v
-                                                                    i  in
+                                                                    i in
                                                                     let uu____14093
                                                                     =
                                                                     FStar_TypeChecker_Env.try_lookup_lid
                                                                     env
-                                                                    projector
-                                                                     in
+                                                                    projector in
                                                                     (match uu____14093
                                                                     with
                                                                     | 
@@ -6217,51 +5597,41 @@ and (tc_eqn :
                                                                     projector
                                                                     f.FStar_Syntax_Syntax.p)
                                                                     FStar_Syntax_Syntax.Delta_equational
-                                                                    FStar_Pervasives_Native.None
-                                                                     in
+                                                                    FStar_Pervasives_Native.None in
                                                                     let uu____14130
                                                                     =
                                                                     let uu____14131
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    scrutinee_tm1
-                                                                     in
-                                                                    [uu____14131]
-                                                                     in
+                                                                    scrutinee_tm1 in
+                                                                    [uu____14131] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     uu____14129
-                                                                    uu____14130
-                                                                     in
+                                                                    uu____14130 in
                                                                     uu____14128
                                                                     FStar_Pervasives_Native.None
-                                                                    f.FStar_Syntax_Syntax.p
-                                                                     in
+                                                                    f.FStar_Syntax_Syntax.p in
                                                                     build_branch_guard
                                                                     sub_term
-                                                                    ei)))
-                                                             in
+                                                                    ei))) in
                                                           FStar_All.pipe_right
                                                             uu____14045
-                                                            FStar_List.flatten
-                                                           in
+                                                            FStar_List.flatten in
                                                         let uu____14140 =
                                                           discriminate
-                                                            scrutinee_tm1 f
-                                                           in
+                                                            scrutinee_tm1 f in
                                                         FStar_List.append
                                                           uu____14140
                                                           sub_term_guards)
-                                                 | uu____14143 -> []  in
+                                                 | uu____14143 -> [] in
                                                let build_and_check_branch_guard
                                                  scrutinee_tm1 pat =
                                                  let uu____14155 =
                                                    let uu____14156 =
                                                      FStar_TypeChecker_Env.should_verify
-                                                       env
-                                                      in
+                                                       env in
                                                    Prims.op_Negation
-                                                     uu____14156
-                                                    in
+                                                     uu____14156 in
                                                  if uu____14155
                                                  then
                                                    FStar_TypeChecker_Util.fvar_const
@@ -6271,31 +5641,25 @@ and (tc_eqn :
                                                    (let t =
                                                       let uu____14159 =
                                                         build_branch_guard
-                                                          scrutinee_tm1 pat
-                                                         in
+                                                          scrutinee_tm1 pat in
                                                       FStar_All.pipe_left
                                                         FStar_Syntax_Util.mk_conj_l
-                                                        uu____14159
-                                                       in
+                                                        uu____14159 in
                                                     let uu____14164 =
                                                       FStar_Syntax_Util.type_u
-                                                        ()
-                                                       in
+                                                        () in
                                                     match uu____14164 with
                                                     | (k,uu____14170) ->
                                                         let uu____14171 =
                                                           tc_check_tot_or_gtot_term
-                                                            scrutinee_env t k
-                                                           in
+                                                            scrutinee_env t k in
                                                         (match uu____14171
                                                          with
                                                          | (t1,uu____14179,uu____14180)
-                                                             -> t1))
-                                                  in
+                                                             -> t1)) in
                                                let branch_guard =
                                                  build_and_check_branch_guard
-                                                   scrutinee_tm norm_pat_exp
-                                                  in
+                                                   scrutinee_tm norm_pat_exp in
                                                let branch_guard1 =
                                                  match when_condition with
                                                  | FStar_Pervasives_Native.None
@@ -6303,24 +5667,19 @@ and (tc_eqn :
                                                  | FStar_Pervasives_Native.Some
                                                      w ->
                                                      FStar_Syntax_Util.mk_conj
-                                                       branch_guard w
-                                                  in
-                                               branch_guard1)
-                                             in
+                                                       branch_guard w in
+                                               branch_guard1) in
                                           let guard =
                                             FStar_TypeChecker_Rel.conj_guard
-                                              g_when1 g_branch2
-                                             in
+                                              g_when1 g_branch2 in
                                           ((let uu____14186 =
                                               FStar_TypeChecker_Env.debug env
-                                                FStar_Options.High
-                                               in
+                                                FStar_Options.High in
                                             if uu____14186
                                             then
                                               let uu____14187 =
                                                 FStar_TypeChecker_Rel.guard_to_string
-                                                  env guard
-                                                 in
+                                                  env guard in
                                               FStar_All.pipe_left
                                                 (FStar_Util.print1
                                                    "Carrying guard from match: %s\n")
@@ -6329,24 +5688,22 @@ and (tc_eqn :
                                            (let uu____14189 =
                                               FStar_Syntax_Subst.close_branch
                                                 (pattern1, when_clause1,
-                                                  branch_exp1)
-                                               in
+                                                  branch_exp1) in
                                             (uu____14189, branch_guard,
                                               effect_label, cflags,
                                               maybe_return_c, guard)))))))))
-
-and (check_top_level_let :
+and check_top_level_let:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
-      let env1 = instantiate_both env  in
+      let env1 = instantiate_both env in
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
-          let uu____14219 = check_let_bound_def true env1 lb  in
+          let uu____14219 = check_let_bound_def true env1 lb in
           (match uu____14219 with
            | (e1,univ_vars1,c1,g1,annotated) ->
                let uu____14241 =
@@ -6356,32 +5713,27 @@ and (check_top_level_let :
                  then
                    let uu____14258 =
                      FStar_TypeChecker_Normalize.reduce_uvar_solutions env1
-                       e1
-                      in
+                       e1 in
                    (g1, uu____14258, univ_vars1, c1)
                  else
                    (let g11 =
                       let uu____14261 =
                         FStar_TypeChecker_Rel.solve_deferred_constraints env1
-                          g1
-                         in
+                          g1 in
                       FStar_All.pipe_right uu____14261
-                        FStar_TypeChecker_Rel.resolve_implicits
-                       in
+                        FStar_TypeChecker_Rel.resolve_implicits in
                     let uu____14265 =
                       let uu____14278 =
                         let uu____14293 =
                           let uu____14302 =
                             let uu____14313 =
-                              FStar_Syntax_Syntax.lcomp_comp c1  in
+                              FStar_Syntax_Syntax.lcomp_comp c1 in
                             ((lb.FStar_Syntax_Syntax.lbname), e1,
-                              uu____14313)
-                             in
-                          [uu____14302]  in
+                              uu____14313) in
+                          [uu____14302] in
                         FStar_TypeChecker_Util.generalize env1 false
-                          uu____14293
-                         in
-                      FStar_List.hd uu____14278  in
+                          uu____14293 in
+                      FStar_List.hd uu____14278 in
                     match uu____14265 with
                     | (uu____14358,univs1,e11,c11,gvs) ->
                         let g12 =
@@ -6393,31 +5745,27 @@ and (check_top_level_let :
                                FStar_TypeChecker_Normalize.CompressUvars;
                                FStar_TypeChecker_Normalize.NoFullNorm;
                                FStar_TypeChecker_Normalize.Exclude
-                                 FStar_TypeChecker_Normalize.Zeta] env1)
-                           in
+                                 FStar_TypeChecker_Normalize.Zeta] env1) in
                         let g13 =
-                          FStar_TypeChecker_Rel.abstract_guard_n gvs g12  in
-                        let uu____14371 = FStar_Syntax_Util.lcomp_of_comp c11
-                           in
-                        (g13, e11, univs1, uu____14371))
-                  in
+                          FStar_TypeChecker_Rel.abstract_guard_n gvs g12 in
+                        let uu____14371 = FStar_Syntax_Util.lcomp_of_comp c11 in
+                        (g13, e11, univs1, uu____14371)) in
                (match uu____14241 with
                 | (g11,e11,univ_vars2,c11) ->
                     let uu____14382 =
                       let uu____14389 =
-                        FStar_TypeChecker_Env.should_verify env1  in
+                        FStar_TypeChecker_Env.should_verify env1 in
                       if uu____14389
                       then
                         let uu____14396 =
-                          FStar_TypeChecker_Util.check_top_level env1 g11 c11
-                           in
+                          FStar_TypeChecker_Util.check_top_level env1 g11 c11 in
                         match uu____14396 with
                         | (ok,c12) ->
                             (if ok
                              then (e2, c12)
                              else
                                ((let uu____14419 =
-                                   FStar_TypeChecker_Env.get_range env1  in
+                                   FStar_TypeChecker_Env.get_range env1 in
                                  FStar_Errors.log_issue uu____14419
                                    FStar_TypeChecker_Err.top_level_effect);
                                 (let uu____14420 =
@@ -6427,27 +5775,25 @@ and (check_top_level_let :
                                           (FStar_Syntax_Syntax.Meta_desugared
                                              FStar_Syntax_Syntax.Masked_effect)))
                                      FStar_Pervasives_Native.None
-                                     e2.FStar_Syntax_Syntax.pos
-                                    in
+                                     e2.FStar_Syntax_Syntax.pos in
                                  (uu____14420, c12))))
                       else
                         (FStar_TypeChecker_Rel.force_trivial_guard env1 g11;
                          (let c =
                             let uu____14430 =
-                              FStar_Syntax_Syntax.lcomp_comp c11  in
+                              FStar_Syntax_Syntax.lcomp_comp c11 in
                             FStar_All.pipe_right uu____14430
                               (FStar_TypeChecker_Normalize.normalize_comp
                                  [FStar_TypeChecker_Normalize.Beta;
-                                 FStar_TypeChecker_Normalize.NoFullNorm] env1)
-                             in
+                                 FStar_TypeChecker_Normalize.NoFullNorm] env1) in
                           let e21 =
                             let uu____14434 =
-                              FStar_Syntax_Util.is_pure_comp c  in
+                              FStar_Syntax_Util.is_pure_comp c in
                             if uu____14434
                             then e2
                             else
                               ((let uu____14439 =
-                                  FStar_TypeChecker_Env.get_range env1  in
+                                  FStar_TypeChecker_Env.get_range env1 in
                                 FStar_Errors.log_issue uu____14439
                                   FStar_TypeChecker_Err.top_level_effect);
                                FStar_Syntax_Syntax.mk
@@ -6456,52 +5802,46 @@ and (check_top_level_let :
                                       (FStar_Syntax_Syntax.Meta_desugared
                                          FStar_Syntax_Syntax.Masked_effect)))
                                  FStar_Pervasives_Native.None
-                                 e2.FStar_Syntax_Syntax.pos)
-                             in
-                          (e21, c)))
-                       in
+                                 e2.FStar_Syntax_Syntax.pos) in
+                          (e21, c))) in
                     (match uu____14382 with
                      | (e21,c12) ->
                          let cres =
                            FStar_TypeChecker_Env.null_wp_for_eff env1
                              (FStar_Syntax_Util.comp_effect_name c12)
                              FStar_Syntax_Syntax.U_zero
-                             FStar_Syntax_Syntax.t_unit
-                            in
+                             FStar_Syntax_Syntax.t_unit in
                          let lb1 =
                            FStar_Syntax_Util.close_univs_and_mk_letbinding
                              FStar_Pervasives_Native.None
                              lb.FStar_Syntax_Syntax.lbname univ_vars2
                              (FStar_Syntax_Util.comp_result c12)
                              (FStar_Syntax_Util.comp_effect_name c12) e11
-                             lb.FStar_Syntax_Syntax.lbattrs
-                            in
+                             lb.FStar_Syntax_Syntax.lbattrs in
                          let uu____14460 =
                            FStar_Syntax_Syntax.mk
                              (FStar_Syntax_Syntax.Tm_let
                                 ((false, [lb1]), e21))
                              FStar_Pervasives_Native.None
-                             e.FStar_Syntax_Syntax.pos
-                            in
+                             e.FStar_Syntax_Syntax.pos in
                          let uu____14473 =
-                           FStar_Syntax_Util.lcomp_of_comp cres  in
+                           FStar_Syntax_Util.lcomp_of_comp cres in
                          (uu____14460, uu____14473,
                            FStar_TypeChecker_Rel.trivial_guard))))
       | uu____14476 -> failwith "Impossible"
-
-and (check_inner_let :
+and check_inner_let:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
-      let env1 = instantiate_both env  in
+      let env1 = instantiate_both env in
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
           let env2 =
-            let uu___96_14507 = env1  in
+            let uu___96_14507 = env1 in
             {
               FStar_TypeChecker_Env.solver =
                 (uu___96_14507.FStar_TypeChecker_Env.solver);
@@ -6572,14 +5912,12 @@ and (check_inner_let :
                 (uu___96_14507.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.dep_graph =
                 (uu___96_14507.FStar_TypeChecker_Env.dep_graph)
-            }  in
+            } in
           let uu____14508 =
             let uu____14519 =
-              let uu____14520 = FStar_TypeChecker_Env.clear_expected_typ env2
-                 in
-              FStar_All.pipe_right uu____14520 FStar_Pervasives_Native.fst
-               in
-            check_let_bound_def false uu____14519 lb  in
+              let uu____14520 = FStar_TypeChecker_Env.clear_expected_typ env2 in
+              FStar_All.pipe_right uu____14520 FStar_Pervasives_Native.fst in
+            check_let_bound_def false uu____14519 lb in
           (match uu____14508 with
            | (e1,uu____14542,c1,g1,annotated) ->
                ((let uu____14547 =
@@ -6589,31 +5927,26 @@ and (check_inner_let :
                       lb.FStar_Syntax_Syntax.lbattrs)
                      &&
                      (let uu____14549 =
-                        FStar_Syntax_Util.is_pure_or_ghost_lcomp c1  in
-                      Prims.op_Negation uu____14549)
-                    in
+                        FStar_Syntax_Util.is_pure_or_ghost_lcomp c1 in
+                      Prims.op_Negation uu____14549) in
                  if uu____14547
                  then
                    let uu____14550 =
                      let uu____14555 =
-                       let uu____14556 = FStar_Syntax_Print.term_to_string e1
-                          in
+                       let uu____14556 = FStar_Syntax_Print.term_to_string e1 in
                        let uu____14557 =
                          FStar_Syntax_Print.lid_to_string
-                           c1.FStar_Syntax_Syntax.eff_name
-                          in
+                           c1.FStar_Syntax_Syntax.eff_name in
                        FStar_Util.format2
                          "Definitions marked @inline_let are expected to be pure or ghost; got an expression \"%s\" with effect \"%s\""
-                         uu____14556 uu____14557
-                        in
-                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____14555)
-                      in
+                         uu____14556 uu____14557 in
+                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____14555) in
                    FStar_Errors.raise_error uu____14550
                      e1.FStar_Syntax_Syntax.pos
                  else ());
                 (let x =
                    let uu___97_14560 =
-                     FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
+                     FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                    {
                      FStar_Syntax_Syntax.ppname =
                        (uu___97_14560.FStar_Syntax_Syntax.ppname);
@@ -6621,117 +5954,101 @@ and (check_inner_let :
                        (uu___97_14560.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort =
                        (c1.FStar_Syntax_Syntax.res_typ)
-                   }  in
+                   } in
                  let uu____14561 =
                    let uu____14566 =
-                     let uu____14567 = FStar_Syntax_Syntax.mk_binder x  in
-                     [uu____14567]  in
-                   FStar_Syntax_Subst.open_term uu____14566 e2  in
+                     let uu____14567 = FStar_Syntax_Syntax.mk_binder x in
+                     [uu____14567] in
+                   FStar_Syntax_Subst.open_term uu____14566 e2 in
                  match uu____14561 with
                  | (xb,e21) ->
-                     let xbinder = FStar_List.hd xb  in
-                     let x1 = FStar_Pervasives_Native.fst xbinder  in
-                     let env_x = FStar_TypeChecker_Env.push_bv env2 x1  in
-                     let uu____14587 = tc_term env_x e21  in
+                     let xbinder = FStar_List.hd xb in
+                     let x1 = FStar_Pervasives_Native.fst xbinder in
+                     let env_x = FStar_TypeChecker_Env.push_bv env2 x1 in
+                     let uu____14587 = tc_term env_x e21 in
                      (match uu____14587 with
                       | (e22,c2,g2) ->
                           let cres =
                             FStar_TypeChecker_Util.maybe_return_e2_and_bind
                               e1.FStar_Syntax_Syntax.pos env2
                               (FStar_Pervasives_Native.Some e1) c1 e22
-                              ((FStar_Pervasives_Native.Some x1), c2)
-                             in
+                              ((FStar_Pervasives_Native.Some x1), c2) in
                           let e11 =
                             FStar_TypeChecker_Util.maybe_lift env2 e1
                               c1.FStar_Syntax_Syntax.eff_name
                               cres.FStar_Syntax_Syntax.eff_name
-                              c1.FStar_Syntax_Syntax.res_typ
-                             in
+                              c1.FStar_Syntax_Syntax.res_typ in
                           let e23 =
                             FStar_TypeChecker_Util.maybe_lift env2 e22
                               c2.FStar_Syntax_Syntax.eff_name
                               cres.FStar_Syntax_Syntax.eff_name
-                              c2.FStar_Syntax_Syntax.res_typ
-                             in
+                              c2.FStar_Syntax_Syntax.res_typ in
                           let lb1 =
                             FStar_Syntax_Util.mk_letbinding
                               (FStar_Util.Inl x1) []
                               c1.FStar_Syntax_Syntax.res_typ
                               cres.FStar_Syntax_Syntax.eff_name e11
-                              lb.FStar_Syntax_Syntax.lbattrs
-                             in
+                              lb.FStar_Syntax_Syntax.lbattrs in
                           let e3 =
                             let uu____14612 =
                               let uu____14615 =
                                 let uu____14616 =
                                   let uu____14629 =
-                                    FStar_Syntax_Subst.close xb e23  in
-                                  ((false, [lb1]), uu____14629)  in
-                                FStar_Syntax_Syntax.Tm_let uu____14616  in
-                              FStar_Syntax_Syntax.mk uu____14615  in
+                                    FStar_Syntax_Subst.close xb e23 in
+                                  ((false, [lb1]), uu____14629) in
+                                FStar_Syntax_Syntax.Tm_let uu____14616 in
+                              FStar_Syntax_Syntax.mk uu____14615 in
                             uu____14612 FStar_Pervasives_Native.None
-                              e.FStar_Syntax_Syntax.pos
-                             in
+                              e.FStar_Syntax_Syntax.pos in
                           let e4 =
                             FStar_TypeChecker_Util.maybe_monadic env2 e3
                               cres.FStar_Syntax_Syntax.eff_name
-                              cres.FStar_Syntax_Syntax.res_typ
-                             in
+                              cres.FStar_Syntax_Syntax.res_typ in
                           let x_eq_e1 =
                             let uu____14643 =
                               let uu____14644 =
                                 env2.FStar_TypeChecker_Env.universe_of env2
-                                  c1.FStar_Syntax_Syntax.res_typ
-                                 in
+                                  c1.FStar_Syntax_Syntax.res_typ in
                               let uu____14645 =
-                                FStar_Syntax_Syntax.bv_to_name x1  in
+                                FStar_Syntax_Syntax.bv_to_name x1 in
                               FStar_Syntax_Util.mk_eq2 uu____14644
                                 c1.FStar_Syntax_Syntax.res_typ uu____14645
-                                e11
-                               in
+                                e11 in
                             FStar_All.pipe_left
                               (fun _0_42  ->
                                  FStar_TypeChecker_Common.NonTrivial _0_42)
-                              uu____14643
-                             in
+                              uu____14643 in
                           let g21 =
                             let uu____14647 =
                               let uu____14648 =
                                 FStar_TypeChecker_Rel.guard_of_guard_formula
-                                  x_eq_e1
-                                 in
-                              FStar_TypeChecker_Rel.imp_guard uu____14648 g2
-                               in
+                                  x_eq_e1 in
+                              FStar_TypeChecker_Rel.imp_guard uu____14648 g2 in
                             FStar_TypeChecker_Rel.close_guard env2 xb
-                              uu____14647
-                             in
-                          let guard = FStar_TypeChecker_Rel.conj_guard g1 g21
-                             in
+                              uu____14647 in
+                          let guard = FStar_TypeChecker_Rel.conj_guard g1 g21 in
                           let uu____14650 =
                             let uu____14651 =
-                              FStar_TypeChecker_Env.expected_typ env2  in
-                            FStar_Option.isSome uu____14651  in
+                              FStar_TypeChecker_Env.expected_typ env2 in
+                            FStar_Option.isSome uu____14651 in
                           if uu____14650
                           then
                             let tt =
                               let uu____14661 =
-                                FStar_TypeChecker_Env.expected_typ env2  in
+                                FStar_TypeChecker_Env.expected_typ env2 in
                               FStar_All.pipe_right uu____14661
-                                FStar_Option.get
-                               in
+                                FStar_Option.get in
                             ((let uu____14667 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env2)
-                                  (FStar_Options.Other "Exports")
-                                 in
+                                  (FStar_Options.Other "Exports") in
                               if uu____14667
                               then
                                 let uu____14668 =
-                                  FStar_Syntax_Print.term_to_string tt  in
+                                  FStar_Syntax_Print.term_to_string tt in
                                 let uu____14669 =
                                   FStar_Syntax_Print.term_to_string
-                                    cres.FStar_Syntax_Syntax.res_typ
-                                   in
+                                    cres.FStar_Syntax_Syntax.res_typ in
                                 FStar_Util.print2
                                   "Got expected type from env %s\ncres.res_typ=%s\n"
                                   uu____14668 uu____14669
@@ -6740,27 +6057,24 @@ and (check_inner_let :
                           else
                             (let t =
                                check_no_escape FStar_Pervasives_Native.None
-                                 env2 [x1] cres.FStar_Syntax_Syntax.res_typ
-                                in
+                                 env2 [x1] cres.FStar_Syntax_Syntax.res_typ in
                              (let uu____14674 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env2)
-                                  (FStar_Options.Other "Exports")
-                                 in
+                                  (FStar_Options.Other "Exports") in
                               if uu____14674
                               then
                                 let uu____14675 =
                                   FStar_Syntax_Print.term_to_string
-                                    cres.FStar_Syntax_Syntax.res_typ
-                                   in
+                                    cres.FStar_Syntax_Syntax.res_typ in
                                 let uu____14676 =
-                                  FStar_Syntax_Print.term_to_string t  in
+                                  FStar_Syntax_Print.term_to_string t in
                                 FStar_Util.print2
                                   "Checked %s has no escaping types; normalized to %s\n"
                                   uu____14675 uu____14676
                               else ());
                              (e4,
-                               ((let uu___98_14679 = cres  in
+                               ((let uu___98_14679 = cres in
                                  {
                                    FStar_Syntax_Syntax.eff_name =
                                      (uu___98_14679.FStar_Syntax_Syntax.eff_name);
@@ -6771,51 +6085,46 @@ and (check_inner_let :
                                      (uu___98_14679.FStar_Syntax_Syntax.comp_thunk)
                                  })), guard))))))
       | uu____14680 -> failwith "Impossible"
-
-and (check_top_level_let_rec :
+and check_top_level_let_rec:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun top  ->
-      let env1 = instantiate_both env  in
+      let env1 = instantiate_both env in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____14712 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          let uu____14712 = FStar_Syntax_Subst.open_let_rec lbs e2 in
           (match uu____14712 with
            | (lbs1,e21) ->
                let uu____14731 =
-                 FStar_TypeChecker_Env.clear_expected_typ env1  in
+                 FStar_TypeChecker_Env.clear_expected_typ env1 in
                (match uu____14731 with
                 | (env0,topt) ->
-                    let uu____14750 = build_let_rec_env true env0 lbs1  in
+                    let uu____14750 = build_let_rec_env true env0 lbs1 in
                     (match uu____14750 with
                      | (lbs2,rec_env) ->
-                         let uu____14769 = check_let_recs rec_env lbs2  in
+                         let uu____14769 = check_let_recs rec_env lbs2 in
                          (match uu____14769 with
                           | (lbs3,g_lbs) ->
                               let g_lbs1 =
                                 let uu____14789 =
                                   FStar_TypeChecker_Rel.solve_deferred_constraints
-                                    env1 g_lbs
-                                   in
+                                    env1 g_lbs in
                                 FStar_All.pipe_right uu____14789
-                                  FStar_TypeChecker_Rel.resolve_implicits
-                                 in
+                                  FStar_TypeChecker_Rel.resolve_implicits in
                               let all_lb_names =
                                 let uu____14795 =
                                   FStar_All.pipe_right lbs3
                                     (FStar_List.map
                                        (fun lb  ->
                                           FStar_Util.right
-                                            lb.FStar_Syntax_Syntax.lbname))
-                                   in
+                                            lb.FStar_Syntax_Syntax.lbname)) in
                                 FStar_All.pipe_right uu____14795
                                   (fun _0_43  ->
-                                     FStar_Pervasives_Native.Some _0_43)
-                                 in
+                                     FStar_Pervasives_Native.Some _0_43) in
                               let lbs4 =
                                 if
                                   Prims.op_Negation
@@ -6827,8 +6136,7 @@ and (check_top_level_let_rec :
                                           let lbdef =
                                             FStar_TypeChecker_Normalize.reduce_uvar_solutions
                                               env1
-                                              lb.FStar_Syntax_Syntax.lbdef
-                                             in
+                                              lb.FStar_Syntax_Syntax.lbdef in
                                           if
                                             lb.FStar_Syntax_Syntax.lbunivs =
                                               []
@@ -6850,15 +6158,12 @@ and (check_top_level_let_rec :
                                             (fun lb  ->
                                                let uu____14884 =
                                                  FStar_Syntax_Syntax.mk_Total
-                                                   lb.FStar_Syntax_Syntax.lbtyp
-                                                  in
+                                                   lb.FStar_Syntax_Syntax.lbtyp in
                                                ((lb.FStar_Syntax_Syntax.lbname),
                                                  (lb.FStar_Syntax_Syntax.lbdef),
-                                                 uu____14884)))
-                                        in
+                                                 uu____14884))) in
                                      FStar_TypeChecker_Util.generalize env1
-                                       true uu____14844
-                                      in
+                                       true uu____14844 in
                                    FStar_List.map2
                                      (fun uu____14918  ->
                                         fun lb  ->
@@ -6871,24 +6176,20 @@ and (check_top_level_let_rec :
                                                 (FStar_Syntax_Util.comp_effect_name
                                                    c) e
                                                 lb.FStar_Syntax_Syntax.lbattrs)
-                                     ecs lbs3)
-                                 in
+                                     ecs lbs3) in
                               let cres =
                                 let uu____14966 =
                                   FStar_Syntax_Syntax.mk_Total
-                                    FStar_Syntax_Syntax.t_unit
-                                   in
+                                    FStar_Syntax_Syntax.t_unit in
                                 FStar_All.pipe_left
-                                  FStar_Syntax_Util.lcomp_of_comp uu____14966
-                                 in
+                                  FStar_Syntax_Util.lcomp_of_comp uu____14966 in
                               let uu____14971 =
-                                FStar_Syntax_Subst.close_let_rec lbs4 e21  in
+                                FStar_Syntax_Subst.close_let_rec lbs4 e21 in
                               (match uu____14971 with
                                | (lbs5,e22) ->
                                    ((let uu____14991 =
                                        FStar_TypeChecker_Rel.discharge_guard
-                                         env1 g_lbs1
-                                        in
+                                         env1 g_lbs1 in
                                      FStar_All.pipe_right uu____14991
                                        (FStar_TypeChecker_Rel.force_trivial_guard
                                           env1));
@@ -6897,34 +6198,32 @@ and (check_top_level_let_rec :
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((true, lbs5), e22))
                                          FStar_Pervasives_Native.None
-                                         top.FStar_Syntax_Syntax.pos
-                                        in
+                                         top.FStar_Syntax_Syntax.pos in
                                      (uu____14992, cres,
                                        FStar_TypeChecker_Rel.trivial_guard))))))))
       | uu____15005 -> failwith "Impossible"
-
-and (check_inner_let_rec :
+and check_inner_let_rec:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun top  ->
-      let env1 = instantiate_both env  in
+      let env1 = instantiate_both env in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____15037 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          let uu____15037 = FStar_Syntax_Subst.open_let_rec lbs e2 in
           (match uu____15037 with
            | (lbs1,e21) ->
                let uu____15056 =
-                 FStar_TypeChecker_Env.clear_expected_typ env1  in
+                 FStar_TypeChecker_Env.clear_expected_typ env1 in
                (match uu____15056 with
                 | (env0,topt) ->
-                    let uu____15075 = build_let_rec_env false env0 lbs1  in
+                    let uu____15075 = build_let_rec_env false env0 lbs1 in
                     (match uu____15075 with
                      | (lbs2,rec_env) ->
-                         let uu____15094 = check_let_recs rec_env lbs2  in
+                         let uu____15094 = check_let_recs rec_env lbs2 in
                          (match uu____15094 with
                           | (lbs3,g_lbs) ->
                               let uu____15113 =
@@ -6935,8 +6234,7 @@ and (check_inner_let_rec :
                                           let x =
                                             let uu___99_15136 =
                                               FStar_Util.left
-                                                lb.FStar_Syntax_Syntax.lbname
-                                               in
+                                                lb.FStar_Syntax_Syntax.lbname in
                                             {
                                               FStar_Syntax_Syntax.ppname =
                                                 (uu___99_15136.FStar_Syntax_Syntax.ppname);
@@ -6944,9 +6242,9 @@ and (check_inner_let_rec :
                                                 (uu___99_15136.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort =
                                                 (lb.FStar_Syntax_Syntax.lbtyp)
-                                            }  in
+                                            } in
                                           let lb1 =
-                                            let uu___100_15138 = lb  in
+                                            let uu___100_15138 = lb in
                                             {
                                               FStar_Syntax_Syntax.lbname =
                                                 (FStar_Util.Inl x);
@@ -6960,16 +6258,14 @@ and (check_inner_let_rec :
                                                 (uu___100_15138.FStar_Syntax_Syntax.lbdef);
                                               FStar_Syntax_Syntax.lbattrs =
                                                 (uu___100_15138.FStar_Syntax_Syntax.lbattrs)
-                                            }  in
+                                            } in
                                           let env3 =
                                             FStar_TypeChecker_Env.push_let_binding
                                               env2
                                               lb1.FStar_Syntax_Syntax.lbname
                                               ([],
-                                                (lb1.FStar_Syntax_Syntax.lbtyp))
-                                             in
-                                          (env3, lb1)) env1)
-                                 in
+                                                (lb1.FStar_Syntax_Syntax.lbtyp)) in
+                                          (env3, lb1)) env1) in
                               (match uu____15113 with
                                | (env2,lbs4) ->
                                    let bvs =
@@ -6977,43 +6273,35 @@ and (check_inner_let_rec :
                                        (FStar_List.map
                                           (fun lb  ->
                                              FStar_Util.left
-                                               lb.FStar_Syntax_Syntax.lbname))
-                                      in
-                                   let uu____15165 = tc_term env2 e21  in
+                                               lb.FStar_Syntax_Syntax.lbname)) in
+                                   let uu____15165 = tc_term env2 e21 in
                                    (match uu____15165 with
                                     | (e22,cres,g2) ->
                                         let cres1 =
                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
-                                            env2 e22 cres
-                                           in
+                                            env2 e22 cres in
                                         let cres2 =
                                           FStar_Syntax_Util.lcomp_set_flags
                                             cres1
-                                            [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
-                                           in
+                                            [FStar_Syntax_Syntax.SHOULD_NOT_INLINE] in
                                         let guard =
                                           let uu____15184 =
                                             let uu____15185 =
                                               FStar_List.map
                                                 FStar_Syntax_Syntax.mk_binder
-                                                bvs
-                                               in
+                                                bvs in
                                             FStar_TypeChecker_Rel.close_guard
-                                              env2 uu____15185 g2
-                                             in
+                                              env2 uu____15185 g2 in
                                           FStar_TypeChecker_Rel.conj_guard
-                                            g_lbs uu____15184
-                                           in
+                                            g_lbs uu____15184 in
                                         let cres3 =
                                           FStar_TypeChecker_Util.close_lcomp
-                                            env2 bvs cres2
-                                           in
+                                            env2 bvs cres2 in
                                         let tres =
                                           norm env2
-                                            cres3.FStar_Syntax_Syntax.res_typ
-                                           in
+                                            cres3.FStar_Syntax_Syntax.res_typ in
                                         let cres4 =
-                                          let uu___101_15189 = cres3  in
+                                          let uu___101_15189 = cres3 in
                                           {
                                             FStar_Syntax_Syntax.eff_name =
                                               (uu___101_15189.FStar_Syntax_Syntax.eff_name);
@@ -7023,11 +6311,10 @@ and (check_inner_let_rec :
                                               (uu___101_15189.FStar_Syntax_Syntax.cflags);
                                             FStar_Syntax_Syntax.comp_thunk =
                                               (uu___101_15189.FStar_Syntax_Syntax.comp_thunk)
-                                          }  in
+                                          } in
                                         let uu____15190 =
                                           FStar_Syntax_Subst.close_let_rec
-                                            lbs4 e22
-                                           in
+                                            lbs4 e22 in
                                         (match uu____15190 with
                                          | (lbs5,e23) ->
                                              let e =
@@ -7035,8 +6322,7 @@ and (check_inner_let_rec :
                                                  (FStar_Syntax_Syntax.Tm_let
                                                     ((true, lbs5), e23))
                                                  FStar_Pervasives_Native.None
-                                                 top.FStar_Syntax_Syntax.pos
-                                                in
+                                                 top.FStar_Syntax_Syntax.pos in
                                              (match topt with
                                               | FStar_Pervasives_Native.Some
                                                   uu____15226 ->
@@ -7046,11 +6332,10 @@ and (check_inner_let_rec :
                                                   let tres1 =
                                                     check_no_escape
                                                       FStar_Pervasives_Native.None
-                                                      env2 bvs tres
-                                                     in
+                                                      env2 bvs tres in
                                                   let cres5 =
                                                     let uu___102_15231 =
-                                                      cres4  in
+                                                      cres4 in
                                                     {
                                                       FStar_Syntax_Syntax.eff_name
                                                         =
@@ -7063,31 +6348,30 @@ and (check_inner_let_rec :
                                                       FStar_Syntax_Syntax.comp_thunk
                                                         =
                                                         (uu___102_15231.FStar_Syntax_Syntax.comp_thunk)
-                                                    }  in
+                                                    } in
                                                   (e, cres5, guard)))))))))
       | uu____15234 -> failwith "Impossible"
-
-and (build_let_rec_env :
+and build_let_rec_env:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.letbinding Prims.list ->
         (FStar_Syntax_Syntax.letbinding Prims.list,FStar_TypeChecker_Env.env_t)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun top_level  ->
     fun env  ->
       fun lbs  ->
-        let env0 = env  in
+        let env0 = env in
         let termination_check_enabled lbname lbdef lbtyp =
-          let uu____15263 = FStar_Options.ml_ish ()  in
+          let uu____15263 = FStar_Options.ml_ish () in
           if uu____15263
           then false
           else
-            (let t = FStar_TypeChecker_Normalize.unfold_whnf env lbtyp  in
-             let uu____15266 = FStar_Syntax_Util.arrow_formals_comp t  in
+            (let t = FStar_TypeChecker_Normalize.unfold_whnf env lbtyp in
+             let uu____15266 = FStar_Syntax_Util.arrow_formals_comp t in
              match uu____15266 with
              | (formals,c) ->
-                 let uu____15291 = FStar_Syntax_Util.abs_formals lbdef  in
+                 let uu____15291 = FStar_Syntax_Util.abs_formals lbdef in
                  (match uu____15291 with
                   | (actuals,uu____15301,uu____15302) ->
                       if
@@ -7099,73 +6383,63 @@ and (build_let_rec_env :
                         let uu____15315 =
                           let uu____15320 =
                             let uu____15321 =
-                              FStar_Syntax_Print.term_to_string lbdef  in
+                              FStar_Syntax_Print.term_to_string lbdef in
                             let uu____15322 =
-                              FStar_Syntax_Print.term_to_string lbtyp  in
+                              FStar_Syntax_Print.term_to_string lbtyp in
                             FStar_Util.format2
                               "Only function literals with arrow types can be defined recursively; got %s : %s"
-                              uu____15321 uu____15322
-                             in
+                              uu____15321 uu____15322 in
                           (FStar_Errors.Fatal_RecursiveFunctionLiteral,
-                            uu____15320)
-                           in
+                            uu____15320) in
                         FStar_Errors.raise_error uu____15315
                           lbtyp.FStar_Syntax_Syntax.pos
                       else
                         (let actuals1 =
                            let uu____15325 =
-                             FStar_TypeChecker_Env.set_expected_typ env lbtyp
-                              in
+                             FStar_TypeChecker_Env.set_expected_typ env lbtyp in
                            FStar_TypeChecker_Util.maybe_add_implicit_binders
-                             uu____15325 actuals
-                            in
+                             uu____15325 actuals in
                          if
                            (FStar_List.length formals) <>
                              (FStar_List.length actuals1)
                          then
                            (let actuals_msg =
-                              let n1 = FStar_List.length actuals1  in
+                              let n1 = FStar_List.length actuals1 in
                               if n1 = (Prims.parse_int "1")
                               then "1 argument was found"
                               else
                                 (let uu____15346 =
-                                   FStar_Util.string_of_int n1  in
+                                   FStar_Util.string_of_int n1 in
                                  FStar_Util.format1 "%s arguments were found"
-                                   uu____15346)
-                               in
+                                   uu____15346) in
                             let formals_msg =
-                              let n1 = FStar_List.length formals  in
+                              let n1 = FStar_List.length formals in
                               if n1 = (Prims.parse_int "1")
                               then "1 argument"
                               else
                                 (let uu____15364 =
-                                   FStar_Util.string_of_int n1  in
+                                   FStar_Util.string_of_int n1 in
                                  FStar_Util.format1 "%s arguments"
-                                   uu____15364)
-                               in
+                                   uu____15364) in
                             let msg =
                               let uu____15372 =
-                                FStar_Syntax_Print.term_to_string lbtyp  in
+                                FStar_Syntax_Print.term_to_string lbtyp in
                               let uu____15373 =
-                                FStar_Syntax_Print.lbname_to_string lbname
-                                 in
+                                FStar_Syntax_Print.lbname_to_string lbname in
                               FStar_Util.format4
                                 "From its type %s, the definition of `let rec %s` expects a function with %s, but %s"
                                 uu____15372 uu____15373 formals_msg
-                                actuals_msg
-                               in
+                                actuals_msg in
                             FStar_Errors.raise_error
                               (FStar_Errors.Fatal_LetRecArgumentMismatch,
                                 msg) lbdef.FStar_Syntax_Syntax.pos)
                          else ();
                          (let quals =
                             FStar_TypeChecker_Env.lookup_effect_quals env
-                              (FStar_Syntax_Util.comp_effect_name c)
-                             in
+                              (FStar_Syntax_Util.comp_effect_name c) in
                           FStar_All.pipe_right quals
                             (FStar_List.contains
-                               FStar_Syntax_Syntax.TotalEffect)))))
-           in
+                               FStar_Syntax_Syntax.TotalEffect))))) in
         let uu____15380 =
           FStar_List.fold_left
             (fun uu____15406  ->
@@ -7174,18 +6448,15 @@ and (build_let_rec_env :
                  | (lbs1,env1) ->
                      let uu____15426 =
                        FStar_TypeChecker_Util.extract_let_rec_annotation env1
-                         lb
-                        in
+                         lb in
                      (match uu____15426 with
                       | (univ_vars1,t,check_t) ->
                           let env2 =
                             FStar_TypeChecker_Env.push_univ_vars env1
-                              univ_vars1
-                             in
+                              univ_vars1 in
                           let e =
                             FStar_Syntax_Util.unascribe
-                              lb.FStar_Syntax_Syntax.lbdef
-                             in
+                              lb.FStar_Syntax_Syntax.lbdef in
                           let t1 =
                             if Prims.op_Negation check_t
                             then t
@@ -7193,12 +6464,11 @@ and (build_let_rec_env :
                               (let uu____15446 =
                                  let uu____15453 =
                                    let uu____15454 =
-                                     FStar_Syntax_Util.type_u ()  in
+                                     FStar_Syntax_Util.type_u () in
                                    FStar_All.pipe_left
-                                     FStar_Pervasives_Native.fst uu____15454
-                                    in
+                                     FStar_Pervasives_Native.fst uu____15454 in
                                  tc_check_tot_or_gtot_term
-                                   (let uu___103_15465 = env0  in
+                                   (let uu___103_15465 = env0 in
                                     {
                                       FStar_TypeChecker_Env.solver =
                                         (uu___103_15465.FStar_TypeChecker_Env.solver);
@@ -7271,30 +6541,25 @@ and (build_let_rec_env :
                                         (uu___103_15465.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.dep_graph =
                                         (uu___103_15465.FStar_TypeChecker_Env.dep_graph)
-                                    }) t uu____15453
-                                  in
+                                    }) t uu____15453 in
                                match uu____15446 with
                                | (t1,uu____15467,g) ->
                                    let g1 =
                                      FStar_TypeChecker_Rel.resolve_implicits
-                                       g
-                                      in
+                                       g in
                                    ((let uu____15471 =
                                        FStar_TypeChecker_Rel.discharge_guard
-                                         env2 g1
-                                        in
+                                         env2 g1 in
                                      FStar_All.pipe_left
                                        FStar_Pervasives.ignore uu____15471);
-                                    norm env0 t1))
-                             in
+                                    norm env0 t1)) in
                           let env3 =
                             let uu____15473 =
                               termination_check_enabled
-                                lb.FStar_Syntax_Syntax.lbname e t1
-                               in
+                                lb.FStar_Syntax_Syntax.lbname e t1 in
                             if uu____15473
                             then
-                              let uu___104_15474 = env2  in
+                              let uu___104_15474 = env2 in
                               {
                                 FStar_TypeChecker_Env.solver =
                                   (uu___104_15474.FStar_TypeChecker_Env.solver);
@@ -7372,10 +6637,9 @@ and (build_let_rec_env :
                             else
                               FStar_TypeChecker_Env.push_let_binding env2
                                 lb.FStar_Syntax_Syntax.lbname
-                                (univ_vars1, t1)
-                             in
+                                (univ_vars1, t1) in
                           let lb1 =
-                            let uu___105_15491 = lb  in
+                            let uu___105_15491 = lb in
                             {
                               FStar_Syntax_Syntax.lbname =
                                 (uu___105_15491.FStar_Syntax_Syntax.lbname);
@@ -7386,16 +6650,14 @@ and (build_let_rec_env :
                               FStar_Syntax_Syntax.lbdef = e;
                               FStar_Syntax_Syntax.lbattrs =
                                 (uu___105_15491.FStar_Syntax_Syntax.lbattrs)
-                            }  in
-                          ((lb1 :: lbs1), env3))) ([], env) lbs
-           in
+                            } in
+                          ((lb1 :: lbs1), env3))) ([], env) lbs in
         match uu____15380 with | (lbs1,env1) -> ((FStar_List.rev lbs1), env1)
-
-and (check_let_recs :
+and check_let_recs:
   FStar_TypeChecker_Env.env_t ->
     FStar_Syntax_Syntax.letbinding Prims.list ->
       (FStar_Syntax_Syntax.letbinding Prims.list,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun lbs  ->
@@ -7406,25 +6668,23 @@ and (check_let_recs :
                (fun lb  ->
                   let uu____15549 =
                     FStar_Syntax_Util.abs_formals
-                      lb.FStar_Syntax_Syntax.lbdef
-                     in
+                      lb.FStar_Syntax_Syntax.lbdef in
                   match uu____15549 with
                   | (bs,t,lcomp) ->
                       (match bs with
                        | [] ->
                            let uu____15577 =
                              FStar_Syntax_Syntax.range_of_lbname
-                               lb.FStar_Syntax_Syntax.lbname
-                              in
+                               lb.FStar_Syntax_Syntax.lbname in
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_RecursiveFunctionLiteral,
                                "Only function literals may be defined recursively")
                              uu____15577
                        | uu____15582 ->
                            let lb1 =
-                             let uu___106_15585 = lb  in
+                             let uu___106_15585 = lb in
                              let uu____15586 =
-                               FStar_Syntax_Util.abs bs t lcomp  in
+                               FStar_Syntax_Util.abs bs t lcomp in
                              {
                                FStar_Syntax_Syntax.lbname =
                                  (uu___106_15585.FStar_Syntax_Syntax.lbname);
@@ -7437,21 +6697,19 @@ and (check_let_recs :
                                FStar_Syntax_Syntax.lbdef = uu____15586;
                                FStar_Syntax_Syntax.lbattrs =
                                  (uu___106_15585.FStar_Syntax_Syntax.lbattrs)
-                             }  in
+                             } in
                            let uu____15589 =
                              let uu____15596 =
                                FStar_TypeChecker_Env.set_expected_typ env
-                                 lb1.FStar_Syntax_Syntax.lbtyp
-                                in
+                                 lb1.FStar_Syntax_Syntax.lbtyp in
                              tc_tot_or_gtot_term uu____15596
-                               lb1.FStar_Syntax_Syntax.lbdef
-                              in
+                               lb1.FStar_Syntax_Syntax.lbdef in
                            (match uu____15589 with
                             | (e,c,g) ->
                                 ((let uu____15605 =
                                     let uu____15606 =
-                                      FStar_Syntax_Util.is_total_lcomp c  in
-                                    Prims.op_Negation uu____15606  in
+                                      FStar_Syntax_Util.is_total_lcomp c in
+                                    Prims.op_Negation uu____15606 in
                                   if uu____15605
                                   then
                                     FStar_Errors.raise_error
@@ -7465,35 +6723,31 @@ and (check_let_recs :
                                       lb1.FStar_Syntax_Syntax.lbunivs
                                       lb1.FStar_Syntax_Syntax.lbtyp
                                       FStar_Parser_Const.effect_Tot_lid e
-                                      lb1.FStar_Syntax_Syntax.lbattrs
-                                     in
-                                  (lb2, g)))))))
-           in
-        FStar_All.pipe_right uu____15523 FStar_List.unzip  in
+                                      lb1.FStar_Syntax_Syntax.lbattrs in
+                                  (lb2, g))))))) in
+        FStar_All.pipe_right uu____15523 FStar_List.unzip in
       match uu____15514 with
       | (lbs1,gs) ->
           let g_lbs =
             FStar_List.fold_right FStar_TypeChecker_Rel.conj_guard gs
-              FStar_TypeChecker_Rel.trivial_guard
-             in
+              FStar_TypeChecker_Rel.trivial_guard in
           (lbs1, g_lbs)
-
-and (check_let_bound_def :
+and check_let_bound_def:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.letbinding ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.univ_names,FStar_Syntax_Syntax.lcomp,
           FStar_TypeChecker_Env.guard_t,Prims.bool)
-          FStar_Pervasives_Native.tuple5)
+          FStar_Pervasives_Native.tuple5
   =
   fun top_level  ->
     fun env  ->
       fun lb  ->
-        let uu____15655 = FStar_TypeChecker_Env.clear_expected_typ env  in
+        let uu____15655 = FStar_TypeChecker_Env.clear_expected_typ env in
         match uu____15655 with
         | (env1,uu____15673) ->
-            let e1 = lb.FStar_Syntax_Syntax.lbdef  in
-            let uu____15681 = check_lbtyp top_level env lb  in
+            let e1 = lb.FStar_Syntax_Syntax.lbdef in
+            let uu____15681 = check_lbtyp top_level env lb in
             (match uu____15681 with
              | (topt,wf_annot,univ_vars1,univ_opening,env11) ->
                  (if (Prims.op_Negation top_level) && (univ_vars1 <> [])
@@ -7503,10 +6757,10 @@ and (check_let_bound_def :
                         "Inner let-bound definitions cannot be universe polymorphic")
                       e1.FStar_Syntax_Syntax.pos
                   else ();
-                  (let e11 = FStar_Syntax_Subst.subst univ_opening e1  in
+                  (let e11 = FStar_Syntax_Subst.subst univ_opening e1 in
                    let uu____15725 =
                      tc_maybe_toplevel_term
-                       (let uu___107_15734 = env11  in
+                       (let uu___107_15734 = env11 in
                         {
                           FStar_TypeChecker_Env.solver =
                             (uu___107_15734.FStar_TypeChecker_Env.solver);
@@ -7577,68 +6831,60 @@ and (check_let_bound_def :
                             (uu___107_15734.FStar_TypeChecker_Env.dsenv);
                           FStar_TypeChecker_Env.dep_graph =
                             (uu___107_15734.FStar_TypeChecker_Env.dep_graph)
-                        }) e11
-                      in
+                        }) e11 in
                    match uu____15725 with
                    | (e12,c1,g1) ->
                        let uu____15748 =
                          let uu____15753 =
                            FStar_TypeChecker_Env.set_range env11
-                             e12.FStar_Syntax_Syntax.pos
-                            in
+                             e12.FStar_Syntax_Syntax.pos in
                          FStar_TypeChecker_Util.strengthen_precondition
                            (FStar_Pervasives_Native.Some
                               (fun uu____15757  ->
                                  FStar_Util.return_all
                                    FStar_TypeChecker_Err.ill_kinded_type))
-                           uu____15753 e12 c1 wf_annot
-                          in
+                           uu____15753 e12 c1 wf_annot in
                        (match uu____15748 with
                         | (c11,guard_f) ->
                             let g11 =
-                              FStar_TypeChecker_Rel.conj_guard g1 guard_f  in
+                              FStar_TypeChecker_Rel.conj_guard g1 guard_f in
                             ((let uu____15772 =
                                 FStar_TypeChecker_Env.debug env
-                                  FStar_Options.Extreme
-                                 in
+                                  FStar_Options.Extreme in
                               if uu____15772
                               then
                                 let uu____15773 =
                                   FStar_Syntax_Print.lbname_to_string
-                                    lb.FStar_Syntax_Syntax.lbname
-                                   in
+                                    lb.FStar_Syntax_Syntax.lbname in
                                 let uu____15774 =
-                                  FStar_Syntax_Print.lcomp_to_string c11  in
+                                  FStar_Syntax_Print.lcomp_to_string c11 in
                                 let uu____15775 =
                                   FStar_TypeChecker_Rel.guard_to_string env
-                                    g11
-                                   in
+                                    g11 in
                                 FStar_Util.print3
                                   "checked let-bound def %s : %s guard is %s\n"
                                   uu____15773 uu____15774 uu____15775
                               else ());
                              (e12, univ_vars1, c11, g11,
                                (FStar_Option.isSome topt)))))))
-
-and (check_lbtyp :
+and check_lbtyp:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.letbinding ->
         (FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option,FStar_TypeChecker_Env.guard_t,
           FStar_Syntax_Syntax.univ_names,FStar_Syntax_Syntax.subst_elt
                                            Prims.list,FStar_TypeChecker_Env.env)
-          FStar_Pervasives_Native.tuple5)
+          FStar_Pervasives_Native.tuple5
   =
   fun top_level  ->
     fun env  ->
       fun lb  ->
-        let t = FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp  in
+        let t = FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp in
         match t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_unknown  ->
             let uu____15809 =
               FStar_Syntax_Subst.univ_var_opening
-                lb.FStar_Syntax_Syntax.lbunivs
-               in
+                lb.FStar_Syntax_Syntax.lbunivs in
             (match uu____15809 with
              | (univ_opening,univ_vars1) ->
                  (FStar_Pervasives_Native.None,
@@ -7647,123 +6893,110 @@ and (check_lbtyp :
         | uu____15848 ->
             let uu____15849 =
               FStar_Syntax_Subst.univ_var_opening
-                lb.FStar_Syntax_Syntax.lbunivs
-               in
+                lb.FStar_Syntax_Syntax.lbunivs in
             (match uu____15849 with
              | (univ_opening,univ_vars1) ->
-                 let t1 = FStar_Syntax_Subst.subst univ_opening t  in
+                 let t1 = FStar_Syntax_Subst.subst univ_opening t in
                  let env1 =
-                   FStar_TypeChecker_Env.push_univ_vars env univ_vars1  in
+                   FStar_TypeChecker_Env.push_univ_vars env univ_vars1 in
                  if
                    top_level &&
                      (Prims.op_Negation env.FStar_TypeChecker_Env.generalize)
                  then
                    let uu____15898 =
-                     FStar_TypeChecker_Env.set_expected_typ env1 t1  in
+                     FStar_TypeChecker_Env.set_expected_typ env1 t1 in
                    ((FStar_Pervasives_Native.Some t1),
                      FStar_TypeChecker_Rel.trivial_guard, univ_vars1,
                      univ_opening, uu____15898)
                  else
-                   (let uu____15906 = FStar_Syntax_Util.type_u ()  in
+                   (let uu____15906 = FStar_Syntax_Util.type_u () in
                     match uu____15906 with
                     | (k,uu____15926) ->
-                        let uu____15927 = tc_check_tot_or_gtot_term env1 t1 k
-                           in
+                        let uu____15927 = tc_check_tot_or_gtot_term env1 t1 k in
                         (match uu____15927 with
                          | (t2,uu____15949,g) ->
                              ((let uu____15952 =
                                  FStar_TypeChecker_Env.debug env
-                                   FStar_Options.Medium
-                                  in
+                                   FStar_Options.Medium in
                                if uu____15952
                                then
                                  let uu____15953 =
                                    let uu____15954 =
                                      FStar_Syntax_Syntax.range_of_lbname
-                                       lb.FStar_Syntax_Syntax.lbname
-                                      in
-                                   FStar_Range.string_of_range uu____15954
-                                    in
+                                       lb.FStar_Syntax_Syntax.lbname in
+                                   FStar_Range.string_of_range uu____15954 in
                                  let uu____15955 =
-                                   FStar_Syntax_Print.term_to_string t2  in
+                                   FStar_Syntax_Print.term_to_string t2 in
                                  FStar_Util.print2
                                    "(%s) Checked type annotation %s\n"
                                    uu____15953 uu____15955
                                else ());
-                              (let t3 = norm env1 t2  in
+                              (let t3 = norm env1 t2 in
                                let uu____15958 =
                                  FStar_TypeChecker_Env.set_expected_typ env1
-                                   t3
-                                  in
+                                   t3 in
                                ((FStar_Pervasives_Native.Some t3), g,
                                  univ_vars1, univ_opening, uu____15958))))))
-
-and (tc_binder :
+and tc_binder:
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
       FStar_Pervasives_Native.tuple2 ->
       ((FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
          FStar_Pervasives_Native.tuple2,FStar_TypeChecker_Env.env,FStar_TypeChecker_Env.guard_t,
-        FStar_Syntax_Syntax.universe) FStar_Pervasives_Native.tuple4)
+        FStar_Syntax_Syntax.universe) FStar_Pervasives_Native.tuple4
   =
   fun env  ->
     fun uu____15966  ->
       match uu____15966 with
       | (x,imp) ->
-          let uu____15985 = FStar_Syntax_Util.type_u ()  in
+          let uu____15985 = FStar_Syntax_Util.type_u () in
           (match uu____15985 with
            | (tu,u) ->
                ((let uu____16005 =
-                   FStar_TypeChecker_Env.debug env FStar_Options.Extreme  in
+                   FStar_TypeChecker_Env.debug env FStar_Options.Extreme in
                  if uu____16005
                  then
-                   let uu____16006 = FStar_Syntax_Print.bv_to_string x  in
+                   let uu____16006 = FStar_Syntax_Print.bv_to_string x in
                    let uu____16007 =
                      FStar_Syntax_Print.term_to_string
-                       x.FStar_Syntax_Syntax.sort
-                      in
-                   let uu____16008 = FStar_Syntax_Print.term_to_string tu  in
+                       x.FStar_Syntax_Syntax.sort in
+                   let uu____16008 = FStar_Syntax_Print.term_to_string tu in
                    FStar_Util.print3 "Checking binders %s:%s at type %s\n"
                      uu____16006 uu____16007 uu____16008
                  else ());
                 (let uu____16010 =
                    tc_check_tot_or_gtot_term env x.FStar_Syntax_Syntax.sort
-                     tu
-                    in
+                     tu in
                  match uu____16010 with
                  | (t,uu____16030,g) ->
                      let x1 =
-                       ((let uu___108_16038 = x  in
+                       ((let uu___108_16038 = x in
                          {
                            FStar_Syntax_Syntax.ppname =
                              (uu___108_16038.FStar_Syntax_Syntax.ppname);
                            FStar_Syntax_Syntax.index =
                              (uu___108_16038.FStar_Syntax_Syntax.index);
                            FStar_Syntax_Syntax.sort = t
-                         }), imp)
-                        in
+                         }), imp) in
                      ((let uu____16040 =
-                         FStar_TypeChecker_Env.debug env FStar_Options.High
-                          in
+                         FStar_TypeChecker_Env.debug env FStar_Options.High in
                        if uu____16040
                        then
                          let uu____16041 =
                            FStar_Syntax_Print.bv_to_string
-                             (FStar_Pervasives_Native.fst x1)
-                            in
+                             (FStar_Pervasives_Native.fst x1) in
                          let uu____16042 =
-                           FStar_Syntax_Print.term_to_string t  in
+                           FStar_Syntax_Print.term_to_string t in
                          FStar_Util.print2 "Pushing binder %s at type %s\n"
                            uu____16041 uu____16042
                        else ());
-                      (let uu____16044 = push_binding env x1  in
+                      (let uu____16044 = push_binding env x1 in
                        (x1, uu____16044, g, u))))))
-
-and (tc_binders :
+and tc_binders:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
       (FStar_Syntax_Syntax.binders,FStar_TypeChecker_Env.env,FStar_TypeChecker_Env.guard_t,
-        FStar_Syntax_Syntax.universes) FStar_Pervasives_Native.tuple4)
+        FStar_Syntax_Syntax.universes) FStar_Pervasives_Native.tuple4
   =
   fun env  ->
     fun bs  ->
@@ -7771,28 +7004,25 @@ and (tc_binders :
         match bs1 with
         | [] -> ([], env1, FStar_TypeChecker_Rel.trivial_guard, [])
         | b::bs2 ->
-            let uu____16134 = tc_binder env1 b  in
+            let uu____16134 = tc_binder env1 b in
             (match uu____16134 with
              | (b1,env',g,u) ->
-                 let uu____16175 = aux env' bs2  in
+                 let uu____16175 = aux env' bs2 in
                  (match uu____16175 with
                   | (bs3,env'1,g',us) ->
                       let uu____16228 =
                         let uu____16229 =
-                          FStar_TypeChecker_Rel.close_guard_univs [u] [b1] g'
-                           in
-                        FStar_TypeChecker_Rel.conj_guard g uu____16229  in
-                      ((b1 :: bs3), env'1, uu____16228, (u :: us))))
-         in
+                          FStar_TypeChecker_Rel.close_guard_univs [u] [b1] g' in
+                        FStar_TypeChecker_Rel.conj_guard g uu____16229 in
+                      ((b1 :: bs3), env'1, uu____16228, (u :: us)))) in
       aux env bs
-
-and (tc_pats :
+and tc_pats:
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
       FStar_Pervasives_Native.tuple2 Prims.list Prims.list ->
       ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,FStar_Syntax_Syntax.aqual)
          FStar_Pervasives_Native.tuple2 Prims.list Prims.list,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun pats  ->
@@ -7802,138 +7032,124 @@ and (tc_pats :
              fun uu____16315  ->
                match (uu____16314, uu____16315) with
                | ((t,imp),(args1,g)) ->
-                   let uu____16384 = tc_term env1 t  in
+                   let uu____16384 = tc_term env1 t in
                    (match uu____16384 with
                     | (t1,uu____16402,g') ->
                         let uu____16404 =
-                          FStar_TypeChecker_Rel.conj_guard g g'  in
+                          FStar_TypeChecker_Rel.conj_guard g g' in
                         (((t1, imp) :: args1), uu____16404))) args
-          ([], FStar_TypeChecker_Rel.trivial_guard)
-         in
+          ([], FStar_TypeChecker_Rel.trivial_guard) in
       FStar_List.fold_right
         (fun p  ->
            fun uu____16446  ->
              match uu____16446 with
              | (pats1,g) ->
-                 let uu____16471 = tc_args env p  in
+                 let uu____16471 = tc_args env p in
                  (match uu____16471 with
                   | (args,g') ->
-                      let uu____16484 = FStar_TypeChecker_Rel.conj_guard g g'
-                         in
+                      let uu____16484 = FStar_TypeChecker_Rel.conj_guard g g' in
                       ((args :: pats1), uu____16484))) pats
         ([], FStar_TypeChecker_Rel.trivial_guard)
-
-and (tc_tot_or_gtot_term :
+and tc_tot_or_gtot_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
-      let uu____16497 = tc_maybe_toplevel_term env e  in
+      let uu____16497 = tc_maybe_toplevel_term env e in
       match uu____16497 with
       | (e1,c,g) ->
-          let uu____16513 = FStar_Syntax_Util.is_tot_or_gtot_lcomp c  in
+          let uu____16513 = FStar_Syntax_Util.is_tot_or_gtot_lcomp c in
           if uu____16513
           then (e1, c, g)
           else
-            (let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g
-                in
-             let c1 = FStar_Syntax_Syntax.lcomp_comp c  in
-             let c2 = norm_c env c1  in
+            (let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g in
+             let c1 = FStar_Syntax_Syntax.lcomp_comp c in
+             let c2 = norm_c env c1 in
              let uu____16524 =
                let uu____16529 =
                  FStar_TypeChecker_Util.is_pure_effect env
-                   (FStar_Syntax_Util.comp_effect_name c2)
-                  in
+                   (FStar_Syntax_Util.comp_effect_name c2) in
                if uu____16529
                then
                  let uu____16534 =
                    FStar_Syntax_Syntax.mk_Total
-                     (FStar_Syntax_Util.comp_result c2)
-                    in
+                     (FStar_Syntax_Util.comp_result c2) in
                  (uu____16534, false)
                else
                  (let uu____16536 =
                     FStar_Syntax_Syntax.mk_GTotal
-                      (FStar_Syntax_Util.comp_result c2)
-                     in
-                  (uu____16536, true))
-                in
+                      (FStar_Syntax_Util.comp_result c2) in
+                  (uu____16536, true)) in
              match uu____16524 with
              | (target_comp,allow_ghost) ->
                  let uu____16545 =
-                   FStar_TypeChecker_Rel.sub_comp env c2 target_comp  in
+                   FStar_TypeChecker_Rel.sub_comp env c2 target_comp in
                  (match uu____16545 with
                   | FStar_Pervasives_Native.Some g' ->
                       let uu____16555 =
-                        FStar_Syntax_Util.lcomp_of_comp target_comp  in
+                        FStar_Syntax_Util.lcomp_of_comp target_comp in
                       let uu____16556 =
-                        FStar_TypeChecker_Rel.conj_guard g1 g'  in
+                        FStar_TypeChecker_Rel.conj_guard g1 g' in
                       (e1, uu____16555, uu____16556)
                   | uu____16557 ->
                       if allow_ghost
                       then
                         let uu____16566 =
                           FStar_TypeChecker_Err.expected_ghost_expression e1
-                            c2
-                           in
+                            c2 in
                         FStar_Errors.raise_error uu____16566
                           e1.FStar_Syntax_Syntax.pos
                       else
                         (let uu____16578 =
                            FStar_TypeChecker_Err.expected_pure_expression e1
-                             c2
-                            in
+                             c2 in
                          FStar_Errors.raise_error uu____16578
                            e1.FStar_Syntax_Syntax.pos)))
-
-and (tc_check_tot_or_gtot_term :
+and tc_check_tot_or_gtot_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.typ ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       fun t  ->
-        let env1 = FStar_TypeChecker_Env.set_expected_typ env t  in
+        let env1 = FStar_TypeChecker_Env.set_expected_typ env t in
         tc_tot_or_gtot_term env1 e
-
-and (tc_trivial_guard :
+and tc_trivial_guard:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun t  ->
-      let uu____16601 = tc_tot_or_gtot_term env t  in
+      let uu____16601 = tc_tot_or_gtot_term env t in
       match uu____16601 with
       | (t1,c,g) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env g; (t1, c))
-
-let (type_of_tot_term :
+let type_of_tot_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.typ,FStar_TypeChecker_Env.guard_t)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       (let uu____16629 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "RelCheck")
-          in
+           (FStar_Options.Other "RelCheck") in
        if uu____16629
        then
-         let uu____16630 = FStar_Syntax_Print.term_to_string e  in
+         let uu____16630 = FStar_Syntax_Print.term_to_string e in
          FStar_Util.print1 "Checking term %s\n" uu____16630
        else ());
       (let env1 =
-         let uu___109_16633 = env  in
+         let uu___109_16633 = env in
          {
            FStar_TypeChecker_Env.solver =
              (uu___109_16633.FStar_TypeChecker_Env.solver);
@@ -8003,33 +7219,29 @@ let (type_of_tot_term :
              (uu___109_16633.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.dep_graph =
              (uu___109_16633.FStar_TypeChecker_Env.dep_graph)
-         }  in
+         } in
        let uu____16640 =
          try tc_tot_or_gtot_term env1 e
          with
          | FStar_Errors.Error (e1,msg,uu____16675) ->
-             let uu____16676 = FStar_TypeChecker_Env.get_range env1  in
-             FStar_Errors.raise_error (e1, msg) uu____16676
-          in
+             let uu____16676 = FStar_TypeChecker_Env.get_range env1 in
+             FStar_Errors.raise_error (e1, msg) uu____16676 in
        match uu____16640 with
        | (t,c,g) ->
-           let uu____16692 = FStar_Syntax_Util.is_total_lcomp c  in
+           let uu____16692 = FStar_Syntax_Util.is_total_lcomp c in
            if uu____16692
            then (t, (c.FStar_Syntax_Syntax.res_typ), g)
            else
              (let uu____16702 =
                 let uu____16707 =
-                  let uu____16708 = FStar_Syntax_Print.term_to_string e  in
+                  let uu____16708 = FStar_Syntax_Print.term_to_string e in
                   FStar_Util.format1
                     "Implicit argument: Expected a total term; got a ghost term: %s"
-                    uu____16708
-                   in
-                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____16707)
-                 in
-              let uu____16709 = FStar_TypeChecker_Env.get_range env1  in
+                    uu____16708 in
+                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____16707) in
+              let uu____16709 = FStar_TypeChecker_Env.get_range env1 in
               FStar_Errors.raise_error uu____16702 uu____16709))
-  
-let level_of_type_fail :
+let level_of_type_fail:
   'Auu____16720 .
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term -> Prims.string -> 'Auu____16720
@@ -8039,26 +7251,24 @@ let level_of_type_fail :
       fun t  ->
         let uu____16733 =
           let uu____16738 =
-            let uu____16739 = FStar_Syntax_Print.term_to_string e  in
+            let uu____16739 = FStar_Syntax_Print.term_to_string e in
             FStar_Util.format2 "Expected a term of type 'Type'; got %s : %s"
-              uu____16739 t
-             in
-          (FStar_Errors.Fatal_UnexpectedTermType, uu____16738)  in
-        let uu____16740 = FStar_TypeChecker_Env.get_range env  in
+              uu____16739 t in
+          (FStar_Errors.Fatal_UnexpectedTermType, uu____16738) in
+        let uu____16740 = FStar_TypeChecker_Env.get_range env in
         FStar_Errors.raise_error uu____16733 uu____16740
-  
-let (level_of_type :
+let level_of_type:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe
   =
   fun env  ->
     fun e  ->
       fun t  ->
         let rec aux retry t1 =
           let uu____16757 =
-            let uu____16758 = FStar_Syntax_Util.unrefine t1  in
-            uu____16758.FStar_Syntax_Syntax.n  in
+            let uu____16758 = FStar_Syntax_Util.unrefine t1 in
+            uu____16758.FStar_Syntax_Syntax.n in
           match uu____16757 with
           | FStar_Syntax_Syntax.Tm_type u -> u
           | uu____16762 ->
@@ -8067,15 +7277,14 @@ let (level_of_type :
                 let t2 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Normalize.UnfoldUntil
-                       FStar_Syntax_Syntax.Delta_constant] env t1
-                   in
+                       FStar_Syntax_Syntax.Delta_constant] env t1 in
                 aux false t2
               else
-                (let uu____16765 = FStar_Syntax_Util.type_u ()  in
+                (let uu____16765 = FStar_Syntax_Util.type_u () in
                  match uu____16765 with
                  | (t_u,u) ->
                      let env1 =
-                       let uu___112_16773 = env  in
+                       let uu___112_16773 = env in
                        {
                          FStar_TypeChecker_Env.solver =
                            (uu___112_16773.FStar_TypeChecker_Env.solver);
@@ -8146,35 +7355,33 @@ let (level_of_type :
                            (uu___112_16773.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.dep_graph =
                            (uu___112_16773.FStar_TypeChecker_Env.dep_graph)
-                       }  in
-                     let g = FStar_TypeChecker_Rel.teq env1 t1 t_u  in
+                       } in
+                     let g = FStar_TypeChecker_Rel.teq env1 t1 t_u in
                      ((match g.FStar_TypeChecker_Env.guard_f with
                        | FStar_TypeChecker_Common.NonTrivial f ->
                            let uu____16777 =
-                             FStar_Syntax_Print.term_to_string t1  in
+                             FStar_Syntax_Print.term_to_string t1 in
                            level_of_type_fail env1 e uu____16777
                        | uu____16778 ->
                            FStar_TypeChecker_Rel.force_trivial_guard env1 g);
-                      u))
-           in
+                      u)) in
         aux true t
-  
-let rec (universe_of_aux :
+let rec universe_of_aux:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
   =
   fun env  ->
     fun e  ->
       let uu____16787 =
-        let uu____16788 = FStar_Syntax_Subst.compress e  in
-        uu____16788.FStar_Syntax_Syntax.n  in
+        let uu____16788 = FStar_Syntax_Subst.compress e in
+        uu____16788.FStar_Syntax_Syntax.n in
       match uu____16787 with
       | FStar_Syntax_Syntax.Tm_bvar uu____16793 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_delayed uu____16798 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_let uu____16825 ->
-          let e1 = FStar_TypeChecker_Normalize.normalize [] env e  in
+          let e1 = FStar_TypeChecker_Normalize.normalize [] env e in
           universe_of_aux env e1
       | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____16841) ->
           level_of_type_fail env e "arrow type"
@@ -8184,8 +7391,7 @@ let rec (universe_of_aux :
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let uu____16898 =
             FStar_TypeChecker_Env.lookup_lid env
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           (match uu____16898 with | ((uu____16909,t),uu____16911) -> t)
       | FStar_Syntax_Syntax.Tm_ascribed
           (uu____16916,(FStar_Util.Inl t,uu____16918),uu____16919) -> t
@@ -8205,13 +7411,12 @@ let rec (universe_of_aux :
           ->
           let uu____17026 =
             FStar_TypeChecker_Env.lookup_lid env
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           (match uu____17026 with
            | ((us',t),uu____17039) ->
                (if (FStar_List.length us) <> (FStar_List.length us')
                 then
-                  (let uu____17045 = FStar_TypeChecker_Env.get_range env  in
+                  (let uu____17045 = FStar_TypeChecker_Env.get_range env in
                    FStar_Errors.raise_error
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
                        "Unexpected number of universe instantiations")
@@ -8230,7 +7435,7 @@ let rec (universe_of_aux :
       | FStar_Syntax_Syntax.Tm_refine (x,uu____17072) ->
           universe_of_aux env x.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____17095 = FStar_Syntax_Subst.open_comp bs c  in
+          let uu____17095 = FStar_Syntax_Subst.open_comp bs c in
           (match uu____17095 with
            | (bs1,c1) ->
                let us =
@@ -8239,33 +7444,29 @@ let rec (universe_of_aux :
                       match uu____17115 with
                       | (b,uu____17121) ->
                           let uu____17122 =
-                            universe_of_aux env b.FStar_Syntax_Syntax.sort
-                             in
+                            universe_of_aux env b.FStar_Syntax_Syntax.sort in
                           level_of_type env b.FStar_Syntax_Syntax.sort
-                            uu____17122) bs1
-                  in
+                            uu____17122) bs1 in
                let u_res =
-                 let res = FStar_Syntax_Util.comp_result c1  in
-                 let uu____17127 = universe_of_aux env res  in
-                 level_of_type env res uu____17127  in
+                 let res = FStar_Syntax_Util.comp_result c1 in
+                 let uu____17127 = universe_of_aux env res in
+                 level_of_type env res uu____17127 in
                let u_c =
                  let uu____17129 =
-                   FStar_TypeChecker_Env.effect_repr env c1 u_res  in
+                   FStar_TypeChecker_Env.effect_repr env c1 u_res in
                  match uu____17129 with
                  | FStar_Pervasives_Native.None  -> u_res
                  | FStar_Pervasives_Native.Some trepr ->
-                     let uu____17133 = universe_of_aux env trepr  in
-                     level_of_type env trepr uu____17133
-                  in
+                     let uu____17133 = universe_of_aux env trepr in
+                     level_of_type env trepr uu____17133 in
                let u =
                  FStar_TypeChecker_Normalize.normalize_universe env
-                   (FStar_Syntax_Syntax.U_max (u_c :: us))
-                  in
+                   (FStar_Syntax_Syntax.U_max (u_c :: us)) in
                FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
                  FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos)
       | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
           let rec type_of_head retry hd2 args1 =
-            let hd3 = FStar_Syntax_Subst.compress hd2  in
+            let hd3 = FStar_Syntax_Subst.compress hd2 in
             match hd3.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
             | FStar_Syntax_Syntax.Tm_bvar uu____17226 ->
@@ -8273,59 +7474,57 @@ let rec (universe_of_aux :
             | FStar_Syntax_Syntax.Tm_delayed uu____17241 ->
                 failwith "Impossible"
             | FStar_Syntax_Syntax.Tm_fvar uu____17280 ->
-                let uu____17281 = universe_of_aux env hd3  in
+                let uu____17281 = universe_of_aux env hd3 in
                 (uu____17281, args1)
             | FStar_Syntax_Syntax.Tm_name uu____17294 ->
-                let uu____17295 = universe_of_aux env hd3  in
+                let uu____17295 = universe_of_aux env hd3 in
                 (uu____17295, args1)
             | FStar_Syntax_Syntax.Tm_uvar uu____17308 ->
-                let uu____17325 = universe_of_aux env hd3  in
+                let uu____17325 = universe_of_aux env hd3 in
                 (uu____17325, args1)
             | FStar_Syntax_Syntax.Tm_uinst uu____17338 ->
-                let uu____17345 = universe_of_aux env hd3  in
+                let uu____17345 = universe_of_aux env hd3 in
                 (uu____17345, args1)
             | FStar_Syntax_Syntax.Tm_ascribed uu____17358 ->
-                let uu____17385 = universe_of_aux env hd3  in
+                let uu____17385 = universe_of_aux env hd3 in
                 (uu____17385, args1)
             | FStar_Syntax_Syntax.Tm_refine uu____17398 ->
-                let uu____17405 = universe_of_aux env hd3  in
+                let uu____17405 = universe_of_aux env hd3 in
                 (uu____17405, args1)
             | FStar_Syntax_Syntax.Tm_constant uu____17418 ->
-                let uu____17419 = universe_of_aux env hd3  in
+                let uu____17419 = universe_of_aux env hd3 in
                 (uu____17419, args1)
             | FStar_Syntax_Syntax.Tm_arrow uu____17432 ->
-                let uu____17445 = universe_of_aux env hd3  in
+                let uu____17445 = universe_of_aux env hd3 in
                 (uu____17445, args1)
             | FStar_Syntax_Syntax.Tm_meta uu____17458 ->
-                let uu____17465 = universe_of_aux env hd3  in
+                let uu____17465 = universe_of_aux env hd3 in
                 (uu____17465, args1)
             | FStar_Syntax_Syntax.Tm_type uu____17478 ->
-                let uu____17479 = universe_of_aux env hd3  in
+                let uu____17479 = universe_of_aux env hd3 in
                 (uu____17479, args1)
             | FStar_Syntax_Syntax.Tm_match (uu____17492,hd4::uu____17494) ->
-                let uu____17559 = FStar_Syntax_Subst.open_branch hd4  in
+                let uu____17559 = FStar_Syntax_Subst.open_branch hd4 in
                 (match uu____17559 with
                  | (uu____17574,uu____17575,hd5) ->
-                     let uu____17593 = FStar_Syntax_Util.head_and_args hd5
-                        in
+                     let uu____17593 = FStar_Syntax_Util.head_and_args hd5 in
                      (match uu____17593 with
                       | (hd6,args2) -> type_of_head retry hd6 args2))
             | uu____17644 when retry ->
                 let e1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Normalize.Beta;
-                    FStar_TypeChecker_Normalize.NoDeltaSteps] env e
-                   in
-                let uu____17646 = FStar_Syntax_Util.head_and_args e1  in
+                    FStar_TypeChecker_Normalize.NoDeltaSteps] env e in
+                let uu____17646 = FStar_Syntax_Util.head_and_args e1 in
                 (match uu____17646 with
                  | (hd4,args2) -> type_of_head false hd4 args2)
             | uu____17697 ->
                 let uu____17698 =
-                  FStar_TypeChecker_Env.clear_expected_typ env  in
+                  FStar_TypeChecker_Env.clear_expected_typ env in
                 (match uu____17698 with
                  | (env1,uu____17720) ->
                      let env2 =
-                       let uu___113_17726 = env1  in
+                       let uu___113_17726 = env1 in
                        {
                          FStar_TypeChecker_Env.solver =
                            (uu___113_17726.FStar_TypeChecker_Env.solver);
@@ -8394,24 +7593,23 @@ let rec (universe_of_aux :
                            (uu___113_17726.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.dep_graph =
                            (uu___113_17726.FStar_TypeChecker_Env.dep_graph)
-                       }  in
+                       } in
                      ((let uu____17728 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env2)
-                           (FStar_Options.Other "UniverseOf")
-                          in
+                           (FStar_Options.Other "UniverseOf") in
                        if uu____17728
                        then
                          let uu____17729 =
                            let uu____17730 =
-                             FStar_TypeChecker_Env.get_range env2  in
-                           FStar_Range.string_of_range uu____17730  in
+                             FStar_TypeChecker_Env.get_range env2 in
+                           FStar_Range.string_of_range uu____17730 in
                          let uu____17731 =
-                           FStar_Syntax_Print.term_to_string hd3  in
+                           FStar_Syntax_Print.term_to_string hd3 in
                          FStar_Util.print2 "%s: About to type-check %s\n"
                            uu____17729 uu____17731
                        else ());
-                      (let uu____17733 = tc_term env2 hd3  in
+                      (let uu____17733 = tc_term env2 hd3 in
                        match uu____17733 with
                        | (uu____17754,{
                                         FStar_Syntax_Syntax.eff_name =
@@ -8424,76 +7622,68 @@ let rec (universe_of_aux :
                            ->
                            ((let uu____17777 =
                                FStar_TypeChecker_Rel.solve_deferred_constraints
-                                 env2 g
-                                in
+                                 env2 g in
                              FStar_All.pipe_right uu____17777
                                FStar_Pervasives.ignore);
-                            (t, args1)))))
-             in
-          let uu____17788 = type_of_head true hd1 args  in
+                            (t, args1))))) in
+          let uu____17788 = type_of_head true hd1 args in
           (match uu____17788 with
            | (t,args1) ->
                let t1 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Normalize.UnfoldUntil
-                      FStar_Syntax_Syntax.Delta_constant] env t
-                  in
-               let uu____17828 = FStar_Syntax_Util.arrow_formals_comp t1  in
+                      FStar_Syntax_Syntax.Delta_constant] env t in
+               let uu____17828 = FStar_Syntax_Util.arrow_formals_comp t1 in
                (match uu____17828 with
                 | (bs,res) ->
-                    let res1 = FStar_Syntax_Util.comp_result res  in
+                    let res1 = FStar_Syntax_Util.comp_result res in
                     if (FStar_List.length bs) = (FStar_List.length args1)
                     then
-                      let subst1 = FStar_Syntax_Util.subst_of_list bs args1
-                         in
+                      let subst1 = FStar_Syntax_Util.subst_of_list bs args1 in
                       FStar_Syntax_Subst.subst subst1 res1
                     else
                       (let uu____17872 =
-                         FStar_Syntax_Print.term_to_string res1  in
+                         FStar_Syntax_Print.term_to_string res1 in
                        level_of_type_fail env e uu____17872)))
       | FStar_Syntax_Syntax.Tm_match (uu____17875,hd1::uu____17877) ->
-          let uu____17942 = FStar_Syntax_Subst.open_branch hd1  in
+          let uu____17942 = FStar_Syntax_Subst.open_branch hd1 in
           (match uu____17942 with
            | (uu____17945,uu____17946,hd2) -> universe_of_aux env hd2)
       | FStar_Syntax_Syntax.Tm_match (uu____17964,[]) ->
           level_of_type_fail env e "empty match cases"
-  
-let (universe_of :
+let universe_of:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe
   =
   fun env  ->
     fun e  ->
-      let uu____18007 = universe_of_aux env e  in
+      let uu____18007 = universe_of_aux env e in
       level_of_type env e uu____18007
-  
-let (tc_tparams :
+let tc_tparams:
   FStar_TypeChecker_Env.env_t ->
     FStar_Syntax_Syntax.binders ->
       (FStar_Syntax_Syntax.binders,FStar_TypeChecker_Env.env,FStar_Syntax_Syntax.universes)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun tps  ->
-      let uu____18026 = tc_binders env tps  in
+      let uu____18026 = tc_binders env tps in
       match uu____18026 with
       | (tps1,env1,g,us) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env1 g; (tps1, env1, us))
-  
-let rec (type_of_well_typed_term :
+let rec type_of_well_typed_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option
   =
   fun env  ->
     fun t  ->
       let mk_tm_type u =
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
-          FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-         in
+          FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos in
       let uu____18070 =
-        let uu____18071 = FStar_Syntax_Subst.compress t  in
-        uu____18071.FStar_Syntax_Syntax.n  in
+        let uu____18071 = FStar_Syntax_Subst.compress t in
+        uu____18071.FStar_Syntax_Syntax.n in
       match uu____18070 with
       | FStar_Syntax_Syntax.Tm_delayed uu____18076 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_bvar uu____18103 -> failwith "Impossible"
@@ -8502,8 +7692,7 @@ let rec (type_of_well_typed_term :
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let uu____18110 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env []
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           FStar_Util.bind_opt uu____18110
             (fun uu____18124  ->
                match uu____18124 with
@@ -8515,17 +7704,16 @@ let rec (type_of_well_typed_term :
           ->
           let uu____18141 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env us
-              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           FStar_Util.bind_opt uu____18141
             (fun uu____18155  ->
                match uu____18155 with
                | (t1,uu____18163) -> FStar_Pervasives_Native.Some t1)
       | FStar_Syntax_Syntax.Tm_constant sc ->
-          let uu____18165 = tc_constant env t.FStar_Syntax_Syntax.pos sc  in
+          let uu____18165 = tc_constant env t.FStar_Syntax_Syntax.pos sc in
           FStar_Pervasives_Native.Some uu____18165
       | FStar_Syntax_Syntax.Tm_type u ->
-          let uu____18167 = mk_tm_type (FStar_Syntax_Syntax.U_succ u)  in
+          let uu____18167 = mk_tm_type (FStar_Syntax_Syntax.U_succ u) in
           FStar_Pervasives_Native.Some uu____18167
       | FStar_Syntax_Syntax.Tm_abs
           (bs,body,FStar_Pervasives_Native.Some
@@ -8542,11 +7730,10 @@ let rec (type_of_well_typed_term :
                 FStar_Ident.lid_equals eff FStar_Parser_Const.effect_GTot_lid
               then
                 FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_GTotal'
-              else FStar_Pervasives_Native.None
-             in
+              else FStar_Pervasives_Native.None in
           FStar_Util.bind_opt mk_comp
             (fun f  ->
-               let uu____18263 = universe_of_well_typed_term env tbody  in
+               let uu____18263 = universe_of_well_typed_term env tbody in
                FStar_Util.bind_opt uu____18263
                  (fun u  ->
                     let uu____18271 =
@@ -8554,16 +7741,15 @@ let rec (type_of_well_typed_term :
                         let uu____18277 =
                           let uu____18278 =
                             let uu____18291 =
-                              f tbody (FStar_Pervasives_Native.Some u)  in
-                            (bs, uu____18291)  in
-                          FStar_Syntax_Syntax.Tm_arrow uu____18278  in
-                        FStar_Syntax_Syntax.mk uu____18277  in
+                              f tbody (FStar_Pervasives_Native.Some u) in
+                            (bs, uu____18291) in
+                          FStar_Syntax_Syntax.Tm_arrow uu____18278 in
+                        FStar_Syntax_Syntax.mk uu____18277 in
                       uu____18274 FStar_Pervasives_Native.None
-                        t.FStar_Syntax_Syntax.pos
-                       in
+                        t.FStar_Syntax_Syntax.pos in
                     FStar_Pervasives_Native.Some uu____18271))
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____18321 = FStar_Syntax_Subst.open_comp bs c  in
+          let uu____18321 = FStar_Syntax_Subst.open_comp bs c in
           (match uu____18321 with
            | (bs1,c1) ->
                let rec aux env1 us bs2 =
@@ -8571,61 +7757,55 @@ let rec (type_of_well_typed_term :
                  | [] ->
                      let uu____18368 =
                        universe_of_well_typed_term env1
-                         (FStar_Syntax_Util.comp_result c1)
-                        in
+                         (FStar_Syntax_Util.comp_result c1) in
                      FStar_Util.bind_opt uu____18368
                        (fun uc  ->
                           let uu____18376 =
-                            mk_tm_type (FStar_Syntax_Syntax.U_max (uc :: us))
-                             in
+                            mk_tm_type (FStar_Syntax_Syntax.U_max (uc :: us)) in
                           FStar_Pervasives_Native.Some uu____18376)
                  | (x,imp)::bs3 ->
                      let uu____18394 =
                        universe_of_well_typed_term env1
-                         x.FStar_Syntax_Syntax.sort
-                        in
+                         x.FStar_Syntax_Syntax.sort in
                      FStar_Util.bind_opt uu____18394
                        (fun u_x  ->
-                          let env2 = FStar_TypeChecker_Env.push_bv env1 x  in
-                          aux env2 (u_x :: us) bs3)
-                  in
+                          let env2 = FStar_TypeChecker_Env.push_bv env1 x in
+                          aux env2 (u_x :: us) bs3) in
                aux env [] bs1)
       | FStar_Syntax_Syntax.Tm_abs uu____18403 ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_refine (x,uu____18421) ->
           let uu____18426 =
-            universe_of_well_typed_term env x.FStar_Syntax_Syntax.sort  in
+            universe_of_well_typed_term env x.FStar_Syntax_Syntax.sort in
           FStar_Util.bind_opt uu____18426
             (fun u_x  ->
-               let uu____18434 = mk_tm_type u_x  in
+               let uu____18434 = mk_tm_type u_x in
                FStar_Pervasives_Native.Some uu____18434)
       | FStar_Syntax_Syntax.Tm_app (hd1,args) ->
-          let t_hd = type_of_well_typed_term env hd1  in
+          let t_hd = type_of_well_typed_term env hd1 in
           let rec aux t_hd1 =
             let uu____18470 =
               let uu____18471 =
-                FStar_TypeChecker_Normalize.unfold_whnf env t_hd1  in
-              uu____18471.FStar_Syntax_Syntax.n  in
+                FStar_TypeChecker_Normalize.unfold_whnf env t_hd1 in
+              uu____18471.FStar_Syntax_Syntax.n in
             match uu____18470 with
             | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                let n_args = FStar_List.length args  in
-                let n_bs = FStar_List.length bs  in
+                let n_args = FStar_List.length args in
+                let n_bs = FStar_List.length bs in
                 let bs_t_opt =
                   if n_args < n_bs
                   then
-                    let uu____18533 = FStar_Util.first_N n_args bs  in
+                    let uu____18533 = FStar_Util.first_N n_args bs in
                     match uu____18533 with
                     | (bs1,rest) ->
                         let t1 =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_arrow (rest, c))
                             FStar_Pervasives_Native.None
-                            t_hd1.FStar_Syntax_Syntax.pos
-                           in
+                            t_hd1.FStar_Syntax_Syntax.pos in
                         let uu____18603 =
-                          let uu____18608 = FStar_Syntax_Syntax.mk_Total t1
-                             in
-                          FStar_Syntax_Subst.open_comp bs1 uu____18608  in
+                          let uu____18608 = FStar_Syntax_Syntax.mk_Total t1 in
+                          FStar_Syntax_Subst.open_comp bs1 uu____18608 in
                         (match uu____18603 with
                          | (bs2,c1) ->
                              FStar_Pervasives_Native.Some
@@ -8633,19 +7813,17 @@ let rec (type_of_well_typed_term :
                   else
                     if n_args = n_bs
                     then
-                      (let uu____18644 = FStar_Syntax_Subst.open_comp bs c
-                          in
+                      (let uu____18644 = FStar_Syntax_Subst.open_comp bs c in
                        match uu____18644 with
                        | (bs1,c1) ->
                            let uu____18659 =
-                             FStar_Syntax_Util.is_tot_or_gtot_comp c1  in
+                             FStar_Syntax_Util.is_tot_or_gtot_comp c1 in
                            if uu____18659
                            then
                              FStar_Pervasives_Native.Some
                                (bs1, (FStar_Syntax_Util.comp_result c1))
                            else FStar_Pervasives_Native.None)
-                    else FStar_Pervasives_Native.None
-                   in
+                    else FStar_Pervasives_Native.None in
                 FStar_Util.bind_opt bs_t_opt
                   (fun uu____18701  ->
                      match uu____18701 with
@@ -8657,16 +7835,14 @@ let rec (type_of_well_typed_term :
                                   FStar_Syntax_Syntax.NT
                                     ((FStar_Pervasives_Native.fst b),
                                       (FStar_Pervasives_Native.fst a))) bs1
-                             args
-                            in
-                         let uu____18747 = FStar_Syntax_Subst.subst subst1 t1
-                            in
+                             args in
+                         let uu____18747 = FStar_Syntax_Subst.subst subst1 t1 in
                          FStar_Pervasives_Native.Some uu____18747)
             | FStar_Syntax_Syntax.Tm_refine (x,uu____18749) ->
                 aux x.FStar_Syntax_Syntax.sort
             | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____18755,uu____18756) ->
                 aux t1
-            | uu____18797 -> FStar_Pervasives_Native.None  in
+            | uu____18797 -> FStar_Pervasives_Native.None in
           FStar_Util.bind_opt t_hd aux
       | FStar_Syntax_Syntax.Tm_ascribed
           (uu____18798,(FStar_Util.Inl t1,uu____18800),uu____18801) ->
@@ -8685,15 +7861,14 @@ let rec (type_of_well_typed_term :
       | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_uinst uu____18972 ->
           FStar_Pervasives_Native.None
-
-and (universe_of_well_typed_term :
+and universe_of_well_typed_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option)
+      FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
   =
   fun env  ->
     fun t  ->
-      let uu____18983 = type_of_well_typed_term env t  in
+      let uu____18983 = type_of_well_typed_term env t in
       match uu____18983 with
       | FStar_Pervasives_Native.Some
           { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_type u;
@@ -8701,20 +7876,19 @@ and (universe_of_well_typed_term :
             FStar_Syntax_Syntax.vars = uu____18990;_}
           -> FStar_Pervasives_Native.Some u
       | uu____18995 -> FStar_Pervasives_Native.None
-
-let (check_type_of_well_typed_term :
+let check_type_of_well_typed_term:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.typ -> FStar_TypeChecker_Env.guard_t)
+        FStar_Syntax_Syntax.typ -> FStar_TypeChecker_Env.guard_t
   =
   fun must_total  ->
     fun env  ->
       fun t  ->
         fun k  ->
-          let env1 = FStar_TypeChecker_Env.set_expected_typ env k  in
+          let env1 = FStar_TypeChecker_Env.set_expected_typ env k in
           let env2 =
-            let uu___114_19012 = env1  in
+            let uu___114_19012 = env1 in
             {
               FStar_TypeChecker_Env.solver =
                 (uu___114_19012.FStar_TypeChecker_Env.solver);
@@ -8785,61 +7959,49 @@ let (check_type_of_well_typed_term :
                 (uu___114_19012.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.dep_graph =
                 (uu___114_19012.FStar_TypeChecker_Env.dep_graph)
-            }  in
+            } in
           let slow_check uu____19016 =
             if must_total
             then
-              let uu____19017 = env2.FStar_TypeChecker_Env.type_of env2 t  in
+              let uu____19017 = env2.FStar_TypeChecker_Env.type_of env2 t in
               match uu____19017 with | (uu____19024,uu____19025,g) -> g
             else
-              (let uu____19028 = env2.FStar_TypeChecker_Env.tc_term env2 t
-                  in
-               match uu____19028 with | (uu____19035,uu____19036,g) -> g)
-             in
+              (let uu____19028 = env2.FStar_TypeChecker_Env.tc_term env2 t in
+               match uu____19028 with | (uu____19035,uu____19036,g) -> g) in
           let uu____19038 =
-            let uu____19039 = FStar_Options.__temp_fast_implicits ()  in
-            FStar_All.pipe_left Prims.op_Negation uu____19039  in
+            let uu____19039 = FStar_Options.__temp_fast_implicits () in
+            FStar_All.pipe_left Prims.op_Negation uu____19039 in
           if uu____19038
           then slow_check ()
           else
-            (let uu____19041 = type_of_well_typed_term env2 t  in
+            (let uu____19041 = type_of_well_typed_term env2 t in
              match uu____19041 with
              | FStar_Pervasives_Native.None  -> slow_check ()
              | FStar_Pervasives_Native.Some k' ->
                  ((let uu____19046 =
                      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
-                       (FStar_Options.Other "FastImplicits")
-                      in
+                       (FStar_Options.Other "FastImplicits") in
                    if uu____19046
                    then
                      let uu____19047 =
-                       FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos
-                        in
-                     let uu____19048 = FStar_Syntax_Print.term_to_string t
-                        in
-                     let uu____19049 = FStar_Syntax_Print.term_to_string k'
-                        in
-                     let uu____19050 = FStar_Syntax_Print.term_to_string k
-                        in
+                       FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos in
+                     let uu____19048 = FStar_Syntax_Print.term_to_string t in
+                     let uu____19049 = FStar_Syntax_Print.term_to_string k' in
+                     let uu____19050 = FStar_Syntax_Print.term_to_string k in
                      FStar_Util.print4 "(%s) Fast check  %s : %s <:? %s\n"
                        uu____19047 uu____19048 uu____19049 uu____19050
                    else ());
-                  (let b = FStar_TypeChecker_Rel.subtype_nosmt env2 k' k  in
+                  (let b = FStar_TypeChecker_Rel.subtype_nosmt env2 k' k in
                    (let uu____19054 =
                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
-                        (FStar_Options.Other "FastImplicits")
-                       in
+                        (FStar_Options.Other "FastImplicits") in
                     if uu____19054
                     then
                       let uu____19055 =
-                        FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos
-                         in
-                      let uu____19056 = FStar_Syntax_Print.term_to_string t
-                         in
-                      let uu____19057 = FStar_Syntax_Print.term_to_string k'
-                         in
-                      let uu____19058 = FStar_Syntax_Print.term_to_string k
-                         in
+                        FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos in
+                      let uu____19056 = FStar_Syntax_Print.term_to_string t in
+                      let uu____19057 = FStar_Syntax_Print.term_to_string k' in
+                      let uu____19058 = FStar_Syntax_Print.term_to_string k in
                       FStar_Util.print5 "(%s) Fast check %s: %s : %s <: %s\n"
                         uu____19055 (if b then "succeeded" else "failed")
                         uu____19056 uu____19057 uu____19058
@@ -8847,4 +8009,3 @@ let (check_type_of_well_typed_term :
                    if b
                    then FStar_TypeChecker_Rel.trivial_guard
                    else slow_check ())))
-  

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -2,75 +2,67 @@ open Prims
 type lcomp_with_binder =
   (FStar_Syntax_Syntax.bv FStar_Pervasives_Native.option,FStar_Syntax_Syntax.lcomp)
     FStar_Pervasives_Native.tuple2[@@deriving show]
-let (report :
-  FStar_TypeChecker_Env.env -> Prims.string Prims.list -> Prims.unit) =
+let report:
+  FStar_TypeChecker_Env.env -> Prims.string Prims.list -> Prims.unit =
   fun env  ->
     fun errs  ->
-      let uu____17 = FStar_TypeChecker_Env.get_range env  in
-      let uu____18 = FStar_TypeChecker_Err.failed_to_prove_specification errs
-         in
+      let uu____17 = FStar_TypeChecker_Env.get_range env in
+      let uu____18 = FStar_TypeChecker_Err.failed_to_prove_specification errs in
       FStar_Errors.log_issue uu____17 uu____18
-  
-let (is_type : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_type: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____26 =
-      let uu____27 = FStar_Syntax_Subst.compress t  in
-      uu____27.FStar_Syntax_Syntax.n  in
+      let uu____27 = FStar_Syntax_Subst.compress t in
+      uu____27.FStar_Syntax_Syntax.n in
     match uu____26 with
     | FStar_Syntax_Syntax.Tm_type uu____30 -> true
     | uu____31 -> false
-  
-let (t_binders :
+let t_binders:
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.aqual)
-      FStar_Pervasives_Native.tuple2 Prims.list)
+      FStar_Pervasives_Native.tuple2 Prims.list
   =
   fun env  ->
-    let uu____41 = FStar_TypeChecker_Env.all_binders env  in
+    let uu____41 = FStar_TypeChecker_Env.all_binders env in
     FStar_All.pipe_right uu____41
       (FStar_List.filter
          (fun uu____55  ->
             match uu____55 with
             | (x,uu____61) -> is_type x.FStar_Syntax_Syntax.sort))
-  
-let (new_uvar_aux :
+let new_uvar_aux:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
       (FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.typ)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun k  ->
       let bs =
         let uu____73 =
           (FStar_Options.full_context_dependency ()) ||
-            (let uu____75 = FStar_TypeChecker_Env.current_module env  in
-             FStar_Ident.lid_equals FStar_Parser_Const.prims_lid uu____75)
-           in
+            (let uu____75 = FStar_TypeChecker_Env.current_module env in
+             FStar_Ident.lid_equals FStar_Parser_Const.prims_lid uu____75) in
         if uu____73
         then FStar_TypeChecker_Env.all_binders env
-        else t_binders env  in
-      let uu____77 = FStar_TypeChecker_Env.get_range env  in
+        else t_binders env in
+      let uu____77 = FStar_TypeChecker_Env.get_range env in
       FStar_TypeChecker_Rel.new_uvar uu____77 bs k
-  
-let (new_uvar :
+let new_uvar:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
+    FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
   =
   fun env  ->
     fun k  ->
-      let uu____84 = new_uvar_aux env k  in
+      let uu____84 = new_uvar_aux env k in
       FStar_Pervasives_Native.fst uu____84
-  
-let (as_uvar : FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.uvar) =
+let as_uvar: FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.uvar =
   fun uu___80_93  ->
     match uu___80_93 with
     | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar (uv,uu____95);
         FStar_Syntax_Syntax.pos = uu____96;
         FStar_Syntax_Syntax.vars = uu____97;_} -> uv
     | uu____124 -> failwith "Impossible"
-  
-let (new_implicit_var :
+let new_implicit_var:
   Prims.string ->
     FStar_Range.range ->
       FStar_TypeChecker_Env.env ->
@@ -78,35 +70,33 @@ let (new_implicit_var :
           (FStar_Syntax_Syntax.term,(FStar_Syntax_Syntax.uvar,FStar_Range.range)
                                       FStar_Pervasives_Native.tuple2
                                       Prims.list,FStar_TypeChecker_Env.guard_t)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun reason  ->
     fun r  ->
       fun env  ->
         fun k  ->
           let uu____149 =
-            FStar_Syntax_Util.destruct k FStar_Parser_Const.range_of_lid  in
+            FStar_Syntax_Util.destruct k FStar_Parser_Const.range_of_lid in
           match uu____149 with
           | FStar_Pervasives_Native.Some (uu____172::(tm,uu____174)::[]) ->
               let t =
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_constant
                      (FStar_Const.Const_range (tm.FStar_Syntax_Syntax.pos)))
-                  FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos
-                 in
+                  FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos in
               (t, [], FStar_TypeChecker_Rel.trivial_guard)
           | uu____226 ->
-              let uu____237 = new_uvar_aux env k  in
+              let uu____237 = new_uvar_aux env k in
               (match uu____237 with
                | (t,u) ->
                    let g =
-                     let uu___104_257 = FStar_TypeChecker_Rel.trivial_guard
-                        in
+                     let uu___104_257 = FStar_TypeChecker_Rel.trivial_guard in
                      let uu____258 =
                        let uu____273 =
-                         let uu____286 = as_uvar u  in
-                         (reason, env, uu____286, t, k, r)  in
-                       [uu____273]  in
+                         let uu____286 = as_uvar u in
+                         (reason, env, uu____286, t, k, r) in
+                       [uu____273] in
                      {
                        FStar_TypeChecker_Env.guard_f =
                          (uu___104_257.FStar_TypeChecker_Env.guard_f);
@@ -115,53 +105,48 @@ let (new_implicit_var :
                        FStar_TypeChecker_Env.univ_ineqs =
                          (uu___104_257.FStar_TypeChecker_Env.univ_ineqs);
                        FStar_TypeChecker_Env.implicits = uu____258
-                     }  in
+                     } in
                    let uu____311 =
                      let uu____318 =
-                       let uu____323 = as_uvar u  in (uu____323, r)  in
-                     [uu____318]  in
+                       let uu____323 = as_uvar u in (uu____323, r) in
+                     [uu____318] in
                    (t, uu____311, g))
-  
-let (check_uvars :
-  FStar_Range.range -> FStar_Syntax_Syntax.typ -> Prims.unit) =
+let check_uvars: FStar_Range.range -> FStar_Syntax_Syntax.typ -> Prims.unit =
   fun r  ->
     fun t  ->
-      let uvs = FStar_Syntax_Free.uvars t  in
+      let uvs = FStar_Syntax_Free.uvars t in
       let uu____351 =
-        let uu____352 = FStar_Util.set_is_empty uvs  in
-        Prims.op_Negation uu____352  in
+        let uu____352 = FStar_Util.set_is_empty uvs in
+        Prims.op_Negation uu____352 in
       if uu____351
       then
         let us =
           let uu____358 =
-            let uu____361 = FStar_Util.set_elements uvs  in
+            let uu____361 = FStar_Util.set_elements uvs in
             FStar_List.map
               (fun uu____379  ->
                  match uu____379 with
                  | (x,uu____385) -> FStar_Syntax_Print.uvar_to_string x)
-              uu____361
-             in
-          FStar_All.pipe_right uu____358 (FStar_String.concat ", ")  in
+              uu____361 in
+          FStar_All.pipe_right uu____358 (FStar_String.concat ", ") in
         (FStar_Options.push ();
          FStar_Options.set_option "hide_uvar_nums" (FStar_Options.Bool false);
          FStar_Options.set_option "print_implicits" (FStar_Options.Bool true);
          (let uu____392 =
             let uu____397 =
-              let uu____398 = FStar_Syntax_Print.term_to_string t  in
+              let uu____398 = FStar_Syntax_Print.term_to_string t in
               FStar_Util.format2
                 "Unconstrained unification variables %s in type signature %s; please add an annotation"
-                us uu____398
-               in
-            (FStar_Errors.Error_UncontrainedUnificationVar, uu____397)  in
+                us uu____398 in
+            (FStar_Errors.Error_UncontrainedUnificationVar, uu____397) in
           FStar_Errors.log_issue r uu____392);
          FStar_Options.pop ())
       else ()
-  
-let (extract_let_rec_annotation :
+let extract_let_rec_annotation:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.letbinding ->
       (FStar_Syntax_Syntax.univ_names,FStar_Syntax_Syntax.typ,Prims.bool)
-        FStar_Pervasives_Native.tuple3)
+        FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun uu____411  ->
@@ -172,8 +157,8 @@ let (extract_let_rec_annotation :
           FStar_Syntax_Syntax.lbeff = uu____421;
           FStar_Syntax_Syntax.lbdef = e;
           FStar_Syntax_Syntax.lbattrs = uu____423;_} ->
-          let rng = FStar_Syntax_Syntax.range_of_lbname lbname  in
-          let t1 = FStar_Syntax_Subst.compress t  in
+          let rng = FStar_Syntax_Syntax.range_of_lbname lbname in
+          let t1 = FStar_Syntax_Subst.compress t in
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown  ->
                (if univ_vars1 <> []
@@ -181,27 +166,24 @@ let (extract_let_rec_annotation :
                   failwith
                     "Impossible: non-empty universe variables but the type is unknown"
                 else ();
-                (let r = FStar_TypeChecker_Env.get_range env  in
+                (let r = FStar_TypeChecker_Env.get_range env in
                  let mk_binder1 scope a =
                    let uu____472 =
                      let uu____473 =
-                       FStar_Syntax_Subst.compress a.FStar_Syntax_Syntax.sort
-                        in
-                     uu____473.FStar_Syntax_Syntax.n  in
+                       FStar_Syntax_Subst.compress a.FStar_Syntax_Syntax.sort in
+                     uu____473.FStar_Syntax_Syntax.n in
                    match uu____472 with
                    | FStar_Syntax_Syntax.Tm_unknown  ->
-                       let uu____480 = FStar_Syntax_Util.type_u ()  in
+                       let uu____480 = FStar_Syntax_Util.type_u () in
                        (match uu____480 with
                         | (k,uu____490) ->
                             let t2 =
                               let uu____492 =
                                 FStar_TypeChecker_Rel.new_uvar
-                                  e.FStar_Syntax_Syntax.pos scope k
-                                 in
+                                  e.FStar_Syntax_Syntax.pos scope k in
                               FStar_All.pipe_right uu____492
-                                FStar_Pervasives_Native.fst
-                               in
-                            ((let uu___105_502 = a  in
+                                FStar_Pervasives_Native.fst in
+                            ((let uu___105_502 = a in
                               {
                                 FStar_Syntax_Syntax.ppname =
                                   (uu___105_502.FStar_Syntax_Syntax.ppname);
@@ -209,9 +191,9 @@ let (extract_let_rec_annotation :
                                   (uu___105_502.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t2
                               }), false))
-                   | uu____503 -> (a, true)  in
+                   | uu____503 -> (a, true) in
                  let rec aux must_check_ty vars e1 =
-                   let e2 = FStar_Syntax_Subst.compress e1  in
+                   let e2 = FStar_Syntax_Subst.compress e1 in
                    match e2.FStar_Syntax_Syntax.n with
                    | FStar_Syntax_Syntax.Tm_meta (e3,uu____540) ->
                        aux must_check_ty vars e3
@@ -228,47 +210,43 @@ let (extract_let_rec_annotation :
                                        let uu____770 =
                                          if must_check_ty1
                                          then (a, true)
-                                         else mk_binder1 scope a  in
+                                         else mk_binder1 scope a in
                                        (match uu____770 with
                                         | (tb,must_check_ty2) ->
-                                            let b = (tb, imp)  in
+                                            let b = (tb, imp) in
                                             let bs2 =
-                                              FStar_List.append bs1 [b]  in
+                                              FStar_List.append bs1 [b] in
                                             let scope1 =
-                                              FStar_List.append scope [b]  in
+                                              FStar_List.append scope [b] in
                                             (scope1, bs2, must_check_ty2)))
-                              (vars, [], must_check_ty))
-                          in
+                              (vars, [], must_check_ty)) in
                        (match uu____631 with
                         | (scope,bs1,must_check_ty1) ->
-                            let uu____882 = aux must_check_ty1 scope body  in
+                            let uu____882 = aux must_check_ty1 scope body in
                             (match uu____882 with
                              | (res,must_check_ty2) ->
                                  let c =
                                    match res with
                                    | FStar_Util.Inl t2 ->
                                        let uu____911 =
-                                         FStar_Options.ml_ish ()  in
+                                         FStar_Options.ml_ish () in
                                        if uu____911
                                        then FStar_Syntax_Util.ml_comp t2 r
                                        else FStar_Syntax_Syntax.mk_Total t2
-                                   | FStar_Util.Inr c -> c  in
-                                 let t2 = FStar_Syntax_Util.arrow bs1 c  in
+                                   | FStar_Util.Inr c -> c in
+                                 let t2 = FStar_Syntax_Util.arrow bs1 c in
                                  ((let uu____918 =
                                      FStar_TypeChecker_Env.debug env
-                                       FStar_Options.High
-                                      in
+                                       FStar_Options.High in
                                    if uu____918
                                    then
                                      let uu____919 =
-                                       FStar_Range.string_of_range r  in
+                                       FStar_Range.string_of_range r in
                                      let uu____920 =
-                                       FStar_Syntax_Print.term_to_string t2
-                                        in
+                                       FStar_Syntax_Print.term_to_string t2 in
                                      let uu____921 =
                                        FStar_Util.string_of_bool
-                                         must_check_ty2
-                                        in
+                                         must_check_ty2 in
                                      FStar_Util.print3
                                        "(%s) Using type %s .... must check = %s\n"
                                        uu____919 uu____920 uu____921
@@ -282,48 +260,41 @@ let (extract_let_rec_annotation :
                             let uu____950 =
                               let uu____951 =
                                 FStar_TypeChecker_Rel.new_uvar r vars
-                                  FStar_Syntax_Util.ktype0
-                                 in
+                                  FStar_Syntax_Util.ktype0 in
                               FStar_All.pipe_right uu____951
-                                FStar_Pervasives_Native.fst
-                               in
-                            FStar_Util.Inl uu____950  in
-                          (uu____945, false))
-                    in
+                                FStar_Pervasives_Native.fst in
+                            FStar_Util.Inl uu____950 in
+                          (uu____945, false)) in
                  let uu____964 =
-                   let uu____973 = t_binders env  in aux false uu____973 e
-                    in
+                   let uu____973 = t_binders env in aux false uu____973 e in
                  match uu____964 with
                  | (t2,b) ->
                      let t3 =
                        match t2 with
                        | FStar_Util.Inr c ->
                            let uu____998 =
-                             FStar_Syntax_Util.is_tot_or_gtot_comp c  in
+                             FStar_Syntax_Util.is_tot_or_gtot_comp c in
                            if uu____998
                            then FStar_Syntax_Util.comp_result c
                            else
                              (let uu____1002 =
                                 let uu____1007 =
                                   let uu____1008 =
-                                    FStar_Syntax_Print.comp_to_string c  in
+                                    FStar_Syntax_Print.comp_to_string c in
                                   FStar_Util.format1
                                     "Expected a 'let rec' to be annotated with a value type; got a computation type %s"
-                                    uu____1008
-                                   in
+                                    uu____1008 in
                                 (FStar_Errors.Fatal_UnexpectedComputationTypeForLetRec,
-                                  uu____1007)
-                                 in
+                                  uu____1007) in
                               FStar_Errors.raise_error uu____1002 rng)
-                       | FStar_Util.Inl t3 -> t3  in
+                       | FStar_Util.Inl t3 -> t3 in
                      ([], t3, b)))
            | uu____1016 ->
                let uu____1017 =
-                 FStar_Syntax_Subst.open_univ_vars univ_vars1 t1  in
+                 FStar_Syntax_Subst.open_univ_vars univ_vars1 t1 in
                (match uu____1017 with
                 | (univ_vars2,t2) -> (univ_vars2, t2, false)))
-  
-let (pat_as_exp :
+let pat_as_exp:
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.pat ->
@@ -334,7 +305,7 @@ let (pat_as_exp :
           ->
           (FStar_Syntax_Syntax.bv Prims.list,FStar_Syntax_Syntax.term,
             FStar_TypeChecker_Env.guard_t,FStar_Syntax_Syntax.pat)
-            FStar_Pervasives_Native.tuple4)
+            FStar_Pervasives_Native.tuple4
   =
   fun allow_implicits  ->
     fun env  ->
@@ -343,28 +314,27 @@ let (pat_as_exp :
           let check_bv env1 x =
             let uu____1097 =
               let uu____1102 =
-                FStar_Syntax_Subst.compress x.FStar_Syntax_Syntax.sort  in
+                FStar_Syntax_Subst.compress x.FStar_Syntax_Syntax.sort in
               match uu____1102 with
               | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_unknown ;
                   FStar_Syntax_Syntax.pos = uu____1107;
                   FStar_Syntax_Syntax.vars = uu____1108;_} ->
-                  let uu____1111 = FStar_Syntax_Util.type_u ()  in
+                  let uu____1111 = FStar_Syntax_Util.type_u () in
                   (match uu____1111 with
                    | (t,uu____1121) ->
-                       let uu____1122 = new_uvar env1 t  in
+                       let uu____1122 = new_uvar env1 t in
                        (uu____1122, FStar_TypeChecker_Rel.trivial_guard))
-              | t -> tc_annot env1 t  in
+              | t -> tc_annot env1 t in
             match uu____1097 with
             | (t_x,guard) ->
-                ((let uu___106_1131 = x  in
+                ((let uu___106_1131 = x in
                   {
                     FStar_Syntax_Syntax.ppname =
                       (uu___106_1131.FStar_Syntax_Syntax.ppname);
                     FStar_Syntax_Syntax.index =
                       (uu___106_1131.FStar_Syntax_Syntax.index);
                     FStar_Syntax_Syntax.sort = t_x
-                  }), guard)
-             in
+                  }), guard) in
           let rec pat_as_arg_with_env allow_wc_dependence env1 p1 =
             match p1.FStar_Syntax_Syntax.v with
             | FStar_Syntax_Syntax.Pat_constant c ->
@@ -378,68 +348,64 @@ let (pat_as_exp :
                   | uu____1200 ->
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_constant c)
-                        FStar_Pervasives_Native.None p1.FStar_Syntax_Syntax.p
-                   in
+                        FStar_Pervasives_Native.None p1.FStar_Syntax_Syntax.p in
                 ([], [], [], env1, e, FStar_TypeChecker_Rel.trivial_guard,
                   p1)
             | FStar_Syntax_Syntax.Pat_dot_term (x,uu____1208) ->
-                let uu____1213 = FStar_Syntax_Util.type_u ()  in
+                let uu____1213 = FStar_Syntax_Util.type_u () in
                 (match uu____1213 with
                  | (k,uu____1239) ->
-                     let t = new_uvar env1 k  in
+                     let t = new_uvar env1 k in
                      let x1 =
-                       let uu___107_1242 = x  in
+                       let uu___107_1242 = x in
                        {
                          FStar_Syntax_Syntax.ppname =
                            (uu___107_1242.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
                            (uu___107_1242.FStar_Syntax_Syntax.index);
                          FStar_Syntax_Syntax.sort = t
-                       }  in
+                       } in
                      let uu____1243 =
                        let uu____1248 =
-                         FStar_TypeChecker_Env.all_binders env1  in
+                         FStar_TypeChecker_Env.all_binders env1 in
                        FStar_TypeChecker_Rel.new_uvar
-                         p1.FStar_Syntax_Syntax.p uu____1248 t
-                        in
+                         p1.FStar_Syntax_Syntax.p uu____1248 t in
                      (match uu____1243 with
                       | (e,u) ->
                           let p2 =
-                            let uu___108_1274 = p1  in
+                            let uu___108_1274 = p1 in
                             {
                               FStar_Syntax_Syntax.v =
                                 (FStar_Syntax_Syntax.Pat_dot_term (x1, e));
                               FStar_Syntax_Syntax.p =
                                 (uu___108_1274.FStar_Syntax_Syntax.p)
-                            }  in
+                            } in
                           ([], [], [], env1, e,
                             FStar_TypeChecker_Rel.trivial_guard, p2)))
             | FStar_Syntax_Syntax.Pat_wild x ->
-                let uu____1284 = check_bv env1 x  in
+                let uu____1284 = check_bv env1 x in
                 (match uu____1284 with
                  | (x1,g) ->
                      let env2 =
                        if allow_wc_dependence
                        then FStar_TypeChecker_Env.push_bv env1 x1
-                       else env1  in
+                       else env1 in
                      let e =
                        FStar_Syntax_Syntax.mk
                          (FStar_Syntax_Syntax.Tm_name x1)
                          FStar_Pervasives_Native.None
-                         p1.FStar_Syntax_Syntax.p
-                        in
+                         p1.FStar_Syntax_Syntax.p in
                      ([x1], [], [x1], env2, e, g, p1))
             | FStar_Syntax_Syntax.Pat_var x ->
-                let uu____1325 = check_bv env1 x  in
+                let uu____1325 = check_bv env1 x in
                 (match uu____1325 with
                  | (x1,g) ->
-                     let env2 = FStar_TypeChecker_Env.push_bv env1 x1  in
+                     let env2 = FStar_TypeChecker_Env.push_bv env1 x1 in
                      let e =
                        FStar_Syntax_Syntax.mk
                          (FStar_Syntax_Syntax.Tm_name x1)
                          FStar_Pervasives_Native.None
-                         p1.FStar_Syntax_Syntax.p
-                        in
+                         p1.FStar_Syntax_Syntax.p in
                      ([x1], [x1], [], env2, e, g, p1))
             | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
                 let uu____1382 =
@@ -451,24 +417,21 @@ let (pat_as_exp :
                             | ((b,a,w,env2,args,guard,pats1),(p2,imp)) ->
                                 let uu____1717 =
                                   pat_as_arg_with_env allow_wc_dependence
-                                    env2 p2
-                                   in
+                                    env2 p2 in
                                 (match uu____1717 with
                                  | (b',a',w',env3,te,guard',pat) ->
                                      let arg =
                                        if imp
                                        then FStar_Syntax_Syntax.iarg te
-                                       else FStar_Syntax_Syntax.as_arg te  in
+                                       else FStar_Syntax_Syntax.as_arg te in
                                      let uu____1793 =
                                        FStar_TypeChecker_Rel.conj_guard guard
-                                         guard'
-                                        in
+                                         guard' in
                                      ((b' :: b), (a' :: a), (w' :: w), env3,
                                        (arg :: args), uu____1793, ((pat, imp)
                                        :: pats1))))
                        ([], [], [], env1, [],
-                         FStar_TypeChecker_Rel.trivial_guard, []))
-                   in
+                         FStar_TypeChecker_Rel.trivial_guard, [])) in
                 (match uu____1382 with
                  | (b,a,w,env2,args,guard,pats1) ->
                      let e =
@@ -478,47 +441,38 @@ let (pat_as_exp :
                              let uu____1935 =
                                let uu____1938 =
                                  let uu____1939 =
-                                   FStar_Syntax_Syntax.fv_to_tm fv  in
+                                   FStar_Syntax_Syntax.fv_to_tm fv in
                                  let uu____1940 =
-                                   FStar_All.pipe_right args FStar_List.rev
-                                    in
+                                   FStar_All.pipe_right args FStar_List.rev in
                                  FStar_Syntax_Syntax.mk_Tm_app uu____1939
-                                   uu____1940
-                                  in
+                                   uu____1940 in
                                uu____1938 FStar_Pervasives_Native.None
-                                 p1.FStar_Syntax_Syntax.p
-                                in
+                                 p1.FStar_Syntax_Syntax.p in
                              (uu____1935,
                                (FStar_Syntax_Syntax.Meta_desugared
-                                  FStar_Syntax_Syntax.Data_app))
-                              in
-                           FStar_Syntax_Syntax.Tm_meta uu____1928  in
-                         FStar_Syntax_Syntax.mk uu____1927  in
+                                  FStar_Syntax_Syntax.Data_app)) in
+                           FStar_Syntax_Syntax.Tm_meta uu____1928 in
+                         FStar_Syntax_Syntax.mk uu____1927 in
                        uu____1924 FStar_Pervasives_Native.None
-                         p1.FStar_Syntax_Syntax.p
-                        in
+                         p1.FStar_Syntax_Syntax.p in
                      let uu____1952 =
                        FStar_All.pipe_right (FStar_List.rev b)
-                         FStar_List.flatten
-                        in
+                         FStar_List.flatten in
                      let uu____1963 =
                        FStar_All.pipe_right (FStar_List.rev a)
-                         FStar_List.flatten
-                        in
+                         FStar_List.flatten in
                      let uu____1974 =
                        FStar_All.pipe_right (FStar_List.rev w)
-                         FStar_List.flatten
-                        in
+                         FStar_List.flatten in
                      (uu____1952, uu____1963, uu____1974, env2, e, guard,
-                       (let uu___109_1996 = p1  in
+                       (let uu___109_1996 = p1 in
                         {
                           FStar_Syntax_Syntax.v =
                             (FStar_Syntax_Syntax.Pat_cons
                                (fv, (FStar_List.rev pats1)));
                           FStar_Syntax_Syntax.p =
                             (uu___109_1996.FStar_Syntax_Syntax.p)
-                        })))
-             in
+                        }))) in
           let rec elaborate_pat env1 p1 =
             let maybe_dot inaccessible a r =
               if allow_implicits && inaccessible
@@ -528,8 +482,7 @@ let (pat_as_exp :
                      (a, FStar_Syntax_Syntax.tun)) r
               else
                 FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_var a)
-                  r
-               in
+                  r in
             match p1.FStar_Syntax_Syntax.v with
             | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
                 let pats1 =
@@ -537,16 +490,14 @@ let (pat_as_exp :
                     (fun uu____2080  ->
                        match uu____2080 with
                        | (p2,imp) ->
-                           let uu____2099 = elaborate_pat env1 p2  in
-                           (uu____2099, imp)) pats
-                   in
+                           let uu____2099 = elaborate_pat env1 p2 in
+                           (uu____2099, imp)) pats in
                 let uu____2104 =
                   FStar_TypeChecker_Env.lookup_datacon env1
-                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                   in
+                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                 (match uu____2104 with
                  | (uu____2111,t) ->
-                     let uu____2113 = FStar_Syntax_Util.arrow_formals t  in
+                     let uu____2113 = FStar_Syntax_Util.arrow_formals t in
                      (match uu____2113 with
                       | (f,uu____2129) ->
                           let rec aux formals pats2 =
@@ -572,37 +523,29 @@ let (pat_as_exp :
                                                    let uu____2409 =
                                                      let uu____2412 =
                                                        FStar_Syntax_Syntax.range_of_bv
-                                                         t1
-                                                        in
+                                                         t1 in
                                                      FStar_Pervasives_Native.Some
-                                                       uu____2412
-                                                      in
+                                                       uu____2412 in
                                                    FStar_Syntax_Syntax.new_bv
                                                      uu____2409
-                                                     FStar_Syntax_Syntax.tun
-                                                    in
+                                                     FStar_Syntax_Syntax.tun in
                                                  let r =
                                                    FStar_Ident.range_of_lid
-                                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                                    in
+                                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                                                  let uu____2414 =
-                                                   maybe_dot inaccessible a r
-                                                    in
+                                                   maybe_dot inaccessible a r in
                                                  (uu____2414, true)
                                              | uu____2419 ->
                                                  let uu____2422 =
                                                    let uu____2427 =
                                                      let uu____2428 =
                                                        FStar_Syntax_Print.pat_to_string
-                                                         p1
-                                                        in
+                                                         p1 in
                                                      FStar_Util.format1
                                                        "Insufficient pattern arguments (%s)"
-                                                       uu____2428
-                                                      in
+                                                       uu____2428 in
                                                    (FStar_Errors.Fatal_InsufficientPatternArguments,
-                                                     uu____2427)
-                                                    in
+                                                     uu____2427) in
                                                  FStar_Errors.raise_error
                                                    uu____2422
                                                    (FStar_Ident.range_of_lid
@@ -612,7 +555,7 @@ let (pat_as_exp :
                                  | (uu____2502,FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Implicit
                                     uu____2503)) when p_imp ->
-                                     let uu____2506 = aux formals' pats'  in
+                                     let uu____2506 = aux formals' pats' in
                                      (p2, true) :: uu____2506
                                  | (uu____2523,FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Implicit
@@ -621,71 +564,62 @@ let (pat_as_exp :
                                        FStar_Syntax_Syntax.new_bv
                                          (FStar_Pervasives_Native.Some
                                             (p2.FStar_Syntax_Syntax.p))
-                                         FStar_Syntax_Syntax.tun
-                                        in
+                                         FStar_Syntax_Syntax.tun in
                                      let p3 =
                                        maybe_dot inaccessible a
                                          (FStar_Ident.range_of_lid
-                                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                                        in
-                                     let uu____2531 = aux formals' pats2  in
+                                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
+                                     let uu____2531 = aux formals' pats2 in
                                      (p3, true) :: uu____2531
                                  | (uu____2548,imp) ->
                                      let uu____2554 =
                                        let uu____2561 =
-                                         FStar_Syntax_Syntax.is_implicit imp
-                                          in
-                                       (p2, uu____2561)  in
-                                     let uu____2564 = aux formals' pats'  in
-                                     uu____2554 :: uu____2564)
-                             in
-                          let uu___110_2579 = p1  in
+                                         FStar_Syntax_Syntax.is_implicit imp in
+                                       (p2, uu____2561) in
+                                     let uu____2564 = aux formals' pats' in
+                                     uu____2554 :: uu____2564) in
+                          let uu___110_2579 = p1 in
                           let uu____2582 =
                             let uu____2583 =
-                              let uu____2596 = aux f pats1  in
-                              (fv, uu____2596)  in
-                            FStar_Syntax_Syntax.Pat_cons uu____2583  in
+                              let uu____2596 = aux f pats1 in
+                              (fv, uu____2596) in
+                            FStar_Syntax_Syntax.Pat_cons uu____2583 in
                           {
                             FStar_Syntax_Syntax.v = uu____2582;
                             FStar_Syntax_Syntax.p =
                               (uu___110_2579.FStar_Syntax_Syntax.p)
                           }))
-            | uu____2613 -> p1  in
+            | uu____2613 -> p1 in
           let one_pat allow_wc_dependence env1 p1 =
-            let p2 = elaborate_pat env1 p1  in
-            let uu____2649 = pat_as_arg_with_env allow_wc_dependence env1 p2
-               in
+            let p2 = elaborate_pat env1 p1 in
+            let uu____2649 = pat_as_arg_with_env allow_wc_dependence env1 p2 in
             match uu____2649 with
             | (b,a,w,env2,arg,guard,p3) ->
                 let uu____2707 =
                   FStar_All.pipe_right b
-                    (FStar_Util.find_dup FStar_Syntax_Syntax.bv_eq)
-                   in
+                    (FStar_Util.find_dup FStar_Syntax_Syntax.bv_eq) in
                 (match uu____2707 with
                  | FStar_Pervasives_Native.Some x ->
                      let uu____2733 =
-                       FStar_TypeChecker_Err.nonlinear_pattern_variable x  in
+                       FStar_TypeChecker_Err.nonlinear_pattern_variable x in
                      FStar_Errors.raise_error uu____2733
                        p3.FStar_Syntax_Syntax.p
-                 | uu____2756 -> (b, a, w, arg, guard, p3))
-             in
-          let uu____2765 = one_pat true env p  in
+                 | uu____2756 -> (b, a, w, arg, guard, p3)) in
+          let uu____2765 = one_pat true env p in
           match uu____2765 with
           | (b,uu____2795,uu____2796,tm,guard,p1) -> (b, tm, guard, p1)
-  
-let (decorate_pattern :
+let decorate_pattern:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.pat ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.pat)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.pat
   =
   fun env  ->
     fun p  ->
       fun exp  ->
-        let qq = p  in
+        let qq = p in
         let rec aux p1 e =
-          let pkg q = FStar_Syntax_Syntax.withinfo q p1.FStar_Syntax_Syntax.p
-             in
-          let e1 = FStar_Syntax_Util.unmeta e  in
+          let pkg q = FStar_Syntax_Syntax.withinfo q p1.FStar_Syntax_Syntax.p in
+          let e1 = FStar_Syntax_Util.unmeta e in
           match ((p1.FStar_Syntax_Syntax.v), (e1.FStar_Syntax_Syntax.n)) with
           | (uu____2842,FStar_Syntax_Syntax.Tm_uinst (e2,uu____2844)) ->
               aux p1 e2
@@ -695,24 +629,21 @@ let (decorate_pattern :
               (if Prims.op_Negation (FStar_Syntax_Syntax.bv_eq x y)
                then
                  (let uu____2854 =
-                    let uu____2855 = FStar_Syntax_Print.bv_to_string x  in
-                    let uu____2856 = FStar_Syntax_Print.bv_to_string y  in
+                    let uu____2855 = FStar_Syntax_Print.bv_to_string x in
+                    let uu____2856 = FStar_Syntax_Print.bv_to_string y in
                     FStar_Util.format2 "Expected pattern variable %s; got %s"
-                      uu____2855 uu____2856
-                     in
+                      uu____2855 uu____2856 in
                   failwith uu____2854)
                else ();
                (let uu____2859 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                    (FStar_Options.Other "Pat")
-                   in
+                    (FStar_Options.Other "Pat") in
                 if uu____2859
                 then
-                  let uu____2860 = FStar_Syntax_Print.bv_to_string x  in
+                  let uu____2860 = FStar_Syntax_Print.bv_to_string x in
                   let uu____2861 =
                     FStar_TypeChecker_Normalize.term_to_string env
-                      y.FStar_Syntax_Syntax.sort
-                     in
+                      y.FStar_Syntax_Syntax.sort in
                   FStar_Util.print2
                     "Pattern variable %s introduced at type %s\n" uu____2860
                     uu____2861
@@ -720,63 +651,58 @@ let (decorate_pattern :
                (let s =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Normalize.Beta] env
-                    y.FStar_Syntax_Syntax.sort
-                   in
+                    y.FStar_Syntax_Syntax.sort in
                 let x1 =
-                  let uu___111_2865 = x  in
+                  let uu___111_2865 = x in
                   {
                     FStar_Syntax_Syntax.ppname =
                       (uu___111_2865.FStar_Syntax_Syntax.ppname);
                     FStar_Syntax_Syntax.index =
                       (uu___111_2865.FStar_Syntax_Syntax.index);
                     FStar_Syntax_Syntax.sort = s
-                  }  in
+                  } in
                 pkg (FStar_Syntax_Syntax.Pat_var x1)))
           | (FStar_Syntax_Syntax.Pat_wild x,FStar_Syntax_Syntax.Tm_name y) ->
               ((let uu____2869 =
                   FStar_All.pipe_right (FStar_Syntax_Syntax.bv_eq x y)
-                    Prims.op_Negation
-                   in
+                    Prims.op_Negation in
                 if uu____2869
                 then
                   let uu____2870 =
-                    let uu____2871 = FStar_Syntax_Print.bv_to_string x  in
-                    let uu____2872 = FStar_Syntax_Print.bv_to_string y  in
+                    let uu____2871 = FStar_Syntax_Print.bv_to_string x in
+                    let uu____2872 = FStar_Syntax_Print.bv_to_string y in
                     FStar_Util.format2 "Expected pattern variable %s; got %s"
-                      uu____2871 uu____2872
-                     in
+                      uu____2871 uu____2872 in
                   failwith uu____2870
                 else ());
                (let s =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Normalize.Beta] env
-                    y.FStar_Syntax_Syntax.sort
-                   in
+                    y.FStar_Syntax_Syntax.sort in
                 let x1 =
-                  let uu___112_2876 = x  in
+                  let uu___112_2876 = x in
                   {
                     FStar_Syntax_Syntax.ppname =
                       (uu___112_2876.FStar_Syntax_Syntax.ppname);
                     FStar_Syntax_Syntax.index =
                       (uu___112_2876.FStar_Syntax_Syntax.index);
                     FStar_Syntax_Syntax.sort = s
-                  }  in
+                  } in
                 pkg (FStar_Syntax_Syntax.Pat_wild x1)))
           | (FStar_Syntax_Syntax.Pat_dot_term (x,uu____2878),uu____2879) ->
               pkg (FStar_Syntax_Syntax.Pat_dot_term (x, e1))
           | (FStar_Syntax_Syntax.Pat_cons (fv,[]),FStar_Syntax_Syntax.Tm_fvar
              fv') ->
               ((let uu____2901 =
-                  let uu____2902 = FStar_Syntax_Syntax.fv_eq fv fv'  in
-                  Prims.op_Negation uu____2902  in
+                  let uu____2902 = FStar_Syntax_Syntax.fv_eq fv fv' in
+                  Prims.op_Negation uu____2902 in
                 if uu____2901
                 then
                   let uu____2903 =
                     FStar_Util.format2
                       "Expected pattern constructor %s; got %s"
                       ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                      ((fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                     in
+                      ((fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str in
                   failwith uu____2903
                 else ());
                pkg (FStar_Syntax_Syntax.Pat_cons (fv', [])))
@@ -787,19 +713,18 @@ let (decorate_pattern :
                 FStar_Syntax_Syntax.vars = uu____2923;_},args))
               ->
               ((let uu____2962 =
-                  let uu____2963 = FStar_Syntax_Syntax.fv_eq fv fv'  in
-                  FStar_All.pipe_right uu____2963 Prims.op_Negation  in
+                  let uu____2963 = FStar_Syntax_Syntax.fv_eq fv fv' in
+                  FStar_All.pipe_right uu____2963 Prims.op_Negation in
                 if uu____2962
                 then
                   let uu____2964 =
                     FStar_Util.format2
                       "Expected pattern constructor %s; got %s"
                       ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                      ((fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                     in
+                      ((fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str in
                   failwith uu____2964
                 else ());
-               (let fv1 = fv'  in
+               (let fv1 = fv' in
                 let rec match_args matched_pats args1 argpats1 =
                   match (args1, argpats1) with
                   | ([],[]) ->
@@ -815,34 +740,28 @@ let (decorate_pattern :
                              FStar_Syntax_Syntax.new_bv
                                (FStar_Pervasives_Native.Some
                                   (p1.FStar_Syntax_Syntax.p))
-                               FStar_Syntax_Syntax.tun
-                              in
+                               FStar_Syntax_Syntax.tun in
                            let q =
                              FStar_Syntax_Syntax.withinfo
                                (FStar_Syntax_Syntax.Pat_dot_term (x, e2))
-                               p1.FStar_Syntax_Syntax.p
-                              in
+                               p1.FStar_Syntax_Syntax.p in
                            match_args ((q, true) :: matched_pats) args2
                              argpats2
                        | ((e2,imp),uu____3212) ->
                            let pat =
-                             let uu____3234 = aux argpat e2  in
+                             let uu____3234 = aux argpat e2 in
                              let uu____3235 =
-                               FStar_Syntax_Syntax.is_implicit imp  in
-                             (uu____3234, uu____3235)  in
+                               FStar_Syntax_Syntax.is_implicit imp in
+                             (uu____3234, uu____3235) in
                            match_args (pat :: matched_pats) args2 argpats2)
                   | uu____3240 ->
                       let uu____3263 =
-                        let uu____3264 = FStar_Syntax_Print.pat_to_string p1
-                           in
-                        let uu____3265 = FStar_Syntax_Print.term_to_string e1
-                           in
+                        let uu____3264 = FStar_Syntax_Print.pat_to_string p1 in
+                        let uu____3265 = FStar_Syntax_Print.term_to_string e1 in
                         FStar_Util.format2
                           "Unexpected number of pattern arguments: \n\t%s\n\t%s\n"
-                          uu____3264 uu____3265
-                         in
-                      failwith uu____3263
-                   in
+                          uu____3264 uu____3265 in
+                      failwith uu____3263 in
                 match_args [] args argpats))
           | (FStar_Syntax_Syntax.Pat_cons
              (fv,argpats),FStar_Syntax_Syntax.Tm_app
@@ -855,19 +774,18 @@ let (decorate_pattern :
                 FStar_Syntax_Syntax.vars = uu____3281;_},args))
               ->
               ((let uu____3324 =
-                  let uu____3325 = FStar_Syntax_Syntax.fv_eq fv fv'  in
-                  FStar_All.pipe_right uu____3325 Prims.op_Negation  in
+                  let uu____3325 = FStar_Syntax_Syntax.fv_eq fv fv' in
+                  FStar_All.pipe_right uu____3325 Prims.op_Negation in
                 if uu____3324
                 then
                   let uu____3326 =
                     FStar_Util.format2
                       "Expected pattern constructor %s; got %s"
                       ((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                      ((fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str
-                     in
+                      ((fv'.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v).FStar_Ident.str in
                   failwith uu____3326
                 else ());
-               (let fv1 = fv'  in
+               (let fv1 = fv' in
                 let rec match_args matched_pats args1 argpats1 =
                   match (args1, argpats1) with
                   | ([],[]) ->
@@ -883,101 +801,89 @@ let (decorate_pattern :
                              FStar_Syntax_Syntax.new_bv
                                (FStar_Pervasives_Native.Some
                                   (p1.FStar_Syntax_Syntax.p))
-                               FStar_Syntax_Syntax.tun
-                              in
+                               FStar_Syntax_Syntax.tun in
                            let q =
                              FStar_Syntax_Syntax.withinfo
                                (FStar_Syntax_Syntax.Pat_dot_term (x, e2))
-                               p1.FStar_Syntax_Syntax.p
-                              in
+                               p1.FStar_Syntax_Syntax.p in
                            match_args ((q, true) :: matched_pats) args2
                              argpats2
                        | ((e2,imp),uu____3574) ->
                            let pat =
-                             let uu____3596 = aux argpat e2  in
+                             let uu____3596 = aux argpat e2 in
                              let uu____3597 =
-                               FStar_Syntax_Syntax.is_implicit imp  in
-                             (uu____3596, uu____3597)  in
+                               FStar_Syntax_Syntax.is_implicit imp in
+                             (uu____3596, uu____3597) in
                            match_args (pat :: matched_pats) args2 argpats2)
                   | uu____3602 ->
                       let uu____3625 =
-                        let uu____3626 = FStar_Syntax_Print.pat_to_string p1
-                           in
-                        let uu____3627 = FStar_Syntax_Print.term_to_string e1
-                           in
+                        let uu____3626 = FStar_Syntax_Print.pat_to_string p1 in
+                        let uu____3627 = FStar_Syntax_Print.term_to_string e1 in
                         FStar_Util.format2
                           "Unexpected number of pattern arguments: \n\t%s\n\t%s\n"
-                          uu____3626 uu____3627
-                         in
-                      failwith uu____3625
-                   in
+                          uu____3626 uu____3627 in
+                      failwith uu____3625 in
                 match_args [] args argpats))
           | uu____3636 ->
               let uu____3641 =
                 let uu____3642 =
-                  FStar_Range.string_of_range qq.FStar_Syntax_Syntax.p  in
-                let uu____3643 = FStar_Syntax_Print.pat_to_string qq  in
-                let uu____3644 = FStar_Syntax_Print.term_to_string exp  in
+                  FStar_Range.string_of_range qq.FStar_Syntax_Syntax.p in
+                let uu____3643 = FStar_Syntax_Print.pat_to_string qq in
+                let uu____3644 = FStar_Syntax_Print.term_to_string exp in
                 FStar_Util.format3
                   "(%s) Impossible: pattern to decorate is %s; expression is %s\n"
-                  uu____3642 uu____3643 uu____3644
-                 in
-              failwith uu____3641
-           in
+                  uu____3642 uu____3643 uu____3644 in
+              failwith uu____3641 in
         aux p exp
-  
-let rec (decorated_pattern_as_term :
+let rec decorated_pattern_as_term:
   FStar_Syntax_Syntax.pat ->
     (FStar_Syntax_Syntax.bv Prims.list,FStar_Syntax_Syntax.term)
-      FStar_Pervasives_Native.tuple2)
+      FStar_Pervasives_Native.tuple2
   =
   fun pat  ->
     let mk1 f =
       FStar_Syntax_Syntax.mk f FStar_Pervasives_Native.None
-        pat.FStar_Syntax_Syntax.p
-       in
+        pat.FStar_Syntax_Syntax.p in
     let pat_as_arg uu____3681 =
       match uu____3681 with
       | (p,i) ->
-          let uu____3698 = decorated_pattern_as_term p  in
+          let uu____3698 = decorated_pattern_as_term p in
           (match uu____3698 with
            | (vars,te) ->
                let uu____3721 =
-                 let uu____3726 = FStar_Syntax_Syntax.as_implicit i  in
-                 (te, uu____3726)  in
-               (vars, uu____3721))
-       in
+                 let uu____3726 = FStar_Syntax_Syntax.as_implicit i in
+                 (te, uu____3726) in
+               (vars, uu____3721)) in
     match pat.FStar_Syntax_Syntax.v with
     | FStar_Syntax_Syntax.Pat_constant c ->
-        let uu____3740 = mk1 (FStar_Syntax_Syntax.Tm_constant c)  in
+        let uu____3740 = mk1 (FStar_Syntax_Syntax.Tm_constant c) in
         ([], uu____3740)
     | FStar_Syntax_Syntax.Pat_wild x ->
-        let uu____3744 = mk1 (FStar_Syntax_Syntax.Tm_name x)  in
+        let uu____3744 = mk1 (FStar_Syntax_Syntax.Tm_name x) in
         ([x], uu____3744)
     | FStar_Syntax_Syntax.Pat_var x ->
-        let uu____3748 = mk1 (FStar_Syntax_Syntax.Tm_name x)  in
+        let uu____3748 = mk1 (FStar_Syntax_Syntax.Tm_name x) in
         ([x], uu____3748)
     | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
         let uu____3769 =
           let uu____3784 =
-            FStar_All.pipe_right pats (FStar_List.map pat_as_arg)  in
-          FStar_All.pipe_right uu____3784 FStar_List.unzip  in
+            FStar_All.pipe_right pats (FStar_List.map pat_as_arg) in
+          FStar_All.pipe_right uu____3784 FStar_List.unzip in
         (match uu____3769 with
          | (vars,args) ->
-             let vars1 = FStar_List.flatten vars  in
+             let vars1 = FStar_List.flatten vars in
              let uu____3894 =
                let uu____3895 =
                  let uu____3896 =
-                   let uu____3911 = FStar_Syntax_Syntax.fv_to_tm fv  in
-                   (uu____3911, args)  in
-                 FStar_Syntax_Syntax.Tm_app uu____3896  in
-               mk1 uu____3895  in
+                   let uu____3911 = FStar_Syntax_Syntax.fv_to_tm fv in
+                   (uu____3911, args) in
+                 FStar_Syntax_Syntax.Tm_app uu____3896 in
+               mk1 uu____3895 in
              (vars1, uu____3894))
     | FStar_Syntax_Syntax.Pat_dot_term (x,e) -> ([], e)
-  
-let (comp_univ_opt :
+let comp_univ_opt:
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option)
+    FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
@@ -987,11 +893,10 @@ let (comp_univ_opt :
         (match c1.FStar_Syntax_Syntax.comp_univs with
          | [] -> FStar_Pervasives_Native.None
          | hd1::uu____3965 -> FStar_Pervasives_Native.Some hd1)
-  
-let (destruct_comp :
+let destruct_comp:
   FStar_Syntax_Syntax.comp_typ ->
     (FStar_Syntax_Syntax.universe,FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.typ)
-      FStar_Pervasives_Native.tuple3)
+      FStar_Pervasives_Native.tuple3
   =
   fun c  ->
     let wp =
@@ -1005,37 +910,32 @@ let (destruct_comp :
                   (fun uu____4027  ->
                      match uu____4027 with
                      | (x,uu____4033) -> FStar_Syntax_Print.term_to_string x)
-                  c.FStar_Syntax_Syntax.effect_args
-                 in
-              FStar_All.pipe_right uu____4017 (FStar_String.concat ", ")  in
+                  c.FStar_Syntax_Syntax.effect_args in
+              FStar_All.pipe_right uu____4017 (FStar_String.concat ", ") in
             FStar_Util.format2
               "Impossible: Got a computation %s with effect args [%s]"
-              (c.FStar_Syntax_Syntax.effect_name).FStar_Ident.str uu____4016
-             in
-          failwith uu____4015
-       in
-    let uu____4038 = FStar_List.hd c.FStar_Syntax_Syntax.comp_univs  in
+              (c.FStar_Syntax_Syntax.effect_name).FStar_Ident.str uu____4016 in
+          failwith uu____4015 in
+    let uu____4038 = FStar_List.hd c.FStar_Syntax_Syntax.comp_univs in
     (uu____4038, (c.FStar_Syntax_Syntax.result_typ), wp)
-  
-let (lift_comp :
+let lift_comp:
   FStar_Syntax_Syntax.comp_typ ->
     FStar_Ident.lident ->
-      FStar_TypeChecker_Env.mlift -> FStar_Syntax_Syntax.comp_typ)
+      FStar_TypeChecker_Env.mlift -> FStar_Syntax_Syntax.comp_typ
   =
   fun c  ->
     fun m  ->
       fun lift  ->
-        let uu____4052 = destruct_comp c  in
+        let uu____4052 = destruct_comp c in
         match uu____4052 with
         | (u,uu____4060,wp) ->
             let uu____4062 =
               let uu____4071 =
                 let uu____4072 =
                   lift.FStar_TypeChecker_Env.mlift_wp u
-                    c.FStar_Syntax_Syntax.result_typ wp
-                   in
-                FStar_Syntax_Syntax.as_arg uu____4072  in
-              [uu____4071]  in
+                    c.FStar_Syntax_Syntax.result_typ wp in
+                FStar_Syntax_Syntax.as_arg uu____4072 in
+              [uu____4071] in
             {
               FStar_Syntax_Syntax.comp_univs = [u];
               FStar_Syntax_Syntax.effect_name = m;
@@ -1044,39 +944,35 @@ let (lift_comp :
               FStar_Syntax_Syntax.effect_args = uu____4062;
               FStar_Syntax_Syntax.flags = []
             }
-  
-let (join_effects :
+let join_effects:
   FStar_TypeChecker_Env.env ->
-    FStar_Ident.lident -> FStar_Ident.lident -> FStar_Ident.lident)
+    FStar_Ident.lident -> FStar_Ident.lident -> FStar_Ident.lident
   =
   fun env  ->
     fun l1  ->
       fun l2  ->
         let uu____4082 =
-          let uu____4089 = FStar_TypeChecker_Env.norm_eff_name env l1  in
-          let uu____4090 = FStar_TypeChecker_Env.norm_eff_name env l2  in
-          FStar_TypeChecker_Env.join env uu____4089 uu____4090  in
+          let uu____4089 = FStar_TypeChecker_Env.norm_eff_name env l1 in
+          let uu____4090 = FStar_TypeChecker_Env.norm_eff_name env l2 in
+          FStar_TypeChecker_Env.join env uu____4089 uu____4090 in
         match uu____4082 with | (m,uu____4092,uu____4093) -> m
-  
-let (join_lcomp :
+let join_lcomp:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.lcomp ->
-      FStar_Syntax_Syntax.lcomp -> FStar_Ident.lident)
+      FStar_Syntax_Syntax.lcomp -> FStar_Ident.lident
   =
   fun env  ->
     fun c1  ->
       fun c2  ->
         let uu____4103 =
           (FStar_Syntax_Util.is_total_lcomp c1) &&
-            (FStar_Syntax_Util.is_total_lcomp c2)
-           in
+            (FStar_Syntax_Util.is_total_lcomp c2) in
         if uu____4103
         then FStar_Parser_Const.effect_Tot_lid
         else
           join_effects env c1.FStar_Syntax_Syntax.eff_name
             c2.FStar_Syntax_Syntax.eff_name
-  
-let (lift_and_destruct :
+let lift_and_destruct:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp ->
       FStar_Syntax_Syntax.comp ->
@@ -1086,53 +982,48 @@ let (lift_and_destruct :
                                             FStar_Pervasives_Native.tuple3,
           (FStar_Syntax_Syntax.universe,FStar_Syntax_Syntax.typ,FStar_Syntax_Syntax.typ)
             FStar_Pervasives_Native.tuple3)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun c1  ->
       fun c2  ->
-        let c11 = FStar_TypeChecker_Env.unfold_effect_abbrev env c1  in
-        let c21 = FStar_TypeChecker_Env.unfold_effect_abbrev env c2  in
+        let c11 = FStar_TypeChecker_Env.unfold_effect_abbrev env c1 in
+        let c21 = FStar_TypeChecker_Env.unfold_effect_abbrev env c2 in
         let uu____4140 =
           FStar_TypeChecker_Env.join env c11.FStar_Syntax_Syntax.effect_name
-            c21.FStar_Syntax_Syntax.effect_name
-           in
+            c21.FStar_Syntax_Syntax.effect_name in
         match uu____4140 with
         | (m,lift1,lift2) ->
-            let m1 = lift_comp c11 m lift1  in
-            let m2 = lift_comp c21 m lift2  in
-            let md = FStar_TypeChecker_Env.get_effect_decl env m  in
+            let m1 = lift_comp c11 m lift1 in
+            let m2 = lift_comp c21 m lift2 in
+            let md = FStar_TypeChecker_Env.get_effect_decl env m in
             let uu____4177 =
               FStar_TypeChecker_Env.wp_signature env
-                md.FStar_Syntax_Syntax.mname
-               in
+                md.FStar_Syntax_Syntax.mname in
             (match uu____4177 with
              | (a,kwp) ->
-                 let uu____4208 = destruct_comp m1  in
-                 let uu____4215 = destruct_comp m2  in
+                 let uu____4208 = destruct_comp m1 in
+                 let uu____4215 = destruct_comp m2 in
                  ((md, a, kwp), uu____4208, uu____4215))
-  
-let (is_pure_effect :
-  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool) =
+let is_pure_effect:
+  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun l  ->
-      let l1 = FStar_TypeChecker_Env.norm_eff_name env l  in
+      let l1 = FStar_TypeChecker_Env.norm_eff_name env l in
       FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_PURE_lid
-  
-let (is_pure_or_ghost_effect :
-  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool) =
+let is_pure_or_ghost_effect:
+  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun l  ->
-      let l1 = FStar_TypeChecker_Env.norm_eff_name env l  in
+      let l1 = FStar_TypeChecker_Env.norm_eff_name env l in
       (FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_PURE_lid) ||
         (FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GHOST_lid)
-  
-let (mk_comp_l :
+let mk_comp_l:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.universe ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
         FStar_Syntax_Syntax.term ->
-          FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp)
+          FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp
   =
   fun mname  ->
     fun u_result  ->
@@ -1141,29 +1032,28 @@ let (mk_comp_l :
           fun flags1  ->
             let uu____4277 =
               let uu____4278 =
-                let uu____4287 = FStar_Syntax_Syntax.as_arg wp  in
-                [uu____4287]  in
+                let uu____4287 = FStar_Syntax_Syntax.as_arg wp in
+                [uu____4287] in
               {
                 FStar_Syntax_Syntax.comp_univs = [u_result];
                 FStar_Syntax_Syntax.effect_name = mname;
                 FStar_Syntax_Syntax.result_typ = result;
                 FStar_Syntax_Syntax.effect_args = uu____4278;
                 FStar_Syntax_Syntax.flags = flags1
-              }  in
+              } in
             FStar_Syntax_Syntax.mk_Comp uu____4277
-  
-let (mk_comp :
+let mk_comp:
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.universe ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
         FStar_Syntax_Syntax.term ->
-          FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp)
-  = fun md  -> mk_comp_l md.FStar_Syntax_Syntax.mname 
-let (lax_mk_tot_or_comp_l :
+          FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp
+  = fun md  -> mk_comp_l md.FStar_Syntax_Syntax.mname
+let lax_mk_tot_or_comp_l:
   FStar_Ident.lident ->
     FStar_Syntax_Syntax.universe ->
       FStar_Syntax_Syntax.typ ->
-        FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp)
+        FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp
   =
   fun mname  ->
     fun u_result  ->
@@ -1174,33 +1064,30 @@ let (lax_mk_tot_or_comp_l :
             FStar_Syntax_Syntax.mk_Total' result
               (FStar_Pervasives_Native.Some u_result)
           else mk_comp_l mname u_result result FStar_Syntax_Syntax.tun flags1
-  
-let (subst_lcomp :
+let subst_lcomp:
   FStar_Syntax_Syntax.subst_t ->
-    FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp)
+    FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
   =
   fun subst1  ->
     fun lc  ->
       let uu____4326 =
-        FStar_Syntax_Subst.subst subst1 lc.FStar_Syntax_Syntax.res_typ  in
+        FStar_Syntax_Subst.subst subst1 lc.FStar_Syntax_Syntax.res_typ in
       FStar_Syntax_Syntax.mk_lcomp lc.FStar_Syntax_Syntax.eff_name uu____4326
         lc.FStar_Syntax_Syntax.cflags
         (fun uu____4329  ->
-           let uu____4330 = FStar_Syntax_Syntax.lcomp_comp lc  in
+           let uu____4330 = FStar_Syntax_Syntax.lcomp_comp lc in
            FStar_Syntax_Subst.subst_comp subst1 uu____4330)
-  
-let (is_function : FStar_Syntax_Syntax.term -> Prims.bool) =
+let is_function: FStar_Syntax_Syntax.term -> Prims.bool =
   fun t  ->
     let uu____4334 =
-      let uu____4335 = FStar_Syntax_Subst.compress t  in
-      uu____4335.FStar_Syntax_Syntax.n  in
+      let uu____4335 = FStar_Syntax_Subst.compress t in
+      uu____4335.FStar_Syntax_Syntax.n in
     match uu____4334 with
     | FStar_Syntax_Syntax.Tm_arrow uu____4338 -> true
     | uu____4351 -> false
-  
-let (label :
+let label:
   Prims.string ->
-    FStar_Range.range -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
+    FStar_Range.range -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
   =
   fun reason  ->
     fun r  ->
@@ -1209,11 +1096,10 @@ let (label :
           (FStar_Syntax_Syntax.Tm_meta
              (f, (FStar_Syntax_Syntax.Meta_labeled (reason, r, false))))
           FStar_Pervasives_Native.None f.FStar_Syntax_Syntax.pos
-  
-let (label_opt :
+let label_opt:
   FStar_TypeChecker_Env.env ->
     (Prims.unit -> Prims.string) FStar_Pervasives_Native.option ->
-      FStar_Range.range -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
+      FStar_Range.range -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ
   =
   fun env  ->
     fun reason  ->
@@ -1223,16 +1109,15 @@ let (label_opt :
           | FStar_Pervasives_Native.None  -> f
           | FStar_Pervasives_Native.Some reason1 ->
               let uu____4389 =
-                let uu____4390 = FStar_TypeChecker_Env.should_verify env  in
-                FStar_All.pipe_left Prims.op_Negation uu____4390  in
+                let uu____4390 = FStar_TypeChecker_Env.should_verify env in
+                FStar_All.pipe_left Prims.op_Negation uu____4390 in
               if uu____4389
               then f
-              else (let uu____4392 = reason1 ()  in label uu____4392 r f)
-  
-let (label_guard :
+              else (let uu____4392 = reason1 () in label uu____4392 r f)
+let label_guard:
   FStar_Range.range ->
     Prims.string ->
-      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
+      FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t
   =
   fun r  ->
     fun reason  ->
@@ -1240,10 +1125,10 @@ let (label_guard :
         match g.FStar_TypeChecker_Env.guard_f with
         | FStar_TypeChecker_Common.Trivial  -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___113_4403 = g  in
+            let uu___113_4403 = g in
             let uu____4404 =
-              let uu____4405 = label reason r f  in
-              FStar_TypeChecker_Common.NonTrivial uu____4405  in
+              let uu____4405 = label reason r f in
+              FStar_TypeChecker_Common.NonTrivial uu____4405 in
             {
               FStar_TypeChecker_Env.guard_f = uu____4404;
               FStar_TypeChecker_Env.deferred =
@@ -1253,21 +1138,20 @@ let (label_guard :
               FStar_TypeChecker_Env.implicits =
                 (uu___113_4403.FStar_TypeChecker_Env.implicits)
             }
-  
-let (close_comp :
+let close_comp:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.bv Prims.list ->
-      FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
+      FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp
   =
   fun env  ->
     fun bvs  ->
       fun c  ->
-        let uu____4419 = FStar_Syntax_Util.is_ml_comp c  in
+        let uu____4419 = FStar_Syntax_Util.is_ml_comp c in
         if uu____4419
         then c
         else
           (let uu____4421 =
-             env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ())  in
+             env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
            if uu____4421
            then c
            else
@@ -1276,64 +1160,55 @@ let (close_comp :
                   (fun x  ->
                      fun wp  ->
                        let bs =
-                         let uu____4460 = FStar_Syntax_Syntax.mk_binder x  in
-                         [uu____4460]  in
+                         let uu____4460 = FStar_Syntax_Syntax.mk_binder x in
+                         [uu____4460] in
                        let us =
                          let uu____4464 =
                            let uu____4467 =
                              env.FStar_TypeChecker_Env.universe_of env
-                               x.FStar_Syntax_Syntax.sort
-                              in
-                           [uu____4467]  in
-                         u_res :: uu____4464  in
+                               x.FStar_Syntax_Syntax.sort in
+                           [uu____4467] in
+                         u_res :: uu____4464 in
                        let wp1 =
                          FStar_Syntax_Util.abs bs wp
                            (FStar_Pervasives_Native.Some
                               (FStar_Syntax_Util.mk_residual_comp
                                  FStar_Parser_Const.effect_Tot_lid
                                  FStar_Pervasives_Native.None
-                                 [FStar_Syntax_Syntax.TOTAL]))
-                          in
+                                 [FStar_Syntax_Syntax.TOTAL])) in
                        let uu____4471 =
                          let uu____4472 =
                            FStar_TypeChecker_Env.inst_effect_fun_with us env
-                             md md.FStar_Syntax_Syntax.close_wp
-                            in
+                             md md.FStar_Syntax_Syntax.close_wp in
                          let uu____4473 =
-                           let uu____4474 = FStar_Syntax_Syntax.as_arg res_t
-                              in
+                           let uu____4474 = FStar_Syntax_Syntax.as_arg res_t in
                            let uu____4475 =
                              let uu____4478 =
                                FStar_Syntax_Syntax.as_arg
-                                 x.FStar_Syntax_Syntax.sort
-                                in
+                                 x.FStar_Syntax_Syntax.sort in
                              let uu____4479 =
                                let uu____4482 =
-                                 FStar_Syntax_Syntax.as_arg wp1  in
-                               [uu____4482]  in
-                             uu____4478 :: uu____4479  in
-                           uu____4474 :: uu____4475  in
-                         FStar_Syntax_Syntax.mk_Tm_app uu____4472 uu____4473
-                          in
+                                 FStar_Syntax_Syntax.as_arg wp1 in
+                               [uu____4482] in
+                             uu____4478 :: uu____4479 in
+                           uu____4474 :: uu____4475 in
+                         FStar_Syntax_Syntax.mk_Tm_app uu____4472 uu____4473 in
                        uu____4471 FStar_Pervasives_Native.None
-                         wp0.FStar_Syntax_Syntax.pos) bvs1 wp0
-                 in
-              let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c  in
-              let uu____4486 = destruct_comp c1  in
+                         wp0.FStar_Syntax_Syntax.pos) bvs1 wp0 in
+              let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
+              let uu____4486 = destruct_comp c1 in
               match uu____4486 with
               | (u_res_t,res_t,wp) ->
                   let md =
                     FStar_TypeChecker_Env.get_effect_decl env
-                      c1.FStar_Syntax_Syntax.effect_name
-                     in
-                  let wp1 = close_wp u_res_t md res_t bvs wp  in
+                      c1.FStar_Syntax_Syntax.effect_name in
+                  let wp1 = close_wp u_res_t md res_t bvs wp in
                   mk_comp md u_res_t c1.FStar_Syntax_Syntax.result_typ wp1
                     c1.FStar_Syntax_Syntax.flags))
-  
-let (close_lcomp :
+let close_lcomp:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.bv Prims.list ->
-      FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp)
+      FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
   =
   fun env  ->
     fun bvs  ->
@@ -1341,10 +1216,9 @@ let (close_lcomp :
         FStar_Syntax_Syntax.mk_lcomp lc.FStar_Syntax_Syntax.eff_name
           lc.FStar_Syntax_Syntax.res_typ lc.FStar_Syntax_Syntax.cflags
           (fun uu____4513  ->
-             let uu____4514 = FStar_Syntax_Syntax.lcomp_comp lc  in
+             let uu____4514 = FStar_Syntax_Syntax.lcomp_comp lc in
              close_comp env bvs uu____4514)
-  
-let (should_not_inline_lc : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+let should_not_inline_lc: FStar_Syntax_Syntax.lcomp -> Prims.bool =
   fun lc  ->
     FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags
       (FStar_Util.for_some
@@ -1352,11 +1226,10 @@ let (should_not_inline_lc : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
             match uu___81_4521 with
             | FStar_Syntax_Syntax.SHOULD_NOT_INLINE  -> true
             | uu____4522 -> false))
-  
-let (should_return :
+let should_return:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
-      FStar_Syntax_Syntax.lcomp -> Prims.bool)
+      FStar_Syntax_Syntax.lcomp -> Prims.bool
   =
   fun env  ->
     fun eopt  ->
@@ -1366,35 +1239,31 @@ let (should_return :
         | FStar_Pervasives_Native.Some e ->
             (((FStar_Syntax_Util.is_pure_or_ghost_lcomp lc) &&
                 (let uu____4538 =
-                   FStar_Syntax_Util.is_unit lc.FStar_Syntax_Syntax.res_typ
-                    in
+                   FStar_Syntax_Util.is_unit lc.FStar_Syntax_Syntax.res_typ in
                  Prims.op_Negation uu____4538))
                &&
-               (let uu____4545 = FStar_Syntax_Util.head_and_args' e  in
+               (let uu____4545 = FStar_Syntax_Util.head_and_args' e in
                 match uu____4545 with
                 | (head1,uu____4559) ->
                     let uu____4576 =
-                      let uu____4577 = FStar_Syntax_Util.un_uinst head1  in
-                      uu____4577.FStar_Syntax_Syntax.n  in
+                      let uu____4577 = FStar_Syntax_Util.un_uinst head1 in
+                      uu____4577.FStar_Syntax_Syntax.n in
                     (match uu____4576 with
                      | FStar_Syntax_Syntax.Tm_fvar fv ->
                          let uu____4581 =
-                           let uu____4582 = FStar_Syntax_Syntax.lid_of_fv fv
-                              in
+                           let uu____4582 = FStar_Syntax_Syntax.lid_of_fv fv in
                            FStar_TypeChecker_Env.is_irreducible env
-                             uu____4582
-                            in
+                             uu____4582 in
                          Prims.op_Negation uu____4581
                      | uu____4583 -> true)))
               &&
-              (let uu____4585 = should_not_inline_lc lc  in
+              (let uu____4585 = should_not_inline_lc lc in
                Prims.op_Negation uu____4585)
-  
-let (return_value :
+let return_value:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option ->
       FStar_Syntax_Syntax.typ ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.comp)
+        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.comp
   =
   fun env  ->
     fun u_t_opt  ->
@@ -1404,13 +1273,12 @@ let (return_value :
             let uu____4603 =
               let uu____4604 =
                 FStar_TypeChecker_Env.lid_exists env
-                  FStar_Parser_Const.effect_GTot_lid
-                 in
-              FStar_All.pipe_left Prims.op_Negation uu____4604  in
+                  FStar_Parser_Const.effect_GTot_lid in
+              FStar_All.pipe_left Prims.op_Negation uu____4604 in
             if uu____4603
             then FStar_Syntax_Syntax.mk_Total t
             else
-              (let uu____4606 = FStar_Syntax_Util.is_unit t  in
+              (let uu____4606 = FStar_Syntax_Util.is_unit t in
                if uu____4606
                then
                  FStar_Syntax_Syntax.mk_Total' t
@@ -1418,77 +1286,66 @@ let (return_value :
                else
                  (let m =
                     FStar_TypeChecker_Env.get_effect_decl env
-                      FStar_Parser_Const.effect_PURE_lid
-                     in
+                      FStar_Parser_Const.effect_PURE_lid in
                   let u_t =
                     match u_t_opt with
                     | FStar_Pervasives_Native.None  ->
                         env.FStar_TypeChecker_Env.universe_of env t
-                    | FStar_Pervasives_Native.Some u_t -> u_t  in
+                    | FStar_Pervasives_Native.Some u_t -> u_t in
                   let wp =
                     let uu____4612 =
                       env.FStar_TypeChecker_Env.lax &&
-                        (FStar_Options.ml_ish ())
-                       in
+                        (FStar_Options.ml_ish ()) in
                     if uu____4612
                     then FStar_Syntax_Syntax.tun
                     else
                       (let uu____4614 =
                          FStar_TypeChecker_Env.wp_signature env
-                           FStar_Parser_Const.effect_PURE_lid
-                          in
+                           FStar_Parser_Const.effect_PURE_lid in
                        match uu____4614 with
                        | (a,kwp) ->
                            let k =
                              FStar_Syntax_Subst.subst
-                               [FStar_Syntax_Syntax.NT (a, t)] kwp
-                              in
+                               [FStar_Syntax_Syntax.NT (a, t)] kwp in
                            let uu____4622 =
                              let uu____4623 =
                                let uu____4624 =
                                  FStar_TypeChecker_Env.inst_effect_fun_with
-                                   [u_t] env m m.FStar_Syntax_Syntax.ret_wp
-                                  in
+                                   [u_t] env m m.FStar_Syntax_Syntax.ret_wp in
                                let uu____4625 =
                                  let uu____4626 =
-                                   FStar_Syntax_Syntax.as_arg t  in
+                                   FStar_Syntax_Syntax.as_arg t in
                                  let uu____4627 =
                                    let uu____4630 =
-                                     FStar_Syntax_Syntax.as_arg v1  in
-                                   [uu____4630]  in
-                                 uu____4626 :: uu____4627  in
+                                     FStar_Syntax_Syntax.as_arg v1 in
+                                   [uu____4630] in
+                                 uu____4626 :: uu____4627 in
                                FStar_Syntax_Syntax.mk_Tm_app uu____4624
-                                 uu____4625
-                                in
+                                 uu____4625 in
                              uu____4623 FStar_Pervasives_Native.None
-                               v1.FStar_Syntax_Syntax.pos
-                              in
+                               v1.FStar_Syntax_Syntax.pos in
                            FStar_TypeChecker_Normalize.normalize
                              [FStar_TypeChecker_Normalize.Beta;
                              FStar_TypeChecker_Normalize.NoFullNorm] env
-                             uu____4622)
-                     in
-                  mk_comp m u_t t wp [FStar_Syntax_Syntax.RETURN]))
-             in
+                             uu____4622) in
+                  mk_comp m u_t t wp [FStar_Syntax_Syntax.RETURN])) in
           (let uu____4634 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-               (FStar_Options.Other "Return")
-              in
+               (FStar_Options.Other "Return") in
            if uu____4634
            then
              let uu____4635 =
-               FStar_Range.string_of_range v1.FStar_Syntax_Syntax.pos  in
-             let uu____4636 = FStar_Syntax_Print.term_to_string v1  in
+               FStar_Range.string_of_range v1.FStar_Syntax_Syntax.pos in
+             let uu____4636 = FStar_Syntax_Print.term_to_string v1 in
              let uu____4637 =
-               FStar_TypeChecker_Normalize.comp_to_string env c  in
+               FStar_TypeChecker_Normalize.comp_to_string env c in
              FStar_Util.print3 "(%s) returning %s at comp type %s\n"
                uu____4635 uu____4636 uu____4637
            else ());
           c
-  
-let (weaken_flags :
+let weaken_flags:
   FStar_Syntax_Syntax.cflags Prims.list ->
-    FStar_Syntax_Syntax.cflags Prims.list)
+    FStar_Syntax_Syntax.cflags Prims.list
   =
   fun flags1  ->
     let uu____4648 =
@@ -1497,8 +1354,7 @@ let (weaken_flags :
            (fun uu___82_4652  ->
               match uu___82_4652 with
               | FStar_Syntax_Syntax.SHOULD_NOT_INLINE  -> true
-              | uu____4653 -> false))
-       in
+              | uu____4653 -> false)) in
     if uu____4648
     then [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
     else
@@ -1512,79 +1368,71 @@ let (weaken_flags :
                   [FStar_Syntax_Syntax.PARTIAL_RETURN;
                   FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
               | f -> [f]))
-  
-let (weaken_comp :
+let weaken_comp:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.comp)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.comp
   =
   fun env  ->
     fun c  ->
       fun formula  ->
-        let uu____4675 = FStar_Syntax_Util.is_ml_comp c  in
+        let uu____4675 = FStar_Syntax_Util.is_ml_comp c in
         if uu____4675
         then c
         else
-          (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c  in
-           let uu____4678 = destruct_comp c1  in
+          (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
+           let uu____4678 = destruct_comp c1 in
            match uu____4678 with
            | (u_res_t,res_t,wp) ->
                let md =
                  FStar_TypeChecker_Env.get_effect_decl env
-                   c1.FStar_Syntax_Syntax.effect_name
-                  in
+                   c1.FStar_Syntax_Syntax.effect_name in
                let wp1 =
                  let uu____4692 =
                    let uu____4693 =
                      FStar_TypeChecker_Env.inst_effect_fun_with [u_res_t] env
-                       md md.FStar_Syntax_Syntax.assume_p
-                      in
+                       md md.FStar_Syntax_Syntax.assume_p in
                    let uu____4694 =
-                     let uu____4695 = FStar_Syntax_Syntax.as_arg res_t  in
+                     let uu____4695 = FStar_Syntax_Syntax.as_arg res_t in
                      let uu____4696 =
-                       let uu____4699 = FStar_Syntax_Syntax.as_arg formula
-                          in
+                       let uu____4699 = FStar_Syntax_Syntax.as_arg formula in
                        let uu____4700 =
-                         let uu____4703 = FStar_Syntax_Syntax.as_arg wp  in
-                         [uu____4703]  in
-                       uu____4699 :: uu____4700  in
-                     uu____4695 :: uu____4696  in
-                   FStar_Syntax_Syntax.mk_Tm_app uu____4693 uu____4694  in
+                         let uu____4703 = FStar_Syntax_Syntax.as_arg wp in
+                         [uu____4703] in
+                       uu____4699 :: uu____4700 in
+                     uu____4695 :: uu____4696 in
+                   FStar_Syntax_Syntax.mk_Tm_app uu____4693 uu____4694 in
                  uu____4692 FStar_Pervasives_Native.None
-                   wp.FStar_Syntax_Syntax.pos
-                  in
-               let uu____4706 = weaken_flags c1.FStar_Syntax_Syntax.flags  in
+                   wp.FStar_Syntax_Syntax.pos in
+               let uu____4706 = weaken_flags c1.FStar_Syntax_Syntax.flags in
                mk_comp md u_res_t res_t wp1 uu____4706)
-  
-let (weaken_precondition :
+let weaken_precondition:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.lcomp ->
-      FStar_TypeChecker_Common.guard_formula -> FStar_Syntax_Syntax.lcomp)
+      FStar_TypeChecker_Common.guard_formula -> FStar_Syntax_Syntax.lcomp
   =
   fun env  ->
     fun lc  ->
       fun f  ->
         let weaken uu____4721 =
-          let c = FStar_Syntax_Syntax.lcomp_comp lc  in
+          let c = FStar_Syntax_Syntax.lcomp_comp lc in
           let uu____4723 =
-            env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ())  in
+            env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
           if uu____4723
           then c
           else
             (match f with
              | FStar_TypeChecker_Common.Trivial  -> c
-             | FStar_TypeChecker_Common.NonTrivial f1 -> weaken_comp env c f1)
-           in
-        let uu____4726 = weaken_flags lc.FStar_Syntax_Syntax.cflags  in
+             | FStar_TypeChecker_Common.NonTrivial f1 -> weaken_comp env c f1) in
+        let uu____4726 = weaken_flags lc.FStar_Syntax_Syntax.cflags in
         FStar_Syntax_Syntax.mk_lcomp lc.FStar_Syntax_Syntax.eff_name
           lc.FStar_Syntax_Syntax.res_typ uu____4726 weaken
-  
-let (strengthen_comp :
+let strengthen_comp:
   FStar_TypeChecker_Env.env ->
     (Prims.unit -> Prims.string) FStar_Pervasives_Native.option ->
       FStar_Syntax_Syntax.comp ->
         FStar_Syntax_Syntax.formula ->
-          FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp)
+          FStar_Syntax_Syntax.cflags Prims.list -> FStar_Syntax_Syntax.comp
   =
   fun env  ->
     fun reason  ->
@@ -1594,70 +1442,61 @@ let (strengthen_comp :
             if env.FStar_TypeChecker_Env.lax
             then c
             else
-              (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c  in
-               let uu____4759 = destruct_comp c1  in
+              (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
+               let uu____4759 = destruct_comp c1 in
                match uu____4759 with
                | (u_res_t,res_t,wp) ->
                    let md =
                      FStar_TypeChecker_Env.get_effect_decl env
-                       c1.FStar_Syntax_Syntax.effect_name
-                      in
+                       c1.FStar_Syntax_Syntax.effect_name in
                    let wp1 =
                      let uu____4773 =
                        let uu____4774 =
                          FStar_TypeChecker_Env.inst_effect_fun_with [u_res_t]
-                           env md md.FStar_Syntax_Syntax.assert_p
-                          in
+                           env md md.FStar_Syntax_Syntax.assert_p in
                        let uu____4775 =
-                         let uu____4776 = FStar_Syntax_Syntax.as_arg res_t
-                            in
+                         let uu____4776 = FStar_Syntax_Syntax.as_arg res_t in
                          let uu____4777 =
                            let uu____4780 =
                              let uu____4781 =
                                let uu____4782 =
-                                 FStar_TypeChecker_Env.get_range env  in
-                               label_opt env reason uu____4782 f  in
+                                 FStar_TypeChecker_Env.get_range env in
+                               label_opt env reason uu____4782 f in
                              FStar_All.pipe_left FStar_Syntax_Syntax.as_arg
-                               uu____4781
-                              in
+                               uu____4781 in
                            let uu____4783 =
-                             let uu____4786 = FStar_Syntax_Syntax.as_arg wp
-                                in
-                             [uu____4786]  in
-                           uu____4780 :: uu____4783  in
-                         uu____4776 :: uu____4777  in
-                       FStar_Syntax_Syntax.mk_Tm_app uu____4774 uu____4775
-                        in
+                             let uu____4786 = FStar_Syntax_Syntax.as_arg wp in
+                             [uu____4786] in
+                           uu____4780 :: uu____4783 in
+                         uu____4776 :: uu____4777 in
+                       FStar_Syntax_Syntax.mk_Tm_app uu____4774 uu____4775 in
                      uu____4773 FStar_Pervasives_Native.None
-                       wp.FStar_Syntax_Syntax.pos
-                      in
+                       wp.FStar_Syntax_Syntax.pos in
                    mk_comp md u_res_t res_t wp1 flags1)
-  
-let (strengthen_precondition :
+let strengthen_precondition:
   (Prims.unit -> Prims.string) FStar_Pervasives_Native.option ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Syntax.lcomp ->
           FStar_TypeChecker_Env.guard_t ->
             (FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-              FStar_Pervasives_Native.tuple2)
+              FStar_Pervasives_Native.tuple2
   =
   fun reason  ->
     fun env  ->
       fun e_for_debug_only  ->
         fun lc  ->
           fun g0  ->
-            let uu____4821 = FStar_TypeChecker_Rel.is_trivial g0  in
+            let uu____4821 = FStar_TypeChecker_Rel.is_trivial g0 in
             if uu____4821
             then (lc, g0)
             else
               (let flags1 =
                  let uu____4830 =
-                   let uu____4837 = FStar_Syntax_Util.is_tot_or_gtot_lcomp lc
-                      in
+                   let uu____4837 = FStar_Syntax_Util.is_tot_or_gtot_lcomp lc in
                    if uu____4837
                    then (true, [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION])
-                   else (false, [])  in
+                   else (false, []) in
                  match uu____4830 with
                  | (maybe_trivial_post,flags1) ->
                      let uu____4857 =
@@ -1678,51 +1517,43 @@ let (strengthen_precondition :
                                    [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
                                | FStar_Syntax_Syntax.SHOULD_NOT_INLINE  ->
                                    [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
-                               | uu____4868 -> []))
-                        in
-                     FStar_List.append flags1 uu____4857
-                  in
+                               | uu____4868 -> [])) in
+                     FStar_List.append flags1 uu____4857 in
                let strengthen uu____4872 =
-                 let c = FStar_Syntax_Syntax.lcomp_comp lc  in
+                 let c = FStar_Syntax_Syntax.lcomp_comp lc in
                  if env.FStar_TypeChecker_Env.lax
                  then c
                  else
-                   (let g01 = FStar_TypeChecker_Rel.simplify_guard env g0  in
-                    let uu____4876 = FStar_TypeChecker_Rel.guard_form g01  in
+                   (let g01 = FStar_TypeChecker_Rel.simplify_guard env g0 in
+                    let uu____4876 = FStar_TypeChecker_Rel.guard_form g01 in
                     match uu____4876 with
                     | FStar_TypeChecker_Common.Trivial  -> c
                     | FStar_TypeChecker_Common.NonTrivial f ->
                         ((let uu____4879 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
-                              FStar_Options.Extreme
-                             in
+                              FStar_Options.Extreme in
                           if uu____4879
                           then
                             let uu____4880 =
                               FStar_TypeChecker_Normalize.term_to_string env
-                                e_for_debug_only
-                               in
+                                e_for_debug_only in
                             let uu____4881 =
                               FStar_TypeChecker_Normalize.term_to_string env
-                                f
-                               in
+                                f in
                             FStar_Util.print2
                               "-------------Strengthening pre-condition of term %s with guard %s\n"
                               uu____4880 uu____4881
                           else ());
-                         strengthen_comp env reason c f flags1))
-                  in
+                         strengthen_comp env reason c f flags1)) in
                let uu____4883 =
                  let uu____4884 =
                    FStar_TypeChecker_Env.norm_eff_name env
-                     lc.FStar_Syntax_Syntax.eff_name
-                    in
+                     lc.FStar_Syntax_Syntax.eff_name in
                  FStar_Syntax_Syntax.mk_lcomp uu____4884
-                   lc.FStar_Syntax_Syntax.res_typ flags1 strengthen
-                  in
+                   lc.FStar_Syntax_Syntax.res_typ flags1 strengthen in
                (uu____4883,
-                 (let uu___114_4886 = g0  in
+                 (let uu___114_4886 = g0 in
                   {
                     FStar_TypeChecker_Env.guard_f =
                       FStar_TypeChecker_Common.Trivial;
@@ -1733,20 +1564,17 @@ let (strengthen_precondition :
                     FStar_TypeChecker_Env.implicits =
                       (uu___114_4886.FStar_TypeChecker_Env.implicits)
                   })))
-  
-let (stable_lcomp : FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+let stable_lcomp: FStar_Syntax_Syntax.lcomp -> Prims.bool =
   fun lc  ->
     (FStar_Syntax_Util.is_tot_or_gtot_lcomp lc) ||
       (FStar_Syntax_Util.is_tac_lcomp lc)
-  
-let (stable_comp :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+let stable_comp:
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool =
   fun c  ->
     (FStar_Syntax_Util.is_tot_or_gtot_comp c) ||
       (FStar_Syntax_Util.is_tac_comp c)
-  
-let (lcomp_has_trivial_postcondition :
-  FStar_Syntax_Syntax.lcomp -> Prims.bool) =
+let lcomp_has_trivial_postcondition: FStar_Syntax_Syntax.lcomp -> Prims.bool
+  =
   fun lc  ->
     (stable_lcomp lc) ||
       (FStar_Util.for_some
@@ -1755,12 +1583,11 @@ let (lcomp_has_trivial_postcondition :
             | FStar_Syntax_Syntax.SOMETRIVIAL  -> true
             | FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION  -> true
             | uu____4902 -> false) lc.FStar_Syntax_Syntax.cflags)
-  
-let (maybe_add_with_type :
+let maybe_add_with_type:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option ->
       FStar_Syntax_Syntax.lcomp ->
-        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun uopt  ->
@@ -1768,8 +1595,7 @@ let (maybe_add_with_type :
         fun e  ->
           let uu____4919 =
             (FStar_Syntax_Util.is_lcomp_partial_return lc) ||
-              env.FStar_TypeChecker_Env.lax
-             in
+              env.FStar_TypeChecker_Env.lax in
           if uu____4919
           then e
           else
@@ -1777,10 +1603,8 @@ let (maybe_add_with_type :
                (lcomp_has_trivial_postcondition lc) &&
                  (let uu____4923 =
                     FStar_TypeChecker_Env.try_lookup_lid env
-                      FStar_Parser_Const.with_type_lid
-                     in
-                  FStar_Option.isSome uu____4923)
-                in
+                      FStar_Parser_Const.with_type_lid in
+                  FStar_Option.isSome uu____4923) in
              if uu____4921
              then
                let u =
@@ -1788,18 +1612,16 @@ let (maybe_add_with_type :
                  | FStar_Pervasives_Native.Some u -> u
                  | FStar_Pervasives_Native.None  ->
                      env.FStar_TypeChecker_Env.universe_of env
-                       lc.FStar_Syntax_Syntax.res_typ
-                  in
+                       lc.FStar_Syntax_Syntax.res_typ in
                FStar_Syntax_Util.mk_with_type u
                  lc.FStar_Syntax_Syntax.res_typ e
              else e)
-  
-let (bind :
+let bind:
   FStar_Range.range ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
         FStar_Syntax_Syntax.lcomp ->
-          lcomp_with_binder -> FStar_Syntax_Syntax.lcomp)
+          lcomp_with_binder -> FStar_Syntax_Syntax.lcomp
   =
   fun r1  ->
     fun env  ->
@@ -1813,83 +1635,73 @@ let (bind :
                     (FStar_TypeChecker_Env.debug env FStar_Options.Extreme)
                       ||
                       (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                         (FStar_Options.Other "bind"))
-                     in
-                  if uu____4979 then f () else ()  in
+                         (FStar_Options.Other "bind")) in
+                  if uu____4979 then f () else () in
                 let lc11 =
-                  FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc1  in
+                  FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc1 in
                 let lc21 =
-                  FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc2  in
-                let joined_eff = join_lcomp env lc11 lc21  in
+                  FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc2 in
+                let joined_eff = join_lcomp env lc11 lc21 in
                 let bind_flags =
                   let uu____4987 =
                     (should_not_inline_lc lc11) ||
-                      (should_not_inline_lc lc21)
-                     in
+                      (should_not_inline_lc lc21) in
                   if uu____4987
                   then [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
                   else
                     (let flags1 =
-                       let uu____4994 = FStar_Syntax_Util.is_total_lcomp lc11
-                          in
+                       let uu____4994 = FStar_Syntax_Util.is_total_lcomp lc11 in
                        if uu____4994
                        then
                          let uu____4997 =
-                           FStar_Syntax_Util.is_total_lcomp lc21  in
+                           FStar_Syntax_Util.is_total_lcomp lc21 in
                          (if uu____4997
                           then [FStar_Syntax_Syntax.TOTAL]
                           else
-                            (let uu____5001 = stable_lcomp lc21  in
+                            (let uu____5001 = stable_lcomp lc21 in
                              if uu____5001
                              then [FStar_Syntax_Syntax.SOMETRIVIAL]
                              else []))
                        else
                          (let uu____5006 =
-                            (stable_lcomp lc11) && (stable_lcomp lc21)  in
+                            (stable_lcomp lc11) && (stable_lcomp lc21) in
                           if uu____5006
                           then [FStar_Syntax_Syntax.SOMETRIVIAL]
-                          else [])
-                        in
-                     let uu____5010 = lcomp_has_trivial_postcondition lc21
-                        in
+                          else []) in
+                     let uu____5010 = lcomp_has_trivial_postcondition lc21 in
                      if uu____5010
                      then FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION :: flags1
-                     else flags1)
-                   in
+                     else flags1) in
                 let bind_it uu____5017 =
                   let uu____5018 =
                     env.FStar_TypeChecker_Env.lax &&
-                      (FStar_Options.ml_ish ())
-                     in
+                      (FStar_Options.ml_ish ()) in
                   if uu____5018
                   then
                     let u_t =
                       env.FStar_TypeChecker_Env.universe_of env
-                        lc21.FStar_Syntax_Syntax.res_typ
-                       in
+                        lc21.FStar_Syntax_Syntax.res_typ in
                     lax_mk_tot_or_comp_l joined_eff u_t
                       lc21.FStar_Syntax_Syntax.res_typ []
                   else
-                    (let c1 = FStar_Syntax_Syntax.lcomp_comp lc11  in
-                     let c2 = FStar_Syntax_Syntax.lcomp_comp lc21  in
+                    (let c1 = FStar_Syntax_Syntax.lcomp_comp lc11 in
+                     let c2 = FStar_Syntax_Syntax.lcomp_comp lc21 in
                      debug1
                        (fun uu____5032  ->
                           let uu____5033 =
-                            FStar_Syntax_Print.comp_to_string c1  in
+                            FStar_Syntax_Print.comp_to_string c1 in
                           let uu____5034 =
                             match b with
                             | FStar_Pervasives_Native.None  -> "none"
                             | FStar_Pervasives_Native.Some x ->
-                                FStar_Syntax_Print.bv_to_string x
-                             in
+                                FStar_Syntax_Print.bv_to_string x in
                           let uu____5036 =
-                            FStar_Syntax_Print.comp_to_string c2  in
+                            FStar_Syntax_Print.comp_to_string c2 in
                           FStar_Util.print3
                             "(1) bind: \n\tc1=%s\n\tx=%s\n\tc2=%s\n(1. end bind)\n"
                             uu____5033 uu____5034 uu____5036);
                      (let aux uu____5048 =
-                        let uu____5049 = FStar_Syntax_Util.is_trivial_wp c1
-                           in
+                        let uu____5049 = FStar_Syntax_Util.is_trivial_wp c1 in
                         if uu____5049
                         then
                           match b with
@@ -1897,7 +1709,7 @@ let (bind :
                               FStar_Util.Inl (c2, "trivial no binder")
                           | FStar_Pervasives_Native.Some uu____5070 ->
                               let uu____5071 =
-                                FStar_Syntax_Util.is_ml_comp c2  in
+                                FStar_Syntax_Util.is_ml_comp c2 in
                               (if uu____5071
                                then FStar_Util.Inl (c2, "trivial ml")
                                else
@@ -1906,14 +1718,12 @@ let (bind :
                         else
                           (let uu____5090 =
                              (FStar_Syntax_Util.is_ml_comp c1) &&
-                               (FStar_Syntax_Util.is_ml_comp c2)
-                              in
+                               (FStar_Syntax_Util.is_ml_comp c2) in
                            if uu____5090
                            then FStar_Util.Inl (c2, "both ml")
                            else
                              FStar_Util.Inr
-                               "c1 not trivial, and both are not ML")
-                         in
+                               "c1 not trivial, and both are not ML") in
                       let subst_c2 e1opt1 reason =
                         match (e1opt1, b) with
                         | (FStar_Pervasives_Native.Some
@@ -1921,18 +1731,16 @@ let (bind :
                             let uu____5157 =
                               let uu____5162 =
                                 FStar_Syntax_Subst.subst_comp
-                                  [FStar_Syntax_Syntax.NT (x, e)] c2
-                                 in
-                              (uu____5162, reason)  in
+                                  [FStar_Syntax_Syntax.NT (x, e)] c2 in
+                              (uu____5162, reason) in
                             FStar_Util.Inl uu____5157
-                        | uu____5169 -> aux ()  in
+                        | uu____5169 -> aux () in
                       let try_simplify uu____5191 =
                         let rec maybe_close t x c =
                           let uu____5202 =
                             let uu____5203 =
-                              FStar_TypeChecker_Normalize.unfold_whnf env t
-                               in
-                            uu____5203.FStar_Syntax_Syntax.n  in
+                              FStar_TypeChecker_Normalize.unfold_whnf env t in
+                            uu____5203.FStar_Syntax_Syntax.n in
                           match uu____5202 with
                           | FStar_Syntax_Syntax.Tm_refine (y,uu____5207) ->
                               maybe_close y.FStar_Syntax_Syntax.sort x c
@@ -1940,24 +1748,23 @@ let (bind :
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.unit_lid
                               -> close_comp env [x] c
-                          | uu____5213 -> c  in
+                          | uu____5213 -> c in
                         let uu____5214 =
                           let uu____5215 =
                             FStar_TypeChecker_Env.try_lookup_effect_lid env
-                              FStar_Parser_Const.effect_GTot_lid
-                             in
-                          FStar_Option.isNone uu____5215  in
+                              FStar_Parser_Const.effect_GTot_lid in
+                          FStar_Option.isNone uu____5215 in
                         if uu____5214
                         then
                           let uu____5226 =
-                            (stable_comp c1) && (stable_comp c2)  in
+                            (stable_comp c1) && (stable_comp c2) in
                           (if uu____5226
                            then
                              FStar_Util.Inl
                                (c2, "Early in prims; we don't have bind yet")
                            else
                              (let uu____5240 =
-                                FStar_TypeChecker_Env.get_range env  in
+                                FStar_TypeChecker_Env.get_range env in
                               FStar_Errors.raise_error
                                 (FStar_Errors.Fatal_NonTrivialPreConditionInPrims,
                                   "Non-trivial pre-conditions very early in prims, even before we have defined the PURE monad")
@@ -1965,40 +1772,35 @@ let (bind :
                         else
                           (let uu____5250 =
                              (FStar_Syntax_Util.is_total_comp c1) &&
-                               (FStar_Syntax_Util.is_total_comp c2)
-                              in
+                               (FStar_Syntax_Util.is_total_comp c2) in
                            if uu____5250
                            then subst_c2 e1opt "both total"
                            else
                              (let uu____5260 =
                                 (FStar_Syntax_Util.is_tot_or_gtot_comp c1) &&
-                                  (FStar_Syntax_Util.is_tot_or_gtot_comp c2)
-                                 in
+                                  (FStar_Syntax_Util.is_tot_or_gtot_comp c2) in
                               if uu____5260
                               then
                                 let uu____5269 =
                                   let uu____5274 =
                                     FStar_Syntax_Syntax.mk_GTotal
-                                      (FStar_Syntax_Util.comp_result c2)
-                                     in
-                                  (uu____5274, "both gtot")  in
+                                      (FStar_Syntax_Util.comp_result c2) in
+                                  (uu____5274, "both gtot") in
                                 FStar_Util.Inl uu____5269
                               else
                                 (let uu____5280 =
-                                   (stable_comp c1) && (stable_comp c2)  in
+                                   (stable_comp c1) && (stable_comp c2) in
                                  if uu____5280
                                  then
-                                   let ty = FStar_Syntax_Util.comp_result c2
-                                      in
+                                   let ty = FStar_Syntax_Util.comp_result c2 in
                                    let uu____5292 =
                                      let uu____5297 =
                                        let uu____5298 =
                                          let uu____5299 =
                                            let uu____5300 =
                                              env.FStar_TypeChecker_Env.universe_of
-                                               env ty
-                                              in
-                                           [uu____5300]  in
+                                               env ty in
+                                           [uu____5300] in
                                          {
                                            FStar_Syntax_Syntax.comp_univs =
                                              uu____5299;
@@ -2011,10 +1813,9 @@ let (bind :
                                            FStar_Syntax_Syntax.flags =
                                              [FStar_Syntax_Syntax.SOMETRIVIAL;
                                              FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
-                                         }  in
-                                       FStar_Syntax_Syntax.mk_Comp uu____5298
-                                        in
-                                     (uu____5297, "both Tac")  in
+                                         } in
+                                       FStar_Syntax_Syntax.mk_Comp uu____5298 in
+                                     (uu____5297, "both Tac") in
                                    FStar_Util.Inl uu____5292
                                  else
                                    (match (e1opt, b) with
@@ -2025,19 +1826,16 @@ let (bind :
                                             &&
                                             (let uu____5332 =
                                                FStar_Syntax_Syntax.is_null_bv
-                                                 x
-                                                in
-                                             Prims.op_Negation uu____5332)
-                                           in
+                                                 x in
+                                             Prims.op_Negation uu____5332) in
                                         if uu____5330
                                         then
                                           let c21 =
                                             FStar_Syntax_Subst.subst_comp
                                               [FStar_Syntax_Syntax.NT (x, e)]
-                                              c2
-                                             in
+                                              c2 in
                                           let x1 =
-                                            let uu___115_5343 = x  in
+                                            let uu___115_5343 = x in
                                             {
                                               FStar_Syntax_Syntax.ppname =
                                                 (uu___115_5343.FStar_Syntax_Syntax.ppname);
@@ -2046,25 +1844,23 @@ let (bind :
                                               FStar_Syntax_Syntax.sort =
                                                 (FStar_Syntax_Util.comp_result
                                                    c1)
-                                            }  in
+                                            } in
                                           let uu____5344 =
                                             let uu____5349 =
                                               maybe_close
                                                 x1.FStar_Syntax_Syntax.sort
-                                                x1 c21
-                                               in
-                                            (uu____5349, "c1 Tot")  in
+                                                x1 c21 in
+                                            (uu____5349, "c1 Tot") in
                                           FStar_Util.Inl uu____5344
                                         else aux ()
-                                    | uu____5355 -> aux ()))))
-                         in
-                      let uu____5364 = try_simplify ()  in
+                                    | uu____5355 -> aux ())))) in
+                      let uu____5364 = try_simplify () in
                       match uu____5364 with
                       | FStar_Util.Inl (c,reason) ->
                           (debug1
                              (fun uu____5384  ->
                                 let uu____5385 =
-                                  FStar_Syntax_Print.comp_to_string c  in
+                                  FStar_Syntax_Print.comp_to_string c in
                                 FStar_Util.print2
                                   "(2) bind: Simplified (because %s) to\n\t%s\n"
                                   reason uu____5385);
@@ -2076,170 +1872,141 @@ let (bind :
                                   "(2) bind: Not simplified because %s\n"
                                   reason);
                            (let mk_bind c11 b1 c21 =
-                              let uu____5409 = lift_and_destruct env c11 c21
-                                 in
+                              let uu____5409 = lift_and_destruct env c11 c21 in
                               match uu____5409 with
                               | ((md,a,kwp),(u_t1,t1,wp1),(u_t2,t2,wp2)) ->
                                   let bs =
                                     match b1 with
                                     | FStar_Pervasives_Native.None  ->
                                         let uu____5466 =
-                                          FStar_Syntax_Syntax.null_binder t1
-                                           in
+                                          FStar_Syntax_Syntax.null_binder t1 in
                                         [uu____5466]
                                     | FStar_Pervasives_Native.Some x ->
                                         let uu____5468 =
-                                          FStar_Syntax_Syntax.mk_binder x  in
-                                        [uu____5468]
-                                     in
+                                          FStar_Syntax_Syntax.mk_binder x in
+                                        [uu____5468] in
                                   let mk_lam wp =
                                     FStar_Syntax_Util.abs bs wp
                                       (FStar_Pervasives_Native.Some
                                          (FStar_Syntax_Util.mk_residual_comp
                                             FStar_Parser_Const.effect_Tot_lid
                                             FStar_Pervasives_Native.None
-                                            [FStar_Syntax_Syntax.TOTAL]))
-                                     in
+                                            [FStar_Syntax_Syntax.TOTAL])) in
                                   let r11 =
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_constant
                                          (FStar_Const.Const_range r1))
-                                      FStar_Pervasives_Native.None r1
-                                     in
+                                      FStar_Pervasives_Native.None r1 in
                                   let wp_args =
                                     let uu____5481 =
-                                      FStar_Syntax_Syntax.as_arg r11  in
+                                      FStar_Syntax_Syntax.as_arg r11 in
                                     let uu____5482 =
                                       let uu____5485 =
-                                        FStar_Syntax_Syntax.as_arg t1  in
+                                        FStar_Syntax_Syntax.as_arg t1 in
                                       let uu____5486 =
                                         let uu____5489 =
-                                          FStar_Syntax_Syntax.as_arg t2  in
+                                          FStar_Syntax_Syntax.as_arg t2 in
                                         let uu____5490 =
                                           let uu____5493 =
-                                            FStar_Syntax_Syntax.as_arg wp1
-                                             in
+                                            FStar_Syntax_Syntax.as_arg wp1 in
                                           let uu____5494 =
                                             let uu____5497 =
-                                              let uu____5498 = mk_lam wp2  in
+                                              let uu____5498 = mk_lam wp2 in
                                               FStar_Syntax_Syntax.as_arg
-                                                uu____5498
-                                               in
-                                            [uu____5497]  in
-                                          uu____5493 :: uu____5494  in
-                                        uu____5489 :: uu____5490  in
-                                      uu____5485 :: uu____5486  in
-                                    uu____5481 :: uu____5482  in
+                                                uu____5498 in
+                                            [uu____5497] in
+                                          uu____5493 :: uu____5494 in
+                                        uu____5489 :: uu____5490 in
+                                      uu____5485 :: uu____5486 in
+                                    uu____5481 :: uu____5482 in
                                   let wp =
                                     let uu____5502 =
                                       let uu____5503 =
                                         FStar_TypeChecker_Env.inst_effect_fun_with
                                           [u_t1; u_t2] env md
-                                          md.FStar_Syntax_Syntax.bind_wp
-                                         in
+                                          md.FStar_Syntax_Syntax.bind_wp in
                                       FStar_Syntax_Syntax.mk_Tm_app
-                                        uu____5503 wp_args
-                                       in
+                                        uu____5503 wp_args in
                                     uu____5502 FStar_Pervasives_Native.None
-                                      t2.FStar_Syntax_Syntax.pos
-                                     in
-                                  mk_comp md u_t2 t2 wp bind_flags
-                               in
+                                      t2.FStar_Syntax_Syntax.pos in
+                                  mk_comp md u_t2 t2 wp bind_flags in
                             let mk_seq c11 b1 c21 =
                               let c12 =
                                 FStar_TypeChecker_Env.unfold_effect_abbrev
-                                  env c11
-                                 in
+                                  env c11 in
                               let c22 =
                                 FStar_TypeChecker_Env.unfold_effect_abbrev
-                                  env c21
-                                 in
+                                  env c21 in
                               let uu____5522 =
                                 FStar_TypeChecker_Env.join env
                                   c12.FStar_Syntax_Syntax.effect_name
-                                  c22.FStar_Syntax_Syntax.effect_name
-                                 in
+                                  c22.FStar_Syntax_Syntax.effect_name in
                               match uu____5522 with
                               | (m,uu____5530,lift2) ->
                                   let c23 =
-                                    let uu____5533 = lift_comp c22 m lift2
-                                       in
-                                    FStar_Syntax_Syntax.mk_Comp uu____5533
-                                     in
-                                  let uu____5534 = destruct_comp c12  in
+                                    let uu____5533 = lift_comp c22 m lift2 in
+                                    FStar_Syntax_Syntax.mk_Comp uu____5533 in
+                                  let uu____5534 = destruct_comp c12 in
                                   (match uu____5534 with
                                    | (u1,t1,wp1) ->
                                        let md_pure_or_ghost =
                                          FStar_TypeChecker_Env.get_effect_decl
                                            env
-                                           c12.FStar_Syntax_Syntax.effect_name
-                                          in
+                                           c12.FStar_Syntax_Syntax.effect_name in
                                        let vc1 =
                                          let uu____5548 =
                                            let uu____5549 =
                                              FStar_TypeChecker_Env.inst_effect_fun_with
                                                [u1] env md_pure_or_ghost
-                                               md_pure_or_ghost.FStar_Syntax_Syntax.trivial
-                                              in
+                                               md_pure_or_ghost.FStar_Syntax_Syntax.trivial in
                                            let uu____5550 =
                                              let uu____5551 =
-                                               FStar_Syntax_Syntax.as_arg t1
-                                                in
+                                               FStar_Syntax_Syntax.as_arg t1 in
                                              let uu____5552 =
                                                let uu____5555 =
                                                  FStar_Syntax_Syntax.as_arg
-                                                   wp1
-                                                  in
-                                               [uu____5555]  in
-                                             uu____5551 :: uu____5552  in
+                                                   wp1 in
+                                               [uu____5555] in
+                                             uu____5551 :: uu____5552 in
                                            FStar_Syntax_Syntax.mk_Tm_app
-                                             uu____5549 uu____5550
-                                            in
+                                             uu____5549 uu____5550 in
                                          uu____5548
-                                           FStar_Pervasives_Native.None r1
-                                          in
+                                           FStar_Pervasives_Native.None r1 in
                                        strengthen_comp env
                                          FStar_Pervasives_Native.None c23 vc1
-                                         bind_flags)
-                               in
+                                         bind_flags) in
                             let c1_typ =
                               FStar_TypeChecker_Env.unfold_effect_abbrev env
-                                c1
-                               in
-                            let uu____5561 = destruct_comp c1_typ  in
+                                c1 in
+                            let uu____5561 = destruct_comp c1_typ in
                             match uu____5561 with
                             | (u_res_t1,res_t1,uu____5570) ->
                                 let uu____5571 =
                                   (FStar_Option.isSome b) &&
-                                    (should_return env e1opt lc11)
-                                   in
+                                    (should_return env e1opt lc11) in
                                 if uu____5571
                                 then
-                                  let e1 = FStar_Option.get e1opt  in
-                                  let x = FStar_Option.get b  in
+                                  let e1 = FStar_Option.get e1opt in
+                                  let x = FStar_Option.get b in
                                   let uu____5574 =
-                                    FStar_Syntax_Util.is_partial_return c1
-                                     in
+                                    FStar_Syntax_Util.is_partial_return c1 in
                                   (if uu____5574
                                    then
                                      (debug1
                                         (fun uu____5582  ->
                                            let uu____5583 =
                                              FStar_TypeChecker_Normalize.term_to_string
-                                               env e1
-                                              in
+                                               env e1 in
                                            let uu____5584 =
                                              FStar_Syntax_Print.bv_to_string
-                                               x
-                                              in
+                                               x in
                                            FStar_Util.print2
                                              "(3) bind (case a): Substituting %s for %s"
                                              uu____5583 uu____5584);
                                       (let c21 =
                                          FStar_Syntax_Subst.subst_comp
                                            [FStar_Syntax_Syntax.NT (x, e1)]
-                                           c2
-                                          in
+                                           c2 in
                                        mk_bind c1 b c21))
                                    else
                                      (let uu____5587 =
@@ -2252,94 +2019,80 @@ let (bind :
                                           (let uu____5589 =
                                              FStar_TypeChecker_Env.try_lookup_lid
                                                env
-                                               FStar_Parser_Const.with_type_lid
-                                              in
-                                           FStar_Option.isSome uu____5589)
-                                         in
+                                               FStar_Parser_Const.with_type_lid in
+                                           FStar_Option.isSome uu____5589) in
                                       if uu____5587
                                       then
                                         let e1' =
                                           let uu____5611 =
                                             FStar_Options.vcgen_decorate_with_type
-                                              ()
-                                             in
+                                              () in
                                           if uu____5611
                                           then
                                             FStar_Syntax_Util.mk_with_type
                                               u_res_t1 res_t1 e1
-                                          else e1  in
+                                          else e1 in
                                         (debug1
                                            (fun uu____5622  ->
                                               let uu____5623 =
                                                 FStar_TypeChecker_Normalize.term_to_string
-                                                  env e1'
-                                                 in
+                                                  env e1' in
                                               let uu____5624 =
                                                 FStar_Syntax_Print.bv_to_string
-                                                  x
-                                                 in
+                                                  x in
                                               FStar_Util.print2
                                                 "(3) bind (case b): Substituting %s for %s"
                                                 uu____5623 uu____5624);
                                          (let c21 =
                                             FStar_Syntax_Subst.subst_comp
                                               [FStar_Syntax_Syntax.NT
-                                                 (x, e1')] c2
-                                             in
+                                                 (x, e1')] c2 in
                                           mk_seq c1 b c21))
                                       else
                                         (debug1
                                            (fun uu____5636  ->
                                               let uu____5637 =
                                                 FStar_TypeChecker_Normalize.term_to_string
-                                                  env e1
-                                                 in
+                                                  env e1 in
                                               let uu____5638 =
                                                 FStar_Syntax_Print.bv_to_string
-                                                  x
-                                                 in
+                                                  x in
                                               FStar_Util.print2
                                                 "(3) bind (case c): Adding equality %s = %s"
                                                 uu____5637 uu____5638);
                                          (let c21 =
                                             FStar_Syntax_Subst.subst_comp
                                               [FStar_Syntax_Syntax.NT (x, e1)]
-                                              c2
-                                             in
+                                              c2 in
                                           let x_eq_e =
                                             let uu____5641 =
                                               FStar_Syntax_Syntax.bv_to_name
-                                                x
-                                               in
+                                                x in
                                             FStar_Syntax_Util.mk_eq2 u_res_t1
-                                              res_t1 e1 uu____5641
-                                             in
+                                              res_t1 e1 uu____5641 in
                                           let c22 =
-                                            weaken_comp env c21 x_eq_e  in
+                                            weaken_comp env c21 x_eq_e in
                                           mk_bind c1 b c22))))
-                                else mk_bind c1 b c2))))
-                   in
+                                else mk_bind c1 b c2)))) in
                 FStar_Syntax_Syntax.mk_lcomp joined_eff
                   lc21.FStar_Syntax_Syntax.res_typ bind_flags bind_it
-  
-let (weaken_guard :
+let weaken_guard:
   FStar_TypeChecker_Common.guard_formula ->
     FStar_TypeChecker_Common.guard_formula ->
-      FStar_TypeChecker_Common.guard_formula)
+      FStar_TypeChecker_Common.guard_formula
   =
   fun g1  ->
     fun g2  ->
       match (g1, g2) with
       | (FStar_TypeChecker_Common.NonTrivial
          f1,FStar_TypeChecker_Common.NonTrivial f2) ->
-          let g = FStar_Syntax_Util.mk_imp f1 f2  in
+          let g = FStar_Syntax_Util.mk_imp f1 f2 in
           FStar_TypeChecker_Common.NonTrivial g
       | uu____5653 -> g2
-  
-let (maybe_assume_result_eq_pure_term :
+let maybe_assume_result_eq_pure_term:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp)
+      FStar_Syntax_Syntax.lcomp -> FStar_Syntax_Syntax.lcomp
   =
   fun env  ->
     fun e  ->
@@ -2350,44 +2103,40 @@ let (maybe_assume_result_eq_pure_term :
                  FStar_Parser_Const.effect_GTot_lid))
              && (should_return env (FStar_Pervasives_Native.Some e) lc))
             &&
-            (let uu____5669 = FStar_Syntax_Util.is_lcomp_partial_return lc
-                in
-             Prims.op_Negation uu____5669)
-           in
+            (let uu____5669 = FStar_Syntax_Util.is_lcomp_partial_return lc in
+             Prims.op_Negation uu____5669) in
         let flags1 =
           if should_return1
           then
-            let uu____5675 = FStar_Syntax_Util.is_total_lcomp lc  in
+            let uu____5675 = FStar_Syntax_Util.is_total_lcomp lc in
             (if uu____5675
              then FStar_Syntax_Syntax.RETURN ::
                (lc.FStar_Syntax_Syntax.cflags)
              else FStar_Syntax_Syntax.PARTIAL_RETURN ::
                (lc.FStar_Syntax_Syntax.cflags))
-          else lc.FStar_Syntax_Syntax.cflags  in
+          else lc.FStar_Syntax_Syntax.cflags in
         let refine1 uu____5683 =
-          let c = FStar_Syntax_Syntax.lcomp_comp lc  in
+          let c = FStar_Syntax_Syntax.lcomp_comp lc in
           let u_t =
             match comp_univ_opt c with
             | FStar_Pervasives_Native.Some u_t -> u_t
             | FStar_Pervasives_Native.None  ->
                 env.FStar_TypeChecker_Env.universe_of env
-                  (FStar_Syntax_Util.comp_result c)
-             in
-          let uu____5687 = FStar_Syntax_Util.is_tot_or_gtot_comp c  in
+                  (FStar_Syntax_Util.comp_result c) in
+          let uu____5687 = FStar_Syntax_Util.is_tot_or_gtot_comp c in
           if uu____5687
           then
             let retc =
               return_value env (FStar_Pervasives_Native.Some u_t)
-                (FStar_Syntax_Util.comp_result c) e
-               in
+                (FStar_Syntax_Util.comp_result c) e in
             let uu____5689 =
-              let uu____5690 = FStar_Syntax_Util.is_pure_comp c  in
-              Prims.op_Negation uu____5690  in
+              let uu____5690 = FStar_Syntax_Util.is_pure_comp c in
+              Prims.op_Negation uu____5690 in
             (if uu____5689
              then
-               let retc1 = FStar_Syntax_Util.comp_to_comp_typ retc  in
+               let retc1 = FStar_Syntax_Util.comp_to_comp_typ retc in
                let retc2 =
-                 let uu___116_5693 = retc1  in
+                 let uu___116_5693 = retc1 in
                  {
                    FStar_Syntax_Syntax.comp_univs =
                      (uu___116_5693.FStar_Syntax_Syntax.comp_univs);
@@ -2398,56 +2147,48 @@ let (maybe_assume_result_eq_pure_term :
                    FStar_Syntax_Syntax.effect_args =
                      (uu___116_5693.FStar_Syntax_Syntax.effect_args);
                    FStar_Syntax_Syntax.flags = flags1
-                 }  in
+                 } in
                FStar_Syntax_Syntax.mk_Comp retc2
              else FStar_Syntax_Util.comp_set_flags retc flags1)
           else
-            (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c  in
-             let t = c1.FStar_Syntax_Syntax.result_typ  in
-             let c2 = FStar_Syntax_Syntax.mk_Comp c1  in
+            (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
+             let t = c1.FStar_Syntax_Syntax.result_typ in
+             let c2 = FStar_Syntax_Syntax.mk_Comp c1 in
              let x =
                FStar_Syntax_Syntax.new_bv
-                 (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos)) t
-                in
-             let xexp = FStar_Syntax_Syntax.bv_to_name x  in
+                 (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos)) t in
+             let xexp = FStar_Syntax_Syntax.bv_to_name x in
              let ret1 =
                let uu____5704 =
                  let uu____5707 =
-                   return_value env (FStar_Pervasives_Native.Some u_t) t xexp
-                    in
+                   return_value env (FStar_Pervasives_Native.Some u_t) t xexp in
                  FStar_Syntax_Util.comp_set_flags uu____5707
-                   [FStar_Syntax_Syntax.PARTIAL_RETURN]
-                  in
-               FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____5704
-                in
-             let eq1 = FStar_Syntax_Util.mk_eq2 u_t t xexp e  in
+                   [FStar_Syntax_Syntax.PARTIAL_RETURN] in
+               FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp uu____5704 in
+             let eq1 = FStar_Syntax_Util.mk_eq2 u_t t xexp e in
              let eq_ret =
                weaken_precondition env ret1
-                 (FStar_TypeChecker_Common.NonTrivial eq1)
-                in
+                 (FStar_TypeChecker_Common.NonTrivial eq1) in
              let uu____5712 =
                let uu____5713 =
-                 let uu____5714 = FStar_Syntax_Util.lcomp_of_comp c2  in
+                 let uu____5714 = FStar_Syntax_Util.lcomp_of_comp c2 in
                  bind e.FStar_Syntax_Syntax.pos env
                    FStar_Pervasives_Native.None uu____5714
-                   ((FStar_Pervasives_Native.Some x), eq_ret)
-                  in
-               FStar_Syntax_Syntax.lcomp_comp uu____5713  in
-             FStar_Syntax_Util.comp_set_flags uu____5712 flags1)
-           in
+                   ((FStar_Pervasives_Native.Some x), eq_ret) in
+               FStar_Syntax_Syntax.lcomp_comp uu____5713 in
+             FStar_Syntax_Util.comp_set_flags uu____5712 flags1) in
         if Prims.op_Negation should_return1
         then lc
         else
           FStar_Syntax_Syntax.mk_lcomp lc.FStar_Syntax_Syntax.eff_name
             lc.FStar_Syntax_Syntax.res_typ flags1 refine1
-  
-let (maybe_return_e2_and_bind :
+let maybe_return_e2_and_bind:
   FStar_Range.range ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
         FStar_Syntax_Syntax.lcomp ->
           FStar_Syntax_Syntax.term ->
-            lcomp_with_binder -> FStar_Syntax_Syntax.lcomp)
+            lcomp_with_binder -> FStar_Syntax_Syntax.lcomp
   =
   fun r  ->
     fun env  ->
@@ -2460,42 +2201,37 @@ let (maybe_return_e2_and_bind :
                   let lc21 =
                     let eff1 =
                       FStar_TypeChecker_Env.norm_eff_name env
-                        lc1.FStar_Syntax_Syntax.eff_name
-                       in
+                        lc1.FStar_Syntax_Syntax.eff_name in
                     let eff2 =
                       FStar_TypeChecker_Env.norm_eff_name env
-                        lc2.FStar_Syntax_Syntax.eff_name
-                       in
+                        lc2.FStar_Syntax_Syntax.eff_name in
                     let uu____5749 =
-                      ((let uu____5752 = is_pure_or_ghost_effect env eff1  in
+                      ((let uu____5752 = is_pure_or_ghost_effect env eff1 in
                         Prims.op_Negation uu____5752) ||
                          (should_not_inline_lc lc1))
-                        && (is_pure_or_ghost_effect env eff2)
-                       in
+                        && (is_pure_or_ghost_effect env eff2) in
                     if uu____5749
                     then maybe_assume_result_eq_pure_term env e2 lc2
-                    else lc2  in
+                    else lc2 in
                   bind r env e1opt lc1 (x, lc21)
-  
-let (fvar_const :
-  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term)
+let fvar_const:
+  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun lid  ->
       let uu____5762 =
-        let uu____5763 = FStar_TypeChecker_Env.get_range env  in
-        FStar_Ident.set_lid_range lid uu____5763  in
+        let uu____5763 = FStar_TypeChecker_Env.get_range env in
+        FStar_Ident.set_lid_range lid uu____5763 in
       FStar_Syntax_Syntax.fvar uu____5762 FStar_Syntax_Syntax.Delta_constant
         FStar_Pervasives_Native.None
-  
-let (bind_cases :
+let bind_cases:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
       (FStar_Syntax_Syntax.typ,FStar_Ident.lident,FStar_Syntax_Syntax.cflags
                                                     Prims.list,Prims.bool ->
                                                                  FStar_Syntax_Syntax.lcomp)
         FStar_Pervasives_Native.tuple4 Prims.list ->
-        FStar_Syntax_Syntax.lcomp)
+        FStar_Syntax_Syntax.lcomp
   =
   fun env  ->
     fun res_t  ->
@@ -2507,8 +2243,7 @@ let (bind_cases :
                  match uu____5822 with
                  | (uu____5835,eff_label,uu____5837,uu____5838) ->
                      join_effects env eff eff_label)
-            FStar_Parser_Const.effect_PURE_lid lcases
-           in
+            FStar_Parser_Const.effect_PURE_lid lcases in
         let uu____5847 =
           let uu____5854 =
             FStar_All.pipe_right lcases
@@ -2522,105 +2257,88 @@ let (bind_cases :
                                 match uu___86_5914 with
                                 | FStar_Syntax_Syntax.SHOULD_NOT_INLINE  ->
                                     true
-                                | uu____5915 -> false))))
-             in
+                                | uu____5915 -> false)))) in
           if uu____5854
           then (true, [FStar_Syntax_Syntax.SHOULD_NOT_INLINE])
-          else (false, [])  in
+          else (false, []) in
         match uu____5847 with
         | (should_not_inline_whole_match,bind_cases_flags) ->
             let bind_cases uu____5936 =
-              let u_res_t = env.FStar_TypeChecker_Env.universe_of env res_t
-                 in
+              let u_res_t = env.FStar_TypeChecker_Env.universe_of env res_t in
               let uu____5938 =
-                env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ())
-                 in
+                env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
               if uu____5938
               then lax_mk_tot_or_comp_l eff u_res_t res_t []
               else
                 (let ifthenelse md res_t1 g wp_t wp_e =
                    let uu____5958 =
                      FStar_Range.union_ranges wp_t.FStar_Syntax_Syntax.pos
-                       wp_e.FStar_Syntax_Syntax.pos
-                      in
+                       wp_e.FStar_Syntax_Syntax.pos in
                    let uu____5959 =
                      let uu____5960 =
                        FStar_TypeChecker_Env.inst_effect_fun_with [u_res_t]
-                         env md md.FStar_Syntax_Syntax.if_then_else
-                        in
+                         env md md.FStar_Syntax_Syntax.if_then_else in
                      let uu____5961 =
-                       let uu____5962 = FStar_Syntax_Syntax.as_arg res_t1  in
+                       let uu____5962 = FStar_Syntax_Syntax.as_arg res_t1 in
                        let uu____5963 =
-                         let uu____5966 = FStar_Syntax_Syntax.as_arg g  in
+                         let uu____5966 = FStar_Syntax_Syntax.as_arg g in
                          let uu____5967 =
-                           let uu____5970 = FStar_Syntax_Syntax.as_arg wp_t
-                              in
+                           let uu____5970 = FStar_Syntax_Syntax.as_arg wp_t in
                            let uu____5971 =
-                             let uu____5974 = FStar_Syntax_Syntax.as_arg wp_e
-                                in
-                             [uu____5974]  in
-                           uu____5970 :: uu____5971  in
-                         uu____5966 :: uu____5967  in
-                       uu____5962 :: uu____5963  in
-                     FStar_Syntax_Syntax.mk_Tm_app uu____5960 uu____5961  in
-                   uu____5959 FStar_Pervasives_Native.None uu____5958  in
+                             let uu____5974 = FStar_Syntax_Syntax.as_arg wp_e in
+                             [uu____5974] in
+                           uu____5970 :: uu____5971 in
+                         uu____5966 :: uu____5967 in
+                       uu____5962 :: uu____5963 in
+                     FStar_Syntax_Syntax.mk_Tm_app uu____5960 uu____5961 in
+                   uu____5959 FStar_Pervasives_Native.None uu____5958 in
                  let default_case =
                    let post_k =
                      let uu____5981 =
-                       let uu____5988 = FStar_Syntax_Syntax.null_binder res_t
-                          in
-                       [uu____5988]  in
+                       let uu____5988 = FStar_Syntax_Syntax.null_binder res_t in
+                       [uu____5988] in
                      let uu____5989 =
-                       FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0
-                        in
-                     FStar_Syntax_Util.arrow uu____5981 uu____5989  in
+                       FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
+                     FStar_Syntax_Util.arrow uu____5981 uu____5989 in
                    let kwp =
                      let uu____5995 =
                        let uu____6002 =
-                         FStar_Syntax_Syntax.null_binder post_k  in
-                       [uu____6002]  in
+                         FStar_Syntax_Syntax.null_binder post_k in
+                       [uu____6002] in
                      let uu____6003 =
-                       FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0
-                        in
-                     FStar_Syntax_Util.arrow uu____5995 uu____6003  in
+                       FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
+                     FStar_Syntax_Util.arrow uu____5995 uu____6003 in
                    let post =
                      FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                       post_k
-                      in
+                       post_k in
                    let wp =
                      let uu____6008 =
-                       let uu____6009 = FStar_Syntax_Syntax.mk_binder post
-                          in
-                       [uu____6009]  in
+                       let uu____6009 = FStar_Syntax_Syntax.mk_binder post in
+                       [uu____6009] in
                      let uu____6010 =
                        let uu____6011 =
-                         let uu____6014 = FStar_TypeChecker_Env.get_range env
-                            in
+                         let uu____6014 = FStar_TypeChecker_Env.get_range env in
                          label FStar_TypeChecker_Err.exhaustiveness_check
-                           uu____6014
-                          in
+                           uu____6014 in
                        let uu____6015 =
-                         fvar_const env FStar_Parser_Const.false_lid  in
-                       FStar_All.pipe_left uu____6011 uu____6015  in
+                         fvar_const env FStar_Parser_Const.false_lid in
+                       FStar_All.pipe_left uu____6011 uu____6015 in
                      FStar_Syntax_Util.abs uu____6008 uu____6010
                        (FStar_Pervasives_Native.Some
                           (FStar_Syntax_Util.mk_residual_comp
                              FStar_Parser_Const.effect_Tot_lid
                              FStar_Pervasives_Native.None
-                             [FStar_Syntax_Syntax.TOTAL]))
-                      in
+                             [FStar_Syntax_Syntax.TOTAL])) in
                    let md =
                      FStar_TypeChecker_Env.get_effect_decl env
-                       FStar_Parser_Const.effect_PURE_lid
-                      in
-                   mk_comp md u_res_t res_t wp []  in
+                       FStar_Parser_Const.effect_PURE_lid in
+                   mk_comp md u_res_t res_t wp [] in
                  let maybe_return eff_label_then cthen =
                    let uu____6031 =
                      should_not_inline_whole_match ||
-                       (let uu____6033 = is_pure_or_ghost_effect env eff  in
-                        Prims.op_Negation uu____6033)
-                      in
-                   if uu____6031 then cthen true else cthen false  in
+                       (let uu____6033 = is_pure_or_ghost_effect env eff in
+                        Prims.op_Negation uu____6033) in
+                   if uu____6031 then cthen true else cthen false in
                  let comp =
                    FStar_List.fold_right
                      (fun uu____6065  ->
@@ -2630,30 +2348,26 @@ let (bind_cases :
                               let uu____6091 =
                                 let uu____6116 =
                                   let uu____6117 =
-                                    maybe_return eff_label cthen  in
-                                  FStar_Syntax_Syntax.lcomp_comp uu____6117
-                                   in
-                                lift_and_destruct env uu____6116 celse  in
+                                    maybe_return eff_label cthen in
+                                  FStar_Syntax_Syntax.lcomp_comp uu____6117 in
+                                lift_and_destruct env uu____6116 celse in
                               (match uu____6091 with
                                | ((md,uu____6119,uu____6120),(uu____6121,uu____6122,wp_then),
                                   (uu____6124,uu____6125,wp_else)) ->
                                    let uu____6145 =
-                                     ifthenelse md res_t g wp_then wp_else
-                                      in
+                                     ifthenelse md res_t g wp_then wp_else in
                                    mk_comp md u_res_t res_t uu____6145 []))
-                     lcases default_case
-                    in
+                     lcases default_case in
                  match lcases with
                  | [] -> comp
                  | uu____6158::[] -> comp
                  | uu____6195 ->
                      let comp1 =
-                       FStar_TypeChecker_Env.comp_to_comp_typ env comp  in
+                       FStar_TypeChecker_Env.comp_to_comp_typ env comp in
                      let md =
                        FStar_TypeChecker_Env.get_effect_decl env
-                         comp1.FStar_Syntax_Syntax.effect_name
-                        in
-                     let uu____6212 = destruct_comp comp1  in
+                         comp1.FStar_Syntax_Syntax.effect_name in
+                     let uu____6212 = destruct_comp comp1 in
                      (match uu____6212 with
                       | (uu____6219,uu____6220,wp) ->
                           let wp1 =
@@ -2661,74 +2375,67 @@ let (bind_cases :
                               let uu____6226 =
                                 FStar_TypeChecker_Env.inst_effect_fun_with
                                   [u_res_t] env md
-                                  md.FStar_Syntax_Syntax.ite_wp
-                                 in
+                                  md.FStar_Syntax_Syntax.ite_wp in
                               let uu____6227 =
                                 let uu____6228 =
-                                  FStar_Syntax_Syntax.as_arg res_t  in
+                                  FStar_Syntax_Syntax.as_arg res_t in
                                 let uu____6229 =
                                   let uu____6232 =
-                                    FStar_Syntax_Syntax.as_arg wp  in
-                                  [uu____6232]  in
-                                uu____6228 :: uu____6229  in
+                                    FStar_Syntax_Syntax.as_arg wp in
+                                  [uu____6232] in
+                                uu____6228 :: uu____6229 in
                               FStar_Syntax_Syntax.mk_Tm_app uu____6226
-                                uu____6227
-                               in
+                                uu____6227 in
                             uu____6225 FStar_Pervasives_Native.None
-                              wp.FStar_Syntax_Syntax.pos
-                             in
-                          mk_comp md u_res_t res_t wp1 bind_cases_flags))
-               in
+                              wp.FStar_Syntax_Syntax.pos in
+                          mk_comp md u_res_t res_t wp1 bind_cases_flags)) in
             FStar_Syntax_Syntax.mk_lcomp eff res_t bind_cases_flags
               bind_cases
-  
-let (check_comp :
+let check_comp:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.comp ->
         FStar_Syntax_Syntax.comp ->
           (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.comp,FStar_TypeChecker_Env.guard_t)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       fun c  ->
         fun c'  ->
-          let uu____6259 = FStar_TypeChecker_Rel.sub_comp env c c'  in
+          let uu____6259 = FStar_TypeChecker_Rel.sub_comp env c c' in
           match uu____6259 with
           | FStar_Pervasives_Native.None  ->
               let uu____6268 =
                 FStar_TypeChecker_Err.computed_computation_type_does_not_match_annotation
-                  env e c c'
-                 in
-              let uu____6273 = FStar_TypeChecker_Env.get_range env  in
+                  env e c c' in
+              let uu____6273 = FStar_TypeChecker_Env.get_range env in
               FStar_Errors.raise_error uu____6268 uu____6273
           | FStar_Pervasives_Native.Some g -> (e, c', g)
-  
-let (maybe_coerce_bool_to_type :
+let maybe_coerce_bool_to_type:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.lcomp ->
         FStar_Syntax_Syntax.typ ->
           (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun e  ->
       fun lc  ->
         fun t  ->
           let is_type1 t1 =
-            let t2 = FStar_TypeChecker_Normalize.unfold_whnf env t1  in
+            let t2 = FStar_TypeChecker_Normalize.unfold_whnf env t1 in
             let uu____6306 =
-              let uu____6307 = FStar_Syntax_Subst.compress t2  in
-              uu____6307.FStar_Syntax_Syntax.n  in
+              let uu____6307 = FStar_Syntax_Subst.compress t2 in
+              uu____6307.FStar_Syntax_Syntax.n in
             match uu____6306 with
             | FStar_Syntax_Syntax.Tm_type uu____6310 -> true
-            | uu____6311 -> false  in
+            | uu____6311 -> false in
           let uu____6312 =
             let uu____6313 =
-              FStar_Syntax_Util.unrefine lc.FStar_Syntax_Syntax.res_typ  in
-            uu____6313.FStar_Syntax_Syntax.n  in
+              FStar_Syntax_Util.unrefine lc.FStar_Syntax_Syntax.res_typ in
+            uu____6313.FStar_Syntax_Syntax.n in
           match uu____6312 with
           | FStar_Syntax_Syntax.Tm_fvar fv when
               (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.bool_lid)
@@ -2736,47 +2443,40 @@ let (maybe_coerce_bool_to_type :
               ->
               let uu____6321 =
                 FStar_TypeChecker_Env.lookup_lid env
-                  FStar_Parser_Const.b2t_lid
-                 in
+                  FStar_Parser_Const.b2t_lid in
               let b2t1 =
                 FStar_Syntax_Syntax.fvar
                   (FStar_Ident.set_lid_range FStar_Parser_Const.b2t_lid
                      e.FStar_Syntax_Syntax.pos)
                   (FStar_Syntax_Syntax.Delta_defined_at_level
-                     (Prims.parse_int "1")) FStar_Pervasives_Native.None
-                 in
+                     (Prims.parse_int "1")) FStar_Pervasives_Native.None in
               let lc1 =
                 let uu____6332 =
                   let uu____6333 =
                     let uu____6334 =
-                      FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0
-                       in
+                      FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
                     FStar_All.pipe_left FStar_Syntax_Util.lcomp_of_comp
-                      uu____6334
-                     in
-                  (FStar_Pervasives_Native.None, uu____6333)  in
+                      uu____6334 in
+                  (FStar_Pervasives_Native.None, uu____6333) in
                 bind e.FStar_Syntax_Syntax.pos env
-                  (FStar_Pervasives_Native.Some e) lc uu____6332
-                 in
+                  (FStar_Pervasives_Native.Some e) lc uu____6332 in
               let e1 =
                 let uu____6344 =
                   let uu____6345 =
-                    let uu____6346 = FStar_Syntax_Syntax.as_arg e  in
-                    [uu____6346]  in
-                  FStar_Syntax_Syntax.mk_Tm_app b2t1 uu____6345  in
+                    let uu____6346 = FStar_Syntax_Syntax.as_arg e in
+                    [uu____6346] in
+                  FStar_Syntax_Syntax.mk_Tm_app b2t1 uu____6345 in
                 uu____6344 FStar_Pervasives_Native.None
-                  e.FStar_Syntax_Syntax.pos
-                 in
+                  e.FStar_Syntax_Syntax.pos in
               (e1, lc1)
           | uu____6351 -> (e, lc)
-  
-let (weaken_result_typ :
+let weaken_result_typ:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.lcomp ->
         FStar_Syntax_Syntax.typ ->
           (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.lcomp,FStar_TypeChecker_Env.guard_t)
-            FStar_Pervasives_Native.tuple3)
+            FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
@@ -2786,29 +2486,24 @@ let (weaken_result_typ :
             env.FStar_TypeChecker_Env.use_eq ||
               (let uu____6380 =
                  FStar_TypeChecker_Env.effect_decl_opt env
-                   lc.FStar_Syntax_Syntax.eff_name
-                  in
+                   lc.FStar_Syntax_Syntax.eff_name in
                match uu____6380 with
                | FStar_Pervasives_Native.Some (ed,qualifiers) ->
                    FStar_All.pipe_right qualifiers
                      (FStar_List.contains FStar_Syntax_Syntax.Reifiable)
-               | uu____6403 -> false)
-             in
+               | uu____6403 -> false) in
           let gopt =
             if use_eq
             then
               let uu____6425 =
                 FStar_TypeChecker_Rel.try_teq true env
-                  lc.FStar_Syntax_Syntax.res_typ t
-                 in
+                  lc.FStar_Syntax_Syntax.res_typ t in
               (uu____6425, false)
             else
               (let uu____6431 =
                  FStar_TypeChecker_Rel.get_subtyping_predicate env
-                   lc.FStar_Syntax_Syntax.res_typ t
-                  in
-               (uu____6431, true))
-             in
+                   lc.FStar_Syntax_Syntax.res_typ t in
+               (uu____6431, true)) in
           match gopt with
           | (FStar_Pervasives_Native.None ,uu____6442) ->
               if env.FStar_TypeChecker_Env.failhard
@@ -2816,14 +2511,13 @@ let (weaken_result_typ :
                 let uu____6451 =
                   FStar_TypeChecker_Err.basic_type_error env
                     (FStar_Pervasives_Native.Some e) t
-                    lc.FStar_Syntax_Syntax.res_typ
-                   in
+                    lc.FStar_Syntax_Syntax.res_typ in
                 FStar_Errors.raise_error uu____6451 e.FStar_Syntax_Syntax.pos
               else
                 (FStar_TypeChecker_Rel.subtype_fail env e
                    lc.FStar_Syntax_Syntax.res_typ t;
                  (e,
-                   ((let uu___117_6465 = lc  in
+                   ((let uu___117_6465 = lc in
                      {
                        FStar_Syntax_Syntax.eff_name =
                          (uu___117_6465.FStar_Syntax_Syntax.eff_name);
@@ -2834,11 +2528,11 @@ let (weaken_result_typ :
                          (uu___117_6465.FStar_Syntax_Syntax.comp_thunk)
                      })), FStar_TypeChecker_Rel.trivial_guard))
           | (FStar_Pervasives_Native.Some g,apply_guard1) ->
-              let uu____6470 = FStar_TypeChecker_Rel.guard_form g  in
+              let uu____6470 = FStar_TypeChecker_Rel.guard_form g in
               (match uu____6470 with
                | FStar_TypeChecker_Common.Trivial  ->
                    let lc1 =
-                     let uu___118_6478 = lc  in
+                     let uu___118_6478 = lc in
                      {
                        FStar_Syntax_Syntax.eff_name =
                          (uu___118_6478.FStar_Syntax_Syntax.eff_name);
@@ -2847,11 +2541,11 @@ let (weaken_result_typ :
                          (uu___118_6478.FStar_Syntax_Syntax.cflags);
                        FStar_Syntax_Syntax.comp_thunk =
                          (uu___118_6478.FStar_Syntax_Syntax.comp_thunk)
-                     }  in
+                     } in
                    (e, lc1, g)
                | FStar_TypeChecker_Common.NonTrivial f ->
                    let g1 =
-                     let uu___119_6481 = g  in
+                     let uu___119_6481 = g in
                      {
                        FStar_TypeChecker_Env.guard_f =
                          FStar_TypeChecker_Common.Trivial;
@@ -2861,12 +2555,11 @@ let (weaken_result_typ :
                          (uu___119_6481.FStar_TypeChecker_Env.univ_ineqs);
                        FStar_TypeChecker_Env.implicits =
                          (uu___119_6481.FStar_TypeChecker_Env.implicits)
-                     }  in
+                     } in
                    let strengthen uu____6485 =
                      let uu____6486 =
                        env.FStar_TypeChecker_Env.lax &&
-                         (FStar_Options.ml_ish ())
-                        in
+                         (FStar_Options.ml_ish ()) in
                      if uu____6486
                      then FStar_Syntax_Syntax.lcomp_comp lc
                      else
@@ -2875,11 +2568,10 @@ let (weaken_result_typ :
                             [FStar_TypeChecker_Normalize.Beta;
                             FStar_TypeChecker_Normalize.Eager_unfolding;
                             FStar_TypeChecker_Normalize.Simplify;
-                            FStar_TypeChecker_Normalize.Primops] env f
-                           in
+                            FStar_TypeChecker_Normalize.Primops] env f in
                         let uu____6489 =
-                          let uu____6490 = FStar_Syntax_Subst.compress f1  in
-                          uu____6490.FStar_Syntax_Syntax.n  in
+                          let uu____6490 = FStar_Syntax_Subst.compress f1 in
+                          uu____6490.FStar_Syntax_Syntax.n in
                         match uu____6489 with
                         | FStar_Syntax_Syntax.Tm_abs
                             (uu____6493,{
@@ -2894,7 +2586,7 @@ let (weaken_result_typ :
                               FStar_Parser_Const.true_lid
                             ->
                             let lc1 =
-                              let uu___120_6519 = lc  in
+                              let uu___120_6519 = lc in
                               {
                                 FStar_Syntax_Syntax.eff_name =
                                   (uu___120_6519.FStar_Syntax_Syntax.eff_name);
@@ -2903,86 +2595,75 @@ let (weaken_result_typ :
                                   (uu___120_6519.FStar_Syntax_Syntax.cflags);
                                 FStar_Syntax_Syntax.comp_thunk =
                                   (uu___120_6519.FStar_Syntax_Syntax.comp_thunk)
-                              }  in
+                              } in
                             FStar_Syntax_Syntax.lcomp_comp lc1
                         | uu____6520 ->
-                            let c = FStar_Syntax_Syntax.lcomp_comp lc  in
+                            let c = FStar_Syntax_Syntax.lcomp_comp lc in
                             ((let uu____6523 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
-                                  FStar_Options.Extreme
-                                 in
+                                  FStar_Options.Extreme in
                               if uu____6523
                               then
                                 let uu____6524 =
                                   FStar_TypeChecker_Normalize.term_to_string
-                                    env lc.FStar_Syntax_Syntax.res_typ
-                                   in
+                                    env lc.FStar_Syntax_Syntax.res_typ in
                                 let uu____6525 =
                                   FStar_TypeChecker_Normalize.term_to_string
-                                    env t
-                                   in
+                                    env t in
                                 let uu____6526 =
                                   FStar_TypeChecker_Normalize.comp_to_string
-                                    env c
-                                   in
+                                    env c in
                                 let uu____6527 =
                                   FStar_TypeChecker_Normalize.term_to_string
-                                    env f1
-                                   in
+                                    env f1 in
                                 FStar_Util.print4
                                   "Weakened from %s to %s\nStrengthening %s with guard %s\n"
                                   uu____6524 uu____6525 uu____6526 uu____6527
                               else ());
-                             (let u_t_opt = comp_univ_opt c  in
+                             (let u_t_opt = comp_univ_opt c in
                               let x =
                                 FStar_Syntax_Syntax.new_bv
                                   (FStar_Pervasives_Native.Some
-                                     (t.FStar_Syntax_Syntax.pos)) t
-                                 in
-                              let xexp = FStar_Syntax_Syntax.bv_to_name x  in
-                              let cret = return_value env u_t_opt t xexp  in
+                                     (t.FStar_Syntax_Syntax.pos)) t in
+                              let xexp = FStar_Syntax_Syntax.bv_to_name x in
+                              let cret = return_value env u_t_opt t xexp in
                               let guard =
                                 if apply_guard1
                                 then
                                   let uu____6540 =
                                     let uu____6541 =
                                       let uu____6542 =
-                                        FStar_Syntax_Syntax.as_arg xexp  in
-                                      [uu____6542]  in
+                                        FStar_Syntax_Syntax.as_arg xexp in
+                                      [uu____6542] in
                                     FStar_Syntax_Syntax.mk_Tm_app f1
-                                      uu____6541
-                                     in
+                                      uu____6541 in
                                   uu____6540 FStar_Pervasives_Native.None
                                     f1.FStar_Syntax_Syntax.pos
-                                else f1  in
+                                else f1 in
                               let uu____6546 =
                                 let uu____6551 =
                                   FStar_All.pipe_left
                                     (fun _0_40  ->
                                        FStar_Pervasives_Native.Some _0_40)
                                     (FStar_TypeChecker_Err.subtyping_failed
-                                       env lc.FStar_Syntax_Syntax.res_typ t)
-                                   in
+                                       env lc.FStar_Syntax_Syntax.res_typ t) in
                                 let uu____6564 =
                                   FStar_TypeChecker_Env.set_range env
-                                    e.FStar_Syntax_Syntax.pos
-                                   in
+                                    e.FStar_Syntax_Syntax.pos in
                                 let uu____6565 =
-                                  FStar_Syntax_Util.lcomp_of_comp cret  in
+                                  FStar_Syntax_Util.lcomp_of_comp cret in
                                 let uu____6566 =
                                   FStar_All.pipe_left
                                     FStar_TypeChecker_Rel.guard_of_guard_formula
                                     (FStar_TypeChecker_Common.NonTrivial
-                                       guard)
-                                   in
+                                       guard) in
                                 strengthen_precondition uu____6551 uu____6564
-                                  e uu____6565 uu____6566
-                                 in
+                                  e uu____6565 uu____6566 in
                               match uu____6546 with
                               | (eq_ret,_trivial_so_ok_to_discard) ->
                                   let x1 =
-                                    let uu___121_6570 = x  in
+                                    let uu___121_6570 = x in
                                     {
                                       FStar_Syntax_Syntax.ppname =
                                         (uu___121_6570.FStar_Syntax_Syntax.ppname);
@@ -2990,34 +2671,29 @@ let (weaken_result_typ :
                                         (uu___121_6570.FStar_Syntax_Syntax.index);
                                       FStar_Syntax_Syntax.sort =
                                         (lc.FStar_Syntax_Syntax.res_typ)
-                                    }  in
+                                    } in
                                   let c1 =
                                     let uu____6572 =
-                                      FStar_Syntax_Util.lcomp_of_comp c  in
+                                      FStar_Syntax_Util.lcomp_of_comp c in
                                     bind e.FStar_Syntax_Syntax.pos env
                                       (FStar_Pervasives_Native.Some e)
                                       uu____6572
                                       ((FStar_Pervasives_Native.Some x1),
-                                        eq_ret)
-                                     in
-                                  let c2 = FStar_Syntax_Syntax.lcomp_comp c1
-                                     in
+                                        eq_ret) in
+                                  let c2 = FStar_Syntax_Syntax.lcomp_comp c1 in
                                   ((let uu____6577 =
                                       FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env)
-                                        FStar_Options.Extreme
-                                       in
+                                        FStar_Options.Extreme in
                                     if uu____6577
                                     then
                                       let uu____6578 =
                                         FStar_TypeChecker_Normalize.comp_to_string
-                                          env c2
-                                         in
+                                          env c2 in
                                       FStar_Util.print1
                                         "Strengthened to %s\n" uu____6578
                                     else ());
-                                   c2))))
-                      in
+                                   c2)))) in
                    let flags1 =
                      FStar_All.pipe_right lc.FStar_Syntax_Syntax.cflags
                        (FStar_List.collect
@@ -3029,18 +2705,15 @@ let (weaken_result_typ :
                                  [FStar_Syntax_Syntax.PARTIAL_RETURN]
                              | FStar_Syntax_Syntax.CPS  ->
                                  [FStar_Syntax_Syntax.CPS]
-                             | uu____6591 -> []))
-                      in
+                             | uu____6591 -> [])) in
                    let lc1 =
                      let uu____6593 =
                        FStar_TypeChecker_Env.norm_eff_name env
-                         lc.FStar_Syntax_Syntax.eff_name
-                        in
+                         lc.FStar_Syntax_Syntax.eff_name in
                      FStar_Syntax_Syntax.mk_lcomp uu____6593 t flags1
-                       strengthen
-                      in
+                       strengthen in
                    let g2 =
-                     let uu___122_6595 = g1  in
+                     let uu___122_6595 = g1 in
                      {
                        FStar_TypeChecker_Env.guard_f =
                          FStar_TypeChecker_Common.Trivial;
@@ -3050,39 +2723,35 @@ let (weaken_result_typ :
                          (uu___122_6595.FStar_TypeChecker_Env.univ_ineqs);
                        FStar_TypeChecker_Env.implicits =
                          (uu___122_6595.FStar_TypeChecker_Env.implicits)
-                     }  in
+                     } in
                    (e, lc1, g2))
-  
-let (pure_or_ghost_pre_and_post :
+let pure_or_ghost_pre_and_post:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp ->
       (FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option,FStar_Syntax_Syntax.typ)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun comp  ->
       let mk_post_type res_t ens =
-        let x = FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None res_t
-           in
+        let x = FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None res_t in
         let uu____6618 =
           let uu____6619 =
             let uu____6620 =
               let uu____6621 =
-                let uu____6622 = FStar_Syntax_Syntax.bv_to_name x  in
-                FStar_Syntax_Syntax.as_arg uu____6622  in
-              [uu____6621]  in
-            FStar_Syntax_Syntax.mk_Tm_app ens uu____6620  in
+                let uu____6622 = FStar_Syntax_Syntax.bv_to_name x in
+                FStar_Syntax_Syntax.as_arg uu____6622 in
+              [uu____6621] in
+            FStar_Syntax_Syntax.mk_Tm_app ens uu____6620 in
           uu____6619 FStar_Pervasives_Native.None
-            res_t.FStar_Syntax_Syntax.pos
-           in
-        FStar_Syntax_Util.refine x uu____6618  in
+            res_t.FStar_Syntax_Syntax.pos in
+        FStar_Syntax_Util.refine x uu____6618 in
       let norm1 t =
         FStar_TypeChecker_Normalize.normalize
           [FStar_TypeChecker_Normalize.Beta;
           FStar_TypeChecker_Normalize.Eager_unfolding;
-          FStar_TypeChecker_Normalize.EraseUniverses] env t
-         in
-      let uu____6629 = FStar_Syntax_Util.is_tot_or_gtot_comp comp  in
+          FStar_TypeChecker_Normalize.EraseUniverses] env t in
+      let uu____6629 = FStar_Syntax_Util.is_tot_or_gtot_comp comp in
       if uu____6629
       then
         (FStar_Pervasives_Native.None, (FStar_Syntax_Util.comp_result comp))
@@ -3101,224 +2770,194 @@ let (pure_or_ghost_pre_and_post :
                (match ct.FStar_Syntax_Syntax.effect_args with
                 | (req,uu____6691)::(ens,uu____6693)::uu____6694 ->
                     let uu____6723 =
-                      let uu____6726 = norm1 req  in
-                      FStar_Pervasives_Native.Some uu____6726  in
+                      let uu____6726 = norm1 req in
+                      FStar_Pervasives_Native.Some uu____6726 in
                     let uu____6727 =
                       let uu____6728 =
-                        mk_post_type ct.FStar_Syntax_Syntax.result_typ ens
-                         in
-                      FStar_All.pipe_left norm1 uu____6728  in
+                        mk_post_type ct.FStar_Syntax_Syntax.result_typ ens in
+                      FStar_All.pipe_left norm1 uu____6728 in
                     (uu____6723, uu____6727)
                 | uu____6731 ->
                     let uu____6740 =
                       let uu____6745 =
                         let uu____6746 =
-                          FStar_Syntax_Print.comp_to_string comp  in
+                          FStar_Syntax_Print.comp_to_string comp in
                         FStar_Util.format1
                           "Effect constructor is not fully applied; got %s"
-                          uu____6746
-                         in
+                          uu____6746 in
                       (FStar_Errors.Fatal_EffectConstructorNotFullyApplied,
-                        uu____6745)
-                       in
+                        uu____6745) in
                     FStar_Errors.raise_error uu____6740
                       comp.FStar_Syntax_Syntax.pos)
              else
-               (let ct1 = FStar_TypeChecker_Env.unfold_effect_abbrev env comp
-                   in
+               (let ct1 = FStar_TypeChecker_Env.unfold_effect_abbrev env comp in
                 match ct1.FStar_Syntax_Syntax.effect_args with
                 | (wp,uu____6762)::uu____6763 ->
                     let uu____6782 =
                       let uu____6787 =
                         FStar_TypeChecker_Env.lookup_lid env
-                          FStar_Parser_Const.as_requires
-                         in
+                          FStar_Parser_Const.as_requires in
                       FStar_All.pipe_left FStar_Pervasives_Native.fst
-                        uu____6787
-                       in
+                        uu____6787 in
                     (match uu____6782 with
                      | (us_r,uu____6819) ->
                          let uu____6820 =
                            let uu____6825 =
                              FStar_TypeChecker_Env.lookup_lid env
-                               FStar_Parser_Const.as_ensures
-                              in
+                               FStar_Parser_Const.as_ensures in
                            FStar_All.pipe_left FStar_Pervasives_Native.fst
-                             uu____6825
-                            in
+                             uu____6825 in
                          (match uu____6820 with
                           | (us_e,uu____6857) ->
                               let r =
-                                (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
-                                 in
+                                (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
                               let as_req =
                                 let uu____6860 =
                                   FStar_Syntax_Syntax.fvar
                                     (FStar_Ident.set_lid_range
                                        FStar_Parser_Const.as_requires r)
                                     FStar_Syntax_Syntax.Delta_equational
-                                    FStar_Pervasives_Native.None
-                                   in
+                                    FStar_Pervasives_Native.None in
                                 FStar_Syntax_Syntax.mk_Tm_uinst uu____6860
-                                  us_r
-                                 in
+                                  us_r in
                               let as_ens =
                                 let uu____6862 =
                                   FStar_Syntax_Syntax.fvar
                                     (FStar_Ident.set_lid_range
                                        FStar_Parser_Const.as_ensures r)
                                     FStar_Syntax_Syntax.Delta_equational
-                                    FStar_Pervasives_Native.None
-                                   in
+                                    FStar_Pervasives_Native.None in
                                 FStar_Syntax_Syntax.mk_Tm_uinst uu____6862
-                                  us_e
-                                 in
+                                  us_e in
                               let req =
                                 let uu____6866 =
                                   let uu____6867 =
                                     let uu____6868 =
                                       let uu____6879 =
-                                        FStar_Syntax_Syntax.as_arg wp  in
-                                      [uu____6879]  in
+                                        FStar_Syntax_Syntax.as_arg wp in
+                                      [uu____6879] in
                                     ((ct1.FStar_Syntax_Syntax.result_typ),
                                       (FStar_Pervasives_Native.Some
                                          FStar_Syntax_Syntax.imp_tag))
-                                      :: uu____6868
-                                     in
+                                      :: uu____6868 in
                                   FStar_Syntax_Syntax.mk_Tm_app as_req
-                                    uu____6867
-                                   in
+                                    uu____6867 in
                                 uu____6866 FStar_Pervasives_Native.None
-                                  (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
-                                 in
+                                  (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
                               let ens =
                                 let uu____6897 =
                                   let uu____6898 =
                                     let uu____6899 =
                                       let uu____6910 =
-                                        FStar_Syntax_Syntax.as_arg wp  in
-                                      [uu____6910]  in
+                                        FStar_Syntax_Syntax.as_arg wp in
+                                      [uu____6910] in
                                     ((ct1.FStar_Syntax_Syntax.result_typ),
                                       (FStar_Pervasives_Native.Some
                                          FStar_Syntax_Syntax.imp_tag))
-                                      :: uu____6899
-                                     in
+                                      :: uu____6899 in
                                   FStar_Syntax_Syntax.mk_Tm_app as_ens
-                                    uu____6898
-                                   in
+                                    uu____6898 in
                                 uu____6897 FStar_Pervasives_Native.None
-                                  (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
-                                 in
+                                  (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
                               let uu____6925 =
-                                let uu____6928 = norm1 req  in
-                                FStar_Pervasives_Native.Some uu____6928  in
+                                let uu____6928 = norm1 req in
+                                FStar_Pervasives_Native.Some uu____6928 in
                               let uu____6929 =
                                 let uu____6930 =
                                   mk_post_type
-                                    ct1.FStar_Syntax_Syntax.result_typ ens
-                                   in
-                                norm1 uu____6930  in
+                                    ct1.FStar_Syntax_Syntax.result_typ ens in
+                                norm1 uu____6930 in
                               (uu____6925, uu____6929)))
                 | uu____6933 -> failwith "Impossible"))
-  
-let (is_reifiable :
-  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool) =
+let is_reifiable:
+  FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool =
   fun env  ->
     fun effect_name  ->
-      let edecl_opt = FStar_TypeChecker_Env.effect_decl_opt env effect_name
-         in
+      let edecl_opt = FStar_TypeChecker_Env.effect_decl_opt env effect_name in
       (FStar_Util.is_some edecl_opt) &&
-        (let uu____6970 = FStar_All.pipe_right edecl_opt FStar_Util.must  in
+        (let uu____6970 = FStar_All.pipe_right edecl_opt FStar_Util.must in
          FStar_All.pipe_right uu____6970
            (fun uu____7006  ->
               match uu____7006 with
               | (uu____7013,quals) ->
                   FStar_All.pipe_right quals
                     (FStar_List.contains FStar_Syntax_Syntax.Reifiable)))
-  
-let (reify_body :
+let reify_body:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun t  ->
-      let tm = FStar_Syntax_Util.mk_reify t  in
+      let tm = FStar_Syntax_Util.mk_reify t in
       let tm' =
         FStar_TypeChecker_Normalize.normalize
           [FStar_TypeChecker_Normalize.Beta;
           FStar_TypeChecker_Normalize.Reify;
           FStar_TypeChecker_Normalize.Eager_unfolding;
           FStar_TypeChecker_Normalize.EraseUniverses;
-          FStar_TypeChecker_Normalize.AllowUnboundUniverses] env tm
-         in
+          FStar_TypeChecker_Normalize.AllowUnboundUniverses] env tm in
       (let uu____7032 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "SMTEncodingReify")
-          in
+           (FStar_Options.Other "SMTEncodingReify") in
        if uu____7032
        then
-         let uu____7033 = FStar_Syntax_Print.term_to_string tm  in
-         let uu____7034 = FStar_Syntax_Print.term_to_string tm'  in
+         let uu____7033 = FStar_Syntax_Print.term_to_string tm in
+         let uu____7034 = FStar_Syntax_Print.term_to_string tm' in
          FStar_Util.print2 "Reified body %s \nto %s\n" uu____7033 uu____7034
        else ());
       tm'
-  
-let (reify_body_with_arg :
+let reify_body_with_arg:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.arg -> FStar_Syntax_Syntax.term)
+      FStar_Syntax_Syntax.arg -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun head1  ->
       fun arg  ->
         let tm =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (head1, [arg]))
-            FStar_Pervasives_Native.None head1.FStar_Syntax_Syntax.pos
-           in
+            FStar_Pervasives_Native.None head1.FStar_Syntax_Syntax.pos in
         let tm' =
           FStar_TypeChecker_Normalize.normalize
             [FStar_TypeChecker_Normalize.Beta;
             FStar_TypeChecker_Normalize.Reify;
             FStar_TypeChecker_Normalize.Eager_unfolding;
             FStar_TypeChecker_Normalize.EraseUniverses;
-            FStar_TypeChecker_Normalize.AllowUnboundUniverses] env tm
-           in
+            FStar_TypeChecker_Normalize.AllowUnboundUniverses] env tm in
         (let uu____7052 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "SMTEncodingReify")
-            in
+             (FStar_Options.Other "SMTEncodingReify") in
          if uu____7052
          then
-           let uu____7053 = FStar_Syntax_Print.term_to_string tm  in
-           let uu____7054 = FStar_Syntax_Print.term_to_string tm'  in
+           let uu____7053 = FStar_Syntax_Print.term_to_string tm in
+           let uu____7054 = FStar_Syntax_Print.term_to_string tm' in
            FStar_Util.print2 "Reified body %s \nto %s\n" uu____7053
              uu____7054
          else ());
         tm'
-  
-let (remove_reify : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+let remove_reify: FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term =
   fun t  ->
     let uu____7059 =
       let uu____7060 =
-        let uu____7061 = FStar_Syntax_Subst.compress t  in
-        uu____7061.FStar_Syntax_Syntax.n  in
+        let uu____7061 = FStar_Syntax_Subst.compress t in
+        uu____7061.FStar_Syntax_Syntax.n in
       match uu____7060 with
       | FStar_Syntax_Syntax.Tm_app uu____7064 -> false
-      | uu____7079 -> true  in
+      | uu____7079 -> true in
     if uu____7059
     then t
     else
-      (let uu____7081 = FStar_Syntax_Util.head_and_args t  in
+      (let uu____7081 = FStar_Syntax_Util.head_and_args t in
        match uu____7081 with
        | (head1,args) ->
            let uu____7118 =
              let uu____7119 =
-               let uu____7120 = FStar_Syntax_Subst.compress head1  in
-               uu____7120.FStar_Syntax_Syntax.n  in
+               let uu____7120 = FStar_Syntax_Subst.compress head1 in
+               uu____7120.FStar_Syntax_Syntax.n in
              match uu____7119 with
              | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify ) ->
                  true
-             | uu____7123 -> false  in
+             | uu____7123 -> false in
            if uu____7118
            then
              (match args with
@@ -3327,23 +2966,22 @@ let (remove_reify : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
                   failwith
                     "Impossible : Reify applied to multiple arguments after normalization.")
            else t)
-  
-let (maybe_instantiate :
+let maybe_instantiate:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.typ ->
         (FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.typ,FStar_TypeChecker_Env.guard_t)
-          FStar_Pervasives_Native.tuple3)
+          FStar_Pervasives_Native.tuple3
   =
   fun env  ->
     fun e  ->
       fun t  ->
-        let torig = FStar_Syntax_Subst.compress t  in
+        let torig = FStar_Syntax_Subst.compress t in
         if Prims.op_Negation env.FStar_TypeChecker_Env.instantiate_imp
         then (e, torig, FStar_TypeChecker_Rel.trivial_guard)
         else
           (let number_of_implicits t1 =
-             let uu____7182 = FStar_Syntax_Util.arrow_formals t1  in
+             let uu____7182 = FStar_Syntax_Util.arrow_formals t1 in
              match uu____7182 with
              | (formals,uu____7196) ->
                  let n_implicits =
@@ -3356,54 +2994,44 @@ let (maybe_instantiate :
                                  (imp = FStar_Pervasives_Native.None) ||
                                    (imp =
                                       (FStar_Pervasives_Native.Some
-                                         FStar_Syntax_Syntax.Equality))))
-                      in
+                                         FStar_Syntax_Syntax.Equality)))) in
                    match uu____7214 with
                    | FStar_Pervasives_Native.None  ->
                        FStar_List.length formals
                    | FStar_Pervasives_Native.Some
                        (implicits,_first_explicit,_rest) ->
-                       FStar_List.length implicits
-                    in
-                 n_implicits
-              in
+                       FStar_List.length implicits in
+                 n_implicits in
            let inst_n_binders t1 =
-             let uu____7428 = FStar_TypeChecker_Env.expected_typ env  in
+             let uu____7428 = FStar_TypeChecker_Env.expected_typ env in
              match uu____7428 with
              | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
              | FStar_Pervasives_Native.Some expected_t ->
-                 let n_expected = number_of_implicits expected_t  in
-                 let n_available = number_of_implicits t1  in
+                 let n_expected = number_of_implicits expected_t in
+                 let n_available = number_of_implicits t1 in
                  if n_available < n_expected
                  then
                    let uu____7452 =
                      let uu____7457 =
-                       let uu____7458 = FStar_Util.string_of_int n_expected
-                          in
-                       let uu____7465 = FStar_Syntax_Print.term_to_string e
-                          in
-                       let uu____7466 = FStar_Util.string_of_int n_available
-                          in
+                       let uu____7458 = FStar_Util.string_of_int n_expected in
+                       let uu____7465 = FStar_Syntax_Print.term_to_string e in
+                       let uu____7466 = FStar_Util.string_of_int n_available in
                        FStar_Util.format3
                          "Expected a term with %s implicit arguments, but %s has only %s"
-                         uu____7458 uu____7465 uu____7466
-                        in
+                         uu____7458 uu____7465 uu____7466 in
                      (FStar_Errors.Fatal_MissingImplicitArguments,
-                       uu____7457)
-                      in
-                   let uu____7473 = FStar_TypeChecker_Env.get_range env  in
+                       uu____7457) in
+                   let uu____7473 = FStar_TypeChecker_Env.get_range env in
                    FStar_Errors.raise_error uu____7452 uu____7473
-                 else FStar_Pervasives_Native.Some (n_available - n_expected)
-              in
+                 else FStar_Pervasives_Native.Some (n_available - n_expected) in
            let decr_inst uu___88_7494 =
              match uu___88_7494 with
              | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
              | FStar_Pervasives_Native.Some i ->
-                 FStar_Pervasives_Native.Some (i - (Prims.parse_int "1"))
-              in
+                 FStar_Pervasives_Native.Some (i - (Prims.parse_int "1")) in
            match torig.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-               let uu____7524 = FStar_Syntax_Subst.open_comp bs c  in
+               let uu____7524 = FStar_Syntax_Subst.open_comp bs c in
                (match uu____7524 with
                 | (bs1,c1) ->
                     let rec aux subst1 inst_n bs2 =
@@ -3417,42 +3045,38 @@ let (maybe_instantiate :
                           ->
                           let t1 =
                             FStar_Syntax_Subst.subst subst1
-                              x.FStar_Syntax_Syntax.sort
-                             in
+                              x.FStar_Syntax_Syntax.sort in
                           let uu____7709 =
                             new_implicit_var
                               "Instantiation of implicit argument"
-                              e.FStar_Syntax_Syntax.pos env t1
-                             in
+                              e.FStar_Syntax_Syntax.pos env t1 in
                           (match uu____7709 with
                            | (v1,uu____7749,g) ->
                                let subst2 = (FStar_Syntax_Syntax.NT (x, v1))
-                                 :: subst1  in
+                                 :: subst1 in
                                let uu____7766 =
-                                 aux subst2 (decr_inst inst_n) rest  in
+                                 aux subst2 (decr_inst inst_n) rest in
                                (match uu____7766 with
                                 | (args,bs3,subst3,g') ->
                                     let uu____7859 =
-                                      FStar_TypeChecker_Rel.conj_guard g g'
-                                       in
+                                      FStar_TypeChecker_Rel.conj_guard g g' in
                                     (((v1,
                                         (FStar_Pervasives_Native.Some
                                            (FStar_Syntax_Syntax.Implicit dot)))
                                       :: args), bs3, subst3, uu____7859)))
                       | (uu____7886,bs3) ->
                           ([], bs3, subst1,
-                            FStar_TypeChecker_Rel.trivial_guard)
-                       in
+                            FStar_TypeChecker_Rel.trivial_guard) in
                     let uu____7932 =
-                      let uu____7959 = inst_n_binders t  in
-                      aux [] uu____7959 bs1  in
+                      let uu____7959 = inst_n_binders t in
+                      aux [] uu____7959 bs1 in
                     (match uu____7932 with
                      | (args,bs2,subst1,guard) ->
                          (match (args, bs2) with
                           | ([],uu____8030) -> (e, torig, guard)
                           | (uu____8061,[]) when
                               let uu____8092 =
-                                FStar_Syntax_Util.is_total_comp c1  in
+                                FStar_Syntax_Util.is_total_comp c1 in
                               Prims.op_Negation uu____8092 ->
                               (e, torig, FStar_TypeChecker_Rel.trivial_guard)
                           | uu____8093 ->
@@ -3460,112 +3084,99 @@ let (maybe_instantiate :
                                 match bs2 with
                                 | [] -> FStar_Syntax_Util.comp_result c1
                                 | uu____8125 ->
-                                    FStar_Syntax_Util.arrow bs2 c1
-                                 in
-                              let t2 = FStar_Syntax_Subst.subst subst1 t1  in
+                                    FStar_Syntax_Util.arrow bs2 c1 in
+                              let t2 = FStar_Syntax_Subst.subst subst1 t1 in
                               let e1 =
                                 FStar_Syntax_Syntax.mk_Tm_app e args
                                   FStar_Pervasives_Native.None
-                                  e.FStar_Syntax_Syntax.pos
-                                 in
+                                  e.FStar_Syntax_Syntax.pos in
                               (e1, t2, guard))))
            | uu____8140 -> (e, t, FStar_TypeChecker_Rel.trivial_guard))
-  
-let (string_of_univs :
-  FStar_Syntax_Syntax.universe_uvar FStar_Util.set -> Prims.string) =
+let string_of_univs:
+  FStar_Syntax_Syntax.universe_uvar FStar_Util.set -> Prims.string =
   fun univs1  ->
     let uu____8148 =
-      let uu____8151 = FStar_Util.set_elements univs1  in
+      let uu____8151 = FStar_Util.set_elements univs1 in
       FStar_All.pipe_right uu____8151
         (FStar_List.map
            (fun u  ->
-              let uu____8161 = FStar_Syntax_Unionfind.univ_uvar_id u  in
-              FStar_All.pipe_right uu____8161 FStar_Util.string_of_int))
-       in
+              let uu____8161 = FStar_Syntax_Unionfind.univ_uvar_id u in
+              FStar_All.pipe_right uu____8161 FStar_Util.string_of_int)) in
     FStar_All.pipe_right uu____8148 (FStar_String.concat ", ")
-  
-let (gen_univs :
+let gen_univs:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.universe_uvar FStar_Util.set ->
-      FStar_Syntax_Syntax.univ_name Prims.list)
+      FStar_Syntax_Syntax.univ_name Prims.list
   =
   fun env  ->
     fun x  ->
-      let uu____8178 = FStar_Util.set_is_empty x  in
+      let uu____8178 = FStar_Util.set_is_empty x in
       if uu____8178
       then []
       else
         (let s =
            let uu____8185 =
-             let uu____8188 = FStar_TypeChecker_Env.univ_vars env  in
-             FStar_Util.set_difference x uu____8188  in
-           FStar_All.pipe_right uu____8185 FStar_Util.set_elements  in
+             let uu____8188 = FStar_TypeChecker_Env.univ_vars env in
+             FStar_Util.set_difference x uu____8188 in
+           FStar_All.pipe_right uu____8185 FStar_Util.set_elements in
          (let uu____8196 =
             FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-              (FStar_Options.Other "Gen")
-             in
+              (FStar_Options.Other "Gen") in
           if uu____8196
           then
             let uu____8197 =
-              let uu____8198 = FStar_TypeChecker_Env.univ_vars env  in
-              string_of_univs uu____8198  in
+              let uu____8198 = FStar_TypeChecker_Env.univ_vars env in
+              string_of_univs uu____8198 in
             FStar_Util.print1 "univ_vars in env: %s\n" uu____8197
           else ());
          (let r =
-            let uu____8205 = FStar_TypeChecker_Env.get_range env  in
-            FStar_Pervasives_Native.Some uu____8205  in
+            let uu____8205 = FStar_TypeChecker_Env.get_range env in
+            FStar_Pervasives_Native.Some uu____8205 in
           let u_names =
             FStar_All.pipe_right s
               (FStar_List.map
                  (fun u  ->
-                    let u_name = FStar_Syntax_Syntax.new_univ_name r  in
+                    let u_name = FStar_Syntax_Syntax.new_univ_name r in
                     (let uu____8220 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                         (FStar_Options.Other "Gen")
-                        in
+                         (FStar_Options.Other "Gen") in
                      if uu____8220
                      then
                        let uu____8221 =
                          let uu____8222 =
-                           FStar_Syntax_Unionfind.univ_uvar_id u  in
+                           FStar_Syntax_Unionfind.univ_uvar_id u in
                          FStar_All.pipe_left FStar_Util.string_of_int
-                           uu____8222
-                          in
+                           uu____8222 in
                        let uu____8223 =
                          FStar_Syntax_Print.univ_to_string
-                           (FStar_Syntax_Syntax.U_unif u)
-                          in
+                           (FStar_Syntax_Syntax.U_unif u) in
                        let uu____8224 =
                          FStar_Syntax_Print.univ_to_string
-                           (FStar_Syntax_Syntax.U_name u_name)
-                          in
+                           (FStar_Syntax_Syntax.U_name u_name) in
                        FStar_Util.print3 "Setting ?%s (%s) to %s\n"
                          uu____8221 uu____8223 uu____8224
                      else ());
                     FStar_Syntax_Unionfind.univ_change u
                       (FStar_Syntax_Syntax.U_name u_name);
-                    u_name))
-             in
+                    u_name)) in
           u_names))
-  
-let (gather_free_univnames :
+let gather_free_univnames:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.univ_name Prims.list)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.univ_name Prims.list
   =
   fun env  ->
     fun t  ->
-      let ctx_univnames = FStar_TypeChecker_Env.univnames env  in
-      let tm_univnames = FStar_Syntax_Free.univnames t  in
+      let ctx_univnames = FStar_TypeChecker_Env.univnames env in
+      let tm_univnames = FStar_Syntax_Free.univnames t in
       let univnames1 =
         let uu____8246 =
-          FStar_Util.fifo_set_difference tm_univnames ctx_univnames  in
-        FStar_All.pipe_right uu____8246 FStar_Util.fifo_set_elements  in
+          FStar_Util.fifo_set_difference tm_univnames ctx_univnames in
+        FStar_All.pipe_right uu____8246 FStar_Util.fifo_set_elements in
       univnames1
-  
-let (check_universe_generalization :
+let check_universe_generalization:
   FStar_Syntax_Syntax.univ_name Prims.list ->
     FStar_Syntax_Syntax.univ_name Prims.list ->
-      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.univ_name Prims.list)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.univ_name Prims.list
   =
   fun explicit_univ_names  ->
     fun generalized_univ_names  ->
@@ -3576,53 +3187,45 @@ let (check_universe_generalization :
         | uu____8292 ->
             let uu____8301 =
               let uu____8306 =
-                let uu____8307 = FStar_Syntax_Print.term_to_string t  in
+                let uu____8307 = FStar_Syntax_Print.term_to_string t in
                 Prims.strcat
                   "Generalized universe in a term containing explicit universe annotation : "
-                  uu____8307
-                 in
-              (FStar_Errors.Fatal_UnexpectedGeneralizedUniverse, uu____8306)
-               in
+                  uu____8307 in
+              (FStar_Errors.Fatal_UnexpectedGeneralizedUniverse, uu____8306) in
             FStar_Errors.raise_error uu____8301 t.FStar_Syntax_Syntax.pos
-  
-let (generalize_universes :
+let generalize_universes:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.tscheme)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.tscheme
   =
   fun env  ->
     fun t0  ->
       let t =
         FStar_TypeChecker_Normalize.normalize
           [FStar_TypeChecker_Normalize.NoFullNorm;
-          FStar_TypeChecker_Normalize.Beta] env t0
-         in
-      let univnames1 = gather_free_univnames env t  in
-      let univs1 = FStar_Syntax_Free.univs t  in
+          FStar_TypeChecker_Normalize.Beta] env t0 in
+      let univnames1 = gather_free_univnames env t in
+      let univs1 = FStar_Syntax_Free.univs t in
       (let uu____8324 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-           (FStar_Options.Other "Gen")
-          in
+           (FStar_Options.Other "Gen") in
        if uu____8324
        then
-         let uu____8325 = string_of_univs univs1  in
+         let uu____8325 = string_of_univs univs1 in
          FStar_Util.print1 "univs to gen : %s\n" uu____8325
        else ());
-      (let gen1 = gen_univs env univs1  in
+      (let gen1 = gen_univs env univs1 in
        (let uu____8331 =
           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-            (FStar_Options.Other "Gen")
-           in
+            (FStar_Options.Other "Gen") in
         if uu____8331
         then
-          let uu____8332 = FStar_Syntax_Print.term_to_string t  in
+          let uu____8332 = FStar_Syntax_Print.term_to_string t in
           FStar_Util.print1 "After generalization: %s\n" uu____8332
         else ());
-       (let univs2 = check_universe_generalization univnames1 gen1 t0  in
-        let t1 = FStar_TypeChecker_Normalize.reduce_uvar_solutions env t  in
-        let ts = FStar_Syntax_Subst.close_univ_vars univs2 t1  in
-        (univs2, ts)))
-  
-let (gen :
+       (let univs2 = check_universe_generalization univnames1 gen1 t0 in
+        let t1 = FStar_TypeChecker_Normalize.reduce_uvar_solutions env t in
+        let ts = FStar_Syntax_Subst.close_univ_vars univs2 t1 in (univs2, ts)))
+let gen:
   FStar_TypeChecker_Env.env ->
     Prims.bool ->
       (FStar_Syntax_Syntax.lbname,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.comp)
@@ -3631,7 +3234,7 @@ let (gen :
           FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.comp,FStar_Syntax_Syntax.binder
                                                               Prims.list)
           FStar_Pervasives_Native.tuple5 Prims.list
-          FStar_Pervasives_Native.option)
+          FStar_Pervasives_Native.option
   =
   fun env  ->
     fun is_rec  ->
@@ -3642,23 +3245,22 @@ let (gen :
               (fun uu____8416  ->
                  match uu____8416 with
                  | (uu____8425,uu____8426,c) ->
-                     FStar_Syntax_Util.is_pure_or_ghost_comp c) lecs
-             in
-          FStar_All.pipe_left Prims.op_Negation uu____8403  in
+                     FStar_Syntax_Util.is_pure_or_ghost_comp c) lecs in
+          FStar_All.pipe_left Prims.op_Negation uu____8403 in
         if uu____8402
         then FStar_Pervasives_Native.None
         else
           (let norm1 c =
              (let uu____8472 =
-                FStar_TypeChecker_Env.debug env FStar_Options.Medium  in
+                FStar_TypeChecker_Env.debug env FStar_Options.Medium in
               if uu____8472
               then
-                let uu____8473 = FStar_Syntax_Print.comp_to_string c  in
+                let uu____8473 = FStar_Syntax_Print.comp_to_string c in
                 FStar_Util.print1 "Normalizing before generalizing:\n\t %s\n"
                   uu____8473
               else ());
              (let c1 =
-                let uu____8476 = FStar_TypeChecker_Env.should_verify env  in
+                let uu____8476 = FStar_TypeChecker_Env.should_verify env in
                 if uu____8476
                 then
                   FStar_TypeChecker_Normalize.normalize_comp
@@ -3672,105 +3274,90 @@ let (gen :
                     [FStar_TypeChecker_Normalize.Beta;
                     FStar_TypeChecker_Normalize.Exclude
                       FStar_TypeChecker_Normalize.Zeta;
-                    FStar_TypeChecker_Normalize.NoFullNorm] env c
-                 in
+                    FStar_TypeChecker_Normalize.NoFullNorm] env c in
               (let uu____8479 =
-                 FStar_TypeChecker_Env.debug env FStar_Options.Medium  in
+                 FStar_TypeChecker_Env.debug env FStar_Options.Medium in
                if uu____8479
                then
-                 let uu____8480 = FStar_Syntax_Print.comp_to_string c1  in
+                 let uu____8480 = FStar_Syntax_Print.comp_to_string c1 in
                  FStar_Util.print1 "Normalized to:\n\t %s\n" uu____8480
                else ());
-              c1)
-              in
-           let env_uvars = FStar_TypeChecker_Env.uvars_in_env env  in
+              c1) in
+           let env_uvars = FStar_TypeChecker_Env.uvars_in_env env in
            let gen_uvars uvs =
-             let uu____8541 = FStar_Util.set_difference uvs env_uvars  in
-             FStar_All.pipe_right uu____8541 FStar_Util.set_elements  in
+             let uu____8541 = FStar_Util.set_difference uvs env_uvars in
+             FStar_All.pipe_right uu____8541 FStar_Util.set_elements in
            let univs_and_uvars_of_lec uu____8671 =
              match uu____8671 with
              | (lbname,e,c) ->
                  let t =
                    FStar_All.pipe_right (FStar_Syntax_Util.comp_result c)
-                     FStar_Syntax_Subst.compress
-                    in
-                 let c1 = norm1 c  in
-                 let t1 = FStar_Syntax_Util.comp_result c1  in
-                 let univs1 = FStar_Syntax_Free.univs t1  in
-                 let uvt = FStar_Syntax_Free.uvars t1  in
+                     FStar_Syntax_Subst.compress in
+                 let c1 = norm1 c in
+                 let t1 = FStar_Syntax_Util.comp_result c1 in
+                 let univs1 = FStar_Syntax_Free.univs t1 in
+                 let uvt = FStar_Syntax_Free.uvars t1 in
                  ((let uu____8737 =
                      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                       (FStar_Options.Other "Gen")
-                      in
+                       (FStar_Options.Other "Gen") in
                    if uu____8737
                    then
                      let uu____8738 =
                        let uu____8739 =
-                         let uu____8742 = FStar_Util.set_elements univs1  in
+                         let uu____8742 = FStar_Util.set_elements univs1 in
                          FStar_All.pipe_right uu____8742
                            (FStar_List.map
                               (fun u  ->
                                  FStar_Syntax_Print.univ_to_string
-                                   (FStar_Syntax_Syntax.U_unif u)))
-                          in
+                                   (FStar_Syntax_Syntax.U_unif u))) in
                        FStar_All.pipe_right uu____8739
-                         (FStar_String.concat ", ")
-                        in
+                         (FStar_String.concat ", ") in
                      let uu____8769 =
                        let uu____8770 =
-                         let uu____8773 = FStar_Util.set_elements uvt  in
+                         let uu____8773 = FStar_Util.set_elements uvt in
                          FStar_All.pipe_right uu____8773
                            (FStar_List.map
                               (fun uu____8801  ->
                                  match uu____8801 with
                                  | (u,t2) ->
                                      let uu____8808 =
-                                       FStar_Syntax_Print.uvar_to_string u
-                                        in
+                                       FStar_Syntax_Print.uvar_to_string u in
                                      let uu____8809 =
-                                       FStar_Syntax_Print.term_to_string t2
-                                        in
+                                       FStar_Syntax_Print.term_to_string t2 in
                                      FStar_Util.format2 "(%s : %s)"
-                                       uu____8808 uu____8809))
-                          in
+                                       uu____8808 uu____8809)) in
                        FStar_All.pipe_right uu____8770
-                         (FStar_String.concat ", ")
-                        in
+                         (FStar_String.concat ", ") in
                      FStar_Util.print2
                        "^^^^\n\tFree univs = %s\n\tFree uvt=%s\n" uu____8738
                        uu____8769
                    else ());
                   (let univs2 =
-                     let uu____8816 = FStar_Util.set_elements uvt  in
+                     let uu____8816 = FStar_Util.set_elements uvt in
                      FStar_List.fold_left
                        (fun univs2  ->
                           fun uu____8839  ->
                             match uu____8839 with
                             | (uu____8848,t2) ->
-                                let uu____8850 = FStar_Syntax_Free.univs t2
-                                   in
+                                let uu____8850 = FStar_Syntax_Free.univs t2 in
                                 FStar_Util.set_union univs2 uu____8850)
-                       univs1 uu____8816
-                      in
-                   let uvs = gen_uvars uvt  in
+                       univs1 uu____8816 in
+                   let uvs = gen_uvars uvt in
                    (let uu____8873 =
                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                        (FStar_Options.Other "Gen")
-                       in
+                        (FStar_Options.Other "Gen") in
                     if uu____8873
                     then
                       let uu____8874 =
                         let uu____8875 =
-                          let uu____8878 = FStar_Util.set_elements univs2  in
+                          let uu____8878 = FStar_Util.set_elements univs2 in
                           FStar_All.pipe_right uu____8878
                             (FStar_List.map
                                (fun u  ->
                                   FStar_Syntax_Print.univ_to_string
-                                    (FStar_Syntax_Syntax.U_unif u)))
-                           in
+                                    (FStar_Syntax_Syntax.U_unif u))) in
                         FStar_All.pipe_right uu____8875
-                          (FStar_String.concat ", ")
-                         in
+                          (FStar_String.concat ", ") in
                       let uu____8905 =
                         let uu____8906 =
                           FStar_All.pipe_right uvs
@@ -3779,58 +3366,50 @@ let (gen :
                                   match uu____8938 with
                                   | (u,t2) ->
                                       let uu____8945 =
-                                        FStar_Syntax_Print.uvar_to_string u
-                                         in
+                                        FStar_Syntax_Print.uvar_to_string u in
                                       let uu____8946 =
                                         FStar_TypeChecker_Normalize.term_to_string
-                                          env t2
-                                         in
+                                          env t2 in
                                       FStar_Util.format2 "(%s : %s)"
-                                        uu____8945 uu____8946))
-                           in
+                                        uu____8945 uu____8946)) in
                         FStar_All.pipe_right uu____8906
-                          (FStar_String.concat ", ")
-                         in
+                          (FStar_String.concat ", ") in
                       FStar_Util.print2
                         "^^^^\n\tFree univs = %s\n\tgen_uvars =%s" uu____8874
                         uu____8905
                     else ());
-                   (univs2, uvs, (lbname, e, c1))))
-              in
+                   (univs2, uvs, (lbname, e, c1)))) in
            let uu____8976 =
-             let uu____9009 = FStar_List.hd lecs  in
-             univs_and_uvars_of_lec uu____9009  in
+             let uu____9009 = FStar_List.hd lecs in
+             univs_and_uvars_of_lec uu____9009 in
            match uu____8976 with
            | (univs1,uvs,lec_hd) ->
                let force_univs_eq lec2 u1 u2 =
                  let uu____9127 =
                    (FStar_Util.set_is_subset_of u1 u2) &&
-                     (FStar_Util.set_is_subset_of u2 u1)
-                    in
+                     (FStar_Util.set_is_subset_of u2 u1) in
                  if uu____9127
                  then ()
                  else
-                   (let uu____9129 = lec_hd  in
+                   (let uu____9129 = lec_hd in
                     match uu____9129 with
                     | (lb1,uu____9137,uu____9138) ->
-                        let uu____9139 = lec2  in
+                        let uu____9139 = lec2 in
                         (match uu____9139 with
                          | (lb2,uu____9147,uu____9148) ->
                              let msg =
                                let uu____9150 =
-                                 FStar_Syntax_Print.lbname_to_string lb1  in
+                                 FStar_Syntax_Print.lbname_to_string lb1 in
                                let uu____9151 =
-                                 FStar_Syntax_Print.lbname_to_string lb2  in
+                                 FStar_Syntax_Print.lbname_to_string lb2 in
                                FStar_Util.format2
                                  "Generalizing the types of these mutually recursive definitions requires an incompatible set of universes for %s and %s"
-                                 uu____9150 uu____9151
-                                in
+                                 uu____9150 uu____9151 in
                              let uu____9152 =
-                               FStar_TypeChecker_Env.get_range env  in
+                               FStar_TypeChecker_Env.get_range env in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_IncompatibleSetOfUniverse,
-                                 msg) uu____9152))
-                  in
+                                 msg) uu____9152)) in
                let force_uvars_eq lec2 u1 u2 =
                  let uvars_subseteq u11 u21 =
                    FStar_All.pipe_right u11
@@ -3843,82 +3422,72 @@ let (gen :
                                     (fun uu____9293  ->
                                        match uu____9293 with
                                        | (u',uu____9301) ->
-                                           FStar_Syntax_Unionfind.equiv u u'))))
-                    in
+                                           FStar_Syntax_Unionfind.equiv u u')))) in
                  let uu____9306 =
-                   (uvars_subseteq u1 u2) && (uvars_subseteq u2 u1)  in
+                   (uvars_subseteq u1 u2) && (uvars_subseteq u2 u1) in
                  if uu____9306
                  then ()
                  else
-                   (let uu____9308 = lec_hd  in
+                   (let uu____9308 = lec_hd in
                     match uu____9308 with
                     | (lb1,uu____9316,uu____9317) ->
-                        let uu____9318 = lec2  in
+                        let uu____9318 = lec2 in
                         (match uu____9318 with
                          | (lb2,uu____9326,uu____9327) ->
                              let msg =
                                let uu____9329 =
-                                 FStar_Syntax_Print.lbname_to_string lb1  in
+                                 FStar_Syntax_Print.lbname_to_string lb1 in
                                let uu____9330 =
-                                 FStar_Syntax_Print.lbname_to_string lb2  in
+                                 FStar_Syntax_Print.lbname_to_string lb2 in
                                FStar_Util.format2
                                  "Generalizing the types of these mutually recursive definitions requires an incompatible number of types for %s and %s"
-                                 uu____9329 uu____9330
-                                in
+                                 uu____9329 uu____9330 in
                              let uu____9331 =
-                               FStar_TypeChecker_Env.get_range env  in
+                               FStar_TypeChecker_Env.get_range env in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_IncompatibleNumberOfTypes,
-                                 msg) uu____9331))
-                  in
+                                 msg) uu____9331)) in
                let lecs1 =
-                 let uu____9341 = FStar_List.tl lecs  in
+                 let uu____9341 = FStar_List.tl lecs in
                  FStar_List.fold_right
                    (fun this_lec  ->
                       fun lecs1  ->
-                        let uu____9400 = univs_and_uvars_of_lec this_lec  in
+                        let uu____9400 = univs_and_uvars_of_lec this_lec in
                         match uu____9400 with
                         | (this_univs,this_uvs,this_lec1) ->
                             (force_univs_eq this_lec1 univs1 this_univs;
                              force_uvars_eq this_lec1 uvs this_uvs;
                              this_lec1
                              ::
-                             lecs1)) uu____9341 []
-                  in
-               let lecs2 = lec_hd :: lecs1  in
+                             lecs1)) uu____9341 [] in
+               let lecs2 = lec_hd :: lecs1 in
                let gen_types uvs1 =
                  let fail k =
-                   let uu____9553 = lec_hd  in
+                   let uu____9553 = lec_hd in
                    match uu____9553 with
                    | (lbname,e,c) ->
                        let uu____9563 =
                          let uu____9568 =
                            let uu____9569 =
-                             FStar_Syntax_Print.term_to_string k  in
+                             FStar_Syntax_Print.term_to_string k in
                            let uu____9570 =
-                             FStar_Syntax_Print.lbname_to_string lbname  in
+                             FStar_Syntax_Print.lbname_to_string lbname in
                            let uu____9571 =
                              FStar_Syntax_Print.term_to_string
-                               (FStar_Syntax_Util.comp_result c)
-                              in
+                               (FStar_Syntax_Util.comp_result c) in
                            FStar_Util.format3
                              "Failed to resolve implicit argument of type '%s' in the type of %s (%s)"
-                             uu____9569 uu____9570 uu____9571
-                            in
+                             uu____9569 uu____9570 uu____9571 in
                          (FStar_Errors.Fatal_FailToResolveImplicitArgument,
-                           uu____9568)
-                          in
-                       let uu____9572 = FStar_TypeChecker_Env.get_range env
-                          in
-                       FStar_Errors.raise_error uu____9563 uu____9572
-                    in
+                           uu____9568) in
+                       let uu____9572 = FStar_TypeChecker_Env.get_range env in
+                       FStar_Errors.raise_error uu____9563 uu____9572 in
                  FStar_All.pipe_right uvs1
                    (FStar_List.map
                       (fun uu____9602  ->
                          match uu____9602 with
                          | (u,k) ->
-                             let uu____9615 = FStar_Syntax_Unionfind.find u
-                                in
+                             let uu____9615 = FStar_Syntax_Unionfind.find u in
                              (match uu____9615 with
                               | FStar_Pervasives_Native.Some uu____9624 ->
                                   failwith
@@ -3929,35 +3498,28 @@ let (gen :
                                       [FStar_TypeChecker_Normalize.Beta;
                                       FStar_TypeChecker_Normalize.Exclude
                                         FStar_TypeChecker_Normalize.Zeta] env
-                                      k
-                                     in
+                                      k in
                                   let uu____9635 =
-                                    FStar_Syntax_Util.arrow_formals k1  in
+                                    FStar_Syntax_Util.arrow_formals k1 in
                                   (match uu____9635 with
                                    | (bs,kres) ->
                                        ((let uu____9673 =
                                            let uu____9674 =
                                              let uu____9677 =
                                                FStar_TypeChecker_Normalize.unfold_whnf
-                                                 env kres
-                                                in
+                                                 env kres in
                                              FStar_Syntax_Util.unrefine
-                                               uu____9677
-                                              in
-                                           uu____9674.FStar_Syntax_Syntax.n
-                                            in
+                                               uu____9677 in
+                                           uu____9674.FStar_Syntax_Syntax.n in
                                          match uu____9673 with
                                          | FStar_Syntax_Syntax.Tm_type
                                              uu____9678 ->
                                              let free =
-                                               FStar_Syntax_Free.names kres
-                                                in
+                                               FStar_Syntax_Free.names kres in
                                              let uu____9682 =
                                                let uu____9683 =
-                                                 FStar_Util.set_is_empty free
-                                                  in
-                                               Prims.op_Negation uu____9683
-                                                in
+                                                 FStar_Util.set_is_empty free in
+                                               Prims.op_Negation uu____9683 in
                                              if uu____9682
                                              then fail kres
                                              else ()
@@ -3966,33 +3528,27 @@ let (gen :
                                            let uu____9687 =
                                              let uu____9690 =
                                                FStar_TypeChecker_Env.get_range
-                                                 env
-                                                in
+                                                 env in
                                              FStar_All.pipe_left
                                                (fun _0_42  ->
                                                   FStar_Pervasives_Native.Some
-                                                    _0_42) uu____9690
-                                              in
+                                                    _0_42) uu____9690 in
                                            FStar_Syntax_Syntax.new_bv
-                                             uu____9687 kres
-                                            in
+                                             uu____9687 kres in
                                          let t =
                                            let uu____9694 =
-                                             FStar_Syntax_Syntax.bv_to_name a
-                                              in
+                                             FStar_Syntax_Syntax.bv_to_name a in
                                            FStar_Syntax_Util.abs bs
                                              uu____9694
                                              (FStar_Pervasives_Native.Some
                                                 (FStar_Syntax_Util.residual_tot
-                                                   kres))
-                                            in
+                                                   kres)) in
                                          FStar_Syntax_Util.set_uvar u t;
                                          (a,
                                            (FStar_Pervasives_Native.Some
-                                              FStar_Syntax_Syntax.imp_tag))))))))
-                  in
-               let gen_univs1 = gen_univs env univs1  in
-               let gen_tvars = gen_types uvs  in
+                                              FStar_Syntax_Syntax.imp_tag)))))))) in
+               let gen_univs1 = gen_univs env univs1 in
+               let gen_tvars = gen_types uvs in
                let ecs =
                  FStar_All.pipe_right lecs2
                    (FStar_List.map
@@ -4003,7 +3559,7 @@ let (gen :
                                match (gen_tvars, gen_univs1) with
                                | ([],[]) -> (e, c, [])
                                | uu____9928 ->
-                                   let uu____9943 = (e, c)  in
+                                   let uu____9943 = (e, c) in
                                    (match uu____9943 with
                                     | (e0,c0) ->
                                         let c1 =
@@ -4014,12 +3570,10 @@ let (gen :
                                             FStar_TypeChecker_Normalize.NoFullNorm;
                                             FStar_TypeChecker_Normalize.Exclude
                                               FStar_TypeChecker_Normalize.Zeta]
-                                            env c
-                                           in
+                                            env c in
                                         let e1 =
                                           FStar_TypeChecker_Normalize.reduce_uvar_solutions
-                                            env e
-                                           in
+                                            env e in
                                         let e2 =
                                           if is_rec
                                           then
@@ -4030,46 +3584,40 @@ let (gen :
                                                    | (x,uu____9988) ->
                                                        let uu____9993 =
                                                          FStar_Syntax_Syntax.bv_to_name
-                                                           x
-                                                          in
+                                                           x in
                                                        FStar_Syntax_Syntax.iarg
                                                          uu____9993)
-                                                gen_tvars
-                                               in
+                                                gen_tvars in
                                             let instantiate_lbname_with_app
                                               tm fv =
                                               let uu____10003 =
                                                 let uu____10004 =
-                                                  FStar_Util.right lbname  in
+                                                  FStar_Util.right lbname in
                                                 FStar_Syntax_Syntax.fv_eq fv
-                                                  uu____10004
-                                                 in
+                                                  uu____10004 in
                                               if uu____10003
                                               then
                                                 FStar_Syntax_Syntax.mk_Tm_app
                                                   tm tvar_args
                                                   FStar_Pervasives_Native.None
                                                   tm.FStar_Syntax_Syntax.pos
-                                              else tm  in
+                                              else tm in
                                             FStar_Syntax_InstFV.inst
                                               instantiate_lbname_with_app e1
-                                          else e1  in
+                                          else e1 in
                                         let t =
                                           let uu____10012 =
                                             let uu____10013 =
                                               FStar_Syntax_Subst.compress
                                                 (FStar_Syntax_Util.comp_result
-                                                   c1)
-                                               in
-                                            uu____10013.FStar_Syntax_Syntax.n
-                                             in
+                                                   c1) in
+                                            uu____10013.FStar_Syntax_Syntax.n in
                                           match uu____10012 with
                                           | FStar_Syntax_Syntax.Tm_arrow
                                               (bs,cod) ->
                                               let uu____10036 =
                                                 FStar_Syntax_Subst.open_comp
-                                                  bs cod
-                                                 in
+                                                  bs cod in
                                               (match uu____10036 with
                                                | (bs1,cod1) ->
                                                    FStar_Syntax_Util.arrow
@@ -4077,39 +3625,33 @@ let (gen :
                                                         gen_tvars bs1) cod1)
                                           | uu____10051 ->
                                               FStar_Syntax_Util.arrow
-                                                gen_tvars c1
-                                           in
+                                                gen_tvars c1 in
                                         let e' =
                                           FStar_Syntax_Util.abs gen_tvars e2
                                             (FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Util.residual_comp_of_comp
-                                                  c1))
-                                           in
+                                                  c1)) in
                                         let uu____10053 =
-                                          FStar_Syntax_Syntax.mk_Total t  in
-                                        (e', uu____10053, gen_tvars))
-                                in
+                                          FStar_Syntax_Syntax.mk_Total t in
+                                        (e', uu____10053, gen_tvars)) in
                              (match uu____9859 with
                               | (e1,c1,gvs) ->
-                                  (lbname, gen_univs1, e1, c1, gvs))))
-                  in
+                                  (lbname, gen_univs1, e1, c1, gvs)))) in
                FStar_Pervasives_Native.Some ecs)
-  
-let (generalize :
+let generalize:
   FStar_TypeChecker_Env.env ->
     Prims.bool ->
       (FStar_Syntax_Syntax.lbname,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.comp)
         FStar_Pervasives_Native.tuple3 Prims.list ->
         (FStar_Syntax_Syntax.lbname,FStar_Syntax_Syntax.univ_names,FStar_Syntax_Syntax.term,
           FStar_Syntax_Syntax.comp,FStar_Syntax_Syntax.binder Prims.list)
-          FStar_Pervasives_Native.tuple5 Prims.list)
+          FStar_Pervasives_Native.tuple5 Prims.list
   =
   fun env  ->
     fun is_rec  ->
       fun lecs  ->
-        (let uu____10199 = Obj.magic ()  in ());
-        (let uu____10201 = FStar_TypeChecker_Env.debug env FStar_Options.Low
-            in
+        (let uu____10199 = Obj.magic () in ());
+        (let uu____10201 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
          if uu____10201
          then
            let uu____10202 =
@@ -4118,19 +3660,17 @@ let (generalize :
                  (fun uu____10216  ->
                     match uu____10216 with
                     | (lb,uu____10224,uu____10225) ->
-                        FStar_Syntax_Print.lbname_to_string lb) lecs
-                in
-             FStar_All.pipe_right uu____10203 (FStar_String.concat ", ")  in
+                        FStar_Syntax_Print.lbname_to_string lb) lecs in
+             FStar_All.pipe_right uu____10203 (FStar_String.concat ", ") in
            FStar_Util.print1 "Generalizing: %s\n" uu____10202
          else ());
         (let univnames_lecs =
            FStar_List.map
              (fun uu____10246  ->
                 match uu____10246 with
-                | (l,t,c) -> gather_free_univnames env t) lecs
-            in
+                | (l,t,c) -> gather_free_univnames env t) lecs in
          let generalized_lecs =
-           let uu____10275 = gen env is_rec lecs  in
+           let uu____10275 = gen env is_rec lecs in
            match uu____10275 with
            | FStar_Pervasives_Native.None  ->
                FStar_All.pipe_right lecs
@@ -4139,7 +3679,7 @@ let (generalize :
                        match uu____10374 with | (l,t,c) -> (l, [], t, c, [])))
            | FStar_Pervasives_Native.Some luecs ->
                ((let uu____10436 =
-                   FStar_TypeChecker_Env.debug env FStar_Options.Medium  in
+                   FStar_TypeChecker_Env.debug env FStar_Options.Medium in
                  if uu____10436
                  then
                    FStar_All.pipe_right luecs
@@ -4149,27 +3689,23 @@ let (generalize :
                            | (l,us,e,c,gvs) ->
                                let uu____10514 =
                                  FStar_Range.string_of_range
-                                   e.FStar_Syntax_Syntax.pos
-                                  in
+                                   e.FStar_Syntax_Syntax.pos in
                                let uu____10515 =
-                                 FStar_Syntax_Print.lbname_to_string l  in
+                                 FStar_Syntax_Print.lbname_to_string l in
                                let uu____10516 =
                                  FStar_Syntax_Print.term_to_string
-                                   (FStar_Syntax_Util.comp_result c)
-                                  in
+                                   (FStar_Syntax_Util.comp_result c) in
                                let uu____10517 =
-                                 FStar_Syntax_Print.term_to_string e  in
+                                 FStar_Syntax_Print.term_to_string e in
                                let uu____10518 =
                                  FStar_Syntax_Print.binders_to_string ", "
-                                   gvs
-                                  in
+                                   gvs in
                                FStar_Util.print5
                                  "(%s) Generalized %s at type %s\n%s\nVars = (%s)\n"
                                  uu____10514 uu____10515 uu____10516
                                  uu____10517 uu____10518))
                  else ());
-                luecs)
-            in
+                luecs) in
          FStar_List.map2
            (fun univnames1  ->
               fun uu____10559  ->
@@ -4177,56 +3713,51 @@ let (generalize :
                 | (l,generalized_univs,t,c,gvs) ->
                     let uu____10603 =
                       check_universe_generalization univnames1
-                        generalized_univs t
-                       in
+                        generalized_univs t in
                     (l, uu____10603, t, c, gvs)) univnames_lecs
            generalized_lecs)
-  
-let (check_and_ascribe :
+let check_and_ascribe:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Syntax_Syntax.typ ->
         FStar_Syntax_Syntax.typ ->
           (FStar_Syntax_Syntax.term,FStar_TypeChecker_Env.guard_t)
-            FStar_Pervasives_Native.tuple2)
+            FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun e  ->
       fun t1  ->
         fun t2  ->
           let env1 =
-            FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos  in
+            FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos in
           let check env2 t11 t21 =
             if env2.FStar_TypeChecker_Env.use_eq
             then FStar_TypeChecker_Rel.try_teq true env2 t11 t21
             else
               (let uu____10646 =
-                 FStar_TypeChecker_Rel.get_subtyping_predicate env2 t11 t21
-                  in
+                 FStar_TypeChecker_Rel.get_subtyping_predicate env2 t11 t21 in
                match uu____10646 with
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some f ->
-                   let uu____10652 = FStar_TypeChecker_Rel.apply_guard f e
-                      in
+                   let uu____10652 = FStar_TypeChecker_Rel.apply_guard f e in
                    FStar_All.pipe_left
                      (fun _0_43  -> FStar_Pervasives_Native.Some _0_43)
-                     uu____10652)
-             in
+                     uu____10652) in
           let is_var e1 =
             let uu____10659 =
-              let uu____10660 = FStar_Syntax_Subst.compress e1  in
-              uu____10660.FStar_Syntax_Syntax.n  in
+              let uu____10660 = FStar_Syntax_Subst.compress e1 in
+              uu____10660.FStar_Syntax_Syntax.n in
             match uu____10659 with
             | FStar_Syntax_Syntax.Tm_name uu____10663 -> true
-            | uu____10664 -> false  in
+            | uu____10664 -> false in
           let decorate e1 t =
-            let e2 = FStar_Syntax_Subst.compress e1  in
+            let e2 = FStar_Syntax_Subst.compress e1 in
             match e2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_name x ->
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_name
-                     (let uu___123_10680 = x  in
+                     (let uu___123_10680 = x in
                       {
                         FStar_Syntax_Syntax.ppname =
                           (uu___123_10680.FStar_Syntax_Syntax.ppname);
@@ -4235,13 +3766,12 @@ let (check_and_ascribe :
                         FStar_Syntax_Syntax.sort = t2
                       })) FStar_Pervasives_Native.None
                   e2.FStar_Syntax_Syntax.pos
-            | uu____10681 -> e2  in
+            | uu____10681 -> e2 in
           let env2 =
-            let uu___124_10683 = env1  in
+            let uu___124_10683 = env1 in
             let uu____10684 =
               env1.FStar_TypeChecker_Env.use_eq ||
-                (env1.FStar_TypeChecker_Env.is_pattern && (is_var e))
-               in
+                (env1.FStar_TypeChecker_Env.is_pattern && (is_var e)) in
             {
               FStar_TypeChecker_Env.solver =
                 (uu___124_10683.FStar_TypeChecker_Env.solver);
@@ -4312,110 +3842,99 @@ let (check_and_ascribe :
                 (uu___124_10683.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.dep_graph =
                 (uu___124_10683.FStar_TypeChecker_Env.dep_graph)
-            }  in
-          let uu____10685 = check env2 t1 t2  in
+            } in
+          let uu____10685 = check env2 t1 t2 in
           match uu____10685 with
           | FStar_Pervasives_Native.None  ->
               let uu____10692 =
                 FStar_TypeChecker_Err.expected_expression_of_type env2 t2 e
-                  t1
-                 in
-              let uu____10697 = FStar_TypeChecker_Env.get_range env2  in
+                  t1 in
+              let uu____10697 = FStar_TypeChecker_Env.get_range env2 in
               FStar_Errors.raise_error uu____10692 uu____10697
           | FStar_Pervasives_Native.Some g ->
               ((let uu____10704 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
-                    (FStar_Options.Other "Rel")
-                   in
+                    (FStar_Options.Other "Rel") in
                 if uu____10704
                 then
                   let uu____10705 =
-                    FStar_TypeChecker_Rel.guard_to_string env2 g  in
+                    FStar_TypeChecker_Rel.guard_to_string env2 g in
                   FStar_All.pipe_left
                     (FStar_Util.print1 "Applied guard is %s\n") uu____10705
                 else ());
-               (let uu____10707 = decorate e t2  in (uu____10707, g)))
-  
-let (check_top_level :
+               (let uu____10707 = decorate e t2 in (uu____10707, g)))
+let check_top_level:
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Env.guard_t ->
       FStar_Syntax_Syntax.lcomp ->
-        (Prims.bool,FStar_Syntax_Syntax.comp) FStar_Pervasives_Native.tuple2)
+        (Prims.bool,FStar_Syntax_Syntax.comp) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun g  ->
       fun lc  ->
         let discharge g1 =
           FStar_TypeChecker_Rel.force_trivial_guard env g1;
-          FStar_Syntax_Util.is_pure_lcomp lc  in
-        let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g  in
-        let uu____10735 = FStar_Syntax_Util.is_total_lcomp lc  in
+          FStar_Syntax_Util.is_pure_lcomp lc in
+        let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g in
+        let uu____10735 = FStar_Syntax_Util.is_total_lcomp lc in
         if uu____10735
         then
-          let uu____10740 = discharge g1  in
-          let uu____10741 = FStar_Syntax_Syntax.lcomp_comp lc  in
+          let uu____10740 = discharge g1 in
+          let uu____10741 = FStar_Syntax_Syntax.lcomp_comp lc in
           (uu____10740, uu____10741)
         else
-          (let c = FStar_Syntax_Syntax.lcomp_comp lc  in
-           let steps = [FStar_TypeChecker_Normalize.Beta]  in
+          (let c = FStar_Syntax_Syntax.lcomp_comp lc in
+           let steps = [FStar_TypeChecker_Normalize.Beta] in
            let c1 =
              let uu____10748 =
                let uu____10749 =
                  let uu____10750 =
-                   FStar_TypeChecker_Env.unfold_effect_abbrev env c  in
-                 FStar_All.pipe_right uu____10750 FStar_Syntax_Syntax.mk_Comp
-                  in
+                   FStar_TypeChecker_Env.unfold_effect_abbrev env c in
+                 FStar_All.pipe_right uu____10750 FStar_Syntax_Syntax.mk_Comp in
                FStar_All.pipe_right uu____10749
-                 (FStar_TypeChecker_Normalize.normalize_comp steps env)
-                in
+                 (FStar_TypeChecker_Normalize.normalize_comp steps env) in
              FStar_All.pipe_right uu____10748
-               (FStar_TypeChecker_Env.comp_to_comp_typ env)
-              in
+               (FStar_TypeChecker_Env.comp_to_comp_typ env) in
            let md =
              FStar_TypeChecker_Env.get_effect_decl env
-               c1.FStar_Syntax_Syntax.effect_name
-              in
-           let uu____10752 = destruct_comp c1  in
+               c1.FStar_Syntax_Syntax.effect_name in
+           let uu____10752 = destruct_comp c1 in
            match uu____10752 with
            | (u_t,t,wp) ->
                let vc =
-                 let uu____10769 = FStar_TypeChecker_Env.get_range env  in
+                 let uu____10769 = FStar_TypeChecker_Env.get_range env in
                  let uu____10770 =
                    let uu____10771 =
                      FStar_TypeChecker_Env.inst_effect_fun_with [u_t] env md
-                       md.FStar_Syntax_Syntax.trivial
-                      in
+                       md.FStar_Syntax_Syntax.trivial in
                    let uu____10772 =
-                     let uu____10773 = FStar_Syntax_Syntax.as_arg t  in
+                     let uu____10773 = FStar_Syntax_Syntax.as_arg t in
                      let uu____10774 =
-                       let uu____10777 = FStar_Syntax_Syntax.as_arg wp  in
-                       [uu____10777]  in
-                     uu____10773 :: uu____10774  in
-                   FStar_Syntax_Syntax.mk_Tm_app uu____10771 uu____10772  in
-                 uu____10770 FStar_Pervasives_Native.None uu____10769  in
+                       let uu____10777 = FStar_Syntax_Syntax.as_arg wp in
+                       [uu____10777] in
+                     uu____10773 :: uu____10774 in
+                   FStar_Syntax_Syntax.mk_Tm_app uu____10771 uu____10772 in
+                 uu____10770 FStar_Pervasives_Native.None uu____10769 in
                ((let uu____10781 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
-                     (FStar_Options.Other "Simplification")
-                    in
+                     (FStar_Options.Other "Simplification") in
                  if uu____10781
                  then
-                   let uu____10782 = FStar_Syntax_Print.term_to_string vc  in
+                   let uu____10782 = FStar_Syntax_Print.term_to_string vc in
                    FStar_Util.print1 "top-level VC: %s\n" uu____10782
                  else ());
                 (let g2 =
                    let uu____10785 =
                      FStar_All.pipe_left
                        FStar_TypeChecker_Rel.guard_of_guard_formula
-                       (FStar_TypeChecker_Common.NonTrivial vc)
-                      in
-                   FStar_TypeChecker_Rel.conj_guard g1 uu____10785  in
-                 let uu____10786 = discharge g2  in
-                 let uu____10787 = FStar_Syntax_Syntax.mk_Comp c1  in
+                       (FStar_TypeChecker_Common.NonTrivial vc) in
+                   FStar_TypeChecker_Rel.conj_guard g1 uu____10785 in
+                 let uu____10786 = discharge g2 in
+                 let uu____10787 = FStar_Syntax_Syntax.mk_Comp c1 in
                  (uu____10786, uu____10787))))
-  
-let (short_circuit :
+let short_circuit:
   FStar_Syntax_Syntax.term ->
-    FStar_Syntax_Syntax.args -> FStar_TypeChecker_Common.guard_formula)
+    FStar_Syntax_Syntax.args -> FStar_TypeChecker_Common.guard_formula
   =
   fun head1  ->
     fun seen_args  ->
@@ -4423,71 +3942,65 @@ let (short_circuit :
         match uu___89_10811 with
         | [] -> FStar_TypeChecker_Common.Trivial
         | (fst1,uu____10819)::[] -> f fst1
-        | uu____10836 -> failwith "Unexpexted args to binary operator"  in
+        | uu____10836 -> failwith "Unexpexted args to binary operator" in
       let op_and_e e =
-        let uu____10841 = FStar_Syntax_Util.b2t e  in
+        let uu____10841 = FStar_Syntax_Util.b2t e in
         FStar_All.pipe_right uu____10841
-          (fun _0_44  -> FStar_TypeChecker_Common.NonTrivial _0_44)
-         in
+          (fun _0_44  -> FStar_TypeChecker_Common.NonTrivial _0_44) in
       let op_or_e e =
         let uu____10850 =
-          let uu____10853 = FStar_Syntax_Util.b2t e  in
-          FStar_Syntax_Util.mk_neg uu____10853  in
+          let uu____10853 = FStar_Syntax_Util.b2t e in
+          FStar_Syntax_Util.mk_neg uu____10853 in
         FStar_All.pipe_right uu____10850
-          (fun _0_45  -> FStar_TypeChecker_Common.NonTrivial _0_45)
-         in
+          (fun _0_45  -> FStar_TypeChecker_Common.NonTrivial _0_45) in
       let op_and_t t =
         FStar_All.pipe_right t
-          (fun _0_46  -> FStar_TypeChecker_Common.NonTrivial _0_46)
-         in
+          (fun _0_46  -> FStar_TypeChecker_Common.NonTrivial _0_46) in
       let op_or_t t =
-        let uu____10864 = FStar_All.pipe_right t FStar_Syntax_Util.mk_neg  in
+        let uu____10864 = FStar_All.pipe_right t FStar_Syntax_Util.mk_neg in
         FStar_All.pipe_right uu____10864
-          (fun _0_47  -> FStar_TypeChecker_Common.NonTrivial _0_47)
-         in
+          (fun _0_47  -> FStar_TypeChecker_Common.NonTrivial _0_47) in
       let op_imp_t t =
         FStar_All.pipe_right t
-          (fun _0_48  -> FStar_TypeChecker_Common.NonTrivial _0_48)
-         in
+          (fun _0_48  -> FStar_TypeChecker_Common.NonTrivial _0_48) in
       let short_op_ite uu___90_10878 =
         match uu___90_10878 with
         | [] -> FStar_TypeChecker_Common.Trivial
         | (guard,uu____10886)::[] ->
             FStar_TypeChecker_Common.NonTrivial guard
         | _then::(guard,uu____10905)::[] ->
-            let uu____10934 = FStar_Syntax_Util.mk_neg guard  in
+            let uu____10934 = FStar_Syntax_Util.mk_neg guard in
             FStar_All.pipe_right uu____10934
               (fun _0_49  -> FStar_TypeChecker_Common.NonTrivial _0_49)
-        | uu____10939 -> failwith "Unexpected args to ITE"  in
+        | uu____10939 -> failwith "Unexpected args to ITE" in
       let table =
         let uu____10949 =
-          let uu____10956 = short_bin_op op_and_e  in
-          (FStar_Parser_Const.op_And, uu____10956)  in
+          let uu____10956 = short_bin_op op_and_e in
+          (FStar_Parser_Const.op_And, uu____10956) in
         let uu____10961 =
           let uu____10970 =
-            let uu____10977 = short_bin_op op_or_e  in
-            (FStar_Parser_Const.op_Or, uu____10977)  in
+            let uu____10977 = short_bin_op op_or_e in
+            (FStar_Parser_Const.op_Or, uu____10977) in
           let uu____10982 =
             let uu____10991 =
-              let uu____10998 = short_bin_op op_and_t  in
-              (FStar_Parser_Const.and_lid, uu____10998)  in
+              let uu____10998 = short_bin_op op_and_t in
+              (FStar_Parser_Const.and_lid, uu____10998) in
             let uu____11003 =
               let uu____11012 =
-                let uu____11019 = short_bin_op op_or_t  in
-                (FStar_Parser_Const.or_lid, uu____11019)  in
+                let uu____11019 = short_bin_op op_or_t in
+                (FStar_Parser_Const.or_lid, uu____11019) in
               let uu____11024 =
                 let uu____11033 =
-                  let uu____11040 = short_bin_op op_imp_t  in
-                  (FStar_Parser_Const.imp_lid, uu____11040)  in
-                [uu____11033; (FStar_Parser_Const.ite_lid, short_op_ite)]  in
-              uu____11012 :: uu____11024  in
-            uu____10991 :: uu____11003  in
-          uu____10970 :: uu____10982  in
-        uu____10949 :: uu____10961  in
+                  let uu____11040 = short_bin_op op_imp_t in
+                  (FStar_Parser_Const.imp_lid, uu____11040) in
+                [uu____11033; (FStar_Parser_Const.ite_lid, short_op_ite)] in
+              uu____11012 :: uu____11024 in
+            uu____10991 :: uu____11003 in
+          uu____10970 :: uu____10982 in
+        uu____10949 :: uu____10961 in
       match head1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-             in
+          let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
           let uu____11091 =
             FStar_Util.find_map table
               (fun uu____11104  ->
@@ -4495,21 +4008,19 @@ let (short_circuit :
                  | (x,mk1) ->
                      if FStar_Ident.lid_equals x lid
                      then
-                       let uu____11121 = mk1 seen_args  in
+                       let uu____11121 = mk1 seen_args in
                        FStar_Pervasives_Native.Some uu____11121
-                     else FStar_Pervasives_Native.None)
-             in
+                     else FStar_Pervasives_Native.None) in
           (match uu____11091 with
            | FStar_Pervasives_Native.None  ->
                FStar_TypeChecker_Common.Trivial
            | FStar_Pervasives_Native.Some g -> g)
       | uu____11124 -> FStar_TypeChecker_Common.Trivial
-  
-let (short_circuit_head : FStar_Syntax_Syntax.term -> Prims.bool) =
+let short_circuit_head: FStar_Syntax_Syntax.term -> Prims.bool =
   fun l  ->
     let uu____11128 =
-      let uu____11129 = FStar_Syntax_Util.un_uinst l  in
-      uu____11129.FStar_Syntax_Syntax.n  in
+      let uu____11129 = FStar_Syntax_Util.un_uinst l in
+      uu____11129.FStar_Syntax_Syntax.n in
     match uu____11128 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv)
@@ -4520,10 +4031,9 @@ let (short_circuit_head : FStar_Syntax_Syntax.term -> Prims.bool) =
           FStar_Parser_Const.imp_lid;
           FStar_Parser_Const.ite_lid]
     | uu____11133 -> false
-  
-let (maybe_add_implicit_binders :
+let maybe_add_implicit_binders:
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders)
+    FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders
   =
   fun env  ->
     fun bs  ->
@@ -4531,18 +4041,18 @@ let (maybe_add_implicit_binders :
         match bs1 with
         | (hd1,uu____11157)::uu____11158 ->
             FStar_Syntax_Syntax.range_of_bv hd1
-        | uu____11169 -> FStar_TypeChecker_Env.get_range env  in
+        | uu____11169 -> FStar_TypeChecker_Env.get_range env in
       match bs with
       | (uu____11176,FStar_Pervasives_Native.Some
          (FStar_Syntax_Syntax.Implicit uu____11177))::uu____11178 -> bs
       | uu____11195 ->
-          let uu____11196 = FStar_TypeChecker_Env.expected_typ env  in
+          let uu____11196 = FStar_TypeChecker_Env.expected_typ env in
           (match uu____11196 with
            | FStar_Pervasives_Native.None  -> bs
            | FStar_Pervasives_Native.Some t ->
                let uu____11200 =
-                 let uu____11201 = FStar_Syntax_Subst.compress t  in
-                 uu____11201.FStar_Syntax_Syntax.n  in
+                 let uu____11201 = FStar_Syntax_Subst.compress t in
+                 uu____11201.FStar_Syntax_Syntax.n in
                (match uu____11200 with
                 | FStar_Syntax_Syntax.Tm_arrow (bs',uu____11205) ->
                     let uu____11222 =
@@ -4552,8 +4062,7 @@ let (maybe_add_implicit_binders :
                            | (uu____11269,FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Implicit uu____11270)) ->
                                false
-                           | uu____11273 -> true) bs'
-                       in
+                           | uu____11273 -> true) bs' in
                     (match uu____11222 with
                      | FStar_Pervasives_Native.None  -> bs
                      | FStar_Pervasives_Native.Some
@@ -4568,11 +4077,10 @@ let (maybe_add_implicit_binders :
                                    | (x,uu____11481) ->
                                        FStar_Util.starts_with
                                          (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-                                         "'"))
-                            in
+                                         "'")) in
                          if uu____11455
                          then
-                           let r = pos bs  in
+                           let r = pos bs in
                            let imps1 =
                              FStar_All.pipe_right imps
                                (FStar_List.map
@@ -4581,28 +4089,25 @@ let (maybe_add_implicit_binders :
                                      | (x,i) ->
                                          let uu____11547 =
                                            FStar_Syntax_Syntax.set_range_of_bv
-                                             x r
-                                            in
-                                         (uu____11547, i)))
-                              in
+                                             x r in
+                                         (uu____11547, i))) in
                            FStar_List.append imps1 bs
                          else bs)
                 | uu____11557 -> bs))
-  
-let (maybe_lift :
+let maybe_lift:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Ident.lident ->
         FStar_Ident.lident ->
-          FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term)
+          FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun e  ->
       fun c1  ->
         fun c2  ->
           fun t  ->
-            let m1 = FStar_TypeChecker_Env.norm_eff_name env c1  in
-            let m2 = FStar_TypeChecker_Env.norm_eff_name env c2  in
+            let m1 = FStar_TypeChecker_Env.norm_eff_name env c1 in
+            let m2 = FStar_TypeChecker_Env.norm_eff_name env c2 in
             if
               ((FStar_Ident.lid_equals m1 m2) ||
                  ((FStar_Syntax_Util.is_pure_effect c1) &&
@@ -4616,24 +4121,22 @@ let (maybe_lift :
                 (FStar_Syntax_Syntax.Tm_meta
                    (e, (FStar_Syntax_Syntax.Meta_monadic_lift (m1, m2, t))))
                 FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-  
-let (maybe_monadic :
+let maybe_monadic:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
       FStar_Ident.lident ->
-        FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term)
+        FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term
   =
   fun env  ->
     fun e  ->
       fun c  ->
         fun t  ->
-          let m = FStar_TypeChecker_Env.norm_eff_name env c  in
+          let m = FStar_TypeChecker_Env.norm_eff_name env c in
           let uu____11589 =
             ((is_pure_or_ghost_effect env m) ||
                (FStar_Ident.lid_equals m FStar_Parser_Const.effect_Tot_lid))
               ||
-              (FStar_Ident.lid_equals m FStar_Parser_Const.effect_GTot_lid)
-             in
+              (FStar_Ident.lid_equals m FStar_Parser_Const.effect_GTot_lid) in
           if uu____11589
           then e
           else
@@ -4641,34 +4144,32 @@ let (maybe_monadic :
               (FStar_Syntax_Syntax.Tm_meta
                  (e, (FStar_Syntax_Syntax.Meta_monadic (m, t))))
               FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-  
-let (d : Prims.string -> Prims.unit) =
-  fun s  -> FStar_Util.print1 "\027[01;36m%s\027[00m\n" s 
-let (mk_toplevel_definition :
+let d: Prims.string -> Prims.unit =
+  fun s  -> FStar_Util.print1 "\027[01;36m%s\027[00m\n" s
+let mk_toplevel_definition:
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
       FStar_Syntax_Syntax.term ->
         (FStar_Syntax_Syntax.sigelt,FStar_Syntax_Syntax.term)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun lident  ->
       fun def  ->
         (let uu____11612 =
-           FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED")  in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
          if uu____11612
          then
            (d (FStar_Ident.text_of_lid lident);
-            (let uu____11614 = FStar_Syntax_Print.term_to_string def  in
+            (let uu____11614 = FStar_Syntax_Print.term_to_string def in
              FStar_Util.print2 "Registering top-level definition: %s\n%s\n"
                (FStar_Ident.text_of_lid lident) uu____11614))
          else ());
         (let fv =
-           let uu____11617 = FStar_Syntax_Util.incr_delta_qualifier def  in
+           let uu____11617 = FStar_Syntax_Util.incr_delta_qualifier def in
            FStar_Syntax_Syntax.lid_as_fv lident uu____11617
-             FStar_Pervasives_Native.None
-            in
-         let lbname = FStar_Util.Inr fv  in
+             FStar_Pervasives_Native.None in
+         let lbname = FStar_Util.Inr fv in
          let lb =
            (false,
              [{
@@ -4678,17 +4179,14 @@ let (mk_toplevel_definition :
                 FStar_Syntax_Syntax.lbeff = FStar_Parser_Const.effect_Tot_lid;
                 FStar_Syntax_Syntax.lbdef = def;
                 FStar_Syntax_Syntax.lbattrs = []
-              }])
-            in
+              }]) in
          let sig_ctx =
            FStar_Syntax_Syntax.mk_sigelt
-             (FStar_Syntax_Syntax.Sig_let (lb, [lident]))
-            in
+             (FStar_Syntax_Syntax.Sig_let (lb, [lident])) in
          let uu____11627 =
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
-             FStar_Pervasives_Native.None FStar_Range.dummyRange
-            in
-         ((let uu___125_11633 = sig_ctx  in
+             FStar_Pervasives_Native.None FStar_Range.dummyRange in
+         ((let uu___125_11633 = sig_ctx in
            {
              FStar_Syntax_Syntax.sigel =
                (uu___125_11633.FStar_Syntax_Syntax.sigel);
@@ -4701,15 +4199,14 @@ let (mk_toplevel_definition :
              FStar_Syntax_Syntax.sigattrs =
                (uu___125_11633.FStar_Syntax_Syntax.sigattrs)
            }), uu____11627))
-  
-let (check_sigelt_quals :
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> Prims.unit) =
+let check_sigelt_quals:
+  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> Prims.unit =
   fun env  ->
     fun se  ->
       let visibility uu___92_11643 =
         match uu___92_11643 with
         | FStar_Syntax_Syntax.Private  -> true
-        | uu____11644 -> false  in
+        | uu____11644 -> false in
       let reducibility uu___93_11648 =
         match uu___93_11648 with
         | FStar_Syntax_Syntax.Abstract  -> true
@@ -4717,17 +4214,17 @@ let (check_sigelt_quals :
         | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen  -> true
         | FStar_Syntax_Syntax.Visible_default  -> true
         | FStar_Syntax_Syntax.Inline_for_extraction  -> true
-        | uu____11649 -> false  in
+        | uu____11649 -> false in
       let assumption uu___94_11653 =
         match uu___94_11653 with
         | FStar_Syntax_Syntax.Assumption  -> true
         | FStar_Syntax_Syntax.New  -> true
-        | uu____11654 -> false  in
+        | uu____11654 -> false in
       let reification uu___95_11658 =
         match uu___95_11658 with
         | FStar_Syntax_Syntax.Reifiable  -> true
         | FStar_Syntax_Syntax.Reflectable uu____11659 -> true
-        | uu____11660 -> false  in
+        | uu____11660 -> false in
       let inferred uu___96_11664 =
         match uu___96_11664 with
         | FStar_Syntax_Syntax.Discriminator uu____11665 -> true
@@ -4737,12 +4234,12 @@ let (check_sigelt_quals :
         | FStar_Syntax_Syntax.ExceptionConstructor  -> true
         | FStar_Syntax_Syntax.HasMaskedEffect  -> true
         | FStar_Syntax_Syntax.Effect  -> true
-        | uu____11689 -> false  in
+        | uu____11689 -> false in
       let has_eq uu___97_11693 =
         match uu___97_11693 with
         | FStar_Syntax_Syntax.Noeq  -> true
         | FStar_Syntax_Syntax.Unopteq  -> true
-        | uu____11694 -> false  in
+        | uu____11694 -> false in
       let quals_combo_ok quals q =
         match q with
         | FStar_Syntax_Syntax.Assumption  ->
@@ -4862,8 +4359,8 @@ let (check_sigelt_quals :
                     (((reification x) || (inferred x)) || (visibility x)) ||
                       (x = FStar_Syntax_Syntax.TotalEffect)))
         | FStar_Syntax_Syntax.Private  -> true
-        | uu____11759 -> true  in
-      let quals = FStar_Syntax_Util.quals_of_sigelt se  in
+        | uu____11759 -> true in
+      let quals = FStar_Syntax_Util.quals_of_sigelt se in
       let uu____11763 =
         let uu____11764 =
           FStar_All.pipe_right quals
@@ -4871,35 +4368,32 @@ let (check_sigelt_quals :
                (fun uu___98_11768  ->
                   match uu___98_11768 with
                   | FStar_Syntax_Syntax.OnlyName  -> true
-                  | uu____11769 -> false))
-           in
-        FStar_All.pipe_right uu____11764 Prims.op_Negation  in
+                  | uu____11769 -> false)) in
+        FStar_All.pipe_right uu____11764 Prims.op_Negation in
       if uu____11763
       then
-        let r = FStar_Syntax_Util.range_of_sigelt se  in
+        let r = FStar_Syntax_Util.range_of_sigelt se in
         let no_dup_quals =
-          FStar_Util.remove_dups (fun x  -> fun y  -> x = y) quals  in
+          FStar_Util.remove_dups (fun x  -> fun y  -> x = y) quals in
         let err' msg =
           let uu____11782 =
             let uu____11787 =
-              let uu____11788 = FStar_Syntax_Print.quals_to_string quals  in
+              let uu____11788 = FStar_Syntax_Print.quals_to_string quals in
               FStar_Util.format2
                 "The qualifier list \"[%s]\" is not permissible for this element%s"
-                uu____11788 msg
-               in
-            (FStar_Errors.Fatal_QulifierListNotPermitted, uu____11787)  in
-          FStar_Errors.raise_error uu____11782 r  in
-        let err msg = err' (Prims.strcat ": " msg)  in
-        let err'1 uu____11796 = err' ""  in
+                uu____11788 msg in
+            (FStar_Errors.Fatal_QulifierListNotPermitted, uu____11787) in
+          FStar_Errors.raise_error uu____11782 r in
+        let err msg = err' (Prims.strcat ": " msg) in
+        let err'1 uu____11796 = err' "" in
         (if (FStar_List.length quals) <> (FStar_List.length no_dup_quals)
          then err "duplicate qualifiers"
          else ();
          (let uu____11800 =
             let uu____11801 =
               FStar_All.pipe_right quals
-                (FStar_List.for_all (quals_combo_ok quals))
-               in
-            Prims.op_Negation uu____11801  in
+                (FStar_List.for_all (quals_combo_ok quals)) in
+            Prims.op_Negation uu____11801 in
           if uu____11800 then err "ill-formed combination" else ());
          (match se.FStar_Syntax_Syntax.sigel with
           | FStar_Syntax_Syntax.Sig_let ((is_rec,uu____11806),uu____11807) ->
@@ -4907,16 +4401,14 @@ let (check_sigelt_quals :
                   is_rec &&
                     (FStar_All.pipe_right quals
                        (FStar_List.contains
-                          FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen))
-                   in
+                          FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)) in
                 if uu____11823
                 then err "recursive definitions cannot be marked inline"
                 else ());
                (let uu____11827 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
-                       (fun x  -> (assumption x) || (has_eq x)))
-                   in
+                       (fun x  -> (assumption x) || (has_eq x))) in
                 if uu____11827
                 then
                   err
@@ -4931,13 +4423,12 @@ let (check_sigelt_quals :
                           (((x = FStar_Syntax_Syntax.Abstract) ||
                               (inferred x))
                              || (visibility x))
-                            || (has_eq x)))
-                   in
-                Prims.op_Negation uu____11843  in
+                            || (has_eq x))) in
+                Prims.op_Negation uu____11843 in
               if uu____11842 then err'1 () else ()
           | FStar_Syntax_Syntax.Sig_declare_typ uu____11849 ->
               let uu____11856 =
-                FStar_All.pipe_right quals (FStar_Util.for_some has_eq)  in
+                FStar_All.pipe_right quals (FStar_Util.for_some has_eq) in
               if uu____11856 then err'1 () else ()
           | FStar_Syntax_Syntax.Sig_assume uu____11860 ->
               let uu____11867 =
@@ -4946,9 +4437,8 @@ let (check_sigelt_quals :
                     (FStar_Util.for_all
                        (fun x  ->
                           (visibility x) ||
-                            (x = FStar_Syntax_Syntax.Assumption)))
-                   in
-                Prims.op_Negation uu____11868  in
+                            (x = FStar_Syntax_Syntax.Assumption))) in
+                Prims.op_Negation uu____11868 in
               if uu____11867 then err'1 () else ()
           | FStar_Syntax_Syntax.Sig_new_effect uu____11874 ->
               let uu____11875 =
@@ -4959,9 +4449,8 @@ let (check_sigelt_quals :
                           (((x = FStar_Syntax_Syntax.TotalEffect) ||
                               (inferred x))
                              || (visibility x))
-                            || (reification x)))
-                   in
-                Prims.op_Negation uu____11876  in
+                            || (reification x))) in
+                Prims.op_Negation uu____11876 in
               if uu____11875 then err'1 () else ()
           | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____11882 ->
               let uu____11883 =
@@ -4972,23 +4461,20 @@ let (check_sigelt_quals :
                           (((x = FStar_Syntax_Syntax.TotalEffect) ||
                               (inferred x))
                              || (visibility x))
-                            || (reification x)))
-                   in
-                Prims.op_Negation uu____11884  in
+                            || (reification x))) in
+                Prims.op_Negation uu____11884 in
               if uu____11883 then err'1 () else ()
           | FStar_Syntax_Syntax.Sig_effect_abbrev uu____11890 ->
               let uu____11903 =
                 let uu____11904 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
-                       (fun x  -> (inferred x) || (visibility x)))
-                   in
-                Prims.op_Negation uu____11904  in
+                       (fun x  -> (inferred x) || (visibility x))) in
+                Prims.op_Negation uu____11904 in
               if uu____11903 then err'1 () else ()
           | uu____11910 -> ()))
       else ()
-  
-let (mk_discriminator_and_indexed_projectors :
+let mk_discriminator_and_indexed_projectors:
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_Syntax_Syntax.fv_qual ->
       Prims.bool ->
@@ -4999,7 +4485,7 @@ let (mk_discriminator_and_indexed_projectors :
                 FStar_Syntax_Syntax.binders ->
                   FStar_Syntax_Syntax.binders ->
                     FStar_Syntax_Syntax.binders ->
-                      FStar_Syntax_Syntax.sigelt Prims.list)
+                      FStar_Syntax_Syntax.sigelt Prims.list
   =
   fun iquals  ->
     fun fvq  ->
@@ -5011,17 +4497,15 @@ let (mk_discriminator_and_indexed_projectors :
                 fun inductive_tps  ->
                   fun indices  ->
                     fun fields  ->
-                      let p = FStar_Ident.range_of_lid lid  in
-                      let pos q = FStar_Syntax_Syntax.withinfo q p  in
+                      let p = FStar_Ident.range_of_lid lid in
+                      let pos q = FStar_Syntax_Syntax.withinfo q p in
                       let projectee ptyp =
                         FStar_Syntax_Syntax.gen_bv "projectee"
-                          (FStar_Pervasives_Native.Some p) ptyp
-                         in
+                          (FStar_Pervasives_Native.Some p) ptyp in
                       let inst_univs =
                         FStar_List.map
-                          (fun u  -> FStar_Syntax_Syntax.U_name u) uvs
-                         in
-                      let tps = inductive_tps  in
+                          (fun u  -> FStar_Syntax_Syntax.U_name u) uvs in
+                      let tps = inductive_tps in
                       let arg_typ =
                         let inst_tc =
                           let uu____11973 =
@@ -5031,14 +4515,12 @@ let (mk_discriminator_and_indexed_projectors :
                                   let uu____11985 =
                                     FStar_Syntax_Syntax.lid_as_fv tc
                                       FStar_Syntax_Syntax.Delta_constant
-                                      FStar_Pervasives_Native.None
-                                     in
-                                  FStar_Syntax_Syntax.fv_to_tm uu____11985
-                                   in
-                                (uu____11984, inst_univs)  in
-                              FStar_Syntax_Syntax.Tm_uinst uu____11977  in
-                            FStar_Syntax_Syntax.mk uu____11976  in
-                          uu____11973 FStar_Pervasives_Native.None p  in
+                                      FStar_Pervasives_Native.None in
+                                  FStar_Syntax_Syntax.fv_to_tm uu____11985 in
+                                (uu____11984, inst_univs) in
+                              FStar_Syntax_Syntax.Tm_uinst uu____11977 in
+                            FStar_Syntax_Syntax.mk uu____11976 in
+                          uu____11973 FStar_Pervasives_Native.None p in
                         let args =
                           FStar_All.pipe_right
                             (FStar_List.append tps indices)
@@ -5047,67 +4529,58 @@ let (mk_discriminator_and_indexed_projectors :
                                   match uu____12026 with
                                   | (x,imp) ->
                                       let uu____12037 =
-                                        FStar_Syntax_Syntax.bv_to_name x  in
-                                      (uu____12037, imp)))
-                           in
+                                        FStar_Syntax_Syntax.bv_to_name x in
+                                      (uu____12037, imp))) in
                         FStar_Syntax_Syntax.mk_Tm_app inst_tc args
-                          FStar_Pervasives_Native.None p
-                         in
+                          FStar_Pervasives_Native.None p in
                       let unrefined_arg_binder =
-                        let uu____12039 = projectee arg_typ  in
-                        FStar_Syntax_Syntax.mk_binder uu____12039  in
+                        let uu____12039 = projectee arg_typ in
+                        FStar_Syntax_Syntax.mk_binder uu____12039 in
                       let arg_binder =
                         if Prims.op_Negation refine_domain
                         then unrefined_arg_binder
                         else
                           (let disc_name =
-                             FStar_Syntax_Util.mk_discriminator lid  in
+                             FStar_Syntax_Util.mk_discriminator lid in
                            let x =
                              FStar_Syntax_Syntax.new_bv
-                               (FStar_Pervasives_Native.Some p) arg_typ
-                              in
+                               (FStar_Pervasives_Native.Some p) arg_typ in
                            let sort =
                              let disc_fvar =
                                FStar_Syntax_Syntax.fvar
                                  (FStar_Ident.set_lid_range disc_name p)
                                  FStar_Syntax_Syntax.Delta_equational
-                                 FStar_Pervasives_Native.None
-                                in
+                                 FStar_Pervasives_Native.None in
                              let uu____12048 =
                                let uu____12049 =
                                  let uu____12050 =
                                    let uu____12051 =
                                      FStar_Syntax_Syntax.mk_Tm_uinst
-                                       disc_fvar inst_univs
-                                      in
+                                       disc_fvar inst_univs in
                                    let uu____12052 =
                                      let uu____12053 =
                                        let uu____12054 =
-                                         FStar_Syntax_Syntax.bv_to_name x  in
+                                         FStar_Syntax_Syntax.bv_to_name x in
                                        FStar_All.pipe_left
                                          FStar_Syntax_Syntax.as_arg
-                                         uu____12054
-                                        in
-                                     [uu____12053]  in
+                                         uu____12054 in
+                                     [uu____12053] in
                                    FStar_Syntax_Syntax.mk_Tm_app uu____12051
-                                     uu____12052
-                                    in
-                                 uu____12050 FStar_Pervasives_Native.None p
-                                  in
-                               FStar_Syntax_Util.b2t uu____12049  in
-                             FStar_Syntax_Util.refine x uu____12048  in
+                                     uu____12052 in
+                                 uu____12050 FStar_Pervasives_Native.None p in
+                               FStar_Syntax_Util.b2t uu____12049 in
+                             FStar_Syntax_Util.refine x uu____12048 in
                            let uu____12057 =
-                             let uu___126_12058 = projectee arg_typ  in
+                             let uu___126_12058 = projectee arg_typ in
                              {
                                FStar_Syntax_Syntax.ppname =
                                  (uu___126_12058.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
                                  (uu___126_12058.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort = sort
-                             }  in
-                           FStar_Syntax_Syntax.mk_binder uu____12057)
-                         in
-                      let ntps = FStar_List.length tps  in
+                             } in
+                           FStar_Syntax_Syntax.mk_binder uu____12057) in
+                      let ntps = FStar_List.length tps in
                       let all_params =
                         let uu____12073 =
                           FStar_List.map
@@ -5116,9 +4589,8 @@ let (mk_discriminator_and_indexed_projectors :
                                | (x,uu____12107) ->
                                    (x,
                                      (FStar_Pervasives_Native.Some
-                                        FStar_Syntax_Syntax.imp_tag))) tps
-                           in
-                        FStar_List.append uu____12073 fields  in
+                                        FStar_Syntax_Syntax.imp_tag))) tps in
+                        FStar_List.append uu____12073 fields in
                       let imp_binders =
                         FStar_All.pipe_right (FStar_List.append tps indices)
                           (FStar_List.map
@@ -5127,28 +4599,25 @@ let (mk_discriminator_and_indexed_projectors :
                                 | (x,uu____12168) ->
                                     (x,
                                       (FStar_Pervasives_Native.Some
-                                         FStar_Syntax_Syntax.imp_tag))))
-                         in
+                                         FStar_Syntax_Syntax.imp_tag)))) in
                       let discriminator_ses =
                         if fvq <> FStar_Syntax_Syntax.Data_ctor
                         then []
                         else
                           (let discriminator_name =
-                             FStar_Syntax_Util.mk_discriminator lid  in
-                           let no_decl = false  in
+                             FStar_Syntax_Util.mk_discriminator lid in
+                           let no_decl = false in
                            let only_decl =
                              (let uu____12182 =
-                                FStar_TypeChecker_Env.current_module env  in
+                                FStar_TypeChecker_Env.current_module env in
                               FStar_Ident.lid_equals
                                 FStar_Parser_Const.prims_lid uu____12182)
                                ||
                                (let uu____12184 =
                                   let uu____12185 =
-                                    FStar_TypeChecker_Env.current_module env
-                                     in
-                                  uu____12185.FStar_Ident.str  in
-                                FStar_Options.dont_gen_projectors uu____12184)
-                              in
+                                    FStar_TypeChecker_Env.current_module env in
+                                  uu____12185.FStar_Ident.str in
+                                FStar_Options.dont_gen_projectors uu____12184) in
                            let quals =
                              let uu____12189 =
                                FStar_List.filter
@@ -5157,20 +4626,17 @@ let (mk_discriminator_and_indexed_projectors :
                                     | FStar_Syntax_Syntax.Abstract  ->
                                         Prims.op_Negation only_decl
                                     | FStar_Syntax_Syntax.Private  -> true
-                                    | uu____12194 -> false) iquals
-                                in
+                                    | uu____12194 -> false) iquals in
                              FStar_List.append
                                ((FStar_Syntax_Syntax.Discriminator lid) ::
                                (if only_decl
                                 then
                                   [FStar_Syntax_Syntax.Logic;
                                   FStar_Syntax_Syntax.Assumption]
-                                else [])) uu____12189
-                              in
+                                else [])) uu____12189 in
                            let binders =
                              FStar_List.append imp_binders
-                               [unrefined_arg_binder]
-                              in
+                               [unrefined_arg_binder] in
                            let t =
                              let bool_typ =
                                let uu____12215 =
@@ -5178,16 +4644,14 @@ let (mk_discriminator_and_indexed_projectors :
                                    FStar_Syntax_Syntax.lid_as_fv
                                      FStar_Parser_Const.bool_lid
                                      FStar_Syntax_Syntax.Delta_constant
-                                     FStar_Pervasives_Native.None
-                                    in
-                                 FStar_Syntax_Syntax.fv_to_tm uu____12216  in
-                               FStar_Syntax_Syntax.mk_Total uu____12215  in
+                                     FStar_Pervasives_Native.None in
+                                 FStar_Syntax_Syntax.fv_to_tm uu____12216 in
+                               FStar_Syntax_Syntax.mk_Total uu____12215 in
                              let uu____12217 =
-                               FStar_Syntax_Util.arrow binders bool_typ  in
+                               FStar_Syntax_Util.arrow binders bool_typ in
                              FStar_All.pipe_left
                                (FStar_Syntax_Subst.close_univ_vars uvs)
-                               uu____12217
-                              in
+                               uu____12217 in
                            let decl =
                              {
                                FStar_Syntax_Syntax.sigel =
@@ -5199,15 +4663,14 @@ let (mk_discriminator_and_indexed_projectors :
                                FStar_Syntax_Syntax.sigmeta =
                                  FStar_Syntax_Syntax.default_sigmeta;
                                FStar_Syntax_Syntax.sigattrs = []
-                             }  in
+                             } in
                            (let uu____12220 =
                               FStar_TypeChecker_Env.debug env
-                                (FStar_Options.Other "LogTypes")
-                               in
+                                (FStar_Options.Other "LogTypes") in
                             if uu____12220
                             then
                               let uu____12221 =
-                                FStar_Syntax_Print.sigelt_to_string decl  in
+                                FStar_Syntax_Print.sigelt_to_string decl in
                               FStar_Util.print1
                                 "Declaration of a discriminator %s\n"
                                 uu____12221
@@ -5228,8 +4691,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                | (x,imp) ->
                                                    let b =
                                                      FStar_Syntax_Syntax.is_implicit
-                                                       imp
-                                                      in
+                                                       imp in
                                                    if b && (j < ntps)
                                                    then
                                                      let uu____12298 =
@@ -5239,15 +4701,12 @@ let (mk_discriminator_and_indexed_projectors :
                                                              FStar_Syntax_Syntax.gen_bv
                                                                (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                                                FStar_Pervasives_Native.None
-                                                               FStar_Syntax_Syntax.tun
-                                                              in
+                                                               FStar_Syntax_Syntax.tun in
                                                            (uu____12309,
-                                                             FStar_Syntax_Syntax.tun)
-                                                            in
+                                                             FStar_Syntax_Syntax.tun) in
                                                          FStar_Syntax_Syntax.Pat_dot_term
-                                                           uu____12302
-                                                          in
-                                                       pos uu____12301  in
+                                                           uu____12302 in
+                                                       pos uu____12301 in
                                                      (uu____12298, b)
                                                    else
                                                      (let uu____12313 =
@@ -5256,14 +4715,11 @@ let (mk_discriminator_and_indexed_projectors :
                                                             FStar_Syntax_Syntax.gen_bv
                                                               (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                                               FStar_Pervasives_Native.None
-                                                              FStar_Syntax_Syntax.tun
-                                                             in
+                                                              FStar_Syntax_Syntax.tun in
                                                           FStar_Syntax_Syntax.Pat_wild
-                                                            uu____12317
-                                                           in
-                                                        pos uu____12316  in
-                                                      (uu____12313, b))))
-                                      in
+                                                            uu____12317 in
+                                                        pos uu____12316 in
+                                                      (uu____12313, b)))) in
                                    let pat_true =
                                      let uu____12335 =
                                        let uu____12338 =
@@ -5273,90 +4729,75 @@ let (mk_discriminator_and_indexed_projectors :
                                                lid
                                                FStar_Syntax_Syntax.Delta_constant
                                                (FStar_Pervasives_Native.Some
-                                                  fvq)
-                                              in
-                                           (uu____12352, arg_pats)  in
+                                                  fvq) in
+                                           (uu____12352, arg_pats) in
                                          FStar_Syntax_Syntax.Pat_cons
-                                           uu____12339
-                                          in
-                                       pos uu____12338  in
+                                           uu____12339 in
+                                       pos uu____12338 in
                                      (uu____12335,
                                        FStar_Pervasives_Native.None,
-                                       FStar_Syntax_Util.exp_true_bool)
-                                      in
+                                       FStar_Syntax_Util.exp_true_bool) in
                                    let pat_false =
                                      let uu____12386 =
                                        let uu____12389 =
                                          let uu____12390 =
                                            FStar_Syntax_Syntax.new_bv
                                              FStar_Pervasives_Native.None
-                                             FStar_Syntax_Syntax.tun
-                                            in
+                                             FStar_Syntax_Syntax.tun in
                                          FStar_Syntax_Syntax.Pat_wild
-                                           uu____12390
-                                          in
-                                       pos uu____12389  in
+                                           uu____12390 in
+                                       pos uu____12389 in
                                      (uu____12386,
                                        FStar_Pervasives_Native.None,
-                                       FStar_Syntax_Util.exp_false_bool)
-                                      in
+                                       FStar_Syntax_Util.exp_false_bool) in
                                    let arg_exp =
                                      FStar_Syntax_Syntax.bv_to_name
                                        (FStar_Pervasives_Native.fst
-                                          unrefined_arg_binder)
-                                      in
+                                          unrefined_arg_binder) in
                                    let uu____12402 =
                                      let uu____12405 =
                                        let uu____12406 =
                                          let uu____12429 =
                                            let uu____12432 =
                                              FStar_Syntax_Util.branch
-                                               pat_true
-                                              in
+                                               pat_true in
                                            let uu____12433 =
                                              let uu____12436 =
                                                FStar_Syntax_Util.branch
-                                                 pat_false
-                                                in
-                                             [uu____12436]  in
-                                           uu____12432 :: uu____12433  in
-                                         (arg_exp, uu____12429)  in
+                                                 pat_false in
+                                             [uu____12436] in
+                                           uu____12432 :: uu____12433 in
+                                         (arg_exp, uu____12429) in
                                        FStar_Syntax_Syntax.Tm_match
-                                         uu____12406
-                                        in
-                                     FStar_Syntax_Syntax.mk uu____12405  in
-                                   uu____12402 FStar_Pervasives_Native.None p)
-                                 in
+                                         uu____12406 in
+                                     FStar_Syntax_Syntax.mk uu____12405 in
+                                   uu____12402 FStar_Pervasives_Native.None p) in
                               let dd =
                                 let uu____12443 =
                                   FStar_All.pipe_right quals
                                     (FStar_List.contains
-                                       FStar_Syntax_Syntax.Abstract)
-                                   in
+                                       FStar_Syntax_Syntax.Abstract) in
                                 if uu____12443
                                 then
                                   FStar_Syntax_Syntax.Delta_abstract
                                     FStar_Syntax_Syntax.Delta_equational
-                                else FStar_Syntax_Syntax.Delta_equational  in
+                                else FStar_Syntax_Syntax.Delta_equational in
                               let imp =
                                 FStar_Syntax_Util.abs binders body
-                                  FStar_Pervasives_Native.None
-                                 in
+                                  FStar_Pervasives_Native.None in
                               let lbtyp =
                                 if no_decl
                                 then t
-                                else FStar_Syntax_Syntax.tun  in
+                                else FStar_Syntax_Syntax.tun in
                               let lb =
                                 let uu____12451 =
                                   let uu____12456 =
                                     FStar_Syntax_Syntax.lid_as_fv
                                       discriminator_name dd
-                                      FStar_Pervasives_Native.None
-                                     in
-                                  FStar_Util.Inr uu____12456  in
+                                      FStar_Pervasives_Native.None in
+                                  FStar_Util.Inr uu____12456 in
                                 let uu____12457 =
-                                  FStar_Syntax_Subst.close_univ_vars uvs imp
-                                   in
+                                  FStar_Syntax_Subst.close_univ_vars uvs imp in
                                 {
                                   FStar_Syntax_Syntax.lbname = uu____12451;
                                   FStar_Syntax_Syntax.lbunivs = uvs;
@@ -5365,7 +4806,7 @@ let (mk_discriminator_and_indexed_projectors :
                                     FStar_Parser_Const.effect_Tot_lid;
                                   FStar_Syntax_Syntax.lbdef = uu____12457;
                                   FStar_Syntax_Syntax.lbattrs = []
-                                }  in
+                                } in
                               let impl =
                                 let uu____12463 =
                                   let uu____12464 =
@@ -5374,15 +4815,13 @@ let (mk_discriminator_and_indexed_projectors :
                                         let uu____12475 =
                                           FStar_All.pipe_right
                                             lb.FStar_Syntax_Syntax.lbname
-                                            FStar_Util.right
-                                           in
+                                            FStar_Util.right in
                                         FStar_All.pipe_right uu____12475
                                           (fun fv  ->
-                                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                                         in
-                                      [uu____12474]  in
-                                    ((false, [lb]), uu____12471)  in
-                                  FStar_Syntax_Syntax.Sig_let uu____12464  in
+                                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
+                                      [uu____12474] in
+                                    ((false, [lb]), uu____12471) in
+                                  FStar_Syntax_Syntax.Sig_let uu____12464 in
                                 {
                                   FStar_Syntax_Syntax.sigel = uu____12463;
                                   FStar_Syntax_Syntax.sigrng = p;
@@ -5390,31 +4829,26 @@ let (mk_discriminator_and_indexed_projectors :
                                   FStar_Syntax_Syntax.sigmeta =
                                     FStar_Syntax_Syntax.default_sigmeta;
                                   FStar_Syntax_Syntax.sigattrs = []
-                                }  in
+                                } in
                               (let uu____12493 =
                                  FStar_TypeChecker_Env.debug env
-                                   (FStar_Options.Other "LogTypes")
-                                  in
+                                   (FStar_Options.Other "LogTypes") in
                                if uu____12493
                                then
                                  let uu____12494 =
-                                   FStar_Syntax_Print.sigelt_to_string impl
-                                    in
+                                   FStar_Syntax_Print.sigelt_to_string impl in
                                  FStar_Util.print1
                                    "Implementation of a discriminator %s\n"
                                    uu____12494
                                else ());
-                              [decl; impl]))
-                         in
+                              [decl; impl])) in
                       let arg_exp =
                         FStar_Syntax_Syntax.bv_to_name
-                          (FStar_Pervasives_Native.fst arg_binder)
-                         in
+                          (FStar_Pervasives_Native.fst arg_binder) in
                       let binders =
-                        FStar_List.append imp_binders [arg_binder]  in
+                        FStar_List.append imp_binders [arg_binder] in
                       let arg =
-                        FStar_Syntax_Util.arg_of_non_null_binder arg_binder
-                         in
+                        FStar_Syntax_Util.arg_of_non_null_binder arg_binder in
                       let subst1 =
                         FStar_All.pipe_right fields
                           (FStar_List.mapi
@@ -5424,8 +4858,7 @@ let (mk_discriminator_and_indexed_projectors :
                                   | (a,uu____12542) ->
                                       let uu____12543 =
                                         FStar_Syntax_Util.mk_field_projector_name
-                                          lid a i
-                                         in
+                                          lid a i in
                                       (match uu____12543 with
                                        | (field_name,uu____12549) ->
                                            let field_proj_tm =
@@ -5434,21 +4867,16 @@ let (mk_discriminator_and_indexed_projectors :
                                                  FStar_Syntax_Syntax.lid_as_fv
                                                    field_name
                                                    FStar_Syntax_Syntax.Delta_equational
-                                                   FStar_Pervasives_Native.None
-                                                  in
+                                                   FStar_Pervasives_Native.None in
                                                FStar_Syntax_Syntax.fv_to_tm
-                                                 uu____12552
-                                                in
+                                                 uu____12552 in
                                              FStar_Syntax_Syntax.mk_Tm_uinst
-                                               uu____12551 inst_univs
-                                              in
+                                               uu____12551 inst_univs in
                                            let proj =
                                              FStar_Syntax_Syntax.mk_Tm_app
                                                field_proj_tm [arg]
-                                               FStar_Pervasives_Native.None p
-                                              in
-                                           FStar_Syntax_Syntax.NT (a, proj))))
-                         in
+                                               FStar_Pervasives_Native.None p in
+                                           FStar_Syntax_Syntax.NT (a, proj)))) in
                       let projectors_ses =
                         let uu____12569 =
                           FStar_All.pipe_right fields
@@ -5458,12 +4886,10 @@ let (mk_discriminator_and_indexed_projectors :
                                     match uu____12601 with
                                     | (x,uu____12609) ->
                                         let p1 =
-                                          FStar_Syntax_Syntax.range_of_bv x
-                                           in
+                                          FStar_Syntax_Syntax.range_of_bv x in
                                         let uu____12611 =
                                           FStar_Syntax_Util.mk_field_projector_name
-                                            lid x i
-                                           in
+                                            lid x i in
                                         (match uu____12611 with
                                          | (field_name,uu____12619) ->
                                              let t =
@@ -5472,23 +4898,18 @@ let (mk_discriminator_and_indexed_projectors :
                                                    let uu____12625 =
                                                      FStar_Syntax_Subst.subst
                                                        subst1
-                                                       x.FStar_Syntax_Syntax.sort
-                                                      in
+                                                       x.FStar_Syntax_Syntax.sort in
                                                    FStar_Syntax_Syntax.mk_Total
-                                                     uu____12625
-                                                    in
+                                                     uu____12625 in
                                                  FStar_Syntax_Util.arrow
-                                                   binders uu____12622
-                                                  in
+                                                   binders uu____12622 in
                                                FStar_All.pipe_left
                                                  (FStar_Syntax_Subst.close_univ_vars
-                                                    uvs) uu____12621
-                                                in
+                                                    uvs) uu____12621 in
                                              let only_decl =
                                                (let uu____12629 =
                                                   FStar_TypeChecker_Env.current_module
-                                                    env
-                                                   in
+                                                    env in
                                                 FStar_Ident.lid_equals
                                                   FStar_Parser_Const.prims_lid
                                                   uu____12629)
@@ -5496,14 +4917,11 @@ let (mk_discriminator_and_indexed_projectors :
                                                  (let uu____12631 =
                                                     let uu____12632 =
                                                       FStar_TypeChecker_Env.current_module
-                                                        env
-                                                       in
-                                                    uu____12632.FStar_Ident.str
-                                                     in
+                                                        env in
+                                                    uu____12632.FStar_Ident.str in
                                                   FStar_Options.dont_gen_projectors
-                                                    uu____12631)
-                                                in
-                                             let no_decl = false  in
+                                                    uu____12631) in
+                                             let no_decl = false in
                                              let quals q =
                                                if only_decl
                                                then
@@ -5515,11 +4933,10 @@ let (mk_discriminator_and_indexed_projectors :
                                                         | FStar_Syntax_Syntax.Abstract
                                                              -> false
                                                         | uu____12651 -> true)
-                                                     q
-                                                    in
+                                                     q in
                                                  FStar_Syntax_Syntax.Assumption
                                                    :: uu____12646
-                                               else q  in
+                                               else q in
                                              let quals1 =
                                                let iquals1 =
                                                  FStar_All.pipe_right iquals
@@ -5532,20 +4949,17 @@ let (mk_discriminator_and_indexed_projectors :
                                                          | FStar_Syntax_Syntax.Private
                                                               -> true
                                                          | uu____12665 ->
-                                                             false))
-                                                  in
+                                                             false)) in
                                                quals
                                                  ((FStar_Syntax_Syntax.Projector
                                                      (lid,
                                                        (x.FStar_Syntax_Syntax.ppname)))
-                                                 :: iquals1)
-                                                in
+                                                 :: iquals1) in
                                              let attrs =
                                                if only_decl
                                                then []
                                                else
-                                                 [FStar_Syntax_Util.attr_substitute]
-                                                in
+                                                 [FStar_Syntax_Util.attr_substitute] in
                                              let decl =
                                                {
                                                  FStar_Syntax_Syntax.sigel =
@@ -5561,19 +4975,17 @@ let (mk_discriminator_and_indexed_projectors :
                                                    FStar_Syntax_Syntax.default_sigmeta;
                                                  FStar_Syntax_Syntax.sigattrs
                                                    = attrs
-                                               }  in
+                                               } in
                                              ((let uu____12684 =
                                                  FStar_TypeChecker_Env.debug
                                                    env
                                                    (FStar_Options.Other
-                                                      "LogTypes")
-                                                  in
+                                                      "LogTypes") in
                                                if uu____12684
                                                then
                                                  let uu____12685 =
                                                    FStar_Syntax_Print.sigelt_to_string
-                                                     decl
-                                                    in
+                                                     decl in
                                                  FStar_Util.print1
                                                    "Declaration of a projector %s\n"
                                                    uu____12685
@@ -5585,8 +4997,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                    FStar_Syntax_Syntax.gen_bv
                                                      (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                                      FStar_Pervasives_Native.None
-                                                     FStar_Syntax_Syntax.tun
-                                                    in
+                                                     FStar_Syntax_Syntax.tun in
                                                  let arg_pats =
                                                    FStar_All.pipe_right
                                                      all_params
@@ -5599,8 +5010,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                              | (x1,imp) ->
                                                                  let b =
                                                                    FStar_Syntax_Syntax.is_implicit
-                                                                    imp
-                                                                    in
+                                                                    imp in
                                                                  if
                                                                    (i + ntps)
                                                                     = j
@@ -5609,8 +5019,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     =
                                                                     pos
                                                                     (FStar_Syntax_Syntax.Pat_var
-                                                                    projection)
-                                                                     in
+                                                                    projection) in
                                                                    (uu____12757,
                                                                     b)
                                                                  else
@@ -5629,17 +5038,13 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                                                     FStar_Pervasives_Native.None
-                                                                    FStar_Syntax_Syntax.tun
-                                                                     in
+                                                                    FStar_Syntax_Syntax.tun in
                                                                     (uu____12784,
-                                                                    FStar_Syntax_Syntax.tun)
-                                                                     in
+                                                                    FStar_Syntax_Syntax.tun) in
                                                                     FStar_Syntax_Syntax.Pat_dot_term
-                                                                    uu____12777
-                                                                     in
+                                                                    uu____12777 in
                                                                     pos
-                                                                    uu____12776
-                                                                     in
+                                                                    uu____12776 in
                                                                     (uu____12773,
                                                                     b))
                                                                    else
@@ -5652,17 +5057,13 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     (x1.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
                                                                     FStar_Pervasives_Native.None
-                                                                    FStar_Syntax_Syntax.tun
-                                                                     in
+                                                                    FStar_Syntax_Syntax.tun in
                                                                     FStar_Syntax_Syntax.Pat_wild
-                                                                    uu____12792
-                                                                     in
+                                                                    uu____12792 in
                                                                     pos
-                                                                    uu____12791
-                                                                     in
+                                                                    uu____12791 in
                                                                     (uu____12788,
-                                                                    b))))
-                                                    in
+                                                                    b)))) in
                                                  let pat =
                                                    let uu____12808 =
                                                      let uu____12811 =
@@ -5672,23 +5073,18 @@ let (mk_discriminator_and_indexed_projectors :
                                                              lid
                                                              FStar_Syntax_Syntax.Delta_constant
                                                              (FStar_Pervasives_Native.Some
-                                                                fvq)
-                                                            in
+                                                                fvq) in
                                                          (uu____12825,
-                                                           arg_pats)
-                                                          in
+                                                           arg_pats) in
                                                        FStar_Syntax_Syntax.Pat_cons
-                                                         uu____12812
-                                                        in
-                                                     pos uu____12811  in
+                                                         uu____12812 in
+                                                     pos uu____12811 in
                                                    let uu____12834 =
                                                      FStar_Syntax_Syntax.bv_to_name
-                                                       projection
-                                                      in
+                                                       projection in
                                                    (uu____12808,
                                                      FStar_Pervasives_Native.None,
-                                                     uu____12834)
-                                                    in
+                                                     uu____12834) in
                                                  let body =
                                                    let uu____12846 =
                                                      let uu____12849 =
@@ -5696,61 +5092,49 @@ let (mk_discriminator_and_indexed_projectors :
                                                          let uu____12873 =
                                                            let uu____12876 =
                                                              FStar_Syntax_Util.branch
-                                                               pat
-                                                              in
-                                                           [uu____12876]  in
+                                                               pat in
+                                                           [uu____12876] in
                                                          (arg_exp,
-                                                           uu____12873)
-                                                          in
+                                                           uu____12873) in
                                                        FStar_Syntax_Syntax.Tm_match
-                                                         uu____12850
-                                                        in
+                                                         uu____12850 in
                                                      FStar_Syntax_Syntax.mk
-                                                       uu____12849
-                                                      in
+                                                       uu____12849 in
                                                    uu____12846
                                                      FStar_Pervasives_Native.None
-                                                     p1
-                                                    in
+                                                     p1 in
                                                  let imp =
                                                    FStar_Syntax_Util.abs
                                                      binders body
-                                                     FStar_Pervasives_Native.None
-                                                    in
+                                                     FStar_Pervasives_Native.None in
                                                  let dd =
                                                    let uu____12884 =
                                                      FStar_All.pipe_right
                                                        quals1
                                                        (FStar_List.contains
-                                                          FStar_Syntax_Syntax.Abstract)
-                                                      in
+                                                          FStar_Syntax_Syntax.Abstract) in
                                                    if uu____12884
                                                    then
                                                      FStar_Syntax_Syntax.Delta_abstract
                                                        FStar_Syntax_Syntax.Delta_equational
                                                    else
-                                                     FStar_Syntax_Syntax.Delta_equational
-                                                    in
+                                                     FStar_Syntax_Syntax.Delta_equational in
                                                  let lbtyp =
                                                    if no_decl
                                                    then t
                                                    else
-                                                     FStar_Syntax_Syntax.tun
-                                                    in
+                                                     FStar_Syntax_Syntax.tun in
                                                  let lb =
                                                    let uu____12891 =
                                                      let uu____12896 =
                                                        FStar_Syntax_Syntax.lid_as_fv
                                                          field_name dd
-                                                         FStar_Pervasives_Native.None
-                                                        in
+                                                         FStar_Pervasives_Native.None in
                                                      FStar_Util.Inr
-                                                       uu____12896
-                                                      in
+                                                       uu____12896 in
                                                    let uu____12897 =
                                                      FStar_Syntax_Subst.close_univ_vars
-                                                       uvs imp
-                                                      in
+                                                       uvs imp in
                                                    {
                                                      FStar_Syntax_Syntax.lbname
                                                        = uu____12891;
@@ -5765,7 +5149,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                        = uu____12897;
                                                      FStar_Syntax_Syntax.lbattrs
                                                        = []
-                                                   }  in
+                                                   } in
                                                  let impl =
                                                    let uu____12903 =
                                                      let uu____12904 =
@@ -5774,20 +5158,16 @@ let (mk_discriminator_and_indexed_projectors :
                                                            let uu____12915 =
                                                              FStar_All.pipe_right
                                                                lb.FStar_Syntax_Syntax.lbname
-                                                               FStar_Util.right
-                                                              in
+                                                               FStar_Util.right in
                                                            FStar_All.pipe_right
                                                              uu____12915
                                                              (fun fv  ->
-                                                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-                                                            in
-                                                         [uu____12914]  in
+                                                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
+                                                         [uu____12914] in
                                                        ((false, [lb]),
-                                                         uu____12911)
-                                                        in
+                                                         uu____12911) in
                                                      FStar_Syntax_Syntax.Sig_let
-                                                       uu____12904
-                                                      in
+                                                       uu____12904 in
                                                    {
                                                      FStar_Syntax_Syntax.sigel
                                                        = uu____12903;
@@ -5800,36 +5180,31 @@ let (mk_discriminator_and_indexed_projectors :
                                                        FStar_Syntax_Syntax.default_sigmeta;
                                                      FStar_Syntax_Syntax.sigattrs
                                                        = attrs
-                                                   }  in
+                                                   } in
                                                  (let uu____12933 =
                                                     FStar_TypeChecker_Env.debug
                                                       env
                                                       (FStar_Options.Other
-                                                         "LogTypes")
-                                                     in
+                                                         "LogTypes") in
                                                   if uu____12933
                                                   then
                                                     let uu____12934 =
                                                       FStar_Syntax_Print.sigelt_to_string
-                                                        impl
-                                                       in
+                                                        impl in
                                                     FStar_Util.print1
                                                       "Implementation of a projector %s\n"
                                                       uu____12934
                                                   else ());
                                                  if no_decl
                                                  then [impl]
-                                                 else [decl; impl])))))
-                           in
-                        FStar_All.pipe_right uu____12569 FStar_List.flatten
-                         in
+                                                 else [decl; impl]))))) in
+                        FStar_All.pipe_right uu____12569 FStar_List.flatten in
                       FStar_List.append discriminator_ses projectors_ses
-  
-let (mk_data_operations :
+let mk_data_operations:
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.sigelt Prims.list ->
-        FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt Prims.list)
+        FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt Prims.list
   =
   fun iquals  ->
     fun env  ->
@@ -5842,11 +5217,11 @@ let (mk_data_operations :
                 (FStar_Ident.lid_equals constr_lid
                    FStar_Parser_Const.lexcons_lid)
               ->
-              let uu____12979 = FStar_Syntax_Subst.univ_var_opening uvs  in
+              let uu____12979 = FStar_Syntax_Subst.univ_var_opening uvs in
               (match uu____12979 with
                | (univ_opening,uvs1) ->
-                   let t1 = FStar_Syntax_Subst.subst univ_opening t  in
-                   let uu____13001 = FStar_Syntax_Util.arrow_formals t1  in
+                   let t1 = FStar_Syntax_Subst.subst univ_opening t in
+                   let uu____13001 = FStar_Syntax_Util.arrow_formals t1 in
                    (match uu____13001 with
                     | (formals,uu____13017) ->
                         let uu____13034 =
@@ -5856,11 +5231,9 @@ let (mk_data_operations :
                                  let uu____13066 =
                                    let uu____13067 =
                                      let uu____13068 =
-                                       FStar_Syntax_Util.lid_of_sigelt se1
-                                        in
-                                     FStar_Util.must uu____13068  in
-                                   FStar_Ident.lid_equals typ_lid uu____13067
-                                    in
+                                       FStar_Syntax_Util.lid_of_sigelt se1 in
+                                     FStar_Util.must uu____13068 in
+                                   FStar_Ident.lid_equals typ_lid uu____13067 in
                                  if uu____13066
                                  then
                                    match se1.FStar_Syntax_Syntax.sigel with
@@ -5872,8 +5245,7 @@ let (mk_data_operations :
                                            ((FStar_List.length constrs) >
                                               (Prims.parse_int "1")))
                                    | uu____13110 -> failwith "Impossible"
-                                 else FStar_Pervasives_Native.None)
-                             in
+                                 else FStar_Pervasives_Native.None) in
                           match tps_opt with
                           | FStar_Pervasives_Native.Some x -> x
                           | FStar_Pervasives_Native.None  ->
@@ -5885,18 +5257,16 @@ let (mk_data_operations :
                                 FStar_Errors.raise_error
                                   (FStar_Errors.Fatal_UnexpectedDataConstructor,
                                     "Unexpected data constructor")
-                                  se.FStar_Syntax_Syntax.sigrng
-                           in
+                                  se.FStar_Syntax_Syntax.sigrng in
                         (match uu____13034 with
                          | (inductive_tps,typ0,should_refine) ->
                              let inductive_tps1 =
                                FStar_Syntax_Subst.subst_binders univ_opening
-                                 inductive_tps
-                                in
+                                 inductive_tps in
                              let typ01 =
-                               FStar_Syntax_Subst.subst univ_opening typ0  in
+                               FStar_Syntax_Subst.subst univ_opening typ0 in
                              let uu____13183 =
-                               FStar_Syntax_Util.arrow_formals typ01  in
+                               FStar_Syntax_Util.arrow_formals typ01 in
                              (match uu____13183 with
                               | (indices,uu____13199) ->
                                   let refine_domain =
@@ -5908,11 +5278,10 @@ let (mk_data_operations :
                                               match uu___102_13222 with
                                               | FStar_Syntax_Syntax.RecordConstructor
                                                   uu____13223 -> true
-                                              | uu____13232 -> false))
-                                       in
+                                              | uu____13232 -> false)) in
                                     if uu____13217
                                     then false
-                                    else should_refine  in
+                                    else should_refine in
                                   let fv_qual =
                                     let filter_records uu___103_13240 =
                                       match uu___103_13240 with
@@ -5922,27 +5291,25 @@ let (mk_data_operations :
                                             (FStar_Syntax_Syntax.Record_ctor
                                                (constr_lid, fns))
                                       | uu____13255 ->
-                                          FStar_Pervasives_Native.None
-                                       in
+                                          FStar_Pervasives_Native.None in
                                     let uu____13256 =
                                       FStar_Util.find_map
                                         se.FStar_Syntax_Syntax.sigquals
-                                        filter_records
-                                       in
+                                        filter_records in
                                     match uu____13256 with
                                     | FStar_Pervasives_Native.None  ->
                                         FStar_Syntax_Syntax.Data_ctor
-                                    | FStar_Pervasives_Native.Some q -> q  in
+                                    | FStar_Pervasives_Native.Some q -> q in
                                   let iquals1 =
                                     if
                                       FStar_List.contains
                                         FStar_Syntax_Syntax.Abstract iquals
                                     then FStar_Syntax_Syntax.Private ::
                                       iquals
-                                    else iquals  in
+                                    else iquals in
                                   let fields =
                                     let uu____13267 =
-                                      FStar_Util.first_N n_typars formals  in
+                                      FStar_Util.first_N n_typars formals in
                                     match uu____13267 with
                                     | (imp_tps,fields) ->
                                         let rename =
@@ -5957,30 +5324,26 @@ let (mk_data_operations :
                                                      let uu____13362 =
                                                        let uu____13369 =
                                                          FStar_Syntax_Syntax.bv_to_name
-                                                           x'
-                                                          in
-                                                       (x, uu____13369)  in
+                                                           x' in
+                                                       (x, uu____13369) in
                                                      FStar_Syntax_Syntax.NT
                                                        uu____13362) imp_tps
-                                            inductive_tps1
-                                           in
+                                            inductive_tps1 in
                                         FStar_Syntax_Subst.subst_binders
-                                          rename fields
-                                     in
+                                          rename fields in
                                   mk_discriminator_and_indexed_projectors
                                     iquals1 fv_qual refine_domain env typ_lid
                                     constr_lid uvs1 inductive_tps1 indices
                                     fields))))
           | uu____13370 -> []
-  
-let (get_optimized_haseq_axiom :
+let get_optimized_haseq_axiom:
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt ->
       FStar_Syntax_Syntax.subst_elt Prims.list ->
         FStar_Syntax_Syntax.univ_names ->
           (FStar_Ident.lident,FStar_Syntax_Syntax.term,FStar_Syntax_Syntax.binders,
             FStar_Syntax_Syntax.binders,FStar_Syntax_Syntax.term)
-            FStar_Pervasives_Native.tuple5)
+            FStar_Pervasives_Native.tuple5
   =
   fun en  ->
     fun ty  ->
@@ -5991,39 +5354,35 @@ let (get_optimized_haseq_axiom :
             | FStar_Syntax_Syntax.Sig_inductive_typ
                 (lid,uu____13421,bs,t,uu____13424,uu____13425) ->
                 (lid, bs, t)
-            | uu____13434 -> failwith "Impossible!"  in
+            | uu____13434 -> failwith "Impossible!" in
           match uu____13407 with
           | (lid,bs,t) ->
-              let bs1 = FStar_Syntax_Subst.subst_binders usubst bs  in
+              let bs1 = FStar_Syntax_Subst.subst_binders usubst bs in
               let t1 =
                 let uu____13456 =
                   FStar_Syntax_Subst.shift_subst (FStar_List.length bs1)
-                    usubst
-                   in
-                FStar_Syntax_Subst.subst uu____13456 t  in
-              let uu____13463 = FStar_Syntax_Subst.open_term bs1 t1  in
+                    usubst in
+                FStar_Syntax_Subst.subst uu____13456 t in
+              let uu____13463 = FStar_Syntax_Subst.open_term bs1 t1 in
               (match uu____13463 with
                | (bs2,t2) ->
                    let ibs =
                      let uu____13487 =
-                       let uu____13488 = FStar_Syntax_Subst.compress t2  in
-                       uu____13488.FStar_Syntax_Syntax.n  in
+                       let uu____13488 = FStar_Syntax_Subst.compress t2 in
+                       uu____13488.FStar_Syntax_Syntax.n in
                      match uu____13487 with
                      | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____13498) -> ibs
-                     | uu____13515 -> []  in
-                   let ibs1 = FStar_Syntax_Subst.open_binders ibs  in
+                     | uu____13515 -> [] in
+                   let ibs1 = FStar_Syntax_Subst.open_binders ibs in
                    let ind =
                      let uu____13522 =
                        FStar_Syntax_Syntax.fvar lid
                          FStar_Syntax_Syntax.Delta_constant
-                         FStar_Pervasives_Native.None
-                        in
+                         FStar_Pervasives_Native.None in
                      let uu____13523 =
                        FStar_List.map
-                         (fun u  -> FStar_Syntax_Syntax.U_name u) us
-                        in
-                     FStar_Syntax_Syntax.mk_Tm_uinst uu____13522 uu____13523
-                      in
+                         (fun u  -> FStar_Syntax_Syntax.U_name u) us in
+                     FStar_Syntax_Syntax.mk_Tm_uinst uu____13522 uu____13523 in
                    let ind1 =
                      let uu____13529 =
                        let uu____13530 =
@@ -6032,13 +5391,11 @@ let (get_optimized_haseq_axiom :
                               match uu____13543 with
                               | (bv,aq) ->
                                   let uu____13554 =
-                                    FStar_Syntax_Syntax.bv_to_name bv  in
-                                  (uu____13554, aq)) bs2
-                          in
-                       FStar_Syntax_Syntax.mk_Tm_app ind uu____13530  in
+                                    FStar_Syntax_Syntax.bv_to_name bv in
+                                  (uu____13554, aq)) bs2 in
+                       FStar_Syntax_Syntax.mk_Tm_app ind uu____13530 in
                      uu____13529 FStar_Pervasives_Native.None
-                       FStar_Range.dummyRange
-                      in
+                       FStar_Range.dummyRange in
                    let ind2 =
                      let uu____13560 =
                        let uu____13561 =
@@ -6047,35 +5404,29 @@ let (get_optimized_haseq_axiom :
                               match uu____13574 with
                               | (bv,aq) ->
                                   let uu____13585 =
-                                    FStar_Syntax_Syntax.bv_to_name bv  in
-                                  (uu____13585, aq)) ibs1
-                          in
-                       FStar_Syntax_Syntax.mk_Tm_app ind1 uu____13561  in
+                                    FStar_Syntax_Syntax.bv_to_name bv in
+                                  (uu____13585, aq)) ibs1 in
+                       FStar_Syntax_Syntax.mk_Tm_app ind1 uu____13561 in
                      uu____13560 FStar_Pervasives_Native.None
-                       FStar_Range.dummyRange
-                      in
+                       FStar_Range.dummyRange in
                    let haseq_ind =
                      let uu____13591 =
                        let uu____13592 =
-                         let uu____13593 = FStar_Syntax_Syntax.as_arg ind2
-                            in
-                         [uu____13593]  in
+                         let uu____13593 = FStar_Syntax_Syntax.as_arg ind2 in
+                         [uu____13593] in
                        FStar_Syntax_Syntax.mk_Tm_app
-                         FStar_Syntax_Util.t_haseq uu____13592
-                        in
+                         FStar_Syntax_Util.t_haseq uu____13592 in
                      uu____13591 FStar_Pervasives_Native.None
-                       FStar_Range.dummyRange
-                      in
+                       FStar_Range.dummyRange in
                    let bs' =
                      FStar_List.filter
                        (fun b  ->
                           let uu____13614 =
-                            let uu____13615 = FStar_Syntax_Util.type_u ()  in
-                            FStar_Pervasives_Native.fst uu____13615  in
+                            let uu____13615 = FStar_Syntax_Util.type_u () in
+                            FStar_Pervasives_Native.fst uu____13615 in
                           FStar_TypeChecker_Rel.subtype_nosmt en
                             (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                            uu____13614) bs2
-                      in
+                            uu____13614) bs2 in
                    let haseq_bs =
                      FStar_List.fold_left
                        (fun t3  ->
@@ -6086,42 +5437,37 @@ let (get_optimized_haseq_axiom :
                                   let uu____13629 =
                                     let uu____13630 =
                                       FStar_Syntax_Syntax.bv_to_name
-                                        (FStar_Pervasives_Native.fst b)
-                                       in
-                                    FStar_Syntax_Syntax.as_arg uu____13630
-                                     in
-                                  [uu____13629]  in
+                                        (FStar_Pervasives_Native.fst b) in
+                                    FStar_Syntax_Syntax.as_arg uu____13630 in
+                                  [uu____13629] in
                                 FStar_Syntax_Syntax.mk_Tm_app
-                                  FStar_Syntax_Util.t_haseq uu____13628
-                                 in
+                                  FStar_Syntax_Util.t_haseq uu____13628 in
                               uu____13627 FStar_Pervasives_Native.None
-                                FStar_Range.dummyRange
-                               in
+                                FStar_Range.dummyRange in
                             FStar_Syntax_Util.mk_conj t3 uu____13626)
-                       FStar_Syntax_Util.t_true bs'
-                      in
-                   let fml = FStar_Syntax_Util.mk_imp haseq_bs haseq_ind  in
+                       FStar_Syntax_Util.t_true bs' in
+                   let fml = FStar_Syntax_Util.mk_imp haseq_bs haseq_ind in
                    let fml1 =
-                     let uu___127_13637 = fml  in
+                     let uu___127_13637 = fml in
                      let uu____13638 =
                        let uu____13639 =
                          let uu____13646 =
                            let uu____13647 =
                              let uu____13658 =
                                let uu____13661 =
-                                 FStar_Syntax_Syntax.as_arg haseq_ind  in
-                               [uu____13661]  in
-                             [uu____13658]  in
-                           FStar_Syntax_Syntax.Meta_pattern uu____13647  in
-                         (fml, uu____13646)  in
-                       FStar_Syntax_Syntax.Tm_meta uu____13639  in
+                                 FStar_Syntax_Syntax.as_arg haseq_ind in
+                               [uu____13661] in
+                             [uu____13658] in
+                           FStar_Syntax_Syntax.Meta_pattern uu____13647 in
+                         (fml, uu____13646) in
+                       FStar_Syntax_Syntax.Tm_meta uu____13639 in
                      {
                        FStar_Syntax_Syntax.n = uu____13638;
                        FStar_Syntax_Syntax.pos =
                          (uu___127_13637.FStar_Syntax_Syntax.pos);
                        FStar_Syntax_Syntax.vars =
                          (uu___127_13637.FStar_Syntax_Syntax.vars)
-                     }  in
+                     } in
                    let fml2 =
                      FStar_List.fold_right
                        (fun b  ->
@@ -6131,21 +5477,18 @@ let (get_optimized_haseq_axiom :
                                 let uu____13676 =
                                   let uu____13677 =
                                     let uu____13678 =
-                                      FStar_Syntax_Subst.close [b] t3  in
+                                      FStar_Syntax_Subst.close [b] t3 in
                                     FStar_Syntax_Util.abs
                                       [((FStar_Pervasives_Native.fst b),
                                          FStar_Pervasives_Native.None)]
                                       uu____13678
-                                      FStar_Pervasives_Native.None
-                                     in
-                                  FStar_Syntax_Syntax.as_arg uu____13677  in
-                                [uu____13676]  in
+                                      FStar_Pervasives_Native.None in
+                                  FStar_Syntax_Syntax.as_arg uu____13677 in
+                                [uu____13676] in
                               FStar_Syntax_Syntax.mk_Tm_app
-                                FStar_Syntax_Util.tforall uu____13675
-                               in
+                                FStar_Syntax_Util.tforall uu____13675 in
                             uu____13674 FStar_Pervasives_Native.None
-                              FStar_Range.dummyRange) ibs1 fml1
-                      in
+                              FStar_Range.dummyRange) ibs1 fml1 in
                    let fml3 =
                      FStar_List.fold_right
                        (fun b  ->
@@ -6155,28 +5498,23 @@ let (get_optimized_haseq_axiom :
                                 let uu____13705 =
                                   let uu____13706 =
                                     let uu____13707 =
-                                      FStar_Syntax_Subst.close [b] t3  in
+                                      FStar_Syntax_Subst.close [b] t3 in
                                     FStar_Syntax_Util.abs
                                       [((FStar_Pervasives_Native.fst b),
                                          FStar_Pervasives_Native.None)]
                                       uu____13707
-                                      FStar_Pervasives_Native.None
-                                     in
-                                  FStar_Syntax_Syntax.as_arg uu____13706  in
-                                [uu____13705]  in
+                                      FStar_Pervasives_Native.None in
+                                  FStar_Syntax_Syntax.as_arg uu____13706 in
+                                [uu____13705] in
                               FStar_Syntax_Syntax.mk_Tm_app
-                                FStar_Syntax_Util.tforall uu____13704
-                               in
+                                FStar_Syntax_Util.tforall uu____13704 in
                             uu____13703 FStar_Pervasives_Native.None
-                              FStar_Range.dummyRange) bs2 fml2
-                      in
+                              FStar_Range.dummyRange) bs2 fml2 in
                    let axiom_lid =
                      FStar_Ident.lid_of_ids
                        (FStar_List.append lid.FStar_Ident.ns
                           [FStar_Ident.id_of_text
                              (Prims.strcat
                                 (lid.FStar_Ident.ident).FStar_Ident.idText
-                                "_haseq")])
-                      in
+                                "_haseq")]) in
                    (axiom_lid, fml3, bs2, ibs1, haseq_bs))
-  

--- a/src/ocaml-output/FStar_Universal.ml
+++ b/src/ocaml-output/FStar_Universal.ml
@@ -1,14 +1,13 @@
 open Prims
-let (module_or_interface_name :
+let module_or_interface_name:
   FStar_Syntax_Syntax.modul ->
-    (Prims.bool,FStar_Ident.lident) FStar_Pervasives_Native.tuple2)
+    (Prims.bool,FStar_Ident.lident) FStar_Pervasives_Native.tuple2
   =
   fun m  ->
     ((m.FStar_Syntax_Syntax.is_interface), (m.FStar_Syntax_Syntax.name))
-  
-let (user_tactics_modules : Prims.string Prims.list FStar_ST.ref) =
-  FStar_TypeChecker_Tc.user_tactics_modules 
-let with_tcenv :
+let user_tactics_modules: Prims.string Prims.list FStar_ST.ref =
+  FStar_TypeChecker_Tc.user_tactics_modules
+let with_tcenv:
   'a .
     FStar_TypeChecker_Env.env ->
       'a FStar_ToSyntax_Env.withenv ->
@@ -16,11 +15,11 @@ let with_tcenv :
   =
   fun env  ->
     fun f  ->
-      let uu____47 = f env.FStar_TypeChecker_Env.dsenv  in
+      let uu____47 = f env.FStar_TypeChecker_Env.dsenv in
       match uu____47 with
       | (a,dsenv) ->
           (a,
-            (let uu___51_61 = env  in
+            (let uu___51_61 = env in
              {
                FStar_TypeChecker_Env.solver =
                  (uu___51_61.FStar_TypeChecker_Env.solver);
@@ -92,25 +91,24 @@ let with_tcenv :
                FStar_TypeChecker_Env.dep_graph =
                  (uu___51_61.FStar_TypeChecker_Env.dep_graph)
              }))
-  
-let (parse :
+let parse:
   FStar_TypeChecker_Env.env ->
     Prims.string FStar_Pervasives_Native.option ->
       Prims.string ->
         (FStar_Syntax_Syntax.modul,FStar_TypeChecker_Env.env)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun pre_fn  ->
       fun fn  ->
-        let uu____83 = FStar_Parser_Driver.parse_file fn  in
+        let uu____83 = FStar_Parser_Driver.parse_file fn in
         match uu____83 with
         | (ast,uu____99) ->
             let uu____112 =
               match pre_fn with
               | FStar_Pervasives_Native.None  -> (ast, env)
               | FStar_Pervasives_Native.Some pre_fn1 ->
-                  let uu____122 = FStar_Parser_Driver.parse_file pre_fn1  in
+                  let uu____122 = FStar_Parser_Driver.parse_file pre_fn1 in
                   (match uu____122 with
                    | (pre_ast,uu____138) ->
                        (match (pre_ast, ast) with
@@ -121,37 +119,32 @@ let (parse :
                             let uu____168 =
                               let uu____173 =
                                 FStar_ToSyntax_Interleave.initialize_interface
-                                  lid1 decls1
-                                 in
-                              FStar_All.pipe_left (with_tcenv env) uu____173
-                               in
+                                  lid1 decls1 in
+                              FStar_All.pipe_left (with_tcenv env) uu____173 in
                             (match uu____168 with
                              | (uu____190,env1) ->
                                  let uu____192 =
                                    FStar_ToSyntax_Interleave.interleave_module
-                                     ast true
-                                    in
+                                     ast true in
                                  FStar_All.pipe_left (with_tcenv env1)
                                    uu____192)
                         | uu____205 ->
                             FStar_Errors.raise_err
                               (FStar_Errors.Fatal_PreModuleMismatch,
-                                "mismatch between pre-module and module\n")))
-               in
+                                "mismatch between pre-module and module\n"))) in
             (match uu____112 with
              | (ast1,env1) ->
                  let uu____220 =
-                   FStar_ToSyntax_ToSyntax.ast_modul_to_modul ast1  in
+                   FStar_ToSyntax_ToSyntax.ast_modul_to_modul ast1 in
                  FStar_All.pipe_left (with_tcenv env1) uu____220)
-  
-let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
+let init_env: FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env =
   fun deps  ->
     let solver1 =
-      let uu____237 = FStar_Options.lax ()  in
+      let uu____237 = FStar_Options.lax () in
       if uu____237
       then FStar_SMTEncoding_Solver.dummy
       else
-        (let uu___52_239 = FStar_SMTEncoding_Solver.solver  in
+        (let uu___52_239 = FStar_SMTEncoding_Solver.solver in
          {
            FStar_TypeChecker_Env.init =
              (uu___52_239.FStar_TypeChecker_Env.init);
@@ -171,17 +164,15 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
              (uu___52_239.FStar_TypeChecker_Env.finish);
            FStar_TypeChecker_Env.refresh =
              (uu___52_239.FStar_TypeChecker_Env.refresh)
-         })
-       in
+         }) in
     let env =
       FStar_TypeChecker_Env.initial_env deps FStar_TypeChecker_TcTerm.tc_term
         FStar_TypeChecker_TcTerm.type_of_tot_term
         FStar_TypeChecker_TcTerm.universe_of
         FStar_TypeChecker_TcTerm.check_type_of_well_typed_term solver1
-        FStar_Parser_Const.prims_lid
-       in
+        FStar_Parser_Const.prims_lid in
     let env1 =
-      let uu___53_242 = env  in
+      let uu___53_242 = env in
       {
         FStar_TypeChecker_Env.solver =
           (uu___53_242.FStar_TypeChecker_Env.solver);
@@ -251,9 +242,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (uu___53_242.FStar_TypeChecker_Env.dsenv);
         FStar_TypeChecker_Env.dep_graph =
           (uu___53_242.FStar_TypeChecker_Env.dep_graph)
-      }  in
+      } in
     let env2 =
-      let uu___54_244 = env1  in
+      let uu___54_244 = env1 in
       {
         FStar_TypeChecker_Env.solver =
           (uu___54_244.FStar_TypeChecker_Env.solver);
@@ -324,15 +315,14 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (uu___54_244.FStar_TypeChecker_Env.dsenv);
         FStar_TypeChecker_Env.dep_graph =
           (uu___54_244.FStar_TypeChecker_Env.dep_graph)
-      }  in
+      } in
     (env2.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.init env2; env2
-  
-let (tc_one_fragment :
+let tc_one_fragment:
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     FStar_TypeChecker_Env.env ->
       FStar_Parser_ParseIt.input_frag ->
         (FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option,FStar_TypeChecker_Env.env)
-          FStar_Pervasives_Native.tuple2)
+          FStar_Pervasives_Native.tuple2
   =
   fun curmod  ->
     fun env  ->
@@ -340,14 +330,14 @@ let (tc_one_fragment :
         let acceptable_mod_name modul =
           let uu____269 =
             let uu____270 =
-              let uu____271 = FStar_Options.file_list ()  in
-              FStar_List.hd uu____271  in
-            FStar_Parser_Dep.lowercase_module_name uu____270  in
+              let uu____271 = FStar_Options.file_list () in
+              FStar_List.hd uu____271 in
+            FStar_Parser_Dep.lowercase_module_name uu____270 in
           let uu____274 =
             let uu____275 =
-              FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
-            FStar_String.lowercase uu____275  in
-          uu____269 = uu____274  in
+              FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
+            FStar_String.lowercase uu____275 in
+          uu____269 = uu____274 in
         let range_of_first_mod_decl modul =
           match modul with
           | FStar_Parser_AST.Module
@@ -364,44 +354,39 @@ let (tc_one_fragment :
                            FStar_Parser_AST.quals = uu____297;
                            FStar_Parser_AST.attrs = uu____298;_}::uu____299,uu____300)
               -> d
-          | uu____307 -> FStar_Range.dummyRange  in
-        let uu____308 = FStar_Parser_Driver.parse_fragment frag  in
+          | uu____307 -> FStar_Range.dummyRange in
+        let uu____308 = FStar_Parser_Driver.parse_fragment frag in
         match uu____308 with
         | FStar_Parser_Driver.Empty  -> (curmod, env)
         | FStar_Parser_Driver.Decls [] -> (curmod, env)
         | FStar_Parser_Driver.Modul ast_modul ->
             let uu____320 =
               let uu____325 =
-                FStar_ToSyntax_Interleave.interleave_module ast_modul false
-                 in
-              FStar_All.pipe_left (with_tcenv env) uu____325  in
+                FStar_ToSyntax_Interleave.interleave_module ast_modul false in
+              FStar_All.pipe_left (with_tcenv env) uu____325 in
             (match uu____320 with
              | (ast_modul1,env1) ->
                  let uu____346 =
                    let uu____351 =
                      FStar_ToSyntax_ToSyntax.partial_ast_modul_to_modul
-                       curmod ast_modul1
-                      in
-                   FStar_All.pipe_left (with_tcenv env1) uu____351  in
+                       curmod ast_modul1 in
+                   FStar_All.pipe_left (with_tcenv env1) uu____351 in
                  (match uu____346 with
                   | (modul,env2) ->
                       ((let uu____373 =
-                          let uu____374 = acceptable_mod_name modul  in
-                          Prims.op_Negation uu____374  in
+                          let uu____374 = acceptable_mod_name modul in
+                          Prims.op_Negation uu____374 in
                         if uu____373
                         then
                           let msg =
                             let uu____376 =
                               let uu____377 =
-                                let uu____378 = FStar_Options.file_list ()
-                                   in
-                                FStar_List.hd uu____378  in
-                              FStar_Parser_Dep.module_name_of_file uu____377
-                               in
+                                let uu____378 = FStar_Options.file_list () in
+                                FStar_List.hd uu____378 in
+                              FStar_Parser_Dep.module_name_of_file uu____377 in
                             FStar_Util.format1
                               "Interactive mode only supports a single module at the top-level. Expected module %s"
-                              uu____376
-                             in
+                              uu____376 in
                           FStar_Errors.raise_error
                             (FStar_Errors.Fatal_NonSingletonTopLevelModule,
                               msg) (range_of_first_mod_decl ast_modul1)
@@ -409,21 +394,19 @@ let (tc_one_fragment :
                        (let uu____382 =
                           let uu____391 =
                             FStar_ToSyntax_Env.syntax_only
-                              env2.FStar_TypeChecker_Env.dsenv
-                             in
+                              env2.FStar_TypeChecker_Env.dsenv in
                           if uu____391
                           then (modul, [], env2)
                           else
                             FStar_TypeChecker_Tc.tc_partial_modul env2 modul
-                              false
-                           in
+                              false in
                         match uu____382 with
                         | (modul1,uu____410,env3) ->
                             ((FStar_Pervasives_Native.Some modul1), env3)))))
         | FStar_Parser_Driver.Decls ast_decls ->
             (match curmod with
              | FStar_Pervasives_Native.None  ->
-                 let uu____427 = FStar_List.hd ast_decls  in
+                 let uu____427 = FStar_List.hd ast_decls in
                  (match uu____427 with
                   | { FStar_Parser_AST.d = uu____434;
                       FStar_Parser_AST.drange = rng;
@@ -441,48 +424,40 @@ let (tc_one_fragment :
                           let uu____466 =
                             let uu____473 =
                               FStar_ToSyntax_Interleave.prefix_with_interface_decls
-                                a_decl
-                               in
-                            FStar_All.pipe_left (with_tcenv env1) uu____473
-                             in
+                                a_decl in
+                            FStar_All.pipe_left (with_tcenv env1) uu____473 in
                           match uu____466 with
-                          | (decls,env2) -> (env2, decls)) env ast_decls
-                    in
+                          | (decls,env2) -> (env2, decls)) env ast_decls in
                  (match uu____448 with
                   | (env1,ast_decls_l) ->
                       let uu____524 =
                         let uu____529 =
                           FStar_ToSyntax_ToSyntax.decls_to_sigelts
-                            (FStar_List.flatten ast_decls_l)
-                           in
-                        FStar_All.pipe_left (with_tcenv env1) uu____529  in
+                            (FStar_List.flatten ast_decls_l) in
+                        FStar_All.pipe_left (with_tcenv env1) uu____529 in
                       (match uu____524 with
                        | (sigelts,env2) ->
                            let uu____550 =
                              let uu____559 =
                                FStar_ToSyntax_Env.syntax_only
-                                 env2.FStar_TypeChecker_Env.dsenv
-                                in
+                                 env2.FStar_TypeChecker_Env.dsenv in
                              if uu____559
                              then (modul, [], env2)
                              else
                                FStar_TypeChecker_Tc.tc_more_partial_modul
-                                 env2 modul sigelts
-                              in
+                                 env2 modul sigelts in
                            (match uu____550 with
                             | (modul1,uu____578,env3) ->
                                 ((FStar_Pervasives_Native.Some modul1), env3)))))
-  
-let (load_interface_decls :
+let load_interface_decls:
   FStar_TypeChecker_Env.env ->
-    FStar_Parser_ParseIt.filename -> FStar_TypeChecker_Env.env)
+    FStar_Parser_ParseIt.filename -> FStar_TypeChecker_Env.env
   =
   fun env  ->
     fun interface_file_name  ->
       let r =
         FStar_Parser_ParseIt.parse
-          (FStar_Parser_ParseIt.Filename interface_file_name)
-         in
+          (FStar_Parser_ParseIt.Filename interface_file_name) in
       match r with
       | FStar_Parser_ParseIt.ASTFragment
           (FStar_Util.Inl (FStar_Parser_AST.Interface
@@ -490,85 +465,75 @@ let (load_interface_decls :
           ->
           let uu____621 =
             let uu____626 =
-              FStar_ToSyntax_Interleave.initialize_interface l decls  in
-            FStar_All.pipe_left (with_tcenv env) uu____626  in
+              FStar_ToSyntax_Interleave.initialize_interface l decls in
+            FStar_All.pipe_left (with_tcenv env) uu____626 in
           FStar_Pervasives_Native.snd uu____621
       | FStar_Parser_ParseIt.ASTFragment uu____639 ->
           let uu____650 =
             let uu____655 =
               FStar_Util.format1
                 "Unexpected result from parsing %s; expected a single interface"
-                interface_file_name
-               in
-            (FStar_Errors.Fatal_ParseErrors, uu____655)  in
+                interface_file_name in
+            (FStar_Errors.Fatal_ParseErrors, uu____655) in
           FStar_Errors.raise_err uu____650
       | FStar_Parser_ParseIt.ParseError (err,msg,rng) ->
           FStar_Exn.raise (FStar_Errors.Error (err, msg, rng))
       | FStar_Parser_ParseIt.Term uu____659 ->
           failwith
             "Impossible: parsing a Toplevel always results in an ASTFragment"
-  
-let (load_module_from_cache :
+let load_module_from_cache:
   FStar_TypeChecker_Env.env ->
     Prims.string ->
       (FStar_Syntax_Syntax.modul,FStar_ToSyntax_Env.module_inclusion_info)
-        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
   fun env  ->
     fun fn  ->
       let cache_file =
         let uu____679 =
           FStar_Parser_Dep.all_cmd_line_files
-            env.FStar_TypeChecker_Env.dep_graph
-           in
-        FStar_Parser_Dep.cache_file_name uu____679 fn  in
+            env.FStar_TypeChecker_Env.dep_graph in
+        FStar_Parser_Dep.cache_file_name uu____679 fn in
       let fail1 tag =
         (let uu____693 =
            let uu____694 =
-             FStar_Range.mk_pos (Prims.parse_int "0") (Prims.parse_int "0")
-              in
+             FStar_Range.mk_pos (Prims.parse_int "0") (Prims.parse_int "0") in
            let uu____695 =
-             FStar_Range.mk_pos (Prims.parse_int "0") (Prims.parse_int "0")
-              in
-           FStar_Range.mk_range fn uu____694 uu____695  in
+             FStar_Range.mk_pos (Prims.parse_int "0") (Prims.parse_int "0") in
+           FStar_Range.mk_range fn uu____694 uu____695 in
          let uu____696 =
            let uu____701 =
              FStar_Util.format3 "%s cache file %s; will recheck %s" tag
-               cache_file fn
-              in
-           (FStar_Errors.Warning_CachedFile, uu____701)  in
+               cache_file fn in
+           (FStar_Errors.Warning_CachedFile, uu____701) in
          FStar_Errors.log_issue uu____693 uu____696);
-        FStar_Pervasives_Native.None  in
+        FStar_Pervasives_Native.None in
       if FStar_Util.file_exists cache_file
       then
-        let uu____712 = FStar_Util.load_value_from_file cache_file  in
+        let uu____712 = FStar_Util.load_value_from_file cache_file in
         match uu____712 with
         | FStar_Pervasives_Native.None  -> fail1 "Corrupt"
         | FStar_Pervasives_Native.Some (digest,tcmod,mii) ->
             let uu____784 =
               FStar_Parser_Dep.hash_dependences
-                env.FStar_TypeChecker_Env.dep_graph fn
-               in
+                env.FStar_TypeChecker_Env.dep_graph fn in
             (match uu____784 with
              | FStar_Pervasives_Native.Some digest' ->
                  if digest = digest'
                  then FStar_Pervasives_Native.Some (tcmod, mii)
                  else
-                   ((let uu____830 = FStar_Options.debug_any ()  in
+                   ((let uu____830 = FStar_Options.debug_any () in
                      if uu____830
                      then
                        ((let uu____832 =
                            FStar_Util.string_of_int
-                             (FStar_List.length digest')
-                            in
+                             (FStar_List.length digest') in
                          let uu____837 =
-                           FStar_Parser_Dep.print_digest digest'  in
+                           FStar_Parser_Dep.print_digest digest' in
                          let uu____838 =
                            FStar_Util.string_of_int
-                             (FStar_List.length digest)
-                            in
-                         let uu____843 = FStar_Parser_Dep.print_digest digest
-                            in
+                             (FStar_List.length digest) in
+                         let uu____843 = FStar_Parser_Dep.print_digest digest in
                          FStar_Util.print4
                            "Expected (%s) hashes:\n%s\n\nGot (%s) hashes:\n\t%s\n"
                            uu____832 uu____837 uu____838 uu____843);
@@ -585,12 +550,10 @@ let (load_module_from_cache :
                                      then
                                        let uu____898 =
                                          FStar_Parser_Dep.print_digest
-                                           [(x, y)]
-                                          in
+                                           [(x, y)] in
                                        let uu____907 =
                                          FStar_Parser_Dep.print_digest
-                                           [(x', y')]
-                                          in
+                                           [(x', y')] in
                                        FStar_Util.print2
                                          "Differ at: Expected %s\n Got %s\n"
                                          uu____898 uu____907
@@ -600,12 +563,11 @@ let (load_module_from_cache :
                     fail1 "Stale")
              | uu____919 -> fail1 "Stale")
       else fail1 "Absent"
-  
-let (store_module_to_cache :
+let store_module_to_cache:
   FStar_TypeChecker_Env.env ->
     Prims.string ->
       FStar_Syntax_Syntax.modul ->
-        FStar_ToSyntax_Env.module_inclusion_info -> Prims.unit)
+        FStar_ToSyntax_Env.module_inclusion_info -> Prims.unit
   =
   fun env  ->
     fun fn  ->
@@ -614,13 +576,11 @@ let (store_module_to_cache :
           let cache_file =
             let uu____942 =
               FStar_Parser_Dep.all_cmd_line_files
-                env.FStar_TypeChecker_Env.dep_graph
-               in
-            FStar_Parser_Dep.cache_file_name uu____942 fn  in
+                env.FStar_TypeChecker_Env.dep_graph in
+            FStar_Parser_Dep.cache_file_name uu____942 fn in
           let digest =
             FStar_Parser_Dep.hash_dependences
-              env.FStar_TypeChecker_Env.dep_graph fn
-             in
+              env.FStar_TypeChecker_Env.dep_graph fn in
           match digest with
           | FStar_Pervasives_Native.Some hashes ->
               FStar_Util.save_value_to_file cache_file (hashes, modul, mii)
@@ -628,75 +588,66 @@ let (store_module_to_cache :
               let uu____994 =
                 let uu____995 =
                   FStar_Range.mk_pos (Prims.parse_int "0")
-                    (Prims.parse_int "0")
-                   in
+                    (Prims.parse_int "0") in
                 let uu____996 =
                   FStar_Range.mk_pos (Prims.parse_int "0")
-                    (Prims.parse_int "0")
-                   in
-                FStar_Range.mk_range fn uu____995 uu____996  in
+                    (Prims.parse_int "0") in
+                FStar_Range.mk_range fn uu____995 uu____996 in
               let uu____997 =
                 let uu____1002 =
                   FStar_Util.format1
                     "%s was not written, since some of its dependences were not also checked"
-                    cache_file
-                   in
-                (FStar_Errors.Warning_FileNotWritten, uu____1002)  in
+                    cache_file in
+                (FStar_Errors.Warning_FileNotWritten, uu____1002) in
               FStar_Errors.log_issue uu____994 uu____997
-  
-let (tc_one_file :
+let tc_one_file:
   FStar_TypeChecker_Env.env ->
     Prims.string FStar_Pervasives_Native.option ->
       Prims.string ->
         ((FStar_Syntax_Syntax.modul,Prims.int) FStar_Pervasives_Native.tuple2,
-          FStar_TypeChecker_Env.env) FStar_Pervasives_Native.tuple2)
+          FStar_TypeChecker_Env.env) FStar_Pervasives_Native.tuple2
   =
   fun env  ->
     fun pre_fn  ->
       fun fn  ->
         FStar_Syntax_Syntax.reset_gensym ();
         (let tc_source_file uu____1046 =
-           let uu____1047 = parse env pre_fn fn  in
+           let uu____1047 = parse env pre_fn fn in
            match uu____1047 with
            | (fmod,env1) ->
                let check_mod fmod1 uu____1078 =
                  let uu____1079 =
                    FStar_Util.record_time
                      (fun uu____1093  ->
-                        FStar_TypeChecker_Tc.check_module env1 fmod1)
-                    in
+                        FStar_TypeChecker_Tc.check_module env1 fmod1) in
                  match uu____1079 with
-                 | ((tcmod,env2),time) -> ((tcmod, time), env2)  in
+                 | ((tcmod,env2),time) -> ((tcmod, time), env2) in
                let uu____1113 =
                  let uu____1122 =
                    let uu____1129 =
                      let uu____1130 =
                        FStar_Parser_Dep.all_cmd_line_files
-                         env1.FStar_TypeChecker_Env.dep_graph
-                        in
+                         env1.FStar_TypeChecker_Env.dep_graph in
                      FStar_Parser_Dep.check_or_use_extracted_interface
-                       uu____1130 fn
-                      in
+                       uu____1130 fn in
                    if uu____1129
                    then
                      let extracted_interface =
-                       FStar_TypeChecker_Tc.extract_interface env1 fmod  in
+                       FStar_TypeChecker_Tc.extract_interface env1 fmod in
                      ((let uu____1141 =
                          FStar_Options.dump_module
-                           (fmod.FStar_Syntax_Syntax.name).FStar_Ident.str
-                          in
+                           (fmod.FStar_Syntax_Syntax.name).FStar_Ident.str in
                        if uu____1141
                        then
                          let uu____1142 =
                            FStar_Syntax_Print.modul_to_string
-                             extracted_interface
-                            in
+                             extracted_interface in
                          FStar_Util.print2 "Extracted interface for %s:\n%s"
                            (fmod.FStar_Syntax_Syntax.name).FStar_Ident.str
                            uu____1142
                        else ());
                       (true, extracted_interface,
-                        ((let uu___55_1145 = env1  in
+                        ((let uu___55_1145 = env1 in
                           {
                             FStar_TypeChecker_Env.solver =
                               (uu___55_1145.FStar_TypeChecker_Env.solver);
@@ -768,7 +719,7 @@ let (tc_one_file :
                             FStar_TypeChecker_Env.dep_graph =
                               (uu___55_1145.FStar_TypeChecker_Env.dep_graph)
                           }))))
-                   else (false, fmod, env1)  in
+                   else (false, fmod, env1) in
                  match uu____1122 with
                  | (checking_or_using_extracted_interface,fmod1,env2) ->
                      let uu____1158 =
@@ -776,41 +727,36 @@ let (tc_one_file :
                           (fmod1.FStar_Syntax_Syntax.name).FStar_Ident.str)
                          &&
                          ((FStar_Options.record_hints ()) ||
-                            (FStar_Options.use_hints ()))
-                        in
+                            (FStar_Options.use_hints ())) in
                      if uu____1158
                      then
-                       let uu____1167 = FStar_Parser_ParseIt.find_file fn  in
+                       let uu____1167 = FStar_Parser_ParseIt.find_file fn in
                        FStar_SMTEncoding_Solver.with_hints_db uu____1167
                          checking_or_using_extracted_interface
                          (check_mod fmod1)
-                     else check_mod fmod1 ()
-                  in
+                     else check_mod fmod1 () in
                (match uu____1113 with
                 | (tcmod,env2) ->
                     let mii =
                       FStar_ToSyntax_Env.inclusion_info
                         env2.FStar_TypeChecker_Env.dsenv
-                        (FStar_Pervasives_Native.fst tcmod).FStar_Syntax_Syntax.name
-                       in
-                    (tcmod, mii, env2))
-            in
-         let uu____1202 = FStar_Options.cache_checked_modules ()  in
+                        (FStar_Pervasives_Native.fst tcmod).FStar_Syntax_Syntax.name in
+                    (tcmod, mii, env2)) in
+         let uu____1202 = FStar_Options.cache_checked_modules () in
          if uu____1202
          then
-           let uu____1211 = load_module_from_cache env fn  in
+           let uu____1211 = load_module_from_cache env fn in
            match uu____1211 with
            | FStar_Pervasives_Native.None  ->
-               let uu____1230 = tc_source_file ()  in
+               let uu____1230 = tc_source_file () in
                (match uu____1230 with
                 | (tcmod,mii,env1) ->
                     ((let uu____1261 =
-                        (let uu____1264 = FStar_Errors.get_err_count ()  in
+                        (let uu____1264 = FStar_Errors.get_err_count () in
                          uu____1264 = (Prims.parse_int "0")) &&
                           ((FStar_Options.lax ()) ||
                              (FStar_Options.should_verify
-                                ((FStar_Pervasives_Native.fst tcmod).FStar_Syntax_Syntax.name).FStar_Ident.str))
-                         in
+                                ((FStar_Pervasives_Native.fst tcmod).FStar_Syntax_Syntax.name).FStar_Ident.str)) in
                       if uu____1261
                       then
                         store_module_to_cache env1 fn
@@ -821,46 +767,42 @@ let (tc_one_file :
                let uu____1276 =
                  let uu____1281 =
                    FStar_ToSyntax_ToSyntax.add_modul_to_env tcmod mii
-                     (FStar_TypeChecker_Normalize.erase_universes env)
-                    in
-                 FStar_All.pipe_left (with_tcenv env) uu____1281  in
+                     (FStar_TypeChecker_Normalize.erase_universes env) in
+                 FStar_All.pipe_left (with_tcenv env) uu____1281 in
                (match uu____1276 with
                 | (uu____1302,env1) ->
                     let env2 =
-                      FStar_TypeChecker_Tc.load_checked_module env1 tcmod  in
+                      FStar_TypeChecker_Tc.load_checked_module env1 tcmod in
                     ((tcmod, (Prims.parse_int "0")), env2))
          else
-           (let uu____1310 = tc_source_file ()  in
+           (let uu____1310 = tc_source_file () in
             match uu____1310 with | (tcmod,uu____1330,env1) -> (tcmod, env1)))
-  
-let (needs_interleaving : Prims.string -> Prims.string -> Prims.bool) =
+let needs_interleaving: Prims.string -> Prims.string -> Prims.bool =
   fun intf  ->
     fun impl  ->
-      let m1 = FStar_Parser_Dep.lowercase_module_name intf  in
-      let m2 = FStar_Parser_Dep.lowercase_module_name impl  in
+      let m1 = FStar_Parser_Dep.lowercase_module_name intf in
+      let m2 = FStar_Parser_Dep.lowercase_module_name impl in
       ((m1 = m2) &&
-         (let uu____1353 = FStar_Util.get_file_extension intf  in
+         (let uu____1353 = FStar_Util.get_file_extension intf in
           FStar_List.mem uu____1353 ["fsti"; "fsi"]))
         &&
-        (let uu____1355 = FStar_Util.get_file_extension impl  in
+        (let uu____1355 = FStar_Util.get_file_extension impl in
          FStar_List.mem uu____1355 ["fst"; "fs"])
-  
-let (pop_context : FStar_TypeChecker_Env.env -> Prims.string -> Prims.unit) =
+let pop_context: FStar_TypeChecker_Env.env -> Prims.string -> Prims.unit =
   fun env  ->
     fun msg  ->
-      (let uu____1363 = FStar_ToSyntax_Env.pop ()  in
+      (let uu____1363 = FStar_ToSyntax_Env.pop () in
        FStar_All.pipe_right uu____1363 FStar_Pervasives.ignore);
-      (let uu____1365 = FStar_TypeChecker_Env.pop env msg  in
+      (let uu____1365 = FStar_TypeChecker_Env.pop env msg in
        FStar_All.pipe_right uu____1365 FStar_Pervasives.ignore);
       (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh ()
-  
-let (push_context :
-  FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
+let push_context:
+  FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env =
   fun env  ->
     fun msg  ->
-      let dsenv = FStar_ToSyntax_Env.push env.FStar_TypeChecker_Env.dsenv  in
-      let env1 = FStar_TypeChecker_Env.push env msg  in
-      let uu___56_1374 = env1  in
+      let dsenv = FStar_ToSyntax_Env.push env.FStar_TypeChecker_Env.dsenv in
+      let env1 = FStar_TypeChecker_Env.push env msg in
+      let uu___56_1374 = env1 in
       {
         FStar_TypeChecker_Env.solver =
           (uu___56_1374.FStar_TypeChecker_Env.solver);
@@ -931,13 +873,12 @@ let (push_context :
         FStar_TypeChecker_Env.dep_graph =
           (uu___56_1374.FStar_TypeChecker_Env.dep_graph)
       }
-  
-let (tc_one_file_from_remaining :
+let tc_one_file_from_remaining:
   Prims.string Prims.list ->
     FStar_TypeChecker_Env.env ->
       (Prims.string Prims.list,(FStar_Syntax_Syntax.modul,Prims.int)
                                  FStar_Pervasives_Native.tuple2 Prims.list,
-        FStar_TypeChecker_Env.env) FStar_Pervasives_Native.tuple3)
+        FStar_TypeChecker_Env.env) FStar_Pervasives_Native.tuple3
   =
   fun remaining  ->
     fun env  ->
@@ -945,49 +886,47 @@ let (tc_one_file_from_remaining :
         match remaining with
         | intf::impl::remaining1 when needs_interleaving intf impl ->
             let uu____1437 =
-              tc_one_file env (FStar_Pervasives_Native.Some intf) impl  in
+              tc_one_file env (FStar_Pervasives_Native.Some intf) impl in
             (match uu____1437 with | (m,env1) -> (remaining1, ([m], env1)))
         | intf_or_impl::remaining1 ->
             let uu____1502 =
-              tc_one_file env FStar_Pervasives_Native.None intf_or_impl  in
+              tc_one_file env FStar_Pervasives_Native.None intf_or_impl in
             (match uu____1502 with | (m,env1) -> (remaining1, ([m], env1)))
-        | [] -> ([], ([], env))  in
+        | [] -> ([], ([], env)) in
       match uu____1399 with
       | (remaining1,(nmods,env1)) -> (remaining1, nmods, env1)
-  
-let rec (tc_fold_interleave :
+let rec tc_fold_interleave:
   ((FStar_Syntax_Syntax.modul,Prims.int) FStar_Pervasives_Native.tuple2
      Prims.list,FStar_TypeChecker_Env.env)
     FStar_Pervasives_Native.tuple2 ->
     Prims.string Prims.list ->
       ((FStar_Syntax_Syntax.modul,Prims.int) FStar_Pervasives_Native.tuple2
          Prims.list,FStar_TypeChecker_Env.env)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun acc  ->
     fun remaining  ->
       match remaining with
       | [] -> acc
       | uu____1686 ->
-          let uu____1689 = acc  in
+          let uu____1689 = acc in
           (match uu____1689 with
            | (mods,env) ->
-               let uu____1724 = tc_one_file_from_remaining remaining env  in
+               let uu____1724 = tc_one_file_from_remaining remaining env in
                (match uu____1724 with
                 | (remaining1,nmods,env1) ->
                     tc_fold_interleave ((FStar_List.append mods nmods), env1)
                       remaining1))
-  
-let (batch_mode_tc :
+let batch_mode_tc:
   Prims.string Prims.list ->
     FStar_Parser_Dep.deps ->
       ((FStar_Syntax_Syntax.modul,Prims.int) FStar_Pervasives_Native.tuple2
          Prims.list,FStar_TypeChecker_Env.env)
-        FStar_Pervasives_Native.tuple2)
+        FStar_Pervasives_Native.tuple2
   =
   fun filenames  ->
     fun dep_graph1  ->
-      (let uu____1799 = FStar_Options.debug_any ()  in
+      (let uu____1799 = FStar_Options.debug_any () in
        if uu____1799
        then
          (FStar_Util.print_endline "Auto-deps kicked in; here's some info.";
@@ -997,21 +936,19 @@ let (batch_mode_tc :
           (let uu____1802 =
              let uu____1803 =
                FStar_All.pipe_right filenames
-                 (FStar_List.filter FStar_Options.should_verify_file)
-                in
-             FStar_String.concat " " uu____1803  in
+                 (FStar_List.filter FStar_Options.should_verify_file) in
+             FStar_String.concat " " uu____1803 in
            FStar_Util.print1
              "Here's the list of modules we will verify: %s\n" uu____1802))
        else ());
-      (let env = init_env dep_graph1  in
-       let uu____1812 = tc_fold_interleave ([], env) filenames  in
+      (let env = init_env dep_graph1 in
+       let uu____1812 = tc_fold_interleave ([], env) filenames in
        match uu____1812 with
        | (all_mods,env1) ->
            ((let uu____1858 =
                (FStar_Options.interactive ()) &&
-                 (let uu____1860 = FStar_Errors.get_err_count ()  in
-                  uu____1860 = (Prims.parse_int "0"))
-                in
+                 (let uu____1860 = FStar_Errors.get_err_count () in
+                  uu____1860 = (Prims.parse_int "0")) in
              if uu____1858
              then
                (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.refresh
@@ -1020,4 +957,3 @@ let (batch_mode_tc :
                (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.finish
                  ());
             (all_mods, env1)))
-  

--- a/src/tosyntax/FStar.ToSyntax.Env.fs
+++ b/src/tosyntax/FStar.ToSyntax.Env.fs
@@ -1010,7 +1010,8 @@ let check_admits env m =
   let admitted_sig_lids =
     env.sigaccum |> List.fold_left (fun lids se -> match se.sigel with
       | Sig_declare_typ(l, u, t) ->
-        begin match try_lookup_lid env l with
+        // l is already fully qualified, so no name resolution
+        begin match BU.smap_try_find (sigmap env) l.str with
           | None ->
             if not (Options.interactive ()) then
               FStar.Errors.log_issue (range_of_lid l)


### PR DESCRIPTION
Previously, considering two files A.Foo.fst and Foo.fst:
```
module A.Foo
```
```
module Foo
open A
module M = A.Foo
val x: int
let x = 18
```
`fstar.exe --lax Foo.fst`
Warning: Admitting Foo.x without definition
`fstar.exe --cache_checked_modules --lax Foo.fst`
Warning: Admitting Foo.x without definition
`fstar.exe --cache_checked_modules --lax Foo.fst`
Error: Duplicate top-level names: Foo.x

This pull request solves these problems.