### PR TITLE
Remove link in tutorial to tryfsharp.org

### DIFF
--- a/doc/tutorial/tutorial.mdk
+++ b/doc/tutorial/tutorial.mdk
@@ -123,7 +123,6 @@ resources freely available on the web, e.g., [TryF#],
 [Haskell]: https://www.haskell.org
 
 [F# for fun and profit]: http://fsharpforfunandprofit.com/
-[TryF#]: http://www.tryfsharp.org
 [Introduction to Caml]: https://pl.cs.jhu.edu/pl/lectures/caml-intro.html
 [Real World OCaml]: https://realworldocaml.org/
 


### PR DESCRIPTION
tryfsharp.org is no longer active, so the link should be removed.