### PR TITLE
KreMLin extraction: mark more ghost globals `MustDisappear`

### DIFF
--- a/src/ocaml-output/FStar_Extraction_Kremlin.ml
+++ b/src/ocaml-output/FStar_Extraction_Kremlin.ml
@@ -776,8 +776,8 @@ let thd3 :
       -> 'Auu____2749
   = fun uu____2761  -> match uu____2761 with | (uu____2768,uu____2769,x) -> x 
 let (mk_width : Prims.string -> width FStar_Pervasives_Native.option) =
-  fun uu___34_2775  ->
-    match uu___34_2775 with
+  fun uu___35_2775  ->
+    match uu___35_2775 with
     | "UInt8" -> FStar_Pervasives_Native.Some UInt8
     | "UInt16" -> FStar_Pervasives_Native.Some UInt16
     | "UInt32" -> FStar_Pervasives_Native.Some UInt32
@@ -789,8 +789,8 @@ let (mk_width : Prims.string -> width FStar_Pervasives_Native.option) =
     | uu____2778 -> FStar_Pervasives_Native.None
   
 let (mk_bool_op : Prims.string -> op FStar_Pervasives_Native.option) =
-  fun uu___35_2783  ->
-    match uu___35_2783 with
+  fun uu___36_2783  ->
+    match uu___36_2783 with
     | "op_Negation" -> FStar_Pervasives_Native.Some Not
     | "op_AmpAmp" -> FStar_Pervasives_Native.Some And
     | "op_BarBar" -> FStar_Pervasives_Native.Some Or
@@ -801,8 +801,8 @@ let (mk_bool_op : Prims.string -> op FStar_Pervasives_Native.option) =
 let (is_bool_op : Prims.string -> Prims.bool) =
   fun op  -> (mk_bool_op op) <> FStar_Pervasives_Native.None 
 let (mk_op : Prims.string -> op FStar_Pervasives_Native.option) =
-  fun uu___36_2796  ->
-    match uu___36_2796 with
+  fun uu___37_2796  ->
+    match uu___37_2796 with
     | "add" -> FStar_Pervasives_Native.Some Add
     | "op_Plus_Hat" -> FStar_Pervasives_Native.Some Add
     | "add_mod" -> FStar_Pervasives_Native.Some AddW
@@ -890,21 +890,21 @@ let (extend : env -> Prims.string -> Prims.bool -> env) =
   fun env  ->
     fun x  ->
       fun is_mut  ->
-        let uu___42_2910 = env  in
+        let uu___44_2910 = env  in
         {
           names = ({ pretty = x; mut = is_mut } :: (env.names));
-          names_t = (uu___42_2910.names_t);
-          module_name = (uu___42_2910.module_name)
+          names_t = (uu___44_2910.names_t);
+          module_name = (uu___44_2910.module_name)
         }
   
 let (extend_t : env -> Prims.string -> env) =
   fun env  ->
     fun x  ->
-      let uu___43_2917 = env  in
+      let uu___45_2917 = env  in
       {
-        names = (uu___43_2917.names);
+        names = (uu___45_2917.names);
         names_t = (x :: (env.names_t));
-        module_name = (uu___43_2917.module_name)
+        module_name = (uu___45_2917.module_name)
       }
   
 let (find_name : env -> Prims.string -> name) =
@@ -953,28 +953,40 @@ let add_binders :
              match uu____3002 with
              | (name,uu____3008) -> extend env1 name false) env binders
   
+let rec (is_unit_type : FStar_Extraction_ML_Syntax.mlty -> Prims.bool) =
+  fun uu___38_3011  ->
+    match uu___38_3011 with
+    | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
+        let uu____3015 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+        uu____3015 = "Prims.unit" -> true
+    | FStar_Extraction_ML_Syntax.MLTY_Fun
+        (uu____3016,FStar_Extraction_ML_Syntax.E_GHOST ,uu____3017) -> true
+    | FStar_Extraction_ML_Syntax.MLTY_Fun
+        (uu____3018,FStar_Extraction_ML_Syntax.E_PURE ,t) -> is_unit_type t
+    | uu____3020 -> false
+  
 let rec (translate : FStar_Extraction_ML_Syntax.mllib -> file Prims.list) =
