### PR TITLE
Allow IDEs to interrupt long-running computations

### DIFF
--- a/src/basic/FStar.Common.fs
+++ b/src/basic/FStar.Common.fs
@@ -24,7 +24,7 @@ module BU = FStar.Util
 
 let has_cygpath =
     try
-        let _, t_out, _ = BU.run_proc "which" "cygpath" "" in
+        let t_out = BU.run_process "has_cygpath" "which" ["cygpath"] None in
         BU.trim_string t_out = "/usr/bin/cygpath"
     with
     | _ -> false
@@ -43,8 +43,8 @@ let try_convert_file_name_to_mixed =
       | Some s ->
           s
       | None ->
-          let _, out, _ = BU.run_proc "cygpath" ("-m " ^ s) "" in
-          let out = BU.trim_string out in
+          let label = "try_convert_file_name_to_mixed" in
+          let out = BU.run_process label "cygpath" ["-m"; s] None |> BU.trim_string in
           BU.smap_add cache s out;
           out
     else

--- a/src/basic/boot/FStar.Util.fsi
+++ b/src/basic/boot/FStar.Util.fsi
@@ -219,15 +219,20 @@ val string_builder_append: string_builder -> string -> unit
 val message_of_exn: exn -> string
 val trace_of_exn: exn -> string
 
+exception SigInt
+type sigint_handler
+val sigint_ignore: sigint_handler
+val sigint_raise: sigint_handler
+val set_sigint_handler: sigint_handler -> unit
+val with_sigint_handler: sigint_handler -> (unit -> 'a) -> 'a
+
 (* not relying on representation *)
 type proc
-val launch_process: bool -> string -> string -> string -> string -> (string -> string -> bool) -> string
-val start_process: bool -> string -> string -> string -> (string -> string -> bool) -> proc
-val ask_process: proc -> string -> string
+val run_process : string -> string -> list<string> -> option<string> -> string
+val start_process: string -> string -> list<string> -> (string -> bool) -> proc
+val ask_process: proc -> string -> (unit -> string) -> string
 val kill_process: proc -> unit
 val kill_all: unit -> unit
-
-val run_proc : string -> string -> string -> (bool * string * string)
 
 val get_file_extension: string -> string
 val is_path_absolute: string -> bool

--- a/src/basic/boot/FStar.Util.fsi
+++ b/src/basic/boot/FStar.Util.fsi
@@ -399,6 +399,7 @@ val monitor_enter: 'a -> unit
 val monitor_exit:  'a -> unit
 val monitor_wait: 'a -> unit
 val monitor_pulse:  'a -> unit
+val with_monitor: 'a -> ('b -> 'c) -> 'b -> 'c
 val current_tid: unit -> int
 val sleep: int -> unit
 val atomically: (unit -> 'a) -> 'a

--- a/src/basic/boot/NotFStar.Util.fs
+++ b/src/basic/boot/NotFStar.Util.fs
@@ -71,11 +71,14 @@ let monitor_wait m = ignore <| System.Threading.Monitor.Wait(m)
 let monitor_pulse m = System.Threading.Monitor.Pulse(m)
 let current_tid () = System.Threading.Thread.CurrentThread.ManagedThreadId
 let sleep n = System.Threading.Thread.Sleep(0+n)
+let with_monitor m f x =
+    try
+        System.Threading.Monitor.Enter(m);
+        f x
+    finally
+        System.Threading.Monitor.Exit(m)
 let atomically (f:unit -> 'a) =
-    System.Threading.Monitor.Enter(global_lock);
-    let result = f () in
-    System.Threading.Monitor.Exit(global_lock);
-    result
+    with_monitor global_lock f ()
 let spawn (f:unit -> unit) = let t = new Thread(f) in t.Start()
 let ctr = ref 0
 

--- a/src/basic/boot/NotFStar.Util.fs
+++ b/src/basic/boot/NotFStar.Util.fs
@@ -25,6 +25,7 @@ open System.IO.Compression
 open System.Security.Cryptography
 open System.Runtime.Serialization
 open System.Runtime.Serialization.Json
+open System.Text.RegularExpressions
 
 let return_all x = x
 
@@ -48,6 +49,14 @@ exception HardError of string
 
 let max_int = System.Int32.MaxValue
 
+// Interrupts are only handled in OCaml
+exception SigInt
+type sigint_handler = { placeholder: unit } // F* doesn't want hidden abbreviations
+let sigint_ignore = { placeholder = () }
+let sigint_raise = { placeholder = () }
+let with_sigint_handler (_: sigint_handler) f = f ()
+let set_sigint_handler (_: sigint_handler) = ()
+
 type proc = {m:Object;
              outbuf:StringBuilder;
              proc:Process;
@@ -70,7 +79,15 @@ let atomically (f:unit -> 'a) =
 let spawn (f:unit -> unit) = let t = new Thread(f) in t.Start()
 let ctr = ref 0
 
-let start_process (raw:bool) (id:string) (prog:string) (args:string) (cond:string -> string -> bool) : proc =
+// https://stackoverflow.com/questions/5510343/escape-command-line-arguments-in-c-sharp
+let quote_arg arg =
+  let arg = Regex.Replace(arg, @"(\\*)" + "\"", @"$1$1\" + "\"") in
+  "\"" + Regex.Replace(arg, @"(\\+)$", @"$1$1") + "\""
+
+let quote_args args =
+  String.concat " " (List.map quote_arg args)
+
+let start_process (id:string) (prog:string) (args: list<string>) (cond:string -> bool) : proc =
     let signal = new Object() in
     let startInfo = new ProcessStartInfo() in
     let driverOutput = new StringBuilder() in
@@ -84,7 +101,7 @@ let start_process (raw:bool) (id:string) (prog:string) (args:string) (cond:strin
                         id=prog ^ ":" ^id^ "-" ^ (string_of_int !ctr)} in
 
     startInfo.FileName <- prog;
-    startInfo.Arguments <- args;
+    startInfo.Arguments <- quote_args args;
     startInfo.UseShellExecute <- false;
     startInfo.RedirectStandardOutput <- true;
     startInfo.RedirectStandardInput <- true;
@@ -95,12 +112,10 @@ let start_process (raw:bool) (id:string) (prog:string) (args:string) (cond:strin
                     if !killed then ()
                     else
                         ignore <| driverOutput.Append(args.Data);
-                        if not raw then (
-                            ignore <| driverOutput.Append("\n");
-                            if null = args.Data
-                                then (Printf.printf "Unexpected output from %s\n%s\n" prog (driverOutput.ToString()));
-                        );
-                        if null = args.Data || cond id args.Data
+                        ignore <| driverOutput.Append("\n");
+                        if null = args.Data
+                            then (Printf.printf "Unexpected output from %s\n%s\n" prog (driverOutput.ToString()));
+                        if null = args.Data || cond args.Data
                         then
                             System.Threading.Monitor.Enter(signal);
                             ignore (proc_wrapper.outbuf.Clear());
@@ -126,7 +141,7 @@ let start_process (raw:bool) (id:string) (prog:string) (args:string) (cond:strin
     proc_wrapper
 let tid () = System.Threading.Thread.CurrentThread.ManagedThreadId |> string_of_int
 
-let ask_process (p:proc) (input:string) : string =
+let ask_process (p:proc) (input:string) (exn_handler: unit -> string): string =
     System.Threading.Monitor.Enter(p.m);
     //Printf.printf "Thread %s is asking process %s\n" (tid()) p.id;
     //Printf.printf "Thread %s is writing to process %s ... responding?=%A\n" (tid()) p.id p.proc.Responding;
@@ -152,15 +167,10 @@ let kill_process (p:proc) =
     System.Threading.Monitor.Exit(p.m);
     p.proc.WaitForExit()
 
-let launch_process (raw:bool) (id:string) (prog:string) (args:string) (input:string) (cond:string -> string -> bool) : string =
-  let proc = start_process raw id prog args cond in
-  let output = ask_process proc input in
-  kill_process proc; output
-
 let kill_all () = !all_procs |> List.iter (fun p -> if not !p.killed then kill_process p)
 
-let run_proc (name:string) (args:string) (stdin:string) : bool * string * string =
-  let pinfo = new ProcessStartInfo(name, args) in
+let run_process (id: string) (prog: string) (args: list<string>) (stdin: option<string>) : string =
+  let pinfo = new ProcessStartInfo(prog, quote_args args) in
   pinfo.RedirectStandardOutput <- true;
   pinfo.RedirectStandardError <- true;
   pinfo.UseShellExecute <- false;
@@ -168,10 +178,10 @@ let run_proc (name:string) (args:string) (stdin:string) : bool * string * string
   let proc = new Process() in
   proc.StartInfo <- pinfo;
   let result = proc.Start() in
-  proc.StandardInput.Write(stdin);
+  (match stdin with Some s -> proc.StandardInput.Write(s) | None -> ());
   let stdout = proc.StandardOutput.ReadToEnd() in
   let stderr = proc.StandardError.ReadToEnd() in
-  result, stdout, stderr
+  stdout
 
 let get_file_extension (fn: string) :string = (Path.GetExtension fn).[1..]
 let is_path_absolute p = System.IO.Path.IsPathRooted(p)

--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -81,6 +81,10 @@ let monitor_wait _ = ()
 let monitor_pulse _ = ()
 let current_tid _ = Z.zero
 
+let with_monitor _ f x =
+  monitor_enter ();
+  BatPervasives.finally monitor_exit f x
+
 let atomically =
   (* let mutex = Mutex.create () in *)
   fun f -> f ()

--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -30,11 +30,41 @@ let string_of_time = string_of_float
 exception Impos
 exception NYI of string
 exception HardError of string
+exception Interrupt
+
+let cur_sigint_handler : Sys.signal_behavior ref =
+  ref Sys.Signal_default
+
+exception SigInt
+type sigint_handler = Sys.signal_behavior
+
+let sigint_ignore: sigint_handler =
+  Sys.Signal_ignore
+
+let sigint_raise: sigint_handler =
+  (* This function should not do anything complicated, lest it cause deadlocks.
+   * Calling print_string, for example, can cause a deadlock (print_string →
+   * caml_flush → process_pending_signals → caml_execute_signal → raise_sigint →
+   * print_string → caml_io_mutex_lock ⇒ deadlock) *)
+  Sys.Signal_handle (fun _ -> raise SigInt)
+
+let set_sigint_handler sigint_handler =
+  cur_sigint_handler := sigint_handler;
+  Sys.set_signal Sys.sigint !cur_sigint_handler
+
+let with_sigint_handler handler f =
+  let original_handler = !cur_sigint_handler in
+  BatPervasives.finally
+    (fun () -> Sys.set_signal Sys.sigint original_handler)
+    (fun () -> set_sigint_handler handler; f ())
+    ()
 
 type proc =
-    {inc : in_channel;
+    {pid: int;
+     inc : in_channel;
      outc : out_channel;
      mutable killed : bool;
+     stop_marker: (string -> bool) option;
      id : string}
 
 let all_procs : (proc list) ref = ref []
@@ -59,102 +89,97 @@ let atomically =
 let spawn f =
   let _ = Thread.create f () in ()
 
-let write_input in_write input =
-  output_string in_write input;
-  flush in_write
-
-(*let cnt = ref 0*)
-
-let launch_process (raw:bool) (id:string) (prog:string) (args:string) (input:string) (cond:string -> string -> bool): string =
-  (*let fc = open_out ("tmp/q"^(string_of_int !cnt)) in
-  output_string fc input;
-  close_out fc;*)
-  let cmd = prog^" "^args in
-  let (to_chd_r, to_chd_w) = Unix.pipe () in
-  let (from_chd_r, from_chd_w) = Unix.pipe () in
-  Unix.set_close_on_exec to_chd_w;
-  Unix.set_close_on_exec from_chd_r;
-  let _pid = Unix.create_process "/bin/sh" [| "/bin/sh"; "-c"; cmd |]
-  (*let pid = Unix.create_process "/bin/sh" [| "/bin/sh"; "-c"; ("run.sh "^(string_of_int (!cnt)))^" | " ^ cmd |]*)
-                               to_chd_r from_chd_w Unix.stderr
-  in
-  (*cnt := !cnt +1;*)
-  Unix.close from_chd_w;
-  Unix.close to_chd_r;
-  let cin = Unix.in_channel_of_descr from_chd_r in
-  let cout = Unix.out_channel_of_descr to_chd_w in
-
-  (* parallel reading thread *)
-  let out = Buffer.create 16 in
-  let rec read_out _ =
-    let s, eof = (try
-                    BatString.trim (input_line cin), false
-                  with End_of_file ->
-                    if not raw then
-                        Buffer.add_string out ("\nkilled\n")
-                    else (); "", true) in
-    if not raw then (
-        if not eof then
-          if s = "Done!" then ()
-          else (Buffer.add_string out (s ^ "\n"); read_out ())
-    ) else (
-        if not eof then
-          (Buffer.add_string out s; read_out ())
-    )
-  in
-  let child_thread = Thread.create (fun _ -> read_out ()) () in
-
-  (* writing to z3 *)
-  write_input cout input;
-  close_out cout;
-
-  (* waiting for z3 to finish *)
-  Thread.join child_thread;
-  close_in cin;
-  Buffer.contents out
-
-let start_process (raw:bool) (id:string) (prog:string) (args:string) (cond:string -> string -> bool) : proc =
-  let command = prog^" "^args in
-  let (inc,outc) = Unix.open_process command in
-  let proc = {inc = inc; outc = outc; killed = false; id = prog^":"^id} in
-  all_procs := proc::!all_procs;
+(* On the OCaml side it would make more sense to take stop_marker in
+   ask_process, but the F# side isn't built that way *)
+let start_process'
+      (id: string) (prog: string) (args: string list)
+      (stop_marker: (string -> bool) option) : proc =
+  let (stdout_r, stdout_w) = Unix.pipe () in
+  let (stdin_r, stdin_w) = Unix.pipe () in
+  Unix.set_close_on_exec stdin_w;
+  Unix.set_close_on_exec stdout_r;
+  let pid = Unix.create_process prog (Array.of_list (prog :: args)) stdin_r stdout_w stdout_w in
+  Unix.close stdin_r;
+  Unix.close stdout_w;
+  let proc = { pid = pid; id = prog ^ ":" ^ id;
+               inc = Unix.in_channel_of_descr stdout_r;
+               outc = Unix.out_channel_of_descr stdin_w;
+               stop_marker = stop_marker;
+               killed = false } in
+  all_procs := proc :: !all_procs;
   proc
 
-let ask_process (p:proc) (stdin:string) : string =
-  let out = Buffer.create 16 in
+let start_process
+      (id: string) (prog: string) (args: string list)
+      (stop_marker: string -> bool) : proc =
+  start_process' id prog args (Some stop_marker)
 
-  let rec read_out _ =
-    let s, eof = (try
-                    BatString.trim (input_line p.inc), false
-                  with End_of_file ->
-                    Buffer.add_string out ("\nkilled\n") ; "", true) in
-    if not eof then
-      if s = "Done!" then ()
-      else (Buffer.add_string out (s ^ "\n"); read_out ())
-  in
+let rec waitpid_ignore_signals pid =
+  try ignore (Unix.waitpid [] pid)
+  with Unix.Unix_error (Unix.EINTR, _, _) ->
+    waitpid_ignore_signals pid
 
-  let child_thread = Thread.create (fun _ -> read_out ()) () in
-  output_string p.outc stdin;
-  flush p.outc;
-  Thread.join child_thread;
-  Buffer.contents out
-
-let kill_process (p:proc) =
-  let _ = Unix.close_process (p.inc, p.outc) in
-  p.killed <- true
+let kill_process (p: proc) =
+  if not p.killed then begin
+      (* Close the fds directly: close_in and close_out both call `flush`,
+         potentially forcing us to wait until p starts reading again *)
+      Unix.close (Unix.descr_of_in_channel p.inc);
+      Unix.close (Unix.descr_of_out_channel p.outc);
+      Unix.kill p.pid Sys.sigkill;
+      (* Avoid zombie processes (Unix.close_process does the same thing. *)
+      waitpid_ignore_signals p.pid;
+      p.killed <- true
+    end
 
 let kill_all () =
-  FStar_List.iter (fun p -> if not p.killed then kill_process p) !all_procs
+  BatList.iter kill_process !all_procs
 
-let run_proc (name:string) (args:string) (stdin:string) : bool * string * string =
-  let command = name^" "^args in
-  let (inc,outc,errc) = Unix.open_process_full command (Unix.environment ()) in
-  output_string outc stdin;
-  flush outc;
-  let res = BatPervasives.input_all inc in
-  let err = BatPervasives.input_all errc in
-  let _ = Unix.close_process_full (inc, outc, errc) in
-  (true, res, err)
+let process_read_all_output (p: proc) =
+  (* Pass cleanup:false because kill_process closes both fds already. *)
+  BatIO.read_all (BatIO.input_channel ~autoclose:true ~cleanup:false p.inc)
+
+let process_read_async p stdin reader_fn =
+  let child_thread = Thread.create reader_fn () in
+  (match stdin with
+   | Some s -> output_string p.outc s; flush p.outc
+   | None -> ());
+  Thread.join child_thread
+
+let run_process (id: string) (prog: string) (args: string list) (stdin: string option): string =
+  let p = start_process' id prog args None in
+  let output = ref "" in
+  process_read_async p stdin (fun () -> output := process_read_all_output p);
+  kill_process p;
+  !output
+
+type read_result = EOF | SIGINT
+
+let ask_process
+      (p: proc) (stdin: string)
+      (exn_handler: unit -> string): string =
+  let result = ref None in
+  let out = Buffer.create 16 in
+  let stop_marker = BatOption.default (fun s -> false) p.stop_marker in
+
+  let reader_fn () =
+    let rec loop p out =
+      let s = BatString.trim (input_line p.inc) in (* raises EOF *)
+      if stop_marker s then ()
+      else (Buffer.add_string out (s ^ "\n"); loop p out) in
+
+    try loop p out;
+    with | SigInt -> result := Some SIGINT
+         | End_of_file -> result := Some EOF in
+
+  try
+    process_read_async p (Some stdin) reader_fn;
+    (match !result with
+     | Some EOF -> kill_process p; Buffer.add_string out (exn_handler ())
+     | Some SIGINT -> raise SigInt (* Though this thread should have received it as well *)
+     | None -> ());
+    Buffer.contents out
+  with SigInt ->
+    kill_process p; raise SigInt
 
 let get_file_extension (fn:string) : string = snd (BatString.rsplit fn ".")
 let is_path_absolute path_str =

--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -129,7 +129,8 @@ let kill_process (p: proc) =
          potentially forcing us to wait until p starts reading again *)
       Unix.close (Unix.descr_of_in_channel p.inc);
       Unix.close (Unix.descr_of_out_channel p.outc);
-      Unix.kill p.pid Sys.sigkill;
+      (try Unix.kill p.pid Sys.sigkill
+       with Unix.Unix_error (Unix.ESRCH, _, _) -> ());
       (* Avoid zombie processes (Unix.close_process does the same thing. *)
       waitpid_ignore_signals p.pid;
       p.killed <- true

--- a/src/fstar/FStar.Interactive.Ide.fs
+++ b/src/fstar/FStar.Interactive.Ide.fs
@@ -64,9 +64,9 @@ let set_check_kind env check_kind =
   { env with lax = (check_kind = LaxCheck);
              dsenv = DsEnv.set_syntax_only env.dsenv (check_kind = SyntaxCheck)}
 
-let with_captured_errors' env f =
+let with_captured_errors' env sigint_handler f =
   try
-    f env
+    Util.with_sigint_handler sigint_handler (fun _ -> f env)
   with
   | Failure (msg) ->
     let msg = "ASSERTION FAILURE: " ^ msg ^ "\n" ^
@@ -78,7 +78,10 @@ let with_captured_errors' env f =
     Errors.log_issue (TcEnv.get_range env) (Errors.Error_IDEAssertionFailure, msg);
     None
 
-  | Error(e, msg, r) ->
+  | Util.SigInt ->
+    Util.print_string "Interrupted"; None
+
+  | Error (e, msg, r) ->
     TcErr.add_errors env [(e, msg, r)];
     None
 
@@ -89,9 +92,9 @@ let with_captured_errors' env f =
   | Stop ->
     None
 
-let with_captured_errors env f =
+let with_captured_errors env sigint_handler f =
   if Options.trace_error () then f env
-  else with_captured_errors' env f
+  else with_captured_errors' env sigint_handler f
 
 (*************************)
 (* REPL tasks and states *)
@@ -154,13 +157,13 @@ let pop_repl st =
   match !repl_stack with
   | [] -> failwith "Too many pops"
   | (_, st') :: stack ->
-    pop st.repl_env "#pop";
+    pop st.repl_env "REPL pop_repl";
     repl_stack := stack;
     st'
 
 let push_repl push_kind task st =
   repl_stack := (task, st) :: !repl_stack;
-  push (set_check_kind st.repl_env push_kind) ""
+  push (set_check_kind st.repl_env push_kind) "REPL push_repl"
 
 (** Check whether users can issue further ``pop`` commands. **)
 let nothing_left_to_pop st =
@@ -361,10 +364,19 @@ let run_repl_transaction st push_kind must_rollback task =
   let check_success () =
     get_err_count () = 0 && not must_rollback in
 
+  let sigint_handler =
+    // Ideally we'd want everything to be interruptible, but in practice the
+    // code in Typechecker.Tc does not ensure that each ‘push_context’ in
+    // ‘finish_partial_modul’ is always followed by a corresponding
+    // ‘pop_context’ (that's only true if no exceptions occur).
+    match task with
+    | PushFragment _ -> Util.sigint_raise
+    | _ -> Util.sigint_ignore in
+
   // Run the task (and capture errors)
   let curmod, env, success =
-    match with_captured_errors env
-            (fun env -> Some <| run_repl_task st.repl_curmod env task) with
+    match with_captured_errors env sigint_handler
+              (fun env -> Some <| run_repl_task st.repl_curmod env task) with
     | Some (curmod, env) when check_success () -> curmod, env, true
     | _ -> st.repl_curmod, env, false in
 
@@ -559,7 +571,7 @@ let interactive_protocol_features =
    "describe-protocol"; "describe-repl"; "exit";
    "lookup"; "lookup/context"; "lookup/documentation"; "lookup/definition";
    "peek"; "pop"; "push"; "search"; "segment";
-   "vfs-add"; "tactic-ranges"]
+   "vfs-add"; "tactic-ranges"; "interrupt"]
 
 exception InvalidQuery of string
 type query_status = | QueryOK | QueryNOK | QueryViolatesProtocol
@@ -896,7 +908,8 @@ let run_segment (st: repl_state) (code: string) =
     | Parser.Driver.Modul (Parser.AST.Module (_, decls))
     | Parser.Driver.Modul (Parser.AST.Interface (_, decls, _)) -> decls in
 
-  match with_captured_errors st.repl_env (fun _ -> Some <| collect_decls ()) with
+  match with_captured_errors st.repl_env Util.sigint_ignore
+            (fun _ -> Some <| collect_decls ()) with
     | None ->
       let errors = collect_errors () |> List.map json_of_issue in
       ((QueryNOK, JsonList errors), Inl st)
@@ -924,7 +937,7 @@ let run_pop st =
 Return an new REPL state wrapped in ``Inr`` in case of failure, and a new REPL
 plus with a list of completed tasks wrapped in ``Inl`` in case of success. **)
 let load_deps st =
-  match with_captured_errors st.repl_env
+  match with_captured_errors st.repl_env Util.sigint_ignore
           (fun _env -> Some <| deps_and_repl_ld_tasks_of_our_file st.repl_fname) with
   | None -> Inr st
   | Some (deps, tasks, dep_graph) ->
@@ -1159,10 +1172,13 @@ let run_autocomplete st search_term context =
 //        (k ^ ": " ^ (sigelt_to_string v)) :: acc) []
 //   |> Util.concat_l "\n"
 
-let run_and_rewind st task =
-  let env' = push st.repl_env "#compute" in
-  let results = try Inl <| task st with e -> Inr e in
-  pop env' "#compute";
+let run_and_rewind st sigint_default task =
+  let env' = push st.repl_env "REPL run_and_rewind" in
+  let results =
+    try Util.with_sigint_handler Util.sigint_raise (fun _ -> Inl <| task st)
+    with | Util.SigInt -> Inl sigint_default
+         | e -> Inr e in
+  pop env' "REPL run_and_rewind";
   match results with
   | Inl results -> (results, Inl ({ st with repl_env = env' }))
   | Inr e -> raise e
@@ -1190,7 +1206,7 @@ let run_with_parsed_and_tc_term st term line column continuation =
     let ses, _, _ = FStar.TypeChecker.Tc.tc_decls tcenv decls in
     ses in
 
-  run_and_rewind st (fun st ->
+  run_and_rewind st (QueryNOK, JsonStr "Computation interrupted") (fun st ->
     let tcenv = st.repl_env in
     let frag = dummy_let_fragment term in
     match st.repl_curmod with
@@ -1212,9 +1228,9 @@ let run_with_parsed_and_tc_term st term line column continuation =
           aux ()
         else
           try aux ()
-          with | e -> (QueryNOK, (match FStar.Errors.issue_of_exn e with
-                                 | Some issue -> JsonStr (FStar.Errors.format_issue issue)
-                                 | None -> raise e)))
+          with | e -> (match FStar.Errors.issue_of_exn e with
+                      | Some issue -> (QueryNOK, JsonStr (FStar.Errors.format_issue issue))
+                      | None -> raise e))
 
 let run_compute st term rules =
   let rules =
@@ -1448,6 +1464,9 @@ let interactive_mode' init_st =
 
 let interactive_mode (filename:string): unit =
   install_ide_mode_hooks write_json;
+
+  // Ignore unexpected interrupts (some methods override this handler)
+  Util.set_sigint_handler Util.sigint_ignore;
 
   if Option.isSome (Options.codegen ()) then
     Errors.log_issue Range.dummyRange (Errors.Warning_IDEIgnoreCodeGen, "--ide: ignoring --codegen");

--- a/src/ocaml-output/FStar_Common.ml
+++ b/src/ocaml-output/FStar_Common.ml
@@ -1,25 +1,28 @@
 open Prims
 let (has_cygpath : Prims.bool) =
   try
-    let uu____7 = FStar_Util.run_proc "which" "cygpath" ""  in
-    match uu____7 with
-    | (uu____14,t_out,uu____16) ->
-        (FStar_Util.trim_string t_out) = "/usr/bin/cygpath"
-  with | uu____20 -> false 
+    let t_out =
+      FStar_Util.run_process "has_cygpath" "which" ["cygpath"]
+        FStar_Pervasives_Native.None
+       in
+    (FStar_Util.trim_string t_out) = "/usr/bin/cygpath"
+  with | uu____8 -> false 
 let (try_convert_file_name_to_mixed : Prims.string -> Prims.string) =
   let cache = FStar_Util.smap_create (Prims.parse_int "20")  in
   fun s  ->
     if has_cygpath && (FStar_Util.starts_with s "/")
     then
-      let uu____29 = FStar_Util.smap_try_find cache s  in
-      match uu____29 with
+      let uu____17 = FStar_Util.smap_try_find cache s  in
+      match uu____17 with
       | FStar_Pervasives_Native.Some s1 -> s1
       | FStar_Pervasives_Native.None  ->
-          let uu____33 =
-            FStar_Util.run_proc "cygpath" (Prims.strcat "-m " s) ""  in
-          (match uu____33 with
-           | (uu____40,out,uu____42) ->
-               let out1 = FStar_Util.trim_string out  in
-               (FStar_Util.smap_add cache s out1; out1))
+          let label = "try_convert_file_name_to_mixed"  in
+          let out =
+            let uu____23 =
+              FStar_Util.run_process label "cygpath" ["-m"; s]
+                FStar_Pervasives_Native.None
+               in
+            FStar_All.pipe_right uu____23 FStar_Util.trim_string  in
+          (FStar_Util.smap_add cache s out; out)
     else s
   

--- a/src/ocaml-output/FStar_Interactive_Ide.ml
+++ b/src/ocaml-output/FStar_Interactive_Ide.ml
@@ -111,53 +111,65 @@ let (set_check_kind :
       }
   
 let with_captured_errors' :
-  'Auu____60 .
+  'Auu____62 .
     FStar_TypeChecker_Env.env ->
-      (FStar_TypeChecker_Env.env -> 'Auu____60 FStar_Pervasives_Native.option)
-        -> 'Auu____60 FStar_Pervasives_Native.option
+      FStar_Util.sigint_handler ->
+        (FStar_TypeChecker_Env.env ->
+           'Auu____62 FStar_Pervasives_Native.option)
+          -> 'Auu____62 FStar_Pervasives_Native.option
   =
   fun env  ->
-    fun f  ->
-      try f env
-      with
-      | FStar_All.Failure msg ->
-          let msg1 =
-            Prims.strcat "ASSERTION FAILURE: "
-              (Prims.strcat msg
-                 (Prims.strcat "\n"
-                    (Prims.strcat "F* may be in an inconsistent state.\n"
-                       (Prims.strcat
-                          "Please file a bug report, ideally with a "
-                          "minimized version of the program that triggered the error."))))
-             in
-          ((let uu____98 = FStar_TypeChecker_Env.get_range env  in
-            FStar_Errors.log_issue uu____98
-              (FStar_Errors.Error_IDEAssertionFailure, msg1));
-           FStar_Pervasives_Native.None)
-      | FStar_Errors.Error (e,msg,r) ->
-          (FStar_TypeChecker_Err.add_errors env [(e, msg, r)];
-           FStar_Pervasives_Native.None)
-      | FStar_Errors.Err (e,msg) ->
-          ((let uu____118 =
-              let uu____127 =
-                let uu____134 = FStar_TypeChecker_Env.get_range env  in
-                (e, msg, uu____134)  in
-              [uu____127]  in
-            FStar_TypeChecker_Err.add_errors env uu____118);
-           FStar_Pervasives_Native.None)
-      | FStar_Errors.Stop  -> FStar_Pervasives_Native.None
+    fun sigint_handler  ->
+      fun f  ->
+        try
+          FStar_Util.with_sigint_handler sigint_handler
+            (fun uu____98  -> f env)
+        with
+        | FStar_All.Failure msg ->
+            let msg1 =
+              Prims.strcat "ASSERTION FAILURE: "
+                (Prims.strcat msg
+                   (Prims.strcat "\n"
+                      (Prims.strcat "F* may be in an inconsistent state.\n"
+                         (Prims.strcat
+                            "Please file a bug report, ideally with a "
+                            "minimized version of the program that triggered the error."))))
+               in
+            ((let uu____109 = FStar_TypeChecker_Env.get_range env  in
+              FStar_Errors.log_issue uu____109
+                (FStar_Errors.Error_IDEAssertionFailure, msg1));
+             FStar_Pervasives_Native.None)
+        | FStar_Util.SigInt  ->
+            (FStar_Util.print_string "Interrupted";
+             FStar_Pervasives_Native.None)
+        | FStar_Errors.Error (e,msg,r) ->
+            (FStar_TypeChecker_Err.add_errors env [(e, msg, r)];
+             FStar_Pervasives_Native.None)
+        | FStar_Errors.Err (e,msg) ->
+            ((let uu____130 =
+                let uu____139 =
+                  let uu____146 = FStar_TypeChecker_Env.get_range env  in
+                  (e, msg, uu____146)  in
+                [uu____139]  in
+              FStar_TypeChecker_Err.add_errors env uu____130);
+             FStar_Pervasives_Native.None)
+        | FStar_Errors.Stop  -> FStar_Pervasives_Native.None
   
 let with_captured_errors :
-  'Auu____153 .
+  'Auu____167 .
     FStar_TypeChecker_Env.env ->
-      (FStar_TypeChecker_Env.env ->
-         'Auu____153 FStar_Pervasives_Native.option)
-        -> 'Auu____153 FStar_Pervasives_Native.option
+      FStar_Util.sigint_handler ->
+        (FStar_TypeChecker_Env.env ->
+           'Auu____167 FStar_Pervasives_Native.option)
+          -> 'Auu____167 FStar_Pervasives_Native.option
   =
   fun env  ->
-    fun f  ->
-      let uu____175 = FStar_Options.trace_error ()  in
-      if uu____175 then f env else with_captured_errors' env f
+    fun sigint_handler  ->
+      fun f  ->
+        let uu____194 = FStar_Options.trace_error ()  in
+        if uu____194
+        then f env
+        else with_captured_errors' env sigint_handler f
   
 type timed_fname = {
   tf_fname: Prims.string ;
@@ -178,21 +190,21 @@ let (__proj__Mktimed_fname__item__tf_modtime :
 let (t0 : FStar_Util.time) = FStar_Util.now () 
 let (tf_of_fname : Prims.string -> timed_fname) =
   fun fname  ->
-    let uu____208 =
+    let uu____227 =
       FStar_Parser_ParseIt.get_file_last_modification_time fname  in
-    { tf_fname = fname; tf_modtime = uu____208 }
+    { tf_fname = fname; tf_modtime = uu____227 }
   
 let (dummy_tf_of_fname : Prims.string -> timed_fname) =
   fun fname  -> { tf_fname = fname; tf_modtime = t0 } 
 let (string_of_timed_fname : timed_fname -> Prims.string) =
-  fun uu____218  ->
-    match uu____218 with
+  fun uu____237  ->
+    match uu____237 with
     | { tf_fname = fname; tf_modtime = modtime;_} ->
         if modtime = t0
         then FStar_Util.format1 "{ %s }" fname
         else
-          (let uu____222 = FStar_Util.string_of_time modtime  in
-           FStar_Util.format2 "{ %s; %s }" fname uu____222)
+          (let uu____241 = FStar_Util.string_of_time modtime  in
+           FStar_Util.format2 "{ %s; %s }" fname uu____241)
   
 type push_query =
   {
@@ -247,14 +259,14 @@ type repl_task =
   | PushFragment of FStar_Parser_ParseIt.input_frag [@@deriving show]
 let (uu___is_LDInterleaved : repl_task -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LDInterleaved _0 -> true | uu____334 -> false
+    match projectee with | LDInterleaved _0 -> true | uu____353 -> false
   
 let (__proj__LDInterleaved__item___0 :
   repl_task -> (timed_fname,timed_fname) FStar_Pervasives_Native.tuple2) =
   fun projectee  -> match projectee with | LDInterleaved _0 -> _0 
 let (uu___is_LDSingle : repl_task -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LDSingle _0 -> true | uu____360 -> false
+    match projectee with | LDSingle _0 -> true | uu____379 -> false
   
 let (__proj__LDSingle__item___0 : repl_task -> timed_fname) =
   fun projectee  -> match projectee with | LDSingle _0 -> _0 
@@ -262,13 +274,13 @@ let (uu___is_LDInterfaceOfCurrentFile : repl_task -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | LDInterfaceOfCurrentFile _0 -> true
-    | uu____374 -> false
+    | uu____393 -> false
   
 let (__proj__LDInterfaceOfCurrentFile__item___0 : repl_task -> timed_fname) =
   fun projectee  -> match projectee with | LDInterfaceOfCurrentFile _0 -> _0 
 let (uu___is_PushFragment : repl_task -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PushFragment _0 -> true | uu____388 -> false
+    match projectee with | PushFragment _0 -> true | uu____407 -> false
   
 let (__proj__PushFragment__item___0 :
   repl_task -> FStar_Parser_ParseIt.input_frag) =
@@ -384,11 +396,11 @@ let (repl_stack :
   = FStar_Util.mk_ref [] 
 let (pop_repl : repl_state -> repl_state) =
   fun st  ->
-    let uu____667 = FStar_ST.op_Bang repl_stack  in
-    match uu____667 with
+    let uu____686 = FStar_ST.op_Bang repl_stack  in
+    match uu____686 with
     | [] -> failwith "Too many pops"
-    | (uu____713,st')::stack ->
-        (pop st.repl_env "#pop";
+    | (uu____732,st')::stack ->
+        (pop st.repl_env "REPL pop_repl";
          FStar_ST.op_Colon_Equals repl_stack stack;
          st')
   
@@ -397,20 +409,20 @@ let (push_repl :
   fun push_kind  ->
     fun task  ->
       fun st  ->
-        (let uu____779 =
-           let uu____786 = FStar_ST.op_Bang repl_stack  in (task, st) ::
-             uu____786
+        (let uu____798 =
+           let uu____805 = FStar_ST.op_Bang repl_stack  in (task, st) ::
+             uu____805
             in
-         FStar_ST.op_Colon_Equals repl_stack uu____779);
-        (let uu____867 = set_check_kind st.repl_env push_kind  in
-         push uu____867 "")
+         FStar_ST.op_Colon_Equals repl_stack uu____798);
+        (let uu____886 = set_check_kind st.repl_env push_kind  in
+         push uu____886 "REPL push_repl")
   
 let (nothing_left_to_pop : repl_state -> Prims.bool) =
   fun st  ->
-    let uu____873 =
-      let uu____874 = FStar_ST.op_Bang repl_stack  in
-      FStar_List.length uu____874  in
-    uu____873 = (FStar_List.length st.repl_deps_stack)
+    let uu____892 =
+      let uu____893 = FStar_ST.op_Bang repl_stack  in
+      FStar_List.length uu____893  in
+    uu____892 = (FStar_List.length st.repl_deps_stack)
   
 type name_tracking_event =
   | NTAlias of (FStar_Ident.lid,FStar_Ident.ident,FStar_Ident.lid)
@@ -422,7 +434,7 @@ type name_tracking_event =
   | NTBinding of FStar_TypeChecker_Env.binding [@@deriving show]
 let (uu___is_NTAlias : name_tracking_event -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NTAlias _0 -> true | uu____974 -> false
+    match projectee with | NTAlias _0 -> true | uu____993 -> false
   
 let (__proj__NTAlias__item___0 :
   name_tracking_event ->
@@ -431,7 +443,7 @@ let (__proj__NTAlias__item___0 :
   = fun projectee  -> match projectee with | NTAlias _0 -> _0 
 let (uu___is_NTOpen : name_tracking_event -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NTOpen _0 -> true | uu____1010 -> false
+    match projectee with | NTOpen _0 -> true | uu____1029 -> false
   
 let (__proj__NTOpen__item___0 :
   name_tracking_event ->
@@ -440,7 +452,7 @@ let (__proj__NTOpen__item___0 :
   = fun projectee  -> match projectee with | NTOpen _0 -> _0 
 let (uu___is_NTInclude : name_tracking_event -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NTInclude _0 -> true | uu____1040 -> false
+    match projectee with | NTInclude _0 -> true | uu____1059 -> false
   
 let (__proj__NTInclude__item___0 :
   name_tracking_event ->
@@ -448,7 +460,7 @@ let (__proj__NTInclude__item___0 :
   = fun projectee  -> match projectee with | NTInclude _0 -> _0 
 let (uu___is_NTBinding : name_tracking_event -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NTBinding _0 -> true | uu____1066 -> false
+    match projectee with | NTBinding _0 -> true | uu____1085 -> false
   
 let (__proj__NTBinding__item___0 :
   name_tracking_event -> FStar_TypeChecker_Env.binding) =
@@ -475,32 +487,32 @@ let (update_names_from_event :
         | NTAlias (host,id1,included) ->
             if is_cur_mod host
             then
-              let uu____1112 = FStar_Ident.text_of_id id1  in
-              let uu____1113 = query_of_lid included  in
+              let uu____1131 = FStar_Ident.text_of_id id1  in
+              let uu____1132 = query_of_lid included  in
               FStar_Interactive_CompletionTable.register_alias table
-                uu____1112 [] uu____1113
+                uu____1131 [] uu____1132
             else table
         | NTOpen (host,(included,kind)) ->
             if is_cur_mod host
             then
-              let uu____1122 = query_of_lid included  in
+              let uu____1141 = query_of_lid included  in
               FStar_Interactive_CompletionTable.register_open table
-                (kind = FStar_Syntax_DsEnv.Open_module) [] uu____1122
+                (kind = FStar_Syntax_DsEnv.Open_module) [] uu____1141
             else table
         | NTInclude (host,included) ->
-            let uu____1126 =
+            let uu____1145 =
               if is_cur_mod host then [] else query_of_lid host  in
-            let uu____1128 = query_of_lid included  in
+            let uu____1147 = query_of_lid included  in
             FStar_Interactive_CompletionTable.register_include table
-              uu____1126 uu____1128
+              uu____1145 uu____1147
         | NTBinding binding ->
             let lids =
               match binding with
-              | FStar_TypeChecker_Env.Binding_lid (lid,uu____1136) -> [lid]
-              | FStar_TypeChecker_Env.Binding_sig (lids,uu____1138) -> lids
+              | FStar_TypeChecker_Env.Binding_lid (lid,uu____1155) -> [lid]
+              | FStar_TypeChecker_Env.Binding_sig (lids,uu____1157) -> lids
               | FStar_TypeChecker_Env.Binding_sig_inst
-                  (lids,uu____1144,uu____1145) -> lids
-              | uu____1150 -> []  in
+                  (lids,uu____1163,uu____1164) -> lids
+              | uu____1169 -> []  in
             FStar_List.fold_left
               (fun tbl  ->
                  fun lid  ->
@@ -508,10 +520,10 @@ let (update_names_from_event :
                      if lid.FStar_Ident.nsstr = cur_mod_str
                      then []
                      else query_of_ids lid.FStar_Ident.ns  in
-                   let uu____1163 =
+                   let uu____1182 =
                      FStar_Ident.text_of_id lid.FStar_Ident.ident  in
                    FStar_Interactive_CompletionTable.insert tbl ns_query
-                     uu____1163 lid) table lids
+                     uu____1182 lid) table lids
   
 let (commit_name_tracking' :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
@@ -526,8 +538,8 @@ let (commit_name_tracking' :
           match cur_mod with
           | FStar_Pervasives_Native.None  -> ""
           | FStar_Pervasives_Native.Some md ->
-              let uu____1189 = FStar_Syntax_Syntax.mod_name md  in
-              uu____1189.FStar_Ident.str
+              let uu____1208 = FStar_Syntax_Syntax.mod_name md  in
+              uu____1208.FStar_Ident.str
            in
         let updater = update_names_from_event cur_mod_str  in
         FStar_List.fold_left updater names1 name_events
@@ -538,15 +550,15 @@ let (commit_name_tracking :
     fun name_events  ->
       let names1 =
         commit_name_tracking' st.repl_curmod st.repl_names name_events  in
-      let uu___91_1214 = st  in
+      let uu___91_1233 = st  in
       {
-        repl_line = (uu___91_1214.repl_line);
-        repl_column = (uu___91_1214.repl_column);
-        repl_fname = (uu___91_1214.repl_fname);
-        repl_deps_stack = (uu___91_1214.repl_deps_stack);
-        repl_curmod = (uu___91_1214.repl_curmod);
-        repl_env = (uu___91_1214.repl_env);
-        repl_stdin = (uu___91_1214.repl_stdin);
+        repl_line = (uu___91_1233.repl_line);
+        repl_column = (uu___91_1233.repl_column);
+        repl_fname = (uu___91_1233.repl_fname);
+        repl_deps_stack = (uu___91_1233.repl_deps_stack);
+        repl_curmod = (uu___91_1233.repl_curmod);
+        repl_env = (uu___91_1233.repl_env);
+        repl_stdin = (uu___91_1233.repl_stdin);
         repl_names = names1
       }
   
@@ -555,49 +567,49 @@ let (fresh_name_tracking_hooks :
     (name_tracking_event Prims.list FStar_ST.ref,FStar_Syntax_DsEnv.dsenv_hooks,
       FStar_TypeChecker_Env.tcenv_hooks) FStar_Pervasives_Native.tuple3)
   =
-  fun uu____1229  ->
+  fun uu____1248  ->
     let events = FStar_Util.mk_ref []  in
     let push_event evt =
-      let uu____1243 =
-        let uu____1246 = FStar_ST.op_Bang events  in evt :: uu____1246  in
-      FStar_ST.op_Colon_Equals events uu____1243  in
+      let uu____1262 =
+        let uu____1265 = FStar_ST.op_Bang events  in evt :: uu____1265  in
+      FStar_ST.op_Colon_Equals events uu____1262  in
     (events,
       {
         FStar_Syntax_DsEnv.ds_push_open_hook =
           (fun dsenv1  ->
              fun op  ->
-               let uu____1381 =
-                 let uu____1382 =
-                   let uu____1387 = FStar_Syntax_DsEnv.current_module dsenv1
+               let uu____1400 =
+                 let uu____1401 =
+                   let uu____1406 = FStar_Syntax_DsEnv.current_module dsenv1
                       in
-                   (uu____1387, op)  in
-                 NTOpen uu____1382  in
-               push_event uu____1381);
+                   (uu____1406, op)  in
+                 NTOpen uu____1401  in
+               push_event uu____1400);
         FStar_Syntax_DsEnv.ds_push_include_hook =
           (fun dsenv1  ->
              fun ns  ->
-               let uu____1393 =
-                 let uu____1394 =
-                   let uu____1399 = FStar_Syntax_DsEnv.current_module dsenv1
+               let uu____1412 =
+                 let uu____1413 =
+                   let uu____1418 = FStar_Syntax_DsEnv.current_module dsenv1
                       in
-                   (uu____1399, ns)  in
-                 NTInclude uu____1394  in
-               push_event uu____1393);
+                   (uu____1418, ns)  in
+                 NTInclude uu____1413  in
+               push_event uu____1412);
         FStar_Syntax_DsEnv.ds_push_module_abbrev_hook =
           (fun dsenv1  ->
              fun x  ->
                fun l  ->
-                 let uu____1407 =
-                   let uu____1408 =
-                     let uu____1415 =
+                 let uu____1426 =
+                   let uu____1427 =
+                     let uu____1434 =
                        FStar_Syntax_DsEnv.current_module dsenv1  in
-                     (uu____1415, x, l)  in
-                   NTAlias uu____1408  in
-                 push_event uu____1407)
+                     (uu____1434, x, l)  in
+                   NTAlias uu____1427  in
+                 push_event uu____1426)
       },
       {
         FStar_TypeChecker_Env.tc_push_in_gamma_hook =
-          (fun uu____1420  -> fun s  -> push_event (NTBinding s))
+          (fun uu____1439  -> fun s  -> push_event (NTBinding s))
       })
   
 let (track_name_changes :
@@ -609,48 +621,48 @@ let (track_name_changes :
   =
   fun env  ->
     let set_hooks dshooks tchooks env1 =
-      let uu____1469 =
+      let uu____1488 =
         FStar_Universal.with_tcenv env1
           (fun dsenv1  ->
-             let uu____1477 = FStar_Syntax_DsEnv.set_ds_hooks dsenv1 dshooks
+             let uu____1496 = FStar_Syntax_DsEnv.set_ds_hooks dsenv1 dshooks
                 in
-             ((), uu____1477))
+             ((), uu____1496))
          in
-      match uu____1469 with
+      match uu____1488 with
       | ((),tcenv') -> FStar_TypeChecker_Env.set_tc_hooks tcenv' tchooks  in
-    let uu____1479 =
-      let uu____1484 =
+    let uu____1498 =
+      let uu____1503 =
         FStar_Syntax_DsEnv.ds_hooks env.FStar_TypeChecker_Env.dsenv  in
-      let uu____1485 = FStar_TypeChecker_Env.tc_hooks env  in
-      (uu____1484, uu____1485)  in
-    match uu____1479 with
+      let uu____1504 = FStar_TypeChecker_Env.tc_hooks env  in
+      (uu____1503, uu____1504)  in
+    match uu____1498 with
     | (old_dshooks,old_tchooks) ->
-        let uu____1501 = fresh_name_tracking_hooks ()  in
-        (match uu____1501 with
+        let uu____1520 = fresh_name_tracking_hooks ()  in
+        (match uu____1520 with
          | (events,new_dshooks,new_tchooks) ->
-             let uu____1536 = set_hooks new_dshooks new_tchooks env  in
-             (uu____1536,
+             let uu____1555 = set_hooks new_dshooks new_tchooks env  in
+             (uu____1555,
                ((fun env1  ->
-                   let uu____1550 = set_hooks old_dshooks old_tchooks env1
+                   let uu____1569 = set_hooks old_dshooks old_tchooks env1
                       in
-                   let uu____1551 =
-                     let uu____1554 = FStar_ST.op_Bang events  in
-                     FStar_List.rev uu____1554  in
-                   (uu____1550, uu____1551)))))
+                   let uu____1570 =
+                     let uu____1573 = FStar_ST.op_Bang events  in
+                     FStar_List.rev uu____1573  in
+                   (uu____1569, uu____1570)))))
   
 let (string_of_repl_task : repl_task -> Prims.string) =
-  fun uu___73_1612  ->
-    match uu___73_1612 with
+  fun uu___73_1631  ->
+    match uu___73_1631 with
     | LDInterleaved (intf,impl) ->
-        let uu____1615 = string_of_timed_fname intf  in
-        let uu____1616 = string_of_timed_fname impl  in
-        FStar_Util.format2 "LDInterleaved (%s, %s)" uu____1615 uu____1616
+        let uu____1634 = string_of_timed_fname intf  in
+        let uu____1635 = string_of_timed_fname impl  in
+        FStar_Util.format2 "LDInterleaved (%s, %s)" uu____1634 uu____1635
     | LDSingle intf_or_impl ->
-        let uu____1618 = string_of_timed_fname intf_or_impl  in
-        FStar_Util.format1 "LDSingle %s" uu____1618
+        let uu____1637 = string_of_timed_fname intf_or_impl  in
+        FStar_Util.format1 "LDSingle %s" uu____1637
     | LDInterfaceOfCurrentFile intf ->
-        let uu____1620 = string_of_timed_fname intf  in
-        FStar_Util.format1 "LDInterfaceOfCurrentFile %s" uu____1620
+        let uu____1639 = string_of_timed_fname intf  in
+        FStar_Util.format1 "LDInterfaceOfCurrentFile %s" uu____1639
     | PushFragment frag ->
         FStar_Util.format1 "PushFragment { code = %s }"
           frag.FStar_Parser_ParseIt.frag_text
@@ -663,12 +675,12 @@ let (tc_one :
   fun env  ->
     fun intf_opt  ->
       fun modf  ->
-        let uu____1641 =
+        let uu____1660 =
           FStar_Universal.tc_one_file env FStar_Pervasives_Native.None
             intf_opt modf
            in
-        match uu____1641 with
-        | (uu____1655,env1,delta1) ->
+        match uu____1660 with
+        | (uu____1674,env1,delta1) ->
             let env2 = FStar_Universal.apply_delta_env env1 delta1  in env2
   
 let (run_repl_task :
@@ -680,20 +692,20 @@ let (run_repl_task :
       fun task  ->
         match task with
         | LDInterleaved (intf,impl) ->
-            let uu____1694 =
+            let uu____1713 =
               tc_one env (FStar_Pervasives_Native.Some (intf.tf_fname))
                 impl.tf_fname
                in
-            (curmod, uu____1694)
+            (curmod, uu____1713)
         | LDSingle intf_or_impl ->
-            let uu____1696 =
+            let uu____1715 =
               tc_one env FStar_Pervasives_Native.None intf_or_impl.tf_fname
                in
-            (curmod, uu____1696)
+            (curmod, uu____1715)
         | LDInterfaceOfCurrentFile intf ->
-            let uu____1698 =
+            let uu____1717 =
               FStar_Universal.load_interface_decls env intf.tf_fname  in
-            (curmod, uu____1698)
+            (curmod, uu____1717)
         | PushFragment frag ->
             FStar_Universal.tc_one_fragment curmod env frag
   
@@ -706,11 +718,11 @@ let (repl_ld_tasks_of_deps :
         match deps1 with
         | intf::impl::deps' when FStar_Universal.needs_interleaving intf impl
             ->
-            let uu____1753 = aux deps' final_tasks1  in
-            (LDInterleaved ((wrap intf), (wrap impl))) :: uu____1753
+            let uu____1772 = aux deps' final_tasks1  in
+            (LDInterleaved ((wrap intf), (wrap impl))) :: uu____1772
         | intf_or_impl::deps' ->
-            let uu____1760 = aux deps' final_tasks1  in
-            (LDSingle (wrap intf_or_impl)) :: uu____1760
+            let uu____1779 = aux deps' final_tasks1  in
+            (LDSingle (wrap intf_or_impl)) :: uu____1779
         | [] -> final_tasks1  in
       aux deps final_tasks
   
@@ -723,81 +735,81 @@ let (deps_and_repl_ld_tasks_of_our_file :
     let get_mod_name fname = FStar_Parser_Dep.lowercase_module_name fname  in
     let our_mod_name = get_mod_name filename  in
     let has_our_mod_name f =
-      let uu____1801 = get_mod_name f  in uu____1801 = our_mod_name  in
-    let uu____1802 = FStar_Dependencies.find_deps_if_needed [filename]  in
-    match uu____1802 with
+      let uu____1820 = get_mod_name f  in uu____1820 = our_mod_name  in
+    let uu____1821 = FStar_Dependencies.find_deps_if_needed [filename]  in
+    match uu____1821 with
     | (deps,dep_graph1) ->
-        let uu____1825 = FStar_List.partition has_our_mod_name deps  in
-        (match uu____1825 with
+        let uu____1844 = FStar_List.partition has_our_mod_name deps  in
+        (match uu____1844 with
          | (same_name,real_deps) ->
              let intf_tasks =
                match same_name with
                | intf::impl::[] ->
-                   ((let uu____1862 =
-                       let uu____1863 = FStar_Parser_Dep.is_interface intf
+                   ((let uu____1881 =
+                       let uu____1882 = FStar_Parser_Dep.is_interface intf
                           in
-                       Prims.op_Negation uu____1863  in
-                     if uu____1862
+                       Prims.op_Negation uu____1882  in
+                     if uu____1881
                      then
-                       let uu____1864 =
-                         let uu____1869 =
+                       let uu____1883 =
+                         let uu____1888 =
                            FStar_Util.format1
                              "Expecting an interface, got %s" intf
                             in
-                         (FStar_Errors.Fatal_MissingInterface, uu____1869)
+                         (FStar_Errors.Fatal_MissingInterface, uu____1888)
                           in
-                       FStar_Errors.raise_err uu____1864
+                       FStar_Errors.raise_err uu____1883
                      else ());
-                    (let uu____1872 =
-                       let uu____1873 =
+                    (let uu____1891 =
+                       let uu____1892 =
                          FStar_Parser_Dep.is_implementation impl  in
-                       Prims.op_Negation uu____1873  in
-                     if uu____1872
+                       Prims.op_Negation uu____1892  in
+                     if uu____1891
                      then
-                       let uu____1874 =
-                         let uu____1879 =
+                       let uu____1893 =
+                         let uu____1898 =
                            FStar_Util.format1
                              "Expecting an implementation, got %s" impl
                             in
                          (FStar_Errors.Fatal_MissingImplementation,
-                           uu____1879)
+                           uu____1898)
                           in
-                       FStar_Errors.raise_err uu____1874
+                       FStar_Errors.raise_err uu____1893
                      else ());
                     [LDInterfaceOfCurrentFile (dummy_tf_of_fname intf)])
                | impl::[] -> []
-               | uu____1882 ->
+               | uu____1901 ->
                    let mods_str = FStar_String.concat " " same_name  in
                    let message = "Too many or too few files matching %s: %s"
                       in
-                   ((let uu____1888 =
-                       let uu____1893 =
+                   ((let uu____1907 =
+                       let uu____1912 =
                          FStar_Util.format message [our_mod_name; mods_str]
                           in
                        (FStar_Errors.Fatal_TooManyOrTooFewFileMatch,
-                         uu____1893)
+                         uu____1912)
                         in
-                     FStar_Errors.raise_err uu____1888);
+                     FStar_Errors.raise_err uu____1907);
                     [])
                 in
              let tasks = repl_ld_tasks_of_deps real_deps intf_tasks  in
              (real_deps, tasks, dep_graph1))
   
 let (update_task_timestamps : repl_task -> repl_task) =
-  fun uu___74_1905  ->
-    match uu___74_1905 with
+  fun uu___74_1924  ->
+    match uu___74_1924 with
     | LDInterleaved (intf,impl) ->
-        let uu____1908 =
-          let uu____1913 = tf_of_fname intf.tf_fname  in
-          let uu____1914 = tf_of_fname impl.tf_fname  in
-          (uu____1913, uu____1914)  in
-        LDInterleaved uu____1908
+        let uu____1927 =
+          let uu____1932 = tf_of_fname intf.tf_fname  in
+          let uu____1933 = tf_of_fname impl.tf_fname  in
+          (uu____1932, uu____1933)  in
+        LDInterleaved uu____1927
     | LDSingle intf_or_impl ->
-        let uu____1916 = tf_of_fname intf_or_impl.tf_fname  in
-        LDSingle uu____1916
+        let uu____1935 = tf_of_fname intf_or_impl.tf_fname  in
+        LDSingle uu____1935
     | LDInterfaceOfCurrentFile intf ->
-        let uu____1918 = tf_of_fname intf.tf_fname  in
-        LDInterfaceOfCurrentFile uu____1918
+        let uu____1937 = tf_of_fname intf.tf_fname  in
+        LDInterfaceOfCurrentFile uu____1937
     | PushFragment frag -> PushFragment frag
   
 let (run_repl_transaction :
@@ -811,44 +823,48 @@ let (run_repl_transaction :
       fun must_rollback  ->
         fun task  ->
           let env = push_repl push_kind task st  in
-          let uu____1945 = track_name_changes env  in
-          match uu____1945 with
+          let uu____1964 = track_name_changes env  in
+          match uu____1964 with
           | (env1,finish_name_tracking) ->
-              let check_success uu____1988 =
-                (let uu____1991 = FStar_Errors.get_err_count ()  in
-                 uu____1991 = (Prims.parse_int "0")) &&
+              let check_success uu____2007 =
+                (let uu____2010 = FStar_Errors.get_err_count ()  in
+                 uu____2010 = (Prims.parse_int "0")) &&
                   (Prims.op_Negation must_rollback)
                  in
-              let uu____1992 =
-                let uu____1999 =
-                  with_captured_errors env1
+              let sigint_handler =
+                match task with
+                | PushFragment uu____2012 -> FStar_Util.sigint_raise
+                | uu____2013 -> FStar_Util.sigint_ignore  in
+              let uu____2014 =
+                let uu____2021 =
+                  with_captured_errors env1 sigint_handler
                     (fun env2  ->
-                       let uu____2013 =
+                       let uu____2035 =
                          run_repl_task st.repl_curmod env2 task  in
                        FStar_All.pipe_left
                          (fun _0_17  -> FStar_Pervasives_Native.Some _0_17)
-                         uu____2013)
+                         uu____2035)
                    in
-                match uu____1999 with
+                match uu____2021 with
                 | FStar_Pervasives_Native.Some (curmod,env2) when
                     check_success () -> (curmod, env2, true)
-                | uu____2044 -> ((st.repl_curmod), env1, false)  in
-              (match uu____1992 with
+                | uu____2066 -> ((st.repl_curmod), env1, false)  in
+              (match uu____2014 with
                | (curmod,env2,success) ->
-                   let uu____2058 = finish_name_tracking env2  in
-                   (match uu____2058 with
+                   let uu____2080 = finish_name_tracking env2  in
+                   (match uu____2080 with
                     | (env',name_events) ->
                         let st1 =
-                          let uu___92_2076 = st  in
+                          let uu___92_2098 = st  in
                           {
-                            repl_line = (uu___92_2076.repl_line);
-                            repl_column = (uu___92_2076.repl_column);
-                            repl_fname = (uu___92_2076.repl_fname);
-                            repl_deps_stack = (uu___92_2076.repl_deps_stack);
+                            repl_line = (uu___92_2098.repl_line);
+                            repl_column = (uu___92_2098.repl_column);
+                            repl_fname = (uu___92_2098.repl_fname);
+                            repl_deps_stack = (uu___92_2098.repl_deps_stack);
                             repl_curmod = curmod;
                             repl_env = env2;
-                            repl_stdin = (uu___92_2076.repl_stdin);
-                            repl_names = (uu___92_2076.repl_names)
+                            repl_stdin = (uu___92_2098.repl_stdin);
+                            repl_names = (uu___92_2098.repl_names)
                           }  in
                         let st2 =
                           if success
@@ -863,115 +879,115 @@ let (run_repl_ld_transactions :
   fun st  ->
     fun tasks  ->
       let debug1 verb task =
-        let uu____2108 = FStar_Options.debug_any ()  in
-        if uu____2108
+        let uu____2130 = FStar_Options.debug_any ()  in
+        if uu____2130
         then
-          let uu____2109 = string_of_repl_task task  in
-          FStar_Util.print2 "%s %s" verb uu____2109
+          let uu____2131 = string_of_repl_task task  in
+          FStar_Util.print2 "%s %s" verb uu____2131
         else ()  in
-      let rec revert_many st1 uu___75_2127 =
-        match uu___75_2127 with
+      let rec revert_many st1 uu___75_2149 =
+        match uu___75_2149 with
         | [] -> st1
         | (task,_st')::entries ->
             (debug1 "Reverting" task;
-             (let uu____2154 = pop_repl st1  in
-              revert_many uu____2154 entries))
+             (let uu____2176 = pop_repl st1  in
+              revert_many uu____2176 entries))
          in
       let rec aux st1 tasks1 previous =
         match (tasks1, previous) with
         | ([],[]) -> FStar_Util.Inl st1
         | (task::tasks2,[]) ->
             (debug1 "Loading" task;
-             (let uu____2205 = FStar_Options.restore_cmd_line_options false
+             (let uu____2227 = FStar_Options.restore_cmd_line_options false
                  in
-              FStar_All.pipe_right uu____2205 (fun a240  -> ()));
+              FStar_All.pipe_right uu____2227 (fun a240  -> ()));
              (let timestamped_task = update_task_timestamps task  in
               let push_kind =
-                let uu____2208 = FStar_Options.lax ()  in
-                if uu____2208 then LaxCheck else FullCheck  in
-              let uu____2210 =
+                let uu____2230 = FStar_Options.lax ()  in
+                if uu____2230 then LaxCheck else FullCheck  in
+              let uu____2232 =
                 run_repl_transaction st1 push_kind false timestamped_task  in
-              match uu____2210 with
+              match uu____2232 with
               | (success,st2) ->
                   if success
                   then
-                    let uu____2225 =
-                      let uu___93_2226 = st2  in
-                      let uu____2227 = FStar_ST.op_Bang repl_stack  in
+                    let uu____2247 =
+                      let uu___93_2248 = st2  in
+                      let uu____2249 = FStar_ST.op_Bang repl_stack  in
                       {
-                        repl_line = (uu___93_2226.repl_line);
-                        repl_column = (uu___93_2226.repl_column);
-                        repl_fname = (uu___93_2226.repl_fname);
-                        repl_deps_stack = uu____2227;
-                        repl_curmod = (uu___93_2226.repl_curmod);
-                        repl_env = (uu___93_2226.repl_env);
-                        repl_stdin = (uu___93_2226.repl_stdin);
-                        repl_names = (uu___93_2226.repl_names)
+                        repl_line = (uu___93_2248.repl_line);
+                        repl_column = (uu___93_2248.repl_column);
+                        repl_fname = (uu___93_2248.repl_fname);
+                        repl_deps_stack = uu____2249;
+                        repl_curmod = (uu___93_2248.repl_curmod);
+                        repl_env = (uu___93_2248.repl_env);
+                        repl_stdin = (uu___93_2248.repl_stdin);
+                        repl_names = (uu___93_2248.repl_names)
                       }  in
-                    aux uu____2225 tasks2 []
+                    aux uu____2247 tasks2 []
                   else FStar_Util.Inr st2))
         | (task::tasks2,prev::previous1) when
-            let uu____2282 = update_task_timestamps task  in
-            (FStar_Pervasives_Native.fst prev) = uu____2282 ->
+            let uu____2304 = update_task_timestamps task  in
+            (FStar_Pervasives_Native.fst prev) = uu____2304 ->
             (debug1 "Skipping" task; aux st1 tasks2 previous1)
         | (tasks2,previous1) ->
-            let uu____2294 = revert_many st1 previous1  in
-            aux uu____2294 tasks2 []
+            let uu____2316 = revert_many st1 previous1  in
+            aux uu____2316 tasks2 []
          in
       aux st tasks (FStar_List.rev st.repl_deps_stack)
   
 let (json_debug : FStar_Util.json -> Prims.string) =
-  fun uu___76_2303  ->
-    match uu___76_2303 with
+  fun uu___76_2325  ->
+    match uu___76_2325 with
     | FStar_Util.JsonNull  -> "null"
     | FStar_Util.JsonBool b ->
         FStar_Util.format1 "bool (%s)" (if b then "true" else "false")
     | FStar_Util.JsonInt i ->
-        let uu____2307 = FStar_Util.string_of_int i  in
-        FStar_Util.format1 "int (%s)" uu____2307
+        let uu____2329 = FStar_Util.string_of_int i  in
+        FStar_Util.format1 "int (%s)" uu____2329
     | FStar_Util.JsonStr s -> FStar_Util.format1 "string (%s)" s
-    | FStar_Util.JsonList uu____2309 -> "list (...)"
-    | FStar_Util.JsonAssoc uu____2312 -> "dictionary (...)"
+    | FStar_Util.JsonList uu____2331 -> "list (...)"
+    | FStar_Util.JsonAssoc uu____2334 -> "dictionary (...)"
   
 exception UnexpectedJsonType of (Prims.string,FStar_Util.json)
   FStar_Pervasives_Native.tuple2 
 let (uu___is_UnexpectedJsonType : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
-    | UnexpectedJsonType uu____2332 -> true
-    | uu____2337 -> false
+    | UnexpectedJsonType uu____2354 -> true
+    | uu____2359 -> false
   
 let (__proj__UnexpectedJsonType__item__uu___ :
   Prims.exn -> (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2)
   =
   fun projectee  ->
-    match projectee with | UnexpectedJsonType uu____2352 -> uu____2352
+    match projectee with | UnexpectedJsonType uu____2374 -> uu____2374
   
-let js_fail : 'Auu____2363 . Prims.string -> FStar_Util.json -> 'Auu____2363
+let js_fail : 'Auu____2385 . Prims.string -> FStar_Util.json -> 'Auu____2385
   =
   fun expected  ->
     fun got  -> FStar_Exn.raise (UnexpectedJsonType (expected, got))
   
 let (js_int : FStar_Util.json -> Prims.int) =
-  fun uu___77_2378  ->
-    match uu___77_2378 with
+  fun uu___77_2400  ->
+    match uu___77_2400 with
     | FStar_Util.JsonInt i -> i
     | other -> js_fail "int" other
   
 let (js_str : FStar_Util.json -> Prims.string) =
-  fun uu___78_2385  ->
-    match uu___78_2385 with
+  fun uu___78_2407  ->
+    match uu___78_2407 with
     | FStar_Util.JsonStr s -> s
     | other -> js_fail "string" other
   
 let js_list :
-  'Auu____2394 .
-    (FStar_Util.json -> 'Auu____2394) ->
-      FStar_Util.json -> 'Auu____2394 Prims.list
+  'Auu____2416 .
+    (FStar_Util.json -> 'Auu____2416) ->
+      FStar_Util.json -> 'Auu____2416 Prims.list
   =
   fun k  ->
-    fun uu___79_2409  ->
-      match uu___79_2409 with
+    fun uu___79_2431  ->
+      match uu___79_2431 with
       | FStar_Util.JsonList l -> FStar_List.map k l
       | other -> js_fail "list" other
   
@@ -979,25 +995,25 @@ let (js_assoc :
   FStar_Util.json ->
     (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list)
   =
-  fun uu___80_2428  ->
-    match uu___80_2428 with
+  fun uu___80_2450  ->
+    match uu___80_2450 with
     | FStar_Util.JsonAssoc a -> a
     | other -> js_fail "dictionary" other
   
 let (js_pushkind : FStar_Util.json -> push_kind) =
   fun s  ->
-    let uu____2454 = js_str s  in
-    match uu____2454 with
+    let uu____2476 = js_str s  in
+    match uu____2476 with
     | "syntax" -> SyntaxCheck
     | "lax" -> LaxCheck
     | "full" -> FullCheck
-    | uu____2455 -> js_fail "push_kind" s
+    | uu____2477 -> js_fail "push_kind" s
   
 let (js_reductionrule : FStar_Util.json -> FStar_TypeChecker_Normalize.step)
   =
   fun s  ->
-    let uu____2461 = js_str s  in
-    match uu____2461 with
+    let uu____2483 = js_str s  in
+    match uu____2483 with
     | "beta" -> FStar_TypeChecker_Normalize.Beta
     | "delta" ->
         FStar_TypeChecker_Normalize.UnfoldUntil
@@ -1007,7 +1023,7 @@ let (js_reductionrule : FStar_Util.json -> FStar_TypeChecker_Normalize.step)
     | "reify" -> FStar_TypeChecker_Normalize.Reify
     | "pure-subterms" ->
         FStar_TypeChecker_Normalize.PureSubtermsWithinComputations
-    | uu____2462 -> js_fail "reduction rule" s
+    | uu____2484 -> js_fail "reduction rule" s
   
 type completion_context =
   | CKCode 
@@ -1016,11 +1032,11 @@ type completion_context =
   FStar_Pervasives_Native.tuple2 [@@deriving show]
 let (uu___is_CKCode : completion_context -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CKCode  -> true | uu____2482 -> false
+    match projectee with | CKCode  -> true | uu____2504 -> false
   
 let (uu___is_CKOption : completion_context -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CKOption _0 -> true | uu____2489 -> false
+    match projectee with | CKOption _0 -> true | uu____2511 -> false
   
 let (__proj__CKOption__item___0 : completion_context -> Prims.bool) =
   fun projectee  -> match projectee with | CKOption _0 -> _0 
@@ -1028,7 +1044,7 @@ let (uu___is_CKModuleOrNamespace : completion_context -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | CKModuleOrNamespace _0 -> true
-    | uu____2507 -> false
+    | uu____2529 -> false
   
 let (__proj__CKModuleOrNamespace__item___0 :
   completion_context ->
@@ -1040,8 +1056,8 @@ let (js_optional_completion_context :
     match k with
     | FStar_Pervasives_Native.None  -> CKCode
     | FStar_Pervasives_Native.Some k1 ->
-        let uu____2537 = js_str k1  in
-        (match uu____2537 with
+        let uu____2559 = js_str k1  in
+        (match uu____2559 with
          | "symbol" -> CKCode
          | "code" -> CKCode
          | "set-options" -> CKOption false
@@ -1050,7 +1066,7 @@ let (js_optional_completion_context :
          | "let-open" -> CKModuleOrNamespace (true, true)
          | "include" -> CKModuleOrNamespace (true, false)
          | "module-alias" -> CKModuleOrNamespace (true, false)
-         | uu____2538 ->
+         | uu____2560 ->
              js_fail
                "completion context (code, set-options, reset-options, open, let-open, include, module-alias)"
                k1)
@@ -1062,19 +1078,19 @@ type lookup_context =
   | LKCode [@@deriving show]
 let (uu___is_LKSymbolOnly : lookup_context -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LKSymbolOnly  -> true | uu____2544 -> false
+    match projectee with | LKSymbolOnly  -> true | uu____2566 -> false
   
 let (uu___is_LKModule : lookup_context -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LKModule  -> true | uu____2550 -> false
+    match projectee with | LKModule  -> true | uu____2572 -> false
   
 let (uu___is_LKOption : lookup_context -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LKOption  -> true | uu____2556 -> false
+    match projectee with | LKOption  -> true | uu____2578 -> false
   
 let (uu___is_LKCode : lookup_context -> Prims.bool) =
   fun projectee  ->
-    match projectee with | LKCode  -> true | uu____2562 -> false
+    match projectee with | LKCode  -> true | uu____2584 -> false
   
 let (js_optional_lookup_context :
   FStar_Util.json FStar_Pervasives_Native.option -> lookup_context) =
@@ -1082,8 +1098,8 @@ let (js_optional_lookup_context :
     match k with
     | FStar_Pervasives_Native.None  -> LKSymbolOnly
     | FStar_Pervasives_Native.Some k1 ->
-        let uu____2573 = js_str k1  in
-        (match uu____2573 with
+        let uu____2595 = js_str k1  in
+        (match uu____2595 with
          | "symbol-only" -> LKSymbolOnly
          | "code" -> LKCode
          | "set-options" -> LKOption
@@ -1092,7 +1108,7 @@ let (js_optional_lookup_context :
          | "let-open" -> LKModule
          | "include" -> LKModule
          | "module-alias" -> LKModule
-         | uu____2574 ->
+         | uu____2596 ->
              js_fail
                "lookup context (symbol-only, code, set-options, reset-options, open, let-open, include, module-alias)"
                k1)
@@ -1126,33 +1142,33 @@ and query = {
   qid: Prims.string }[@@deriving show]
 let (uu___is_Exit : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Exit  -> true | uu____2671 -> false
+    match projectee with | Exit  -> true | uu____2693 -> false
   
 let (uu___is_DescribeProtocol : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | DescribeProtocol  -> true | uu____2677 -> false
+    match projectee with | DescribeProtocol  -> true | uu____2699 -> false
   
 let (uu___is_DescribeRepl : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | DescribeRepl  -> true | uu____2683 -> false
+    match projectee with | DescribeRepl  -> true | uu____2705 -> false
   
 let (uu___is_Segment : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Segment _0 -> true | uu____2690 -> false
+    match projectee with | Segment _0 -> true | uu____2712 -> false
   
 let (__proj__Segment__item___0 : query' -> Prims.string) =
   fun projectee  -> match projectee with | Segment _0 -> _0 
 let (uu___is_Pop : query' -> Prims.bool) =
-  fun projectee  -> match projectee with | Pop  -> true | uu____2703 -> false 
+  fun projectee  -> match projectee with | Pop  -> true | uu____2725 -> false 
 let (uu___is_Push : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Push _0 -> true | uu____2710 -> false
+    match projectee with | Push _0 -> true | uu____2732 -> false
   
 let (__proj__Push__item___0 : query' -> push_query) =
   fun projectee  -> match projectee with | Push _0 -> _0 
 let (uu___is_VfsAdd : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | VfsAdd _0 -> true | uu____2730 -> false
+    match projectee with | VfsAdd _0 -> true | uu____2752 -> false
   
 let (__proj__VfsAdd__item___0 :
   query' ->
@@ -1161,14 +1177,14 @@ let (__proj__VfsAdd__item___0 :
   = fun projectee  -> match projectee with | VfsAdd _0 -> _0 
 let (uu___is_AutoComplete : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | AutoComplete _0 -> true | uu____2766 -> false
+    match projectee with | AutoComplete _0 -> true | uu____2788 -> false
   
 let (__proj__AutoComplete__item___0 :
   query' -> (Prims.string,completion_context) FStar_Pervasives_Native.tuple2)
   = fun projectee  -> match projectee with | AutoComplete _0 -> _0 
 let (uu___is_Lookup : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Lookup _0 -> true | uu____2804 -> false
+    match projectee with | Lookup _0 -> true | uu____2826 -> false
   
 let (__proj__Lookup__item___0 :
   query' ->
@@ -1177,7 +1193,7 @@ let (__proj__Lookup__item___0 :
   = fun projectee  -> match projectee with | Lookup _0 -> _0 
 let (uu___is_Compute : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Compute _0 -> true | uu____2862 -> false
+    match projectee with | Compute _0 -> true | uu____2884 -> false
   
 let (__proj__Compute__item___0 :
   query' ->
@@ -1187,19 +1203,19 @@ let (__proj__Compute__item___0 :
   = fun projectee  -> match projectee with | Compute _0 -> _0 
 let (uu___is_Search : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Search _0 -> true | uu____2900 -> false
+    match projectee with | Search _0 -> true | uu____2922 -> false
   
 let (__proj__Search__item___0 : query' -> Prims.string) =
   fun projectee  -> match projectee with | Search _0 -> _0 
 let (uu___is_GenericError : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | GenericError _0 -> true | uu____2914 -> false
+    match projectee with | GenericError _0 -> true | uu____2936 -> false
   
 let (__proj__GenericError__item___0 : query' -> Prims.string) =
   fun projectee  -> match projectee with | GenericError _0 -> _0 
 let (uu___is_ProtocolViolation : query' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | ProtocolViolation _0 -> true | uu____2928 -> false
+    match projectee with | ProtocolViolation _0 -> true | uu____2950 -> false
   
 let (__proj__ProtocolViolation__item___0 : query' -> Prims.string) =
   fun projectee  -> match projectee with | ProtocolViolation _0 -> _0 
@@ -1214,26 +1230,26 @@ let (__proj__Mkquery__item__qid : query -> Prims.string) =
     | { qq = __fname__qq; qid = __fname__qid;_} -> __fname__qid
   
 let (query_needs_current_module : query' -> Prims.bool) =
-  fun uu___81_2954  ->
-    match uu___81_2954 with
+  fun uu___81_2976  ->
+    match uu___81_2976 with
     | Exit  -> false
     | DescribeProtocol  -> false
     | DescribeRepl  -> false
-    | Segment uu____2955 -> false
+    | Segment uu____2977 -> false
     | Pop  -> false
     | Push
-        { push_kind = uu____2956; push_code = uu____2957;
-          push_line = uu____2958; push_column = uu____2959;
+        { push_kind = uu____2978; push_code = uu____2979;
+          push_line = uu____2980; push_column = uu____2981;
           push_peek_only = false ;_}
         -> false
-    | VfsAdd uu____2960 -> false
-    | GenericError uu____2967 -> false
-    | ProtocolViolation uu____2968 -> false
-    | Push uu____2969 -> true
-    | AutoComplete uu____2970 -> true
-    | Lookup uu____2975 -> true
-    | Compute uu____2988 -> true
-    | Search uu____2997 -> true
+    | VfsAdd uu____2982 -> false
+    | GenericError uu____2989 -> false
+    | ProtocolViolation uu____2990 -> false
+    | Push uu____2991 -> true
+    | AutoComplete uu____2992 -> true
+    | Lookup uu____2997 -> true
+    | Compute uu____3010 -> true
+    | Search uu____3019 -> true
   
 let (interactive_protocol_vernum : Prims.int) = (Prims.parse_int "2") 
 let (interactive_protocol_features : Prims.string Prims.list) =
@@ -1255,17 +1271,18 @@ let (interactive_protocol_features : Prims.string Prims.list) =
   "search";
   "segment";
   "vfs-add";
-  "tactic-ranges"] 
+  "tactic-ranges";
+  "interrupt"] 
 exception InvalidQuery of Prims.string 
 let (uu___is_InvalidQuery : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
-    | InvalidQuery uu____3009 -> true
-    | uu____3010 -> false
+    | InvalidQuery uu____3031 -> true
+    | uu____3032 -> false
   
 let (__proj__InvalidQuery__item__uu___ : Prims.exn -> Prims.string) =
   fun projectee  ->
-    match projectee with | InvalidQuery uu____3017 -> uu____3017
+    match projectee with | InvalidQuery uu____3039 -> uu____3039
   
 type query_status =
   | QueryOK 
@@ -1273,216 +1290,216 @@ type query_status =
   | QueryViolatesProtocol [@@deriving show]
 let (uu___is_QueryOK : query_status -> Prims.bool) =
   fun projectee  ->
-    match projectee with | QueryOK  -> true | uu____3023 -> false
+    match projectee with | QueryOK  -> true | uu____3045 -> false
   
 let (uu___is_QueryNOK : query_status -> Prims.bool) =
   fun projectee  ->
-    match projectee with | QueryNOK  -> true | uu____3029 -> false
+    match projectee with | QueryNOK  -> true | uu____3051 -> false
   
 let (uu___is_QueryViolatesProtocol : query_status -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | QueryViolatesProtocol  -> true
-    | uu____3035 -> false
+    | uu____3057 -> false
   
 let try_assoc :
-  'Auu____3044 'Auu____3045 .
-    'Auu____3044 ->
-      ('Auu____3044,'Auu____3045) FStar_Pervasives_Native.tuple2 Prims.list
-        -> 'Auu____3045 FStar_Pervasives_Native.option
+  'Auu____3066 'Auu____3067 .
+    'Auu____3066 ->
+      ('Auu____3066,'Auu____3067) FStar_Pervasives_Native.tuple2 Prims.list
+        -> 'Auu____3067 FStar_Pervasives_Native.option
   =
   fun key  ->
     fun a  ->
-      let uu____3070 =
+      let uu____3092 =
         FStar_Util.try_find
-          (fun uu____3084  ->
-             match uu____3084 with | (k,uu____3090) -> k = key) a
+          (fun uu____3106  ->
+             match uu____3106 with | (k,uu____3112) -> k = key) a
          in
-      FStar_Util.map_option FStar_Pervasives_Native.snd uu____3070
+      FStar_Util.map_option FStar_Pervasives_Native.snd uu____3092
   
 let (wrap_js_failure :
   Prims.string -> Prims.string -> FStar_Util.json -> query) =
   fun qid  ->
     fun expected  ->
       fun got  ->
-        let uu____3110 =
-          let uu____3111 =
-            let uu____3112 = json_debug got  in
+        let uu____3132 =
+          let uu____3133 =
+            let uu____3134 = json_debug got  in
             FStar_Util.format2 "JSON decoding failed: expected %s, got %s"
-              expected uu____3112
+              expected uu____3134
              in
-          ProtocolViolation uu____3111  in
-        { qq = uu____3110; qid }
+          ProtocolViolation uu____3133  in
+        { qq = uu____3132; qid }
   
 let (unpack_interactive_query : FStar_Util.json -> query) =
   fun json  ->
     let assoc1 errloc key a =
-      let uu____3146 = try_assoc key a  in
-      match uu____3146 with
+      let uu____3168 = try_assoc key a  in
+      match uu____3168 with
       | FStar_Pervasives_Native.Some v1 -> v1
       | FStar_Pervasives_Native.None  ->
-          let uu____3150 =
-            let uu____3151 =
+          let uu____3172 =
+            let uu____3173 =
               FStar_Util.format2 "Missing key [%s] in %s." key errloc  in
-            InvalidQuery uu____3151  in
-          FStar_Exn.raise uu____3150
+            InvalidQuery uu____3173  in
+          FStar_Exn.raise uu____3172
        in
     let request = FStar_All.pipe_right json js_assoc  in
     let qid =
-      let uu____3166 = assoc1 "query" "query-id" request  in
-      FStar_All.pipe_right uu____3166 js_str  in
+      let uu____3188 = assoc1 "query" "query-id" request  in
+      FStar_All.pipe_right uu____3188 js_str  in
     try
       let query =
-        let uu____3175 = assoc1 "query" "query" request  in
-        FStar_All.pipe_right uu____3175 js_str  in
+        let uu____3197 = assoc1 "query" "query" request  in
+        FStar_All.pipe_right uu____3197 js_str  in
       let args =
-        let uu____3183 = assoc1 "query" "args" request  in
-        FStar_All.pipe_right uu____3183 js_assoc  in
+        let uu____3205 = assoc1 "query" "args" request  in
+        FStar_All.pipe_right uu____3205 js_assoc  in
       let arg k = assoc1 "[args]" k args  in
       let try_arg k =
-        let uu____3204 = try_assoc k args  in
-        match uu____3204 with
+        let uu____3226 = try_assoc k args  in
+        match uu____3226 with
         | FStar_Pervasives_Native.Some (FStar_Util.JsonNull ) ->
             FStar_Pervasives_Native.None
         | other -> other  in
-      let uu____3212 =
+      let uu____3234 =
         match query with
         | "exit" -> Exit
         | "pop" -> Pop
         | "describe-protocol" -> DescribeProtocol
         | "describe-repl" -> DescribeRepl
         | "segment" ->
-            let uu____3213 =
-              let uu____3214 = arg "code"  in
-              FStar_All.pipe_right uu____3214 js_str  in
-            Segment uu____3213
+            let uu____3235 =
+              let uu____3236 = arg "code"  in
+              FStar_All.pipe_right uu____3236 js_str  in
+            Segment uu____3235
         | "peek" ->
-            let uu____3215 =
-              let uu____3216 =
-                let uu____3217 = arg "kind"  in
-                FStar_All.pipe_right uu____3217 js_pushkind  in
-              let uu____3218 =
-                let uu____3219 = arg "code"  in
-                FStar_All.pipe_right uu____3219 js_str  in
-              let uu____3220 =
-                let uu____3221 = arg "line"  in
-                FStar_All.pipe_right uu____3221 js_int  in
-              let uu____3222 =
-                let uu____3223 = arg "column"  in
-                FStar_All.pipe_right uu____3223 js_int  in
-              {
-                push_kind = uu____3216;
-                push_code = uu____3218;
-                push_line = uu____3220;
-                push_column = uu____3222;
-                push_peek_only = (query = "peek")
-              }  in
-            Push uu____3215
-        | "push" ->
-            let uu____3224 =
-              let uu____3225 =
-                let uu____3226 = arg "kind"  in
-                FStar_All.pipe_right uu____3226 js_pushkind  in
-              let uu____3227 =
-                let uu____3228 = arg "code"  in
-                FStar_All.pipe_right uu____3228 js_str  in
-              let uu____3229 =
-                let uu____3230 = arg "line"  in
-                FStar_All.pipe_right uu____3230 js_int  in
-              let uu____3231 =
-                let uu____3232 = arg "column"  in
-                FStar_All.pipe_right uu____3232 js_int  in
-              {
-                push_kind = uu____3225;
-                push_code = uu____3227;
-                push_line = uu____3229;
-                push_column = uu____3231;
-                push_peek_only = (query = "peek")
-              }  in
-            Push uu____3224
-        | "autocomplete" ->
-            let uu____3233 =
+            let uu____3237 =
               let uu____3238 =
-                let uu____3239 = arg "partial-symbol"  in
-                FStar_All.pipe_right uu____3239 js_str  in
+                let uu____3239 = arg "kind"  in
+                FStar_All.pipe_right uu____3239 js_pushkind  in
               let uu____3240 =
-                let uu____3241 = try_arg "context"  in
-                FStar_All.pipe_right uu____3241
+                let uu____3241 = arg "code"  in
+                FStar_All.pipe_right uu____3241 js_str  in
+              let uu____3242 =
+                let uu____3243 = arg "line"  in
+                FStar_All.pipe_right uu____3243 js_int  in
+              let uu____3244 =
+                let uu____3245 = arg "column"  in
+                FStar_All.pipe_right uu____3245 js_int  in
+              {
+                push_kind = uu____3238;
+                push_code = uu____3240;
+                push_line = uu____3242;
+                push_column = uu____3244;
+                push_peek_only = (query = "peek")
+              }  in
+            Push uu____3237
+        | "push" ->
+            let uu____3246 =
+              let uu____3247 =
+                let uu____3248 = arg "kind"  in
+                FStar_All.pipe_right uu____3248 js_pushkind  in
+              let uu____3249 =
+                let uu____3250 = arg "code"  in
+                FStar_All.pipe_right uu____3250 js_str  in
+              let uu____3251 =
+                let uu____3252 = arg "line"  in
+                FStar_All.pipe_right uu____3252 js_int  in
+              let uu____3253 =
+                let uu____3254 = arg "column"  in
+                FStar_All.pipe_right uu____3254 js_int  in
+              {
+                push_kind = uu____3247;
+                push_code = uu____3249;
+                push_line = uu____3251;
+                push_column = uu____3253;
+                push_peek_only = (query = "peek")
+              }  in
+            Push uu____3246
+        | "autocomplete" ->
+            let uu____3255 =
+              let uu____3260 =
+                let uu____3261 = arg "partial-symbol"  in
+                FStar_All.pipe_right uu____3261 js_str  in
+              let uu____3262 =
+                let uu____3263 = try_arg "context"  in
+                FStar_All.pipe_right uu____3263
                   js_optional_completion_context
                  in
-              (uu____3238, uu____3240)  in
-            AutoComplete uu____3233
+              (uu____3260, uu____3262)  in
+            AutoComplete uu____3255
         | "lookup" ->
-            let uu____3246 =
-              let uu____3259 =
-                let uu____3260 = arg "symbol"  in
-                FStar_All.pipe_right uu____3260 js_str  in
-              let uu____3261 =
-                let uu____3262 = try_arg "context"  in
-                FStar_All.pipe_right uu____3262 js_optional_lookup_context
+            let uu____3268 =
+              let uu____3281 =
+                let uu____3282 = arg "symbol"  in
+                FStar_All.pipe_right uu____3282 js_str  in
+              let uu____3283 =
+                let uu____3284 = try_arg "context"  in
+                FStar_All.pipe_right uu____3284 js_optional_lookup_context
                  in
-              let uu____3267 =
-                let uu____3276 =
-                  let uu____3285 = try_arg "location"  in
-                  FStar_All.pipe_right uu____3285
+              let uu____3289 =
+                let uu____3298 =
+                  let uu____3307 = try_arg "location"  in
+                  FStar_All.pipe_right uu____3307
                     (FStar_Util.map_option js_assoc)
                    in
-                FStar_All.pipe_right uu____3276
+                FStar_All.pipe_right uu____3298
                   (FStar_Util.map_option
                      (fun loc  ->
-                        let uu____3343 =
-                          let uu____3344 = assoc1 "[location]" "filename" loc
+                        let uu____3365 =
+                          let uu____3366 = assoc1 "[location]" "filename" loc
                              in
-                          FStar_All.pipe_right uu____3344 js_str  in
-                        let uu____3345 =
-                          let uu____3346 = assoc1 "[location]" "line" loc  in
-                          FStar_All.pipe_right uu____3346 js_int  in
-                        let uu____3347 =
-                          let uu____3348 = assoc1 "[location]" "column" loc
+                          FStar_All.pipe_right uu____3366 js_str  in
+                        let uu____3367 =
+                          let uu____3368 = assoc1 "[location]" "line" loc  in
+                          FStar_All.pipe_right uu____3368 js_int  in
+                        let uu____3369 =
+                          let uu____3370 = assoc1 "[location]" "column" loc
                              in
-                          FStar_All.pipe_right uu____3348 js_int  in
-                        (uu____3343, uu____3345, uu____3347)))
+                          FStar_All.pipe_right uu____3370 js_int  in
+                        (uu____3365, uu____3367, uu____3369)))
                  in
-              let uu____3349 =
-                let uu____3352 = arg "requested-info"  in
-                FStar_All.pipe_right uu____3352 (js_list js_str)  in
-              (uu____3259, uu____3261, uu____3267, uu____3349)  in
-            Lookup uu____3246
+              let uu____3371 =
+                let uu____3374 = arg "requested-info"  in
+                FStar_All.pipe_right uu____3374 (js_list js_str)  in
+              (uu____3281, uu____3283, uu____3289, uu____3371)  in
+            Lookup uu____3268
         | "compute" ->
-            let uu____3365 =
-              let uu____3374 =
-                let uu____3375 = arg "term"  in
-                FStar_All.pipe_right uu____3375 js_str  in
-              let uu____3376 =
-                let uu____3381 = try_arg "rules"  in
-                FStar_All.pipe_right uu____3381
+            let uu____3387 =
+              let uu____3396 =
+                let uu____3397 = arg "term"  in
+                FStar_All.pipe_right uu____3397 js_str  in
+              let uu____3398 =
+                let uu____3403 = try_arg "rules"  in
+                FStar_All.pipe_right uu____3403
                   (FStar_Util.map_option (js_list js_reductionrule))
                  in
-              (uu____3374, uu____3376)  in
-            Compute uu____3365
+              (uu____3396, uu____3398)  in
+            Compute uu____3387
         | "search" ->
-            let uu____3396 =
-              let uu____3397 = arg "terms"  in
-              FStar_All.pipe_right uu____3397 js_str  in
-            Search uu____3396
+            let uu____3418 =
+              let uu____3419 = arg "terms"  in
+              FStar_All.pipe_right uu____3419 js_str  in
+            Search uu____3418
         | "vfs-add" ->
-            let uu____3398 =
-              let uu____3405 =
-                let uu____3408 = try_arg "filename"  in
-                FStar_All.pipe_right uu____3408
+            let uu____3420 =
+              let uu____3427 =
+                let uu____3430 = try_arg "filename"  in
+                FStar_All.pipe_right uu____3430
                   (FStar_Util.map_option js_str)
                  in
-              let uu____3415 =
-                let uu____3416 = arg "contents"  in
-                FStar_All.pipe_right uu____3416 js_str  in
-              (uu____3405, uu____3415)  in
-            VfsAdd uu____3398
-        | uu____3419 ->
-            let uu____3420 = FStar_Util.format1 "Unknown query '%s'" query
+              let uu____3437 =
+                let uu____3438 = arg "contents"  in
+                FStar_All.pipe_right uu____3438 js_str  in
+              (uu____3427, uu____3437)  in
+            VfsAdd uu____3420
+        | uu____3441 ->
+            let uu____3442 = FStar_Util.format1 "Unknown query '%s'" query
                in
-            ProtocolViolation uu____3420
+            ProtocolViolation uu____3442
          in
-      { qq = uu____3212; qid }
+      { qq = uu____3234; qid }
     with | InvalidQuery msg -> { qq = (ProtocolViolation msg); qid }
     | UnexpectedJsonType (expected,got) -> wrap_js_failure qid expected got
   
@@ -1494,8 +1511,8 @@ let (deserialize_interactive_query : FStar_Util.json -> query) =
   
 let (parse_interactive_query : Prims.string -> query) =
   fun query_str  ->
-    let uu____3445 = FStar_Util.json_of_string query_str  in
-    match uu____3445 with
+    let uu____3467 = FStar_Util.json_of_string query_str  in
+    match uu____3467 with
     | FStar_Pervasives_Native.None  ->
         { qq = (ProtocolViolation "Json parsing failed."); qid = "?" }
     | FStar_Pervasives_Native.Some request ->
@@ -1503,20 +1520,20 @@ let (parse_interactive_query : Prims.string -> query) =
   
 let (read_interactive_query : FStar_Util.stream_reader -> query) =
   fun stream  ->
-    let uu____3454 = FStar_Util.read_line stream  in
-    match uu____3454 with
+    let uu____3476 = FStar_Util.read_line stream  in
+    match uu____3476 with
     | FStar_Pervasives_Native.None  -> FStar_All.exit (Prims.parse_int "0")
     | FStar_Pervasives_Native.Some line -> parse_interactive_query line
   
 let json_of_opt :
-  'Auu____3464 .
-    ('Auu____3464 -> FStar_Util.json) ->
-      'Auu____3464 FStar_Pervasives_Native.option -> FStar_Util.json
+  'Auu____3486 .
+    ('Auu____3486 -> FStar_Util.json) ->
+      'Auu____3486 FStar_Pervasives_Native.option -> FStar_Util.json
   =
   fun json_of_a  ->
     fun opt_a  ->
-      let uu____3484 = FStar_Util.map_option json_of_a opt_a  in
-      FStar_Util.dflt FStar_Util.JsonNull uu____3484
+      let uu____3506 = FStar_Util.map_option json_of_a opt_a  in
+      FStar_Util.dflt FStar_Util.JsonNull uu____3506
   
 let (json_of_issue_level : FStar_Errors.issue_level -> FStar_Util.json) =
   fun i  ->
@@ -1529,39 +1546,39 @@ let (json_of_issue_level : FStar_Errors.issue_level -> FStar_Util.json) =
   
 let (json_of_issue : FStar_Errors.issue -> FStar_Util.json) =
   fun issue  ->
-    let uu____3497 =
-      let uu____3504 =
-        let uu____3511 =
-          let uu____3518 =
-            let uu____3523 =
-              let uu____3524 =
-                let uu____3527 =
+    let uu____3519 =
+      let uu____3526 =
+        let uu____3533 =
+          let uu____3540 =
+            let uu____3545 =
+              let uu____3546 =
+                let uu____3549 =
                   match issue.FStar_Errors.issue_range with
                   | FStar_Pervasives_Native.None  -> []
                   | FStar_Pervasives_Native.Some r ->
-                      let uu____3533 = FStar_Range.json_of_use_range r  in
-                      [uu____3533]
+                      let uu____3555 = FStar_Range.json_of_use_range r  in
+                      [uu____3555]
                    in
-                let uu____3534 =
+                let uu____3556 =
                   match issue.FStar_Errors.issue_range with
                   | FStar_Pervasives_Native.Some r when
-                      let uu____3540 = FStar_Range.def_range r  in
-                      let uu____3541 = FStar_Range.use_range r  in
-                      uu____3540 <> uu____3541 ->
-                      let uu____3542 = FStar_Range.json_of_def_range r  in
-                      [uu____3542]
-                  | uu____3543 -> []  in
-                FStar_List.append uu____3527 uu____3534  in
-              FStar_Util.JsonList uu____3524  in
-            ("ranges", uu____3523)  in
-          [uu____3518]  in
+                      let uu____3562 = FStar_Range.def_range r  in
+                      let uu____3563 = FStar_Range.use_range r  in
+                      uu____3562 <> uu____3563 ->
+                      let uu____3564 = FStar_Range.json_of_def_range r  in
+                      [uu____3564]
+                  | uu____3565 -> []  in
+                FStar_List.append uu____3549 uu____3556  in
+              FStar_Util.JsonList uu____3546  in
+            ("ranges", uu____3545)  in
+          [uu____3540]  in
         ("message", (FStar_Util.JsonStr (issue.FStar_Errors.issue_message)))
-          :: uu____3511
+          :: uu____3533
          in
       ("level", (json_of_issue_level issue.FStar_Errors.issue_level)) ::
-        uu____3504
+        uu____3526
        in
-    FStar_Util.JsonAssoc uu____3497
+    FStar_Util.JsonAssoc uu____3519
   
 type symbol_lookup_result =
   {
@@ -1615,45 +1632,45 @@ let (alist_of_symbol_lookup_result :
     (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list)
   =
   fun lr  ->
-    let uu____3712 =
-      let uu____3719 =
-        let uu____3724 =
+    let uu____3734 =
+      let uu____3741 =
+        let uu____3746 =
           json_of_opt FStar_Range.json_of_def_range lr.slr_def_range  in
-        ("defined-at", uu____3724)  in
-      let uu____3725 =
-        let uu____3732 =
-          let uu____3737 =
+        ("defined-at", uu____3746)  in
+      let uu____3747 =
+        let uu____3754 =
+          let uu____3759 =
             json_of_opt (fun _0_18  -> FStar_Util.JsonStr _0_18) lr.slr_typ
              in
-          ("type", uu____3737)  in
-        let uu____3738 =
-          let uu____3745 =
-            let uu____3750 =
+          ("type", uu____3759)  in
+        let uu____3760 =
+          let uu____3767 =
+            let uu____3772 =
               json_of_opt (fun _0_19  -> FStar_Util.JsonStr _0_19) lr.slr_doc
                in
-            ("documentation", uu____3750)  in
-          let uu____3751 =
-            let uu____3758 =
-              let uu____3763 =
+            ("documentation", uu____3772)  in
+          let uu____3773 =
+            let uu____3780 =
+              let uu____3785 =
                 json_of_opt (fun _0_20  -> FStar_Util.JsonStr _0_20)
                   lr.slr_def
                  in
-              ("definition", uu____3763)  in
-            [uu____3758]  in
-          uu____3745 :: uu____3751  in
-        uu____3732 :: uu____3738  in
-      uu____3719 :: uu____3725  in
-    ("name", (FStar_Util.JsonStr (lr.slr_name))) :: uu____3712
+              ("definition", uu____3785)  in
+            [uu____3780]  in
+          uu____3767 :: uu____3773  in
+        uu____3754 :: uu____3760  in
+      uu____3741 :: uu____3747  in
+    ("name", (FStar_Util.JsonStr (lr.slr_name))) :: uu____3734
   
 let (alist_of_protocol_info :
   (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list) =
   let js_version = FStar_Util.JsonInt interactive_protocol_vernum  in
   let js_features =
-    let uu____3796 =
+    let uu____3818 =
       FStar_List.map (fun _0_21  -> FStar_Util.JsonStr _0_21)
         interactive_protocol_features
        in
-    FStar_All.pipe_left (fun _0_22  -> FStar_Util.JsonList _0_22) uu____3796
+    FStar_All.pipe_left (fun _0_22  -> FStar_Util.JsonList _0_22) uu____3818
      in
   [("version", js_version); ("features", js_features)] 
 type fstar_option_permission_level =
@@ -1662,20 +1679,20 @@ type fstar_option_permission_level =
   | OptReadOnly [@@deriving show]
 let (uu___is_OptSet : fstar_option_permission_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | OptSet  -> true | uu____3818 -> false
+    match projectee with | OptSet  -> true | uu____3840 -> false
   
 let (uu___is_OptReset : fstar_option_permission_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | OptReset  -> true | uu____3824 -> false
+    match projectee with | OptReset  -> true | uu____3846 -> false
   
 let (uu___is_OptReadOnly : fstar_option_permission_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | OptReadOnly  -> true | uu____3830 -> false
+    match projectee with | OptReadOnly  -> true | uu____3852 -> false
   
 let (string_of_option_permission_level :
   fstar_option_permission_level -> Prims.string) =
-  fun uu___82_3835  ->
-    match uu___82_3835 with
+  fun uu___82_3857  ->
+    match uu___82_3857 with
     | OptSet  -> ""
     | OptReset  -> "requires #reset-options"
     | OptReadOnly  -> "read-only"
@@ -1778,20 +1795,20 @@ let (__proj__Mkfstar_option__item__opt_permission_level :
   
 let rec (kind_of_fstar_option_type : FStar_Options.opt_type -> Prims.string)
   =
-  fun uu___83_4028  ->
-    match uu___83_4028 with
-    | FStar_Options.Const uu____4029 -> "flag"
-    | FStar_Options.IntStr uu____4030 -> "int"
+  fun uu___83_4050  ->
+    match uu___83_4050 with
+    | FStar_Options.Const uu____4051 -> "flag"
+    | FStar_Options.IntStr uu____4052 -> "int"
     | FStar_Options.BoolStr  -> "bool"
-    | FStar_Options.PathStr uu____4031 -> "path"
-    | FStar_Options.SimpleStr uu____4032 -> "string"
-    | FStar_Options.EnumStr uu____4033 -> "enum"
-    | FStar_Options.OpenEnumStr uu____4036 -> "open enum"
-    | FStar_Options.PostProcessed (uu____4043,typ) ->
+    | FStar_Options.PathStr uu____4053 -> "path"
+    | FStar_Options.SimpleStr uu____4054 -> "string"
+    | FStar_Options.EnumStr uu____4055 -> "enum"
+    | FStar_Options.OpenEnumStr uu____4058 -> "open enum"
+    | FStar_Options.PostProcessed (uu____4065,typ) ->
         kind_of_fstar_option_type typ
     | FStar_Options.Accumulated typ -> kind_of_fstar_option_type typ
     | FStar_Options.ReverseAccumulated typ -> kind_of_fstar_option_type typ
-    | FStar_Options.WithSideEffect (uu____4053,typ) ->
+    | FStar_Options.WithSideEffect (uu____4075,typ) ->
         kind_of_fstar_option_type typ
   
 let rec (snippets_of_fstar_option :
@@ -1807,7 +1824,7 @@ let rec (snippets_of_fstar_option :
          in
       let rec arg_snippets_of_type typ1 =
         match typ1 with
-        | FStar_Options.Const uu____4101 -> [""]
+        | FStar_Options.Const uu____4123 -> [""]
         | FStar_Options.BoolStr  -> ["true"; "false"]
         | FStar_Options.IntStr desc -> [mk_field desc]
         | FStar_Options.PathStr desc -> [mk_field desc]
@@ -1815,29 +1832,29 @@ let rec (snippets_of_fstar_option :
         | FStar_Options.EnumStr strs -> strs
         | FStar_Options.OpenEnumStr (strs,desc) ->
             FStar_List.append strs [mk_field desc]
-        | FStar_Options.PostProcessed (uu____4114,elem_spec) ->
+        | FStar_Options.PostProcessed (uu____4136,elem_spec) ->
             arg_snippets_of_type elem_spec
         | FStar_Options.Accumulated elem_spec ->
             arg_snippets_of_type elem_spec
         | FStar_Options.ReverseAccumulated elem_spec ->
             arg_snippets_of_type elem_spec
-        | FStar_Options.WithSideEffect (uu____4124,elem_spec) ->
+        | FStar_Options.WithSideEffect (uu____4146,elem_spec) ->
             arg_snippets_of_type elem_spec
          in
-      let uu____4132 = arg_snippets_of_type typ  in
-      FStar_List.map (mk_snippet name) uu____4132
+      let uu____4154 = arg_snippets_of_type typ  in
+      FStar_List.map (mk_snippet name) uu____4154
   
 let rec (json_of_fstar_option_value :
   FStar_Options.option_val -> FStar_Util.json) =
-  fun uu___84_4139  ->
-    match uu___84_4139 with
+  fun uu___84_4161  ->
+    match uu___84_4161 with
     | FStar_Options.Bool b -> FStar_Util.JsonBool b
     | FStar_Options.String s -> FStar_Util.JsonStr s
     | FStar_Options.Path s -> FStar_Util.JsonStr s
     | FStar_Options.Int n1 -> FStar_Util.JsonInt n1
     | FStar_Options.List vs ->
-        let uu____4147 = FStar_List.map json_of_fstar_option_value vs  in
-        FStar_Util.JsonList uu____4147
+        let uu____4169 = FStar_List.map json_of_fstar_option_value vs  in
+        FStar_Util.JsonList uu____4169
     | FStar_Options.Unset  -> FStar_Util.JsonNull
   
 let (alist_of_fstar_option :
@@ -1845,49 +1862,49 @@ let (alist_of_fstar_option :
     (Prims.string,FStar_Util.json) FStar_Pervasives_Native.tuple2 Prims.list)
   =
   fun opt  ->
-    let uu____4161 =
-      let uu____4168 =
-        let uu____4175 =
-          let uu____4180 = json_of_fstar_option_value opt.opt_value  in
-          ("value", uu____4180)  in
-        let uu____4181 =
-          let uu____4188 =
-            let uu____4193 = json_of_fstar_option_value opt.opt_default  in
-            ("default", uu____4193)  in
-          let uu____4194 =
-            let uu____4201 =
-              let uu____4206 =
+    let uu____4183 =
+      let uu____4190 =
+        let uu____4197 =
+          let uu____4202 = json_of_fstar_option_value opt.opt_value  in
+          ("value", uu____4202)  in
+        let uu____4203 =
+          let uu____4210 =
+            let uu____4215 = json_of_fstar_option_value opt.opt_default  in
+            ("default", uu____4215)  in
+          let uu____4216 =
+            let uu____4223 =
+              let uu____4228 =
                 json_of_opt (fun _0_23  -> FStar_Util.JsonStr _0_23)
                   opt.opt_documentation
                  in
-              ("documentation", uu____4206)  in
-            let uu____4207 =
-              let uu____4214 =
-                let uu____4219 =
-                  let uu____4220 = kind_of_fstar_option_type opt.opt_type  in
-                  FStar_Util.JsonStr uu____4220  in
-                ("type", uu____4219)  in
-              [uu____4214;
+              ("documentation", uu____4228)  in
+            let uu____4229 =
+              let uu____4236 =
+                let uu____4241 =
+                  let uu____4242 = kind_of_fstar_option_type opt.opt_type  in
+                  FStar_Util.JsonStr uu____4242  in
+                ("type", uu____4241)  in
+              [uu____4236;
               ("permission-level",
                 (FStar_Util.JsonStr
                    (string_of_option_permission_level
                       opt.opt_permission_level)))]
                in
-            uu____4201 :: uu____4207  in
-          uu____4188 :: uu____4194  in
-        uu____4175 :: uu____4181  in
-      ("signature", (FStar_Util.JsonStr (opt.opt_sig))) :: uu____4168  in
-    ("name", (FStar_Util.JsonStr (opt.opt_name))) :: uu____4161
+            uu____4223 :: uu____4229  in
+          uu____4210 :: uu____4216  in
+        uu____4197 :: uu____4203  in
+      ("signature", (FStar_Util.JsonStr (opt.opt_sig))) :: uu____4190  in
+    ("name", (FStar_Util.JsonStr (opt.opt_name))) :: uu____4183
   
 let (json_of_fstar_option : fstar_option -> FStar_Util.json) =
   fun opt  ->
-    let uu____4258 = alist_of_fstar_option opt  in
-    FStar_Util.JsonAssoc uu____4258
+    let uu____4280 = alist_of_fstar_option opt  in
+    FStar_Util.JsonAssoc uu____4280
   
 let (write_json : FStar_Util.json -> unit) =
   fun json  ->
-    (let uu____4271 = FStar_Util.string_of_json json  in
-     FStar_Util.print_raw uu____4271);
+    (let uu____4293 = FStar_Util.string_of_json json  in
+     FStar_Util.print_raw uu____4293);
     FStar_Util.print_raw "\n"
   
 let (json_of_response :
@@ -1917,94 +1934,94 @@ let (write_response :
 let (json_of_message : Prims.string -> FStar_Util.json -> FStar_Util.json) =
   fun level  ->
     fun js_contents  ->
-      let uu____4334 =
-        let uu____4341 =
-          let uu____4348 =
-            let uu____4353 =
-              let uu____4354 = FStar_ST.op_Bang repl_current_qid  in
-              json_of_opt (fun _0_24  -> FStar_Util.JsonStr _0_24) uu____4354
+      let uu____4356 =
+        let uu____4363 =
+          let uu____4370 =
+            let uu____4375 =
+              let uu____4376 = FStar_ST.op_Bang repl_current_qid  in
+              json_of_opt (fun _0_24  -> FStar_Util.JsonStr _0_24) uu____4376
                in
-            ("query-id", uu____4353)  in
-          [uu____4348;
+            ("query-id", uu____4375)  in
+          [uu____4370;
           ("level", (FStar_Util.JsonStr level));
           ("contents", js_contents)]  in
-        ("kind", (FStar_Util.JsonStr "message")) :: uu____4341  in
-      FStar_Util.JsonAssoc uu____4334
+        ("kind", (FStar_Util.JsonStr "message")) :: uu____4363  in
+      FStar_Util.JsonAssoc uu____4356
   
 let forward_message :
-  'Auu____4412 .
-    (FStar_Util.json -> 'Auu____4412) ->
-      Prims.string -> FStar_Util.json -> 'Auu____4412
+  'Auu____4434 .
+    (FStar_Util.json -> 'Auu____4434) ->
+      Prims.string -> FStar_Util.json -> 'Auu____4434
   =
   fun callback  ->
     fun level  ->
       fun contents  ->
-        let uu____4433 = json_of_message level contents  in
-        callback uu____4433
+        let uu____4455 = json_of_message level contents  in
+        callback uu____4455
   
 let (json_of_hello : FStar_Util.json) =
   let js_version = FStar_Util.JsonInt interactive_protocol_vernum  in
   let js_features =
-    let uu____4436 =
+    let uu____4458 =
       FStar_List.map (fun _0_25  -> FStar_Util.JsonStr _0_25)
         interactive_protocol_features
        in
-    FStar_Util.JsonList uu____4436  in
+    FStar_Util.JsonList uu____4458  in
   FStar_Util.JsonAssoc (("kind", (FStar_Util.JsonStr "protocol-info")) ::
     alist_of_protocol_info)
   
 let (write_hello : unit -> unit) =
-  fun uu____4447  -> write_json json_of_hello 
+  fun uu____4469  -> write_json json_of_hello 
 let (sig_of_fstar_option :
   Prims.string -> FStar_Options.opt_type -> Prims.string) =
   fun name  ->
     fun typ  ->
       let flag = Prims.strcat "--" name  in
-      let uu____4459 = FStar_Options.desc_of_opt_type typ  in
-      match uu____4459 with
+      let uu____4481 = FStar_Options.desc_of_opt_type typ  in
+      match uu____4481 with
       | FStar_Pervasives_Native.None  -> flag
       | FStar_Pervasives_Native.Some arg_sig ->
           Prims.strcat flag (Prims.strcat " " arg_sig)
   
 let (fstar_options_list_cache : fstar_option Prims.list) =
   let defaults1 = FStar_Util.smap_of_list FStar_Options.defaults  in
-  let uu____4468 =
+  let uu____4490 =
     FStar_All.pipe_right FStar_Options.all_specs_with_types
       (FStar_List.filter_map
-         (fun uu____4497  ->
-            match uu____4497 with
+         (fun uu____4519  ->
+            match uu____4519 with
             | (_shortname,name,typ,doc1) ->
-                let uu____4512 = FStar_Util.smap_try_find defaults1 name  in
-                FStar_All.pipe_right uu____4512
+                let uu____4534 = FStar_Util.smap_try_find defaults1 name  in
+                FStar_All.pipe_right uu____4534
                   (FStar_Util.map_option
                      (fun default_value  ->
-                        let uu____4524 = sig_of_fstar_option name typ  in
-                        let uu____4525 = snippets_of_fstar_option name typ
+                        let uu____4546 = sig_of_fstar_option name typ  in
+                        let uu____4547 = snippets_of_fstar_option name typ
                            in
-                        let uu____4528 =
-                          let uu____4529 = FStar_Options.settable name  in
-                          if uu____4529
+                        let uu____4550 =
+                          let uu____4551 = FStar_Options.settable name  in
+                          if uu____4551
                           then OptSet
                           else
-                            (let uu____4531 = FStar_Options.resettable name
+                            (let uu____4553 = FStar_Options.resettable name
                                 in
-                             if uu____4531 then OptReset else OptReadOnly)
+                             if uu____4553 then OptReset else OptReadOnly)
                            in
                         {
                           opt_name = name;
-                          opt_sig = uu____4524;
+                          opt_sig = uu____4546;
                           opt_value = FStar_Options.Unset;
                           opt_default = default_value;
                           opt_type = typ;
-                          opt_snippets = uu____4525;
+                          opt_snippets = uu____4547;
                           opt_documentation =
                             (if doc1 = ""
                              then FStar_Pervasives_Native.None
                              else FStar_Pervasives_Native.Some doc1);
-                          opt_permission_level = uu____4528
+                          opt_permission_level = uu____4550
                         }))))
      in
-  FStar_All.pipe_right uu____4468
+  FStar_All.pipe_right uu____4490
     (FStar_List.sortWith
        (fun o1  ->
           fun o2  ->
@@ -2018,24 +2035,24 @@ let (fstar_options_map_cache : fstar_option FStar_Util.smap) =
   cache 
 let (update_option : fstar_option -> fstar_option) =
   fun opt  ->
-    let uu___98_4557 = opt  in
-    let uu____4558 = FStar_Options.get_option opt.opt_name  in
+    let uu___98_4579 = opt  in
+    let uu____4580 = FStar_Options.get_option opt.opt_name  in
     {
-      opt_name = (uu___98_4557.opt_name);
-      opt_sig = (uu___98_4557.opt_sig);
-      opt_value = uu____4558;
-      opt_default = (uu___98_4557.opt_default);
-      opt_type = (uu___98_4557.opt_type);
-      opt_snippets = (uu___98_4557.opt_snippets);
-      opt_documentation = (uu___98_4557.opt_documentation);
-      opt_permission_level = (uu___98_4557.opt_permission_level)
+      opt_name = (uu___98_4579.opt_name);
+      opt_sig = (uu___98_4579.opt_sig);
+      opt_value = uu____4580;
+      opt_default = (uu___98_4579.opt_default);
+      opt_type = (uu___98_4579.opt_type);
+      opt_snippets = (uu___98_4579.opt_snippets);
+      opt_documentation = (uu___98_4579.opt_documentation);
+      opt_permission_level = (uu___98_4579.opt_permission_level)
     }
   
 let (current_fstar_options :
   (fstar_option -> Prims.bool) -> fstar_option Prims.list) =
   fun filter1  ->
-    let uu____4571 = FStar_List.filter filter1 fstar_options_list_cache  in
-    FStar_List.map update_option uu____4571
+    let uu____4593 = FStar_List.filter filter1 fstar_options_list_cache  in
+    FStar_List.map update_option uu____4593
   
 let (trim_option_name :
   Prims.string -> (Prims.string,Prims.string) FStar_Pervasives_Native.tuple2)
@@ -2044,52 +2061,52 @@ let (trim_option_name :
     let opt_prefix = "--"  in
     if FStar_Util.starts_with opt_name opt_prefix
     then
-      let uu____4588 =
+      let uu____4610 =
         FStar_Util.substring_from opt_name (FStar_String.length opt_prefix)
          in
-      (opt_prefix, uu____4588)
+      (opt_prefix, uu____4610)
     else ("", opt_name)
   
 let (json_of_repl_state : repl_state -> FStar_Util.json) =
   fun st  ->
-    let filenames uu____4606 =
-      match uu____4606 with
-      | (task,uu____4614) ->
+    let filenames uu____4628 =
+      match uu____4628 with
+      | (task,uu____4636) ->
           (match task with
            | LDInterleaved (intf,impl) -> [intf.tf_fname; impl.tf_fname]
            | LDSingle intf_or_impl -> [intf_or_impl.tf_fname]
            | LDInterfaceOfCurrentFile intf -> [intf.tf_fname]
-           | PushFragment uu____4621 -> [])
+           | PushFragment uu____4643 -> [])
        in
-    let uu____4622 =
-      let uu____4629 =
-        let uu____4634 =
-          let uu____4635 =
-            let uu____4638 =
+    let uu____4644 =
+      let uu____4651 =
+        let uu____4656 =
+          let uu____4657 =
+            let uu____4660 =
               FStar_List.concatMap filenames st.repl_deps_stack  in
             FStar_List.map (fun _0_26  -> FStar_Util.JsonStr _0_26)
-              uu____4638
+              uu____4660
              in
-          FStar_Util.JsonList uu____4635  in
-        ("loaded-dependencies", uu____4634)  in
-      let uu____4645 =
-        let uu____4652 =
-          let uu____4657 =
-            let uu____4658 =
-              let uu____4661 =
-                current_fstar_options (fun uu____4666  -> true)  in
-              FStar_List.map json_of_fstar_option uu____4661  in
-            FStar_Util.JsonList uu____4658  in
-          ("options", uu____4657)  in
-        [uu____4652]  in
-      uu____4629 :: uu____4645  in
-    FStar_Util.JsonAssoc uu____4622
+          FStar_Util.JsonList uu____4657  in
+        ("loaded-dependencies", uu____4656)  in
+      let uu____4667 =
+        let uu____4674 =
+          let uu____4679 =
+            let uu____4680 =
+              let uu____4683 =
+                current_fstar_options (fun uu____4688  -> true)  in
+              FStar_List.map json_of_fstar_option uu____4683  in
+            FStar_Util.JsonList uu____4680  in
+          ("options", uu____4679)  in
+        [uu____4674]  in
+      uu____4651 :: uu____4667  in
+    FStar_Util.JsonAssoc uu____4644
   
 let with_printed_effect_args :
-  'Auu____4683 . (unit -> 'Auu____4683) -> 'Auu____4683 =
+  'Auu____4705 . (unit -> 'Auu____4705) -> 'Auu____4705 =
   fun k  ->
     FStar_Options.with_saved_options
-      (fun uu____4696  ->
+      (fun uu____4718  ->
          FStar_Options.set_option "print_effect_args"
            (FStar_Options.Bool true);
          k ())
@@ -2099,29 +2116,29 @@ let (term_to_string :
   fun tcenv  ->
     fun t  ->
       with_printed_effect_args
-        (fun uu____4709  ->
+        (fun uu____4731  ->
            FStar_TypeChecker_Normalize.term_to_string tcenv t)
   
 let (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun se  ->
     with_printed_effect_args
-      (fun uu____4716  -> FStar_Syntax_Print.sigelt_to_string se)
+      (fun uu____4738  -> FStar_Syntax_Print.sigelt_to_string se)
   
 let run_exit :
-  'Auu____4723 'Auu____4724 .
-    'Auu____4723 ->
+  'Auu____4745 'Auu____4746 .
+    'Auu____4745 ->
       ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-        ('Auu____4724,Prims.int) FStar_Util.either)
+        ('Auu____4746,Prims.int) FStar_Util.either)
         FStar_Pervasives_Native.tuple2
   =
   fun st  ->
     ((QueryOK, FStar_Util.JsonNull), (FStar_Util.Inr (Prims.parse_int "0")))
   
 let run_describe_protocol :
-  'Auu____4756 'Auu____4757 .
-    'Auu____4756 ->
+  'Auu____4778 'Auu____4779 .
+    'Auu____4778 ->
       ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-        ('Auu____4756,'Auu____4757) FStar_Util.either)
+        ('Auu____4778,'Auu____4779) FStar_Util.either)
         FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -2129,23 +2146,23 @@ let run_describe_protocol :
       (FStar_Util.Inl st))
   
 let run_describe_repl :
-  'Auu____4787 .
+  'Auu____4809 .
     repl_state ->
       ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-        (repl_state,'Auu____4787) FStar_Util.either)
+        (repl_state,'Auu____4809) FStar_Util.either)
         FStar_Pervasives_Native.tuple2
   =
   fun st  ->
-    let uu____4805 =
-      let uu____4810 = json_of_repl_state st  in (QueryOK, uu____4810)  in
-    (uu____4805, (FStar_Util.Inl st))
+    let uu____4827 =
+      let uu____4832 = json_of_repl_state st  in (QueryOK, uu____4832)  in
+    (uu____4827, (FStar_Util.Inl st))
   
 let run_protocol_violation :
-  'Auu____4827 'Auu____4828 .
-    'Auu____4827 ->
+  'Auu____4849 'Auu____4850 .
+    'Auu____4849 ->
       Prims.string ->
         ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-          ('Auu____4827,'Auu____4828) FStar_Util.either)
+          ('Auu____4849,'Auu____4850) FStar_Util.either)
           FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -2154,11 +2171,11 @@ let run_protocol_violation :
         (FStar_Util.Inl st))
   
 let run_generic_error :
-  'Auu____4867 'Auu____4868 .
-    'Auu____4867 ->
+  'Auu____4889 'Auu____4890 .
+    'Auu____4889 ->
       Prims.string ->
         ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-          ('Auu____4867,'Auu____4868) FStar_Util.either)
+          ('Auu____4889,'Auu____4890) FStar_Util.either)
           FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -2166,15 +2183,15 @@ let run_generic_error :
       ((QueryNOK, (FStar_Util.JsonStr message)), (FStar_Util.Inl st))
   
 let (collect_errors : unit -> FStar_Errors.issue Prims.list) =
-  fun uu____4905  ->
+  fun uu____4927  ->
     let errors = FStar_Errors.report_all ()  in FStar_Errors.clear (); errors
   
 let run_segment :
-  'Auu____4916 .
+  'Auu____4938 .
     repl_state ->
       Prims.string ->
         ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-          (repl_state,'Auu____4916) FStar_Util.either)
+          (repl_state,'Auu____4938) FStar_Util.either)
           FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -2185,56 +2202,56 @@ let run_segment :
           FStar_Parser_ParseIt.frag_line = (Prims.parse_int "1");
           FStar_Parser_ParseIt.frag_col = (Prims.parse_int "0")
         }  in
-      let collect_decls uu____4947 =
-        let uu____4948 = FStar_Parser_Driver.parse_fragment frag  in
-        match uu____4948 with
+      let collect_decls uu____4969 =
+        let uu____4970 = FStar_Parser_Driver.parse_fragment frag  in
+        match uu____4970 with
         | FStar_Parser_Driver.Empty  -> []
         | FStar_Parser_Driver.Decls decls -> decls
         | FStar_Parser_Driver.Modul (FStar_Parser_AST.Module
-            (uu____4954,decls)) -> decls
+            (uu____4976,decls)) -> decls
         | FStar_Parser_Driver.Modul (FStar_Parser_AST.Interface
-            (uu____4960,decls,uu____4962)) -> decls
+            (uu____4982,decls,uu____4984)) -> decls
          in
-      let uu____4967 =
-        with_captured_errors st.repl_env
-          (fun uu____4976  ->
-             let uu____4977 = collect_decls ()  in
+      let uu____4989 =
+        with_captured_errors st.repl_env FStar_Util.sigint_ignore
+          (fun uu____4998  ->
+             let uu____4999 = collect_decls ()  in
              FStar_All.pipe_left
-               (fun _0_27  -> FStar_Pervasives_Native.Some _0_27) uu____4977)
+               (fun _0_27  -> FStar_Pervasives_Native.Some _0_27) uu____4999)
          in
-      match uu____4967 with
+      match uu____4989 with
       | FStar_Pervasives_Native.None  ->
           let errors =
-            let uu____5005 = collect_errors ()  in
-            FStar_All.pipe_right uu____5005 (FStar_List.map json_of_issue)
+            let uu____5027 = collect_errors ()  in
+            FStar_All.pipe_right uu____5027 (FStar_List.map json_of_issue)
              in
           ((QueryNOK, (FStar_Util.JsonList errors)), (FStar_Util.Inl st))
       | FStar_Pervasives_Native.Some decls ->
           let json_of_decl decl =
-            let uu____5031 =
-              let uu____5038 =
-                let uu____5043 =
+            let uu____5053 =
+              let uu____5060 =
+                let uu____5065 =
                   FStar_Range.json_of_def_range
                     (FStar_Parser_AST.decl_drange decl)
                    in
-                ("def_range", uu____5043)  in
-              [uu____5038]  in
-            FStar_Util.JsonAssoc uu____5031  in
+                ("def_range", uu____5065)  in
+              [uu____5060]  in
+            FStar_Util.JsonAssoc uu____5053  in
           let js_decls =
-            let uu____5053 = FStar_List.map json_of_decl decls  in
+            let uu____5075 = FStar_List.map json_of_decl decls  in
             FStar_All.pipe_left (fun _0_28  -> FStar_Util.JsonList _0_28)
-              uu____5053
+              uu____5075
              in
           ((QueryOK, (FStar_Util.JsonAssoc [("decls", js_decls)])),
             (FStar_Util.Inl st))
   
 let run_vfs_add :
-  'Auu____5082 .
+  'Auu____5104 .
     repl_state ->
       Prims.string FStar_Pervasives_Native.option ->
         Prims.string ->
           ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-            (repl_state,'Auu____5082) FStar_Util.either)
+            (repl_state,'Auu____5104) FStar_Util.either)
             FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -2245,15 +2262,15 @@ let run_vfs_add :
         ((QueryOK, FStar_Util.JsonNull), (FStar_Util.Inl st))
   
 let run_pop :
-  'Auu____5128 .
+  'Auu____5150 .
     repl_state ->
       ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-        (repl_state,'Auu____5128) FStar_Util.either)
+        (repl_state,'Auu____5150) FStar_Util.either)
         FStar_Pervasives_Native.tuple2
   =
   fun st  ->
-    let uu____5146 = nothing_left_to_pop st  in
-    if uu____5146
+    let uu____5168 = nothing_left_to_pop st  in
+    if uu____5168
     then
       ((QueryNOK, (FStar_Util.JsonStr "Too many pops")), (FStar_Util.Inl st))
     else
@@ -2266,150 +2283,150 @@ let (load_deps :
       repl_state) FStar_Util.either)
   =
   fun st  ->
-    let uu____5192 =
-      with_captured_errors st.repl_env
+    let uu____5214 =
+      with_captured_errors st.repl_env FStar_Util.sigint_ignore
         (fun _env  ->
-           let uu____5218 = deps_and_repl_ld_tasks_of_our_file st.repl_fname
+           let uu____5240 = deps_and_repl_ld_tasks_of_our_file st.repl_fname
               in
            FStar_All.pipe_left
-             (fun _0_29  -> FStar_Pervasives_Native.Some _0_29) uu____5218)
+             (fun _0_29  -> FStar_Pervasives_Native.Some _0_29) uu____5240)
        in
-    match uu____5192 with
+    match uu____5214 with
     | FStar_Pervasives_Native.None  -> FStar_Util.Inr st
     | FStar_Pervasives_Native.Some (deps,tasks,dep_graph1) ->
         let st1 =
-          let uu___99_5309 = st  in
-          let uu____5310 =
+          let uu___99_5331 = st  in
+          let uu____5332 =
             FStar_TypeChecker_Env.set_dep_graph st.repl_env dep_graph1  in
           {
-            repl_line = (uu___99_5309.repl_line);
-            repl_column = (uu___99_5309.repl_column);
-            repl_fname = (uu___99_5309.repl_fname);
-            repl_deps_stack = (uu___99_5309.repl_deps_stack);
-            repl_curmod = (uu___99_5309.repl_curmod);
-            repl_env = uu____5310;
-            repl_stdin = (uu___99_5309.repl_stdin);
-            repl_names = (uu___99_5309.repl_names)
+            repl_line = (uu___99_5331.repl_line);
+            repl_column = (uu___99_5331.repl_column);
+            repl_fname = (uu___99_5331.repl_fname);
+            repl_deps_stack = (uu___99_5331.repl_deps_stack);
+            repl_curmod = (uu___99_5331.repl_curmod);
+            repl_env = uu____5332;
+            repl_stdin = (uu___99_5331.repl_stdin);
+            repl_names = (uu___99_5331.repl_names)
           }  in
-        let uu____5311 = run_repl_ld_transactions st1 tasks  in
-        (match uu____5311 with
+        let uu____5333 = run_repl_ld_transactions st1 tasks  in
+        (match uu____5333 with
          | FStar_Util.Inr st2 -> FStar_Util.Inr st2
          | FStar_Util.Inl st2 -> FStar_Util.Inl (st2, deps))
   
 let (rephrase_dependency_error : FStar_Errors.issue -> FStar_Errors.issue) =
   fun issue  ->
-    let uu___100_5347 = issue  in
-    let uu____5348 =
+    let uu___100_5369 = issue  in
+    let uu____5370 =
       FStar_Util.format1 "Error while computing or loading dependencies:\n%s"
         issue.FStar_Errors.issue_message
        in
     {
-      FStar_Errors.issue_message = uu____5348;
-      FStar_Errors.issue_level = (uu___100_5347.FStar_Errors.issue_level);
-      FStar_Errors.issue_range = (uu___100_5347.FStar_Errors.issue_range);
-      FStar_Errors.issue_number = (uu___100_5347.FStar_Errors.issue_number)
+      FStar_Errors.issue_message = uu____5370;
+      FStar_Errors.issue_level = (uu___100_5369.FStar_Errors.issue_level);
+      FStar_Errors.issue_range = (uu___100_5369.FStar_Errors.issue_range);
+      FStar_Errors.issue_number = (uu___100_5369.FStar_Errors.issue_number)
     }
   
 let run_push_without_deps :
-  'Auu____5355 .
+  'Auu____5377 .
     repl_state ->
       push_query ->
         ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-          (repl_state,'Auu____5355) FStar_Util.either)
+          (repl_state,'Auu____5377) FStar_Util.either)
           FStar_Pervasives_Native.tuple2
   =
   fun st  ->
     fun query  ->
       let set_nosynth_flag st1 flag =
-        let uu___101_5389 = st1  in
+        let uu___101_5411 = st1  in
         {
-          repl_line = (uu___101_5389.repl_line);
-          repl_column = (uu___101_5389.repl_column);
-          repl_fname = (uu___101_5389.repl_fname);
-          repl_deps_stack = (uu___101_5389.repl_deps_stack);
-          repl_curmod = (uu___101_5389.repl_curmod);
+          repl_line = (uu___101_5411.repl_line);
+          repl_column = (uu___101_5411.repl_column);
+          repl_fname = (uu___101_5411.repl_fname);
+          repl_deps_stack = (uu___101_5411.repl_deps_stack);
+          repl_curmod = (uu___101_5411.repl_curmod);
           repl_env =
-            (let uu___102_5391 = st1.repl_env  in
+            (let uu___102_5413 = st1.repl_env  in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___102_5391.FStar_TypeChecker_Env.solver);
+                 (uu___102_5413.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range =
-                 (uu___102_5391.FStar_TypeChecker_Env.range);
+                 (uu___102_5413.FStar_TypeChecker_Env.range);
                FStar_TypeChecker_Env.curmodule =
-                 (uu___102_5391.FStar_TypeChecker_Env.curmodule);
+                 (uu___102_5413.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___102_5391.FStar_TypeChecker_Env.gamma);
+                 (uu___102_5413.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___102_5391.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___102_5413.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___102_5391.FStar_TypeChecker_Env.modules);
+                 (uu___102_5413.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___102_5391.FStar_TypeChecker_Env.expected_typ);
+                 (uu___102_5413.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___102_5391.FStar_TypeChecker_Env.sigtab);
+                 (uu___102_5413.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.is_pattern =
-                 (uu___102_5391.FStar_TypeChecker_Env.is_pattern);
+                 (uu___102_5413.FStar_TypeChecker_Env.is_pattern);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___102_5391.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___102_5413.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___102_5391.FStar_TypeChecker_Env.effects);
+                 (uu___102_5413.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___102_5391.FStar_TypeChecker_Env.generalize);
+                 (uu___102_5413.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___102_5391.FStar_TypeChecker_Env.letrecs);
+                 (uu___102_5413.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___102_5391.FStar_TypeChecker_Env.top_level);
+                 (uu___102_5413.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___102_5391.FStar_TypeChecker_Env.check_uvars);
+                 (uu___102_5413.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq =
-                 (uu___102_5391.FStar_TypeChecker_Env.use_eq);
+                 (uu___102_5413.FStar_TypeChecker_Env.use_eq);
                FStar_TypeChecker_Env.is_iface =
-                 (uu___102_5391.FStar_TypeChecker_Env.is_iface);
+                 (uu___102_5413.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___102_5391.FStar_TypeChecker_Env.admit);
+                 (uu___102_5413.FStar_TypeChecker_Env.admit);
                FStar_TypeChecker_Env.lax =
-                 (uu___102_5391.FStar_TypeChecker_Env.lax);
+                 (uu___102_5413.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___102_5391.FStar_TypeChecker_Env.lax_universes);
+                 (uu___102_5413.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.failhard =
-                 (uu___102_5391.FStar_TypeChecker_Env.failhard);
+                 (uu___102_5413.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth = flag;
                FStar_TypeChecker_Env.tc_term =
-                 (uu___102_5391.FStar_TypeChecker_Env.tc_term);
+                 (uu___102_5413.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___102_5391.FStar_TypeChecker_Env.type_of);
+                 (uu___102_5413.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___102_5391.FStar_TypeChecker_Env.universe_of);
+                 (uu___102_5413.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___102_5391.FStar_TypeChecker_Env.check_type_of);
+                 (uu___102_5413.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___102_5391.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___102_5413.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___102_5391.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___102_5413.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___102_5391.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___102_5413.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___102_5391.FStar_TypeChecker_Env.proof_ns);
+                 (uu___102_5413.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___102_5391.FStar_TypeChecker_Env.synth_hook);
+                 (uu___102_5413.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___102_5391.FStar_TypeChecker_Env.splice);
+                 (uu___102_5413.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.is_native_tactic =
-                 (uu___102_5391.FStar_TypeChecker_Env.is_native_tactic);
+                 (uu___102_5413.FStar_TypeChecker_Env.is_native_tactic);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___102_5391.FStar_TypeChecker_Env.identifier_info);
+                 (uu___102_5413.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___102_5391.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___102_5413.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv =
-                 (uu___102_5391.FStar_TypeChecker_Env.dsenv);
+                 (uu___102_5413.FStar_TypeChecker_Env.dsenv);
                FStar_TypeChecker_Env.dep_graph =
-                 (uu___102_5391.FStar_TypeChecker_Env.dep_graph)
+                 (uu___102_5413.FStar_TypeChecker_Env.dep_graph)
              });
-          repl_stdin = (uu___101_5389.repl_stdin);
-          repl_names = (uu___101_5389.repl_names)
+          repl_stdin = (uu___101_5411.repl_stdin);
+          repl_names = (uu___101_5411.repl_names)
         }  in
-      let uu____5392 = query  in
-      match uu____5392 with
+      let uu____5414 = query  in
+      match uu____5414 with
       | { push_kind; push_code = text; push_line = line;
           push_column = column; push_peek_only = peek_only;_} ->
           let frag =
@@ -2420,35 +2437,35 @@ let run_push_without_deps :
             }  in
           (FStar_TypeChecker_Env.toggle_id_info st.repl_env true;
            (let st1 = set_nosynth_flag st peek_only  in
-            let uu____5413 =
+            let uu____5435 =
               run_repl_transaction st1 push_kind peek_only
                 (PushFragment frag)
                in
-            match uu____5413 with
+            match uu____5435 with
             | (success,st2) ->
                 let st3 = set_nosynth_flag st2 false  in
                 let status =
                   if success || peek_only then QueryOK else QueryNOK  in
                 let json_errors =
-                  let uu____5436 =
-                    let uu____5439 = collect_errors ()  in
-                    FStar_All.pipe_right uu____5439
+                  let uu____5458 =
+                    let uu____5461 = collect_errors ()  in
+                    FStar_All.pipe_right uu____5461
                       (FStar_List.map json_of_issue)
                      in
-                  FStar_Util.JsonList uu____5436  in
+                  FStar_Util.JsonList uu____5458  in
                 let st4 =
                   if success
                   then
-                    let uu___103_5447 = st3  in
+                    let uu___103_5469 = st3  in
                     {
                       repl_line = line;
                       repl_column = column;
-                      repl_fname = (uu___103_5447.repl_fname);
-                      repl_deps_stack = (uu___103_5447.repl_deps_stack);
-                      repl_curmod = (uu___103_5447.repl_curmod);
-                      repl_env = (uu___103_5447.repl_env);
-                      repl_stdin = (uu___103_5447.repl_stdin);
-                      repl_names = (uu___103_5447.repl_names)
+                      repl_fname = (uu___103_5469.repl_fname);
+                      repl_deps_stack = (uu___103_5469.repl_deps_stack);
+                      repl_curmod = (uu___103_5469.repl_curmod);
+                      repl_env = (uu___103_5469.repl_env);
+                      repl_stdin = (uu___103_5469.repl_stdin);
+                      repl_names = (uu___103_5469.repl_names)
                     }
                   else st3  in
                 ((status, json_errors), (FStar_Util.Inl st4))))
@@ -2462,11 +2479,11 @@ let (capitalize : Prims.string -> Prims.string) =
          FStar_String.substring str (Prims.parse_int "0")
            (Prims.parse_int "1")
           in
-       let uu____5464 =
+       let uu____5486 =
          FStar_String.substring str (Prims.parse_int "1")
            ((FStar_String.length str) - (Prims.parse_int "1"))
           in
-       Prims.strcat (FStar_String.uppercase first) uu____5464)
+       Prims.strcat (FStar_String.uppercase first) uu____5486)
   
 let (add_module_completions :
   Prims.string ->
@@ -2479,17 +2496,17 @@ let (add_module_completions :
       fun table  ->
         let mods = FStar_Parser_Dep.build_inclusion_candidates_list ()  in
         let loaded_mods_set =
-          let uu____5494 = FStar_Util.psmap_empty ()  in
-          let uu____5497 =
-            let uu____5500 = FStar_Options.prims ()  in uu____5500 :: deps
+          let uu____5516 = FStar_Util.psmap_empty ()  in
+          let uu____5519 =
+            let uu____5522 = FStar_Options.prims ()  in uu____5522 :: deps
              in
           FStar_List.fold_left
             (fun acc  ->
                fun dep1  ->
-                 let uu____5510 = FStar_Parser_Dep.lowercase_module_name dep1
+                 let uu____5532 = FStar_Parser_Dep.lowercase_module_name dep1
                     in
-                 FStar_Util.psmap_add acc uu____5510 true) uu____5494
-            uu____5497
+                 FStar_Util.psmap_add acc uu____5532 true) uu____5516
+            uu____5519
            in
         let loaded modname =
           FStar_Util.psmap_find_default loaded_mods_set modname false  in
@@ -2497,77 +2514,77 @@ let (add_module_completions :
            in
         FStar_List.fold_left
           (fun table1  ->
-             fun uu____5528  ->
-               match uu____5528 with
+             fun uu____5550  ->
+               match uu____5550 with
                | (modname,mod_path) ->
                    let mod_key = FStar_String.lowercase modname  in
                    if this_mod_key = mod_key
                    then table1
                    else
                      (let ns_query =
-                        let uu____5540 = capitalize modname  in
-                        FStar_Util.split uu____5540 "."  in
-                      let uu____5541 = loaded mod_key  in
+                        let uu____5562 = capitalize modname  in
+                        FStar_Util.split uu____5562 "."  in
+                      let uu____5563 = loaded mod_key  in
                       FStar_Interactive_CompletionTable.register_module_path
-                        table1 uu____5541 mod_path ns_query)) table
+                        table1 uu____5563 mod_path ns_query)) table
           (FStar_List.rev mods)
   
 let run_push_with_deps :
-  'Auu____5552 .
+  'Auu____5574 .
     repl_state ->
       push_query ->
         ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-          (repl_state,'Auu____5552) FStar_Util.either)
+          (repl_state,'Auu____5574) FStar_Util.either)
           FStar_Pervasives_Native.tuple2
   =
   fun st  ->
     fun query  ->
-      (let uu____5576 = FStar_Options.debug_any ()  in
-       if uu____5576
+      (let uu____5598 = FStar_Options.debug_any ()  in
+       if uu____5598
        then FStar_Util.print_string "Reloading dependencies"
        else ());
       FStar_TypeChecker_Env.toggle_id_info st.repl_env false;
-      (let uu____5579 = load_deps st  in
-       match uu____5579 with
+      (let uu____5601 = load_deps st  in
+       match uu____5601 with
        | FStar_Util.Inr st1 ->
            let errors =
-             let uu____5612 = collect_errors ()  in
-             FStar_List.map rephrase_dependency_error uu____5612  in
+             let uu____5634 = collect_errors ()  in
+             FStar_List.map rephrase_dependency_error uu____5634  in
            let js_errors =
              FStar_All.pipe_right errors (FStar_List.map json_of_issue)  in
            ((QueryNOK, (FStar_Util.JsonList js_errors)),
              (FStar_Util.Inl st1))
        | FStar_Util.Inl (st1,deps) ->
-           ((let uu____5643 = FStar_Options.restore_cmd_line_options false
+           ((let uu____5665 = FStar_Options.restore_cmd_line_options false
                 in
-             FStar_All.pipe_right uu____5643 (fun a241  -> ()));
+             FStar_All.pipe_right uu____5665 (fun a241  -> ()));
             (let names1 =
                add_module_completions st1.repl_fname deps st1.repl_names  in
              run_push_without_deps
-               (let uu___104_5646 = st1  in
+               (let uu___104_5668 = st1  in
                 {
-                  repl_line = (uu___104_5646.repl_line);
-                  repl_column = (uu___104_5646.repl_column);
-                  repl_fname = (uu___104_5646.repl_fname);
-                  repl_deps_stack = (uu___104_5646.repl_deps_stack);
-                  repl_curmod = (uu___104_5646.repl_curmod);
-                  repl_env = (uu___104_5646.repl_env);
-                  repl_stdin = (uu___104_5646.repl_stdin);
+                  repl_line = (uu___104_5668.repl_line);
+                  repl_column = (uu___104_5668.repl_column);
+                  repl_fname = (uu___104_5668.repl_fname);
+                  repl_deps_stack = (uu___104_5668.repl_deps_stack);
+                  repl_curmod = (uu___104_5668.repl_curmod);
+                  repl_env = (uu___104_5668.repl_env);
+                  repl_stdin = (uu___104_5668.repl_stdin);
                   repl_names = names1
                 }) query)))
   
 let run_push :
-  'Auu____5653 .
+  'Auu____5675 .
     repl_state ->
       push_query ->
         ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-          (repl_state,'Auu____5653) FStar_Util.either)
+          (repl_state,'Auu____5675) FStar_Util.either)
           FStar_Pervasives_Native.tuple2
   =
   fun st  ->
     fun query  ->
-      let uu____5676 = nothing_left_to_pop st  in
-      if uu____5676
+      let uu____5698 = nothing_left_to_pop st  in
+      if uu____5698
       then run_push_with_deps st query
       else run_push_without_deps st query
   
@@ -2590,53 +2607,53 @@ let (run_symbol_lookup :
           let tcenv = st.repl_env  in
           let info_of_lid_str lid_str =
             let lid =
-              let uu____5764 =
+              let uu____5786 =
                 FStar_List.map FStar_Ident.id_of_text
                   (FStar_Util.split lid_str ".")
                  in
-              FStar_Ident.lid_of_ids uu____5764  in
+              FStar_Ident.lid_of_ids uu____5786  in
             let lid1 =
-              let uu____5768 =
+              let uu____5790 =
                 FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                   tcenv.FStar_TypeChecker_Env.dsenv lid
                  in
-              FStar_All.pipe_left (FStar_Util.dflt lid) uu____5768  in
-            let uu____5773 = FStar_TypeChecker_Env.try_lookup_lid tcenv lid1
+              FStar_All.pipe_left (FStar_Util.dflt lid) uu____5790  in
+            let uu____5795 = FStar_TypeChecker_Env.try_lookup_lid tcenv lid1
                in
-            FStar_All.pipe_right uu____5773
+            FStar_All.pipe_right uu____5795
               (FStar_Util.map_option
-                 (fun uu____5828  ->
-                    match uu____5828 with
-                    | ((uu____5847,typ),r) -> ((FStar_Util.Inr lid1), typ, r)))
+                 (fun uu____5850  ->
+                    match uu____5850 with
+                    | ((uu____5869,typ),r) -> ((FStar_Util.Inr lid1), typ, r)))
              in
           let docs_of_lid lid =
-            let uu____5866 =
+            let uu____5888 =
               FStar_Syntax_DsEnv.try_lookup_doc
                 tcenv.FStar_TypeChecker_Env.dsenv lid
                in
-            FStar_All.pipe_right uu____5866
+            FStar_All.pipe_right uu____5888
               (FStar_Util.map_option FStar_Pervasives_Native.fst)
              in
           let def_of_lid lid =
-            let uu____5897 = FStar_TypeChecker_Env.lookup_qname tcenv lid  in
-            FStar_Util.bind_opt uu____5897
-              (fun uu___85_5941  ->
-                 match uu___85_5941 with
-                 | (FStar_Util.Inr (se,uu____5963),uu____5964) ->
-                     let uu____5993 = sigelt_to_string se  in
-                     FStar_Pervasives_Native.Some uu____5993
-                 | uu____5994 -> FStar_Pervasives_Native.None)
+            let uu____5919 = FStar_TypeChecker_Env.lookup_qname tcenv lid  in
+            FStar_Util.bind_opt uu____5919
+              (fun uu___85_5963  ->
+                 match uu___85_5963 with
+                 | (FStar_Util.Inr (se,uu____5985),uu____5986) ->
+                     let uu____6015 = sigelt_to_string se  in
+                     FStar_Pervasives_Native.Some uu____6015
+                 | uu____6016 -> FStar_Pervasives_Native.None)
              in
           let info_at_pos_opt =
             FStar_Util.bind_opt pos_opt
-              (fun uu____6046  ->
-                 match uu____6046 with
+              (fun uu____6068  ->
+                 match uu____6068 with
                  | (file,row,col) ->
                      FStar_TypeChecker_Err.info_at_pos tcenv file row col)
              in
           let info_opt =
             match info_at_pos_opt with
-            | FStar_Pervasives_Native.Some uu____6093 -> info_at_pos_opt
+            | FStar_Pervasives_Native.Some uu____6115 -> info_at_pos_opt
             | FStar_Pervasives_Native.None  ->
                 if symbol = ""
                 then FStar_Pervasives_Native.None
@@ -2653,21 +2670,21 @@ let (run_symbol_lookup :
                 let typ_str =
                   if FStar_List.mem "type" requested_info
                   then
-                    let uu____6221 = term_to_string tcenv typ  in
-                    FStar_Pervasives_Native.Some uu____6221
+                    let uu____6243 = term_to_string tcenv typ  in
+                    FStar_Pervasives_Native.Some uu____6243
                   else FStar_Pervasives_Native.None  in
                 let doc_str =
                   match name_or_lid with
                   | FStar_Util.Inr lid when
                       FStar_List.mem "documentation" requested_info ->
                       docs_of_lid lid
-                  | uu____6229 -> FStar_Pervasives_Native.None  in
+                  | uu____6251 -> FStar_Pervasives_Native.None  in
                 let def_str =
                   match name_or_lid with
                   | FStar_Util.Inr lid when
                       FStar_List.mem "definition" requested_info ->
                       def_of_lid lid
-                  | uu____6240 -> FStar_Pervasives_Native.None  in
+                  | uu____6262 -> FStar_Pervasives_Native.None  in
                 let def_range1 =
                   if FStar_List.mem "defined-at" requested_info
                   then FStar_Pervasives_Native.Some rng
@@ -2680,10 +2697,10 @@ let (run_symbol_lookup :
                     slr_doc = doc_str;
                     slr_def = def_str
                   }  in
-                let uu____6252 =
-                  let uu____6263 = alist_of_symbol_lookup_result result  in
-                  ("symbol", uu____6263)  in
-                FStar_Pervasives_Native.Some uu____6252
+                let uu____6274 =
+                  let uu____6285 = alist_of_symbol_lookup_result result  in
+                  ("symbol", uu____6285)  in
+                FStar_Pervasives_Native.Some uu____6274
              in
           match response with
           | FStar_Pervasives_Native.None  ->
@@ -2698,21 +2715,21 @@ let (run_option_lookup :
       FStar_Util.either)
   =
   fun opt_name  ->
-    let uu____6370 = trim_option_name opt_name  in
-    match uu____6370 with
-    | (uu____6389,trimmed_name) ->
-        let uu____6391 =
+    let uu____6392 = trim_option_name opt_name  in
+    match uu____6392 with
+    | (uu____6411,trimmed_name) ->
+        let uu____6413 =
           FStar_Util.smap_try_find fstar_options_map_cache trimmed_name  in
-        (match uu____6391 with
+        (match uu____6413 with
          | FStar_Pervasives_Native.None  ->
              FStar_Util.Inl (Prims.strcat "Unknown option:" opt_name)
          | FStar_Pervasives_Native.Some opt ->
-             let uu____6419 =
-               let uu____6430 =
-                 let uu____6437 = update_option opt  in
-                 alist_of_fstar_option uu____6437  in
-               ("option", uu____6430)  in
-             FStar_Util.Inr uu____6419)
+             let uu____6441 =
+               let uu____6452 =
+                 let uu____6459 = update_option opt  in
+                 alist_of_fstar_option uu____6459  in
+               ("option", uu____6452)  in
+             FStar_Util.Inr uu____6441)
   
 let (run_module_lookup :
   repl_state ->
@@ -2725,28 +2742,28 @@ let (run_module_lookup :
   fun st  ->
     fun symbol  ->
       let query = FStar_Util.split symbol "."  in
-      let uu____6481 =
+      let uu____6503 =
         FStar_Interactive_CompletionTable.find_module_or_ns st.repl_names
           query
          in
-      match uu____6481 with
+      match uu____6503 with
       | FStar_Pervasives_Native.None  ->
           FStar_Util.Inl "No such module or namespace"
       | FStar_Pervasives_Native.Some
           (FStar_Interactive_CompletionTable.Module mod_info) ->
-          let uu____6509 =
-            let uu____6520 =
+          let uu____6531 =
+            let uu____6542 =
               FStar_Interactive_CompletionTable.alist_of_mod_info mod_info
                in
-            ("module", uu____6520)  in
-          FStar_Util.Inr uu____6509
+            ("module", uu____6542)  in
+          FStar_Util.Inr uu____6531
       | FStar_Pervasives_Native.Some
           (FStar_Interactive_CompletionTable.Namespace ns_info) ->
-          let uu____6544 =
-            let uu____6555 =
+          let uu____6566 =
+            let uu____6577 =
               FStar_Interactive_CompletionTable.alist_of_ns_info ns_info  in
-            ("namespace", uu____6555)  in
-          FStar_Util.Inr uu____6544
+            ("namespace", uu____6577)  in
+          FStar_Util.Inr uu____6566
   
 let (run_code_lookup :
   repl_state ->
@@ -2764,13 +2781,13 @@ let (run_code_lookup :
     fun symbol  ->
       fun pos_opt  ->
         fun requested_info  ->
-          let uu____6632 = run_symbol_lookup st symbol pos_opt requested_info
+          let uu____6654 = run_symbol_lookup st symbol pos_opt requested_info
              in
-          match uu____6632 with
+          match uu____6654 with
           | FStar_Util.Inr alist -> FStar_Util.Inr alist
-          | FStar_Util.Inl uu____6692 ->
-              let uu____6703 = run_module_lookup st symbol  in
-              (match uu____6703 with
+          | FStar_Util.Inl uu____6714 ->
+              let uu____6725 = run_module_lookup st symbol  in
+              (match uu____6725 with
                | FStar_Util.Inr alist -> FStar_Util.Inr alist
                | FStar_Util.Inl err_msg ->
                    FStar_Util.Inl "No such symbol, module, or namespace.")
@@ -2801,7 +2818,7 @@ let (run_lookup' :
             | LKCode  -> run_code_lookup st symbol pos_opt requested_info
   
 let run_lookup :
-  'Auu____6869 .
+  'Auu____6891 .
     repl_state ->
       Prims.string ->
         lookup_context ->
@@ -2809,7 +2826,7 @@ let run_lookup :
             FStar_Pervasives_Native.option ->
             Prims.string Prims.list ->
               ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-                (repl_state,'Auu____6869) FStar_Util.either)
+                (repl_state,'Auu____6891) FStar_Util.either)
                 FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -2817,9 +2834,9 @@ let run_lookup :
       fun context  ->
         fun pos_opt  ->
           fun requested_info  ->
-            let uu____6927 =
+            let uu____6949 =
               run_lookup' st symbol context pos_opt requested_info  in
-            match uu____6927 with
+            match uu____6949 with
             | FStar_Util.Inl err_msg ->
                 ((QueryNOK, (FStar_Util.JsonStr err_msg)),
                   (FStar_Util.Inl st))
@@ -2829,47 +2846,47 @@ let run_lookup :
                       :: info))), (FStar_Util.Inl st))
   
 let code_autocomplete_mod_filter :
-  'Auu____7013 .
-    ('Auu____7013,FStar_Interactive_CompletionTable.mod_symbol)
+  'Auu____7035 .
+    ('Auu____7035,FStar_Interactive_CompletionTable.mod_symbol)
       FStar_Pervasives_Native.tuple2 ->
-      ('Auu____7013,FStar_Interactive_CompletionTable.mod_symbol)
+      ('Auu____7035,FStar_Interactive_CompletionTable.mod_symbol)
         FStar_Pervasives_Native.tuple2 FStar_Pervasives_Native.option
   =
-  fun uu___86_7028  ->
-    match uu___86_7028 with
-    | (uu____7033,FStar_Interactive_CompletionTable.Namespace uu____7034) ->
+  fun uu___86_7050  ->
+    match uu___86_7050 with
+    | (uu____7055,FStar_Interactive_CompletionTable.Namespace uu____7056) ->
         FStar_Pervasives_Native.None
-    | (uu____7039,FStar_Interactive_CompletionTable.Module
-       { FStar_Interactive_CompletionTable.mod_name = uu____7040;
-         FStar_Interactive_CompletionTable.mod_path = uu____7041;
+    | (uu____7061,FStar_Interactive_CompletionTable.Module
+       { FStar_Interactive_CompletionTable.mod_name = uu____7062;
+         FStar_Interactive_CompletionTable.mod_path = uu____7063;
          FStar_Interactive_CompletionTable.mod_loaded = true ;_})
         -> FStar_Pervasives_Native.None
     | (pth,FStar_Interactive_CompletionTable.Module md) ->
-        let uu____7048 =
-          let uu____7053 =
-            let uu____7054 =
-              let uu___105_7055 = md  in
-              let uu____7056 =
-                let uu____7057 =
+        let uu____7070 =
+          let uu____7075 =
+            let uu____7076 =
+              let uu___105_7077 = md  in
+              let uu____7078 =
+                let uu____7079 =
                   FStar_Interactive_CompletionTable.mod_name md  in
-                Prims.strcat uu____7057 "."  in
+                Prims.strcat uu____7079 "."  in
               {
-                FStar_Interactive_CompletionTable.mod_name = uu____7056;
+                FStar_Interactive_CompletionTable.mod_name = uu____7078;
                 FStar_Interactive_CompletionTable.mod_path =
-                  (uu___105_7055.FStar_Interactive_CompletionTable.mod_path);
+                  (uu___105_7077.FStar_Interactive_CompletionTable.mod_path);
                 FStar_Interactive_CompletionTable.mod_loaded =
-                  (uu___105_7055.FStar_Interactive_CompletionTable.mod_loaded)
+                  (uu___105_7077.FStar_Interactive_CompletionTable.mod_loaded)
               }  in
-            FStar_Interactive_CompletionTable.Module uu____7054  in
-          (pth, uu____7053)  in
-        FStar_Pervasives_Native.Some uu____7048
+            FStar_Interactive_CompletionTable.Module uu____7076  in
+          (pth, uu____7075)  in
+        FStar_Pervasives_Native.Some uu____7070
   
 let run_code_autocomplete :
-  'Auu____7068 .
+  'Auu____7090 .
     repl_state ->
       Prims.string ->
         ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-          (repl_state,'Auu____7068) FStar_Util.either)
+          (repl_state,'Auu____7090) FStar_Util.either)
           FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -2891,13 +2908,13 @@ let run_code_autocomplete :
       ((QueryOK, (FStar_Util.JsonList json)), (FStar_Util.Inl st))
   
 let run_module_autocomplete :
-  'Auu____7125 'Auu____7126 'Auu____7127 .
+  'Auu____7147 'Auu____7148 'Auu____7149 .
     repl_state ->
       Prims.string ->
-        'Auu____7125 ->
-          'Auu____7126 ->
+        'Auu____7147 ->
+          'Auu____7148 ->
             ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-              (repl_state,'Auu____7127) FStar_Util.either)
+              (repl_state,'Auu____7149) FStar_Util.either)
               FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -2926,12 +2943,12 @@ let (candidates_of_fstar_option :
   fun match_len  ->
     fun is_reset  ->
       fun opt  ->
-        let uu____7198 =
+        let uu____7220 =
           match opt.opt_permission_level with
           | OptSet  -> (true, "")
           | OptReset  -> (is_reset, "#reset-only")
           | OptReadOnly  -> (false, "read-only")  in
-        match uu____7198 with
+        match uu____7220 with
         | (may_set,explanation) ->
             let opt_type = kind_of_fstar_option_type opt.opt_type  in
             let annot =
@@ -2955,19 +2972,19 @@ let (candidates_of_fstar_option :
                     }))
   
 let run_option_autocomplete :
-  'Auu____7230 'Auu____7231 .
-    'Auu____7230 ->
+  'Auu____7252 'Auu____7253 .
+    'Auu____7252 ->
       Prims.string ->
         Prims.bool ->
           ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-            ('Auu____7230,'Auu____7231) FStar_Util.either)
+            ('Auu____7252,'Auu____7253) FStar_Util.either)
             FStar_Pervasives_Native.tuple2
   =
   fun st  ->
     fun search_term  ->
       fun is_reset  ->
-        let uu____7259 = trim_option_name search_term  in
-        match uu____7259 with
+        let uu____7281 = trim_option_name search_term  in
+        match uu____7281 with
         | ("--",trimmed_name) ->
             let matcher opt =
               FStar_Util.starts_with opt.opt_name trimmed_name  in
@@ -2982,18 +2999,18 @@ let run_option_autocomplete :
                 results
                in
             ((QueryOK, (FStar_Util.JsonList json)), (FStar_Util.Inl st))
-        | (uu____7314,uu____7315) ->
+        | (uu____7336,uu____7337) ->
             ((QueryNOK,
                (FStar_Util.JsonStr "Options should start with '--'")),
               (FStar_Util.Inl st))
   
 let run_autocomplete :
-  'Auu____7332 .
+  'Auu____7354 .
     repl_state ->
       Prims.string ->
         completion_context ->
           ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-            (repl_state,'Auu____7332) FStar_Util.either)
+            (repl_state,'Auu____7354) FStar_Util.either)
             FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -3007,51 +3024,57 @@ let run_autocomplete :
             run_module_autocomplete st search_term modules1 namespaces
   
 let run_and_rewind :
-  'Auu____7371 'Auu____7372 .
+  'Auu____7395 'Auu____7396 .
     repl_state ->
-      (repl_state -> 'Auu____7371) ->
-        ('Auu____7371,(repl_state,'Auu____7372) FStar_Util.either)
-          FStar_Pervasives_Native.tuple2
+      'Auu____7395 ->
+        (repl_state -> 'Auu____7395) ->
+          ('Auu____7395,(repl_state,'Auu____7396) FStar_Util.either)
+            FStar_Pervasives_Native.tuple2
   =
   fun st  ->
-    fun task  ->
-      let env' = push st.repl_env "#compute"  in
-      let results =
-        try
-          let uu____7413 = task st  in
-          FStar_All.pipe_left (fun _0_31  -> FStar_Util.Inl _0_31) uu____7413
-        with | e -> FStar_Util.Inr e  in
-      pop env' "#compute";
-      (match results with
-       | FStar_Util.Inl results1 ->
-           (results1,
-             (FStar_Util.Inl
-                (let uu___108_7441 = st  in
-                 {
-                   repl_line = (uu___108_7441.repl_line);
-                   repl_column = (uu___108_7441.repl_column);
-                   repl_fname = (uu___108_7441.repl_fname);
-                   repl_deps_stack = (uu___108_7441.repl_deps_stack);
-                   repl_curmod = (uu___108_7441.repl_curmod);
-                   repl_env = env';
-                   repl_stdin = (uu___108_7441.repl_stdin);
-                   repl_names = (uu___108_7441.repl_names)
-                 })))
-       | FStar_Util.Inr e -> FStar_Exn.raise e)
+    fun sigint_default  ->
+      fun task  ->
+        let env' = push st.repl_env "REPL run_and_rewind"  in
+        let results =
+          try
+            FStar_Util.with_sigint_handler FStar_Util.sigint_raise
+              (fun uu____7447  ->
+                 let uu____7448 = task st  in
+                 FStar_All.pipe_left (fun _0_31  -> FStar_Util.Inl _0_31)
+                   uu____7448)
+          with | FStar_Util.SigInt  -> FStar_Util.Inl sigint_default
+          | e -> FStar_Util.Inr e  in
+        pop env' "REPL run_and_rewind";
+        (match results with
+         | FStar_Util.Inl results1 ->
+             (results1,
+               (FStar_Util.Inl
+                  (let uu___108_7475 = st  in
+                   {
+                     repl_line = (uu___108_7475.repl_line);
+                     repl_column = (uu___108_7475.repl_column);
+                     repl_fname = (uu___108_7475.repl_fname);
+                     repl_deps_stack = (uu___108_7475.repl_deps_stack);
+                     repl_curmod = (uu___108_7475.repl_curmod);
+                     repl_env = env';
+                     repl_stdin = (uu___108_7475.repl_stdin);
+                     repl_names = (uu___108_7475.repl_names)
+                   })))
+         | FStar_Util.Inr e -> FStar_Exn.raise e)
   
 let run_with_parsed_and_tc_term :
-  'Auu____7467 'Auu____7468 'Auu____7469 .
+  'Auu____7501 'Auu____7502 'Auu____7503 .
     repl_state ->
       Prims.string ->
-        'Auu____7467 ->
-          'Auu____7468 ->
+        'Auu____7501 ->
+          'Auu____7502 ->
             (FStar_TypeChecker_Env.env ->
                FStar_Syntax_Syntax.term ->
                  (query_status,FStar_Util.json)
                    FStar_Pervasives_Native.tuple2)
               ->
               ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-                (repl_state,'Auu____7469) FStar_Util.either)
+                (repl_state,'Auu____7503) FStar_Util.either)
                 FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -3071,53 +3094,54 @@ let run_with_parsed_and_tc_term :
               match ses with
               | {
                   FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-                    ((uu____7562,{ FStar_Syntax_Syntax.lbname = uu____7563;
+                    ((uu____7596,{ FStar_Syntax_Syntax.lbname = uu____7597;
                                    FStar_Syntax_Syntax.lbunivs = univs1;
-                                   FStar_Syntax_Syntax.lbtyp = uu____7565;
-                                   FStar_Syntax_Syntax.lbeff = uu____7566;
+                                   FStar_Syntax_Syntax.lbtyp = uu____7599;
+                                   FStar_Syntax_Syntax.lbeff = uu____7600;
                                    FStar_Syntax_Syntax.lbdef = def;
-                                   FStar_Syntax_Syntax.lbattrs = uu____7568;
-                                   FStar_Syntax_Syntax.lbpos = uu____7569;_}::[]),uu____7570);
-                  FStar_Syntax_Syntax.sigrng = uu____7571;
-                  FStar_Syntax_Syntax.sigquals = uu____7572;
-                  FStar_Syntax_Syntax.sigmeta = uu____7573;
-                  FStar_Syntax_Syntax.sigattrs = uu____7574;_}::[] ->
+                                   FStar_Syntax_Syntax.lbattrs = uu____7602;
+                                   FStar_Syntax_Syntax.lbpos = uu____7603;_}::[]),uu____7604);
+                  FStar_Syntax_Syntax.sigrng = uu____7605;
+                  FStar_Syntax_Syntax.sigquals = uu____7606;
+                  FStar_Syntax_Syntax.sigmeta = uu____7607;
+                  FStar_Syntax_Syntax.sigattrs = uu____7608;_}::[] ->
                   FStar_Pervasives_Native.Some (univs1, def)
-              | uu____7617 -> FStar_Pervasives_Native.None  in
+              | uu____7651 -> FStar_Pervasives_Native.None  in
             let parse1 frag =
-              let uu____7638 =
+              let uu____7672 =
                 FStar_Parser_ParseIt.parse
                   (FStar_Parser_ParseIt.Toplevel frag)
                  in
-              match uu____7638 with
+              match uu____7672 with
               | FStar_Parser_ParseIt.ASTFragment
-                  (FStar_Util.Inr decls,uu____7644) ->
+                  (FStar_Util.Inr decls,uu____7678) ->
                   FStar_Pervasives_Native.Some decls
-              | uu____7669 -> FStar_Pervasives_Native.None  in
+              | uu____7703 -> FStar_Pervasives_Native.None  in
             let desugar env decls =
-              let uu____7687 =
-                let uu____7692 =
+              let uu____7721 =
+                let uu____7726 =
                   FStar_ToSyntax_ToSyntax.decls_to_sigelts decls  in
-                uu____7692 env.FStar_TypeChecker_Env.dsenv  in
-              FStar_Pervasives_Native.fst uu____7687  in
+                uu____7726 env.FStar_TypeChecker_Env.dsenv  in
+              FStar_Pervasives_Native.fst uu____7721  in
             let typecheck tcenv decls =
-              let uu____7716 = FStar_TypeChecker_Tc.tc_decls tcenv decls  in
-              match uu____7716 with | (ses,uu____7730,uu____7731) -> ses  in
+              let uu____7750 = FStar_TypeChecker_Tc.tc_decls tcenv decls  in
+              match uu____7750 with | (ses,uu____7764,uu____7765) -> ses  in
             run_and_rewind st
+              (QueryNOK, (FStar_Util.JsonStr "Computation interrupted"))
               (fun st1  ->
                  let tcenv = st1.repl_env  in
                  let frag = dummy_let_fragment term  in
                  match st1.repl_curmod with
                  | FStar_Pervasives_Native.None  ->
                      (QueryNOK, (FStar_Util.JsonStr "Current module unset"))
-                 | uu____7754 ->
-                     let uu____7755 = parse1 frag  in
-                     (match uu____7755 with
+                 | uu____7788 ->
+                     let uu____7789 = parse1 frag  in
+                     (match uu____7789 with
                       | FStar_Pervasives_Native.None  ->
                           (QueryNOK,
                             (FStar_Util.JsonStr "Could not parse this term"))
                       | FStar_Pervasives_Native.Some decls ->
-                          let aux uu____7780 =
+                          let aux uu____7814 =
                             let decls1 = desugar tcenv decls  in
                             let ses = typecheck tcenv decls1  in
                             match find_let_body ses with
@@ -3126,11 +3150,11 @@ let run_with_parsed_and_tc_term :
                                   (FStar_Util.JsonStr
                                      "Typechecking yielded an unexpected term"))
                             | FStar_Pervasives_Native.Some (univs1,def) ->
-                                let uu____7815 =
+                                let uu____7849 =
                                   FStar_Syntax_Subst.open_univ_vars univs1
                                     def
                                    in
-                                (match uu____7815 with
+                                (match uu____7849 with
                                  | (univs2,def1) ->
                                      let tcenv1 =
                                        FStar_TypeChecker_Env.push_univ_vars
@@ -3138,34 +3162,33 @@ let run_with_parsed_and_tc_term :
                                         in
                                      continuation tcenv1 def1)
                              in
-                          let uu____7827 = FStar_Options.trace_error ()  in
-                          if uu____7827
+                          let uu____7861 = FStar_Options.trace_error ()  in
+                          if uu____7861
                           then aux ()
                           else
                             (try aux ()
                              with
                              | e ->
-                                 let uu____7852 =
-                                   let uu____7853 =
-                                     FStar_Errors.issue_of_exn e  in
-                                   match uu____7853 with
-                                   | FStar_Pervasives_Native.Some issue ->
-                                       let uu____7857 =
-                                         FStar_Errors.format_issue issue  in
-                                       FStar_Util.JsonStr uu____7857
-                                   | FStar_Pervasives_Native.None  ->
-                                       FStar_Exn.raise e
+                                 let uu____7888 = FStar_Errors.issue_of_exn e
                                     in
-                                 (QueryNOK, uu____7852))))
+                                 (match uu____7888 with
+                                  | FStar_Pervasives_Native.Some issue ->
+                                      let uu____7896 =
+                                        let uu____7897 =
+                                          FStar_Errors.format_issue issue  in
+                                        FStar_Util.JsonStr uu____7897  in
+                                      (QueryNOK, uu____7896)
+                                  | FStar_Pervasives_Native.None  ->
+                                      FStar_Exn.raise e))))
   
 let run_compute :
-  'Auu____7866 .
+  'Auu____7910 .
     repl_state ->
       Prims.string ->
         FStar_TypeChecker_Normalize.step Prims.list
           FStar_Pervasives_Native.option ->
           ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-            (repl_state,'Auu____7866) FStar_Util.either)
+            (repl_state,'Auu____7910) FStar_Util.either)
             FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -3192,10 +3215,10 @@ let run_compute :
           (fun tcenv  ->
              fun def  ->
                let normalized = normalize_term1 tcenv rules1 def  in
-               let uu____7938 =
-                 let uu____7939 = term_to_string tcenv normalized  in
-                 FStar_Util.JsonStr uu____7939  in
-               (QueryOK, uu____7938))
+               let uu____7982 =
+                 let uu____7983 = term_to_string tcenv normalized  in
+                 FStar_Util.JsonStr uu____7983  in
+               (QueryOK, uu____7982))
   
 type search_term' =
   | NameContainsStr of Prims.string 
@@ -3205,13 +3228,13 @@ and search_term = {
   st_term: search_term' }[@@deriving show]
 let (uu___is_NameContainsStr : search_term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NameContainsStr _0 -> true | uu____7966 -> false
+    match projectee with | NameContainsStr _0 -> true | uu____8010 -> false
   
 let (__proj__NameContainsStr__item___0 : search_term' -> Prims.string) =
   fun projectee  -> match projectee with | NameContainsStr _0 -> _0 
 let (uu___is_TypeContainsLid : search_term' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | TypeContainsLid _0 -> true | uu____7980 -> false
+    match projectee with | TypeContainsLid _0 -> true | uu____8024 -> false
   
 let (__proj__TypeContainsLid__item___0 : search_term' -> FStar_Ident.lid) =
   fun projectee  -> match projectee with | TypeContainsLid _0 -> _0 
@@ -3228,8 +3251,8 @@ let (__proj__Mksearch_term__item__st_term : search_term -> search_term') =
         __fname__st_term
   
 let (st_cost : search_term' -> Prims.int) =
-  fun uu___87_8006  ->
-    match uu___87_8006 with
+  fun uu___87_8050  ->
+    match uu___87_8050 with
     | NameContainsStr str -> - (FStar_String.length str)
     | TypeContainsLid lid -> (Prims.parse_int "1")
   
@@ -3269,26 +3292,26 @@ let (__proj__Mksearch_candidate__item__sc_fvars :
   
 let (sc_of_lid : FStar_Ident.lid -> search_candidate) =
   fun lid  ->
-    let uu____8221 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-    let uu____8228 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-    { sc_lid = lid; sc_typ = uu____8221; sc_fvars = uu____8228 }
+    let uu____8265 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+    let uu____8272 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+    { sc_lid = lid; sc_typ = uu____8265; sc_fvars = uu____8272 }
   
 let (sc_typ :
   FStar_TypeChecker_Env.env -> search_candidate -> FStar_Syntax_Syntax.typ) =
   fun tcenv  ->
     fun sc  ->
-      let uu____8295 = FStar_ST.op_Bang sc.sc_typ  in
-      match uu____8295 with
+      let uu____8339 = FStar_ST.op_Bang sc.sc_typ  in
+      match uu____8339 with
       | FStar_Pervasives_Native.Some t -> t
       | FStar_Pervasives_Native.None  ->
           let typ =
-            let uu____8329 =
+            let uu____8373 =
               FStar_TypeChecker_Env.try_lookup_lid tcenv sc.sc_lid  in
-            match uu____8329 with
+            match uu____8373 with
             | FStar_Pervasives_Native.None  ->
                 FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
                   FStar_Pervasives_Native.None FStar_Range.dummyRange
-            | FStar_Pervasives_Native.Some ((uu____8350,typ),uu____8352) ->
+            | FStar_Pervasives_Native.Some ((uu____8394,typ),uu____8396) ->
                 typ
              in
           (FStar_ST.op_Colon_Equals sc.sc_typ
@@ -3301,13 +3324,13 @@ let (sc_fvars :
   =
   fun tcenv  ->
     fun sc  ->
-      let uu____8407 = FStar_ST.op_Bang sc.sc_fvars  in
-      match uu____8407 with
+      let uu____8451 = FStar_ST.op_Bang sc.sc_fvars  in
+      match uu____8451 with
       | FStar_Pervasives_Native.Some fv -> fv
       | FStar_Pervasives_Native.None  ->
           let fv =
-            let uu____8455 = sc_typ tcenv sc  in
-            FStar_Syntax_Free.fvars uu____8455  in
+            let uu____8499 = sc_typ tcenv sc  in
+            FStar_Syntax_Free.fvars uu____8499  in
           (FStar_ST.op_Colon_Equals sc.sc_fvars
              (FStar_Pervasives_Native.Some fv);
            fv)
@@ -3317,39 +3340,39 @@ let (json_of_search_result :
   fun tcenv  ->
     fun sc  ->
       let typ_str =
-        let uu____8501 = sc_typ tcenv sc  in term_to_string tcenv uu____8501
+        let uu____8545 = sc_typ tcenv sc  in term_to_string tcenv uu____8545
          in
-      let uu____8502 =
-        let uu____8509 =
-          let uu____8514 =
-            let uu____8515 =
-              let uu____8516 =
+      let uu____8546 =
+        let uu____8553 =
+          let uu____8558 =
+            let uu____8559 =
+              let uu____8560 =
                 FStar_Syntax_DsEnv.shorten_lid
                   tcenv.FStar_TypeChecker_Env.dsenv sc.sc_lid
                  in
-              uu____8516.FStar_Ident.str  in
-            FStar_Util.JsonStr uu____8515  in
-          ("lid", uu____8514)  in
-        [uu____8509; ("type", (FStar_Util.JsonStr typ_str))]  in
-      FStar_Util.JsonAssoc uu____8502
+              uu____8560.FStar_Ident.str  in
+            FStar_Util.JsonStr uu____8559  in
+          ("lid", uu____8558)  in
+        [uu____8553; ("type", (FStar_Util.JsonStr typ_str))]  in
+      FStar_Util.JsonAssoc uu____8546
   
 exception InvalidSearch of Prims.string 
 let (uu___is_InvalidSearch : Prims.exn -> Prims.bool) =
   fun projectee  ->
     match projectee with
-    | InvalidSearch uu____8538 -> true
-    | uu____8539 -> false
+    | InvalidSearch uu____8582 -> true
+    | uu____8583 -> false
   
 let (__proj__InvalidSearch__item__uu___ : Prims.exn -> Prims.string) =
   fun projectee  ->
-    match projectee with | InvalidSearch uu____8546 -> uu____8546
+    match projectee with | InvalidSearch uu____8590 -> uu____8590
   
 let run_search :
-  'Auu____8553 .
+  'Auu____8597 .
     repl_state ->
       Prims.string ->
         ((query_status,FStar_Util.json) FStar_Pervasives_Native.tuple2,
-          (repl_state,'Auu____8553) FStar_Util.either)
+          (repl_state,'Auu____8597) FStar_Util.either)
           FStar_Pervasives_Native.tuple2
   =
   fun st  ->
@@ -3362,8 +3385,8 @@ let run_search :
           | NameContainsStr str ->
               FStar_Util.contains (candidate.sc_lid).FStar_Ident.str str
           | TypeContainsLid lid ->
-              let uu____8594 = sc_fvars tcenv candidate  in
-              FStar_Util.set_mem lid uu____8594
+              let uu____8638 = sc_fvars tcenv candidate  in
+              FStar_Util.set_mem lid uu____8638
            in
         found <> term.st_negate  in
       let parse1 search_str1 =
@@ -3385,32 +3408,32 @@ let run_search :
           let parsed =
             if beg_quote <> end_quote
             then
-              let uu____8624 =
-                let uu____8625 =
+              let uu____8668 =
+                let uu____8669 =
                   FStar_Util.format1 "Improperly quoted search term: %s"
                     term1
                    in
-                InvalidSearch uu____8625  in
-              FStar_Exn.raise uu____8624
+                InvalidSearch uu____8669  in
+              FStar_Exn.raise uu____8668
             else
               if beg_quote
               then
-                (let uu____8627 = strip_quotes term1  in
-                 NameContainsStr uu____8627)
+                (let uu____8671 = strip_quotes term1  in
+                 NameContainsStr uu____8671)
               else
                 (let lid = FStar_Ident.lid_of_str term1  in
-                 let uu____8630 =
+                 let uu____8674 =
                    FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                      tcenv.FStar_TypeChecker_Env.dsenv lid
                     in
-                 match uu____8630 with
+                 match uu____8674 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____8633 =
-                       let uu____8634 =
+                     let uu____8677 =
+                       let uu____8678 =
                          FStar_Util.format1 "Unknown identifier: %s" term1
                           in
-                       InvalidSearch uu____8634  in
-                     FStar_Exn.raise uu____8633
+                       InvalidSearch uu____8678  in
+                     FStar_Exn.raise uu____8677
                  | FStar_Pervasives_Native.Some lid1 -> TypeContainsLid lid1)
              in
           { st_negate = negate; st_term = parsed }  in
@@ -3419,12 +3442,12 @@ let run_search :
         let cmp x y = (st_cost x.st_term) - (st_cost y.st_term)  in
         FStar_Util.sort_with cmp terms  in
       let pprint_one term =
-        let uu____8656 =
+        let uu____8700 =
           match term.st_term with
           | NameContainsStr s -> FStar_Util.format1 "\"%s\"" s
           | TypeContainsLid l -> FStar_Util.format1 "%s" l.FStar_Ident.str
            in
-        Prims.strcat (if term.st_negate then "-" else "") uu____8656  in
+        Prims.strcat (if term.st_negate then "-" else "") uu____8700  in
       let results =
         try
           let terms = parse1 search_str  in
@@ -3442,15 +3465,15 @@ let run_search :
           match results with
           | [] ->
               let kwds =
-                let uu____8725 = FStar_List.map pprint_one terms  in
-                FStar_Util.concat_l " " uu____8725  in
-              let uu____8728 =
-                let uu____8729 =
+                let uu____8769 = FStar_List.map pprint_one terms  in
+                FStar_Util.concat_l " " uu____8769  in
+              let uu____8772 =
+                let uu____8773 =
                   FStar_Util.format1 "No results found for query [%s]" kwds
                    in
-                InvalidSearch uu____8729  in
-              FStar_Exn.raise uu____8728
-          | uu____8734 -> (QueryOK, (FStar_Util.JsonList js))
+                InvalidSearch uu____8773  in
+              FStar_Exn.raise uu____8772
+          | uu____8778 -> (QueryOK, (FStar_Util.JsonList js))
         with | InvalidSearch s -> (QueryNOK, (FStar_Util.JsonStr s))  in
       (results, (FStar_Util.Inl st))
   
@@ -3485,8 +3508,8 @@ let (validate_query : repl_state -> query -> query) =
     fun q  ->
       match q.qq with
       | Push
-          { push_kind = SyntaxCheck ; push_code = uu____8832;
-            push_line = uu____8833; push_column = uu____8834;
+          { push_kind = SyntaxCheck ; push_code = uu____8876;
+            push_line = uu____8877; push_column = uu____8878;
             push_peek_only = false ;_}
           ->
           {
@@ -3495,12 +3518,12 @@ let (validate_query : repl_state -> query -> query) =
                  "Cannot use 'kind': 'syntax' with 'query': 'push'");
             qid = (q.qid)
           }
-      | uu____8835 ->
+      | uu____8879 ->
           (match st.repl_curmod with
            | FStar_Pervasives_Native.None  when
                query_needs_current_module q.qq ->
                { qq = (GenericError "Current module unset"); qid = (q.qid) }
-           | uu____8836 -> q)
+           | uu____8880 -> q)
   
 let (validate_and_run_query :
   repl_state ->
@@ -3524,8 +3547,8 @@ let (js_repl_eval :
   =
   fun st  ->
     fun query  ->
-      let uu____8906 = validate_and_run_query st query  in
-      match uu____8906 with
+      let uu____8950 = validate_and_run_query st query  in
+      match uu____8950 with
       | ((status,response),st_opt) ->
           let js_response = json_of_response query.qid status response  in
           (js_response, st_opt)
@@ -3538,8 +3561,8 @@ let (js_repl_eval_js :
   =
   fun st  ->
     fun query_js  ->
-      let uu____8965 = deserialize_interactive_query query_js  in
-      js_repl_eval st uu____8965
+      let uu____9009 = deserialize_interactive_query query_js  in
+      js_repl_eval st uu____9009
   
 let (js_repl_eval_str :
   repl_state ->
@@ -3549,18 +3572,18 @@ let (js_repl_eval_str :
   =
   fun st  ->
     fun query_str  ->
-      let uu____8984 =
-        let uu____8993 = parse_interactive_query query_str  in
-        js_repl_eval st uu____8993  in
-      match uu____8984 with
+      let uu____9028 =
+        let uu____9037 = parse_interactive_query query_str  in
+        js_repl_eval st uu____9037  in
+      match uu____9028 with
       | (js_response,st_opt) ->
-          let uu____9012 = FStar_Util.string_of_json js_response  in
-          (uu____9012, st_opt)
+          let uu____9056 = FStar_Util.string_of_json js_response  in
+          (uu____9056, st_opt)
   
 let (js_repl_init_opts : unit -> unit) =
-  fun uu____9021  ->
-    let uu____9022 = FStar_Options.parse_cmd_line ()  in
-    match uu____9022 with
+  fun uu____9065  ->
+    let uu____9066 = FStar_Options.parse_cmd_line ()  in
+    match uu____9066 with
     | (res,fnames) ->
         (match res with
          | FStar_Getopt.Error msg ->
@@ -3571,16 +3594,16 @@ let (js_repl_init_opts : unit -> unit) =
               | [] ->
                   failwith
                     "repl_init: No file name given in --ide invocation"
-              | h::uu____9037::uu____9038 ->
+              | h::uu____9081::uu____9082 ->
                   failwith
                     "repl_init: Too many file names given in --ide invocation"
-              | uu____9041 -> ()))
+              | uu____9085 -> ()))
   
 let rec (go : repl_state -> Prims.int) =
   fun st  ->
     let query = read_interactive_query st.repl_stdin  in
-    let uu____9050 = validate_and_run_query st query  in
-    match uu____9050 with
+    let uu____9094 = validate_and_run_query st query  in
+    match uu____9094 with
     | ((status,response),state_opt) ->
         (write_response query.qid status response;
          (match state_opt with
@@ -3590,21 +3613,21 @@ let rec (go : repl_state -> Prims.int) =
 let (interactive_error_handler : FStar_Errors.error_handler) =
   let issues = FStar_Util.mk_ref []  in
   let add_one1 e =
-    let uu____9094 =
-      let uu____9097 = FStar_ST.op_Bang issues  in e :: uu____9097  in
-    FStar_ST.op_Colon_Equals issues uu____9094  in
-  let count_errors uu____9203 =
-    let uu____9204 =
-      let uu____9207 = FStar_ST.op_Bang issues  in
+    let uu____9138 =
+      let uu____9141 = FStar_ST.op_Bang issues  in e :: uu____9141  in
+    FStar_ST.op_Colon_Equals issues uu____9138  in
+  let count_errors uu____9247 =
+    let uu____9248 =
+      let uu____9251 = FStar_ST.op_Bang issues  in
       FStar_List.filter
         (fun e  -> e.FStar_Errors.issue_level = FStar_Errors.EError)
-        uu____9207
+        uu____9251
        in
-    FStar_List.length uu____9204  in
-  let report uu____9268 =
-    let uu____9269 = FStar_ST.op_Bang issues  in
-    FStar_List.sortWith FStar_Errors.compare_issues uu____9269  in
-  let clear1 uu____9326 = FStar_ST.op_Colon_Equals issues []  in
+    FStar_List.length uu____9248  in
+  let report uu____9312 =
+    let uu____9313 = FStar_ST.op_Bang issues  in
+    FStar_List.sortWith FStar_Errors.compare_issues uu____9313  in
+  let clear1 uu____9370 = FStar_ST.op_Colon_Equals issues []  in
   {
     FStar_Errors.eh_add_one = add_one1;
     FStar_Errors.eh_count_errors = count_errors;
@@ -3624,8 +3647,8 @@ let (interactive_printer : (FStar_Util.json -> unit) -> FStar_Util.printer) =
         (fun label  ->
            fun get_string  ->
              fun get_json  ->
-               let uu____9408 = get_json ()  in
-               forward_message printer label uu____9408)
+               let uu____9452 = get_json ()  in
+               forward_message printer label uu____9452)
     }
   
 let (install_ide_mode_hooks : (FStar_Util.json -> unit) -> unit) =
@@ -3634,16 +3657,16 @@ let (install_ide_mode_hooks : (FStar_Util.json -> unit) -> unit) =
     FStar_Errors.set_handler interactive_error_handler
   
 let (initial_range : FStar_Range.range) =
-  let uu____9420 =
+  let uu____9464 =
     FStar_Range.mk_pos (Prims.parse_int "1") (Prims.parse_int "0")  in
-  let uu____9421 =
+  let uu____9465 =
     FStar_Range.mk_pos (Prims.parse_int "1") (Prims.parse_int "0")  in
-  FStar_Range.mk_range "<input>" uu____9420 uu____9421 
+  FStar_Range.mk_range "<input>" uu____9464 uu____9465 
 let (build_initial_repl_state : Prims.string -> repl_state) =
   fun filename  ->
     let env = FStar_Universal.init_env FStar_Parser_Dep.empty_deps  in
     let env1 = FStar_TypeChecker_Env.set_range env initial_range  in
-    let uu____9429 = FStar_Util.open_stdin ()  in
+    let uu____9473 = FStar_Util.open_stdin ()  in
     {
       repl_line = (Prims.parse_int "1");
       repl_column = (Prims.parse_int "0");
@@ -3651,40 +3674,41 @@ let (build_initial_repl_state : Prims.string -> repl_state) =
       repl_deps_stack = [];
       repl_curmod = FStar_Pervasives_Native.None;
       repl_env = env1;
-      repl_stdin = uu____9429;
+      repl_stdin = uu____9473;
       repl_names = FStar_Interactive_CompletionTable.empty
     }
   
-let interactive_mode' : 'Auu____9438 . repl_state -> 'Auu____9438 =
+let interactive_mode' : 'Auu____9482 . repl_state -> 'Auu____9482 =
   fun init_st  ->
     write_hello ();
     (let exit_code =
-       let uu____9446 =
+       let uu____9490 =
          (FStar_Options.record_hints ()) || (FStar_Options.use_hints ())  in
-       if uu____9446
+       if uu____9490
        then
-         let uu____9447 =
-           let uu____9448 = FStar_Options.file_list ()  in
-           FStar_List.hd uu____9448  in
-         FStar_SMTEncoding_Solver.with_hints_db uu____9447
-           (fun uu____9452  -> go init_st)
+         let uu____9491 =
+           let uu____9492 = FStar_Options.file_list ()  in
+           FStar_List.hd uu____9492  in
+         FStar_SMTEncoding_Solver.with_hints_db uu____9491
+           (fun uu____9496  -> go init_st)
        else go init_st  in
      FStar_All.exit exit_code)
   
 let (interactive_mode : Prims.string -> unit) =
   fun filename  ->
     install_ide_mode_hooks write_json;
-    (let uu____9461 =
-       let uu____9462 = FStar_Options.codegen ()  in
-       FStar_Option.isSome uu____9462  in
-     if uu____9461
+    FStar_Util.set_sigint_handler FStar_Util.sigint_ignore;
+    (let uu____9506 =
+       let uu____9507 = FStar_Options.codegen ()  in
+       FStar_Option.isSome uu____9507  in
+     if uu____9506
      then
        FStar_Errors.log_issue FStar_Range.dummyRange
          (FStar_Errors.Warning_IDEIgnoreCodeGen, "--ide: ignoring --codegen")
      else ());
     (let init1 = build_initial_repl_state filename  in
-     let uu____9467 = FStar_Options.trace_error ()  in
-     if uu____9467
+     let uu____9512 = FStar_Options.trace_error ()  in
+     if uu____9512
      then interactive_mode' init1
      else
        (try interactive_mode' init1

--- a/src/ocaml-output/FStar_SMTEncoding_Z3.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Z3.ml
@@ -54,33 +54,35 @@ let (z3hash_warning_message :
   fun uu____76  ->
     let run_proc_result =
       try
-        let uu____105 =
-          let uu____112 = FStar_Options.z3_exe ()  in
-          FStar_Util.run_proc uu____112 "-version" ""  in
-        FStar_Pervasives_Native.Some uu____105
-      with | uu____130 -> FStar_Pervasives_Native.None  in
+        let uu____87 =
+          let uu____88 = FStar_Options.z3_exe ()  in
+          FStar_Util.run_process "z3_version" uu____88 ["-version"]
+            FStar_Pervasives_Native.None
+           in
+        FStar_Pervasives_Native.Some uu____87
+      with | uu____94 -> FStar_Pervasives_Native.None  in
     match run_proc_result with
     | FStar_Pervasives_Native.None  ->
         FStar_Pervasives_Native.Some
           (FStar_Errors.Error_Z3InvocationError, "Could not run Z3")
-    | FStar_Pervasives_Native.Some (uu____153,out,uu____155) ->
-        let uu____162 = parse_z3_version_lines out  in
-        (match uu____162 with
+    | FStar_Pervasives_Native.Some out ->
+        let uu____106 = parse_z3_version_lines out  in
+        (match uu____106 with
          | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
          | FStar_Pervasives_Native.Some msg ->
              FStar_Pervasives_Native.Some
                (FStar_Errors.Warning_Z3InvocationWarning, msg))
   
 let (check_z3hash : unit -> unit) =
-  fun uu____184  ->
-    let uu____185 =
-      let uu____186 = FStar_ST.op_Bang _z3hash_checked  in
-      Prims.op_Negation uu____186  in
-    if uu____185
+  fun uu____128  ->
+    let uu____129 =
+      let uu____130 = FStar_ST.op_Bang _z3hash_checked  in
+      Prims.op_Negation uu____130  in
+    if uu____129
     then
       (FStar_ST.op_Colon_Equals _z3hash_checked true;
-       (let uu____234 = z3hash_warning_message ()  in
-        match uu____234 with
+       (let uu____178 = z3hash_warning_message ()  in
+        match uu____178 with
         | FStar_Pervasives_Native.None  -> ()
         | FStar_Pervasives_Native.Some (e,msg) ->
             let msg1 =
@@ -91,24 +93,30 @@ let (check_z3hash : unit -> unit) =
             FStar_Errors.log_issue FStar_Range.dummyRange (e, msg1)))
     else ()
   
-let (ini_params : unit -> Prims.string) =
-  fun uu____257  ->
+let (ini_params : unit -> Prims.string Prims.list) =
+  fun uu____203  ->
     check_z3hash ();
-    (let uu____259 =
-       let uu____262 =
-         let uu____265 =
-           let uu____268 =
-             let uu____269 =
-               let uu____270 = FStar_Options.z3_seed ()  in
-               FStar_Util.string_of_int uu____270  in
-             FStar_Util.format1 "smt.random_seed=%s" uu____269  in
-           [uu____268]  in
-         "-smt2 -in auto_config=false model=true smt.relevancy=2 smt.case_split=3"
-           :: uu____265
-          in
-       let uu____271 = FStar_Options.z3_cliopt ()  in
-       FStar_List.append uu____262 uu____271  in
-     FStar_String.concat " " uu____259)
+    (let uu____205 =
+       let uu____208 =
+         let uu____211 =
+           let uu____214 =
+             let uu____217 =
+               let uu____220 =
+                 let uu____223 =
+                   let uu____226 =
+                     let uu____227 =
+                       let uu____228 = FStar_Options.z3_seed ()  in
+                       FStar_Util.string_of_int uu____228  in
+                     FStar_Util.format1 "smt.random_seed=%s" uu____227  in
+                   [uu____226]  in
+                 "smt.case_split=3" :: uu____223  in
+               "smt.relevancy=2" :: uu____220  in
+             "model=true" :: uu____217  in
+           "auto_config=false" :: uu____214  in
+         "-in" :: uu____211  in
+       "-smt2" :: uu____208  in
+     let uu____229 = FStar_Options.z3_cliopt ()  in
+     FStar_List.append uu____205 uu____229)
   
 type label = Prims.string[@@deriving show]
 type unsat_core = Prims.string Prims.list FStar_Pervasives_Native.option
@@ -130,13 +138,13 @@ type z3status =
   | KILLED [@@deriving show]
 let (uu___is_UNSAT : z3status -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UNSAT _0 -> true | uu____322 -> false
+    match projectee with | UNSAT _0 -> true | uu____280 -> false
   
 let (__proj__UNSAT__item___0 : z3status -> unsat_core) =
   fun projectee  -> match projectee with | UNSAT _0 -> _0 
 let (uu___is_SAT : z3status -> Prims.bool) =
   fun projectee  ->
-    match projectee with | SAT _0 -> true | uu____342 -> false
+    match projectee with | SAT _0 -> true | uu____300 -> false
   
 let (__proj__SAT__item___0 :
   z3status ->
@@ -146,7 +154,7 @@ let (__proj__SAT__item___0 :
   = fun projectee  -> match projectee with | SAT _0 -> _0 
 let (uu___is_UNKNOWN : z3status -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UNKNOWN _0 -> true | uu____380 -> false
+    match projectee with | UNKNOWN _0 -> true | uu____338 -> false
   
 let (__proj__UNKNOWN__item___0 :
   z3status ->
@@ -156,7 +164,7 @@ let (__proj__UNKNOWN__item___0 :
   = fun projectee  -> match projectee with | UNKNOWN _0 -> _0 
 let (uu___is_TIMEOUT : z3status -> Prims.bool) =
   fun projectee  ->
-    match projectee with | TIMEOUT _0 -> true | uu____418 -> false
+    match projectee with | TIMEOUT _0 -> true | uu____376 -> false
   
 let (__proj__TIMEOUT__item___0 :
   z3status ->
@@ -166,16 +174,16 @@ let (__proj__TIMEOUT__item___0 :
   = fun projectee  -> match projectee with | TIMEOUT _0 -> _0 
 let (uu___is_KILLED : z3status -> Prims.bool) =
   fun projectee  ->
-    match projectee with | KILLED  -> true | uu____449 -> false
+    match projectee with | KILLED  -> true | uu____407 -> false
   
 type z3statistics = Prims.string FStar_Util.smap[@@deriving show]
 let (status_tag : z3status -> Prims.string) =
-  fun uu___39_456  ->
-    match uu___39_456 with
-    | SAT uu____457 -> "sat"
-    | UNSAT uu____464 -> "unsat"
-    | UNKNOWN uu____465 -> "unknown"
-    | TIMEOUT uu____472 -> "timeout"
+  fun uu___39_414  ->
+    match uu___39_414 with
+    | SAT uu____415 -> "sat"
+    | UNSAT uu____422 -> "unsat"
+    | UNKNOWN uu____423 -> "unknown"
+    | TIMEOUT uu____430 -> "timeout"
     | KILLED  -> "killed"
   
 let (status_string_and_errors :
@@ -186,46 +194,45 @@ let (status_string_and_errors :
   fun s  ->
     match s with
     | KILLED  -> ((status_tag s), [])
-    | UNSAT uu____494 -> ((status_tag s), [])
+    | UNSAT uu____452 -> ((status_tag s), [])
     | SAT (errs,msg) ->
-        let uu____503 =
+        let uu____461 =
           FStar_Util.format2 "%s%s" (status_tag s)
             (match msg with
              | FStar_Pervasives_Native.None  -> ""
              | FStar_Pervasives_Native.Some msg1 ->
                  Prims.strcat " because " msg1)
            in
-        (uu____503, errs)
+        (uu____461, errs)
     | UNKNOWN (errs,msg) ->
-        let uu____511 =
+        let uu____469 =
           FStar_Util.format2 "%s%s" (status_tag s)
             (match msg with
              | FStar_Pervasives_Native.None  -> ""
              | FStar_Pervasives_Native.Some msg1 ->
                  Prims.strcat " because " msg1)
            in
-        (uu____511, errs)
+        (uu____469, errs)
     | TIMEOUT (errs,msg) ->
-        let uu____519 =
+        let uu____477 =
           FStar_Util.format2 "%s%s" (status_tag s)
             (match msg with
              | FStar_Pervasives_Native.None  -> ""
              | FStar_Pervasives_Native.Some msg1 ->
                  Prims.strcat " because " msg1)
            in
-        (uu____519, errs)
+        (uu____477, errs)
   
 let (tid : unit -> Prims.string) =
-  fun uu____525  ->
-    let uu____526 = FStar_Util.current_tid ()  in
-    FStar_All.pipe_right uu____526 FStar_Util.string_of_int
+  fun uu____483  ->
+    let uu____484 = FStar_Util.current_tid ()  in
+    FStar_All.pipe_right uu____484 FStar_Util.string_of_int
   
 let (new_z3proc : Prims.string -> FStar_Util.proc) =
   fun id1  ->
-    let cond pid s = let x = (FStar_Util.trim_string s) = "Done!"  in x  in
-    let uu____544 = FStar_Options.z3_exe ()  in
-    let uu____545 = ini_params ()  in
-    FStar_Util.start_process false id1 uu____544 uu____545 cond
+    let uu____490 = FStar_Options.z3_exe ()  in
+    let uu____491 = ini_params ()  in
+    FStar_Util.start_process id1 uu____490 uu____491 (fun s  -> s = "Done!")
   
 type bgproc =
   {
@@ -312,38 +319,38 @@ let (query_logging : query_log) =
     FStar_ST.op_Colon_Equals current_module_name
       (FStar_Pervasives_Native.Some n1)
      in
-  let get_module_name uu____961 =
-    let uu____962 = FStar_ST.op_Bang current_module_name  in
-    match uu____962 with
+  let get_module_name uu____911 =
+    let uu____912 = FStar_ST.op_Bang current_module_name  in
+    match uu____912 with
     | FStar_Pervasives_Native.None  -> failwith "Module name not set"
     | FStar_Pervasives_Native.Some n1 -> n1  in
-  let new_log_file uu____1020 =
-    let uu____1021 = FStar_ST.op_Bang current_module_name  in
-    match uu____1021 with
+  let new_log_file uu____970 =
+    let uu____971 = FStar_ST.op_Bang current_module_name  in
+    match uu____971 with
     | FStar_Pervasives_Native.None  -> failwith "current module not set"
     | FStar_Pervasives_Native.Some n1 ->
         let file_name =
-          let uu____1075 =
-            let uu____1082 = FStar_ST.op_Bang used_file_names  in
+          let uu____1025 =
+            let uu____1032 = FStar_ST.op_Bang used_file_names  in
             FStar_List.tryFind
-              (fun uu____1153  ->
-                 match uu____1153 with | (m,uu____1159) -> n1 = m) uu____1082
+              (fun uu____1103  ->
+                 match uu____1103 with | (m,uu____1109) -> n1 = m) uu____1032
              in
-          match uu____1075 with
+          match uu____1025 with
           | FStar_Pervasives_Native.None  ->
-              ((let uu____1165 =
-                  let uu____1172 = FStar_ST.op_Bang used_file_names  in
-                  (n1, (Prims.parse_int "0")) :: uu____1172  in
-                FStar_ST.op_Colon_Equals used_file_names uu____1165);
+              ((let uu____1115 =
+                  let uu____1122 = FStar_ST.op_Bang used_file_names  in
+                  (n1, (Prims.parse_int "0")) :: uu____1122  in
+                FStar_ST.op_Colon_Equals used_file_names uu____1115);
                n1)
-          | FStar_Pervasives_Native.Some (uu____1297,k) ->
-              ((let uu____1304 =
-                  let uu____1311 = FStar_ST.op_Bang used_file_names  in
-                  (n1, (k + (Prims.parse_int "1"))) :: uu____1311  in
-                FStar_ST.op_Colon_Equals used_file_names uu____1304);
-               (let uu____1436 =
+          | FStar_Pervasives_Native.Some (uu____1247,k) ->
+              ((let uu____1254 =
+                  let uu____1261 = FStar_ST.op_Bang used_file_names  in
+                  (n1, (k + (Prims.parse_int "1"))) :: uu____1261  in
+                FStar_ST.op_Colon_Equals used_file_names uu____1254);
+               (let uu____1386 =
                   FStar_Util.string_of_int (k + (Prims.parse_int "1"))  in
-                FStar_Util.format2 "%s-%s" n1 uu____1436))
+                FStar_Util.format2 "%s-%s" n1 uu____1386))
            in
         let file_name1 = FStar_Util.format1 "queries-%s.smt2" file_name  in
         (FStar_ST.op_Colon_Equals current_file_name
@@ -353,22 +360,22 @@ let (query_logging : query_log) =
             (FStar_Pervasives_Native.Some fh);
           fh))
      in
-  let get_log_file uu____1544 =
-    let uu____1545 = FStar_ST.op_Bang log_file_opt  in
-    match uu____1545 with
+  let get_log_file uu____1494 =
+    let uu____1495 = FStar_ST.op_Bang log_file_opt  in
+    match uu____1495 with
     | FStar_Pervasives_Native.None  -> new_log_file ()
     | FStar_Pervasives_Native.Some fh -> fh  in
   let append_to_log str =
-    let uu____1604 = get_log_file ()  in
-    FStar_Util.append_to_file uu____1604 str  in
+    let uu____1554 = get_log_file ()  in
+    FStar_Util.append_to_file uu____1554 str  in
   let write_to_new_log str =
     let dir_name =
-      let uu____1612 = FStar_ST.op_Bang current_file_name  in
-      match uu____1612 with
+      let uu____1562 = FStar_ST.op_Bang current_file_name  in
+      match uu____1562 with
       | FStar_Pervasives_Native.None  ->
           let dir_name =
-            let uu____1665 = FStar_ST.op_Bang current_module_name  in
-            match uu____1665 with
+            let uu____1615 = FStar_ST.op_Bang current_module_name  in
+            match uu____1615 with
             | FStar_Pervasives_Native.None  ->
                 failwith "current module not set"
             | FStar_Pervasives_Native.Some n1 ->
@@ -380,32 +387,32 @@ let (query_logging : query_log) =
            dir_name)
       | FStar_Pervasives_Native.Some n1 -> n1  in
     let qnum = FStar_ST.op_Bang query_number  in
-    (let uu____1817 =
-       let uu____1818 = FStar_ST.op_Bang query_number  in
-       uu____1818 + (Prims.parse_int "1")  in
-     FStar_ST.op_Colon_Equals query_number uu____1817);
+    (let uu____1767 =
+       let uu____1768 = FStar_ST.op_Bang query_number  in
+       uu____1768 + (Prims.parse_int "1")  in
+     FStar_ST.op_Colon_Equals query_number uu____1767);
     (let file_name =
-       let uu____1910 = FStar_Util.string_of_int qnum  in
-       FStar_Util.format1 "query-%s.smt2" uu____1910  in
+       let uu____1860 = FStar_Util.string_of_int qnum  in
+       FStar_Util.format1 "query-%s.smt2" uu____1860  in
      let file_name1 = FStar_Util.concat_dir_filename dir_name file_name  in
      FStar_Util.write_file file_name1 str)
      in
   let write_to_log str =
-    let uu____1918 =
-      let uu____1919 = FStar_Options.n_cores ()  in
-      uu____1919 > (Prims.parse_int "1")  in
-    if uu____1918 then write_to_new_log str else append_to_log str  in
-  let close_log uu____1926 =
-    let uu____1927 = FStar_ST.op_Bang log_file_opt  in
-    match uu____1927 with
+    let uu____1868 =
+      let uu____1869 = FStar_Options.n_cores ()  in
+      uu____1869 > (Prims.parse_int "1")  in
+    if uu____1868 then write_to_new_log str else append_to_log str  in
+  let close_log uu____1876 =
+    let uu____1877 = FStar_ST.op_Bang log_file_opt  in
+    match uu____1877 with
     | FStar_Pervasives_Native.None  -> ()
     | FStar_Pervasives_Native.Some fh ->
         (FStar_Util.close_file fh;
          FStar_ST.op_Colon_Equals log_file_opt FStar_Pervasives_Native.None)
      in
-  let log_file_name uu____2035 =
-    let uu____2036 = FStar_ST.op_Bang current_file_name  in
-    match uu____2036 with
+  let log_file_name uu____1985 =
+    let uu____1986 = FStar_ST.op_Bang current_file_name  in
+    match uu____1986 with
     | FStar_Pervasives_Native.None  -> failwith "no log file"
     | FStar_Pervasives_Native.Some n1 -> n1  in
   { get_module_name; set_module_name; write_to_log; close_log; log_file_name
@@ -414,65 +421,66 @@ let (bg_z3_proc : bgproc FStar_ST.ref) =
   let the_z3proc = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
   let new_proc =
     let ctr = FStar_Util.mk_ref (~- (Prims.parse_int "1"))  in
-    fun uu____2117  ->
-      let uu____2118 =
-        let uu____2119 =
+    fun uu____2067  ->
+      let uu____2068 =
+        let uu____2069 =
           FStar_Util.incr ctr;
-          (let uu____2154 = FStar_ST.op_Bang ctr  in
-           FStar_All.pipe_right uu____2154 FStar_Util.string_of_int)
+          (let uu____2104 = FStar_ST.op_Bang ctr  in
+           FStar_All.pipe_right uu____2104 FStar_Util.string_of_int)
            in
-        FStar_Util.format1 "bg-%s" uu____2119  in
-      new_z3proc uu____2118
+        FStar_Util.format1 "bg-%s" uu____2069  in
+      new_z3proc uu____2068
      in
-  let z3proc uu____2205 =
-    (let uu____2207 =
-       let uu____2208 = FStar_ST.op_Bang the_z3proc  in
-       uu____2208 = FStar_Pervasives_Native.None  in
-     if uu____2207
+  let z3proc uu____2155 =
+    (let uu____2157 =
+       let uu____2158 = FStar_ST.op_Bang the_z3proc  in
+       uu____2158 = FStar_Pervasives_Native.None  in
+     if uu____2157
      then
-       let uu____2262 =
-         let uu____2265 = new_proc ()  in
-         FStar_Pervasives_Native.Some uu____2265  in
-       FStar_ST.op_Colon_Equals the_z3proc uu____2262
+       let uu____2212 =
+         let uu____2215 = new_proc ()  in
+         FStar_Pervasives_Native.Some uu____2215  in
+       FStar_ST.op_Colon_Equals the_z3proc uu____2212
      else ());
-    (let uu____2316 = FStar_ST.op_Bang the_z3proc  in
-     FStar_Util.must uu____2316)
+    (let uu____2266 = FStar_ST.op_Bang the_z3proc  in
+     FStar_Util.must uu____2266)
      in
   let x = []  in
-  let grab uu____2376 = FStar_Util.monitor_enter x; z3proc ()  in
-  let release uu____2385 = FStar_Util.monitor_exit x  in
   let ask input =
-    let proc = grab ()  in
-    let stdout1 = FStar_Util.ask_process proc input  in release (); stdout1
-     in
-  let refresh uu____2402 =
-    let proc = grab ()  in
-    FStar_Util.kill_process proc;
-    (let uu____2406 =
-       let uu____2409 = new_proc ()  in
-       FStar_Pervasives_Native.Some uu____2409  in
-     FStar_ST.op_Colon_Equals the_z3proc uu____2406);
-    query_logging.close_log ();
-    release ()  in
-  let restart uu____2465 =
-    FStar_Util.monitor_enter ();
+    let kill_handler uu____2332 = "\nkilled\n"  in
+    let uu____2333 = z3proc ()  in
+    FStar_Util.ask_process uu____2333 input kill_handler  in
+  let refresh uu____2339 =
+    (let uu____2341 = z3proc ()  in FStar_Util.kill_process uu____2341);
+    (let uu____2343 =
+       let uu____2346 = new_proc ()  in
+       FStar_Pervasives_Native.Some uu____2346  in
+     FStar_ST.op_Colon_Equals the_z3proc uu____2343);
+    query_logging.close_log ()  in
+  let restart uu____2401 =
     query_logging.close_log ();
     FStar_ST.op_Colon_Equals the_z3proc FStar_Pervasives_Native.None;
-    (let uu____2519 =
-       let uu____2522 = new_proc ()  in
-       FStar_Pervasives_Native.Some uu____2522  in
-     FStar_ST.op_Colon_Equals the_z3proc uu____2519);
-    FStar_Util.monitor_exit ()  in
-  FStar_Util.mk_ref { ask; refresh; restart } 
+    (let uu____2453 =
+       let uu____2456 = new_proc ()  in
+       FStar_Pervasives_Native.Some uu____2456  in
+     FStar_ST.op_Colon_Equals the_z3proc uu____2453)
+     in
+  FStar_Util.mk_ref
+    {
+      ask = (FStar_Util.with_monitor x ask);
+      refresh = (FStar_Util.with_monitor x refresh);
+      restart = (FStar_Util.with_monitor x restart)
+    }
+  
 let (set_bg_z3_proc : bgproc -> unit) =
   fun bgp  -> FStar_ST.op_Colon_Equals bg_z3_proc bgp 
 let (at_log_file : unit -> Prims.string) =
-  fun uu____2604  ->
-    let uu____2605 = FStar_Options.log_queries ()  in
-    if uu____2605
+  fun uu____2544  ->
+    let uu____2545 = FStar_Options.log_queries ()  in
+    if uu____2545
     then
-      let uu____2606 = query_logging.log_file_name ()  in
-      Prims.strcat "@" uu____2606
+      let uu____2546 = query_logging.log_file_name ()  in
+      Prims.strcat "@" uu____2546
     else ""
   
 type smt_output_section = Prims.string Prims.list[@@deriving show]
@@ -545,22 +553,22 @@ let (smt_output_sections :
             if tag = l
             then FStar_Pervasives_Native.Some ([], lines2)
             else
-              (let uu____2833 = until tag lines2  in
-               FStar_Util.map_opt uu____2833
-                 (fun uu____2863  ->
-                    match uu____2863 with
+              (let uu____2773 = until tag lines2  in
+               FStar_Util.map_opt uu____2773
+                 (fun uu____2803  ->
+                    match uu____2803 with
                     | (until_tag,rest) -> ((l :: until_tag), rest)))
          in
       let start_tag tag = Prims.strcat "<" (Prims.strcat tag ">")  in
       let end_tag tag = Prims.strcat "</" (Prims.strcat tag ">")  in
       let find_section tag lines1 =
-        let uu____2941 = until (start_tag tag) lines1  in
-        match uu____2941 with
+        let uu____2881 = until (start_tag tag) lines1  in
+        match uu____2881 with
         | FStar_Pervasives_Native.None  ->
             (FStar_Pervasives_Native.None, lines1)
         | FStar_Pervasives_Native.Some (prefix1,suffix) ->
-            let uu____2996 = until (end_tag tag) suffix  in
-            (match uu____2996 with
+            let uu____2936 = until (end_tag tag) suffix  in
+            (match uu____2936 with
              | FStar_Pervasives_Native.None  ->
                  failwith
                    (Prims.strcat "Parse error: "
@@ -569,25 +577,25 @@ let (smt_output_sections :
                  ((FStar_Pervasives_Native.Some section),
                    (FStar_List.append prefix1 suffix1)))
          in
-      let uu____3061 = find_section "result" lines  in
-      match uu____3061 with
+      let uu____3001 = find_section "result" lines  in
+      match uu____3001 with
       | (result_opt,lines1) ->
           let result = FStar_Util.must result_opt  in
-          let uu____3091 = find_section "reason-unknown" lines1  in
-          (match uu____3091 with
+          let uu____3031 = find_section "reason-unknown" lines1  in
+          (match uu____3031 with
            | (reason_unknown,lines2) ->
-               let uu____3116 = find_section "unsat-core" lines2  in
-               (match uu____3116 with
+               let uu____3056 = find_section "unsat-core" lines2  in
+               (match uu____3056 with
                 | (unsat_core,lines3) ->
-                    let uu____3141 = find_section "statistics" lines3  in
-                    (match uu____3141 with
+                    let uu____3081 = find_section "statistics" lines3  in
+                    (match uu____3081 with
                      | (statistics,lines4) ->
-                         let uu____3166 = find_section "labels" lines4  in
-                         (match uu____3166 with
+                         let uu____3106 = find_section "labels" lines4  in
+                         (match uu____3106 with
                           | (labels,lines5) ->
                               let remaining =
-                                let uu____3194 = until "Done!" lines5  in
-                                match uu____3194 with
+                                let uu____3134 = until "Done!" lines5  in
+                                match uu____3134 with
                                 | FStar_Pervasives_Native.None  -> lines5
                                 | FStar_Pervasives_Native.Some
                                     (prefix1,suffix) ->
@@ -595,21 +603,21 @@ let (smt_output_sections :
                                  in
                               ((match remaining with
                                 | [] -> ()
-                                | uu____3234 ->
-                                    let uu____3237 =
-                                      let uu____3242 =
+                                | uu____3174 ->
+                                    let uu____3177 =
+                                      let uu____3182 =
                                         FStar_Util.format1
                                           "Unexpected output from Z3: %s\n"
                                           (FStar_String.concat "\n" remaining)
                                          in
                                       (FStar_Errors.Warning_UnexpectedZ3Output,
-                                        uu____3242)
+                                        uu____3182)
                                        in
-                                    FStar_Errors.log_issue r uu____3237);
-                               (let uu____3243 = FStar_Util.must result_opt
+                                    FStar_Errors.log_issue r uu____3177);
+                               (let uu____3183 = FStar_Util.must result_opt
                                    in
                                 {
-                                  smt_result = uu____3243;
+                                  smt_result = uu____3183;
                                   smt_reason_unknown = reason_unknown;
                                   smt_unsat_core = unsat_core;
                                   smt_statistics = statistics;
@@ -646,11 +654,11 @@ let (doZ3Exe :
                   if FStar_Util.starts_with s2 "error"
                   then FStar_Pervasives_Native.None
                   else
-                    (let uu____3316 =
+                    (let uu____3256 =
                        FStar_All.pipe_right (FStar_Util.split s2 " ")
                          (FStar_Util.sort_with FStar_String.compare)
                         in
-                     FStar_Pervasives_Native.Some uu____3316)
+                     FStar_Pervasives_Native.Some uu____3256)
                in
             let labels =
               match smt_output.smt_labels with
@@ -660,23 +668,23 @@ let (doZ3Exe :
                     match lines2 with
                     | lname::"false"::rest when
                         FStar_Util.starts_with lname "label_" ->
-                        let uu____3379 = lblnegs rest  in lname :: uu____3379
-                    | lname::uu____3383::rest when
+                        let uu____3319 = lblnegs rest  in lname :: uu____3319
+                    | lname::uu____3323::rest when
                         FStar_Util.starts_with lname "label_" -> lblnegs rest
-                    | uu____3387 -> []  in
+                    | uu____3327 -> []  in
                   let lblnegs1 = lblnegs lines1  in
                   FStar_All.pipe_right lblnegs1
                     (FStar_List.collect
                        (fun l  ->
-                          let uu____3420 =
+                          let uu____3360 =
                             FStar_All.pipe_right label_messages
                               (FStar_List.tryFind
-                                 (fun uu____3459  ->
-                                    match uu____3459 with
-                                    | (m,uu____3471,uu____3472) ->
+                                 (fun uu____3399  ->
+                                    match uu____3399 with
+                                    | (m,uu____3411,uu____3412) ->
                                         (FStar_Pervasives_Native.fst m) = l))
                              in
-                          match uu____3420 with
+                          match uu____3360 with
                           | FStar_Pervasives_Native.None  -> []
                           | FStar_Pervasives_Native.Some (lbl,msg,r1) ->
                               [(lbl, msg, r1)]))
@@ -723,7 +731,7 @@ let (doZ3Exe :
                                  (Prims.parse_int "1"))
                           else ltok  in
                         FStar_Util.smap_add statistics key value
-                    | uu____3586 -> ()  in
+                    | uu____3526 -> ()  in
                   (FStar_List.iter parse_line lines1; statistics)
                in
             let reason_unknown =
@@ -745,14 +753,14 @@ let (doZ3Exe :
                    else ru)
                in
             let status =
-              (let uu____3604 = FStar_Options.debug_any ()  in
-               if uu____3604
+              (let uu____3544 = FStar_Options.debug_any ()  in
+               if uu____3544
                then
-                 let uu____3605 =
+                 let uu____3545 =
                    FStar_Util.format1 "Z3 says: %s\n"
                      (FStar_String.concat "\n" smt_output.smt_result)
                     in
-                 FStar_All.pipe_left FStar_Util.print_string uu____3605
+                 FStar_All.pipe_left FStar_Util.print_string uu____3545
                else ());
               (match smt_output.smt_result with
                | "unsat"::[] -> UNSAT unsat_core
@@ -760,35 +768,33 @@ let (doZ3Exe :
                | "unknown"::[] -> UNKNOWN (labels, reason_unknown)
                | "timeout"::[] -> TIMEOUT (labels, reason_unknown)
                | "killed"::[] ->
-                   ((let uu____3650 =
-                       let uu____3655 = FStar_ST.op_Bang bg_z3_proc  in
-                       uu____3655.restart  in
-                     uu____3650 ());
+                   ((let uu____3590 =
+                       let uu____3595 = FStar_ST.op_Bang bg_z3_proc  in
+                       uu____3595.restart  in
+                     uu____3590 ());
                     KILLED)
-               | uu____3679 ->
-                   let uu____3680 =
+               | uu____3619 ->
+                   let uu____3620 =
                      FStar_Util.format1
                        "Unexpected output from Z3: got output result: %s\n"
                        (FStar_String.concat "\n" smt_output.smt_result)
                       in
-                   failwith uu____3680)
+                   failwith uu____3620)
                in
             (status, statistics)  in
-          let cond pid s = let x = (FStar_Util.trim_string s) = "Done!"  in x
-             in
           let stdout1 =
             if fresh
             then
-              let uu____3694 = tid ()  in
-              let uu____3695 = FStar_Options.z3_exe ()  in
-              let uu____3696 = ini_params ()  in
-              FStar_Util.launch_process false uu____3694 uu____3695
-                uu____3696 input cond
+              let uu____3622 = tid ()  in
+              let uu____3623 = FStar_Options.z3_exe ()  in
+              let uu____3624 = ini_params ()  in
+              FStar_Util.run_process uu____3622 uu____3623 uu____3624
+                (FStar_Pervasives_Native.Some input)
             else
-              (let uu____3698 =
-                 let uu____3703 = FStar_ST.op_Bang bg_z3_proc  in
-                 uu____3703.ask  in
-               uu____3698 input)
+              (let uu____3628 =
+                 let uu____3633 = FStar_ST.op_Bang bg_z3_proc  in
+                 uu____3633.ask  in
+               uu____3628 input)
              in
           parse (FStar_Util.trim_string stdout1)
   
@@ -861,15 +867,6 @@ type z3job = z3result job[@@deriving show]
 let (job_queue : z3job Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
 let (pending_jobs : Prims.int FStar_ST.ref) =
   FStar_Util.mk_ref (Prims.parse_int "0") 
-let with_monitor :
-  'Auu____3954 'Auu____3955 .
-    'Auu____3954 -> (unit -> 'Auu____3955) -> 'Auu____3955
-  =
-  fun m  ->
-    fun f  ->
-      FStar_Util.monitor_enter m;
-      (let res = f ()  in FStar_Util.monitor_exit m; res)
-  
 let (z3_job :
   FStar_Range.range ->
     Prims.bool ->
@@ -882,32 +879,27 @@ let (z3_job :
       fun label_messages  ->
         fun input  ->
           fun qhash  ->
-            fun uu____4005  ->
+            fun uu____3907  ->
               let start = FStar_Util.now ()  in
-              let uu____4009 =
+              let uu____3911 =
                 try doZ3Exe r fresh input label_messages
                 with
-                | uu____4033 when
-                    let uu____4034 = FStar_Options.trace_error ()  in
-                    Prims.op_Negation uu____4034 ->
-                    ((let uu____4036 =
-                        let uu____4041 = FStar_ST.op_Bang bg_z3_proc  in
-                        uu____4041.refresh  in
-                      uu____4036 ());
-                     (let uu____4065 =
-                        FStar_Util.smap_create (Prims.parse_int "0")  in
-                      ((UNKNOWN
-                          ([],
-                            (FStar_Pervasives_Native.Some
-                               "Z3 raised an exception"))), uu____4065)))
+                | e when
+                    let uu____3935 = FStar_Options.trace_error ()  in
+                    Prims.op_Negation uu____3935 ->
+                    ((let uu____3937 =
+                        let uu____3942 = FStar_ST.op_Bang bg_z3_proc  in
+                        uu____3942.refresh  in
+                      uu____3937 ());
+                     FStar_Exn.raise e)
                  in
-              match uu____4009 with
+              match uu____3911 with
               | (status,statistics) ->
-                  let uu____4076 =
-                    let uu____4081 = FStar_Util.now ()  in
-                    FStar_Util.time_diff start uu____4081  in
-                  (match uu____4076 with
-                   | (uu____4082,elapsed_time) ->
+                  let uu____3972 =
+                    let uu____3977 = FStar_Util.now ()  in
+                    FStar_Util.time_diff start uu____3977  in
+                  (match uu____3972 with
+                   | (uu____3978,elapsed_time) ->
                        {
                          z3result_status = status;
                          z3result_time = elapsed_time;
@@ -917,42 +909,43 @@ let (z3_job :
   
 let (running : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false 
 let rec (dequeue' : unit -> unit) =
-  fun uu____4109  ->
+  fun uu____4005  ->
     let j =
-      let uu____4111 = FStar_ST.op_Bang job_queue  in
-      match uu____4111 with
+      let uu____4007 = FStar_ST.op_Bang job_queue  in
+      match uu____4007 with
       | [] -> failwith "Impossible"
       | hd1::tl1 -> (FStar_ST.op_Colon_Equals job_queue tl1; hd1)  in
     FStar_Util.incr pending_jobs;
     FStar_Util.monitor_exit job_queue;
     run_job j;
-    with_monitor job_queue (fun uu____4186  -> FStar_Util.decr pending_jobs);
+    FStar_Util.with_monitor job_queue
+      (fun uu____4082  -> FStar_Util.decr pending_jobs) ();
     dequeue ()
 
 and (dequeue : unit -> unit) =
-  fun uu____4188  ->
-    let uu____4189 = FStar_ST.op_Bang running  in
-    if uu____4189
+  fun uu____4084  ->
+    let uu____4085 = FStar_ST.op_Bang running  in
+    if uu____4085
     then
-      let rec aux uu____4218 =
+      let rec aux uu____4114 =
         FStar_Util.monitor_enter job_queue;
-        (let uu____4224 = FStar_ST.op_Bang job_queue  in
-         match uu____4224 with
+        (let uu____4120 = FStar_ST.op_Bang job_queue  in
+         match uu____4120 with
          | [] ->
              (FStar_Util.monitor_exit job_queue;
               FStar_Util.sleep (Prims.parse_int "50");
               aux ())
-         | uu____4260 -> dequeue' ())
+         | uu____4156 -> dequeue' ())
          in
       aux ()
     else ()
 
 and (run_job : z3job -> unit) =
   fun j  ->
-    let uu____4264 = j.job ()  in FStar_All.pipe_left j.callback uu____4264
+    let uu____4160 = j.job ()  in FStar_All.pipe_left j.callback uu____4160
 
 let (init : unit -> unit) =
-  fun uu____4269  ->
+  fun uu____4165  ->
     FStar_ST.op_Colon_Equals running true;
     (let n_cores1 = FStar_Options.n_cores ()  in
      if n_cores1 > (Prims.parse_int "1")
@@ -967,27 +960,27 @@ let (init : unit -> unit) =
   
 let (enqueue : z3job -> unit) =
   fun j  ->
-    FStar_Util.monitor_enter job_queue;
-    (let uu____4315 =
-       let uu____4318 = FStar_ST.op_Bang job_queue  in
-       FStar_List.append uu____4318 [j]  in
-     FStar_ST.op_Colon_Equals job_queue uu____4315);
-    FStar_Util.monitor_pulse job_queue;
-    FStar_Util.monitor_exit job_queue
+    FStar_Util.with_monitor job_queue
+      (fun uu____4211  ->
+         (let uu____4213 =
+            let uu____4216 = FStar_ST.op_Bang job_queue  in
+            FStar_List.append uu____4216 [j]  in
+          FStar_ST.op_Colon_Equals job_queue uu____4213);
+         FStar_Util.monitor_pulse job_queue) ()
   
 let (finish : unit -> unit) =
-  fun uu____4388  ->
-    let rec aux uu____4394 =
-      let uu____4395 =
-        with_monitor job_queue
-          (fun uu____4411  ->
-             let uu____4412 = FStar_ST.op_Bang pending_jobs  in
-             let uu____4436 =
-               let uu____4437 = FStar_ST.op_Bang job_queue  in
-               FStar_List.length uu____4437  in
-             (uu____4412, uu____4436))
+  fun uu____4281  ->
+    let rec aux uu____4287 =
+      let uu____4288 =
+        FStar_Util.with_monitor job_queue
+          (fun uu____4304  ->
+             let uu____4305 = FStar_ST.op_Bang pending_jobs  in
+             let uu____4329 =
+               let uu____4330 = FStar_ST.op_Bang job_queue  in
+               FStar_List.length uu____4330  in
+             (uu____4305, uu____4329)) ()
          in
-      match uu____4395 with
+      match uu____4288 with
       | (n1,m) ->
           if (n1 + m) = (Prims.parse_int "0")
           then FStar_ST.op_Colon_Equals running false
@@ -1001,75 +994,75 @@ let (fresh_scope :
   FStar_SMTEncoding_Term.decl Prims.list Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [[]] 
 let (mk_fresh_scope : unit -> scope_t) =
-  fun uu____4535  -> FStar_ST.op_Bang fresh_scope 
+  fun uu____4428  -> FStar_ST.op_Bang fresh_scope 
 let (bg_scope : FStar_SMTEncoding_Term.decl Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [] 
 let (push : Prims.string -> unit) =
   fun msg  ->
-    (let uu____4590 =
-       let uu____4595 = FStar_ST.op_Bang fresh_scope  in
+    (let uu____4483 =
+       let uu____4488 = FStar_ST.op_Bang fresh_scope  in
        [FStar_SMTEncoding_Term.Caption msg; FStar_SMTEncoding_Term.Push] ::
-         uu____4595
+         uu____4488
         in
-     FStar_ST.op_Colon_Equals fresh_scope uu____4590);
-    (let uu____4664 =
-       let uu____4667 = FStar_ST.op_Bang bg_scope  in
-       FStar_List.append uu____4667
+     FStar_ST.op_Colon_Equals fresh_scope uu____4483);
+    (let uu____4557 =
+       let uu____4560 = FStar_ST.op_Bang bg_scope  in
+       FStar_List.append uu____4560
          [FStar_SMTEncoding_Term.Push; FStar_SMTEncoding_Term.Caption msg]
         in
-     FStar_ST.op_Colon_Equals bg_scope uu____4664)
+     FStar_ST.op_Colon_Equals bg_scope uu____4557)
   
 let (pop : Prims.string -> unit) =
   fun msg  ->
-    (let uu____4730 =
-       let uu____4735 = FStar_ST.op_Bang fresh_scope  in
-       FStar_List.tl uu____4735  in
-     FStar_ST.op_Colon_Equals fresh_scope uu____4730);
-    (let uu____4804 =
-       let uu____4807 = FStar_ST.op_Bang bg_scope  in
-       FStar_List.append uu____4807
+    (let uu____4623 =
+       let uu____4628 = FStar_ST.op_Bang fresh_scope  in
+       FStar_List.tl uu____4628  in
+     FStar_ST.op_Colon_Equals fresh_scope uu____4623);
+    (let uu____4697 =
+       let uu____4700 = FStar_ST.op_Bang bg_scope  in
+       FStar_List.append uu____4700
          [FStar_SMTEncoding_Term.Caption msg; FStar_SMTEncoding_Term.Pop]
         in
-     FStar_ST.op_Colon_Equals bg_scope uu____4804)
+     FStar_ST.op_Colon_Equals bg_scope uu____4697)
   
 let (giveZ3 : FStar_SMTEncoding_Term.decl Prims.list -> unit) =
   fun decls  ->
     FStar_All.pipe_right decls
       (FStar_List.iter
-         (fun uu___40_4877  ->
-            match uu___40_4877 with
+         (fun uu___40_4770  ->
+            match uu___40_4770 with
             | FStar_SMTEncoding_Term.Push  -> failwith "Unexpected push/pop"
             | FStar_SMTEncoding_Term.Pop  -> failwith "Unexpected push/pop"
-            | uu____4878 -> ()));
-    (let uu____4880 = FStar_ST.op_Bang fresh_scope  in
-     match uu____4880 with
+            | uu____4771 -> ()));
+    (let uu____4773 = FStar_ST.op_Bang fresh_scope  in
+     match uu____4773 with
      | hd1::tl1 ->
          FStar_ST.op_Colon_Equals fresh_scope ((FStar_List.append hd1 decls)
            :: tl1)
-     | uu____4959 -> failwith "Impossible");
-    (let uu____4964 =
-       let uu____4967 = FStar_ST.op_Bang bg_scope  in
-       FStar_List.append uu____4967 decls  in
-     FStar_ST.op_Colon_Equals bg_scope uu____4964)
+     | uu____4852 -> failwith "Impossible");
+    (let uu____4857 =
+       let uu____4860 = FStar_ST.op_Bang bg_scope  in
+       FStar_List.append uu____4860 decls  in
+     FStar_ST.op_Colon_Equals bg_scope uu____4857)
   
 let (refresh : unit -> unit) =
-  fun uu____5028  ->
-    (let uu____5030 =
-       let uu____5031 = FStar_Options.n_cores ()  in
-       uu____5031 < (Prims.parse_int "2")  in
-     if uu____5030
+  fun uu____4921  ->
+    (let uu____4923 =
+       let uu____4924 = FStar_Options.n_cores ()  in
+       uu____4924 < (Prims.parse_int "2")  in
+     if uu____4923
      then
-       let uu____5032 =
-         let uu____5037 = FStar_ST.op_Bang bg_z3_proc  in uu____5037.refresh
+       let uu____4925 =
+         let uu____4930 = FStar_ST.op_Bang bg_z3_proc  in uu____4930.refresh
           in
-       uu____5032 ()
+       uu____4925 ()
      else ());
-    (let uu____5062 =
-       let uu____5065 =
-         let uu____5070 = FStar_ST.op_Bang fresh_scope  in
-         FStar_List.rev uu____5070  in
-       FStar_List.flatten uu____5065  in
-     FStar_ST.op_Colon_Equals bg_scope uu____5062)
+    (let uu____4955 =
+       let uu____4958 =
+         let uu____4963 = FStar_ST.op_Bang fresh_scope  in
+         FStar_List.rev uu____4963  in
+       FStar_List.flatten uu____4958  in
+     FStar_ST.op_Colon_Equals bg_scope uu____4955)
   
 let (mk_input :
   FStar_SMTEncoding_Term.decl Prims.list ->
@@ -1078,24 +1071,24 @@ let (mk_input :
   =
   fun theory  ->
     let options = FStar_ST.op_Bang z3_options  in
-    let uu____5174 =
-      let uu____5181 =
+    let uu____5067 =
+      let uu____5074 =
         (FStar_Options.record_hints ()) ||
           ((FStar_Options.use_hints ()) && (FStar_Options.use_hint_hashes ()))
          in
-      if uu____5181
+      if uu____5074
       then
-        let uu____5188 =
-          let uu____5199 =
+        let uu____5081 =
+          let uu____5092 =
             FStar_All.pipe_right theory
               (FStar_Util.prefix_until
-                 (fun uu___41_5227  ->
-                    match uu___41_5227 with
+                 (fun uu___41_5120  ->
+                    match uu___41_5120 with
                     | FStar_SMTEncoding_Term.CheckSat  -> true
-                    | uu____5228 -> false))
+                    | uu____5121 -> false))
              in
-          FStar_All.pipe_right uu____5199 FStar_Option.get  in
-        match uu____5188 with
+          FStar_All.pipe_right uu____5092 FStar_Option.get  in
+        match uu____5081 with
         | (prefix1,check_sat,suffix) ->
             let pp =
               FStar_List.map (FStar_SMTEncoding_Term.declToSmt options)  in
@@ -1108,57 +1101,57 @@ let (mk_input :
             let ss_lines = pp suffix1  in
             let ps = FStar_String.concat "\n" ps_lines  in
             let ss = FStar_String.concat "\n" ss_lines  in
-            let uncaption uu___42_5312 =
-              match uu___42_5312 with
-              | FStar_SMTEncoding_Term.Caption uu____5313 ->
+            let uncaption uu___42_5205 =
+              match uu___42_5205 with
+              | FStar_SMTEncoding_Term.Caption uu____5206 ->
                   FStar_SMTEncoding_Term.Caption ""
               | FStar_SMTEncoding_Term.Assume a ->
                   FStar_SMTEncoding_Term.Assume
-                    (let uu___47_5317 = a  in
+                    (let uu___47_5210 = a  in
                      {
                        FStar_SMTEncoding_Term.assumption_term =
-                         (uu___47_5317.FStar_SMTEncoding_Term.assumption_term);
+                         (uu___47_5210.FStar_SMTEncoding_Term.assumption_term);
                        FStar_SMTEncoding_Term.assumption_caption =
                          FStar_Pervasives_Native.None;
                        FStar_SMTEncoding_Term.assumption_name =
-                         (uu___47_5317.FStar_SMTEncoding_Term.assumption_name);
+                         (uu___47_5210.FStar_SMTEncoding_Term.assumption_name);
                        FStar_SMTEncoding_Term.assumption_fact_ids =
-                         (uu___47_5317.FStar_SMTEncoding_Term.assumption_fact_ids)
+                         (uu___47_5210.FStar_SMTEncoding_Term.assumption_fact_ids)
                      })
-              | FStar_SMTEncoding_Term.DeclFun (n1,a,s,uu____5321) ->
+              | FStar_SMTEncoding_Term.DeclFun (n1,a,s,uu____5214) ->
                   FStar_SMTEncoding_Term.DeclFun
                     (n1, a, s, FStar_Pervasives_Native.None)
-              | FStar_SMTEncoding_Term.DefineFun (n1,a,s,b,uu____5334) ->
+              | FStar_SMTEncoding_Term.DefineFun (n1,a,s,b,uu____5227) ->
                   FStar_SMTEncoding_Term.DefineFun
                     (n1, a, s, b, FStar_Pervasives_Native.None)
               | d -> d  in
             let hs =
-              let uu____5345 =
-                let uu____5348 =
-                  let uu____5351 =
+              let uu____5238 =
+                let uu____5241 =
+                  let uu____5244 =
                     FStar_All.pipe_right prefix1 (FStar_List.map uncaption)
                      in
-                  FStar_All.pipe_right uu____5351 pp_no_cap  in
-                FStar_All.pipe_right uu____5348
+                  FStar_All.pipe_right uu____5244 pp_no_cap  in
+                FStar_All.pipe_right uu____5241
                   (FStar_List.filter (fun s  -> s <> ""))
                  in
-              FStar_All.pipe_right uu____5345 (FStar_String.concat "\n")  in
-            let uu____5370 =
-              let uu____5373 = FStar_Util.digest_of_string hs  in
-              FStar_Pervasives_Native.Some uu____5373  in
-            ((Prims.strcat ps (Prims.strcat "\n" ss)), uu____5370)
+              FStar_All.pipe_right uu____5238 (FStar_String.concat "\n")  in
+            let uu____5263 =
+              let uu____5266 = FStar_Util.digest_of_string hs  in
+              FStar_Pervasives_Native.Some uu____5266  in
+            ((Prims.strcat ps (Prims.strcat "\n" ss)), uu____5263)
       else
-        (let uu____5377 =
-           let uu____5378 =
+        (let uu____5270 =
+           let uu____5271 =
              FStar_List.map (FStar_SMTEncoding_Term.declToSmt options) theory
               in
-           FStar_All.pipe_right uu____5378 (FStar_String.concat "\n")  in
-         (uu____5377, FStar_Pervasives_Native.None))
+           FStar_All.pipe_right uu____5271 (FStar_String.concat "\n")  in
+         (uu____5270, FStar_Pervasives_Native.None))
        in
-    match uu____5174 with
+    match uu____5067 with
     | (r,hash) ->
-        ((let uu____5398 = FStar_Options.log_queries ()  in
-          if uu____5398 then query_logging.write_to_log r else ());
+        ((let uu____5291 = FStar_Options.log_queries ()  in
+          if uu____5291 then query_logging.write_to_log r else ());
          (r, hash))
   
 type cb = z3result -> unit[@@deriving show]
@@ -1169,10 +1162,10 @@ let (cache_hit :
   fun cache  ->
     fun qhash  ->
       fun cb  ->
-        let uu____5432 =
+        let uu____5325 =
           (FStar_Options.use_hints ()) && (FStar_Options.use_hint_hashes ())
            in
-        if uu____5432
+        if uu____5325
         then
           match qhash with
           | FStar_Pervasives_Native.Some x when qhash = cache ->
@@ -1186,7 +1179,7 @@ let (cache_hit :
                     z3result_query_hash = qhash
                   }  in
                 cb result; true))
-          | uu____5443 -> false
+          | uu____5336 -> false
         else false
   
 let (ask_1_core :
@@ -1206,22 +1199,22 @@ let (ask_1_core :
           fun qry  ->
             fun cb  ->
               let theory =
-                let uu____5501 = FStar_ST.op_Bang bg_scope  in
-                FStar_List.append uu____5501
+                let uu____5394 = FStar_ST.op_Bang bg_scope  in
+                FStar_List.append uu____5394
                   (FStar_List.append [FStar_SMTEncoding_Term.Push]
                      (FStar_List.append qry [FStar_SMTEncoding_Term.Pop]))
                  in
-              let uu____5531 = filter_theory theory  in
-              match uu____5531 with
+              let uu____5424 = filter_theory theory  in
+              match uu____5424 with
               | (theory1,used_unsat_core) ->
-                  let uu____5538 = mk_input theory1  in
-                  (match uu____5538 with
+                  let uu____5431 = mk_input theory1  in
+                  (match uu____5431 with
                    | (input,qhash) ->
                        (FStar_ST.op_Colon_Equals bg_scope [];
-                        (let uu____5579 =
-                           let uu____5580 = cache_hit cache qhash cb  in
-                           Prims.op_Negation uu____5580  in
-                         if uu____5579
+                        (let uu____5472 =
+                           let uu____5473 = cache_hit cache qhash cb  in
+                           Prims.op_Negation uu____5473  in
+                         if uu____5472
                          then
                            run_job
                              {
@@ -1250,30 +1243,30 @@ let (ask_n_cores :
             fun scope  ->
               fun cb  ->
                 let theory =
-                  let uu____5649 =
+                  let uu____5542 =
                     match scope with
                     | FStar_Pervasives_Native.Some s -> FStar_List.rev s
                     | FStar_Pervasives_Native.None  ->
                         (FStar_ST.op_Colon_Equals bg_scope [];
-                         (let uu____5689 = FStar_ST.op_Bang fresh_scope  in
-                          FStar_List.rev uu____5689))
+                         (let uu____5582 = FStar_ST.op_Bang fresh_scope  in
+                          FStar_List.rev uu____5582))
                      in
-                  FStar_List.flatten uu____5649  in
+                  FStar_List.flatten uu____5542  in
                 let theory1 =
                   FStar_List.append theory
                     (FStar_List.append [FStar_SMTEncoding_Term.Push]
                        (FStar_List.append qry [FStar_SMTEncoding_Term.Pop]))
                    in
-                let uu____5730 = filter_theory theory1  in
-                match uu____5730 with
+                let uu____5623 = filter_theory theory1  in
+                match uu____5623 with
                 | (theory2,used_unsat_core) ->
-                    let uu____5737 = mk_input theory2  in
-                    (match uu____5737 with
+                    let uu____5630 = mk_input theory2  in
+                    (match uu____5630 with
                      | (input,qhash) ->
-                         let uu____5750 =
-                           let uu____5751 = cache_hit cache qhash cb  in
-                           Prims.op_Negation uu____5751  in
-                         if uu____5750
+                         let uu____5643 =
+                           let uu____5644 = cache_hit cache qhash cb  in
+                           Prims.op_Negation uu____5644  in
+                         if uu____5643
                          then
                            enqueue
                              {
@@ -1301,10 +1294,10 @@ let (ask :
           fun qry  ->
             fun scope  ->
               fun cb  ->
-                let uu____5819 =
-                  let uu____5820 = FStar_Options.n_cores ()  in
-                  uu____5820 = (Prims.parse_int "1")  in
-                if uu____5819
+                let uu____5712 =
+                  let uu____5713 = FStar_Options.n_cores ()  in
+                  uu____5713 = (Prims.parse_int "1")  in
+                if uu____5712
                 then ask_1_core r filter1 cache label_messages qry cb
                 else ask_n_cores r filter1 cache label_messages qry scope cb
   

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -4343,18 +4343,19 @@ let (unify :
         (fun ps  -> do_unify ps.FStar_Tactics_Types.main_context t1 t2)
   
 let (launch_process :
-  Prims.string -> Prims.string -> Prims.string -> Prims.string tac) =
+  Prims.string -> Prims.string Prims.list -> Prims.string -> Prims.string tac)
+  =
   fun prog  ->
     fun args  ->
       fun input  ->
         bind idtac
-          (fun uu____8910  ->
-             let uu____8911 = FStar_Options.unsafe_tactic_exec ()  in
-             if uu____8911
+          (fun uu____8914  ->
+             let uu____8915 = FStar_Options.unsafe_tactic_exec ()  in
+             if uu____8915
              then
                let s =
-                 FStar_Util.launch_process true "tactic_launch" prog args
-                   input (fun uu____8917  -> fun uu____8918  -> false)
+                 FStar_Util.run_process "tactic_launch" prog args
+                   (FStar_Pervasives_Native.Some input)
                   in
                ret s
              else

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1467,17 +1467,22 @@ and (primitive_steps :
                                                                     =
                                                                     let uu____2950
                                                                     =
+                                                                    let uu____2951
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_string
+                                                                     in
                                                                     mktac3
                                                                     "launch_process"
                                                                     FStar_Tactics_Basic.launch_process
                                                                     FStar_Syntax_Embeddings.e_string
-                                                                    FStar_Syntax_Embeddings.e_string
+                                                                    uu____2951
                                                                     FStar_Syntax_Embeddings.e_string
                                                                     FStar_Syntax_Embeddings.e_string
                                                                      in
-                                                                    let uu____2951
+                                                                    let uu____2958
                                                                     =
-                                                                    let uu____2954
+                                                                    let uu____2961
                                                                     =
                                                                     mktac2
                                                                     "fresh_bv_named"
@@ -1486,9 +1491,9 @@ and (primitive_steps :
                                                                     FStar_Reflection_Embeddings.e_term
                                                                     FStar_Reflection_Embeddings.e_bv
                                                                      in
-                                                                    let uu____2955
+                                                                    let uu____2962
                                                                     =
-                                                                    let uu____2958
+                                                                    let uu____2965
                                                                     =
                                                                     mktac1
                                                                     "change"
@@ -1496,9 +1501,9 @@ and (primitive_steps :
                                                                     FStar_Reflection_Embeddings.e_term
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                      in
-                                                                    let uu____2959
+                                                                    let uu____2966
                                                                     =
-                                                                    let uu____2962
+                                                                    let uu____2969
                                                                     =
                                                                     mktac1
                                                                     "get_guard_policy"
@@ -1506,9 +1511,9 @@ and (primitive_steps :
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     FStar_Tactics_Embedding.e_guard_policy
                                                                      in
-                                                                    let uu____2963
+                                                                    let uu____2970
                                                                     =
-                                                                    let uu____2966
+                                                                    let uu____2973
                                                                     =
                                                                     mktac1
                                                                     "set_guard_policy"
@@ -1516,28 +1521,28 @@ and (primitive_steps :
                                                                     FStar_Tactics_Embedding.e_guard_policy
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                      in
-                                                                    [uu____2966;
+                                                                    [uu____2973;
                                                                     decr_depth_step;
                                                                     incr_depth_step;
                                                                     tracepoint_step;
                                                                     set_proofstate_range_step;
                                                                     push_binder_step]
                                                                      in
+                                                                    uu____2969
+                                                                    ::
+                                                                    uu____2970
+                                                                     in
+                                                                    uu____2965
+                                                                    ::
+                                                                    uu____2966
+                                                                     in
+                                                                    uu____2961
+                                                                    ::
                                                                     uu____2962
-                                                                    ::
-                                                                    uu____2963
-                                                                     in
-                                                                    uu____2958
-                                                                    ::
-                                                                    uu____2959
-                                                                     in
-                                                                    uu____2954
-                                                                    ::
-                                                                    uu____2955
                                                                      in
                                                                     uu____2950
                                                                     ::
-                                                                    uu____2951
+                                                                    uu____2958
                                                                      in
                                                                     uu____2946
                                                                     ::
@@ -1698,12 +1703,12 @@ and unembed_tactic_1 :
              let rng = FStar_Range.dummyRange  in
              let x_tm = FStar_Syntax_Embeddings.embed ea rng x  in
              let app =
-               let uu____2989 =
-                 let uu____2994 =
-                   let uu____2995 = FStar_Syntax_Syntax.as_arg x_tm  in
-                   [uu____2995]  in
-                 FStar_Syntax_Syntax.mk_Tm_app f uu____2994  in
-               uu____2989 FStar_Pervasives_Native.None rng  in
+               let uu____2996 =
+                 let uu____3001 =
+                   let uu____3002 = FStar_Syntax_Syntax.as_arg x_tm  in
+                   [uu____3002]  in
+                 FStar_Syntax_Syntax.mk_Tm_app f uu____3001  in
+               uu____2996 FStar_Pervasives_Native.None rng  in
              unembed_tactic_0 er app)
 
 and unembed_tactic_0 :
@@ -1717,17 +1722,17 @@ and unembed_tactic_0 :
         (fun proof_state  ->
            let rng = embedded_tac_b.FStar_Syntax_Syntax.pos  in
            let tm =
-             let uu____3018 =
-               let uu____3023 =
-                 let uu____3024 =
-                   let uu____3025 =
+             let uu____3025 =
+               let uu____3030 =
+                 let uu____3031 =
+                   let uu____3032 =
                      FStar_Syntax_Embeddings.embed
                        FStar_Tactics_Embedding.e_proofstate rng proof_state
                       in
-                   FStar_Syntax_Syntax.as_arg uu____3025  in
-                 [uu____3024]  in
-               FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b uu____3023  in
-             uu____3018 FStar_Pervasives_Native.None rng  in
+                   FStar_Syntax_Syntax.as_arg uu____3032  in
+                 [uu____3031]  in
+               FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b uu____3030  in
+             uu____3025 FStar_Pervasives_Native.None rng  in
            let steps =
              [FStar_TypeChecker_Normalize.Weak;
              FStar_TypeChecker_Normalize.Reify;
@@ -1736,57 +1741,57 @@ and unembed_tactic_0 :
              FStar_TypeChecker_Normalize.UnfoldTac;
              FStar_TypeChecker_Normalize.Primops;
              FStar_TypeChecker_Normalize.Unascribe]  in
-           (let uu____3032 =
+           (let uu____3039 =
               FStar_TypeChecker_Env.debug
                 proof_state.FStar_Tactics_Types.main_context
                 (FStar_Options.Other "TacVerbose")
                in
-            if uu____3032
+            if uu____3039
             then
-              let uu____3033 = FStar_Syntax_Print.term_to_string tm  in
-              FStar_Util.print1 "Starting normalizer with %s\n" uu____3033
+              let uu____3040 = FStar_Syntax_Print.term_to_string tm  in
+              FStar_Util.print1 "Starting normalizer with %s\n" uu____3040
             else ());
            (let result =
-              let uu____3036 = primitive_steps ()  in
+              let uu____3043 = primitive_steps ()  in
               FStar_TypeChecker_Normalize.normalize_with_primitive_steps
-                uu____3036 steps proof_state.FStar_Tactics_Types.main_context
+                uu____3043 steps proof_state.FStar_Tactics_Types.main_context
                 tm
                in
-            (let uu____3040 =
+            (let uu____3047 =
                FStar_TypeChecker_Env.debug
                  proof_state.FStar_Tactics_Types.main_context
                  (FStar_Options.Other "TacVerbose")
                 in
-             if uu____3040
+             if uu____3047
              then
-               let uu____3041 = FStar_Syntax_Print.term_to_string result  in
-               FStar_Util.print1 "Reduced tactic: got %s\n" uu____3041
+               let uu____3048 = FStar_Syntax_Print.term_to_string result  in
+               FStar_Util.print1 "Reduced tactic: got %s\n" uu____3048
              else ());
             (let res =
-               let uu____3048 = FStar_Tactics_Embedding.e_result eb  in
-               FStar_Syntax_Embeddings.unembed uu____3048 result  in
+               let uu____3055 = FStar_Tactics_Embedding.e_result eb  in
+               FStar_Syntax_Embeddings.unembed uu____3055 result  in
              match res with
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Success
                  (b,ps)) ->
-                 let uu____3061 = FStar_Tactics_Basic.set ps  in
-                 FStar_Tactics_Basic.bind uu____3061
-                   (fun uu____3065  -> FStar_Tactics_Basic.ret b)
+                 let uu____3068 = FStar_Tactics_Basic.set ps  in
+                 FStar_Tactics_Basic.bind uu____3068
+                   (fun uu____3072  -> FStar_Tactics_Basic.ret b)
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Failed
                  (msg,ps)) ->
-                 let uu____3070 = FStar_Tactics_Basic.set ps  in
-                 FStar_Tactics_Basic.bind uu____3070
-                   (fun uu____3074  -> FStar_Tactics_Basic.fail msg)
+                 let uu____3077 = FStar_Tactics_Basic.set ps  in
+                 FStar_Tactics_Basic.bind uu____3077
+                   (fun uu____3081  -> FStar_Tactics_Basic.fail msg)
              | FStar_Pervasives_Native.None  ->
-                 let uu____3077 =
-                   let uu____3082 =
-                     let uu____3083 =
+                 let uu____3084 =
+                   let uu____3089 =
+                     let uu____3090 =
                        FStar_Syntax_Print.term_to_string result  in
                      FStar_Util.format1
                        "Tactic got stuck! Please file a bug report with a minimal reproduction of this issue.\n%s"
-                       uu____3083
+                       uu____3090
                       in
-                   (FStar_Errors.Fatal_TacticGotStuck, uu____3082)  in
-                 FStar_Errors.raise_error uu____3077
+                   (FStar_Errors.Fatal_TacticGotStuck, uu____3089)  in
+                 FStar_Errors.raise_error uu____3084
                    (proof_state.FStar_Tactics_Types.main_context).FStar_TypeChecker_Env.range)))
 
 and unembed_tactic_0' :
@@ -1797,9 +1802,9 @@ and unembed_tactic_0' :
   =
   fun eb  ->
     fun embedded_tac_b  ->
-      let uu____3090 = unembed_tactic_0 eb embedded_tac_b  in
+      let uu____3097 = unembed_tactic_0 eb embedded_tac_b  in
       FStar_All.pipe_left (fun _0_18  -> FStar_Pervasives_Native.Some _0_18)
-        uu____3090
+        uu____3097
 
 let (report_implicits :
   FStar_Tactics_Types.proofstate -> FStar_TypeChecker_Env.implicits -> unit)
@@ -1808,18 +1813,18 @@ let (report_implicits :
     fun is  ->
       let errs =
         FStar_List.map
-          (fun uu____3146  ->
-             match uu____3146 with
-             | (r,uu____3166,uv,uu____3168,ty,rng) ->
-                 let uu____3171 =
-                   let uu____3172 = FStar_Syntax_Print.uvar_to_string uv  in
-                   let uu____3173 = FStar_Syntax_Print.term_to_string ty  in
+          (fun uu____3153  ->
+             match uu____3153 with
+             | (r,uu____3173,uv,uu____3175,ty,rng) ->
+                 let uu____3178 =
+                   let uu____3179 = FStar_Syntax_Print.uvar_to_string uv  in
+                   let uu____3180 = FStar_Syntax_Print.term_to_string ty  in
                    FStar_Util.format3
                      "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
-                     uu____3172 uu____3173 r
+                     uu____3179 uu____3180 r
                     in
                  (FStar_Errors.Fatal_UninstantiatedUnificationVarInTactic,
-                   uu____3171, rng)) is
+                   uu____3178, rng)) is
          in
       match errs with
       | [] -> ()
@@ -1839,288 +1844,288 @@ let (run_tactic_on_typ :
   fun tactic  ->
     fun env  ->
       fun typ  ->
-        (let uu____3228 = FStar_ST.op_Bang tacdbg  in
-         if uu____3228
+        (let uu____3235 = FStar_ST.op_Bang tacdbg  in
+         if uu____3235
          then
-           let uu____3252 = FStar_Syntax_Print.term_to_string tactic  in
-           FStar_Util.print1 "About to reduce uvars on: %s\n" uu____3252
+           let uu____3259 = FStar_Syntax_Print.term_to_string tactic  in
+           FStar_Util.print1 "About to reduce uvars on: %s\n" uu____3259
          else ());
         (let tactic1 =
            FStar_TypeChecker_Normalize.reduce_uvar_solutions env tactic  in
-         (let uu____3256 = FStar_ST.op_Bang tacdbg  in
-          if uu____3256
+         (let uu____3263 = FStar_ST.op_Bang tacdbg  in
+          if uu____3263
           then
-            let uu____3280 = FStar_Syntax_Print.term_to_string tactic1  in
-            FStar_Util.print1 "About to check tactic term: %s\n" uu____3280
+            let uu____3287 = FStar_Syntax_Print.term_to_string tactic1  in
+            FStar_Util.print1 "About to check tactic term: %s\n" uu____3287
           else ());
-         (let uu____3282 =
+         (let uu____3289 =
             FStar_TypeChecker_TcTerm.tc_reified_tactic env tactic1  in
-          match uu____3282 with
-          | (uu____3295,uu____3296,g) ->
+          match uu____3289 with
+          | (uu____3302,uu____3303,g) ->
               (FStar_TypeChecker_Rel.force_trivial_guard env g;
                FStar_Errors.stop_if_err ();
                (let tau =
                   unembed_tactic_0 FStar_Syntax_Embeddings.e_unit tactic1  in
-                let uu____3303 = FStar_TypeChecker_Env.clear_expected_typ env
+                let uu____3310 = FStar_TypeChecker_Env.clear_expected_typ env
                    in
-                match uu____3303 with
-                | (env1,uu____3317) ->
+                match uu____3310 with
+                | (env1,uu____3324) ->
                     let env2 =
-                      let uu___60_3323 = env1  in
+                      let uu___60_3330 = env1  in
                       {
                         FStar_TypeChecker_Env.solver =
-                          (uu___60_3323.FStar_TypeChecker_Env.solver);
+                          (uu___60_3330.FStar_TypeChecker_Env.solver);
                         FStar_TypeChecker_Env.range =
-                          (uu___60_3323.FStar_TypeChecker_Env.range);
+                          (uu___60_3330.FStar_TypeChecker_Env.range);
                         FStar_TypeChecker_Env.curmodule =
-                          (uu___60_3323.FStar_TypeChecker_Env.curmodule);
+                          (uu___60_3330.FStar_TypeChecker_Env.curmodule);
                         FStar_TypeChecker_Env.gamma =
-                          (uu___60_3323.FStar_TypeChecker_Env.gamma);
+                          (uu___60_3330.FStar_TypeChecker_Env.gamma);
                         FStar_TypeChecker_Env.gamma_cache =
-                          (uu___60_3323.FStar_TypeChecker_Env.gamma_cache);
+                          (uu___60_3330.FStar_TypeChecker_Env.gamma_cache);
                         FStar_TypeChecker_Env.modules =
-                          (uu___60_3323.FStar_TypeChecker_Env.modules);
+                          (uu___60_3330.FStar_TypeChecker_Env.modules);
                         FStar_TypeChecker_Env.expected_typ =
-                          (uu___60_3323.FStar_TypeChecker_Env.expected_typ);
+                          (uu___60_3330.FStar_TypeChecker_Env.expected_typ);
                         FStar_TypeChecker_Env.sigtab =
-                          (uu___60_3323.FStar_TypeChecker_Env.sigtab);
+                          (uu___60_3330.FStar_TypeChecker_Env.sigtab);
                         FStar_TypeChecker_Env.is_pattern =
-                          (uu___60_3323.FStar_TypeChecker_Env.is_pattern);
+                          (uu___60_3330.FStar_TypeChecker_Env.is_pattern);
                         FStar_TypeChecker_Env.instantiate_imp = false;
                         FStar_TypeChecker_Env.effects =
-                          (uu___60_3323.FStar_TypeChecker_Env.effects);
+                          (uu___60_3330.FStar_TypeChecker_Env.effects);
                         FStar_TypeChecker_Env.generalize =
-                          (uu___60_3323.FStar_TypeChecker_Env.generalize);
+                          (uu___60_3330.FStar_TypeChecker_Env.generalize);
                         FStar_TypeChecker_Env.letrecs =
-                          (uu___60_3323.FStar_TypeChecker_Env.letrecs);
+                          (uu___60_3330.FStar_TypeChecker_Env.letrecs);
                         FStar_TypeChecker_Env.top_level =
-                          (uu___60_3323.FStar_TypeChecker_Env.top_level);
+                          (uu___60_3330.FStar_TypeChecker_Env.top_level);
                         FStar_TypeChecker_Env.check_uvars =
-                          (uu___60_3323.FStar_TypeChecker_Env.check_uvars);
+                          (uu___60_3330.FStar_TypeChecker_Env.check_uvars);
                         FStar_TypeChecker_Env.use_eq =
-                          (uu___60_3323.FStar_TypeChecker_Env.use_eq);
+                          (uu___60_3330.FStar_TypeChecker_Env.use_eq);
                         FStar_TypeChecker_Env.is_iface =
-                          (uu___60_3323.FStar_TypeChecker_Env.is_iface);
+                          (uu___60_3330.FStar_TypeChecker_Env.is_iface);
                         FStar_TypeChecker_Env.admit =
-                          (uu___60_3323.FStar_TypeChecker_Env.admit);
+                          (uu___60_3330.FStar_TypeChecker_Env.admit);
                         FStar_TypeChecker_Env.lax =
-                          (uu___60_3323.FStar_TypeChecker_Env.lax);
+                          (uu___60_3330.FStar_TypeChecker_Env.lax);
                         FStar_TypeChecker_Env.lax_universes =
-                          (uu___60_3323.FStar_TypeChecker_Env.lax_universes);
+                          (uu___60_3330.FStar_TypeChecker_Env.lax_universes);
                         FStar_TypeChecker_Env.failhard =
-                          (uu___60_3323.FStar_TypeChecker_Env.failhard);
+                          (uu___60_3330.FStar_TypeChecker_Env.failhard);
                         FStar_TypeChecker_Env.nosynth =
-                          (uu___60_3323.FStar_TypeChecker_Env.nosynth);
+                          (uu___60_3330.FStar_TypeChecker_Env.nosynth);
                         FStar_TypeChecker_Env.tc_term =
-                          (uu___60_3323.FStar_TypeChecker_Env.tc_term);
+                          (uu___60_3330.FStar_TypeChecker_Env.tc_term);
                         FStar_TypeChecker_Env.type_of =
-                          (uu___60_3323.FStar_TypeChecker_Env.type_of);
+                          (uu___60_3330.FStar_TypeChecker_Env.type_of);
                         FStar_TypeChecker_Env.universe_of =
-                          (uu___60_3323.FStar_TypeChecker_Env.universe_of);
+                          (uu___60_3330.FStar_TypeChecker_Env.universe_of);
                         FStar_TypeChecker_Env.check_type_of =
-                          (uu___60_3323.FStar_TypeChecker_Env.check_type_of);
+                          (uu___60_3330.FStar_TypeChecker_Env.check_type_of);
                         FStar_TypeChecker_Env.use_bv_sorts =
-                          (uu___60_3323.FStar_TypeChecker_Env.use_bv_sorts);
+                          (uu___60_3330.FStar_TypeChecker_Env.use_bv_sorts);
                         FStar_TypeChecker_Env.qtbl_name_and_index =
-                          (uu___60_3323.FStar_TypeChecker_Env.qtbl_name_and_index);
+                          (uu___60_3330.FStar_TypeChecker_Env.qtbl_name_and_index);
                         FStar_TypeChecker_Env.normalized_eff_names =
-                          (uu___60_3323.FStar_TypeChecker_Env.normalized_eff_names);
+                          (uu___60_3330.FStar_TypeChecker_Env.normalized_eff_names);
                         FStar_TypeChecker_Env.proof_ns =
-                          (uu___60_3323.FStar_TypeChecker_Env.proof_ns);
+                          (uu___60_3330.FStar_TypeChecker_Env.proof_ns);
                         FStar_TypeChecker_Env.synth_hook =
-                          (uu___60_3323.FStar_TypeChecker_Env.synth_hook);
+                          (uu___60_3330.FStar_TypeChecker_Env.synth_hook);
                         FStar_TypeChecker_Env.splice =
-                          (uu___60_3323.FStar_TypeChecker_Env.splice);
+                          (uu___60_3330.FStar_TypeChecker_Env.splice);
                         FStar_TypeChecker_Env.is_native_tactic =
-                          (uu___60_3323.FStar_TypeChecker_Env.is_native_tactic);
+                          (uu___60_3330.FStar_TypeChecker_Env.is_native_tactic);
                         FStar_TypeChecker_Env.identifier_info =
-                          (uu___60_3323.FStar_TypeChecker_Env.identifier_info);
+                          (uu___60_3330.FStar_TypeChecker_Env.identifier_info);
                         FStar_TypeChecker_Env.tc_hooks =
-                          (uu___60_3323.FStar_TypeChecker_Env.tc_hooks);
+                          (uu___60_3330.FStar_TypeChecker_Env.tc_hooks);
                         FStar_TypeChecker_Env.dsenv =
-                          (uu___60_3323.FStar_TypeChecker_Env.dsenv);
+                          (uu___60_3330.FStar_TypeChecker_Env.dsenv);
                         FStar_TypeChecker_Env.dep_graph =
-                          (uu___60_3323.FStar_TypeChecker_Env.dep_graph)
+                          (uu___60_3330.FStar_TypeChecker_Env.dep_graph)
                       }  in
                     let env3 =
-                      let uu___61_3325 = env2  in
+                      let uu___61_3332 = env2  in
                       {
                         FStar_TypeChecker_Env.solver =
-                          (uu___61_3325.FStar_TypeChecker_Env.solver);
+                          (uu___61_3332.FStar_TypeChecker_Env.solver);
                         FStar_TypeChecker_Env.range =
-                          (uu___61_3325.FStar_TypeChecker_Env.range);
+                          (uu___61_3332.FStar_TypeChecker_Env.range);
                         FStar_TypeChecker_Env.curmodule =
-                          (uu___61_3325.FStar_TypeChecker_Env.curmodule);
+                          (uu___61_3332.FStar_TypeChecker_Env.curmodule);
                         FStar_TypeChecker_Env.gamma =
-                          (uu___61_3325.FStar_TypeChecker_Env.gamma);
+                          (uu___61_3332.FStar_TypeChecker_Env.gamma);
                         FStar_TypeChecker_Env.gamma_cache =
-                          (uu___61_3325.FStar_TypeChecker_Env.gamma_cache);
+                          (uu___61_3332.FStar_TypeChecker_Env.gamma_cache);
                         FStar_TypeChecker_Env.modules =
-                          (uu___61_3325.FStar_TypeChecker_Env.modules);
+                          (uu___61_3332.FStar_TypeChecker_Env.modules);
                         FStar_TypeChecker_Env.expected_typ =
-                          (uu___61_3325.FStar_TypeChecker_Env.expected_typ);
+                          (uu___61_3332.FStar_TypeChecker_Env.expected_typ);
                         FStar_TypeChecker_Env.sigtab =
-                          (uu___61_3325.FStar_TypeChecker_Env.sigtab);
+                          (uu___61_3332.FStar_TypeChecker_Env.sigtab);
                         FStar_TypeChecker_Env.is_pattern =
-                          (uu___61_3325.FStar_TypeChecker_Env.is_pattern);
+                          (uu___61_3332.FStar_TypeChecker_Env.is_pattern);
                         FStar_TypeChecker_Env.instantiate_imp =
-                          (uu___61_3325.FStar_TypeChecker_Env.instantiate_imp);
+                          (uu___61_3332.FStar_TypeChecker_Env.instantiate_imp);
                         FStar_TypeChecker_Env.effects =
-                          (uu___61_3325.FStar_TypeChecker_Env.effects);
+                          (uu___61_3332.FStar_TypeChecker_Env.effects);
                         FStar_TypeChecker_Env.generalize =
-                          (uu___61_3325.FStar_TypeChecker_Env.generalize);
+                          (uu___61_3332.FStar_TypeChecker_Env.generalize);
                         FStar_TypeChecker_Env.letrecs =
-                          (uu___61_3325.FStar_TypeChecker_Env.letrecs);
+                          (uu___61_3332.FStar_TypeChecker_Env.letrecs);
                         FStar_TypeChecker_Env.top_level =
-                          (uu___61_3325.FStar_TypeChecker_Env.top_level);
+                          (uu___61_3332.FStar_TypeChecker_Env.top_level);
                         FStar_TypeChecker_Env.check_uvars =
-                          (uu___61_3325.FStar_TypeChecker_Env.check_uvars);
+                          (uu___61_3332.FStar_TypeChecker_Env.check_uvars);
                         FStar_TypeChecker_Env.use_eq =
-                          (uu___61_3325.FStar_TypeChecker_Env.use_eq);
+                          (uu___61_3332.FStar_TypeChecker_Env.use_eq);
                         FStar_TypeChecker_Env.is_iface =
-                          (uu___61_3325.FStar_TypeChecker_Env.is_iface);
+                          (uu___61_3332.FStar_TypeChecker_Env.is_iface);
                         FStar_TypeChecker_Env.admit =
-                          (uu___61_3325.FStar_TypeChecker_Env.admit);
+                          (uu___61_3332.FStar_TypeChecker_Env.admit);
                         FStar_TypeChecker_Env.lax =
-                          (uu___61_3325.FStar_TypeChecker_Env.lax);
+                          (uu___61_3332.FStar_TypeChecker_Env.lax);
                         FStar_TypeChecker_Env.lax_universes = true;
                         FStar_TypeChecker_Env.failhard =
-                          (uu___61_3325.FStar_TypeChecker_Env.failhard);
+                          (uu___61_3332.FStar_TypeChecker_Env.failhard);
                         FStar_TypeChecker_Env.nosynth =
-                          (uu___61_3325.FStar_TypeChecker_Env.nosynth);
+                          (uu___61_3332.FStar_TypeChecker_Env.nosynth);
                         FStar_TypeChecker_Env.tc_term =
-                          (uu___61_3325.FStar_TypeChecker_Env.tc_term);
+                          (uu___61_3332.FStar_TypeChecker_Env.tc_term);
                         FStar_TypeChecker_Env.type_of =
-                          (uu___61_3325.FStar_TypeChecker_Env.type_of);
+                          (uu___61_3332.FStar_TypeChecker_Env.type_of);
                         FStar_TypeChecker_Env.universe_of =
-                          (uu___61_3325.FStar_TypeChecker_Env.universe_of);
+                          (uu___61_3332.FStar_TypeChecker_Env.universe_of);
                         FStar_TypeChecker_Env.check_type_of =
-                          (uu___61_3325.FStar_TypeChecker_Env.check_type_of);
+                          (uu___61_3332.FStar_TypeChecker_Env.check_type_of);
                         FStar_TypeChecker_Env.use_bv_sorts =
-                          (uu___61_3325.FStar_TypeChecker_Env.use_bv_sorts);
+                          (uu___61_3332.FStar_TypeChecker_Env.use_bv_sorts);
                         FStar_TypeChecker_Env.qtbl_name_and_index =
-                          (uu___61_3325.FStar_TypeChecker_Env.qtbl_name_and_index);
+                          (uu___61_3332.FStar_TypeChecker_Env.qtbl_name_and_index);
                         FStar_TypeChecker_Env.normalized_eff_names =
-                          (uu___61_3325.FStar_TypeChecker_Env.normalized_eff_names);
+                          (uu___61_3332.FStar_TypeChecker_Env.normalized_eff_names);
                         FStar_TypeChecker_Env.proof_ns =
-                          (uu___61_3325.FStar_TypeChecker_Env.proof_ns);
+                          (uu___61_3332.FStar_TypeChecker_Env.proof_ns);
                         FStar_TypeChecker_Env.synth_hook =
-                          (uu___61_3325.FStar_TypeChecker_Env.synth_hook);
+                          (uu___61_3332.FStar_TypeChecker_Env.synth_hook);
                         FStar_TypeChecker_Env.splice =
-                          (uu___61_3325.FStar_TypeChecker_Env.splice);
+                          (uu___61_3332.FStar_TypeChecker_Env.splice);
                         FStar_TypeChecker_Env.is_native_tactic =
-                          (uu___61_3325.FStar_TypeChecker_Env.is_native_tactic);
+                          (uu___61_3332.FStar_TypeChecker_Env.is_native_tactic);
                         FStar_TypeChecker_Env.identifier_info =
-                          (uu___61_3325.FStar_TypeChecker_Env.identifier_info);
+                          (uu___61_3332.FStar_TypeChecker_Env.identifier_info);
                         FStar_TypeChecker_Env.tc_hooks =
-                          (uu___61_3325.FStar_TypeChecker_Env.tc_hooks);
+                          (uu___61_3332.FStar_TypeChecker_Env.tc_hooks);
                         FStar_TypeChecker_Env.dsenv =
-                          (uu___61_3325.FStar_TypeChecker_Env.dsenv);
+                          (uu___61_3332.FStar_TypeChecker_Env.dsenv);
                         FStar_TypeChecker_Env.dep_graph =
-                          (uu___61_3325.FStar_TypeChecker_Env.dep_graph)
+                          (uu___61_3332.FStar_TypeChecker_Env.dep_graph)
                       }  in
-                    let uu____3326 =
+                    let uu____3333 =
                       FStar_Tactics_Basic.proofstate_of_goal_ty env3 typ  in
-                    (match uu____3326 with
+                    (match uu____3333 with
                      | (ps,w) ->
-                         ((let uu____3340 = FStar_ST.op_Bang tacdbg  in
-                           if uu____3340
+                         ((let uu____3347 = FStar_ST.op_Bang tacdbg  in
+                           if uu____3347
                            then
-                             let uu____3364 =
+                             let uu____3371 =
                                FStar_Syntax_Print.term_to_string typ  in
                              FStar_Util.print1
-                               "Running tactic with goal = %s\n" uu____3364
+                               "Running tactic with goal = %s\n" uu____3371
                            else ());
-                          (let uu____3366 =
+                          (let uu____3373 =
                              FStar_Util.record_time
-                               (fun uu____3376  ->
+                               (fun uu____3383  ->
                                   FStar_Tactics_Basic.run tau ps)
                               in
-                           match uu____3366 with
+                           match uu____3373 with
                            | (res,ms) ->
-                               ((let uu____3390 = FStar_ST.op_Bang tacdbg  in
-                                 if uu____3390
+                               ((let uu____3397 = FStar_ST.op_Bang tacdbg  in
+                                 if uu____3397
                                  then
-                                   let uu____3414 =
+                                   let uu____3421 =
                                      FStar_Syntax_Print.term_to_string
                                        tactic1
                                       in
-                                   let uu____3415 =
+                                   let uu____3422 =
                                      FStar_Util.string_of_int ms  in
-                                   let uu____3416 =
+                                   let uu____3423 =
                                      FStar_Syntax_Print.lid_to_string
                                        env3.FStar_TypeChecker_Env.curmodule
                                       in
                                    FStar_Util.print3
                                      "Tactic %s ran in %s ms (%s)\n"
-                                     uu____3414 uu____3415 uu____3416
+                                     uu____3421 uu____3422 uu____3423
                                  else ());
                                 (match res with
                                  | FStar_Tactics_Result.Success
-                                     (uu____3424,ps1) ->
-                                     ((let uu____3427 =
+                                     (uu____3431,ps1) ->
+                                     ((let uu____3434 =
                                          FStar_ST.op_Bang tacdbg  in
-                                       if uu____3427
+                                       if uu____3434
                                        then
-                                         let uu____3451 =
+                                         let uu____3458 =
                                            FStar_Syntax_Print.term_to_string
                                              w
                                             in
                                          FStar_Util.print1
                                            "Tactic generated proofterm %s\n"
-                                           uu____3451
+                                           uu____3458
                                        else ());
                                       FStar_List.iter
                                         (fun g1  ->
-                                           let uu____3458 =
+                                           let uu____3465 =
                                              FStar_Tactics_Basic.is_irrelevant
                                                g1
                                               in
-                                           if uu____3458
+                                           if uu____3465
                                            then
-                                             let uu____3459 =
+                                             let uu____3466 =
                                                FStar_TypeChecker_Rel.teq_nosmt
                                                  g1.FStar_Tactics_Types.context
                                                  g1.FStar_Tactics_Types.witness
                                                  FStar_Syntax_Util.exp_unit
                                                 in
-                                             (if uu____3459
+                                             (if uu____3466
                                               then ()
                                               else
-                                                (let uu____3461 =
-                                                   let uu____3462 =
+                                                (let uu____3468 =
+                                                   let uu____3469 =
                                                      FStar_Syntax_Print.term_to_string
                                                        g1.FStar_Tactics_Types.witness
                                                       in
                                                    FStar_Util.format1
                                                      "Irrelevant tactic witness does not unify with (): %s"
-                                                     uu____3462
+                                                     uu____3469
                                                     in
-                                                 failwith uu____3461))
+                                                 failwith uu____3468))
                                            else ())
                                         (FStar_List.append
                                            ps1.FStar_Tactics_Types.goals
                                            ps1.FStar_Tactics_Types.smt_goals);
                                       (let g1 =
-                                         let uu___62_3465 =
+                                         let uu___62_3472 =
                                            FStar_TypeChecker_Rel.trivial_guard
                                             in
                                          {
                                            FStar_TypeChecker_Env.guard_f =
-                                             (uu___62_3465.FStar_TypeChecker_Env.guard_f);
+                                             (uu___62_3472.FStar_TypeChecker_Env.guard_f);
                                            FStar_TypeChecker_Env.deferred =
-                                             (uu___62_3465.FStar_TypeChecker_Env.deferred);
+                                             (uu___62_3472.FStar_TypeChecker_Env.deferred);
                                            FStar_TypeChecker_Env.univ_ineqs =
-                                             (uu___62_3465.FStar_TypeChecker_Env.univ_ineqs);
+                                             (uu___62_3472.FStar_TypeChecker_Env.univ_ineqs);
                                            FStar_TypeChecker_Env.implicits =
                                              (ps1.FStar_Tactics_Types.all_implicits)
                                          }  in
                                        let g2 =
-                                         let uu____3467 =
+                                         let uu____3474 =
                                            FStar_TypeChecker_Rel.solve_deferred_constraints
                                              env3 g1
                                             in
-                                         FStar_All.pipe_right uu____3467
+                                         FStar_All.pipe_right uu____3474
                                            FStar_TypeChecker_Rel.resolve_implicits_tac
                                           in
                                        report_implicits ps1
@@ -2130,25 +2135,25 @@ let (run_tactic_on_typ :
                                            ps1.FStar_Tactics_Types.smt_goals),
                                          w)))
                                  | FStar_Tactics_Result.Failed (s,ps1) ->
-                                     ((let uu____3474 =
-                                         let uu____3475 =
+                                     ((let uu____3481 =
+                                         let uu____3482 =
                                            FStar_TypeChecker_Normalize.psc_subst
                                              ps1.FStar_Tactics_Types.psc
                                             in
                                          FStar_Tactics_Types.subst_proof_state
-                                           uu____3475 ps1
+                                           uu____3482 ps1
                                           in
                                        FStar_Tactics_Basic.dump_proofstate
-                                         uu____3474 "at the time of failure");
-                                      (let uu____3476 =
-                                         let uu____3481 =
+                                         uu____3481 "at the time of failure");
+                                      (let uu____3483 =
+                                         let uu____3488 =
                                            FStar_Util.format1
                                              "user tactic failed: %s" s
                                             in
                                          (FStar_Errors.Fatal_ArgumentLengthMismatch,
-                                           uu____3481)
+                                           uu____3488)
                                           in
-                                       FStar_Errors.raise_error uu____3476
+                                       FStar_Errors.raise_error uu____3483
                                          typ.FStar_Syntax_Syntax.pos)))))))))))
   
 type pol =
@@ -2156,12 +2161,12 @@ type pol =
   | Neg 
   | Both [@@deriving show]
 let (uu___is_Pos : pol -> Prims.bool) =
-  fun projectee  -> match projectee with | Pos  -> true | uu____3493 -> false 
+  fun projectee  -> match projectee with | Pos  -> true | uu____3500 -> false 
 let (uu___is_Neg : pol -> Prims.bool) =
-  fun projectee  -> match projectee with | Neg  -> true | uu____3499 -> false 
+  fun projectee  -> match projectee with | Neg  -> true | uu____3506 -> false 
 let (uu___is_Both : pol -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Both  -> true | uu____3505 -> false
+    match projectee with | Both  -> true | uu____3512 -> false
   
 type 'a tres_m =
   | Unchanged of 'a 
@@ -2171,13 +2176,13 @@ type 'a tres_m =
   FStar_Pervasives_Native.tuple3 [@@deriving show]
 let uu___is_Unchanged : 'a . 'a tres_m -> Prims.bool =
   fun projectee  ->
-    match projectee with | Unchanged _0 -> true | uu____3560 -> false
+    match projectee with | Unchanged _0 -> true | uu____3567 -> false
   
 let __proj__Unchanged__item___0 : 'a . 'a tres_m -> 'a =
   fun projectee  -> match projectee with | Unchanged _0 -> _0 
 let uu___is_Simplified : 'a . 'a tres_m -> Prims.bool =
   fun projectee  ->
-    match projectee with | Simplified _0 -> true | uu____3600 -> false
+    match projectee with | Simplified _0 -> true | uu____3607 -> false
   
 let __proj__Simplified__item___0 :
   'a .
@@ -2186,7 +2191,7 @@ let __proj__Simplified__item___0 :
   = fun projectee  -> match projectee with | Simplified _0 -> _0 
 let uu___is_Dual : 'a . 'a tres_m -> Prims.bool =
   fun projectee  ->
-    match projectee with | Dual _0 -> true | uu____3654 -> false
+    match projectee with | Dual _0 -> true | uu____3661 -> false
   
 let __proj__Dual__item___0 :
   'a .
@@ -2195,7 +2200,7 @@ let __proj__Dual__item___0 :
         FStar_Pervasives_Native.tuple3
   = fun projectee  -> match projectee with | Dual _0 -> _0 
 type tres = FStar_Syntax_Syntax.term tres_m[@@deriving show]
-let tpure : 'Auu____3695 . 'Auu____3695 -> 'Auu____3695 tres_m =
+let tpure : 'Auu____3702 . 'Auu____3702 -> 'Auu____3702 tres_m =
   fun x  -> Unchanged x 
 let (flip : pol -> pol) =
   fun p  -> match p with | Pos  -> Neg | Neg  -> Pos | Both  -> Both 
@@ -2204,18 +2209,18 @@ let (by_tactic_interp :
   fun pol  ->
     fun e  ->
       fun t  ->
-        let uu____3723 = FStar_Syntax_Util.head_and_args t  in
-        match uu____3723 with
+        let uu____3730 = FStar_Syntax_Util.head_and_args t  in
+        match uu____3730 with
         | (hd1,args) ->
-            let uu____3760 =
-              let uu____3773 =
-                let uu____3774 = FStar_Syntax_Util.un_uinst hd1  in
-                uu____3774.FStar_Syntax_Syntax.n  in
-              (uu____3773, args)  in
-            (match uu____3760 with
+            let uu____3767 =
+              let uu____3780 =
+                let uu____3781 = FStar_Syntax_Util.un_uinst hd1  in
+                uu____3781.FStar_Syntax_Syntax.n  in
+              (uu____3780, args)  in
+            (match uu____3767 with
              | (FStar_Syntax_Syntax.Tm_fvar
                 fv,(rett,FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Implicit uu____3787))::(tactic,FStar_Pervasives_Native.None
+                    (FStar_Syntax_Syntax.Implicit uu____3794))::(tactic,FStar_Pervasives_Native.None
                                                                  )::(assertion,FStar_Pervasives_Native.None
                                                                     )::[])
                  when
@@ -2224,16 +2229,16 @@ let (by_tactic_interp :
                  ->
                  (match pol with
                   | Pos  ->
-                      let uu____3850 = run_tactic_on_typ tactic e assertion
+                      let uu____3857 = run_tactic_on_typ tactic e assertion
                          in
-                      (match uu____3850 with
-                       | (gs,uu____3858) ->
+                      (match uu____3857 with
+                       | (gs,uu____3865) ->
                            Simplified (FStar_Syntax_Util.t_true, gs))
                   | Both  ->
-                      let uu____3865 = run_tactic_on_typ tactic e assertion
+                      let uu____3872 = run_tactic_on_typ tactic e assertion
                          in
-                      (match uu____3865 with
-                       | (gs,uu____3873) ->
+                      (match uu____3872 with
+                       | (gs,uu____3880) ->
                            Dual (assertion, FStar_Syntax_Util.t_true, gs))
                   | Neg  -> Simplified (assertion, []))
              | (FStar_Syntax_Syntax.Tm_fvar
@@ -2243,33 +2248,33 @@ let (by_tactic_interp :
                  ->
                  (match pol with
                   | Pos  ->
-                      let uu____3924 =
-                        let uu____3931 =
-                          let uu____3934 =
-                            let uu____3935 =
+                      let uu____3931 =
+                        let uu____3938 =
+                          let uu____3941 =
+                            let uu____3942 =
                               FStar_Tactics_Basic.goal_of_goal_ty e assertion
                                in
                             FStar_All.pipe_left FStar_Pervasives_Native.fst
-                              uu____3935
+                              uu____3942
                              in
-                          [uu____3934]  in
-                        (FStar_Syntax_Util.t_true, uu____3931)  in
-                      Simplified uu____3924
+                          [uu____3941]  in
+                        (FStar_Syntax_Util.t_true, uu____3938)  in
+                      Simplified uu____3931
                   | Both  ->
-                      let uu____3946 =
-                        let uu____3959 =
-                          let uu____3962 =
-                            let uu____3963 =
+                      let uu____3953 =
+                        let uu____3966 =
+                          let uu____3969 =
+                            let uu____3970 =
                               FStar_Tactics_Basic.goal_of_goal_ty e assertion
                                in
                             FStar_All.pipe_left FStar_Pervasives_Native.fst
-                              uu____3963
+                              uu____3970
                              in
-                          [uu____3962]  in
-                        (assertion, FStar_Syntax_Util.t_true, uu____3959)  in
-                      Dual uu____3946
+                          [uu____3969]  in
+                        (assertion, FStar_Syntax_Util.t_true, uu____3966)  in
+                      Dual uu____3953
                   | Neg  -> Simplified (assertion, []))
-             | uu____3984 -> Unchanged t)
+             | uu____3991 -> Unchanged t)
   
 let explode :
   'a .
@@ -2285,17 +2290,17 @@ let explode :
   
 let comb1 : 'a 'b . ('a -> 'b) -> 'a tres_m -> 'b tres_m =
   fun f  ->
-    fun uu___59_4072  ->
-      match uu___59_4072 with
-      | Unchanged t -> let uu____4078 = f t  in Unchanged uu____4078
+    fun uu___59_4079  ->
+      match uu___59_4079 with
+      | Unchanged t -> let uu____4085 = f t  in Unchanged uu____4085
       | Simplified (t,gs) ->
-          let uu____4085 = let uu____4092 = f t  in (uu____4092, gs)  in
-          Simplified uu____4085
+          let uu____4092 = let uu____4099 = f t  in (uu____4099, gs)  in
+          Simplified uu____4092
       | Dual (tn,tp,gs) ->
-          let uu____4102 =
-            let uu____4111 = f tn  in
-            let uu____4112 = f tp  in (uu____4111, uu____4112, gs)  in
-          Dual uu____4102
+          let uu____4109 =
+            let uu____4118 = f tn  in
+            let uu____4119 = f tp  in (uu____4118, uu____4119, gs)  in
+          Dual uu____4109
   
 let comb2 :
   'a 'b 'c . ('a -> 'b -> 'c) -> 'a tres_m -> 'b tres_m -> 'c tres_m =
@@ -2304,33 +2309,33 @@ let comb2 :
       fun y  ->
         match (x, y) with
         | (Unchanged t1,Unchanged t2) ->
-            let uu____4175 = f t1 t2  in Unchanged uu____4175
+            let uu____4182 = f t1 t2  in Unchanged uu____4182
         | (Unchanged t1,Simplified (t2,gs)) ->
-            let uu____4187 = let uu____4194 = f t1 t2  in (uu____4194, gs)
+            let uu____4194 = let uu____4201 = f t1 t2  in (uu____4201, gs)
                in
-            Simplified uu____4187
+            Simplified uu____4194
         | (Simplified (t1,gs),Unchanged t2) ->
-            let uu____4208 = let uu____4215 = f t1 t2  in (uu____4215, gs)
+            let uu____4215 = let uu____4222 = f t1 t2  in (uu____4222, gs)
                in
-            Simplified uu____4208
+            Simplified uu____4215
         | (Simplified (t1,gs1),Simplified (t2,gs2)) ->
-            let uu____4234 =
-              let uu____4241 = f t1 t2  in
-              (uu____4241, (FStar_List.append gs1 gs2))  in
-            Simplified uu____4234
-        | uu____4244 ->
-            let uu____4253 = explode x  in
-            (match uu____4253 with
+            let uu____4241 =
+              let uu____4248 = f t1 t2  in
+              (uu____4248, (FStar_List.append gs1 gs2))  in
+            Simplified uu____4241
+        | uu____4251 ->
+            let uu____4260 = explode x  in
+            (match uu____4260 with
              | (n1,p1,gs1) ->
-                 let uu____4271 = explode y  in
-                 (match uu____4271 with
+                 let uu____4278 = explode y  in
+                 (match uu____4278 with
                   | (n2,p2,gs2) ->
-                      let uu____4289 =
-                        let uu____4298 = f n1 n2  in
-                        let uu____4299 = f p1 p2  in
-                        (uu____4298, uu____4299, (FStar_List.append gs1 gs2))
+                      let uu____4296 =
+                        let uu____4305 = f n1 n2  in
+                        let uu____4306 = f p1 p2  in
+                        (uu____4305, uu____4306, (FStar_List.append gs1 gs2))
                          in
-                      Dual uu____4289))
+                      Dual uu____4296))
   
 let comb_list : 'a . 'a tres_m Prims.list -> 'a Prims.list tres_m =
   fun rs  ->
@@ -2338,15 +2343,15 @@ let comb_list : 'a . 'a tres_m Prims.list -> 'a Prims.list tres_m =
       match rs1 with
       | [] -> acc
       | hd1::tl1 ->
-          let uu____4371 = comb2 (fun l  -> fun r  -> l :: r) hd1 acc  in
-          aux tl1 uu____4371
+          let uu____4378 = comb2 (fun l  -> fun r  -> l :: r) hd1 acc  in
+          aux tl1 uu____4378
        in
     aux (FStar_List.rev rs) (tpure [])
   
 let emit : 'a . FStar_Tactics_Basic.goal Prims.list -> 'a tres_m -> 'a tres_m
   =
   fun gs  ->
-    fun m  -> comb2 (fun uu____4419  -> fun x  -> x) (Simplified ((), gs)) m
+    fun m  -> comb2 (fun uu____4426  -> fun x  -> x) (Simplified ((), gs)) m
   
 let rec (traverse :
   (pol -> FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> tres) ->
@@ -2357,94 +2362,94 @@ let rec (traverse :
       fun e  ->
         fun t  ->
           let r =
-            let uu____4461 =
-              let uu____4462 = FStar_Syntax_Subst.compress t  in
-              uu____4462.FStar_Syntax_Syntax.n  in
-            match uu____4461 with
+            let uu____4468 =
+              let uu____4469 = FStar_Syntax_Subst.compress t  in
+              uu____4469.FStar_Syntax_Syntax.n  in
+            match uu____4468 with
             | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
                 let tr = traverse f pol e t1  in
-                let uu____4474 =
+                let uu____4481 =
                   comb1 (fun t'  -> FStar_Syntax_Syntax.Tm_uinst (t', us))
                    in
-                uu____4474 tr
+                uu____4481 tr
             | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
                 let tr = traverse f pol e t1  in
-                let uu____4500 =
+                let uu____4507 =
                   comb1 (fun t'  -> FStar_Syntax_Syntax.Tm_meta (t', m))  in
-                uu____4500 tr
+                uu____4507 tr
             | FStar_Syntax_Syntax.Tm_app
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                   FStar_Syntax_Syntax.pos = uu____4520;
-                   FStar_Syntax_Syntax.vars = uu____4521;_},(p,uu____4523)::
-                 (q,uu____4525)::[])
+                   FStar_Syntax_Syntax.pos = uu____4527;
+                   FStar_Syntax_Syntax.vars = uu____4528;_},(p,uu____4530)::
+                 (q,uu____4532)::[])
                 when
                 FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid
                 ->
                 let x =
-                  let uu____4565 =
+                  let uu____4572 =
                     FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero p
                      in
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                    uu____4565
+                    uu____4572
                    in
                 let r1 = traverse f (flip pol) e p  in
                 let r2 =
-                  let uu____4568 = FStar_TypeChecker_Env.push_bv e x  in
-                  traverse f pol uu____4568 q  in
+                  let uu____4575 = FStar_TypeChecker_Env.push_bv e x  in
+                  traverse f pol uu____4575 q  in
                 comb2
                   (fun l  ->
                      fun r  ->
-                       let uu____4574 = FStar_Syntax_Util.mk_imp l r  in
-                       uu____4574.FStar_Syntax_Syntax.n) r1 r2
+                       let uu____4581 = FStar_Syntax_Util.mk_imp l r  in
+                       uu____4581.FStar_Syntax_Syntax.n) r1 r2
             | FStar_Syntax_Syntax.Tm_app
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                   FStar_Syntax_Syntax.pos = uu____4578;
-                   FStar_Syntax_Syntax.vars = uu____4579;_},(p,uu____4581)::
-                 (q,uu____4583)::[])
+                   FStar_Syntax_Syntax.pos = uu____4585;
+                   FStar_Syntax_Syntax.vars = uu____4586;_},(p,uu____4588)::
+                 (q,uu____4590)::[])
                 when
                 FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.iff_lid
                 ->
                 let xp =
-                  let uu____4623 =
+                  let uu____4630 =
                     FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero p
                      in
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                    uu____4623
+                    uu____4630
                    in
                 let xq =
-                  let uu____4625 =
+                  let uu____4632 =
                     FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero q
                      in
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                    uu____4625
+                    uu____4632
                    in
                 let r1 =
-                  let uu____4627 = FStar_TypeChecker_Env.push_bv e xq  in
-                  traverse f Both uu____4627 p  in
+                  let uu____4634 = FStar_TypeChecker_Env.push_bv e xq  in
+                  traverse f Both uu____4634 p  in
                 let r2 =
-                  let uu____4629 = FStar_TypeChecker_Env.push_bv e xp  in
-                  traverse f Both uu____4629 q  in
+                  let uu____4636 = FStar_TypeChecker_Env.push_bv e xp  in
+                  traverse f Both uu____4636 q  in
                 (match (r1, r2) with
-                 | (Unchanged uu____4632,Unchanged uu____4633) ->
+                 | (Unchanged uu____4639,Unchanged uu____4640) ->
                      comb2
                        (fun l  ->
                           fun r  ->
-                            let uu____4643 = FStar_Syntax_Util.mk_iff l r  in
-                            uu____4643.FStar_Syntax_Syntax.n) r1 r2
-                 | uu____4646 ->
-                     let uu____4651 = explode r1  in
-                     (match uu____4651 with
+                            let uu____4650 = FStar_Syntax_Util.mk_iff l r  in
+                            uu____4650.FStar_Syntax_Syntax.n) r1 r2
+                 | uu____4653 ->
+                     let uu____4658 = explode r1  in
+                     (match uu____4658 with
                       | (pn,pp,gs1) ->
-                          let uu____4669 = explode r2  in
-                          (match uu____4669 with
+                          let uu____4676 = explode r2  in
+                          (match uu____4676 with
                            | (qn,qp,gs2) ->
                                let t1 =
-                                 let uu____4690 =
+                                 let uu____4697 =
                                    FStar_Syntax_Util.mk_imp pn qp  in
-                                 let uu____4691 =
+                                 let uu____4698 =
                                    FStar_Syntax_Util.mk_imp qn pp  in
-                                 FStar_Syntax_Util.mk_conj uu____4690
-                                   uu____4691
+                                 FStar_Syntax_Util.mk_conj uu____4697
+                                   uu____4698
                                   in
                                Simplified
                                  ((t1.FStar_Syntax_Syntax.n),
@@ -2453,9 +2458,9 @@ let rec (traverse :
                 let r0 = traverse f pol e hd1  in
                 let r1 =
                   FStar_List.fold_right
-                    (fun uu____4743  ->
+                    (fun uu____4750  ->
                        fun r  ->
-                         match uu____4743 with
+                         match uu____4750 with
                          | (a,q) ->
                              let r' = traverse f pol e a  in
                              comb2
@@ -2467,96 +2472,96 @@ let rec (traverse :
                      fun args1  -> FStar_Syntax_Syntax.Tm_app (hd2, args1))
                   r0 r1
             | FStar_Syntax_Syntax.Tm_abs (bs,t1,k) ->
-                let uu____4861 = FStar_Syntax_Subst.open_term bs t1  in
-                (match uu____4861 with
+                let uu____4868 = FStar_Syntax_Subst.open_term bs t1  in
+                (match uu____4868 with
                  | (bs1,topen) ->
                      let e' = FStar_TypeChecker_Env.push_binders e bs1  in
                      let r0 =
                        FStar_List.map
-                         (fun uu____4895  ->
-                            match uu____4895 with
+                         (fun uu____4902  ->
+                            match uu____4902 with
                             | (bv,aq) ->
                                 let r =
                                   traverse f (flip pol) e
                                     bv.FStar_Syntax_Syntax.sort
                                    in
-                                let uu____4909 =
+                                let uu____4916 =
                                   comb1
                                     (fun s'  ->
-                                       ((let uu___63_4935 = bv  in
+                                       ((let uu___63_4942 = bv  in
                                          {
                                            FStar_Syntax_Syntax.ppname =
-                                             (uu___63_4935.FStar_Syntax_Syntax.ppname);
+                                             (uu___63_4942.FStar_Syntax_Syntax.ppname);
                                            FStar_Syntax_Syntax.index =
-                                             (uu___63_4935.FStar_Syntax_Syntax.index);
+                                             (uu___63_4942.FStar_Syntax_Syntax.index);
                                            FStar_Syntax_Syntax.sort = s'
                                          }), aq))
                                    in
-                                uu____4909 r) bs1
+                                uu____4916 r) bs1
                         in
                      let rbs = comb_list r0  in
                      let rt = traverse f pol e' topen  in
                      comb2
                        (fun bs2  ->
                           fun t2  ->
-                            let uu____4955 = FStar_Syntax_Util.abs bs2 t2 k
+                            let uu____4962 = FStar_Syntax_Util.abs bs2 t2 k
                                in
-                            uu____4955.FStar_Syntax_Syntax.n) rbs rt)
+                            uu____4962.FStar_Syntax_Syntax.n) rbs rt)
             | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,ef) ->
-                let uu____5001 = traverse f pol e t1  in
-                let uu____5006 =
+                let uu____5008 = traverse f pol e t1  in
+                let uu____5013 =
                   comb1
                     (fun t2  -> FStar_Syntax_Syntax.Tm_ascribed (t2, asc, ef))
                    in
-                uu____5006 uu____5001
+                uu____5013 uu____5008
             | x -> tpure x  in
           match r with
           | Unchanged tn' ->
               f pol e
-                (let uu___64_5046 = t  in
+                (let uu___64_5053 = t  in
                  {
                    FStar_Syntax_Syntax.n = tn';
                    FStar_Syntax_Syntax.pos =
-                     (uu___64_5046.FStar_Syntax_Syntax.pos);
+                     (uu___64_5053.FStar_Syntax_Syntax.pos);
                    FStar_Syntax_Syntax.vars =
-                     (uu___64_5046.FStar_Syntax_Syntax.vars)
+                     (uu___64_5053.FStar_Syntax_Syntax.vars)
                  })
           | Simplified (tn',gs) ->
-              let uu____5053 =
+              let uu____5060 =
                 f pol e
-                  (let uu___65_5057 = t  in
+                  (let uu___65_5064 = t  in
                    {
                      FStar_Syntax_Syntax.n = tn';
                      FStar_Syntax_Syntax.pos =
-                       (uu___65_5057.FStar_Syntax_Syntax.pos);
+                       (uu___65_5064.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
-                       (uu___65_5057.FStar_Syntax_Syntax.vars)
+                       (uu___65_5064.FStar_Syntax_Syntax.vars)
                    })
                  in
-              emit gs uu____5053
+              emit gs uu____5060
           | Dual (tn,tp,gs) ->
               let rp =
                 f pol e
-                  (let uu___66_5067 = t  in
+                  (let uu___66_5074 = t  in
                    {
                      FStar_Syntax_Syntax.n = tp;
                      FStar_Syntax_Syntax.pos =
-                       (uu___66_5067.FStar_Syntax_Syntax.pos);
+                       (uu___66_5074.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
-                       (uu___66_5067.FStar_Syntax_Syntax.vars)
+                       (uu___66_5074.FStar_Syntax_Syntax.vars)
                    })
                  in
-              let uu____5068 = explode rp  in
-              (match uu____5068 with
-               | (uu____5077,p',gs') ->
+              let uu____5075 = explode rp  in
+              (match uu____5075 with
+               | (uu____5084,p',gs') ->
                    Dual
-                     ((let uu___67_5091 = t  in
+                     ((let uu___67_5098 = t  in
                        {
                          FStar_Syntax_Syntax.n = tn;
                          FStar_Syntax_Syntax.pos =
-                           (uu___67_5091.FStar_Syntax_Syntax.pos);
+                           (uu___67_5098.FStar_Syntax_Syntax.pos);
                          FStar_Syntax_Syntax.vars =
-                           (uu___67_5091.FStar_Syntax_Syntax.vars)
+                           (uu___67_5098.FStar_Syntax_Syntax.vars)
                        }), p', (FStar_List.append gs gs')))
   
 let (getprop :
@@ -2583,90 +2588,90 @@ let (preprocess :
   =
   fun env  ->
     fun goal  ->
-      (let uu____5134 =
+      (let uu____5141 =
          FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")  in
-       FStar_ST.op_Colon_Equals tacdbg uu____5134);
-      (let uu____5159 = FStar_ST.op_Bang tacdbg  in
-       if uu____5159
+       FStar_ST.op_Colon_Equals tacdbg uu____5141);
+      (let uu____5166 = FStar_ST.op_Bang tacdbg  in
+       if uu____5166
        then
-         let uu____5183 =
-           let uu____5184 = FStar_TypeChecker_Env.all_binders env  in
-           FStar_All.pipe_right uu____5184
+         let uu____5190 =
+           let uu____5191 = FStar_TypeChecker_Env.all_binders env  in
+           FStar_All.pipe_right uu____5191
              (FStar_Syntax_Print.binders_to_string ",")
             in
-         let uu____5185 = FStar_Syntax_Print.term_to_string goal  in
-         FStar_Util.print2 "About to preprocess %s |= %s\n" uu____5183
-           uu____5185
+         let uu____5192 = FStar_Syntax_Print.term_to_string goal  in
+         FStar_Util.print2 "About to preprocess %s |= %s\n" uu____5190
+           uu____5192
        else ());
       (let initial = ((Prims.parse_int "1"), [])  in
-       let uu____5214 =
-         let uu____5221 = traverse by_tactic_interp Pos env goal  in
-         match uu____5221 with
+       let uu____5221 =
+         let uu____5228 = traverse by_tactic_interp Pos env goal  in
+         match uu____5228 with
          | Unchanged t' -> (t', [])
          | Simplified (t',gs) -> (t', gs)
-         | uu____5239 -> failwith "no"  in
-       match uu____5214 with
+         | uu____5246 -> failwith "no"  in
+       match uu____5221 with
        | (t',gs) ->
-           ((let uu____5261 = FStar_ST.op_Bang tacdbg  in
-             if uu____5261
+           ((let uu____5268 = FStar_ST.op_Bang tacdbg  in
+             if uu____5268
              then
-               let uu____5285 =
-                 let uu____5286 = FStar_TypeChecker_Env.all_binders env  in
-                 FStar_All.pipe_right uu____5286
+               let uu____5292 =
+                 let uu____5293 = FStar_TypeChecker_Env.all_binders env  in
+                 FStar_All.pipe_right uu____5293
                    (FStar_Syntax_Print.binders_to_string ", ")
                   in
-               let uu____5287 = FStar_Syntax_Print.term_to_string t'  in
+               let uu____5294 = FStar_Syntax_Print.term_to_string t'  in
                FStar_Util.print2 "Main goal simplified to: %s |- %s\n"
-                 uu____5285 uu____5287
+                 uu____5292 uu____5294
              else ());
             (let s = initial  in
              let s1 =
                FStar_List.fold_left
-                 (fun uu____5334  ->
+                 (fun uu____5341  ->
                     fun g  ->
-                      match uu____5334 with
+                      match uu____5341 with
                       | (n1,gs1) ->
                           let phi =
-                            let uu____5379 =
+                            let uu____5386 =
                               getprop g.FStar_Tactics_Types.context
                                 g.FStar_Tactics_Types.goal_ty
                                in
-                            match uu____5379 with
+                            match uu____5386 with
                             | FStar_Pervasives_Native.None  ->
-                                let uu____5382 =
-                                  let uu____5387 =
-                                    let uu____5388 =
+                                let uu____5389 =
+                                  let uu____5394 =
+                                    let uu____5395 =
                                       FStar_Syntax_Print.term_to_string
                                         g.FStar_Tactics_Types.goal_ty
                                        in
                                     FStar_Util.format1
                                       "Tactic returned proof-relevant goal: %s"
-                                      uu____5388
+                                      uu____5395
                                      in
                                   (FStar_Errors.Fatal_TacticProofRelevantGoal,
-                                    uu____5387)
+                                    uu____5394)
                                    in
-                                FStar_Errors.raise_error uu____5382
+                                FStar_Errors.raise_error uu____5389
                                   env.FStar_TypeChecker_Env.range
                             | FStar_Pervasives_Native.Some phi -> phi  in
-                          ((let uu____5391 = FStar_ST.op_Bang tacdbg  in
-                            if uu____5391
+                          ((let uu____5398 = FStar_ST.op_Bang tacdbg  in
+                            if uu____5398
                             then
-                              let uu____5415 = FStar_Util.string_of_int n1
+                              let uu____5422 = FStar_Util.string_of_int n1
                                  in
-                              let uu____5416 =
+                              let uu____5423 =
                                 FStar_Tactics_Basic.goal_to_string g  in
                               FStar_Util.print2 "Got goal #%s: %s\n"
-                                uu____5415 uu____5416
+                                uu____5422 uu____5423
                             else ());
                            (let gt' =
-                              let uu____5419 =
-                                let uu____5420 = FStar_Util.string_of_int n1
+                              let uu____5426 =
+                                let uu____5427 = FStar_Util.string_of_int n1
                                    in
                                 Prims.strcat "Could not prove goal #"
-                                  uu____5420
+                                  uu____5427
                                  in
-                              FStar_TypeChecker_Util.label uu____5419
+                              FStar_TypeChecker_Util.label uu____5426
                                 goal.FStar_Syntax_Syntax.pos phi
                                in
                             ((n1 + (Prims.parse_int "1")),
@@ -2674,34 +2679,34 @@ let (preprocess :
                                  (g.FStar_Tactics_Types.opts)) :: gs1))))) s
                  gs
                 in
-             let uu____5435 = s1  in
-             match uu____5435 with
-             | (uu____5456,gs1) ->
-                 let uu____5474 =
-                   let uu____5481 = FStar_Options.peek ()  in
-                   (env, t', uu____5481)  in
-                 uu____5474 :: gs1)))
+             let uu____5442 = s1  in
+             match uu____5442 with
+             | (uu____5463,gs1) ->
+                 let uu____5481 =
+                   let uu____5488 = FStar_Options.peek ()  in
+                   (env, t', uu____5488)  in
+                 uu____5481 :: gs1)))
   
 let (reify_tactic : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun a  ->
     let r =
-      let uu____5494 =
-        let uu____5495 =
+      let uu____5501 =
+        let uu____5502 =
           FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.reify_tactic_lid
             FStar_Syntax_Syntax.Delta_equational FStar_Pervasives_Native.None
            in
-        FStar_Syntax_Syntax.fv_to_tm uu____5495  in
-      FStar_Syntax_Syntax.mk_Tm_uinst uu____5494 [FStar_Syntax_Syntax.U_zero]
+        FStar_Syntax_Syntax.fv_to_tm uu____5502  in
+      FStar_Syntax_Syntax.mk_Tm_uinst uu____5501 [FStar_Syntax_Syntax.U_zero]
        in
-    let uu____5496 =
-      let uu____5501 =
-        let uu____5502 = FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_unit
+    let uu____5503 =
+      let uu____5508 =
+        let uu____5509 = FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_unit
            in
-        let uu____5503 =
-          let uu____5506 = FStar_Syntax_Syntax.as_arg a  in [uu____5506]  in
-        uu____5502 :: uu____5503  in
-      FStar_Syntax_Syntax.mk_Tm_app r uu____5501  in
-    uu____5496 FStar_Pervasives_Native.None a.FStar_Syntax_Syntax.pos
+        let uu____5510 =
+          let uu____5513 = FStar_Syntax_Syntax.as_arg a  in [uu____5513]  in
+        uu____5509 :: uu____5510  in
+      FStar_Syntax_Syntax.mk_Tm_app r uu____5508  in
+    uu____5503 FStar_Pervasives_Native.None a.FStar_Syntax_Syntax.pos
   
 let (synthesize :
   FStar_TypeChecker_Env.env ->
@@ -2711,26 +2716,26 @@ let (synthesize :
   fun env  ->
     fun typ  ->
       fun tau  ->
-        (let uu____5525 =
+        (let uu____5532 =
            FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")  in
-         FStar_ST.op_Colon_Equals tacdbg uu____5525);
-        (let uu____5549 =
-           let uu____5556 = reify_tactic tau  in
-           run_tactic_on_typ uu____5556 env typ  in
-         match uu____5549 with
+         FStar_ST.op_Colon_Equals tacdbg uu____5532);
+        (let uu____5556 =
+           let uu____5563 = reify_tactic tau  in
+           run_tactic_on_typ uu____5563 env typ  in
+         match uu____5556 with
          | (gs,w) ->
-             let uu____5563 =
+             let uu____5570 =
                FStar_List.existsML
                  (fun g  ->
-                    let uu____5567 =
-                      let uu____5568 =
+                    let uu____5574 =
+                      let uu____5575 =
                         getprop g.FStar_Tactics_Types.context
                           g.FStar_Tactics_Types.goal_ty
                          in
-                      FStar_Option.isSome uu____5568  in
-                    Prims.op_Negation uu____5567) gs
+                      FStar_Option.isSome uu____5575  in
+                    Prims.op_Negation uu____5574) gs
                 in
-             if uu____5563
+             if uu____5570
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_OpenGoalsInSynthesis,
@@ -2743,27 +2748,27 @@ let (splice :
   =
   fun env  ->
     fun tau  ->
-      (let uu____5587 =
+      (let uu____5594 =
          FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")  in
-       FStar_ST.op_Colon_Equals tacdbg uu____5587);
+       FStar_ST.op_Colon_Equals tacdbg uu____5594);
       (let typ = FStar_Syntax_Syntax.t_decls  in
-       let uu____5612 =
-         let uu____5619 = reify_tactic tau  in
-         run_tactic_on_typ uu____5619 env typ  in
-       match uu____5612 with
+       let uu____5619 =
+         let uu____5626 = reify_tactic tau  in
+         run_tactic_on_typ uu____5626 env typ  in
+       match uu____5619 with
        | (gs,w) ->
-           ((let uu____5629 =
+           ((let uu____5636 =
                FStar_List.existsML
                  (fun g  ->
-                    let uu____5633 =
-                      let uu____5634 =
+                    let uu____5640 =
+                      let uu____5641 =
                         getprop g.FStar_Tactics_Types.context
                           g.FStar_Tactics_Types.goal_ty
                          in
-                      FStar_Option.isSome uu____5634  in
-                    Prims.op_Negation uu____5633) gs
+                      FStar_Option.isSome uu____5641  in
+                    Prims.op_Negation uu____5640) gs
                 in
-             if uu____5629
+             if uu____5636
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_OpenGoalsInSynthesis,
@@ -2779,11 +2784,11 @@ let (splice :
                  FStar_TypeChecker_Normalize.Unascribe;
                  FStar_TypeChecker_Normalize.Unmeta] env w
                 in
-             let uu____5639 =
-               let uu____5644 =
+             let uu____5646 =
+               let uu____5651 =
                  FStar_Syntax_Embeddings.e_list
                    FStar_Reflection_Embeddings.e_sigelt
                   in
-               FStar_Syntax_Embeddings.unembed uu____5644 w1  in
-             FStar_All.pipe_left FStar_Util.must uu____5639)))
+               FStar_Syntax_Embeddings.unembed uu____5651 w1  in
+             FStar_All.pipe_left FStar_Util.must uu____5646)))
   

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -10478,7 +10478,7 @@ let (resolve_implicits' :
                                 env1.FStar_TypeChecker_Env.check_type_of
                                   must_total env1 tm1 k
                               with
-                              | e ->
+                              | e when FStar_Errors.handleable e ->
                                   ((let uu____25264 =
                                       let uu____25273 =
                                         let uu____25280 =

--- a/src/parser/ml/FStar_Parser_ParseIt.ml
+++ b/src/parser/ml/FStar_Parser_ParseIt.ml
@@ -143,7 +143,7 @@ let parse fn =
     | FStar_Errors.Error(e, msg, r) ->
       ParseError (e, msg, r)
 
-    | e ->
+    | Parsing.Parse_error as e ->
       let pos = FStar_Parser_Util.pos_of_lexpos lexbuf.cur_p in
       let r = FStar_Range.mk_range filename pos pos in
       ParseError (Fatal_SyntaxError, "Syntax error: " ^ (Printexc.to_string e), r)

--- a/src/smtencoding/FStar.SMTEncoding.Z3.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Z3.fs
@@ -415,9 +415,9 @@ let z3_job (r:Range.range) fresh (label_messages:error_labels) input qhash () : 
   let start = BU.now() in
   let status, statistics =
     try doZ3Exe r fresh input label_messages
-    with _ when not (Options.trace_error()) ->
+    with e when not (Options.trace_error()) ->
          (!bg_z3_proc).refresh();
-         UNKNOWN([], Some "Z3 raised an exception"), BU.smap_create 0
+         raise e
   in
   let _, elapsed_time = BU.time_diff start (BU.now()) in
   { z3result_status     = status;

--- a/src/tactics/FStar.Tactics.Basic.fs
+++ b/src/tactics/FStar.Tactics.Basic.fs
@@ -1421,11 +1421,11 @@ let unify (t1 : term) (t2 : term) : tac<bool> =
     bind get (fun ps ->
     do_unify ps.main_context t1 t2)
 
-let launch_process (prog : string) (args : string) (input : string) : tac<string> =
+let launch_process (prog : string) (args : list<string>) (input : string) : tac<string> =
     // The `bind idtac` thunks the tactic
     bind idtac (fun () ->
     if Options.unsafe_tactic_exec () then
-        let s = BU.launch_process true "tactic_launch" prog args input (fun _ _ -> false) in
+        let s = BU.run_process "tactic_launch" prog args (Some input) in // FIXME
         ret s
     else
         fail "launch_process: will not run anything unless --unsafe_tactic_exec is provided"

--- a/src/tactics/FStar.Tactics.Basic.fsi
+++ b/src/tactics/FStar.Tactics.Basic.fsi
@@ -74,7 +74,7 @@ val is_irrelevant : goal -> bool
 val prune : string -> tac<unit>
 val addns : string -> tac<unit>
 val set_options : string -> tac<unit>
-val launch_process : string -> string -> string -> tac<string>
+val launch_process : string -> list<string> -> string -> tac<string>
 
 val fresh_bv_named : string -> typ -> tac<bv>
 

--- a/src/tactics/boot/FStar.Tactics.Interpreter.fs
+++ b/src/tactics/boot/FStar.Tactics.Interpreter.fs
@@ -434,7 +434,7 @@ and primitive_steps () : list<N.primitive_step> =
 
       mktac2 "uvar_env"      uvar_env RE.e_env (e_option RE.e_term) RE.e_term;
       mktac2 "unify"         unify RE.e_term RE.e_term e_bool;
-      mktac3 "launch_process" launch_process e_string e_string e_string e_string;
+      mktac3 "launch_process" launch_process e_string (e_list e_string) e_string e_string;
 
       mktac2 "fresh_bv_named"  fresh_bv_named e_string RE.e_term RE.e_bv;
       mktac1 "change"          change RE.e_term e_unit;

--- a/src/typechecker/FStar.TypeChecker.Rel.fs
+++ b/src/typechecker/FStar.TypeChecker.Rel.fs
@@ -3093,7 +3093,7 @@ let resolve_implicits' must_total forcelax g =
                let g =
                  try
                    env.check_type_of must_total env tm k
-                 with | e ->
+                 with e when Errors.handleable e ->
                     Errors.add_errors [Error_BadImplicit,
                                        BU.format2 "Failed while checking implicit %s set to %s"
                                                (Print.uvar_to_string u)


### PR DESCRIPTION
With the latest F*, this PR makes it possible to reliably stop processing an F* fragment.

The implementation a few new primitives to FStar.Util, allowing parts of the code to register a handler for interrupts (SIGINT, C-c C-c). The default handler behaves as before (exit F*), but the IDE changes it to ignore C-c C-c instead — except in `run_push` and `run_compute`.  There, C-c C-c transfers control to a handler that raises an exception, which is caught and handled by the --ide code.

There are some subtleties: most of the code in finish_partial_modul, for example, is not safe against exceptions: it uses push in multiple places, but it only pops if it exits with errors.  I don't know that code well at all, so I opted instead to ignore interrupts when loading dependencies.  Additionally, I have not tried to support C-c C-c on the F# side.

Supporting this required refactoring F*'s process management slightly.  We had two functions doing more or less the same thing (run_proc and launch_process) and the output-reading code was duplicated in launch_process and ask_solver.

I think this needs careful review by someone who understands the way OCaml handles pipes, signals, and threads.