### PR TITLE
add explicit package for FSharp.Core, and consume this package in all projects

### DIFF
--- a/src/basic/basic.fsproj
+++ b/src/basic/basic.fsproj
@@ -115,6 +115,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/extraction/extraction.fsproj
+++ b/src/extraction/extraction.fsproj
@@ -96,6 +96,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/format/format.fsproj
+++ b/src/format/format.fsproj
@@ -69,6 +69,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/fsdoc/fsdoc.fsproj
+++ b/src/fsdoc/fsdoc.fsproj
@@ -75,6 +75,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/fstar/fstar.fsproj
+++ b/src/fstar/fstar.fsproj
@@ -139,6 +139,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/parser/packages.config
+++ b/src/parser/packages.config
@@ -4,4 +4,5 @@
   <package id="FsLexYacc" version="6.1.0" targetFramework="net45" />
   <package id="FsLexYacc.Runtime" version="6.1.0" targetFramework="net45" />
   <package id="PPrintForFSharp" version="0.0.2" targetFramework="net45" />
+  <package id="FSharp.Core" version="4.1.18" targetFramework="net45" />
 </packages>

--- a/src/parser/parser.fsproj
+++ b/src/parser/parser.fsproj
@@ -108,6 +108,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/prettyprint/prettyprint.fsproj
+++ b/src/prettyprint/prettyprint.fsproj
@@ -69,6 +69,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/reflection/reflection.fsproj
+++ b/src/reflection/reflection.fsproj
@@ -41,6 +41,10 @@
       <HintPath>..\VS\packages\FSharp.Compatibility.OCaml.0.1.10\lib\net40\FSharp.Compatibility.OCaml.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/src/smtencoding/smtencoding.fsproj
+++ b/src/smtencoding/smtencoding.fsproj
@@ -81,6 +81,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/syntax/syntax.fsproj
+++ b/src/syntax/syntax.fsproj
@@ -87,6 +87,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/tactics/tactics.fsproj
+++ b/src/tactics/tactics.fsproj
@@ -40,6 +40,10 @@
     <Reference Include="FSharp.Compatibility.OCaml">
       <HintPath>..\VS\packages\FSharp.Compatibility.OCaml.0.1.10\lib\net40\FSharp.Compatibility.OCaml.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/tests/tests.fsproj
+++ b/src/tests/tests.fsproj
@@ -76,6 +76,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/tosyntax/tosyntax.fsproj
+++ b/src/tosyntax/tosyntax.fsproj
@@ -104,6 +104,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/typechecker/typechecker.fsproj
+++ b/src/typechecker/typechecker.fsproj
@@ -98,6 +98,10 @@
       <HintPath>..\VS\packages\FsLexYacc.Runtime.6.1.0\lib\net40\FsLexYacc.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\VS\packages\FSharp.Core.4.1.18\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
This is the minimum change to fix #1539 by making the implicit dependency on FSharp.Core from the system GAC an explicit package reference instead. This also has the nice side effect of standardizing the version of FSharp.Core used for FStar instead of allowing the version brought along by Mono/.Net Framework to determine that.  Since FSharp.Core is backwards compatible this is fine.

As a result of this change, you should see `FSharp.Core.dll` in the `bin` directory after a build.  The version of this dll should be 4.4.1.0, as determined by `ildasm path/to/dll`, `monop -r path/to/dll`, or any other decompiler.  In the future, if FStar decides they want to update the version of FSharp.Core they support, it would be a matter of updating the 4.1.18 string to the desired versions.

The change to each project file to pin to this FSharp.Core dependency should also ensure that the FSharp.Core built against is the FSharp.Core that is run against, eliminating compile-time/run-time mismatches.

Finally, I'm running Mono 5.23 previews currently and there have been many overloads to `System.IO.Path` methods that take `ReadOnlySpan<char>`, so some type annotations were necessary to fix compiler errors around indeterminable overload resolution.  These all happened in the `basic` project and were very low-impact.


Questions:
* This is the minimal change, but I noticed that each project has a project file item for `packages.config`, but only `parser` has the `packages.config`. Should those extraneous items be removed? Or should a link be added instead to the 'official' `packages.config`?