-  fun uu____3149  ->
-    match uu____3149 with
+  fun uu____3161  ->
+    match uu____3161 with
     | FStar_Extraction_ML_Syntax.MLLib modules ->
         FStar_List.filter_map
           (fun m  ->
              let m_name =
-               let uu____3197 = m  in
-               match uu____3197 with
-               | (path,uu____3211,uu____3212) ->
+               let uu____3209 = m  in
+               match uu____3209 with
+               | (path,uu____3223,uu____3224) ->
                    FStar_Extraction_ML_Syntax.string_of_mlpath path
                 in
              try
                FStar_Util.print1 "Attempting to translate module %s\n" m_name;
-               (let uu____3234 = translate_module m  in
-                FStar_Pervasives_Native.Some uu____3234)
+               (let uu____3246 = translate_module m  in
+                FStar_Pervasives_Native.Some uu____3246)
              with
              | e ->
-                 ((let uu____3243 = FStar_Util.print_exn e  in
+                 ((let uu____3255 = FStar_Util.print_exn e  in
                    FStar_Util.print2
                      "Unable to translate module: %s because:\n  %s\n" m_name
-                     uu____3243);
+                     uu____3255);
                   FStar_Pervasives_Native.None)) modules
 
 and (translate_module :
@@ -985,9 +997,9 @@ and (translate_module :
     FStar_Extraction_ML_Syntax.mllib) FStar_Pervasives_Native.tuple3 -> 
     file)
   =
-  fun uu____3244  ->
-    match uu____3244 with
-    | (module_name,modul,uu____3259) ->
+  fun uu____3256  ->
+    match uu____3256 with
+    | (module_name,modul,uu____3271) ->
         let module_name1 =
           FStar_List.append (FStar_Pervasives_Native.fst module_name)
             [FStar_Pervasives_Native.snd module_name]
@@ -996,7 +1008,7 @@ and (translate_module :
           match modul with
           | FStar_Pervasives_Native.Some (_signature,decls) ->
               FStar_List.collect (translate_decl (empty module_name1)) decls
-          | uu____3290 ->
+          | uu____3302 ->
               failwith "Unexpected standalone interface or nested modules"
            in
         ((FStar_String.concat "_" module_name1), program)
@@ -1005,8 +1017,8 @@ and (translate_flags :
   FStar_Extraction_ML_Syntax.meta Prims.list -> flag Prims.list) =
   fun flags1  ->
     FStar_List.choose
-      (fun uu___37_3305  ->
-         match uu___37_3305 with
+      (fun uu___39_3317  ->
+         match uu___39_3317 with
          | FStar_Extraction_ML_Syntax.Private  ->
              FStar_Pervasives_Native.Some Private
          | FStar_Extraction_ML_Syntax.NoExtract  ->
@@ -1021,7 +1033,7 @@ and (translate_flags :
              FStar_Pervasives_Native.Some (Comment s)
          | FStar_Extraction_ML_Syntax.StackInline  ->
              FStar_Pervasives_Native.Some MustDisappear
-         | uu____3309 -> FStar_Pervasives_Native.None) flags1
+         | uu____3321 -> FStar_Pervasives_Native.None) flags1
 
 and (translate_decl :
   env -> FStar_Extraction_ML_Syntax.mlmodule1 -> decl Prims.list) =
@@ -1030,12 +1042,12 @@ and (translate_decl :
       match d with
       | FStar_Extraction_ML_Syntax.MLM_Let (flavor,lbs) ->
           FStar_List.choose (translate_let env flavor) lbs
-      | FStar_Extraction_ML_Syntax.MLM_Loc uu____3320 -> []
+      | FStar_Extraction_ML_Syntax.MLM_Loc uu____3332 -> []
       | FStar_Extraction_ML_Syntax.MLM_Ty tys ->
           FStar_List.choose (translate_type_decl env) tys
-      | FStar_Extraction_ML_Syntax.MLM_Top uu____3322 ->
+      | FStar_Extraction_ML_Syntax.MLM_Top uu____3334 ->
           failwith "todo: translate_decl [MLM_Top]"
-      | FStar_Extraction_ML_Syntax.MLM_Exn (m,uu____3326) ->
+      | FStar_Extraction_ML_Syntax.MLM_Exn (m,uu____3338) ->
           (FStar_Util.print1_warning
              "Skipping the translation of exception: %s\n" m;
            [])
@@ -1052,21 +1064,21 @@ and (translate_let :
         | { FStar_Extraction_ML_Syntax.mllb_name = name;
             FStar_Extraction_ML_Syntax.mllb_tysc =
               FStar_Pervasives_Native.Some (tvars,t0);
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____3348;
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____3360;
             FStar_Extraction_ML_Syntax.mllb_def =
               {
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Fun (args,body);
-                FStar_Extraction_ML_Syntax.mlty = uu____3351;
-                FStar_Extraction_ML_Syntax.loc = uu____3352;_};
+                FStar_Extraction_ML_Syntax.mlty = uu____3363;
+                FStar_Extraction_ML_Syntax.loc = uu____3364;_};
             FStar_Extraction_ML_Syntax.mllb_meta = meta;
-            FStar_Extraction_ML_Syntax.print_typ = uu____3354;_} ->
+            FStar_Extraction_ML_Syntax.print_typ = uu____3366;_} ->
             let assumed =
               FStar_Util.for_some
-                (fun uu___38_3373  ->
-                   match uu___38_3373 with
+                (fun uu___40_3385  ->
+                   match uu___40_3385 with
                    | FStar_Extraction_ML_Syntax.Assumed  -> true
-                   | uu____3374 -> false) meta
+                   | uu____3386 -> false) meta
                in
             let env1 =
               if flavor = FStar_Extraction_ML_Syntax.Rec
@@ -1076,50 +1088,52 @@ and (translate_let :
               FStar_List.fold_left
                 (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars
                in
-            let rec find_return_type eff i uu___39_3395 =
-              match uu___39_3395 with
-              | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3400,eff1,t) when
+            let rec find_return_type eff i uu___41_3407 =
+              match uu___41_3407 with
+              | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3412,eff1,t) when
                   i > (Prims.parse_int "0") ->
                   find_return_type eff1 (i - (Prims.parse_int "1")) t
               | t -> (eff, t)  in
-            let uu____3404 =
+            let uu____3416 =
               find_return_type FStar_Extraction_ML_Syntax.E_PURE
                 (FStar_List.length args) t0
                in
-            (match uu____3404 with
+            (match uu____3416 with
              | (eff,t) ->
                  let t1 = translate_type env2 t  in
                  let binders = translate_binders env2 args  in
                  let env3 = add_binders env2 args  in
                  let name1 = ((env3.module_name), name)  in
                  let meta1 =
-                   match (eff, t1) with
-                   | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____3436) ->
-                       let uu____3437 = translate_flags meta  in
-                       MustDisappear :: uu____3437
-                   | (FStar_Extraction_ML_Syntax.E_PURE ,TUnit ) ->
-                       let uu____3440 = translate_flags meta  in
-                       MustDisappear :: uu____3440
-                   | uu____3443 -> translate_flags meta  in
+                   let is_unit =
+                     match eff with
+                     | FStar_Extraction_ML_Syntax.E_GHOST  -> true
+                     | FStar_Extraction_ML_Syntax.E_PURE  -> is_unit_type t0
+                     | uu____3447 -> false  in
+                   if is_unit
+                   then
+                     let uu____3450 = translate_flags meta  in MustDisappear
+                       :: uu____3450
+                   else translate_flags meta  in
                  if assumed
                  then
                    (if (FStar_List.length tvars) = (Prims.parse_int "0")
                     then
-                      let uu____3452 =
-                        let uu____3453 =
-                          let uu____3472 = translate_type env3 t0  in
+                      let uu____3458 =
+                        let uu____3459 =
+                          let uu____3478 = translate_type env3 t0  in
                           (FStar_Pervasives_Native.None, meta1, name1,
-                            uu____3472)
+                            uu____3478)
                            in
-                        DExternal uu____3453  in
-                      FStar_Pervasives_Native.Some uu____3452
+                        DExternal uu____3459  in
+                      FStar_Pervasives_Native.Some uu____3458
                     else
-                      ((let uu____3485 =
+                      ((let uu____3491 =
                           FStar_Extraction_ML_Syntax.string_of_mlpath name1
                            in
                         FStar_Util.print1_warning
                           "No writing anything for %s (polymorphic assume)\n"
-                          uu____3485);
+                          uu____3491);
                        FStar_Pervasives_Native.None))
                  else
                    (try
@@ -1132,20 +1146,20 @@ and (translate_let :
                     with
                     | e ->
                         let msg = FStar_Util.print_exn e  in
-                        ((let uu____3518 =
-                            let uu____3523 =
-                              let uu____3524 =
+                        ((let uu____3524 =
+                            let uu____3529 =
+                              let uu____3530 =
                                 FStar_Extraction_ML_Syntax.string_of_mlpath
                                   name1
                                  in
                               FStar_Util.format2
-                                "Writing a stub for %s (%s)\n" uu____3524 msg
+                                "Writing a stub for %s (%s)\n" uu____3530 msg
                                in
                             (FStar_Errors.Warning_FunctionNotExtacted,
-                              uu____3523)
+                              uu____3529)
                              in
                           FStar_Errors.log_issue FStar_Range.dummyRange
-                            uu____3518);
+                            uu____3524);
                          (let msg1 =
                             Prims.strcat "This function was not extracted:\n"
                               msg
@@ -1158,7 +1172,7 @@ and (translate_let :
         | { FStar_Extraction_ML_Syntax.mllb_name = name;
             FStar_Extraction_ML_Syntax.mllb_tysc =
               FStar_Pervasives_Native.Some (tvars,t0);
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____3541;
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____3547;
             FStar_Extraction_ML_Syntax.mllb_def =
               {
                 FStar_Extraction_ML_Syntax.expr =
@@ -1166,18 +1180,18 @@ and (translate_let :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Fun (args,body);
-                     FStar_Extraction_ML_Syntax.mlty = uu____3544;
-                     FStar_Extraction_ML_Syntax.loc = uu____3545;_},uu____3546,uu____3547);
-                FStar_Extraction_ML_Syntax.mlty = uu____3548;
-                FStar_Extraction_ML_Syntax.loc = uu____3549;_};
+                     FStar_Extraction_ML_Syntax.mlty = uu____3550;
+                     FStar_Extraction_ML_Syntax.loc = uu____3551;_},uu____3552,uu____3553);
+                FStar_Extraction_ML_Syntax.mlty = uu____3554;
+                FStar_Extraction_ML_Syntax.loc = uu____3555;_};
             FStar_Extraction_ML_Syntax.mllb_meta = meta;
-            FStar_Extraction_ML_Syntax.print_typ = uu____3551;_} ->
+            FStar_Extraction_ML_Syntax.print_typ = uu____3557;_} ->
             let assumed =
               FStar_Util.for_some
-                (fun uu___38_3570  ->
-                   match uu___38_3570 with
+                (fun uu___40_3576  ->
+                   match uu___40_3576 with
                    | FStar_Extraction_ML_Syntax.Assumed  -> true
-                   | uu____3571 -> false) meta
+                   | uu____3577 -> false) meta
                in
             let env1 =
               if flavor = FStar_Extraction_ML_Syntax.Rec
@@ -1187,31 +1201,33 @@ and (translate_let :
               FStar_List.fold_left
                 (fun env2  -> fun name1  -> extend_t env2 name1) env1 tvars
                in
-            let rec find_return_type eff i uu___39_3592 =
-              match uu___39_3592 with
-              | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3597,eff1,t) when
+            let rec find_return_type eff i uu___41_3598 =
+              match uu___41_3598 with
+              | FStar_Extraction_ML_Syntax.MLTY_Fun (uu____3603,eff1,t) when
                   i > (Prims.parse_int "0") ->
                   find_return_type eff1 (i - (Prims.parse_int "1")) t
               | t -> (eff, t)  in
-            let uu____3601 =
+            let uu____3607 =
               find_return_type FStar_Extraction_ML_Syntax.E_PURE
                 (FStar_List.length args) t0
                in
-            (match uu____3601 with
+            (match uu____3607 with
              | (eff,t) ->
                  let t1 = translate_type env2 t  in
                  let binders = translate_binders env2 args  in
                  let env3 = add_binders env2 args  in
                  let name1 = ((env3.module_name), name)  in
                  let meta1 =
-                   match (eff, t1) with
-                   | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____3633) ->
-                       let uu____3634 = translate_flags meta  in
-                       MustDisappear :: uu____3634
-                   | (FStar_Extraction_ML_Syntax.E_PURE ,TUnit ) ->
-                       let uu____3637 = translate_flags meta  in
-                       MustDisappear :: uu____3637
-                   | uu____3640 -> translate_flags meta  in
+                   let is_unit =
+                     match eff with
+                     | FStar_Extraction_ML_Syntax.E_GHOST  -> true
+                     | FStar_Extraction_ML_Syntax.E_PURE  -> is_unit_type t0
+                     | uu____3638 -> false  in
+                   if is_unit
+                   then
+                     let uu____3641 = translate_flags meta  in MustDisappear
+                       :: uu____3641
+                   else translate_flags meta  in
                  if assumed
                  then
                    (if (FStar_List.length tvars) = (Prims.parse_int "0")
@@ -1274,6 +1290,9 @@ and (translate_let :
             FStar_Extraction_ML_Syntax.mllb_meta = meta;
             FStar_Extraction_ML_Syntax.print_typ = uu____3741;_} ->
             let meta1 = translate_flags meta  in
+            let meta2 =
+              let uu____3752 = is_unit_type t  in
+              if uu____3752 then MustDisappear :: meta1 else meta1  in
             let env1 =
               FStar_List.fold_left
                 (fun env1  -> fun name1  -> extend_t env1 name1) env tvars
@@ -1284,46 +1303,46 @@ and (translate_let :
                let expr1 = translate_expr env1 expr  in
                FStar_Pervasives_Native.Some
                  (DGlobal
-                    (meta1, name1, (FStar_List.length tvars), t1, expr1))
+                    (meta2, name1, (FStar_List.length tvars), t1, expr1))
              with
              | e ->
-                 ((let uu____3788 =
-                     let uu____3793 =
-                       let uu____3794 =
+                 ((let uu____3795 =
+                     let uu____3800 =
+                       let uu____3801 =
                          FStar_Extraction_ML_Syntax.string_of_mlpath name1
                           in
-                       let uu____3795 = FStar_Util.print_exn e  in
+                       let uu____3802 = FStar_Util.print_exn e  in
                        FStar_Util.format2
                          "Not translating definition for %s (%s)\n"
-                         uu____3794 uu____3795
+                         uu____3801 uu____3802
                         in
                      (FStar_Errors.Warning_DefinitionNotTranslated,
-                       uu____3793)
+                       uu____3800)
                       in
-                   FStar_Errors.log_issue FStar_Range.dummyRange uu____3788);
+                   FStar_Errors.log_issue FStar_Range.dummyRange uu____3795);
                   FStar_Pervasives_Native.Some
                     (DGlobal
-                       (meta1, name1, (FStar_List.length tvars), t1, EAny))))
+                       (meta2, name1, (FStar_List.length tvars), t1, EAny))))
         | { FStar_Extraction_ML_Syntax.mllb_name = name;
             FStar_Extraction_ML_Syntax.mllb_tysc = ts;
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____3806;
-            FStar_Extraction_ML_Syntax.mllb_def = uu____3807;
-            FStar_Extraction_ML_Syntax.mllb_meta = uu____3808;
-            FStar_Extraction_ML_Syntax.print_typ = uu____3809;_} ->
-            ((let uu____3813 =
-                let uu____3818 =
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu____3813;
+            FStar_Extraction_ML_Syntax.mllb_def = uu____3814;
+            FStar_Extraction_ML_Syntax.mllb_meta = uu____3815;
+            FStar_Extraction_ML_Syntax.print_typ = uu____3816;_} ->
+            ((let uu____3820 =
+                let uu____3825 =
                   FStar_Util.format1 "Not translating definition for %s\n"
                     name
                    in
-                (FStar_Errors.Warning_DefinitionNotTranslated, uu____3818)
+                (FStar_Errors.Warning_DefinitionNotTranslated, uu____3825)
                  in
-              FStar_Errors.log_issue FStar_Range.dummyRange uu____3813);
+              FStar_Errors.log_issue FStar_Range.dummyRange uu____3820);
              (match ts with
               | FStar_Pervasives_Native.Some (idents,t) ->
-                  let uu____3826 =
+                  let uu____3833 =
                     FStar_Extraction_ML_Code.string_of_mlty ([], "") t  in
                   FStar_Util.print2 "Type scheme is: forall %s. %s\n"
-                    (FStar_String.concat ", " idents) uu____3826
+                    (FStar_String.concat ", " idents) uu____3833
               | FStar_Pervasives_Native.None  -> ());
              FStar_Pervasives_Native.None)
 
@@ -1349,73 +1368,73 @@ and (translate_type_decl :
                "Not translating type definition (assumed) for %s\n" name2;
              FStar_Pervasives_Native.None)
           else
-            (let uu____3864 =
-               let uu____3865 =
-                 let uu____3882 = translate_flags flags1  in
-                 let uu____3885 = translate_type env1 t  in
-                 (name1, uu____3882, (FStar_List.length args), uu____3885)
+            (let uu____3871 =
+               let uu____3872 =
+                 let uu____3889 = translate_flags flags1  in
+                 let uu____3892 = translate_type env1 t  in
+                 (name1, uu____3889, (FStar_List.length args), uu____3892)
                   in
-               DTypeAlias uu____3865  in
-             FStar_Pervasives_Native.Some uu____3864)
-      | (uu____3894,name,_mangled_name,args,flags1,FStar_Pervasives_Native.Some
+               DTypeAlias uu____3872  in
+             FStar_Pervasives_Native.Some uu____3871)
+      | (uu____3901,name,_mangled_name,args,flags1,FStar_Pervasives_Native.Some
          (FStar_Extraction_ML_Syntax.MLTD_Record fields)) ->
           let name1 = ((env.module_name), name)  in
           let env1 =
             FStar_List.fold_left
               (fun env1  -> fun name2  -> extend_t env1 name2) env args
              in
-          let uu____3926 =
-            let uu____3927 =
-              let uu____3954 = translate_flags flags1  in
-              let uu____3957 =
+          let uu____3933 =
+            let uu____3934 =
+              let uu____3961 = translate_flags flags1  in
+              let uu____3964 =
                 FStar_List.map
-                  (fun uu____3984  ->
-                     match uu____3984 with
+                  (fun uu____3991  ->
+                     match uu____3991 with
                      | (f,t) ->
-                         let uu____3999 =
-                           let uu____4004 = translate_type env1 t  in
-                           (uu____4004, false)  in
-                         (f, uu____3999)) fields
+                         let uu____4006 =
+                           let uu____4011 = translate_type env1 t  in
+                           (uu____4011, false)  in
+                         (f, uu____4006)) fields
                  in
-              (name1, uu____3954, (FStar_List.length args), uu____3957)  in
-            DTypeFlat uu____3927  in
-          FStar_Pervasives_Native.Some uu____3926
-      | (uu____4027,name,_mangled_name,args,flags1,FStar_Pervasives_Native.Some
+              (name1, uu____3961, (FStar_List.length args), uu____3964)  in
+            DTypeFlat uu____3934  in
+          FStar_Pervasives_Native.Some uu____3933
+      | (uu____4034,name,_mangled_name,args,flags1,FStar_Pervasives_Native.Some
          (FStar_Extraction_ML_Syntax.MLTD_DType branches)) ->
           let name1 = ((env.module_name), name)  in
           let flags2 = translate_flags flags1  in
           let env1 = FStar_List.fold_left extend_t env args  in
-          let uu____4064 =
-            let uu____4065 =
-              let uu____4098 =
+          let uu____4071 =
+            let uu____4072 =
+              let uu____4105 =
                 FStar_List.map
-                  (fun uu____4143  ->
-                     match uu____4143 with
+                  (fun uu____4150  ->
+                     match uu____4150 with
                      | (cons1,ts) ->
-                         let uu____4182 =
+                         let uu____4189 =
                            FStar_List.map
-                             (fun uu____4209  ->
-                                match uu____4209 with
+                             (fun uu____4216  ->
+                                match uu____4216 with
                                 | (name2,t) ->
-                                    let uu____4224 =
-                                      let uu____4229 = translate_type env1 t
+                                    let uu____4231 =
+                                      let uu____4236 = translate_type env1 t
                                          in
-                                      (uu____4229, false)  in
-                                    (name2, uu____4224)) ts
+                                      (uu____4236, false)  in
+                                    (name2, uu____4231)) ts
                             in
-                         (cons1, uu____4182)) branches
+                         (cons1, uu____4189)) branches
                  in
-              (name1, flags2, (FStar_List.length args), uu____4098)  in
-            DTypeVariant uu____4065  in
-          FStar_Pervasives_Native.Some uu____4064
-      | (uu____4268,name,_mangled_name,uu____4271,uu____4272,uu____4273) ->
-          ((let uu____4283 =
-              let uu____4288 =
+              (name1, flags2, (FStar_List.length args), uu____4105)  in
+            DTypeVariant uu____4072  in
+          FStar_Pervasives_Native.Some uu____4071
+      | (uu____4275,name,_mangled_name,uu____4278,uu____4279,uu____4280) ->
+          ((let uu____4290 =
+              let uu____4295 =
                 FStar_Util.format1 "Not translating type definition for %s\n"
                   name
                  in
-              (FStar_Errors.Warning_DefinitionNotTranslated, uu____4288)  in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____4283);
+              (FStar_Errors.Warning_DefinitionNotTranslated, uu____4295)  in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu____4290);
            FStar_Pervasives_Native.None)
 
 and (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
@@ -1425,162 +1444,162 @@ and (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
       | FStar_Extraction_ML_Syntax.MLTY_Tuple [] -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Top  -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Var name ->
-          let uu____4292 = find_t env name  in TBound uu____4292
-      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____4294,t2) ->
-          let uu____4296 =
-            let uu____4301 = translate_type env t1  in
-            let uu____4302 = translate_type env t2  in
-            (uu____4301, uu____4302)  in
-          TArrow uu____4296
+          let uu____4299 = find_t env name  in TBound uu____4299
+      | FStar_Extraction_ML_Syntax.MLTY_Fun (t1,uu____4301,t2) ->
+          let uu____4303 =
+            let uu____4308 = translate_type env t1  in
+            let uu____4309 = translate_type env t2  in
+            (uu____4308, uu____4309)  in
+          TArrow uu____4303
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____4306 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4306 = "Prims.unit" -> TUnit
+          let uu____4313 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4313 = "Prims.unit" -> TUnit
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],p) when
-          let uu____4310 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4310 = "Prims.bool" -> TBool
+          let uu____4317 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4317 = "Prims.bool" -> TBool
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t")) when
           is_machine_int m ->
-          let uu____4322 = FStar_Util.must (mk_width m)  in TInt uu____4322
+          let uu____4329 = FStar_Util.must (mk_width m)  in TInt uu____4329
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],("FStar"::m::[],"t'")) when
           is_machine_int m ->
-          let uu____4334 = FStar_Util.must (mk_width m)  in TInt uu____4334
+          let uu____4341 = FStar_Util.must (mk_width m)  in TInt uu____4341
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
-          let uu____4339 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4339 = "FStar.Monotonic.HyperStack.mem" -> TUnit
+          let uu____4346 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4346 = "FStar.Monotonic.HyperStack.mem" -> TUnit
       | FStar_Extraction_ML_Syntax.MLTY_Named
-          (uu____4340::arg::uu____4342::[],p) when
-          (((let uu____4348 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+          (uu____4347::arg::uu____4349::[],p) when
+          (((let uu____4355 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                 in
-             uu____4348 = "FStar.Monotonic.HyperStack.s_mref") ||
-              (let uu____4350 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+             uu____4355 = "FStar.Monotonic.HyperStack.s_mref") ||
+              (let uu____4357 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                   in
-               uu____4350 = "FStar.Monotonic.HyperHeap.mrref"))
+               uu____4357 = "FStar.Monotonic.HyperHeap.mrref"))
              ||
-             (let uu____4352 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+             (let uu____4359 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                  in
-              uu____4352 = "FStar.HyperStack.ST.m_rref"))
+              uu____4359 = "FStar.HyperStack.ST.m_rref"))
             ||
-            (let uu____4354 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+            (let uu____4361 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                 in
-             uu____4354 = "FStar.HyperStack.ST.s_mref")
-          -> let uu____4355 = translate_type env arg  in TBuf uu____4355
-      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::uu____4357::[],p) when
-          ((((((((((let uu____4363 =
+             uu____4361 = "FStar.HyperStack.ST.s_mref")
+          -> let uu____4362 = translate_type env arg  in TBuf uu____4362
+      | FStar_Extraction_ML_Syntax.MLTY_Named (arg::uu____4364::[],p) when
+          ((((((((((let uu____4370 =
                       FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                    uu____4363 = "FStar.Monotonic.HyperStack.mreference") ||
-                     (let uu____4365 =
+                    uu____4370 = "FStar.Monotonic.HyperStack.mreference") ||
+                     (let uu____4372 =
                         FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                      uu____4365 = "FStar.Monotonic.HyperStack.mstackref"))
+                      uu____4372 = "FStar.Monotonic.HyperStack.mstackref"))
                     ||
-                    (let uu____4367 =
+                    (let uu____4374 =
                        FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                     uu____4367 = "FStar.Monotonic.HyperStack.mref"))
+                     uu____4374 = "FStar.Monotonic.HyperStack.mref"))
                    ||
-                   (let uu____4369 =
+                   (let uu____4376 =
                       FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                    uu____4369 = "FStar.Monotonic.HyperStack.mmmstackref"))
+                    uu____4376 = "FStar.Monotonic.HyperStack.mmmstackref"))
                   ||
-                  (let uu____4371 =
+                  (let uu____4378 =
                      FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                   uu____4371 = "FStar.Monotonic.HyperStack.mmmref"))
+                   uu____4378 = "FStar.Monotonic.HyperStack.mmmref"))
                  ||
-                 (let uu____4373 =
+                 (let uu____4380 =
                     FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                  uu____4373 = "FStar.Monotonic.Heap.mref"))
+                  uu____4380 = "FStar.Monotonic.Heap.mref"))
                 ||
-                (let uu____4375 =
+                (let uu____4382 =
                    FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                 uu____4375 = "FStar.HyperStack.ST.mreference"))
+                 uu____4382 = "FStar.HyperStack.ST.mreference"))
                ||
-               (let uu____4377 =
+               (let uu____4384 =
                   FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                uu____4377 = "FStar.HyperStack.ST.mstackref"))
+                uu____4384 = "FStar.HyperStack.ST.mstackref"))
               ||
-              (let uu____4379 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+              (let uu____4386 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                   in
-               uu____4379 = "FStar.HyperStack.ST.mref"))
+               uu____4386 = "FStar.HyperStack.ST.mref"))
              ||
-             (let uu____4381 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+             (let uu____4388 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                  in
-              uu____4381 = "FStar.HyperStack.ST.mmmstackref"))
+              uu____4388 = "FStar.HyperStack.ST.mmmstackref"))
             ||
-            (let uu____4383 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+            (let uu____4390 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                 in
-             uu____4383 = "FStar.HyperStack.ST.mmmref")
-          -> let uu____4384 = translate_type env arg  in TBuf uu____4384
+             uu____4390 = "FStar.HyperStack.ST.mmmref")
+          -> let uu____4391 = translate_type env arg  in TBuf uu____4391
       | FStar_Extraction_ML_Syntax.MLTY_Named (arg::[],p) when
-          ((((((((((let uu____4391 =
+          ((((((((((let uu____4398 =
                       FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                    uu____4391 = "FStar.Buffer.buffer") ||
-                     (let uu____4393 =
+                    uu____4398 = "FStar.Buffer.buffer") ||
+                     (let uu____4400 =
                         FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                      uu____4393 = "FStar.HyperStack.reference"))
+                      uu____4400 = "FStar.HyperStack.reference"))
                     ||
-                    (let uu____4395 =
+                    (let uu____4402 =
                        FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                     uu____4395 = "FStar.HyperStack.stackref"))
+                     uu____4402 = "FStar.HyperStack.stackref"))
                    ||
-                   (let uu____4397 =
+                   (let uu____4404 =
                       FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                    uu____4397 = "FStar.HyperStack.ref"))
+                    uu____4404 = "FStar.HyperStack.ref"))
                   ||
-                  (let uu____4399 =
+                  (let uu____4406 =
                      FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                   uu____4399 = "FStar.HyperStack.mmstackref"))
+                   uu____4406 = "FStar.HyperStack.mmstackref"))
                  ||
-                 (let uu____4401 =
+                 (let uu____4408 =
                     FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                  uu____4401 = "FStar.HyperStack.mmref"))
+                  uu____4408 = "FStar.HyperStack.mmref"))
                 ||
-                (let uu____4403 =
+                (let uu____4410 =
                    FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                 uu____4403 = "FStar.HyperStack.ST.reference"))
+                 uu____4410 = "FStar.HyperStack.ST.reference"))
                ||
-               (let uu____4405 =
+               (let uu____4412 =
                   FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                uu____4405 = "FStar.HyperStack.ST.stackref"))
+                uu____4412 = "FStar.HyperStack.ST.stackref"))
               ||
-              (let uu____4407 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+              (let uu____4414 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                   in
-               uu____4407 = "FStar.HyperStack.ST.ref"))
+               uu____4414 = "FStar.HyperStack.ST.ref"))
              ||
-             (let uu____4409 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+             (let uu____4416 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                  in
-              uu____4409 = "FStar.HyperStack.ST.mmstackref"))
+              uu____4416 = "FStar.HyperStack.ST.mmstackref"))
             ||
-            (let uu____4411 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+            (let uu____4418 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                 in
-             uu____4411 = "FStar.HyperStack.ST.mmref")
-          -> let uu____4412 = translate_type env arg  in TBuf uu____4412
-      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4413::arg::[],p) when
-          (let uu____4420 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-           uu____4420 = "FStar.HyperStack.s_ref") ||
-            (let uu____4422 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+             uu____4418 = "FStar.HyperStack.ST.mmref")
+          -> let uu____4419 = translate_type env arg  in TBuf uu____4419
+      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4420::arg::[],p) when
+          (let uu____4427 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+           uu____4427 = "FStar.HyperStack.s_ref") ||
+            (let uu____4429 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                 in
-             uu____4422 = "FStar.HyperStack.ST.s_ref")
-          -> let uu____4423 = translate_type env arg  in TBuf uu____4423
-      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4424::[],p) when
-          let uu____4428 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4428 = "FStar.Ghost.erased" -> TAny
+             uu____4429 = "FStar.HyperStack.ST.s_ref")
+          -> let uu____4430 = translate_type env arg  in TBuf uu____4430
+      | FStar_Extraction_ML_Syntax.MLTY_Named (uu____4431::[],p) when
+          let uu____4435 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4435 = "FStar.Ghost.erased" -> TAny
       | FStar_Extraction_ML_Syntax.MLTY_Named ([],(path,type_name)) ->
           TQualified (path, type_name)
       | FStar_Extraction_ML_Syntax.MLTY_Named (args,(ns,t1)) when
           ((ns = ["Prims"]) || (ns = ["FStar"; "Pervasives"; "Native"])) &&
             (FStar_Util.starts_with t1 "tuple")
           ->
