### PR TITLE
Allow refinements to outputs of `GTot`s for `elift`s

### DIFF
--- a/ulib/FStar.Ghost.fst.sketch
+++ b/ulib/FStar.Ghost.fst.sketch
@@ -25,5 +25,7 @@ let elift1 #a #b f ga = f ga
 let elift2 #a #b #c f ga gc = f ga gc
 let elift3 #a #b #c #d f ga gc gd = f ga gc gd
 let elift1_p #a #b #p f ga = f ga
+let elift1_pq #a #b #p #q f ga = f ga
 let elift2_p #a #c #p #b f ga gc = f ga gc
+let elift2_pq #a #c #p #b #q f ga gc = f ga gc
 let lemma_haseq_erased a = ()

--- a/ulib/FStar.Ghost.fsti
+++ b/ulib/FStar.Ghost.fsti
@@ -84,6 +84,14 @@ val elift1_p : #a:Type
              -> r:erased a{p (reveal r)}
              -> Tot (z:erased b{reveal z == f (reveal r)})
 
+val elift1_pq : #a:Type
+              -> #b:Type
+              -> #p:(a -> Type)
+              -> #q:(x:a{p x} -> b -> Type)
+              -> $f:(x:a{p x} -> GTot (y:b{q x y}))
+              -> r:erased a{p (reveal r)}
+              -> Tot (z:erased b{reveal z == f (reveal r)})
+
 val elift2_p : #a:Type
              -> #c:Type
              -> #p: (a -> c -> Type)
@@ -92,6 +100,16 @@ val elift2_p : #a:Type
              -> ra:erased a
              -> rc:erased c{p (reveal ra) (reveal rc)}
              -> Tot (x:erased b{reveal x == f (reveal ra) (reveal rc)})
+
+val elift2_pq : #a:Type
+              -> #c:Type
+              -> #p: (a -> c -> Type)
+              -> #b:Type
+              -> #q: (xa:a -> xc:c{p xa xc} -> b -> Type)
+              -> $f:(xa:a -> xc:c{p xa xc} -> GTot (y:b{q xa xc y}))
+              -> ra:erased a
+              -> rc:erased c{p (reveal ra) (reveal rc)}
+              -> Tot (x:erased b{reveal x == f (reveal ra) (reveal rc)})
 
 val lemma_haseq_erased: a:Type -> Lemma (requires (hasEq a))
                                        (ensures (hasEq (erased a)))


### PR DESCRIPTION
Using `elift1_p` and `elift2_p`, we can use `GTot`s which have refinements on the input variables. However, this doesn't allow refinements on the output variables to go through. This PR introduces `elift1_pq` and `elift2_pq` which allow us to have a refinement on the output.

Example usage:
```
let foo (a:int{a > 5}) : GTot (x:int{x = a + 2}) = a + 2
let bar (a:erased int{reveal a > 5}) : Tot (x:erased int) =
  // elift1_p foo a // <--- will not type check
  elift1_pq foo a // <--- this will work
```

One question that remains though, is whether it would make sense to make this part of `elift1_p` and `elift2_p` itself (i.e., replace old definitions of them with these `_pq` versions) or to keep these separate.