### PR TITLE
Inline functions that can't be extracted.

### DIFF
--- a/ulib/FStar.Monotonic.Map.fst
+++ b/ulib/FStar.Monotonic.Map.fst
@@ -15,6 +15,7 @@ type map' (a:Type) (b:a -> Type) =
 type map (a:Type) (b:a -> Type) (inv:map' a b -> Type0) =
   m:map' a b{inv m}
 
+inline_for_extraction
 let upd (#a:eqtype) #b (m:map' a b) (x:a) (y:b x)
   : Tot (map' a b)
   = fun z -> if x = z then Some y else m z
@@ -31,9 +32,10 @@ abstract let grows #a #b #inv :Preorder.preorder (map a b inv) =
 (* Monotone, partial, dependent maps, with a whole-map invariant *)
 type t r a b inv = m_rref r (map a b inv) grows  //maybe grows can include the inv?
 
-let empty_map a b
-  : Tot (map' a b)
-  = fun x -> None
+inline_for_extraction
+let empty_map (a:Type) (b:a -> Type)
+  : Tot (x:a -> Tot (option (b x)))
+  = fun (x:a) -> None
 
 type rid = HST.erid
 


### PR DESCRIPTION
Is this an acceptable way of fixing Kremlin extraction problems reported as follows?

```
Warning 10: : -drop is deprecated
  use a combination of -bundle and -d reachability to make sure the functions are eliminated as you wish
Dropping FStar.Monotonic.Map.upd__any_any (at checking time); if this is normal, please consider using -drop

Warning 4: in top-level declaration FStar.Monotonic.Map.upd__any_any, in file FStar: Malformed input:
Type annotation is not an lid but any -> FStar_Pervasives_Native_option any
Warning 4 is fatal, exiting.
```

I have a hunch that this should really be solved by adding `-bundle`/`-drop` options, but I wasn't able to figure out a way that would work.