-          let uu____4466 = FStar_List.map (translate_type env) args  in
-          TTuple uu____4466
+          let uu____4473 = FStar_List.map (translate_type env) args  in
+          TTuple uu____4473
       | FStar_Extraction_ML_Syntax.MLTY_Named (args,lid) ->
           if (FStar_List.length args) > (Prims.parse_int "0")
           then
-            let uu____4475 =
-              let uu____4488 = FStar_List.map (translate_type env) args  in
-              (lid, uu____4488)  in
-            TApp uu____4475
+            let uu____4482 =
+              let uu____4495 = FStar_List.map (translate_type env) args  in
+              (lid, uu____4495)  in
+            TApp uu____4482
           else TQualified lid
       | FStar_Extraction_ML_Syntax.MLTY_Tuple ts ->
-          let uu____4497 = FStar_List.map (translate_type env) ts  in
-          TTuple uu____4497
+          let uu____4504 = FStar_List.map (translate_type env) ts  in
+          TTuple uu____4504
 
 and (translate_binders :
   env ->
@@ -1594,11 +1613,11 @@ and (translate_binder :
       FStar_Pervasives_Native.tuple2 -> binder)
   =
   fun env  ->
-    fun uu____4513  ->
-      match uu____4513 with
+    fun uu____4520  ->
+      match uu____4520 with
       | (name,typ) ->
-          let uu____4520 = translate_type env typ  in
-          { name; typ = uu____4520; mut = false }
+          let uu____4527 = translate_type env typ  in
+          { name; typ = uu____4527; mut = false }
 
 and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
   fun env  ->
@@ -1607,20 +1626,20 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
       | FStar_Extraction_ML_Syntax.MLE_Tuple [] -> EUnit
       | FStar_Extraction_ML_Syntax.MLE_Const c -> translate_constant c
       | FStar_Extraction_ML_Syntax.MLE_Var name ->
-          let uu____4525 = find env name  in EBound uu____4525
+          let uu____4532 = find env name  in EBound uu____4532
       | FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op) when
           (is_machine_int m) && (is_op op) ->
