### PR TITLE
Show full module names on extraction output

### DIFF
--- a/src/extraction/FStar.Extraction.ML.Modul.fs
+++ b/src/extraction/FStar.Extraction.ML.Modul.fs
@@ -843,7 +843,7 @@ let extract' (g:uenv) (m:modul) : uenv * option<mllib> =
   if m.name.str <> "Prims"
   && (is_kremlin || not m.is_interface)
   then begin
-    BU.print1 "Extracted module %s\n" (Print.lid_to_string m.name);
+    BU.print1 "Extracted module %s\n" (string_of_lid m.name);
     g, Some (MLLib ([name, Some ([], mlm), (MLLib [])]))
   end
   else g, None

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -2041,8 +2041,7 @@ let (extract' :
                   (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
            then
              ((let uu____5688 =
-                 FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name
-                  in
+                 FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
                FStar_Util.print1 "Extracted module %s\n" uu____5688);
               (g2,
                 (FStar_Pervasives_Native.Some


### PR DESCRIPTION
A request by @beurdouche, goes from:
```
Extracted module Native
Extracted module Pervasives
Extracted module Preorder
Extracted module StrongExcludedMiddle
Extracted module PropositionalExtensionality
Extracted module PredicateExtensionality
Extracted module TSet
Extracted module Heap
Extracted module ST
```
to:
```
Extracted module FStar.Pervasives.Native
Extracted module FStar.Pervasives
Extracted module FStar.Preorder
Extracted module FStar.StrongExcludedMiddle
Extracted module FStar.PropositionalExtensionality
Extracted module FStar.PredicateExtensionality
Extracted module FStar.TSet
Extracted module FStar.Heap
Extracted module FStar.ST
```

Mostly important when many modules in the hierarchy have the same final name, such as `Impl`.

The code change is uncontroversial, just making the PR in case this is somehow undesirable.