### PR TITLE
UInt64 eq_mask/gte_mask

### DIFF
--- a/ulib/FStar.UInt64.fst
+++ b/ulib/FStar.UInt64.fst
@@ -164,21 +164,67 @@ let gte (a:t) (b:t) : Tot bool = gte #n (v a) (v b)
 let lt (a:t) (b:t) : Tot bool = lt #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
-abstract
-let eq_mask (a:t) (b:t) : Pure t
-  (requires True)
-  (ensures (fun c -> (v a = v b ==> v c = pow2 n - 1) /\
-                  (v a <> v b ==> v c = 0)))
-  = if v a = v b then Mk (pow2 n - 1)
-    else Mk 0
+inline_for_extraction
+let minus (a:t) = add_mod (lognot a) (uint_to_t 1)
 
-abstract
-let gte_mask (a:t) (b:t) : Pure t
-  (requires True)
-  (ensures (fun c -> (v a >= v b ==> v c = pow2 n - 1) /\
-                  (v a < v b ==> v c = 0)))
-  = if v a >= v b then Mk (pow2 n - 1)
-    else Mk 0
+#set-options "--z3rlimit 10 --initial_fuel 1 --max_fuel 1"
+// With inspiration from https://git.zx2c4.com/WireGuard/commit/src/crypto/curve25519-hacl64.h?id=2e60bb395c1f589a398ec606d611132ef9ef764b
+let eq_mask (a:t) (b:t)
+  : Pure t
+    (requires True)
+    (ensures (fun c -> (v a = v b ==> v c = pow2 n - 1) /\
+                       (v a <> v b ==> v c = 0)))
+  = let x = logxor a b in
+    let minus_x = minus x in
+    let x_or_minus_x = logor x minus_x in
+    let xnx_63 = shift_right x_or_minus_x (UInt32.uint_to_t 63) in
+    let c = sub_mod xnx_63 (uint_to_t 1) in
+    if a = b then
+    begin
+      logxor_self (v a);
+      lognot_lemma_1 #n;
+      logor_lemma_1 (v x);
+      assert (v x = 0 /\ v minus_x = 0 /\
+              v x_or_minus_x = 0 /\ v xnx_63 = 0);
+      assert (v c = ones n)
+    end
+    else
+    begin
+      logxor_neq_nonzero (v a) (v b);
+      lemma_msb_pow2 #n (v (lognot x));
+      lemma_msb_pow2 #n (v minus_x);
+      lemma_minus_zero #n (v x);
+      assert (v c = zero n)
+    end;
+    c
+
+private
+let lemma_sub_msbs (a:t) (b:t)
+  : Lemma ((msb (v a) = msb (v b)) ==> (v a < v b <==> msb (v (sub_mod a b))))
+  = from_vec_propriety (to_vec (v a)) 1;
+    from_vec_propriety (to_vec (v b)) 1;
+    from_vec_propriety (to_vec (v (sub_mod a b))) 1
+
+// With inspiration from https://git.zx2c4.com/WireGuard/commit/src/crypto/curve25519-hacl64.h?id=0a483a9b431d87eca1b275463c632f8d5551978a
+let gte_mask (a:t) (b:t)
+  : Pure t
+    (requires True)
+    (ensures (fun c -> (v a >= v b ==> v c = pow2 n - 1) /\
+                       (v a < v b ==> v c = 0)))
+  = let x = a in
+    let y = b in
+    let x_xor_y = logxor x y in
+    let x_sub_y = sub_mod x y in
+    let x_sub_y_xor_y = logxor x_sub_y y in
+    let q = logor x_xor_y x_sub_y_xor_y in
+    let x_xor_q = logxor x q in
+    let x_xor_q_63 = shift_right x_xor_q 63ul in
+    let c = sub_mod x_xor_q_63 (uint_to_t 1) in
+    lemma_sub_msbs x y;
+    lemma_msb_gte (v x) (v y);
+    lemma_msb_gte (v y) (v x);
+    c
+#reset-options
 
 (* Infix notations *)
 unfold let op_Plus_Hat = add


### PR DESCRIPTION
Added constant-time, verified, Low* `eq_mask` and `gte_mask` to `UInt64`. 

I haven't successfully generalized this into `FStar.UIntN.fstp`, so it's only in `UInt64` for now.

They extract beautifully when I isolate them in my own file:

```
uint64_t UInt64_eq_mask(uint64_t a, uint64_t b)
{
  uint64_t x = a ^ b;
  uint64_t minus_x = ~x + (uint64_t)1U;
  uint64_t x_or_minus_x = x | minus_x;
  uint64_t xnx_63 = x_or_minus_x >> (uint32_t)63U;
  uint64_t c = xnx_63 - (uint64_t)1U;
  return c;
}

uint64_t UInt64_gte_mask(uint64_t a, uint64_t b)
{
  uint64_t x = a;
  uint64_t y = b;
  uint64_t x_xor_y = x ^ y;
  uint64_t x_sub_y = x - y;
  uint64_t x_sub_y_xor_y = x_sub_y ^ y;
  uint64_t q = x_xor_y | x_sub_y_xor_y;
  uint64_t x_xor_q = x ^ q;
  uint64_t x_xor_q_63 = x_xor_q >> (uint32_t)63U;
  uint64_t c = x_xor_q_63 - (uint64_t)1U;
  return c;
}
```

But I wasn't able to convince the Makefiles to produce that from ulib yet. 

I hope that this will allow us to get rid of a bunch of unverified `UInt` files for kremlib soon. Suggestions welcome and feel free to commit to this branch directly, e.g. to move stuff into different files.