-          let uu____4530 =
-            let uu____4535 = FStar_Util.must (mk_op op)  in
-            let uu____4536 = FStar_Util.must (mk_width m)  in
-            (uu____4535, uu____4536)  in
-          EOp uu____4530
+          let uu____4537 =
+            let uu____4542 = FStar_Util.must (mk_op op)  in
+            let uu____4543 = FStar_Util.must (mk_width m)  in
+            (uu____4542, uu____4543)  in
+          EOp uu____4537
       | FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op) when
           is_bool_op op ->
-          let uu____4540 =
-            let uu____4545 = FStar_Util.must (mk_bool_op op)  in
-            (uu____4545, Bool)  in
-          EOp uu____4540
+          let uu____4547 =
+            let uu____4552 = FStar_Util.must (mk_bool_op op)  in
+            (uu____4552, Bool)  in
+          EOp uu____4547
       | FStar_Extraction_ML_Syntax.MLE_Name n1 -> EQualified n1
       | FStar_Extraction_ML_Syntax.MLE_Let
           ((flavor,{ FStar_Extraction_ML_Syntax.mllb_name = name;
@@ -1633,59 +1652,59 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
           ->
           let is_mut =
             FStar_Util.for_some
-              (fun uu___40_4573  ->
-                 match uu___40_4573 with
+              (fun uu___42_4580  ->
+                 match uu___42_4580 with
                  | FStar_Extraction_ML_Syntax.Mutable  -> true
-                 | uu____4574 -> false) flags1
+                 | uu____4581 -> false) flags1
              in
-          let uu____4575 =
+          let uu____4582 =
             if is_mut
             then
-              let uu____4584 =
+              let uu____4591 =
                 match typ with
                 | FStar_Extraction_ML_Syntax.MLTY_Named (t::[],p) when
-                    let uu____4589 =
+                    let uu____4596 =
                       FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-                    uu____4589 = "FStar.ST.stackref" -> t
-                | uu____4590 ->
-                    let uu____4591 =
-                      let uu____4592 =
+                    uu____4596 = "FStar.ST.stackref" -> t
+                | uu____4597 ->
+                    let uu____4598 =
+                      let uu____4599 =
                         FStar_Extraction_ML_Code.string_of_mlty ([], "") typ
                          in
                       FStar_Util.format1
                         "unexpected: bad desugaring of Mutable (typ is %s)"
-                        uu____4592
+                        uu____4599
                        in
-                    failwith uu____4591
+                    failwith uu____4598
                  in
-              let uu____4595 =
+              let uu____4602 =
                 match body with
                 | {
                     FStar_Extraction_ML_Syntax.expr =
                       FStar_Extraction_ML_Syntax.MLE_App
-                      (uu____4596,body1::[]);
-                    FStar_Extraction_ML_Syntax.mlty = uu____4598;
-                    FStar_Extraction_ML_Syntax.loc = uu____4599;_} -> body1
-                | uu____4602 ->
+                      (uu____4603,body1::[]);
+                    FStar_Extraction_ML_Syntax.mlty = uu____4605;
+                    FStar_Extraction_ML_Syntax.loc = uu____4606;_} -> body1
+                | uu____4609 ->
                     failwith "unexpected: bad desugaring of Mutable"
                  in
-              (uu____4584, uu____4595)
+              (uu____4591, uu____4602)
             else (typ, body)  in
-          (match uu____4575 with
+          (match uu____4582 with
            | (typ1,body1) ->
                let binder =
-                 let uu____4607 = translate_type env typ1  in
-                 { name; typ = uu____4607; mut = is_mut }  in
+                 let uu____4614 = translate_type env typ1  in
+                 { name; typ = uu____4614; mut = is_mut }  in
                let body2 = translate_expr env body1  in
                let env1 = extend env name is_mut  in
                let continuation1 = translate_expr env1 continuation  in
                ELet (binder, body2, continuation1))
       | FStar_Extraction_ML_Syntax.MLE_Match (expr,branches) ->
-          let uu____4633 =
-            let uu____4644 = translate_expr env expr  in
-            let uu____4645 = translate_branches env branches  in
-            (uu____4644, uu____4645)  in
-          EMatch uu____4633
+          let uu____4640 =
+            let uu____4651 = translate_expr env expr  in
+            let uu____4652 = translate_branches env branches  in
+            (uu____4651, uu____4652)  in
+          EMatch uu____4640
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1693,18 +1712,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4659;
-                  FStar_Extraction_ML_Syntax.loc = uu____4660;_},t::[]);
-             FStar_Extraction_ML_Syntax.mlty = uu____4662;
-             FStar_Extraction_ML_Syntax.loc = uu____4663;_},arg::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4666;
+                  FStar_Extraction_ML_Syntax.loc = uu____4667;_},t::[]);
+             FStar_Extraction_ML_Syntax.mlty = uu____4669;
+             FStar_Extraction_ML_Syntax.loc = uu____4670;_},arg::[])
           when
-          let uu____4669 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4669 = "FStar.Dyn.undyn" ->
-          let uu____4670 =
-            let uu____4675 = translate_expr env arg  in
-            let uu____4676 = translate_type env t  in
-            (uu____4675, uu____4676)  in
-          ECast uu____4670
+          let uu____4676 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4676 = "FStar.Dyn.undyn" ->
+          let uu____4677 =
+            let uu____4682 = translate_expr env arg  in
+            let uu____4683 = translate_type env t  in
+            (uu____4682, uu____4683)  in
+          ECast uu____4677
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1712,13 +1731,13 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4678;
-                  FStar_Extraction_ML_Syntax.loc = uu____4679;_},uu____4680);
-             FStar_Extraction_ML_Syntax.mlty = uu____4681;
-             FStar_Extraction_ML_Syntax.loc = uu____4682;_},uu____4683)
+                  FStar_Extraction_ML_Syntax.mlty = uu____4685;
+                  FStar_Extraction_ML_Syntax.loc = uu____4686;_},uu____4687);
+             FStar_Extraction_ML_Syntax.mlty = uu____4688;
+             FStar_Extraction_ML_Syntax.loc = uu____4689;_},uu____4690)
           when
-          let uu____4692 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4692 = "Prims.admit" -> EAbort
+          let uu____4699 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4699 = "Prims.admit" -> EAbort
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1726,42 +1745,42 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4694;
-                  FStar_Extraction_ML_Syntax.loc = uu____4695;_},uu____4696);
-             FStar_Extraction_ML_Syntax.mlty = uu____4697;
-             FStar_Extraction_ML_Syntax.loc = uu____4698;_},arg::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4701;
+                  FStar_Extraction_ML_Syntax.loc = uu____4702;_},uu____4703);
+             FStar_Extraction_ML_Syntax.mlty = uu____4704;
+             FStar_Extraction_ML_Syntax.loc = uu____4705;_},arg::[])
           when
-          ((let uu____4708 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+          ((let uu____4715 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                in
-            uu____4708 = "FStar.HyperStack.All.failwith") ||
-             (let uu____4710 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+            uu____4715 = "FStar.HyperStack.All.failwith") ||
+             (let uu____4717 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                  in
-              uu____4710 = "FStar.Error.unexpected"))
+              uu____4717 = "FStar.Error.unexpected"))
             ||
-            (let uu____4712 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+            (let uu____4719 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                 in
-             uu____4712 = "FStar.Error.unreachable")
+             uu____4719 = "FStar.Error.unreachable")
           ->
           (match arg with
            | {
                FStar_Extraction_ML_Syntax.expr =
                  FStar_Extraction_ML_Syntax.MLE_Const
                  (FStar_Extraction_ML_Syntax.MLC_String msg);
-               FStar_Extraction_ML_Syntax.mlty = uu____4714;
-               FStar_Extraction_ML_Syntax.loc = uu____4715;_} -> EAbortS msg
-           | uu____4716 ->
+               FStar_Extraction_ML_Syntax.mlty = uu____4721;
+               FStar_Extraction_ML_Syntax.loc = uu____4722;_} -> EAbortS msg
+           | uu____4723 ->
                let print7 =
-                 let uu____4718 =
-                   let uu____4719 =
-                     let uu____4720 =
+                 let uu____4725 =
+                   let uu____4726 =
+                     let uu____4727 =
                        FStar_Ident.lid_of_str
                          "FStar.HyperStack.IO.print_string"
                         in
-                     FStar_Extraction_ML_Syntax.mlpath_of_lident uu____4720
+                     FStar_Extraction_ML_Syntax.mlpath_of_lident uu____4727
                       in
-                   FStar_Extraction_ML_Syntax.MLE_Name uu____4719  in
+                   FStar_Extraction_ML_Syntax.MLE_Name uu____4726  in
                  FStar_Extraction_ML_Syntax.with_ty
-                   FStar_Extraction_ML_Syntax.MLTY_Top uu____4718
+                   FStar_Extraction_ML_Syntax.MLTY_Top uu____4725
                   in
                let print8 =
                  FStar_Extraction_ML_Syntax.with_ty
@@ -1773,45 +1792,45 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____4726;
-             FStar_Extraction_ML_Syntax.loc = uu____4727;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____4733;
+             FStar_Extraction_ML_Syntax.loc = uu____4734;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Var
                                                                 v1;
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____4729;
+                                                                = uu____4736;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4730;_}::[])
+                                                                = uu____4737;_}::[])
           when
-          (let uu____4735 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-           uu____4735 = "FStar.HyperStack.ST.op_Bang") && (is_mutable env v1)
-          -> let uu____4736 = find env v1  in EBound uu____4736
+          (let uu____4742 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+           uu____4742 = "FStar.HyperStack.ST.op_Bang") && (is_mutable env v1)
+          -> let uu____4743 = find env v1  in EBound uu____4743
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____4738;
-             FStar_Extraction_ML_Syntax.loc = uu____4739;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____4745;
+             FStar_Extraction_ML_Syntax.loc = uu____4746;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Var
                                                                 v1;
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____4741;
+                                                                = uu____4748;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____4742;_}::e1::[])
+                                                                = uu____4749;_}::e1::[])
           when
