### PR TITLE
Remove theory symbols in patterns in ulib

### DIFF
--- a/ulib/FStar.Buffer.fst
+++ b/ulib/FStar.Buffer.fst
@@ -225,7 +225,7 @@ let modifies_bufs_and_refs (bufs:TSet.set abuffer) (refs:Set.set nat) h h' : GTo
 let modifies_buffers (bufs:TSet.set abuffer) h h' : GTot Type0 =
   (forall rid. Set.mem rid (Map.domain (HS.get_hmap h)) ==>
     (HS.modifies_ref rid (arefs bufs) h h' /\
-      (forall (#a:Type) (b:buffer a). {:pattern (frameOf b == rid /\ live h b /\ disjoint_from_bufs b bufs)}
+      (forall (#a:Type) (b:buffer a). {:pattern (frameOf b = rid /\ live h b /\ disjoint_from_bufs b bufs)}
 	(frameOf b == rid /\ live h b /\ disjoint_from_bufs b bufs ==> equal h b h' b /\ live h' b))))
 
 (* General modifies clause for buffers only *)

--- a/ulib/FStar.List.Tot.Properties.fst
+++ b/ulib/FStar.List.Tot.Properties.fst
@@ -1007,7 +1007,8 @@ let precedes_append_cons_prod_r
 : Lemma
   (requires (l == append l1 ((x, y) :: l2)))
   (ensures (x << l /\ y << l))
-  [SMTPatOr [ [ SMTPat (x << l); SMTPat (l == append l1 ((x, y) :: l2))] ; [SMTPat (y << l); SMTPat (l == append l1 ((x, y) :: l2))] ] ]
+  [SMTPatOr [ [ SMTPat (x << l); SMTPat (append l1 ((x, y) :: l2))];
+              [ SMTPat (y << l); SMTPat (append l1 ((x, y) :: l2))] ] ]
 = precedes_append_cons_r l1 (x, y) l2
 
 let rec memP_precedes

--- a/ulib/FStar.UInt.fst
+++ b/ulib/FStar.UInt.fst
@@ -622,7 +622,7 @@ let lognot_lemma_1 #n = nth_lemma (lognot #n (zero n)) (ones n)
 private val to_vec_mod_pow2: #n:nat -> a:uint_t n -> m:pos -> i:nat{n - m <= i /\ i < n} ->
   Lemma (requires (a % pow2 m == 0))
         (ensures  (index (to_vec a) i == false))
-        [SMTPat (index (to_vec #n a) i); SMTPat (a % pow2 m == 0)]
+        [SMTPat (index (to_vec #n a) i); SMTPat (a % pow2 m = 0)]
 let rec to_vec_mod_pow2 #n a m i =
   if i = n - 1 then
     begin
@@ -676,7 +676,7 @@ val logor_disjoint: #n:pos -> a:uint_t n -> b:uint_t n -> m:pos{m < n} ->
   Lemma (requires (a % pow2 m == 0 /\ b < pow2 m))
         (ensures  (logor #n a b == a + b))
 let logor_disjoint #n a b m =
-  assert (a % pow2 m == 0); // To trigger pattern above
+  assert (a % pow2 m = 0); // To trigger pattern above
   assert (forall (i:nat{n - m <= i /\ i < n}).{:pattern (index (to_vec a) i)}
     index (to_vec a) i == false);
   assert (b < pow2 m); // To trigger pattern above

--- a/ulib/LowStar.Monotonic.Buffer.fsti
+++ b/ulib/LowStar.Monotonic.Buffer.fsti
@@ -421,7 +421,7 @@ let loc_union_idem_1
   (s1 s2: loc)
 : Lemma
   (loc_union s1 (loc_union s1 s2) == loc_union s1 s2)
-  [SMTPat (loc_union s1 (loc_union s1 s2) == loc_union s1 s2)]
+  [SMTPat (loc_union s1 (loc_union s1 s2))]
 = loc_union_assoc s1 s1 s2
 
 let loc_union_idem_2

--- a/ulib/LowStar.Vector.fst
+++ b/ulib/LowStar.Vector.fst
@@ -681,8 +681,8 @@ val forall_preserved:
         (ensures (forall_ h1 vec i j p))
 let forall_preserved #a vec i j p dloc h0 h1 =
   modifies_as_seq_within vec i j dloc h0 h1;
-  assert (S.slice (as_seq h0 vec) (U32.v i) (U32.v j) ==
-         S.slice (as_seq h1 vec) (U32.v i) (U32.v j))
+  assert (Seq.equal (S.slice (as_seq h0 vec) (U32.v i) (U32.v j))
+                    (S.slice (as_seq h1 vec) (U32.v i) (U32.v j)))
 
 val forall2_extend:
   #a:Type -> h:HS.mem -> vec:vector a ->

--- a/ulib/LowStar.Vector.fst
+++ b/ulib/LowStar.Vector.fst
@@ -664,10 +664,10 @@ val forall_as_seq:
   Lemma (requires (p (S.index s0 k) /\ S.slice s0 i j == S.slice s1 i j))
         (ensures (p (S.index s1 k)))
         [SMTPat (p (S.index s0 k));
-        SMTPat (S.slice s0 i j == S.slice s1 i j)]
+         SMTPat (Seq.equal (S.slice s0 i j) (S.slice s1 i j))]
 let forall_as_seq #a s0 s1 i j k p =
   assert (S.index (S.slice s0 i j) (k - i) ==
-         S.index (S.slice s1 i j) (k - i))
+          S.index (S.slice s1 i j) (k - i))
 
 val forall_preserved:
   #a:Type -> vec:vector a ->


### PR DESCRIPTION
This removes a few uses of `==` in patterns which are unreliable (see #1660)