-          (let uu____4748 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-           uu____4748 = "FStar.HyperStack.ST.op_Colon_Equals") &&
+          (let uu____4755 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+           uu____4755 = "FStar.HyperStack.ST.op_Colon_Equals") &&
             (is_mutable env v1)
           ->
-          let uu____4749 =
-            let uu____4754 =
-              let uu____4755 = find env v1  in EBound uu____4755  in
-            let uu____4756 = translate_expr env e1  in
-            (uu____4754, uu____4756)  in
-          EAssign uu____4749
+          let uu____4756 =
+            let uu____4761 =
+              let uu____4762 = find env v1  in EBound uu____4762  in
+            let uu____4763 = translate_expr env e1  in
+            (uu____4761, uu____4763)  in
+          EAssign uu____4756
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1819,22 +1838,22 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4758;
-                  FStar_Extraction_ML_Syntax.loc = uu____4759;_},uu____4760);
-             FStar_Extraction_ML_Syntax.mlty = uu____4761;
-             FStar_Extraction_ML_Syntax.loc = uu____4762;_},e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4765;
+                  FStar_Extraction_ML_Syntax.loc = uu____4766;_},uu____4767);
+             FStar_Extraction_ML_Syntax.mlty = uu____4768;
+             FStar_Extraction_ML_Syntax.loc = uu____4769;_},e1::e2::[])
           when
-          (let uu____4773 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-           uu____4773 = "FStar.Buffer.index") ||
-            (let uu____4775 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+          (let uu____4780 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+           uu____4780 = "FStar.Buffer.index") ||
+            (let uu____4782 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                 in
-             uu____4775 = "FStar.Buffer.op_Array_Access")
+             uu____4782 = "FStar.Buffer.op_Array_Access")
           ->
-          let uu____4776 =
-            let uu____4781 = translate_expr env e1  in
-            let uu____4782 = translate_expr env e2  in
-            (uu____4781, uu____4782)  in
-          EBufRead uu____4776
+          let uu____4783 =
+            let uu____4788 = translate_expr env e1  in
+            let uu____4789 = translate_expr env e2  in
+            (uu____4788, uu____4789)  in
+          EBufRead uu____4783
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1842,17 +1861,17 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4784;
-                  FStar_Extraction_ML_Syntax.loc = uu____4785;_},uu____4786);
-             FStar_Extraction_ML_Syntax.mlty = uu____4787;
-             FStar_Extraction_ML_Syntax.loc = uu____4788;_},e1::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4791;
+                  FStar_Extraction_ML_Syntax.loc = uu____4792;_},uu____4793);
+             FStar_Extraction_ML_Syntax.mlty = uu____4794;
+             FStar_Extraction_ML_Syntax.loc = uu____4795;_},e1::[])
           when
-          let uu____4796 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4796 = "FStar.HyperStack.ST.op_Bang" ->
-          let uu____4797 =
-            let uu____4802 = translate_expr env e1  in
-            (uu____4802, (EConstant (UInt32, "0")))  in
-          EBufRead uu____4797
+          let uu____4803 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4803 = "FStar.HyperStack.ST.op_Bang" ->
+          let uu____4804 =
+            let uu____4809 = translate_expr env e1  in
+            (uu____4809, (EConstant (UInt32, "0")))  in
+          EBufRead uu____4804
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1860,18 +1879,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4804;
-                  FStar_Extraction_ML_Syntax.loc = uu____4805;_},uu____4806);
-             FStar_Extraction_ML_Syntax.mlty = uu____4807;
-             FStar_Extraction_ML_Syntax.loc = uu____4808;_},e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4811;
+                  FStar_Extraction_ML_Syntax.loc = uu____4812;_},uu____4813);
+             FStar_Extraction_ML_Syntax.mlty = uu____4814;
+             FStar_Extraction_ML_Syntax.loc = uu____4815;_},e1::e2::[])
           when
-          let uu____4817 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4817 = "FStar.Buffer.create" ->
-          let uu____4818 =
-            let uu____4825 = translate_expr env e1  in
-            let uu____4826 = translate_expr env e2  in
-            (Stack, uu____4825, uu____4826)  in
-          EBufCreate uu____4818
+          let uu____4824 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4824 = "FStar.Buffer.create" ->
+          let uu____4825 =
+            let uu____4832 = translate_expr env e1  in
+            let uu____4833 = translate_expr env e2  in
+            (Stack, uu____4832, uu____4833)  in
+          EBufCreate uu____4825
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1879,17 +1898,17 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4828;
-                  FStar_Extraction_ML_Syntax.loc = uu____4829;_},uu____4830);
-             FStar_Extraction_ML_Syntax.mlty = uu____4831;
-             FStar_Extraction_ML_Syntax.loc = uu____4832;_},init1::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4835;
+                  FStar_Extraction_ML_Syntax.loc = uu____4836;_},uu____4837);
+             FStar_Extraction_ML_Syntax.mlty = uu____4838;
+             FStar_Extraction_ML_Syntax.loc = uu____4839;_},init1::[])
           when
-          let uu____4840 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4840 = "FStar.HyperStack.ST.salloc" ->
-          let uu____4841 =
-            let uu____4848 = translate_expr env init1  in
-            (Eternal, uu____4848, (EConstant (UInt32, "1")))  in
-          EBufCreate uu____4841
+          let uu____4847 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4847 = "FStar.HyperStack.ST.salloc" ->
+          let uu____4848 =
+            let uu____4855 = translate_expr env init1  in
+            (Eternal, uu____4855, (EConstant (UInt32, "1")))  in
+          EBufCreate uu____4848
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1897,17 +1916,17 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4850;
-                  FStar_Extraction_ML_Syntax.loc = uu____4851;_},uu____4852);
-             FStar_Extraction_ML_Syntax.mlty = uu____4853;
-             FStar_Extraction_ML_Syntax.loc = uu____4854;_},_rid::init1::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4857;
+                  FStar_Extraction_ML_Syntax.loc = uu____4858;_},uu____4859);
+             FStar_Extraction_ML_Syntax.mlty = uu____4860;
+             FStar_Extraction_ML_Syntax.loc = uu____4861;_},_rid::init1::[])
           when
-          let uu____4863 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4863 = "FStar.HyperStack.ST.ralloc" ->
-          let uu____4864 =
-            let uu____4871 = translate_expr env init1  in
-            (Eternal, uu____4871, (EConstant (UInt32, "1")))  in
-          EBufCreate uu____4864
+          let uu____4870 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4870 = "FStar.HyperStack.ST.ralloc" ->
+          let uu____4871 =
+            let uu____4878 = translate_expr env init1  in
+            (Eternal, uu____4878, (EConstant (UInt32, "1")))  in
+          EBufCreate uu____4871
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1915,18 +1934,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4873;
-                  FStar_Extraction_ML_Syntax.loc = uu____4874;_},uu____4875);
-             FStar_Extraction_ML_Syntax.mlty = uu____4876;
-             FStar_Extraction_ML_Syntax.loc = uu____4877;_},_e0::e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4880;
+                  FStar_Extraction_ML_Syntax.loc = uu____4881;_},uu____4882);
+             FStar_Extraction_ML_Syntax.mlty = uu____4883;
+             FStar_Extraction_ML_Syntax.loc = uu____4884;_},_e0::e1::e2::[])
           when
-          let uu____4887 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4887 = "FStar.Buffer.rcreate" ->
-          let uu____4888 =
-            let uu____4895 = translate_expr env e1  in
-            let uu____4896 = translate_expr env e2  in
-            (Eternal, uu____4895, uu____4896)  in
-          EBufCreate uu____4888
+          let uu____4894 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4894 = "FStar.Buffer.rcreate" ->
+          let uu____4895 =
+            let uu____4902 = translate_expr env e1  in
+            let uu____4903 = translate_expr env e2  in
+            (Eternal, uu____4902, uu____4903)  in
+          EBufCreate uu____4895
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1934,18 +1953,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4898;
-                  FStar_Extraction_ML_Syntax.loc = uu____4899;_},uu____4900);
-             FStar_Extraction_ML_Syntax.mlty = uu____4901;
-             FStar_Extraction_ML_Syntax.loc = uu____4902;_},_e0::e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4905;
+                  FStar_Extraction_ML_Syntax.loc = uu____4906;_},uu____4907);
+             FStar_Extraction_ML_Syntax.mlty = uu____4908;
+             FStar_Extraction_ML_Syntax.loc = uu____4909;_},_e0::e1::e2::[])
           when
-          let uu____4912 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4912 = "FStar.Buffer.rcreate_mm" ->
-          let uu____4913 =
-            let uu____4920 = translate_expr env e1  in
-            let uu____4921 = translate_expr env e2  in
-            (ManuallyManaged, uu____4920, uu____4921)  in
-          EBufCreate uu____4913
+          let uu____4919 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4919 = "FStar.Buffer.rcreate_mm" ->
+          let uu____4920 =
+            let uu____4927 = translate_expr env e1  in
+            let uu____4928 = translate_expr env e2  in
+            (ManuallyManaged, uu____4927, uu____4928)  in
+          EBufCreate uu____4920
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1953,13 +1972,13 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4923;
-                  FStar_Extraction_ML_Syntax.loc = uu____4924;_},uu____4925);
-             FStar_Extraction_ML_Syntax.mlty = uu____4926;
-             FStar_Extraction_ML_Syntax.loc = uu____4927;_},e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____4930;
+                  FStar_Extraction_ML_Syntax.loc = uu____4931;_},uu____4932);
+             FStar_Extraction_ML_Syntax.mlty = uu____4933;
+             FStar_Extraction_ML_Syntax.loc = uu____4934;_},e2::[])
           when
-          let uu____4935 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____4935 = "FStar.Buffer.createL" ->
+          let uu____4942 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____4942 = "FStar.Buffer.createL" ->
           let rec list_elements acc e21 =
             match e21.FStar_Extraction_ML_Syntax.expr with
             | FStar_Extraction_ML_Syntax.MLE_CTor
@@ -1967,17 +1986,17 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                 list_elements (hd1 :: acc) tl1
             | FStar_Extraction_ML_Syntax.MLE_CTor (("Prims"::[],"Nil"),[]) ->
                 FStar_List.rev acc
-            | uu____4973 ->
+            | uu____4980 ->
                 failwith
                   "Argument of FStar.Buffer.createL is not a string literal!"
              in
           let list_elements1 = list_elements []  in
-          let uu____4981 =
-            let uu____4988 =
-              let uu____4991 = list_elements1 e2  in
-              FStar_List.map (translate_expr env) uu____4991  in
-            (Stack, uu____4988)  in
-          EBufCreateL uu____4981
+          let uu____4988 =
+            let uu____4995 =
+              let uu____4998 = list_elements1 e2  in
+              FStar_List.map (translate_expr env) uu____4998  in
+            (Stack, uu____4995)  in
+          EBufCreateL uu____4988
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -1985,14 +2004,14 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____4997;
-                  FStar_Extraction_ML_Syntax.loc = uu____4998;_},uu____4999);
-             FStar_Extraction_ML_Syntax.mlty = uu____5000;
-             FStar_Extraction_ML_Syntax.loc = uu____5001;_},e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____5004;
+                  FStar_Extraction_ML_Syntax.loc = uu____5005;_},uu____5006);
+             FStar_Extraction_ML_Syntax.mlty = uu____5007;
+             FStar_Extraction_ML_Syntax.loc = uu____5008;_},e2::[])
           when
-          let uu____5009 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5009 = "FStar.Buffer.rfree" ->
-          let uu____5010 = translate_expr env e2  in EBufFree uu____5010
+          let uu____5016 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5016 = "FStar.Buffer.rfree" ->
+          let uu____5017 = translate_expr env e2  in EBufFree uu____5017
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2000,18 +2019,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5012;
-                  FStar_Extraction_ML_Syntax.loc = uu____5013;_},uu____5014);
-             FStar_Extraction_ML_Syntax.mlty = uu____5015;
-             FStar_Extraction_ML_Syntax.loc = uu____5016;_},e1::e2::_e3::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____5019;
+                  FStar_Extraction_ML_Syntax.loc = uu____5020;_},uu____5021);
+             FStar_Extraction_ML_Syntax.mlty = uu____5022;
+             FStar_Extraction_ML_Syntax.loc = uu____5023;_},e1::e2::_e3::[])
           when
-          let uu____5026 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5026 = "FStar.Buffer.sub" ->
-          let uu____5027 =
-            let uu____5032 = translate_expr env e1  in
-            let uu____5033 = translate_expr env e2  in
-            (uu____5032, uu____5033)  in
-          EBufSub uu____5027
+          let uu____5033 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5033 = "FStar.Buffer.sub" ->
+          let uu____5034 =
+            let uu____5039 = translate_expr env e1  in
+            let uu____5040 = translate_expr env e2  in
+            (uu____5039, uu____5040)  in
+          EBufSub uu____5034
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2019,13 +2038,13 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5035;
-                  FStar_Extraction_ML_Syntax.loc = uu____5036;_},uu____5037);
-             FStar_Extraction_ML_Syntax.mlty = uu____5038;
-             FStar_Extraction_ML_Syntax.loc = uu____5039;_},e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____5042;
+                  FStar_Extraction_ML_Syntax.loc = uu____5043;_},uu____5044);
+             FStar_Extraction_ML_Syntax.mlty = uu____5045;
+             FStar_Extraction_ML_Syntax.loc = uu____5046;_},e1::e2::[])
           when
-          let uu____5048 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5048 = "FStar.Buffer.join" -> translate_expr env e1
+          let uu____5055 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5055 = "FStar.Buffer.join" -> translate_expr env e1
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2033,18 +2052,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5050;
-                  FStar_Extraction_ML_Syntax.loc = uu____5051;_},uu____5052);
-             FStar_Extraction_ML_Syntax.mlty = uu____5053;
-             FStar_Extraction_ML_Syntax.loc = uu____5054;_},e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____5057;
+                  FStar_Extraction_ML_Syntax.loc = uu____5058;_},uu____5059);
+             FStar_Extraction_ML_Syntax.mlty = uu____5060;
+             FStar_Extraction_ML_Syntax.loc = uu____5061;_},e1::e2::[])
           when
-          let uu____5063 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5063 = "FStar.Buffer.offset" ->
-          let uu____5064 =
-            let uu____5069 = translate_expr env e1  in
-            let uu____5070 = translate_expr env e2  in
-            (uu____5069, uu____5070)  in
-          EBufSub uu____5064
+          let uu____5070 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5070 = "FStar.Buffer.offset" ->
+          let uu____5071 =
+            let uu____5076 = translate_expr env e1  in
+            let uu____5077 = translate_expr env e2  in
+            (uu____5076, uu____5077)  in
+          EBufSub uu____5071
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2052,23 +2071,23 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5072;
-                  FStar_Extraction_ML_Syntax.loc = uu____5073;_},uu____5074);
-             FStar_Extraction_ML_Syntax.mlty = uu____5075;
-             FStar_Extraction_ML_Syntax.loc = uu____5076;_},e1::e2::e3::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____5079;
+                  FStar_Extraction_ML_Syntax.loc = uu____5080;_},uu____5081);
+             FStar_Extraction_ML_Syntax.mlty = uu____5082;
+             FStar_Extraction_ML_Syntax.loc = uu____5083;_},e1::e2::e3::[])
           when
-          (let uu____5088 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-           uu____5088 = "FStar.Buffer.upd") ||
-            (let uu____5090 = FStar_Extraction_ML_Syntax.string_of_mlpath p
+          (let uu____5095 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+           uu____5095 = "FStar.Buffer.upd") ||
+            (let uu____5097 = FStar_Extraction_ML_Syntax.string_of_mlpath p
                 in
-             uu____5090 = "FStar.Buffer.op_Array_Assignment")
+             uu____5097 = "FStar.Buffer.op_Array_Assignment")
           ->
-          let uu____5091 =
-            let uu____5098 = translate_expr env e1  in
-            let uu____5099 = translate_expr env e2  in
-            let uu____5100 = translate_expr env e3  in
-            (uu____5098, uu____5099, uu____5100)  in
-          EBufWrite uu____5091
+          let uu____5098 =
+            let uu____5105 = translate_expr env e1  in
+            let uu____5106 = translate_expr env e2  in
+            let uu____5107 = translate_expr env e3  in
+            (uu____5105, uu____5106, uu____5107)  in
+          EBufWrite uu____5098
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2076,27 +2095,18 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                ({
                   FStar_Extraction_ML_Syntax.expr =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5102;
-                  FStar_Extraction_ML_Syntax.loc = uu____5103;_},uu____5104);
-             FStar_Extraction_ML_Syntax.mlty = uu____5105;
-             FStar_Extraction_ML_Syntax.loc = uu____5106;_},e1::e2::[])
+                  FStar_Extraction_ML_Syntax.mlty = uu____5109;
+                  FStar_Extraction_ML_Syntax.loc = uu____5110;_},uu____5111);
+             FStar_Extraction_ML_Syntax.mlty = uu____5112;
+             FStar_Extraction_ML_Syntax.loc = uu____5113;_},e1::e2::[])
           when
-          let uu____5115 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5115 = "FStar.HyperStack.ST.op_Colon_Equals" ->
-          let uu____5116 =
-            let uu____5123 = translate_expr env e1  in
-            let uu____5124 = translate_expr env e2  in
-            (uu____5123, (EConstant (UInt32, "0")), uu____5124)  in
-          EBufWrite uu____5116
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____5126;
-             FStar_Extraction_ML_Syntax.loc = uu____5127;_},uu____5128::[])
-          when
-          let uu____5131 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5131 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
+          let uu____5122 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5122 = "FStar.HyperStack.ST.op_Colon_Equals" ->
+          let uu____5123 =
+            let uu____5130 = translate_expr env e1  in
+            let uu____5131 = translate_expr env e2  in
+            (uu____5130, (EConstant (UInt32, "0")), uu____5131)  in
+          EBufWrite uu____5123
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -2105,96 +2115,105 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.loc = uu____5134;_},uu____5135::[])
           when
           let uu____5138 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5138 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_TApp
-               ({
-                  FStar_Extraction_ML_Syntax.expr =
-                    FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5140;
-                  FStar_Extraction_ML_Syntax.loc = uu____5141;_},uu____5142);
-             FStar_Extraction_ML_Syntax.mlty = uu____5143;
-             FStar_Extraction_ML_Syntax.loc = uu____5144;_},e1::e2::e3::e4::e5::[])
-          when
-          let uu____5156 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5156 = "FStar.Buffer.blit" ->
-          let uu____5157 =
-            let uu____5168 = translate_expr env e1  in
-            let uu____5169 = translate_expr env e2  in
-            let uu____5170 = translate_expr env e3  in
-            let uu____5171 = translate_expr env e4  in
-            let uu____5172 = translate_expr env e5  in
-            (uu____5168, uu____5169, uu____5170, uu____5171, uu____5172)  in
-          EBufBlit uu____5157
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_TApp
-               ({
-                  FStar_Extraction_ML_Syntax.expr =
-                    FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu____5174;
-                  FStar_Extraction_ML_Syntax.loc = uu____5175;_},uu____5176);
-             FStar_Extraction_ML_Syntax.mlty = uu____5177;
-             FStar_Extraction_ML_Syntax.loc = uu____5178;_},e1::e2::e3::[])
-          when
-          let uu____5188 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5188 = "FStar.Buffer.fill" ->
-          let uu____5189 =
-            let uu____5196 = translate_expr env e1  in
-            let uu____5197 = translate_expr env e2  in
-            let uu____5198 = translate_expr env e3  in
-            (uu____5196, uu____5197, uu____5198)  in
-          EBufFill uu____5189
+          uu____5138 = "FStar.HyperStack.ST.push_frame" -> EPushFrame
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
-             FStar_Extraction_ML_Syntax.mlty = uu____5200;
-             FStar_Extraction_ML_Syntax.loc = uu____5201;_},uu____5202::[])
+             FStar_Extraction_ML_Syntax.mlty = uu____5140;
+             FStar_Extraction_ML_Syntax.loc = uu____5141;_},uu____5142::[])
           when
-          let uu____5205 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5205 = "FStar.HyperStack.ST.get" -> EUnit
+          let uu____5145 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5145 = "FStar.HyperStack.ST.pop_frame" -> EPopFrame
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_TApp
+               ({
+                  FStar_Extraction_ML_Syntax.expr =
+                    FStar_Extraction_ML_Syntax.MLE_Name p;
+                  FStar_Extraction_ML_Syntax.mlty = uu____5147;
+                  FStar_Extraction_ML_Syntax.loc = uu____5148;_},uu____5149);
+             FStar_Extraction_ML_Syntax.mlty = uu____5150;
+             FStar_Extraction_ML_Syntax.loc = uu____5151;_},e1::e2::e3::e4::e5::[])
+          when
+          let uu____5163 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5163 = "FStar.Buffer.blit" ->
+          let uu____5164 =
+            let uu____5175 = translate_expr env e1  in
+            let uu____5176 = translate_expr env e2  in
+            let uu____5177 = translate_expr env e3  in
+            let uu____5178 = translate_expr env e4  in
+            let uu____5179 = translate_expr env e5  in
+            (uu____5175, uu____5176, uu____5177, uu____5178, uu____5179)  in
+          EBufBlit uu____5164
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_TApp
+               ({
+                  FStar_Extraction_ML_Syntax.expr =
+                    FStar_Extraction_ML_Syntax.MLE_Name p;
+                  FStar_Extraction_ML_Syntax.mlty = uu____5181;
+                  FStar_Extraction_ML_Syntax.loc = uu____5182;_},uu____5183);
+             FStar_Extraction_ML_Syntax.mlty = uu____5184;
+             FStar_Extraction_ML_Syntax.loc = uu____5185;_},e1::e2::e3::[])
+          when
+          let uu____5195 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5195 = "FStar.Buffer.fill" ->
+          let uu____5196 =
+            let uu____5203 = translate_expr env e1  in
+            let uu____5204 = translate_expr env e2  in
+            let uu____5205 = translate_expr env e3  in
+            (uu____5203, uu____5204, uu____5205)  in
+          EBufFill uu____5196
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name p;
              FStar_Extraction_ML_Syntax.mlty = uu____5207;
-             FStar_Extraction_ML_Syntax.loc = uu____5208;_},e1::[])
+             FStar_Extraction_ML_Syntax.loc = uu____5208;_},uu____5209::[])
           when
           let uu____5212 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
-          uu____5212 = "Obj.repr" ->
-          let uu____5213 =
-            let uu____5218 = translate_expr env e1  in (uu____5218, TAny)  in
-          ECast uu____5213
+          uu____5212 = "FStar.HyperStack.ST.get" -> EUnit
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_Name p;
+             FStar_Extraction_ML_Syntax.mlty = uu____5214;
+             FStar_Extraction_ML_Syntax.loc = uu____5215;_},e1::[])
+          when
+          let uu____5219 = FStar_Extraction_ML_Syntax.string_of_mlpath p  in
+          uu____5219 = "Obj.repr" ->
+          let uu____5220 =
+            let uu____5225 = translate_expr env e1  in (uu____5225, TAny)  in
+          ECast uu____5220
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name ("FStar"::m::[],op);
-             FStar_Extraction_ML_Syntax.mlty = uu____5221;
-             FStar_Extraction_ML_Syntax.loc = uu____5222;_},args)
+             FStar_Extraction_ML_Syntax.mlty = uu____5228;
+             FStar_Extraction_ML_Syntax.loc = uu____5229;_},args)
           when (is_machine_int m) && (is_op op) ->
-          let uu____5230 = FStar_Util.must (mk_width m)  in
-          let uu____5231 = FStar_Util.must (mk_op op)  in
-          mk_op_app env uu____5230 uu____5231 args
+          let uu____5237 = FStar_Util.must (mk_width m)  in
+          let uu____5238 = FStar_Util.must (mk_op op)  in
+          mk_op_app env uu____5237 uu____5238 args
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name ("Prims"::[],op);
-             FStar_Extraction_ML_Syntax.mlty = uu____5233;
-             FStar_Extraction_ML_Syntax.loc = uu____5234;_},args)
+             FStar_Extraction_ML_Syntax.mlty = uu____5240;
+             FStar_Extraction_ML_Syntax.loc = uu____5241;_},args)
           when is_bool_op op ->
-          let uu____5242 = FStar_Util.must (mk_bool_op op)  in
-          mk_op_app env Bool uu____5242 args
+          let uu____5249 = FStar_Util.must (mk_bool_op op)  in
+          mk_op_app env Bool uu____5249 args
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::m::[],"int_to_t");
-             FStar_Extraction_ML_Syntax.mlty = uu____5244;
-             FStar_Extraction_ML_Syntax.loc = uu____5245;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____5251;
+             FStar_Extraction_ML_Syntax.loc = uu____5252;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Const
@@ -2202,21 +2221,21 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                                                                 (c,FStar_Pervasives_Native.None
                                                                  ));
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____5247;
+                                                                = uu____5254;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____5248;_}::[])
+                                                                = uu____5255;_}::[])
           when is_machine_int m ->
-          let uu____5263 =
-            let uu____5268 = FStar_Util.must (mk_width m)  in (uu____5268, c)
+          let uu____5270 =
+            let uu____5275 = FStar_Util.must (mk_width m)  in (uu____5275, c)
              in
-          EConstant uu____5263
+          EConstant uu____5270
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::m::[],"uint_to_t");
-             FStar_Extraction_ML_Syntax.mlty = uu____5270;
-             FStar_Extraction_ML_Syntax.loc = uu____5271;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____5277;
+             FStar_Extraction_ML_Syntax.loc = uu____5278;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 =
                                                                 FStar_Extraction_ML_Syntax.MLE_Const
@@ -2224,32 +2243,32 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                                                                 (c,FStar_Pervasives_Native.None
                                                                  ));
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____5273;
+                                                                = uu____5280;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____5274;_}::[])
+                                                                = uu____5281;_}::[])
           when is_machine_int m ->
-          let uu____5289 =
-            let uu____5294 = FStar_Util.must (mk_width m)  in (uu____5294, c)
+          let uu____5296 =
+            let uu____5301 = FStar_Util.must (mk_width m)  in (uu____5301, c)
              in
-          EConstant uu____5289
+          EConstant uu____5296
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("C"::[],"string_of_literal");
-             FStar_Extraction_ML_Syntax.mlty = uu____5295;
-             FStar_Extraction_ML_Syntax.loc = uu____5296;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____5302;
+             FStar_Extraction_ML_Syntax.loc = uu____5303;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 = e1;
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____5298;
+                                                                = uu____5305;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____5299;_}::[])
+                                                                = uu____5306;_}::[])
           ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
-           | uu____5305 ->
+           | uu____5312 ->
                failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
@@ -2257,19 +2276,19 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("C"::"String"::[],"of_literal");
-             FStar_Extraction_ML_Syntax.mlty = uu____5306;
-             FStar_Extraction_ML_Syntax.loc = uu____5307;_},{
+             FStar_Extraction_ML_Syntax.mlty = uu____5313;
+             FStar_Extraction_ML_Syntax.loc = uu____5314;_},{
                                                               FStar_Extraction_ML_Syntax.expr
                                                                 = e1;
                                                               FStar_Extraction_ML_Syntax.mlty
-                                                                = uu____5309;
+                                                                = uu____5316;
                                                               FStar_Extraction_ML_Syntax.loc
-                                                                = uu____5310;_}::[])
+                                                                = uu____5317;_}::[])
           ->
           (match e1 with
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
-           | uu____5316 ->
+           | uu____5323 ->
                failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
@@ -2277,8 +2296,8 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.expr =
                FStar_Extraction_ML_Syntax.MLE_Name
                ("FStar"::"Int"::"Cast"::[],c);
-             FStar_Extraction_ML_Syntax.mlty = uu____5318;
-             FStar_Extraction_ML_Syntax.loc = uu____5319;_},arg::[])
+             FStar_Extraction_ML_Syntax.mlty = uu____5325;
+             FStar_Extraction_ML_Syntax.loc = uu____5326;_},arg::[])
           ->
           let is_known_type =
             (((((((FStar_Util.starts_with c "uint8") ||
@@ -2292,155 +2311,155 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              in
           if (FStar_Util.ends_with c "uint64") && is_known_type
           then
-            let uu____5326 =
-              let uu____5331 = translate_expr env arg  in
-              (uu____5331, (TInt UInt64))  in
-            ECast uu____5326
+            let uu____5333 =
+              let uu____5338 = translate_expr env arg  in
+              (uu____5338, (TInt UInt64))  in
+            ECast uu____5333
           else
             if (FStar_Util.ends_with c "uint32") && is_known_type
             then
-              (let uu____5333 =
-                 let uu____5338 = translate_expr env arg  in
-                 (uu____5338, (TInt UInt32))  in
-               ECast uu____5333)
+              (let uu____5340 =
+                 let uu____5345 = translate_expr env arg  in
+                 (uu____5345, (TInt UInt32))  in
+               ECast uu____5340)
             else
               if (FStar_Util.ends_with c "uint16") && is_known_type
               then
-                (let uu____5340 =
-                   let uu____5345 = translate_expr env arg  in
-                   (uu____5345, (TInt UInt16))  in
-                 ECast uu____5340)
+                (let uu____5347 =
+                   let uu____5352 = translate_expr env arg  in
+                   (uu____5352, (TInt UInt16))  in
+                 ECast uu____5347)
               else
                 if (FStar_Util.ends_with c "uint8") && is_known_type
                 then
-                  (let uu____5347 =
-                     let uu____5352 = translate_expr env arg  in
-                     (uu____5352, (TInt UInt8))  in
-                   ECast uu____5347)
+                  (let uu____5354 =
+                     let uu____5359 = translate_expr env arg  in
+                     (uu____5359, (TInt UInt8))  in
+                   ECast uu____5354)
                 else
                   if (FStar_Util.ends_with c "int64") && is_known_type
                   then
-                    (let uu____5354 =
-                       let uu____5359 = translate_expr env arg  in
-                       (uu____5359, (TInt Int64))  in
-                     ECast uu____5354)
+                    (let uu____5361 =
+                       let uu____5366 = translate_expr env arg  in
+                       (uu____5366, (TInt Int64))  in
+                     ECast uu____5361)
                   else
                     if (FStar_Util.ends_with c "int32") && is_known_type
                     then
-                      (let uu____5361 =
-                         let uu____5366 = translate_expr env arg  in
-                         (uu____5366, (TInt Int32))  in
-                       ECast uu____5361)
+                      (let uu____5368 =
+                         let uu____5373 = translate_expr env arg  in
+                         (uu____5373, (TInt Int32))  in
+                       ECast uu____5368)
                     else
                       if (FStar_Util.ends_with c "int16") && is_known_type
                       then
-                        (let uu____5368 =
-                           let uu____5373 = translate_expr env arg  in
-                           (uu____5373, (TInt Int16))  in
-                         ECast uu____5368)
+                        (let uu____5375 =
+                           let uu____5380 = translate_expr env arg  in
+                           (uu____5380, (TInt Int16))  in
+                         ECast uu____5375)
                       else
                         if (FStar_Util.ends_with c "int8") && is_known_type
                         then
-                          (let uu____5375 =
-                             let uu____5380 = translate_expr env arg  in
-                             (uu____5380, (TInt Int8))  in
-                           ECast uu____5375)
-                        else
                           (let uu____5382 =
-                             let uu____5389 =
-                               let uu____5392 = translate_expr env arg  in
-                               [uu____5392]  in
+                             let uu____5387 = translate_expr env arg  in
+                             (uu____5387, (TInt Int8))  in
+                           ECast uu____5382)
+                        else
+                          (let uu____5389 =
+                             let uu____5396 =
+                               let uu____5399 = translate_expr env arg  in
+                               [uu____5399]  in
                              ((EQualified (["FStar"; "Int"; "Cast"], c)),
-                               uu____5389)
+                               uu____5396)
                               in
-                           EApp uu____5382)
+                           EApp uu____5389)
       | FStar_Extraction_ML_Syntax.MLE_App (head1,args) ->
-          let uu____5403 =
-            let uu____5410 = translate_expr env head1  in
-            let uu____5411 = FStar_List.map (translate_expr env) args  in
-            (uu____5410, uu____5411)  in
-          EApp uu____5403
+          let uu____5410 =
+            let uu____5417 = translate_expr env head1  in
+            let uu____5418 = FStar_List.map (translate_expr env) args  in
+            (uu____5417, uu____5418)  in
+          EApp uu____5410
       | FStar_Extraction_ML_Syntax.MLE_TApp (head1,ty_args) ->
-          let uu____5422 =
-            let uu____5429 = translate_expr env head1  in
-            let uu____5430 = FStar_List.map (translate_type env) ty_args  in
-            (uu____5429, uu____5430)  in
-          ETypApp uu____5422
+          let uu____5429 =
+            let uu____5436 = translate_expr env head1  in
+            let uu____5437 = FStar_List.map (translate_type env) ty_args  in
+            (uu____5436, uu____5437)  in
+          ETypApp uu____5429
       | FStar_Extraction_ML_Syntax.MLE_Coerce (e1,t_from,t_to) ->
-          let uu____5438 =
-            let uu____5443 = translate_expr env e1  in
-            let uu____5444 = translate_type env t_to  in
-            (uu____5443, uu____5444)  in
-          ECast uu____5438
-      | FStar_Extraction_ML_Syntax.MLE_Record (uu____5445,fields) ->
-          let uu____5463 =
-            let uu____5474 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
+          let uu____5445 =
+            let uu____5450 = translate_expr env e1  in
+            let uu____5451 = translate_type env t_to  in
+            (uu____5450, uu____5451)  in
+          ECast uu____5445
+      | FStar_Extraction_ML_Syntax.MLE_Record (uu____5452,fields) ->
+          let uu____5470 =
+            let uu____5481 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
                in
-            let uu____5475 =
+            let uu____5482 =
               FStar_List.map
-                (fun uu____5494  ->
-                   match uu____5494 with
+                (fun uu____5501  ->
+                   match uu____5501 with
                    | (field,expr) ->
-                       let uu____5505 = translate_expr env expr  in
-                       (field, uu____5505)) fields
+                       let uu____5512 = translate_expr env expr  in
+                       (field, uu____5512)) fields
                in
-            (uu____5474, uu____5475)  in
-          EFlat uu____5463
+            (uu____5481, uu____5482)  in
+          EFlat uu____5470
       | FStar_Extraction_ML_Syntax.MLE_Proj (e1,path) ->
-          let uu____5514 =
-            let uu____5521 =
+          let uu____5521 =
+            let uu____5528 =
               assert_lid env e1.FStar_Extraction_ML_Syntax.mlty  in
-            let uu____5522 = translate_expr env e1  in
-            (uu____5521, uu____5522, (FStar_Pervasives_Native.snd path))  in
-          EField uu____5514
-      | FStar_Extraction_ML_Syntax.MLE_Let uu____5525 ->
+            let uu____5529 = translate_expr env e1  in
+            (uu____5528, uu____5529, (FStar_Pervasives_Native.snd path))  in
+          EField uu____5521
+      | FStar_Extraction_ML_Syntax.MLE_Let uu____5532 ->
           failwith "todo: translate_expr [MLE_Let]"
-      | FStar_Extraction_ML_Syntax.MLE_App (head1,uu____5537) ->
-          let uu____5542 =
-            let uu____5543 =
+      | FStar_Extraction_ML_Syntax.MLE_App (head1,uu____5544) ->
+          let uu____5549 =
+            let uu____5550 =
               FStar_Extraction_ML_Code.string_of_mlexpr ([], "") head1  in
             FStar_Util.format1 "todo: translate_expr [MLE_App] (head is: %s)"
-              uu____5543
+              uu____5550
              in
-          failwith uu____5542
+          failwith uu____5549
       | FStar_Extraction_ML_Syntax.MLE_Seq seqs ->
-          let uu____5549 = FStar_List.map (translate_expr env) seqs  in
-          ESequence uu____5549
+          let uu____5556 = FStar_List.map (translate_expr env) seqs  in
+          ESequence uu____5556
       | FStar_Extraction_ML_Syntax.MLE_Tuple es ->
-          let uu____5555 = FStar_List.map (translate_expr env) es  in
-          ETuple uu____5555
-      | FStar_Extraction_ML_Syntax.MLE_CTor ((uu____5558,cons1),es) ->
-          let uu____5575 =
-            let uu____5584 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
+          let uu____5562 = FStar_List.map (translate_expr env) es  in
+          ETuple uu____5562
+      | FStar_Extraction_ML_Syntax.MLE_CTor ((uu____5565,cons1),es) ->
+          let uu____5582 =
+            let uu____5591 = assert_lid env e.FStar_Extraction_ML_Syntax.mlty
                in
-            let uu____5585 = FStar_List.map (translate_expr env) es  in
-            (uu____5584, cons1, uu____5585)  in
-          ECons uu____5575
+            let uu____5592 = FStar_List.map (translate_expr env) es  in
+            (uu____5591, cons1, uu____5592)  in
+          ECons uu____5582
       | FStar_Extraction_ML_Syntax.MLE_Fun (args,body) ->
           let binders = translate_binders env args  in
           let env1 = add_binders env args  in
-          let uu____5608 =
-            let uu____5617 = translate_expr env1 body  in
-            let uu____5618 =
+          let uu____5615 =
+            let uu____5624 = translate_expr env1 body  in
+            let uu____5625 =
               translate_type env1 body.FStar_Extraction_ML_Syntax.mlty  in
-            (binders, uu____5617, uu____5618)  in
-          EFun uu____5608
+            (binders, uu____5624, uu____5625)  in
+          EFun uu____5615
       | FStar_Extraction_ML_Syntax.MLE_If (e1,e2,e3) ->
-          let uu____5628 =
-            let uu____5635 = translate_expr env e1  in
-            let uu____5636 = translate_expr env e2  in
-            let uu____5637 =
+          let uu____5635 =
+            let uu____5642 = translate_expr env e1  in
+            let uu____5643 = translate_expr env e2  in
+            let uu____5644 =
               match e3 with
               | FStar_Pervasives_Native.None  -> EUnit
               | FStar_Pervasives_Native.Some e31 -> translate_expr env e31
                in
-            (uu____5635, uu____5636, uu____5637)  in
-          EIfThenElse uu____5628
-      | FStar_Extraction_ML_Syntax.MLE_Raise uu____5639 ->
+            (uu____5642, uu____5643, uu____5644)  in
+          EIfThenElse uu____5635
+      | FStar_Extraction_ML_Syntax.MLE_Raise uu____5646 ->
           failwith "todo: translate_expr [MLE_Raise]"
-      | FStar_Extraction_ML_Syntax.MLE_Try uu____5646 ->
+      | FStar_Extraction_ML_Syntax.MLE_Try uu____5653 ->
           failwith "todo: translate_expr [MLE_Try]"
-      | FStar_Extraction_ML_Syntax.MLE_Coerce uu____5661 ->
+      | FStar_Extraction_ML_Syntax.MLE_Coerce uu____5668 ->
           failwith "todo: translate_expr [MLE_Coerce]"
 
 and (assert_lid : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
@@ -2450,12 +2469,12 @@ and (assert_lid : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
       | FStar_Extraction_ML_Syntax.MLTY_Named (ts,lid) ->
           if (FStar_List.length ts) > (Prims.parse_int "0")
           then
-            let uu____5676 =
-              let uu____5689 = FStar_List.map (translate_type env) ts  in
-              (lid, uu____5689)  in
-            TApp uu____5676
+            let uu____5683 =
+              let uu____5696 = FStar_List.map (translate_type env) ts  in
+              (lid, uu____5696)  in
+            TApp uu____5683
           else TQualified lid
-      | uu____5695 -> failwith "invalid argument: assert_lid"
+      | uu____5702 -> failwith "invalid argument: assert_lid"
 
 and (translate_branches :
   env ->
@@ -2474,24 +2493,24 @@ and (translate_branch :
       (pattern,expr) FStar_Pervasives_Native.tuple2)
   =
   fun env  ->
-    fun uu____5721  ->
-      match uu____5721 with
+    fun uu____5728  ->
+      match uu____5728 with
       | (pat,guard,expr) ->
           if guard = FStar_Pervasives_Native.None
           then
-            let uu____5747 = translate_pat env pat  in
-            (match uu____5747 with
+            let uu____5754 = translate_pat env pat  in
+            (match uu____5754 with
              | (env1,pat1) ->
-                 let uu____5758 = translate_expr env1 expr  in
-                 (pat1, uu____5758))
+                 let uu____5765 = translate_expr env1 expr  in
+                 (pat1, uu____5765))
           else failwith "todo: translate_branch"
 
 and (translate_width :
   (FStar_Const.signedness,FStar_Const.width) FStar_Pervasives_Native.tuple2
     FStar_Pervasives_Native.option -> width)
   =
-  fun uu___41_5764  ->
-    match uu___41_5764 with
+  fun uu___43_5771  ->
+    match uu___43_5771 with
     | FStar_Pervasives_Native.None  -> CInt
     | FStar_Pervasives_Native.Some (FStar_Const.Signed ,FStar_Const.Int8 ) ->
         Int8
@@ -2524,60 +2543,60 @@ and (translate_pat :
           (FStar_Extraction_ML_Syntax.MLC_Bool b) -> (env, (PBool b))
       | FStar_Extraction_ML_Syntax.MLP_Const
           (FStar_Extraction_ML_Syntax.MLC_Int (s,sw)) ->
-          let uu____5828 =
-            let uu____5829 =
-              let uu____5834 = translate_width sw  in (uu____5834, s)  in
-            PConstant uu____5829  in
-          (env, uu____5828)
+          let uu____5835 =
+            let uu____5836 =
+              let uu____5841 = translate_width sw  in (uu____5841, s)  in
+            PConstant uu____5836  in
+          (env, uu____5835)
       | FStar_Extraction_ML_Syntax.MLP_Var name ->
           let env1 = extend env name false  in
           (env1, (PVar { name; typ = TAny; mut = false }))
       | FStar_Extraction_ML_Syntax.MLP_Wild  ->
           let env1 = extend env "_" false  in
           (env1, (PVar { name = "_"; typ = TAny; mut = false }))
-      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____5838,cons1),ps) ->
-          let uu____5855 =
+      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____5845,cons1),ps) ->
+          let uu____5862 =
             FStar_List.fold_left
-              (fun uu____5875  ->
+              (fun uu____5882  ->
                  fun p1  ->
-                   match uu____5875 with
+                   match uu____5882 with
                    | (env1,acc) ->
-                       let uu____5895 = translate_pat env1 p1  in
-                       (match uu____5895 with
+                       let uu____5902 = translate_pat env1 p1  in
+                       (match uu____5902 with
                         | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
              in
-          (match uu____5855 with
+          (match uu____5862 with
            | (env1,ps1) -> (env1, (PCons (cons1, (FStar_List.rev ps1)))))
-      | FStar_Extraction_ML_Syntax.MLP_Record (uu____5924,ps) ->
-          let uu____5942 =
+      | FStar_Extraction_ML_Syntax.MLP_Record (uu____5931,ps) ->
+          let uu____5949 =
             FStar_List.fold_left
-              (fun uu____5976  ->
-                 fun uu____5977  ->
-                   match (uu____5976, uu____5977) with
+              (fun uu____5983  ->
+                 fun uu____5984  ->
+                   match (uu____5983, uu____5984) with
                    | ((env1,acc),(field,p1)) ->
-                       let uu____6046 = translate_pat env1 p1  in
-                       (match uu____6046 with
+                       let uu____6053 = translate_pat env1 p1  in
+                       (match uu____6053 with
                         | (env2,p2) -> (env2, ((field, p2) :: acc))))
               (env, []) ps
              in
-          (match uu____5942 with
+          (match uu____5949 with
            | (env1,ps1) -> (env1, (PRecord (FStar_List.rev ps1))))
       | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
-          let uu____6108 =
+          let uu____6115 =
             FStar_List.fold_left
-              (fun uu____6128  ->
+              (fun uu____6135  ->
                  fun p1  ->
-                   match uu____6128 with
+                   match uu____6135 with
                    | (env1,acc) ->
-                       let uu____6148 = translate_pat env1 p1  in
-                       (match uu____6148 with
+                       let uu____6155 = translate_pat env1 p1  in
+                       (match uu____6155 with
                         | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
              in
-          (match uu____6108 with
+          (match uu____6115 with
            | (env1,ps1) -> (env1, (PTuple (FStar_List.rev ps1))))
-      | FStar_Extraction_ML_Syntax.MLP_Const uu____6175 ->
+      | FStar_Extraction_ML_Syntax.MLP_Const uu____6182 ->
           failwith "todo: translate_pat [MLP_Const]"
-      | FStar_Extraction_ML_Syntax.MLP_Branch uu____6180 ->
+      | FStar_Extraction_ML_Syntax.MLP_Branch uu____6187 ->
           failwith "todo: translate_pat [MLP_Branch]"
 
 and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
@@ -2586,21 +2605,21 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
     | FStar_Extraction_ML_Syntax.MLC_Unit  -> EUnit
     | FStar_Extraction_ML_Syntax.MLC_Bool b -> EBool b
     | FStar_Extraction_ML_Syntax.MLC_String s ->
-        ((let uu____6191 =
-            let uu____6192 = FStar_String.list_of_string s  in
-            FStar_All.pipe_right uu____6192
+        ((let uu____6198 =
+            let uu____6199 = FStar_String.list_of_string s  in
+            FStar_All.pipe_right uu____6199
               (FStar_Util.for_some
                  (fun c1  ->
                     c1 = (FStar_Char.char_of_int (Prims.parse_int "0"))))
              in
-          if uu____6191
+          if uu____6198
           then
-            let uu____6204 =
+            let uu____6211 =
               FStar_Util.format1
                 "Refusing to translate a string literal that contains a null character: %s"
                 s
                in
-            failwith uu____6204
+            failwith uu____6211
           else ());
          EString s)
     | FStar_Extraction_ML_Syntax.MLC_Char c1 ->
@@ -2610,12 +2629,12 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
         let char_of_int1 = EQualified (["FStar"; "Char"], "char_of_int")  in
         EApp (char_of_int1, [c2])
     | FStar_Extraction_ML_Syntax.MLC_Int
-        (s,FStar_Pervasives_Native.Some uu____6216) ->
+        (s,FStar_Pervasives_Native.Some uu____6223) ->
         failwith
           "impossible: machine integer not desugared to a function call"
-    | FStar_Extraction_ML_Syntax.MLC_Float uu____6231 ->
+    | FStar_Extraction_ML_Syntax.MLC_Float uu____6238 ->
         failwith "todo: translate_expr [MLC_Float]"
-    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____6232 ->
+    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____6239 ->
         failwith "todo: translate_expr [MLC_Bytes]"
     | FStar_Extraction_ML_Syntax.MLC_Int (s,FStar_Pervasives_Native.None ) ->
         EConstant (CInt, s)
@@ -2627,7 +2646,7 @@ and (mk_op_app :
     fun w  ->
       fun op  ->
         fun args  ->
-          let uu____6252 =
-            let uu____6259 = FStar_List.map (translate_expr env) args  in
-            ((EOp (op, w)), uu____6259)  in
-          EApp uu____6252
+          let uu____6259 =
+            let uu____6266 = FStar_List.map (translate_expr env) args  in
+            ((EOp (op, w)), uu____6266)  in
+          EApp uu____6259


### PR DESCRIPTION
A unit type is one of the following:
* the `Prims.unit` type
* a ghost arrow type
* a pure arrow type where the return type is a unit type

All definitions of such types should be marked `MustDisappear`
