### PR TITLE
Fixing the extraction of partial type applications

### DIFF
--- a/examples/bug-reports/Bug1694.fst
+++ b/examples/bug-reports/Bug1694.fst
@@ -1,0 +1,19 @@
+module Bug1694
+type t_min = #a:Type -> a -> Tot a
+let f_min : t_min = fun #a x -> x
+let h_min : t_min = f_min
+
+module B = LowStar.Monotonic.Buffer
+module U32 = FStar.UInt32
+module HST = FStar.HyperStack.ST
+
+inline_for_extraction
+type t =
+  (#rrel : B.srel U32.t) ->
+  (#rel: B.srel U32.t) ->
+  (b: B.mbuffer U32.t rrel rel) ->
+  HST.ST unit (fun _ -> True) (fun _ _ _ -> True)
+
+let f : t = fun #rrel #rel b -> ()
+
+let h : t = f

--- a/examples/bug-reports/Makefile
+++ b/examples/bug-reports/Makefile
@@ -33,7 +33,7 @@ SHOULD_VERIFY_CLOSED=bug022.fst bug024.fst bug025.fst bug026.fst bug026b.fst bug
   Bug1533.fst bug1535a.fst bug1535b.fst Bug1536.fst bug1370a.fst bug1370b.fst bug1534.fst bug575.fst \
   bug1443a.fst bug1443b.fst bug1443c.fst bug1443d.fst bug1443e.fst bug1523.fst bug1141a.fst bug1141b.fst bug1141c.fst bug1141d.fst \
   bug1561a.fst bug1561b.fst bug1065a.fst bug1065b.fst bug1065c.fst bug1568.fst Bug1571.fst Bug1572.fst Bug1592.fst \
-  Bug1595.fst Bug1601.fst Bug1602.fst Bug1604.fst Bug1605.fst Bug1621.fst Bug1680.fst Bug1682.fst
+  Bug1595.fst Bug1601.fst Bug1602.fst Bug1604.fst Bug1605.fst Bug1621.fst Bug1680.fst Bug1682.fst Bug1694.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=bug771.fsti bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=bug016.fst
@@ -119,6 +119,7 @@ CAPPED=$(subst bug,Bug,$*)
 	$(FSTAR) $^
 
 bug1383.verify: OTHERFLAGS += --warn_error @275 #Z3 warnings are fatal
+Bug1694.verify: OTHERFLAGS += --codegen OCaml
 verify: $(subst .fst,.verify,$(SHOULD_VERIFY_CLOSED))
 
 %.iverify: %.fsti

--- a/src/extraction/FStar.Extraction.Kremlin.fs
+++ b/src/extraction/FStar.Extraction.Kremlin.fs
@@ -936,7 +936,8 @@ and assert_lid env t =
         TApp (lid, List.map (translate_type env) ts)
       else
         TQualified lid
-  | _ -> failwith "invalid argument: assert_lid"
+  | _ -> failwith (BU.format1 "invalid argument: expected MLTY_Named, got %s"
+                             (ML.Code.string_of_mlty ([], "") t))
 
 and translate_branches env branches =
   List.map (translate_branch env) branches

--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -400,8 +400,12 @@ let instantiate_maybe_partial (e:mlexpr) (s:mltyscheme) (tyargs:list<mlty>) : ml
       if n_args = 0
       then e, E_PURE, t
       else
-        let tapp = {e with expr=MLE_TApp(e, tyargs) } in
         let ts = instantiate_tyscheme (vars, t) tyargs in
+        let tapp = {
+          e with
+            expr=MLE_TApp(e, tyargs);
+            mlty=ts
+        } in
         tapp, E_PURE, ts
     else if n_args < n_vars
     then //We have a partial type-application in F*
@@ -415,8 +419,12 @@ let instantiate_maybe_partial (e:mlexpr) (s:mltyscheme) (tyargs:list<mlty>) : ml
         rest_vars |> List.map (fun _ -> MLTY_Erased)
       in
       let tyargs = tyargs@extra_tyargs in
-      let tapp = {e with expr=MLE_TApp(e, tyargs) } in
       let ts = instantiate_tyscheme (vars, t) tyargs in
+      let tapp = {
+        e with
+          expr=MLE_TApp(e, tyargs);
+          mlty=ts
+      } in
       let t =
         List.fold_left
           (fun out t -> MLTY_Fun(t, E_PURE, out))

--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -397,9 +397,12 @@ let instantiate_maybe_partial (e:mlexpr) (s:mltyscheme) (tyargs:list<mlty>) : ml
     let n_args = List.length tyargs in
     if n_args = n_vars
     then //easy, just make a type application node
-      let tapp = {e with expr=MLE_TApp(e, tyargs) } in
-      let ts = instantiate_tyscheme (vars, t) tyargs in
-      tapp, E_PURE, ts
+      if n_args = 0
+      then e, E_PURE, t
+      else
+        let tapp = {e with expr=MLE_TApp(e, tyargs) } in
+        let ts = instantiate_tyscheme (vars, t) tyargs in
+        tapp, E_PURE, ts
     else if n_args < n_vars
     then //We have a partial type-application in F*
          //So, make a full type application node in ML,

--- a/src/ocaml-output/FStar_Extraction_Kremlin.ml
+++ b/src/ocaml-output/FStar_Extraction_Kremlin.ml
@@ -2616,7 +2616,14 @@ and (assert_lid : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
               (lid, uu____8146)  in
             TApp uu____8131
           else TQualified lid
-      | uu____8161 -> failwith "invalid argument: assert_lid"
+      | uu____8161 ->
+          let uu____8162 =
+            let uu____8164 =
+              FStar_Extraction_ML_Code.string_of_mlty ([], "") t  in
+            FStar_Util.format1
+              "invalid argument: expected MLTY_Named, got %s" uu____8164
+             in
+          failwith uu____8162
 
 and (translate_branches :
   env ->
@@ -2633,24 +2640,24 @@ and (translate_branch :
       (pattern * expr))
   =
   fun env  ->
-    fun uu____8188  ->
-      match uu____8188 with
+    fun uu____8198  ->
+      match uu____8198 with
       | (pat,guard,expr) ->
           if guard = FStar_Pervasives_Native.None
           then
-            let uu____8215 = translate_pat env pat  in
-            (match uu____8215 with
+            let uu____8225 = translate_pat env pat  in
+            (match uu____8225 with
              | (env1,pat1) ->
-                 let uu____8226 = translate_expr env1 expr  in
-                 (pat1, uu____8226))
+                 let uu____8236 = translate_expr env1 expr  in
+                 (pat1, uu____8236))
           else failwith "todo: translate_branch"
 
 and (translate_width :
   (FStar_Const.signedness * FStar_Const.width) FStar_Pervasives_Native.option
     -> width)
   =
-  fun uu___7_8234  ->
-    match uu___7_8234 with
+  fun uu___7_8244  ->
+    match uu___7_8244 with
     | FStar_Pervasives_Native.None  -> CInt
     | FStar_Pervasives_Native.Some (FStar_Const.Signed ,FStar_Const.Int8 ) ->
         Int8
@@ -2680,60 +2687,60 @@ and (translate_pat :
           (FStar_Extraction_ML_Syntax.MLC_Bool b) -> (env, (PBool b))
       | FStar_Extraction_ML_Syntax.MLP_Const
           (FStar_Extraction_ML_Syntax.MLC_Int (s,sw)) ->
-          let uu____8301 =
-            let uu____8302 =
-              let uu____8308 = translate_width sw  in (uu____8308, s)  in
-            PConstant uu____8302  in
-          (env, uu____8301)
+          let uu____8311 =
+            let uu____8312 =
+              let uu____8318 = translate_width sw  in (uu____8318, s)  in
+            PConstant uu____8312  in
+          (env, uu____8311)
       | FStar_Extraction_ML_Syntax.MLP_Var name ->
           let env1 = extend env name  in
           (env1, (PVar { name; typ = TAny; mut = false }))
       | FStar_Extraction_ML_Syntax.MLP_Wild  ->
           let env1 = extend env "_"  in
           (env1, (PVar { name = "_"; typ = TAny; mut = false }))
-      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____8318,cons1),ps) ->
-          let uu____8333 =
+      | FStar_Extraction_ML_Syntax.MLP_CTor ((uu____8328,cons1),ps) ->
+          let uu____8343 =
             FStar_List.fold_left
-              (fun uu____8353  ->
+              (fun uu____8363  ->
                  fun p1  ->
-                   match uu____8353 with
+                   match uu____8363 with
                    | (env1,acc) ->
-                       let uu____8373 = translate_pat env1 p1  in
-                       (match uu____8373 with
+                       let uu____8383 = translate_pat env1 p1  in
+                       (match uu____8383 with
                         | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
              in
-          (match uu____8333 with
+          (match uu____8343 with
            | (env1,ps1) -> (env1, (PCons (cons1, (FStar_List.rev ps1)))))
-      | FStar_Extraction_ML_Syntax.MLP_Record (uu____8403,ps) ->
-          let uu____8425 =
+      | FStar_Extraction_ML_Syntax.MLP_Record (uu____8413,ps) ->
+          let uu____8435 =
             FStar_List.fold_left
-              (fun uu____8462  ->
-                 fun uu____8463  ->
-                   match (uu____8462, uu____8463) with
+              (fun uu____8472  ->
+                 fun uu____8473  ->
+                   match (uu____8472, uu____8473) with
                    | ((env1,acc),(field,p1)) ->
-                       let uu____8543 = translate_pat env1 p1  in
-                       (match uu____8543 with
+                       let uu____8553 = translate_pat env1 p1  in
+                       (match uu____8553 with
                         | (env2,p2) -> (env2, ((field, p2) :: acc))))
               (env, []) ps
              in
-          (match uu____8425 with
+          (match uu____8435 with
            | (env1,ps1) -> (env1, (PRecord (FStar_List.rev ps1))))
       | FStar_Extraction_ML_Syntax.MLP_Tuple ps ->
-          let uu____8614 =
+          let uu____8624 =
             FStar_List.fold_left
-              (fun uu____8634  ->
+              (fun uu____8644  ->
                  fun p1  ->
-                   match uu____8634 with
+                   match uu____8644 with
                    | (env1,acc) ->
-                       let uu____8654 = translate_pat env1 p1  in
-                       (match uu____8654 with
+                       let uu____8664 = translate_pat env1 p1  in
+                       (match uu____8664 with
                         | (env2,p2) -> (env2, (p2 :: acc)))) (env, []) ps
              in
-          (match uu____8614 with
+          (match uu____8624 with
            | (env1,ps1) -> (env1, (PTuple (FStar_List.rev ps1))))
-      | FStar_Extraction_ML_Syntax.MLP_Const uu____8681 ->
+      | FStar_Extraction_ML_Syntax.MLP_Const uu____8691 ->
           failwith "todo: translate_pat [MLP_Const]"
-      | FStar_Extraction_ML_Syntax.MLP_Branch uu____8687 ->
+      | FStar_Extraction_ML_Syntax.MLP_Branch uu____8697 ->
           failwith "todo: translate_pat [MLP_Branch]"
 
 and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
@@ -2742,21 +2749,21 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
     | FStar_Extraction_ML_Syntax.MLC_Unit  -> EUnit
     | FStar_Extraction_ML_Syntax.MLC_Bool b -> EBool b
     | FStar_Extraction_ML_Syntax.MLC_String s ->
-        ((let uu____8701 =
-            let uu____8703 = FStar_String.list_of_string s  in
-            FStar_All.pipe_right uu____8703
+        ((let uu____8711 =
+            let uu____8713 = FStar_String.list_of_string s  in
+            FStar_All.pipe_right uu____8713
               (FStar_Util.for_some
                  (fun c1  ->
                     c1 = (FStar_Char.char_of_int (Prims.parse_int "0"))))
              in
-          if uu____8701
+          if uu____8711
           then
-            let uu____8718 =
+            let uu____8728 =
               FStar_Util.format1
                 "Refusing to translate a string literal that contains a null character: %s"
                 s
                in
-            failwith uu____8718
+            failwith uu____8728
           else ());
          EString s)
     | FStar_Extraction_ML_Syntax.MLC_Char c1 ->
@@ -2766,12 +2773,12 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
         let char_of_int1 = EQualified (["FStar"; "Char"], "char_of_int")  in
         EApp (char_of_int1, [c2])
     | FStar_Extraction_ML_Syntax.MLC_Int
-        (s,FStar_Pervasives_Native.Some uu____8745) ->
+        (s,FStar_Pervasives_Native.Some uu____8755) ->
         failwith
           "impossible: machine integer not desugared to a function call"
-    | FStar_Extraction_ML_Syntax.MLC_Float uu____8763 ->
+    | FStar_Extraction_ML_Syntax.MLC_Float uu____8773 ->
         failwith "todo: translate_expr [MLC_Float]"
-    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____8765 ->
+    | FStar_Extraction_ML_Syntax.MLC_Bytes uu____8775 ->
         failwith "todo: translate_expr [MLC_Bytes]"
     | FStar_Extraction_ML_Syntax.MLC_Int (s,FStar_Pervasives_Native.None ) ->
         EConstant (CInt, s)
@@ -2783,7 +2790,7 @@ and (mk_op_app :
     fun w  ->
       fun op  ->
         fun args  ->
-          let uu____8789 =
-            let uu____8796 = FStar_List.map (translate_expr env) args  in
-            ((EOp (op, w)), uu____8796)  in
-          EApp uu____8789
+          let uu____8799 =
+            let uu____8806 = FStar_List.map (translate_expr env) args  in
+            ((EOp (op, w)), uu____8806)  in
+          EApp uu____8799

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -52,114 +52,84 @@ let fail :
     FStar_Range.range ->
       (FStar_Errors.raw_error * Prims.string) -> 'Auu____120
   = fun r  -> fun err  -> FStar_Errors.raise_error err r 
-let err_uninst :
-  'Auu____152 .
-    FStar_Extraction_ML_UEnv.uenv ->
-      FStar_Syntax_Syntax.term ->
-        (Prims.string Prims.list * FStar_Extraction_ML_Syntax.mlty) ->
-          FStar_Syntax_Syntax.term -> 'Auu____152
-  =
-  fun env  ->
-    fun t  ->
-      fun uu____178  ->
-        fun app  ->
-          match uu____178 with
-          | (vars,ty) ->
-              let uu____195 =
-                let uu____201 =
-                  let uu____203 = FStar_Syntax_Print.term_to_string t  in
-                  let uu____205 =
-                    FStar_All.pipe_right vars (FStar_String.concat ", ")  in
-                  let uu____212 =
-                    FStar_Extraction_ML_Code.string_of_mlty
-                      env.FStar_Extraction_ML_UEnv.currentModule ty
-                     in
-                  let uu____214 = FStar_Syntax_Print.term_to_string app  in
-                  FStar_Util.format4
-                    "Variable %s has a polymorphic type (forall %s. %s); expected it to be fully instantiated, but got %s"
-                    uu____203 uu____205 uu____212 uu____214
-                   in
-                (FStar_Errors.Fatal_Uninstantiated, uu____201)  in
-              fail t.FStar_Syntax_Syntax.pos uu____195
-  
 let err_ill_typed_application :
-  'Auu____233 'Auu____234 .
+  'Auu____156 'Auu____157 .
     FStar_Extraction_ML_UEnv.uenv ->
       FStar_Syntax_Syntax.term ->
         FStar_Extraction_ML_Syntax.mlexpr ->
-          (FStar_Syntax_Syntax.term * 'Auu____233) Prims.list ->
-            FStar_Extraction_ML_Syntax.mlty -> 'Auu____234
+          (FStar_Syntax_Syntax.term * 'Auu____156) Prims.list ->
+            FStar_Extraction_ML_Syntax.mlty -> 'Auu____157
   =
   fun env  ->
     fun t  ->
       fun mlhead  ->
         fun args  ->
           fun ty  ->
-            let uu____272 =
-              let uu____278 =
-                let uu____280 = FStar_Syntax_Print.term_to_string t  in
-                let uu____282 =
+            let uu____195 =
+              let uu____201 =
+                let uu____203 = FStar_Syntax_Print.term_to_string t  in
+                let uu____205 =
                   FStar_Extraction_ML_Code.string_of_mlexpr
                     env.FStar_Extraction_ML_UEnv.currentModule mlhead
                    in
-                let uu____284 =
+                let uu____207 =
                   FStar_Extraction_ML_Code.string_of_mlty
                     env.FStar_Extraction_ML_UEnv.currentModule ty
                    in
-                let uu____286 =
-                  let uu____288 =
+                let uu____209 =
+                  let uu____211 =
                     FStar_All.pipe_right args
                       (FStar_List.map
-                         (fun uu____309  ->
-                            match uu____309 with
-                            | (x,uu____316) ->
+                         (fun uu____232  ->
+                            match uu____232 with
+                            | (x,uu____239) ->
                                 FStar_Syntax_Print.term_to_string x))
                      in
-                  FStar_All.pipe_right uu____288 (FStar_String.concat " ")
+                  FStar_All.pipe_right uu____211 (FStar_String.concat " ")
                    in
                 FStar_Util.format4
                   "Ill-typed application: source application is %s \n translated prefix to %s at type %s\n remaining args are %s\n"
-                  uu____280 uu____282 uu____284 uu____286
+                  uu____203 uu____205 uu____207 uu____209
                  in
-              (FStar_Errors.Fatal_IllTyped, uu____278)  in
-            fail t.FStar_Syntax_Syntax.pos uu____272
+              (FStar_Errors.Fatal_IllTyped, uu____201)  in
+            fail t.FStar_Syntax_Syntax.pos uu____195
   
 let err_ill_typed_erasure :
-  'Auu____333 .
+  'Auu____256 .
     FStar_Extraction_ML_UEnv.uenv ->
-      FStar_Range.range -> FStar_Extraction_ML_Syntax.mlty -> 'Auu____333
+      FStar_Range.range -> FStar_Extraction_ML_Syntax.mlty -> 'Auu____256
   =
   fun env  ->
     fun pos  ->
       fun ty  ->
-        let uu____349 =
-          let uu____355 =
-            let uu____357 =
+        let uu____272 =
+          let uu____278 =
+            let uu____280 =
               FStar_Extraction_ML_Code.string_of_mlty
                 env.FStar_Extraction_ML_UEnv.currentModule ty
                in
             FStar_Util.format1
               "Erased value found where a value of type %s was expected"
-              uu____357
+              uu____280
              in
-          (FStar_Errors.Fatal_IllTyped, uu____355)  in
-        fail pos uu____349
+          (FStar_Errors.Fatal_IllTyped, uu____278)  in
+        fail pos uu____272
   
 let err_value_restriction :
-  'Auu____366 .
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> 'Auu____366
+  'Auu____289 .
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> 'Auu____289
   =
   fun t  ->
-    let uu____376 =
-      let uu____382 =
-        let uu____384 = FStar_Syntax_Print.tag_of_term t  in
-        let uu____386 = FStar_Syntax_Print.term_to_string t  in
+    let uu____299 =
+      let uu____305 =
+        let uu____307 = FStar_Syntax_Print.tag_of_term t  in
+        let uu____309 = FStar_Syntax_Print.term_to_string t  in
         FStar_Util.format2
           "Refusing to generalize because of the value restriction: (%s) %s"
-          uu____384 uu____386
+          uu____307 uu____309
          in
-      (FStar_Errors.Fatal_ValueRestriction, uu____382)  in
-    fail t.FStar_Syntax_Syntax.pos uu____376
+      (FStar_Errors.Fatal_ValueRestriction, uu____305)  in
+    fail t.FStar_Syntax_Syntax.pos uu____299
   
 let (err_unexpected_eff :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -173,22 +143,22 @@ let (err_unexpected_eff :
       fun ty  ->
         fun f0  ->
           fun f1  ->
-            let uu____420 =
-              let uu____426 =
-                let uu____428 = FStar_Syntax_Print.term_to_string t  in
-                let uu____430 =
+            let uu____343 =
+              let uu____349 =
+                let uu____351 = FStar_Syntax_Print.term_to_string t  in
+                let uu____353 =
                   FStar_Extraction_ML_Code.string_of_mlty
                     env.FStar_Extraction_ML_UEnv.currentModule ty
                    in
-                let uu____432 = FStar_Extraction_ML_Util.eff_to_string f0  in
-                let uu____434 = FStar_Extraction_ML_Util.eff_to_string f1  in
+                let uu____355 = FStar_Extraction_ML_Util.eff_to_string f0  in
+                let uu____357 = FStar_Extraction_ML_Util.eff_to_string f1  in
                 FStar_Util.format4
                   "for expression %s of type %s, Expected effect %s; got effect %s"
-                  uu____428 uu____430 uu____432 uu____434
+                  uu____351 uu____353 uu____355 uu____357
                  in
-              (FStar_Errors.Warning_ExtractionUnexpectedEffect, uu____426)
+              (FStar_Errors.Warning_ExtractionUnexpectedEffect, uu____349)
                in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____420
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____343
   
 let (effect_as_etag :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -196,19 +166,19 @@ let (effect_as_etag :
   =
   let cache = FStar_Util.smap_create (Prims.parse_int "20")  in
   let rec delta_norm_eff g l =
-    let uu____462 = FStar_Util.smap_try_find cache l.FStar_Ident.str  in
-    match uu____462 with
+    let uu____385 = FStar_Util.smap_try_find cache l.FStar_Ident.str  in
+    match uu____385 with
     | FStar_Pervasives_Native.Some l1 -> l1
     | FStar_Pervasives_Native.None  ->
         let res =
-          let uu____467 =
+          let uu____390 =
             FStar_TypeChecker_Env.lookup_effect_abbrev
               g.FStar_Extraction_ML_UEnv.env_tcenv
               [FStar_Syntax_Syntax.U_zero] l
              in
-          match uu____467 with
+          match uu____390 with
           | FStar_Pervasives_Native.None  -> l
-          | FStar_Pervasives_Native.Some (uu____478,c) ->
+          | FStar_Pervasives_Native.Some (uu____401,c) ->
               delta_norm_eff g (FStar_Syntax_Util.comp_effect_name c)
            in
         (FStar_Util.smap_add cache l.FStar_Ident.str res; res)
@@ -216,14 +186,14 @@ let (effect_as_etag :
   fun g  ->
     fun l  ->
       let l1 = delta_norm_eff g l  in
-      let uu____488 =
+      let uu____411 =
         FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_PURE_lid  in
-      if uu____488
+      if uu____411
       then FStar_Extraction_ML_Syntax.E_PURE
       else
-        (let uu____493 =
+        (let uu____416 =
            FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GHOST_lid  in
-         if uu____493
+         if uu____416
          then FStar_Extraction_ML_Syntax.E_GHOST
          else
            (let ed_opt =
@@ -232,12 +202,12 @@ let (effect_as_etag :
                in
             match ed_opt with
             | FStar_Pervasives_Native.Some (ed,qualifiers) ->
-                let uu____519 =
+                let uu____442 =
                   FStar_TypeChecker_Env.is_reifiable_effect
                     g.FStar_Extraction_ML_UEnv.env_tcenv
                     ed.FStar_Syntax_Syntax.mname
                    in
-                if uu____519
+                if uu____442
                 then FStar_Extraction_ML_Syntax.E_PURE
                 else FStar_Extraction_ML_Syntax.E_IMPURE
             | FStar_Pervasives_Native.None  ->
@@ -248,24 +218,24 @@ let rec (is_arity :
   fun env  ->
     fun t  ->
       let t1 = FStar_Syntax_Util.unmeta t  in
-      let uu____543 =
-        let uu____544 = FStar_Syntax_Subst.compress t1  in
-        uu____544.FStar_Syntax_Syntax.n  in
-      match uu____543 with
+      let uu____466 =
+        let uu____467 = FStar_Syntax_Subst.compress t1  in
+        uu____467.FStar_Syntax_Syntax.n  in
+      match uu____466 with
       | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____550 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_ascribed uu____575 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_meta uu____604 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____473 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_ascribed uu____498 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_meta uu____527 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____614 = FStar_Syntax_Util.unfold_lazy i  in
-          is_arity env uu____614
-      | FStar_Syntax_Syntax.Tm_uvar uu____615 -> false
-      | FStar_Syntax_Syntax.Tm_constant uu____629 -> false
-      | FStar_Syntax_Syntax.Tm_name uu____631 -> false
-      | FStar_Syntax_Syntax.Tm_quoted uu____633 -> false
-      | FStar_Syntax_Syntax.Tm_bvar uu____641 -> false
-      | FStar_Syntax_Syntax.Tm_type uu____643 -> true
-      | FStar_Syntax_Syntax.Tm_arrow (uu____645,c) ->
+          let uu____537 = FStar_Syntax_Util.unfold_lazy i  in
+          is_arity env uu____537
+      | FStar_Syntax_Syntax.Tm_uvar uu____538 -> false
+      | FStar_Syntax_Syntax.Tm_constant uu____552 -> false
+      | FStar_Syntax_Syntax.Tm_name uu____554 -> false
+      | FStar_Syntax_Syntax.Tm_quoted uu____556 -> false
+      | FStar_Syntax_Syntax.Tm_bvar uu____564 -> false
+      | FStar_Syntax_Syntax.Tm_type uu____566 -> true
+      | FStar_Syntax_Syntax.Tm_arrow (uu____568,c) ->
           is_arity env (FStar_Syntax_Util.comp_result c)
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let topt =
@@ -277,20 +247,20 @@ let rec (is_arity :
              in
           (match topt with
            | FStar_Pervasives_Native.None  -> false
-           | FStar_Pervasives_Native.Some (uu____681,t2) -> is_arity env t2)
-      | FStar_Syntax_Syntax.Tm_app uu____687 ->
-          let uu____704 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____704 with | (head1,uu____723) -> is_arity env head1)
-      | FStar_Syntax_Syntax.Tm_uinst (head1,uu____749) -> is_arity env head1
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____755) ->
+           | FStar_Pervasives_Native.Some (uu____604,t2) -> is_arity env t2)
+      | FStar_Syntax_Syntax.Tm_app uu____610 ->
+          let uu____627 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____627 with | (head1,uu____646) -> is_arity env head1)
+      | FStar_Syntax_Syntax.Tm_uinst (head1,uu____672) -> is_arity env head1
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____678) ->
           is_arity env x.FStar_Syntax_Syntax.sort
-      | FStar_Syntax_Syntax.Tm_abs (uu____760,body,uu____762) ->
+      | FStar_Syntax_Syntax.Tm_abs (uu____683,body,uu____685) ->
           is_arity env body
-      | FStar_Syntax_Syntax.Tm_let (uu____787,body) -> is_arity env body
-      | FStar_Syntax_Syntax.Tm_match (uu____807,branches) ->
+      | FStar_Syntax_Syntax.Tm_let (uu____710,body) -> is_arity env body
+      | FStar_Syntax_Syntax.Tm_match (uu____730,branches) ->
           (match branches with
-           | (uu____846,uu____847,e)::uu____849 -> is_arity env e
-           | uu____896 -> false)
+           | (uu____769,uu____770,e)::uu____772 -> is_arity env e
+           | uu____819 -> false)
   
 let rec (is_type_aux :
   FStar_Extraction_ML_UEnv.uenv -> FStar_Syntax_Syntax.term -> Prims.bool) =
@@ -298,80 +268,80 @@ let rec (is_type_aux :
     fun t  ->
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____928 ->
-          let uu____951 =
-            let uu____953 = FStar_Syntax_Print.tag_of_term t1  in
-            FStar_Util.format1 "Impossible: %s" uu____953  in
-          failwith uu____951
+      | FStar_Syntax_Syntax.Tm_delayed uu____851 ->
+          let uu____874 =
+            let uu____876 = FStar_Syntax_Print.tag_of_term t1  in
+            FStar_Util.format1 "Impossible: %s" uu____876  in
+          failwith uu____874
       | FStar_Syntax_Syntax.Tm_unknown  ->
-          let uu____957 =
-            let uu____959 = FStar_Syntax_Print.tag_of_term t1  in
-            FStar_Util.format1 "Impossible: %s" uu____959  in
-          failwith uu____957
+          let uu____880 =
+            let uu____882 = FStar_Syntax_Print.tag_of_term t1  in
+            FStar_Util.format1 "Impossible: %s" uu____882  in
+          failwith uu____880
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____964 = FStar_Syntax_Util.unfold_lazy i  in
-          is_type_aux env uu____964
-      | FStar_Syntax_Syntax.Tm_constant uu____965 -> false
-      | FStar_Syntax_Syntax.Tm_type uu____967 -> true
-      | FStar_Syntax_Syntax.Tm_refine uu____969 -> true
-      | FStar_Syntax_Syntax.Tm_arrow uu____977 -> true
+          let uu____887 = FStar_Syntax_Util.unfold_lazy i  in
+          is_type_aux env uu____887
+      | FStar_Syntax_Syntax.Tm_constant uu____888 -> false
+      | FStar_Syntax_Syntax.Tm_type uu____890 -> true
+      | FStar_Syntax_Syntax.Tm_refine uu____892 -> true
+      | FStar_Syntax_Syntax.Tm_arrow uu____900 -> true
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.failwith_lid ->
           false
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_Extraction_ML_UEnv.is_type_name env fv
       | FStar_Syntax_Syntax.Tm_uvar
-          ({ FStar_Syntax_Syntax.ctx_uvar_head = uu____996;
-             FStar_Syntax_Syntax.ctx_uvar_gamma = uu____997;
-             FStar_Syntax_Syntax.ctx_uvar_binders = uu____998;
+          ({ FStar_Syntax_Syntax.ctx_uvar_head = uu____919;
+             FStar_Syntax_Syntax.ctx_uvar_gamma = uu____920;
+             FStar_Syntax_Syntax.ctx_uvar_binders = uu____921;
              FStar_Syntax_Syntax.ctx_uvar_typ = t2;
-             FStar_Syntax_Syntax.ctx_uvar_reason = uu____1000;
-             FStar_Syntax_Syntax.ctx_uvar_should_check = uu____1001;
-             FStar_Syntax_Syntax.ctx_uvar_range = uu____1002;
-             FStar_Syntax_Syntax.ctx_uvar_meta = uu____1003;_},s)
+             FStar_Syntax_Syntax.ctx_uvar_reason = uu____923;
+             FStar_Syntax_Syntax.ctx_uvar_should_check = uu____924;
+             FStar_Syntax_Syntax.ctx_uvar_range = uu____925;
+             FStar_Syntax_Syntax.ctx_uvar_meta = uu____926;_},s)
           ->
-          let uu____1052 = FStar_Syntax_Subst.subst' s t2  in
-          is_arity env uu____1052
+          let uu____975 = FStar_Syntax_Subst.subst' s t2  in
+          is_arity env uu____975
       | FStar_Syntax_Syntax.Tm_bvar
-          { FStar_Syntax_Syntax.ppname = uu____1053;
-            FStar_Syntax_Syntax.index = uu____1054;
+          { FStar_Syntax_Syntax.ppname = uu____976;
+            FStar_Syntax_Syntax.index = uu____977;
             FStar_Syntax_Syntax.sort = t2;_}
           -> is_arity env t2
       | FStar_Syntax_Syntax.Tm_name
-          { FStar_Syntax_Syntax.ppname = uu____1059;
-            FStar_Syntax_Syntax.index = uu____1060;
+          { FStar_Syntax_Syntax.ppname = uu____982;
+            FStar_Syntax_Syntax.index = uu____983;
             FStar_Syntax_Syntax.sort = t2;_}
           -> is_arity env t2
-      | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____1066,uu____1067) ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____989,uu____990) ->
           is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_uinst (t2,uu____1109) -> is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____1116) ->
-          let uu____1141 = FStar_Syntax_Subst.open_term bs body  in
-          (match uu____1141 with
-           | (uu____1147,body1) -> is_type_aux env body1)
+      | FStar_Syntax_Syntax.Tm_uinst (t2,uu____1032) -> is_type_aux env t2
+      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____1039) ->
+          let uu____1064 = FStar_Syntax_Subst.open_term bs body  in
+          (match uu____1064 with
+           | (uu____1070,body1) -> is_type_aux env body1)
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
           let x = FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-          let uu____1167 =
-            let uu____1172 =
-              let uu____1173 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____1173]  in
-            FStar_Syntax_Subst.open_term uu____1172 body  in
-          (match uu____1167 with
-           | (uu____1193,body1) -> is_type_aux env body1)
-      | FStar_Syntax_Syntax.Tm_let ((uu____1195,lbs),body) ->
-          let uu____1215 = FStar_Syntax_Subst.open_let_rec lbs body  in
-          (match uu____1215 with
-           | (uu____1223,body1) -> is_type_aux env body1)
-      | FStar_Syntax_Syntax.Tm_match (uu____1229,branches) ->
+          let uu____1090 =
+            let uu____1095 =
+              let uu____1096 = FStar_Syntax_Syntax.mk_binder x  in
+              [uu____1096]  in
+            FStar_Syntax_Subst.open_term uu____1095 body  in
+          (match uu____1090 with
+           | (uu____1116,body1) -> is_type_aux env body1)
+      | FStar_Syntax_Syntax.Tm_let ((uu____1118,lbs),body) ->
+          let uu____1138 = FStar_Syntax_Subst.open_let_rec lbs body  in
+          (match uu____1138 with
+           | (uu____1146,body1) -> is_type_aux env body1)
+      | FStar_Syntax_Syntax.Tm_match (uu____1152,branches) ->
           (match branches with
-           | b::uu____1269 ->
-               let uu____1314 = FStar_Syntax_Subst.open_branch b  in
-               (match uu____1314 with
-                | (uu____1316,uu____1317,e) -> is_type_aux env e)
-           | uu____1335 -> false)
-      | FStar_Syntax_Syntax.Tm_quoted uu____1353 -> false
-      | FStar_Syntax_Syntax.Tm_meta (t2,uu____1362) -> is_type_aux env t2
-      | FStar_Syntax_Syntax.Tm_app (head1,uu____1368) ->
+           | b::uu____1192 ->
+               let uu____1237 = FStar_Syntax_Subst.open_branch b  in
+               (match uu____1237 with
+                | (uu____1239,uu____1240,e) -> is_type_aux env e)
+           | uu____1258 -> false)
+      | FStar_Syntax_Syntax.Tm_quoted uu____1276 -> false
+      | FStar_Syntax_Syntax.Tm_meta (t2,uu____1285) -> is_type_aux env t2
+      | FStar_Syntax_Syntax.Tm_app (head1,uu____1291) ->
           is_type_aux env head1
   
 let (is_type :
@@ -379,30 +349,30 @@ let (is_type :
   fun env  ->
     fun t  ->
       FStar_Extraction_ML_UEnv.debug env
-        (fun uu____1409  ->
-           let uu____1410 = FStar_Syntax_Print.tag_of_term t  in
-           let uu____1412 = FStar_Syntax_Print.term_to_string t  in
-           FStar_Util.print2 "checking is_type (%s) %s\n" uu____1410
-             uu____1412);
+        (fun uu____1332  ->
+           let uu____1333 = FStar_Syntax_Print.tag_of_term t  in
+           let uu____1335 = FStar_Syntax_Print.term_to_string t  in
+           FStar_Util.print2 "checking is_type (%s) %s\n" uu____1333
+             uu____1335);
       (let b = is_type_aux env t  in
        FStar_Extraction_ML_UEnv.debug env
-         (fun uu____1421  ->
+         (fun uu____1344  ->
             if b
             then
-              let uu____1423 = FStar_Syntax_Print.term_to_string t  in
-              let uu____1425 = FStar_Syntax_Print.tag_of_term t  in
-              FStar_Util.print2 "yes, is_type %s (%s)\n" uu____1423
-                uu____1425
+              let uu____1346 = FStar_Syntax_Print.term_to_string t  in
+              let uu____1348 = FStar_Syntax_Print.tag_of_term t  in
+              FStar_Util.print2 "yes, is_type %s (%s)\n" uu____1346
+                uu____1348
             else
-              (let uu____1430 = FStar_Syntax_Print.term_to_string t  in
-               let uu____1432 = FStar_Syntax_Print.tag_of_term t  in
-               FStar_Util.print2 "not a type %s (%s)\n" uu____1430 uu____1432));
+              (let uu____1353 = FStar_Syntax_Print.term_to_string t  in
+               let uu____1355 = FStar_Syntax_Print.tag_of_term t  in
+               FStar_Util.print2 "not a type %s (%s)\n" uu____1353 uu____1355));
        b)
   
 let is_type_binder :
-  'Auu____1442 .
+  'Auu____1365 .
     FStar_Extraction_ML_UEnv.uenv ->
-      (FStar_Syntax_Syntax.bv * 'Auu____1442) -> Prims.bool
+      (FStar_Syntax_Syntax.bv * 'Auu____1365) -> Prims.bool
   =
   fun env  ->
     fun x  ->
@@ -410,76 +380,76 @@ let is_type_binder :
   
 let (is_constructor : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____1469 =
-      let uu____1470 = FStar_Syntax_Subst.compress t  in
-      uu____1470.FStar_Syntax_Syntax.n  in
-    match uu____1469 with
+    let uu____1392 =
+      let uu____1393 = FStar_Syntax_Subst.compress t  in
+      uu____1393.FStar_Syntax_Syntax.n  in
+    match uu____1392 with
     | FStar_Syntax_Syntax.Tm_fvar
-        { FStar_Syntax_Syntax.fv_name = uu____1474;
-          FStar_Syntax_Syntax.fv_delta = uu____1475;
+        { FStar_Syntax_Syntax.fv_name = uu____1397;
+          FStar_Syntax_Syntax.fv_delta = uu____1398;
           FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
             (FStar_Syntax_Syntax.Data_ctor );_}
         -> true
     | FStar_Syntax_Syntax.Tm_fvar
-        { FStar_Syntax_Syntax.fv_name = uu____1477;
-          FStar_Syntax_Syntax.fv_delta = uu____1478;
+        { FStar_Syntax_Syntax.fv_name = uu____1400;
+          FStar_Syntax_Syntax.fv_delta = uu____1401;
           FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
-            (FStar_Syntax_Syntax.Record_ctor uu____1479);_}
+            (FStar_Syntax_Syntax.Record_ctor uu____1402);_}
         -> true
-    | uu____1487 -> false
+    | uu____1410 -> false
   
 let rec (is_fstar_value : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____1496 =
-      let uu____1497 = FStar_Syntax_Subst.compress t  in
-      uu____1497.FStar_Syntax_Syntax.n  in
-    match uu____1496 with
-    | FStar_Syntax_Syntax.Tm_constant uu____1501 -> true
-    | FStar_Syntax_Syntax.Tm_bvar uu____1503 -> true
-    | FStar_Syntax_Syntax.Tm_fvar uu____1505 -> true
-    | FStar_Syntax_Syntax.Tm_abs uu____1507 -> true
+    let uu____1419 =
+      let uu____1420 = FStar_Syntax_Subst.compress t  in
+      uu____1420.FStar_Syntax_Syntax.n  in
+    match uu____1419 with
+    | FStar_Syntax_Syntax.Tm_constant uu____1424 -> true
+    | FStar_Syntax_Syntax.Tm_bvar uu____1426 -> true
+    | FStar_Syntax_Syntax.Tm_fvar uu____1428 -> true
+    | FStar_Syntax_Syntax.Tm_abs uu____1430 -> true
     | FStar_Syntax_Syntax.Tm_app (head1,args) ->
-        let uu____1553 = is_constructor head1  in
-        if uu____1553
+        let uu____1476 = is_constructor head1  in
+        if uu____1476
         then
           FStar_All.pipe_right args
             (FStar_List.for_all
-               (fun uu____1575  ->
-                  match uu____1575 with
-                  | (te,uu____1584) -> is_fstar_value te))
+               (fun uu____1498  ->
+                  match uu____1498 with
+                  | (te,uu____1507) -> is_fstar_value te))
         else false
-    | FStar_Syntax_Syntax.Tm_meta (t1,uu____1593) -> is_fstar_value t1
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____1599,uu____1600) ->
+    | FStar_Syntax_Syntax.Tm_meta (t1,uu____1516) -> is_fstar_value t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____1522,uu____1523) ->
         is_fstar_value t1
-    | uu____1641 -> false
+    | uu____1564 -> false
   
 let rec (is_ml_value : FStar_Extraction_ML_Syntax.mlexpr -> Prims.bool) =
   fun e  ->
     match e.FStar_Extraction_ML_Syntax.expr with
-    | FStar_Extraction_ML_Syntax.MLE_Const uu____1651 -> true
-    | FStar_Extraction_ML_Syntax.MLE_Var uu____1653 -> true
-    | FStar_Extraction_ML_Syntax.MLE_Name uu____1656 -> true
-    | FStar_Extraction_ML_Syntax.MLE_Fun uu____1658 -> true
-    | FStar_Extraction_ML_Syntax.MLE_CTor (uu____1671,exps) ->
+    | FStar_Extraction_ML_Syntax.MLE_Const uu____1574 -> true
+    | FStar_Extraction_ML_Syntax.MLE_Var uu____1576 -> true
+    | FStar_Extraction_ML_Syntax.MLE_Name uu____1579 -> true
+    | FStar_Extraction_ML_Syntax.MLE_Fun uu____1581 -> true
+    | FStar_Extraction_ML_Syntax.MLE_CTor (uu____1594,exps) ->
         FStar_Util.for_all is_ml_value exps
     | FStar_Extraction_ML_Syntax.MLE_Tuple exps ->
         FStar_Util.for_all is_ml_value exps
-    | FStar_Extraction_ML_Syntax.MLE_Record (uu____1680,fields) ->
+    | FStar_Extraction_ML_Syntax.MLE_Record (uu____1603,fields) ->
         FStar_Util.for_all
-          (fun uu____1710  ->
-             match uu____1710 with | (uu____1717,e1) -> is_ml_value e1)
+          (fun uu____1633  ->
+             match uu____1633 with | (uu____1640,e1) -> is_ml_value e1)
           fields
-    | FStar_Extraction_ML_Syntax.MLE_TApp (h,uu____1722) -> is_ml_value h
-    | uu____1727 -> false
+    | FStar_Extraction_ML_Syntax.MLE_TApp (h,uu____1645) -> is_ml_value h
+    | uu____1650 -> false
   
 let (fresh : Prims.string -> Prims.string) =
   let c = FStar_Util.mk_ref (Prims.parse_int "0")  in
   fun x  ->
     FStar_Util.incr c;
-    (let uu____1745 =
-       let uu____1747 = FStar_ST.op_Bang c  in
-       FStar_Util.string_of_int uu____1747  in
-     Prims.op_Hat x uu____1745)
+    (let uu____1668 =
+       let uu____1670 = FStar_ST.op_Bang c  in
+       FStar_Util.string_of_int uu____1670  in
+     Prims.op_Hat x uu____1668)
   
 let (normalize_abs : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t0  ->
@@ -488,21 +458,21 @@ let (normalize_abs : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_abs (bs',body,copt1) ->
           aux (FStar_List.append bs bs') body copt1
-      | uu____1850 ->
+      | uu____1773 ->
           let e' = FStar_Syntax_Util.unascribe t1  in
-          let uu____1852 = FStar_Syntax_Util.is_fun e'  in
-          if uu____1852
+          let uu____1775 = FStar_Syntax_Util.is_fun e'  in
+          if uu____1775
           then aux bs e' copt
           else FStar_Syntax_Util.abs bs e' copt
        in
     aux [] t0 FStar_Pervasives_Native.None
   
 let (unit_binder : FStar_Syntax_Syntax.binder) =
-  let uu____1866 =
+  let uu____1789 =
     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
       FStar_Syntax_Syntax.t_unit
      in
-  FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____1866 
+  FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____1789 
 let (check_pats_for_ite :
   (FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.term
     FStar_Pervasives_Native.option * FStar_Syntax_Syntax.term) Prims.list ->
@@ -515,13 +485,13 @@ let (check_pats_for_ite :
     if (FStar_List.length l) <> (Prims.parse_int "2")
     then def
     else
-      (let uu____1957 = FStar_List.hd l  in
-       match uu____1957 with
+      (let uu____1880 = FStar_List.hd l  in
+       match uu____1880 with
        | (p1,w1,e1) ->
-           let uu____1992 =
-             let uu____2001 = FStar_List.tl l  in FStar_List.hd uu____2001
+           let uu____1915 =
+             let uu____1924 = FStar_List.tl l  in FStar_List.hd uu____1924
               in
-           (match uu____1992 with
+           (match uu____1915 with
             | (p2,w2,e2) ->
                 (match (w1, w2, (p1.FStar_Syntax_Syntax.v),
                          (p2.FStar_Syntax_Syntax.v))
@@ -540,35 +510,112 @@ let (check_pats_for_ite :
                     (FStar_Const.Const_bool (true ))) ->
                      (true, (FStar_Pervasives_Native.Some e2),
                        (FStar_Pervasives_Native.Some e1))
-                 | uu____2085 -> def)))
+                 | uu____2008 -> def)))
   
-let (instantiate :
+let (instantiate_tyscheme :
   FStar_Extraction_ML_Syntax.mltyscheme ->
     FStar_Extraction_ML_Syntax.mlty Prims.list ->
       FStar_Extraction_ML_Syntax.mlty)
   = fun s  -> fun args  -> FStar_Extraction_ML_Util.subst s args 
+let (instantiate_maybe_partial :
+  FStar_Extraction_ML_Syntax.mlexpr ->
+    FStar_Extraction_ML_Syntax.mltyscheme ->
+      FStar_Extraction_ML_Syntax.mlty Prims.list ->
+        (FStar_Extraction_ML_Syntax.mlexpr * FStar_Extraction_ML_Syntax.e_tag
+          * FStar_Extraction_ML_Syntax.mlty))
+  =
+  fun e  ->
+    fun s  ->
+      fun tyargs  ->
+        let uu____2068 = s  in
+        match uu____2068 with
+        | (vars,t) ->
+            let n_vars = FStar_List.length vars  in
+            let n_args = FStar_List.length tyargs  in
+            if n_args = n_vars
+            then
+              let tapp =
+                let uu___363_2088 = e  in
+                {
+                  FStar_Extraction_ML_Syntax.expr =
+                    (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs));
+                  FStar_Extraction_ML_Syntax.mlty =
+                    (uu___363_2088.FStar_Extraction_ML_Syntax.mlty);
+                  FStar_Extraction_ML_Syntax.loc =
+                    (uu___363_2088.FStar_Extraction_ML_Syntax.loc)
+                }  in
+              let ts = instantiate_tyscheme (vars, t) tyargs  in
+              (tapp, FStar_Extraction_ML_Syntax.E_PURE, ts)
+            else
+              if n_args < n_vars
+              then
+                (let extra_tyargs =
+                   let uu____2104 = FStar_Util.first_N n_args vars  in
+                   match uu____2104 with
+                   | (uu____2118,rest_vars) ->
+                       FStar_All.pipe_right rest_vars
+                         (FStar_List.map
+                            (fun uu____2139  ->
+                               FStar_Extraction_ML_Syntax.MLTY_Erased))
+                    in
+                 let tyargs1 = FStar_List.append tyargs extra_tyargs  in
+                 let tapp =
+                   let uu___374_2145 = e  in
+                   {
+                     FStar_Extraction_ML_Syntax.expr =
+                       (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs1));
+                     FStar_Extraction_ML_Syntax.mlty =
+                       (uu___374_2145.FStar_Extraction_ML_Syntax.mlty);
+                     FStar_Extraction_ML_Syntax.loc =
+                       (uu___374_2145.FStar_Extraction_ML_Syntax.loc)
+                   }  in
+                 let ts = instantiate_tyscheme (vars, t) tyargs1  in
+                 let t1 =
+                   FStar_List.fold_left
+                     (fun out  ->
+                        fun t1  ->
+                          FStar_Extraction_ML_Syntax.MLTY_Fun
+                            (t1, FStar_Extraction_ML_Syntax.E_PURE, out)) ts
+                     extra_tyargs
+                    in
+                 let f =
+                   let vs_ts =
+                     FStar_List.map
+                       (fun t2  ->
+                          let uu____2171 = fresh "t"  in (uu____2171, t2))
+                       extra_tyargs
+                      in
+                   FStar_All.pipe_left
+                     (FStar_Extraction_ML_Syntax.with_ty t1)
+                     (FStar_Extraction_ML_Syntax.MLE_Fun (vs_ts, tapp))
+                    in
+                 (f, FStar_Extraction_ML_Syntax.E_PURE, t1))
+              else
+                failwith
+                  "Impossible: instantiate_maybe_partial called with too many arguments"
+  
 let (eta_expand :
   FStar_Extraction_ML_Syntax.mlty ->
     FStar_Extraction_ML_Syntax.mlexpr -> FStar_Extraction_ML_Syntax.mlexpr)
   =
   fun t  ->
     fun e  ->
-      let uu____2124 = FStar_Extraction_ML_Util.doms_and_cod t  in
-      match uu____2124 with
+      let uu____2202 = FStar_Extraction_ML_Util.doms_and_cod t  in
+      match uu____2202 with
       | (ts,r) ->
           if ts = []
           then e
           else
-            (let vs = FStar_List.map (fun uu____2148  -> fresh "a") ts  in
+            (let vs = FStar_List.map (fun uu____2226  -> fresh "a") ts  in
              let vs_ts = FStar_List.zip vs ts  in
              let vs_es =
-               let uu____2162 = FStar_List.zip vs ts  in
+               let uu____2240 = FStar_List.zip vs ts  in
                FStar_List.map
-                 (fun uu____2179  ->
-                    match uu____2179 with
+                 (fun uu____2257  ->
+                    match uu____2257 with
                     | (v1,t1) ->
                         FStar_Extraction_ML_Syntax.with_ty t1
-                          (FStar_Extraction_ML_Syntax.MLE_Var v1)) uu____2162
+                          (FStar_Extraction_ML_Syntax.MLE_Var v1)) uu____2240
                 in
              let body =
                FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty r)
@@ -583,14 +630,14 @@ let (default_value_for_ty :
   =
   fun g  ->
     fun t  ->
-      let uu____2210 = FStar_Extraction_ML_Util.doms_and_cod t  in
-      match uu____2210 with
+      let uu____2288 = FStar_Extraction_ML_Util.doms_and_cod t  in
+      match uu____2288 with
       | (ts,r) ->
           let body r1 =
             let r2 =
-              let uu____2230 = FStar_Extraction_ML_Util.udelta_unfold g r1
+              let uu____2308 = FStar_Extraction_ML_Util.udelta_unfold g r1
                  in
-              match uu____2230 with
+              match uu____2308 with
               | FStar_Pervasives_Native.None  -> r1
               | FStar_Pervasives_Native.Some r2 -> r2  in
             match r2 with
@@ -600,7 +647,7 @@ let (default_value_for_ty :
                 FStar_Extraction_ML_Syntax.apply_obj_repr
                   FStar_Extraction_ML_Syntax.ml_unit
                   FStar_Extraction_ML_Syntax.MLTY_Erased
-            | uu____2234 ->
+            | uu____2312 ->
                 FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty r2)
                   (FStar_Extraction_ML_Syntax.MLE_Coerce
                      (FStar_Extraction_ML_Syntax.ml_unit,
@@ -609,14 +656,14 @@ let (default_value_for_ty :
           if ts = []
           then body r
           else
-            (let vs = FStar_List.map (fun uu____2246  -> fresh "a") ts  in
+            (let vs = FStar_List.map (fun uu____2324  -> fresh "a") ts  in
              let vs_ts = FStar_List.zip vs ts  in
-             let uu____2257 =
-               let uu____2258 =
-                 let uu____2270 = body r  in (vs_ts, uu____2270)  in
-               FStar_Extraction_ML_Syntax.MLE_Fun uu____2258  in
+             let uu____2335 =
+               let uu____2336 =
+                 let uu____2348 = body r  in (vs_ts, uu____2348)  in
+               FStar_Extraction_ML_Syntax.MLE_Fun uu____2336  in
              FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t)
-               uu____2257)
+               uu____2335)
   
 let (maybe_eta_expand :
   FStar_Extraction_ML_Syntax.mlty ->
@@ -624,12 +671,12 @@ let (maybe_eta_expand :
   =
   fun expect  ->
     fun e  ->
-      let uu____2289 =
+      let uu____2367 =
         (FStar_Options.ml_no_eta_expand_coertions ()) ||
-          (let uu____2292 = FStar_Options.codegen ()  in
-           uu____2292 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin))
+          (let uu____2370 = FStar_Options.codegen ()  in
+           uu____2370 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin))
          in
-      if uu____2289 then e else eta_expand expect e
+      if uu____2367 then e else eta_expand expect e
   
 let (apply_coercion :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -646,54 +693,54 @@ let (apply_coercion :
             | FStar_Extraction_ML_Syntax.MLE_Fun (binders,body1) ->
                 FStar_Extraction_ML_Syntax.MLE_Fun
                   ((binder :: binders), body1)
-            | uu____2370 ->
+            | uu____2448 ->
                 FStar_Extraction_ML_Syntax.MLE_Fun ([binder], body)
              in
           let rec aux e1 ty1 expect1 =
-            let coerce_branch uu____2425 =
-              match uu____2425 with
+            let coerce_branch uu____2503 =
+              match uu____2503 with
               | (pat,w,b) ->
-                  let uu____2449 = aux b ty1 expect1  in (pat, w, uu____2449)
+                  let uu____2527 = aux b ty1 expect1  in (pat, w, uu____2527)
                in
             match ((e1.FStar_Extraction_ML_Syntax.expr), ty1, expect1) with
             | (FStar_Extraction_ML_Syntax.MLE_Fun
                (arg::rest,body),FStar_Extraction_ML_Syntax.MLTY_Fun
-               (t0,uu____2456,t1),FStar_Extraction_ML_Syntax.MLTY_Fun
-               (s0,uu____2459,s1)) ->
+               (t0,uu____2534,t1),FStar_Extraction_ML_Syntax.MLTY_Fun
+               (s0,uu____2537,s1)) ->
                 let body1 =
                   match rest with
                   | [] -> body
-                  | uu____2491 ->
+                  | uu____2569 ->
                       FStar_Extraction_ML_Syntax.with_ty t1
                         (FStar_Extraction_ML_Syntax.MLE_Fun (rest, body))
                    in
                 let body2 = aux body1 t1 s1  in
-                let uu____2507 = type_leq g s0 t0  in
-                if uu____2507
+                let uu____2585 = type_leq g s0 t0  in
+                if uu____2585
                 then
                   FStar_Extraction_ML_Syntax.with_ty expect1
                     (mk_fun arg body2)
                 else
                   (let lb =
-                     let uu____2513 =
-                       let uu____2514 =
-                         let uu____2515 =
-                           let uu____2522 =
+                     let uu____2591 =
+                       let uu____2592 =
+                         let uu____2593 =
+                           let uu____2600 =
                              FStar_All.pipe_left
                                (FStar_Extraction_ML_Syntax.with_ty s0)
                                (FStar_Extraction_ML_Syntax.MLE_Var
                                   (FStar_Pervasives_Native.fst arg))
                               in
-                           (uu____2522, s0, t0)  in
-                         FStar_Extraction_ML_Syntax.MLE_Coerce uu____2515  in
-                       FStar_Extraction_ML_Syntax.with_ty t0 uu____2514  in
+                           (uu____2600, s0, t0)  in
+                         FStar_Extraction_ML_Syntax.MLE_Coerce uu____2593  in
+                       FStar_Extraction_ML_Syntax.with_ty t0 uu____2592  in
                      {
                        FStar_Extraction_ML_Syntax.mllb_name =
                          (FStar_Pervasives_Native.fst arg);
                        FStar_Extraction_ML_Syntax.mllb_tysc =
                          (FStar_Pervasives_Native.Some ([], t0));
                        FStar_Extraction_ML_Syntax.mllb_add_unit = false;
-                       FStar_Extraction_ML_Syntax.mllb_def = uu____2513;
+                       FStar_Extraction_ML_Syntax.mllb_def = uu____2591;
                        FStar_Extraction_ML_Syntax.mllb_meta = [];
                        FStar_Extraction_ML_Syntax.print_typ = false
                      }  in
@@ -706,71 +753,71 @@ let (apply_coercion :
                    FStar_Extraction_ML_Syntax.with_ty expect1
                      (mk_fun ((FStar_Pervasives_Native.fst arg), s0) body3))
             | (FStar_Extraction_ML_Syntax.MLE_Let
-               (lbs,body),uu____2541,uu____2542) ->
-                let uu____2555 =
-                  let uu____2556 =
-                    let uu____2567 = aux body ty1 expect1  in
-                    (lbs, uu____2567)  in
-                  FStar_Extraction_ML_Syntax.MLE_Let uu____2556  in
+               (lbs,body),uu____2619,uu____2620) ->
+                let uu____2633 =
+                  let uu____2634 =
+                    let uu____2645 = aux body ty1 expect1  in
+                    (lbs, uu____2645)  in
+                  FStar_Extraction_ML_Syntax.MLE_Let uu____2634  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2555
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2633
             | (FStar_Extraction_ML_Syntax.MLE_Match
-               (s,branches),uu____2576,uu____2577) ->
-                let uu____2598 =
-                  let uu____2599 =
-                    let uu____2614 = FStar_List.map coerce_branch branches
+               (s,branches),uu____2654,uu____2655) ->
+                let uu____2676 =
+                  let uu____2677 =
+                    let uu____2692 = FStar_List.map coerce_branch branches
                        in
-                    (s, uu____2614)  in
-                  FStar_Extraction_ML_Syntax.MLE_Match uu____2599  in
+                    (s, uu____2692)  in
+                  FStar_Extraction_ML_Syntax.MLE_Match uu____2677  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2598
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2676
             | (FStar_Extraction_ML_Syntax.MLE_If
-               (s,b1,b2_opt),uu____2654,uu____2655) ->
-                let uu____2660 =
-                  let uu____2661 =
-                    let uu____2670 = aux b1 ty1 expect1  in
-                    let uu____2671 =
+               (s,b1,b2_opt),uu____2732,uu____2733) ->
+                let uu____2738 =
+                  let uu____2739 =
+                    let uu____2748 = aux b1 ty1 expect1  in
+                    let uu____2749 =
                       FStar_Util.map_opt b2_opt
                         (fun b2  -> aux b2 ty1 expect1)
                        in
-                    (s, uu____2670, uu____2671)  in
-                  FStar_Extraction_ML_Syntax.MLE_If uu____2661  in
+                    (s, uu____2748, uu____2749)  in
+                  FStar_Extraction_ML_Syntax.MLE_If uu____2739  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2660
-            | (FStar_Extraction_ML_Syntax.MLE_Seq es,uu____2679,uu____2680)
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2738
+            | (FStar_Extraction_ML_Syntax.MLE_Seq es,uu____2757,uu____2758)
                 ->
-                let uu____2683 = FStar_Util.prefix es  in
-                (match uu____2683 with
+                let uu____2761 = FStar_Util.prefix es  in
+                (match uu____2761 with
                  | (prefix1,last1) ->
-                     let uu____2696 =
-                       let uu____2697 =
-                         let uu____2700 =
-                           let uu____2703 = aux last1 ty1 expect1  in
-                           [uu____2703]  in
-                         FStar_List.append prefix1 uu____2700  in
-                       FStar_Extraction_ML_Syntax.MLE_Seq uu____2697  in
+                     let uu____2774 =
+                       let uu____2775 =
+                         let uu____2778 =
+                           let uu____2781 = aux last1 ty1 expect1  in
+                           [uu____2781]  in
+                         FStar_List.append prefix1 uu____2778  in
+                       FStar_Extraction_ML_Syntax.MLE_Seq uu____2775  in
                      FStar_All.pipe_left
                        (FStar_Extraction_ML_Syntax.with_ty expect1)
-                       uu____2696)
+                       uu____2774)
             | (FStar_Extraction_ML_Syntax.MLE_Try
-               (s,branches),uu____2706,uu____2707) ->
-                let uu____2728 =
-                  let uu____2729 =
-                    let uu____2744 = FStar_List.map coerce_branch branches
+               (s,branches),uu____2784,uu____2785) ->
+                let uu____2806 =
+                  let uu____2807 =
+                    let uu____2822 = FStar_List.map coerce_branch branches
                        in
-                    (s, uu____2744)  in
-                  FStar_Extraction_ML_Syntax.MLE_Try uu____2729  in
+                    (s, uu____2822)  in
+                  FStar_Extraction_ML_Syntax.MLE_Try uu____2807  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2728
-            | uu____2781 ->
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2806
+            | uu____2859 ->
                 FStar_Extraction_ML_Syntax.with_ty expect1
                   (FStar_Extraction_ML_Syntax.MLE_Coerce (e1, ty1, expect1))
              in
           aux e ty expect
   
 let maybe_coerce :
-  'Auu____2801 .
-    'Auu____2801 ->
+  'Auu____2879 .
+    'Auu____2879 ->
       FStar_Extraction_ML_UEnv.uenv ->
         FStar_Extraction_ML_Syntax.mlexpr ->
           FStar_Extraction_ML_Syntax.mlty ->
@@ -783,62 +830,62 @@ let maybe_coerce :
         fun ty  ->
           fun expect  ->
             let ty1 = eraseTypeDeep g ty  in
-            let uu____2828 =
+            let uu____2906 =
               type_leq_c g (FStar_Pervasives_Native.Some e) ty1 expect  in
-            match uu____2828 with
+            match uu____2906 with
             | (true ,FStar_Pervasives_Native.Some e') -> e'
-            | uu____2841 ->
+            | uu____2919 ->
                 (match ty1 with
                  | FStar_Extraction_ML_Syntax.MLTY_Erased  ->
                      default_value_for_ty g expect
-                 | uu____2849 ->
-                     let uu____2850 =
-                       let uu____2852 =
+                 | uu____2927 ->
+                     let uu____2928 =
+                       let uu____2930 =
                          FStar_Extraction_ML_Util.erase_effect_annotations
                            ty1
                           in
-                       let uu____2853 =
+                       let uu____2931 =
                          FStar_Extraction_ML_Util.erase_effect_annotations
                            expect
                           in
-                       type_leq g uu____2852 uu____2853  in
-                     if uu____2850
+                       type_leq g uu____2930 uu____2931  in
+                     if uu____2928
                      then
                        (FStar_Extraction_ML_UEnv.debug g
-                          (fun uu____2859  ->
-                             let uu____2860 =
+                          (fun uu____2937  ->
+                             let uu____2938 =
                                FStar_Extraction_ML_Code.string_of_mlexpr
                                  g.FStar_Extraction_ML_UEnv.currentModule e
                                 in
-                             let uu____2862 =
+                             let uu____2940 =
                                FStar_Extraction_ML_Code.string_of_mlty
                                  g.FStar_Extraction_ML_UEnv.currentModule ty1
                                 in
                              FStar_Util.print2
                                "\n Effect mismatch on type of %s : %s\n"
-                               uu____2860 uu____2862);
+                               uu____2938 uu____2940);
                         e)
                      else
                        (FStar_Extraction_ML_UEnv.debug g
-                          (fun uu____2872  ->
-                             let uu____2873 =
+                          (fun uu____2950  ->
+                             let uu____2951 =
                                FStar_Extraction_ML_Code.string_of_mlexpr
                                  g.FStar_Extraction_ML_UEnv.currentModule e
                                 in
-                             let uu____2875 =
+                             let uu____2953 =
                                FStar_Extraction_ML_Code.string_of_mlty
                                  g.FStar_Extraction_ML_UEnv.currentModule ty1
                                 in
-                             let uu____2877 =
+                             let uu____2955 =
                                FStar_Extraction_ML_Code.string_of_mlty
                                  g.FStar_Extraction_ML_UEnv.currentModule
                                  expect
                                 in
                              FStar_Util.print3
                                "\n (*needed to coerce expression \n %s \n of type \n %s \n to type \n %s *) \n"
-                               uu____2873 uu____2875 uu____2877);
-                        (let uu____2880 = apply_coercion g e ty1 expect  in
-                         maybe_eta_expand expect uu____2880)))
+                               uu____2951 uu____2953 uu____2955);
+                        (let uu____2958 = apply_coercion g e ty1 expect  in
+                         maybe_eta_expand expect uu____2958)))
   
 let (bv_as_mlty :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -846,10 +893,10 @@ let (bv_as_mlty :
   =
   fun g  ->
     fun bv  ->
-      let uu____2892 = FStar_Extraction_ML_UEnv.lookup_bv g bv  in
-      match uu____2892 with
+      let uu____2970 = FStar_Extraction_ML_UEnv.lookup_bv g bv  in
+      match uu____2970 with
       | FStar_Util.Inl ty_b -> ty_b.FStar_Extraction_ML_UEnv.ty_b_ty
-      | uu____2894 -> FStar_Extraction_ML_Syntax.MLTY_Top
+      | uu____2972 -> FStar_Extraction_ML_Syntax.MLTY_Top
   
 let (extraction_norm_steps : FStar_TypeChecker_Env.step Prims.list) =
   [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -866,36 +913,36 @@ let (comp_no_args :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____2912 -> c
-    | FStar_Syntax_Syntax.GTotal uu____2921 -> c
+    | FStar_Syntax_Syntax.Total uu____2990 -> c
+    | FStar_Syntax_Syntax.GTotal uu____2999 -> c
     | FStar_Syntax_Syntax.Comp ct ->
         let effect_args =
           FStar_List.map
-            (fun uu____2957  ->
-               match uu____2957 with
-               | (uu____2972,aq) -> (FStar_Syntax_Syntax.t_unit, aq))
+            (fun uu____3035  ->
+               match uu____3035 with
+               | (uu____3050,aq) -> (FStar_Syntax_Syntax.t_unit, aq))
             ct.FStar_Syntax_Syntax.effect_args
            in
         let ct1 =
-          let uu___513_2985 = ct  in
+          let uu___537_3063 = ct  in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___513_2985.FStar_Syntax_Syntax.comp_univs);
+              (uu___537_3063.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___513_2985.FStar_Syntax_Syntax.effect_name);
+              (uu___537_3063.FStar_Syntax_Syntax.effect_name);
             FStar_Syntax_Syntax.result_typ =
-              (uu___513_2985.FStar_Syntax_Syntax.result_typ);
+              (uu___537_3063.FStar_Syntax_Syntax.result_typ);
             FStar_Syntax_Syntax.effect_args = effect_args;
             FStar_Syntax_Syntax.flags =
-              (uu___513_2985.FStar_Syntax_Syntax.flags)
+              (uu___537_3063.FStar_Syntax_Syntax.flags)
           }  in
         let c1 =
-          let uu___516_2989 = c  in
+          let uu___540_3067 = c  in
           {
             FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
-            FStar_Syntax_Syntax.pos = (uu___516_2989.FStar_Syntax_Syntax.pos);
+            FStar_Syntax_Syntax.pos = (uu___540_3067.FStar_Syntax_Syntax.pos);
             FStar_Syntax_Syntax.vars =
-              (uu___516_2989.FStar_Syntax_Syntax.vars)
+              (uu___540_3067.FStar_Syntax_Syntax.vars)
           }  in
         c1
   
@@ -905,29 +952,29 @@ let rec (translate_term_to_mlty :
   =
   fun g  ->
     fun t0  ->
-      let arg_as_mlty g1 uu____3038 =
-        match uu____3038 with
-        | (a,uu____3046) ->
-            let uu____3051 = is_type g1 a  in
-            if uu____3051
+      let arg_as_mlty g1 uu____3116 =
+        match uu____3116 with
+        | (a,uu____3124) ->
+            let uu____3129 = is_type g1 a  in
+            if uu____3129
             then translate_term_to_mlty g1 a
             else FStar_Extraction_ML_UEnv.erasedContent
          in
       let fv_app_as_mlty g1 fv args =
-        let uu____3072 =
-          let uu____3074 = FStar_Extraction_ML_UEnv.is_fv_type g1 fv  in
-          Prims.op_Negation uu____3074  in
-        if uu____3072
+        let uu____3150 =
+          let uu____3152 = FStar_Extraction_ML_UEnv.is_fv_type g1 fv  in
+          Prims.op_Negation uu____3152  in
+        if uu____3150
         then FStar_Extraction_ML_Syntax.MLTY_Top
         else
-          (let uu____3079 =
-             let uu____3094 =
+          (let uu____3157 =
+             let uu____3172 =
                FStar_TypeChecker_Env.lookup_lid
                  g1.FStar_Extraction_ML_UEnv.env_tcenv
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             match uu____3094 with
-             | ((uu____3117,fvty),uu____3119) ->
+             match uu____3172 with
+             | ((uu____3195,fvty),uu____3197) ->
                  let fvty1 =
                    FStar_TypeChecker_Normalize.normalize
                      [FStar_TypeChecker_Env.UnfoldUntil
@@ -936,28 +983,28 @@ let rec (translate_term_to_mlty :
                     in
                  FStar_Syntax_Util.arrow_formals fvty1
               in
-           match uu____3079 with
-           | (formals,uu____3126) ->
+           match uu____3157 with
+           | (formals,uu____3204) ->
                let mlargs = FStar_List.map (arg_as_mlty g1) args  in
                let mlargs1 =
                  let n_args = FStar_List.length args  in
                  if (FStar_List.length formals) > n_args
                  then
-                   let uu____3179 = FStar_Util.first_N n_args formals  in
-                   match uu____3179 with
-                   | (uu____3208,rest) ->
-                       let uu____3242 =
+                   let uu____3257 = FStar_Util.first_N n_args formals  in
+                   match uu____3257 with
+                   | (uu____3286,rest) ->
+                       let uu____3320 =
                          FStar_List.map
-                           (fun uu____3252  ->
+                           (fun uu____3330  ->
                               FStar_Extraction_ML_UEnv.erasedContent) rest
                           in
-                       FStar_List.append mlargs uu____3242
+                       FStar_List.append mlargs uu____3320
                  else mlargs  in
                let nm =
-                 let uu____3262 =
+                 let uu____3340 =
                    FStar_Extraction_ML_UEnv.maybe_mangle_type_projector g1 fv
                     in
-                 match uu____3262 with
+                 match uu____3340 with
                  | FStar_Pervasives_Native.Some p -> p
                  | FStar_Pervasives_Native.None  ->
                      FStar_Extraction_ML_Syntax.mlpath_of_lident
@@ -968,54 +1015,54 @@ let rec (translate_term_to_mlty :
       let aux env t =
         let t1 = FStar_Syntax_Subst.compress t  in
         match t1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_type uu____3280 ->
+        | FStar_Syntax_Syntax.Tm_type uu____3358 ->
             FStar_Extraction_ML_Syntax.MLTY_Erased
-        | FStar_Syntax_Syntax.Tm_bvar uu____3281 ->
-            let uu____3282 =
-              let uu____3284 = FStar_Syntax_Print.term_to_string t1  in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3284
+        | FStar_Syntax_Syntax.Tm_bvar uu____3359 ->
+            let uu____3360 =
+              let uu____3362 = FStar_Syntax_Print.term_to_string t1  in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3362
                in
-            failwith uu____3282
-        | FStar_Syntax_Syntax.Tm_delayed uu____3287 ->
-            let uu____3310 =
-              let uu____3312 = FStar_Syntax_Print.term_to_string t1  in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3312
+            failwith uu____3360
+        | FStar_Syntax_Syntax.Tm_delayed uu____3365 ->
+            let uu____3388 =
+              let uu____3390 = FStar_Syntax_Print.term_to_string t1  in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3390
                in
-            failwith uu____3310
+            failwith uu____3388
         | FStar_Syntax_Syntax.Tm_unknown  ->
-            let uu____3315 =
-              let uu____3317 = FStar_Syntax_Print.term_to_string t1  in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3317
+            let uu____3393 =
+              let uu____3395 = FStar_Syntax_Print.term_to_string t1  in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3395
                in
-            failwith uu____3315
+            failwith uu____3393
         | FStar_Syntax_Syntax.Tm_lazy i ->
-            let uu____3321 = FStar_Syntax_Util.unfold_lazy i  in
-            translate_term_to_mlty env uu____3321
-        | FStar_Syntax_Syntax.Tm_constant uu____3322 ->
+            let uu____3399 = FStar_Syntax_Util.unfold_lazy i  in
+            translate_term_to_mlty env uu____3399
+        | FStar_Syntax_Syntax.Tm_constant uu____3400 ->
             FStar_Extraction_ML_UEnv.unknownType
-        | FStar_Syntax_Syntax.Tm_quoted uu____3323 ->
+        | FStar_Syntax_Syntax.Tm_quoted uu____3401 ->
             FStar_Extraction_ML_UEnv.unknownType
-        | FStar_Syntax_Syntax.Tm_uvar uu____3330 ->
+        | FStar_Syntax_Syntax.Tm_uvar uu____3408 ->
             FStar_Extraction_ML_UEnv.unknownType
-        | FStar_Syntax_Syntax.Tm_meta (t2,uu____3344) ->
+        | FStar_Syntax_Syntax.Tm_meta (t2,uu____3422) ->
             translate_term_to_mlty env t2
         | FStar_Syntax_Syntax.Tm_refine
-            ({ FStar_Syntax_Syntax.ppname = uu____3349;
-               FStar_Syntax_Syntax.index = uu____3350;
-               FStar_Syntax_Syntax.sort = t2;_},uu____3352)
+            ({ FStar_Syntax_Syntax.ppname = uu____3427;
+               FStar_Syntax_Syntax.index = uu____3428;
+               FStar_Syntax_Syntax.sort = t2;_},uu____3430)
             -> translate_term_to_mlty env t2
-        | FStar_Syntax_Syntax.Tm_uinst (t2,uu____3361) ->
+        | FStar_Syntax_Syntax.Tm_uinst (t2,uu____3439) ->
             translate_term_to_mlty env t2
-        | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____3367,uu____3368) ->
+        | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____3445,uu____3446) ->
             translate_term_to_mlty env t2
         | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
         | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv []
         | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-            let uu____3441 = FStar_Syntax_Subst.open_comp bs c  in
-            (match uu____3441 with
+            let uu____3519 = FStar_Syntax_Subst.open_comp bs c  in
+            (match uu____3519 with
              | (bs1,c1) ->
-                 let uu____3448 = binders_as_ml_binders env bs1  in
-                 (match uu____3448 with
+                 let uu____3526 = binders_as_ml_binders env bs1  in
+                 (match uu____3526 with
                   | (mlbs,env1) ->
                       let t_ret =
                         let eff =
@@ -1024,20 +1071,20 @@ let rec (translate_term_to_mlty :
                             (FStar_Syntax_Util.comp_effect_name c1)
                            in
                         let c2 = comp_no_args c1  in
-                        let uu____3481 =
-                          let uu____3488 =
+                        let uu____3559 =
+                          let uu____3566 =
                             FStar_TypeChecker_Env.effect_decl_opt
                               env1.FStar_Extraction_ML_UEnv.env_tcenv eff
                              in
-                          FStar_Util.must uu____3488  in
-                        match uu____3481 with
+                          FStar_Util.must uu____3566  in
+                        match uu____3559 with
                         | (ed,qualifiers) ->
-                            let uu____3509 =
+                            let uu____3587 =
                               FStar_TypeChecker_Env.is_reifiable_effect
                                 g.FStar_Extraction_ML_UEnv.env_tcenv
                                 ed.FStar_Syntax_Syntax.mname
                                in
-                            if uu____3509
+                            if uu____3587
                             then
                               let t2 =
                                 FStar_TypeChecker_Env.reify_comp
@@ -1045,33 +1092,33 @@ let rec (translate_term_to_mlty :
                                   FStar_Syntax_Syntax.U_unknown
                                  in
                               (FStar_Extraction_ML_UEnv.debug env1
-                                 (fun uu____3517  ->
-                                    let uu____3518 =
+                                 (fun uu____3595  ->
+                                    let uu____3596 =
                                       FStar_Syntax_Print.comp_to_string c2
                                        in
-                                    let uu____3520 =
+                                    let uu____3598 =
                                       FStar_Syntax_Print.term_to_string t2
                                        in
                                     FStar_Util.print2
                                       "Translating comp type %s as %s\n"
-                                      uu____3518 uu____3520);
+                                      uu____3596 uu____3598);
                                (let res = translate_term_to_mlty env1 t2  in
                                 FStar_Extraction_ML_UEnv.debug env1
-                                  (fun uu____3529  ->
-                                     let uu____3530 =
+                                  (fun uu____3607  ->
+                                     let uu____3608 =
                                        FStar_Syntax_Print.comp_to_string c2
                                         in
-                                     let uu____3532 =
+                                     let uu____3610 =
                                        FStar_Syntax_Print.term_to_string t2
                                         in
-                                     let uu____3534 =
+                                     let uu____3612 =
                                        FStar_Extraction_ML_Code.string_of_mlty
                                          env1.FStar_Extraction_ML_UEnv.currentModule
                                          res
                                         in
                                      FStar_Util.print3
                                        "Translated comp type %s as %s ... to %s\n"
-                                       uu____3530 uu____3532 uu____3534);
+                                       uu____3608 uu____3610 uu____3612);
                                 res))
                             else
                               translate_term_to_mlty env1
@@ -1081,66 +1128,66 @@ let rec (translate_term_to_mlty :
                         effect_as_etag env1
                           (FStar_Syntax_Util.comp_effect_name c1)
                          in
-                      let uu____3540 =
+                      let uu____3618 =
                         FStar_List.fold_right
-                          (fun uu____3560  ->
-                             fun uu____3561  ->
-                               match (uu____3560, uu____3561) with
-                               | ((uu____3584,t2),(tag,t')) ->
+                          (fun uu____3638  ->
+                             fun uu____3639  ->
+                               match (uu____3638, uu____3639) with
+                               | ((uu____3662,t2),(tag,t')) ->
                                    (FStar_Extraction_ML_Syntax.E_PURE,
                                      (FStar_Extraction_ML_Syntax.MLTY_Fun
                                         (t2, tag, t')))) mlbs (erase, t_ret)
                          in
-                      (match uu____3540 with | (uu____3599,t2) -> t2)))
+                      (match uu____3618 with | (uu____3677,t2) -> t2)))
         | FStar_Syntax_Syntax.Tm_app (head1,args) ->
             let res =
-              let uu____3628 =
-                let uu____3629 = FStar_Syntax_Util.un_uinst head1  in
-                uu____3629.FStar_Syntax_Syntax.n  in
-              match uu____3628 with
+              let uu____3706 =
+                let uu____3707 = FStar_Syntax_Util.un_uinst head1  in
+                uu____3707.FStar_Syntax_Syntax.n  in
+              match uu____3706 with
               | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
               | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv args
               | FStar_Syntax_Syntax.Tm_app (head2,args') ->
-                  let uu____3660 =
+                  let uu____3738 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_app
                          (head2, (FStar_List.append args' args)))
                       FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
                      in
-                  translate_term_to_mlty env uu____3660
-              | uu____3681 -> FStar_Extraction_ML_UEnv.unknownType  in
+                  translate_term_to_mlty env uu____3738
+              | uu____3759 -> FStar_Extraction_ML_UEnv.unknownType  in
             res
-        | FStar_Syntax_Syntax.Tm_abs (bs,ty,uu____3684) ->
-            let uu____3709 = FStar_Syntax_Subst.open_term bs ty  in
-            (match uu____3709 with
+        | FStar_Syntax_Syntax.Tm_abs (bs,ty,uu____3762) ->
+            let uu____3787 = FStar_Syntax_Subst.open_term bs ty  in
+            (match uu____3787 with
              | (bs1,ty1) ->
-                 let uu____3716 = binders_as_ml_binders env bs1  in
-                 (match uu____3716 with
+                 let uu____3794 = binders_as_ml_binders env bs1  in
+                 (match uu____3794 with
                   | (bts,env1) -> translate_term_to_mlty env1 ty1))
-        | FStar_Syntax_Syntax.Tm_let uu____3744 ->
+        | FStar_Syntax_Syntax.Tm_let uu____3822 ->
             FStar_Extraction_ML_UEnv.unknownType
-        | FStar_Syntax_Syntax.Tm_match uu____3758 ->
+        | FStar_Syntax_Syntax.Tm_match uu____3836 ->
             FStar_Extraction_ML_UEnv.unknownType
          in
       let rec is_top_ty t =
         match t with
         | FStar_Extraction_ML_Syntax.MLTY_Top  -> true
-        | FStar_Extraction_ML_Syntax.MLTY_Named uu____3790 ->
-            let uu____3797 = FStar_Extraction_ML_Util.udelta_unfold g t  in
-            (match uu____3797 with
+        | FStar_Extraction_ML_Syntax.MLTY_Named uu____3868 ->
+            let uu____3875 = FStar_Extraction_ML_Util.udelta_unfold g t  in
+            (match uu____3875 with
              | FStar_Pervasives_Native.None  -> false
              | FStar_Pervasives_Native.Some t1 -> is_top_ty t1)
-        | uu____3803 -> false  in
-      let uu____3805 =
+        | uu____3881 -> false  in
+      let uu____3883 =
         FStar_TypeChecker_Util.must_erase_for_extraction
           g.FStar_Extraction_ML_UEnv.env_tcenv t0
          in
-      if uu____3805
+      if uu____3883
       then FStar_Extraction_ML_Syntax.MLTY_Erased
       else
         (let mlt = aux g t0  in
-         let uu____3811 = is_top_ty mlt  in
-         if uu____3811 then FStar_Extraction_ML_Syntax.MLTY_Top else mlt)
+         let uu____3889 = is_top_ty mlt  in
+         if uu____3889 then FStar_Extraction_ML_Syntax.MLTY_Top else mlt)
 
 and (binders_as_ml_binders :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1150,15 +1197,15 @@ and (binders_as_ml_binders :
   =
   fun g  ->
     fun bs  ->
-      let uu____3829 =
+      let uu____3907 =
         FStar_All.pipe_right bs
           (FStar_List.fold_left
-             (fun uu____3885  ->
+             (fun uu____3963  ->
                 fun b  ->
-                  match uu____3885 with
+                  match uu____3963 with
                   | (ml_bs,env) ->
-                      let uu____3931 = is_type_binder g b  in
-                      if uu____3931
+                      let uu____4009 = is_type_binder g b  in
+                      if uu____4009
                       then
                         let b1 = FStar_Pervasives_Native.fst b  in
                         let env1 =
@@ -1167,9 +1214,9 @@ and (binders_as_ml_binders :
                                FStar_Extraction_ML_Syntax.MLTY_Top)
                            in
                         let ml_b =
-                          let uu____3957 =
+                          let uu____4035 =
                             FStar_Extraction_ML_UEnv.bv_as_ml_termvar b1  in
-                          (uu____3957, FStar_Extraction_ML_Syntax.ml_unit_ty)
+                          (uu____4035, FStar_Extraction_ML_Syntax.ml_unit_ty)
                            in
                         ((ml_b :: ml_bs), env1)
                       else
@@ -1178,19 +1225,19 @@ and (binders_as_ml_binders :
                            translate_term_to_mlty env
                              b1.FStar_Syntax_Syntax.sort
                             in
-                         let uu____3978 =
+                         let uu____4056 =
                            FStar_Extraction_ML_UEnv.extend_bv env b1 
                              ([], t) false false false
                             in
-                         match uu____3978 with
-                         | (env1,b2,uu____4003) ->
+                         match uu____4056 with
+                         | (env1,b2,uu____4081) ->
                              let ml_b =
-                               let uu____4012 =
+                               let uu____4090 =
                                  FStar_Extraction_ML_UEnv.removeTick b2  in
-                               (uu____4012, t)  in
+                               (uu____4090, t)  in
                              ((ml_b :: ml_bs), env1))) ([], g))
          in
-      match uu____3829 with | (ml_bs,env) -> ((FStar_List.rev ml_bs), env)
+      match uu____3907 with | (ml_bs,env) -> ((FStar_List.rev ml_bs), env)
 
 let (term_as_mlty :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1216,11 +1263,11 @@ let (mk_MLE_Seq :
       | (FStar_Extraction_ML_Syntax.MLE_Seq
          es1,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 es2)
-      | (FStar_Extraction_ML_Syntax.MLE_Seq es1,uu____4108) ->
+      | (FStar_Extraction_ML_Syntax.MLE_Seq es1,uu____4186) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 [e2])
-      | (uu____4111,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
+      | (uu____4189,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (e1 :: es2)
-      | uu____4115 -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
+      | uu____4193 -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
   
 let (mk_MLE_Let :
   Prims.bool ->
@@ -1246,16 +1293,16 @@ let (mk_MLE_Let :
                     | FStar_Extraction_ML_Syntax.MLE_Var x when
                         x = lb.FStar_Extraction_ML_Syntax.mllb_name ->
                         (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
-                    | uu____4149 when
+                    | uu____4227 when
                         (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
                           =
                           FStar_Extraction_ML_Syntax.ml_unit.FStar_Extraction_ML_Syntax.expr
                         -> body.FStar_Extraction_ML_Syntax.expr
-                    | uu____4150 ->
+                    | uu____4228 ->
                         mk_MLE_Seq lb.FStar_Extraction_ML_Syntax.mllb_def
                           body)
-             | uu____4151 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
-        | uu____4160 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
+             | uu____4229 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
+        | uu____4238 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
   
 let (resugar_pat :
   FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option ->
@@ -1266,11 +1313,11 @@ let (resugar_pat :
     fun p  ->
       match p with
       | FStar_Extraction_ML_Syntax.MLP_CTor (d,pats) ->
-          let uu____4188 = FStar_Extraction_ML_Util.is_xtuple d  in
-          (match uu____4188 with
+          let uu____4266 = FStar_Extraction_ML_Util.is_xtuple d  in
+          (match uu____4266 with
            | FStar_Pervasives_Native.Some n1 ->
                FStar_Extraction_ML_Syntax.MLP_Tuple pats
-           | uu____4195 ->
+           | uu____4273 ->
                (match q with
                 | FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Record_ctor (ty,fns)) ->
@@ -1279,8 +1326,8 @@ let (resugar_pat :
                        in
                     let fs = record_fields fns pats  in
                     FStar_Extraction_ML_Syntax.MLP_Record (path, fs)
-                | uu____4228 -> p))
-      | uu____4231 -> p
+                | uu____4306 -> p))
+      | uu____4309 -> p
   
 let rec (extract_one_pat :
   Prims.bool ->
@@ -1311,81 +1358,81 @@ let rec (extract_one_pat :
                   (if Prims.op_Negation ok
                    then
                      FStar_Extraction_ML_UEnv.debug g
-                       (fun uu____4333  ->
-                          let uu____4334 =
+                       (fun uu____4411  ->
+                          let uu____4412 =
                             FStar_Extraction_ML_Code.string_of_mlty
                               g.FStar_Extraction_ML_UEnv.currentModule t'
                              in
-                          let uu____4336 =
+                          let uu____4414 =
                             FStar_Extraction_ML_Code.string_of_mlty
                               g.FStar_Extraction_ML_UEnv.currentModule t
                              in
                           FStar_Util.print2
                             "Expected pattern type %s; got pattern type %s\n"
-                            uu____4334 uu____4336)
+                            uu____4412 uu____4414)
                    else ();
                    ok)
                in
             match p.FStar_Syntax_Syntax.v with
             | FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_int
                 (c,swopt)) when
-                let uu____4372 = FStar_Options.codegen ()  in
-                uu____4372 <>
+                let uu____4450 = FStar_Options.codegen ()  in
+                uu____4450 <>
                   (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
                 ->
-                let uu____4377 =
+                let uu____4455 =
                   match swopt with
                   | FStar_Pervasives_Native.None  ->
-                      let uu____4390 =
-                        let uu____4391 =
-                          let uu____4392 =
+                      let uu____4468 =
+                        let uu____4469 =
+                          let uu____4470 =
                             FStar_Extraction_ML_Util.mlconst_of_const
                               p.FStar_Syntax_Syntax.p
                               (FStar_Const.Const_int
                                  (c, FStar_Pervasives_Native.None))
                              in
-                          FStar_Extraction_ML_Syntax.MLE_Const uu____4392  in
+                          FStar_Extraction_ML_Syntax.MLE_Const uu____4470  in
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.ml_int_ty) uu____4391
+                             FStar_Extraction_ML_Syntax.ml_int_ty) uu____4469
                          in
-                      (uu____4390, FStar_Extraction_ML_Syntax.ml_int_ty)
+                      (uu____4468, FStar_Extraction_ML_Syntax.ml_int_ty)
                   | FStar_Pervasives_Native.Some sw ->
                       let source_term =
                         FStar_ToSyntax_ToSyntax.desugar_machine_integer
                           (g.FStar_Extraction_ML_UEnv.env_tcenv).FStar_TypeChecker_Env.dsenv
                           c sw FStar_Range.dummyRange
                          in
-                      let uu____4414 = term_as_mlexpr g source_term  in
-                      (match uu____4414 with
-                       | (mlterm,uu____4426,mlty) -> (mlterm, mlty))
+                      let uu____4492 = term_as_mlexpr g source_term  in
+                      (match uu____4492 with
+                       | (mlterm,uu____4504,mlty) -> (mlterm, mlty))
                    in
-                (match uu____4377 with
+                (match uu____4455 with
                  | (mlc,ml_ty) ->
                      let x = FStar_Extraction_ML_Syntax.gensym ()  in
                      let when_clause =
-                       let uu____4448 =
-                         let uu____4449 =
-                           let uu____4456 =
-                             let uu____4459 =
+                       let uu____4526 =
+                         let uu____4527 =
+                           let uu____4534 =
+                             let uu____4537 =
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty ml_ty)
                                  (FStar_Extraction_ML_Syntax.MLE_Var x)
                                 in
-                             [uu____4459; mlc]  in
+                             [uu____4537; mlc]  in
                            (FStar_Extraction_ML_Util.prims_op_equality,
-                             uu____4456)
+                             uu____4534)
                             in
-                         FStar_Extraction_ML_Syntax.MLE_App uu____4449  in
+                         FStar_Extraction_ML_Syntax.MLE_App uu____4527  in
                        FStar_All.pipe_left
                          (FStar_Extraction_ML_Syntax.with_ty
-                            FStar_Extraction_ML_Syntax.ml_bool_ty) uu____4448
+                            FStar_Extraction_ML_Syntax.ml_bool_ty) uu____4526
                         in
-                     let uu____4462 = ok ml_ty  in
+                     let uu____4540 = ok ml_ty  in
                      (g,
                        (FStar_Pervasives_Native.Some
                           ((FStar_Extraction_ML_Syntax.MLP_Var x),
-                            [when_clause])), uu____4462))
+                            [when_clause])), uu____4540))
             | FStar_Syntax_Syntax.Pat_constant s ->
                 let t =
                   FStar_TypeChecker_TcTerm.tc_constant
@@ -1393,103 +1440,103 @@ let rec (extract_one_pat :
                     FStar_Range.dummyRange s
                    in
                 let mlty = term_as_mlty g t  in
-                let uu____4484 =
-                  let uu____4493 =
-                    let uu____4500 =
-                      let uu____4501 =
+                let uu____4562 =
+                  let uu____4571 =
+                    let uu____4578 =
+                      let uu____4579 =
                         FStar_Extraction_ML_Util.mlconst_of_const
                           p.FStar_Syntax_Syntax.p s
                          in
-                      FStar_Extraction_ML_Syntax.MLP_Const uu____4501  in
-                    (uu____4500, [])  in
-                  FStar_Pervasives_Native.Some uu____4493  in
-                let uu____4510 = ok mlty  in (g, uu____4484, uu____4510)
+                      FStar_Extraction_ML_Syntax.MLP_Const uu____4579  in
+                    (uu____4578, [])  in
+                  FStar_Pervasives_Native.Some uu____4571  in
+                let uu____4588 = ok mlty  in (g, uu____4562, uu____4588)
             | FStar_Syntax_Syntax.Pat_var x ->
                 let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort  in
-                let uu____4523 =
+                let uu____4601 =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false
                     false imp
                    in
-                (match uu____4523 with
-                 | (g1,x1,uu____4551) ->
-                     let uu____4554 = ok mlty  in
+                (match uu____4601 with
+                 | (g1,x1,uu____4629) ->
+                     let uu____4632 = ok mlty  in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
                         else
                           FStar_Pervasives_Native.Some
                             ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
-                       uu____4554))
+                       uu____4632))
             | FStar_Syntax_Syntax.Pat_wild x ->
                 let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort  in
-                let uu____4592 =
+                let uu____4670 =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false
                     false imp
                    in
-                (match uu____4592 with
-                 | (g1,x1,uu____4620) ->
-                     let uu____4623 = ok mlty  in
+                (match uu____4670 with
+                 | (g1,x1,uu____4698) ->
+                     let uu____4701 = ok mlty  in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
                         else
                           FStar_Pervasives_Native.Some
                             ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
-                       uu____4623))
-            | FStar_Syntax_Syntax.Pat_dot_term uu____4659 ->
+                       uu____4701))
+            | FStar_Syntax_Syntax.Pat_dot_term uu____4737 ->
                 (g, FStar_Pervasives_Native.None, true)
             | FStar_Syntax_Syntax.Pat_cons (f,pats) ->
-                let uu____4702 =
-                  let uu____4711 = FStar_Extraction_ML_UEnv.lookup_fv g f  in
-                  match uu____4711 with
-                  | { FStar_Extraction_ML_UEnv.exp_b_name = uu____4720;
+                let uu____4780 =
+                  let uu____4789 = FStar_Extraction_ML_UEnv.lookup_fv g f  in
+                  match uu____4789 with
+                  | { FStar_Extraction_ML_UEnv.exp_b_name = uu____4798;
                       FStar_Extraction_ML_UEnv.exp_b_expr =
                         {
                           FStar_Extraction_ML_Syntax.expr =
                             FStar_Extraction_ML_Syntax.MLE_Name n1;
-                          FStar_Extraction_ML_Syntax.mlty = uu____4722;
-                          FStar_Extraction_ML_Syntax.loc = uu____4723;_};
+                          FStar_Extraction_ML_Syntax.mlty = uu____4800;
+                          FStar_Extraction_ML_Syntax.loc = uu____4801;_};
                       FStar_Extraction_ML_UEnv.exp_b_tscheme = ttys;
-                      FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____4725;_}
+                      FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____4803;_}
                       -> (n1, ttys)
-                  | uu____4732 -> failwith "Expected a constructor"  in
-                (match uu____4702 with
+                  | uu____4810 -> failwith "Expected a constructor"  in
+                (match uu____4780 with
                  | (d,tys) ->
                      let nTyVars =
                        FStar_List.length (FStar_Pervasives_Native.fst tys)
                         in
-                     let uu____4769 = FStar_Util.first_N nTyVars pats  in
-                     (match uu____4769 with
+                     let uu____4847 = FStar_Util.first_N nTyVars pats  in
+                     (match uu____4847 with
                       | (tysVarPats,restPats) ->
                           let f_ty_opt =
                             try
-                              (fun uu___811_4873  ->
+                              (fun uu___835_4951  ->
                                  match () with
                                  | () ->
                                      let mlty_args =
                                        FStar_All.pipe_right tysVarPats
                                          (FStar_List.map
-                                            (fun uu____4904  ->
-                                               match uu____4904 with
-                                               | (p1,uu____4911) ->
+                                            (fun uu____4982  ->
+                                               match uu____4982 with
+                                               | (p1,uu____4989) ->
                                                    (match p1.FStar_Syntax_Syntax.v
                                                     with
                                                     | FStar_Syntax_Syntax.Pat_dot_term
-                                                        (uu____4914,t) ->
+                                                        (uu____4992,t) ->
                                                         term_as_mlty g t
-                                                    | uu____4920 ->
+                                                    | uu____4998 ->
                                                         (FStar_Extraction_ML_UEnv.debug
                                                            g
-                                                           (fun uu____4924 
+                                                           (fun uu____5002 
                                                               ->
-                                                              let uu____4925
+                                                              let uu____5003
                                                                 =
                                                                 FStar_Syntax_Print.pat_to_string
                                                                   p1
                                                                  in
                                                               FStar_Util.print1
                                                                 "Pattern %s is not extractable"
-                                                                uu____4925);
+                                                                uu____5003);
                                                          FStar_Exn.raise
                                                            Un_extractable))))
                                         in
@@ -1497,39 +1544,39 @@ let rec (extract_one_pat :
                                        FStar_Extraction_ML_Util.subst tys
                                          mlty_args
                                         in
-                                     let uu____4929 =
+                                     let uu____5007 =
                                        FStar_Extraction_ML_Util.uncurry_mlty_fun
                                          f_ty
                                         in
-                                     FStar_Pervasives_Native.Some uu____4929)
+                                     FStar_Pervasives_Native.Some uu____5007)
                                 ()
                             with
                             | Un_extractable  -> FStar_Pervasives_Native.None
                              in
-                          let uu____4958 =
+                          let uu____5036 =
                             FStar_Util.fold_map
                               (fun g1  ->
-                                 fun uu____4995  ->
-                                   match uu____4995 with
+                                 fun uu____5073  ->
+                                   match uu____5073 with
                                    | (p1,imp1) ->
-                                       let uu____5017 =
+                                       let uu____5095 =
                                          extract_one_pat true g1 p1
                                            FStar_Pervasives_Native.None
                                            term_as_mlexpr
                                           in
-                                       (match uu____5017 with
-                                        | (g2,p2,uu____5048) -> (g2, p2))) g
+                                       (match uu____5095 with
+                                        | (g2,p2,uu____5126) -> (g2, p2))) g
                               tysVarPats
                              in
-                          (match uu____4958 with
+                          (match uu____5036 with
                            | (g1,tyMLPats) ->
-                               let uu____5112 =
+                               let uu____5190 =
                                  FStar_Util.fold_map
-                                   (fun uu____5177  ->
-                                      fun uu____5178  ->
-                                        match (uu____5177, uu____5178) with
+                                   (fun uu____5255  ->
+                                      fun uu____5256  ->
+                                        match (uu____5255, uu____5256) with
                                         | ((g2,f_ty_opt1),(p1,imp1)) ->
-                                            let uu____5276 =
+                                            let uu____5354 =
                                               match f_ty_opt1 with
                                               | FStar_Pervasives_Native.Some
                                                   (hd1::rest,res) ->
@@ -1537,64 +1584,64 @@ let rec (extract_one_pat :
                                                       (rest, res)),
                                                     (FStar_Pervasives_Native.Some
                                                        hd1))
-                                              | uu____5336 ->
+                                              | uu____5414 ->
                                                   (FStar_Pervasives_Native.None,
                                                     FStar_Pervasives_Native.None)
                                                in
-                                            (match uu____5276 with
+                                            (match uu____5354 with
                                              | (f_ty_opt2,expected_ty) ->
-                                                 let uu____5407 =
+                                                 let uu____5485 =
                                                    extract_one_pat false g2
                                                      p1 expected_ty
                                                      term_as_mlexpr
                                                     in
-                                                 (match uu____5407 with
-                                                  | (g3,p2,uu____5450) ->
+                                                 (match uu____5485 with
+                                                  | (g3,p2,uu____5528) ->
                                                       ((g3, f_ty_opt2), p2))))
                                    (g1, f_ty_opt) restPats
                                   in
-                               (match uu____5112 with
+                               (match uu____5190 with
                                 | ((g2,f_ty_opt1),restMLPats) ->
-                                    let uu____5571 =
-                                      let uu____5582 =
+                                    let uu____5649 =
+                                      let uu____5660 =
                                         FStar_All.pipe_right
                                           (FStar_List.append tyMLPats
                                              restMLPats)
                                           (FStar_List.collect
-                                             (fun uu___0_5633  ->
-                                                match uu___0_5633 with
+                                             (fun uu___0_5711  ->
+                                                match uu___0_5711 with
                                                 | FStar_Pervasives_Native.Some
                                                     x -> [x]
-                                                | uu____5675 -> []))
+                                                | uu____5753 -> []))
                                          in
-                                      FStar_All.pipe_right uu____5582
+                                      FStar_All.pipe_right uu____5660
                                         FStar_List.split
                                        in
-                                    (match uu____5571 with
+                                    (match uu____5649 with
                                      | (mlPats,when_clauses) ->
                                          let pat_ty_compat =
                                            match f_ty_opt1 with
                                            | FStar_Pervasives_Native.Some
                                                ([],t) -> ok t
-                                           | uu____5751 -> false  in
-                                         let uu____5761 =
-                                           let uu____5770 =
-                                             let uu____5777 =
+                                           | uu____5829 -> false  in
+                                         let uu____5839 =
+                                           let uu____5848 =
+                                             let uu____5855 =
                                                resugar_pat
                                                  f.FStar_Syntax_Syntax.fv_qual
                                                  (FStar_Extraction_ML_Syntax.MLP_CTor
                                                     (d, mlPats))
                                                 in
-                                             let uu____5780 =
+                                             let uu____5858 =
                                                FStar_All.pipe_right
                                                  when_clauses
                                                  FStar_List.flatten
                                                 in
-                                             (uu____5777, uu____5780)  in
+                                             (uu____5855, uu____5858)  in
                                            FStar_Pervasives_Native.Some
-                                             uu____5770
+                                             uu____5848
                                             in
-                                         (g2, uu____5761, pat_ty_compat))))))
+                                         (g2, uu____5839, pat_ty_compat))))))
   
 let (extract_pat :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1616,27 +1663,27 @@ let (extract_pat :
       fun expected_t  ->
         fun term_as_mlexpr  ->
           let extract_one_pat1 g1 p1 expected_t1 =
-            let uu____5912 =
+            let uu____5990 =
               extract_one_pat false g1 p1 expected_t1 term_as_mlexpr  in
-            match uu____5912 with
+            match uu____5990 with
             | (g2,FStar_Pervasives_Native.Some (x,v1),b) -> (g2, (x, v1), b)
-            | uu____5975 ->
+            | uu____6053 ->
                 failwith "Impossible: Unable to translate pattern"
              in
           let mk_when_clause whens =
             match whens with
             | [] -> FStar_Pervasives_Native.None
             | hd1::tl1 ->
-                let uu____6023 =
+                let uu____6101 =
                   FStar_List.fold_left FStar_Extraction_ML_Util.conjoin hd1
                     tl1
                    in
-                FStar_Pervasives_Native.Some uu____6023
+                FStar_Pervasives_Native.Some uu____6101
              in
-          let uu____6024 =
+          let uu____6102 =
             extract_one_pat1 g p (FStar_Pervasives_Native.Some expected_t)
              in
-          match uu____6024 with
+          match uu____6102 with
           | (g1,(p1,whens),b) ->
               let when_clause = mk_when_clause whens  in
               (g1, [(p1, when_clause)], b)
@@ -1654,40 +1701,40 @@ let (maybe_eta_data_and_project_record :
         fun mlAppExpr  ->
           let rec eta_args more_args t =
             match t with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (t0,uu____6184,t1) ->
+            | FStar_Extraction_ML_Syntax.MLTY_Fun (t0,uu____6262,t1) ->
                 let x = FStar_Extraction_ML_Syntax.gensym ()  in
-                let uu____6188 =
-                  let uu____6200 =
-                    let uu____6210 =
+                let uu____6266 =
+                  let uu____6278 =
+                    let uu____6288 =
                       FStar_All.pipe_left
                         (FStar_Extraction_ML_Syntax.with_ty t0)
                         (FStar_Extraction_ML_Syntax.MLE_Var x)
                        in
-                    ((x, t0), uu____6210)  in
-                  uu____6200 :: more_args  in
-                eta_args uu____6188 t1
-            | FStar_Extraction_ML_Syntax.MLTY_Named (uu____6226,uu____6227)
+                    ((x, t0), uu____6288)  in
+                  uu____6278 :: more_args  in
+                eta_args uu____6266 t1
+            | FStar_Extraction_ML_Syntax.MLTY_Named (uu____6304,uu____6305)
                 -> ((FStar_List.rev more_args), t)
-            | uu____6252 ->
-                let uu____6253 =
-                  let uu____6255 =
+            | uu____6330 ->
+                let uu____6331 =
+                  let uu____6333 =
                     FStar_Extraction_ML_Code.string_of_mlexpr
                       g.FStar_Extraction_ML_UEnv.currentModule mlAppExpr
                      in
-                  let uu____6257 =
+                  let uu____6335 =
                     FStar_Extraction_ML_Code.string_of_mlty
                       g.FStar_Extraction_ML_UEnv.currentModule t
                      in
                   FStar_Util.format2
                     "Impossible: Head type is not an arrow: (%s : %s)"
-                    uu____6255 uu____6257
+                    uu____6333 uu____6335
                    in
-                failwith uu____6253
+                failwith uu____6331
              in
           let as_record qual1 e =
             match ((e.FStar_Extraction_ML_Syntax.expr), qual1) with
             | (FStar_Extraction_ML_Syntax.MLE_CTor
-               (uu____6292,args),FStar_Pervasives_Native.Some
+               (uu____6370,args),FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Record_ctor (tyname,fields))) ->
                 let path =
                   FStar_List.map FStar_Ident.text_of_id tyname.FStar_Ident.ns
@@ -1697,25 +1744,25 @@ let (maybe_eta_data_and_project_record :
                   (FStar_Extraction_ML_Syntax.with_ty
                      e.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_Record (path, fields1))
-            | uu____6329 -> e  in
+            | uu____6407 -> e  in
           let resugar_and_maybe_eta qual1 e =
-            let uu____6351 = eta_args [] residualType  in
-            match uu____6351 with
+            let uu____6429 = eta_args [] residualType  in
+            match uu____6429 with
             | (eargs,tres) ->
                 (match eargs with
                  | [] ->
-                     let uu____6409 = as_record qual1 e  in
-                     FStar_Extraction_ML_Util.resugar_exp uu____6409
-                 | uu____6410 ->
-                     let uu____6422 = FStar_List.unzip eargs  in
-                     (match uu____6422 with
+                     let uu____6487 = as_record qual1 e  in
+                     FStar_Extraction_ML_Util.resugar_exp uu____6487
+                 | uu____6488 ->
+                     let uu____6500 = FStar_List.unzip eargs  in
+                     (match uu____6500 with
                       | (binders,eargs1) ->
                           (match e.FStar_Extraction_ML_Syntax.expr with
                            | FStar_Extraction_ML_Syntax.MLE_CTor (head1,args)
                                ->
                                let body =
-                                 let uu____6468 =
-                                   let uu____6469 =
+                                 let uu____6546 =
+                                   let uu____6547 =
                                      FStar_All.pipe_left
                                        (FStar_Extraction_ML_Syntax.with_ty
                                           tres)
@@ -1724,28 +1771,28 @@ let (maybe_eta_data_and_project_record :
                                             (FStar_List.append args eargs1)))
                                       in
                                    FStar_All.pipe_left (as_record qual1)
-                                     uu____6469
+                                     uu____6547
                                     in
                                  FStar_All.pipe_left
                                    FStar_Extraction_ML_Util.resugar_exp
-                                   uu____6468
+                                   uu____6546
                                   in
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     e.FStar_Extraction_ML_Syntax.mlty)
                                  (FStar_Extraction_ML_Syntax.MLE_Fun
                                     (binders, body))
-                           | uu____6479 ->
+                           | uu____6557 ->
                                failwith "Impossible: Not a constructor")))
              in
           match ((mlAppExpr.FStar_Extraction_ML_Syntax.expr), qual) with
-          | (uu____6483,FStar_Pervasives_Native.None ) -> mlAppExpr
+          | (uu____6561,FStar_Pervasives_Native.None ) -> mlAppExpr
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6487;
-                FStar_Extraction_ML_Syntax.loc = uu____6488;_},mle::args),FStar_Pervasives_Native.Some
+                FStar_Extraction_ML_Syntax.mlty = uu____6565;
+                FStar_Extraction_ML_Syntax.loc = uu____6566;_},mle::args),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
               let f1 =
                 FStar_Ident.lid_of_ids
@@ -1756,79 +1803,18 @@ let (maybe_eta_data_and_project_record :
               let e =
                 match args with
                 | [] -> proj
-                | uu____6511 ->
-                    let uu____6514 =
-                      let uu____6521 =
+                | uu____6589 ->
+                    let uu____6592 =
+                      let uu____6599 =
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
                              FStar_Extraction_ML_Syntax.MLTY_Top) proj
                          in
-                      (uu____6521, args)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____6514
+                      (uu____6599, args)  in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____6592
                  in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
-          | (FStar_Extraction_ML_Syntax.MLE_App
-             ({
-                FStar_Extraction_ML_Syntax.expr =
-                  FStar_Extraction_ML_Syntax.MLE_TApp
-                  ({
-                     FStar_Extraction_ML_Syntax.expr =
-                       FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6525;
-                     FStar_Extraction_ML_Syntax.loc = uu____6526;_},uu____6527);
-                FStar_Extraction_ML_Syntax.mlty = uu____6528;
-                FStar_Extraction_ML_Syntax.loc = uu____6529;_},mle::args),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
-              let f1 =
-                FStar_Ident.lid_of_ids
-                  (FStar_List.append constrname.FStar_Ident.ns [f])
-                 in
-              let fn = FStar_Extraction_ML_Util.mlpath_of_lid f1  in
-              let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn)  in
-              let e =
-                match args with
-                | [] -> proj
-                | uu____6556 ->
-                    let uu____6559 =
-                      let uu____6566 =
-                        FStar_All.pipe_left
-                          (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top) proj
-                         in
-                      (uu____6566, args)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____6559
-                 in
-              FStar_Extraction_ML_Syntax.with_ty
-                mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
-          | (FStar_Extraction_ML_Syntax.MLE_App
-             ({
-                FStar_Extraction_ML_Syntax.expr =
-                  FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6570;
-                FStar_Extraction_ML_Syntax.loc = uu____6571;_},mlargs),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Data_ctor )) ->
-              let uu____6579 =
-                FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
-                 in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6579
-          | (FStar_Extraction_ML_Syntax.MLE_App
-             ({
-                FStar_Extraction_ML_Syntax.expr =
-                  FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6583;
-                FStar_Extraction_ML_Syntax.loc = uu____6584;_},mlargs),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6586)) ->
-              let uu____6599 =
-                FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
-                 in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6599
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -1839,15 +1825,57 @@ let (maybe_eta_data_and_project_record :
                      FStar_Extraction_ML_Syntax.mlty = uu____6603;
                      FStar_Extraction_ML_Syntax.loc = uu____6604;_},uu____6605);
                 FStar_Extraction_ML_Syntax.mlty = uu____6606;
-                FStar_Extraction_ML_Syntax.loc = uu____6607;_},mlargs),FStar_Pervasives_Native.Some
+                FStar_Extraction_ML_Syntax.loc = uu____6607;_},mle::args),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
+              let f1 =
+                FStar_Ident.lid_of_ids
+                  (FStar_List.append constrname.FStar_Ident.ns [f])
+                 in
+              let fn = FStar_Extraction_ML_Util.mlpath_of_lid f1  in
+              let proj = FStar_Extraction_ML_Syntax.MLE_Proj (mle, fn)  in
+              let e =
+                match args with
+                | [] -> proj
+                | uu____6634 ->
+                    let uu____6637 =
+                      let uu____6644 =
+                        FStar_All.pipe_left
+                          (FStar_Extraction_ML_Syntax.with_ty
+                             FStar_Extraction_ML_Syntax.MLTY_Top) proj
+                         in
+                      (uu____6644, args)  in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____6637
+                 in
+              FStar_Extraction_ML_Syntax.with_ty
+                mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
+          | (FStar_Extraction_ML_Syntax.MLE_App
+             ({
+                FStar_Extraction_ML_Syntax.expr =
+                  FStar_Extraction_ML_Syntax.MLE_Name mlp;
+                FStar_Extraction_ML_Syntax.mlty = uu____6648;
+                FStar_Extraction_ML_Syntax.loc = uu____6649;_},mlargs),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Data_ctor )) ->
-              let uu____6619 =
+              let uu____6657 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6619
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6657
+          | (FStar_Extraction_ML_Syntax.MLE_App
+             ({
+                FStar_Extraction_ML_Syntax.expr =
+                  FStar_Extraction_ML_Syntax.MLE_Name mlp;
+                FStar_Extraction_ML_Syntax.mlty = uu____6661;
+                FStar_Extraction_ML_Syntax.loc = uu____6662;_},mlargs),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_ctor uu____6664)) ->
+              let uu____6677 =
+                FStar_All.pipe_left
+                  (FStar_Extraction_ML_Syntax.with_ty
+                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
+                 in
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6677
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -1855,67 +1883,86 @@ let (maybe_eta_data_and_project_record :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6623;
-                     FStar_Extraction_ML_Syntax.loc = uu____6624;_},uu____6625);
-                FStar_Extraction_ML_Syntax.mlty = uu____6626;
-                FStar_Extraction_ML_Syntax.loc = uu____6627;_},mlargs),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6629)) ->
-              let uu____6646 =
+                     FStar_Extraction_ML_Syntax.mlty = uu____6681;
+                     FStar_Extraction_ML_Syntax.loc = uu____6682;_},uu____6683);
+                FStar_Extraction_ML_Syntax.mlty = uu____6684;
+                FStar_Extraction_ML_Syntax.loc = uu____6685;_},mlargs),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Data_ctor )) ->
+              let uu____6697 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6646
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6697
+          | (FStar_Extraction_ML_Syntax.MLE_App
+             ({
+                FStar_Extraction_ML_Syntax.expr =
+                  FStar_Extraction_ML_Syntax.MLE_TApp
+                  ({
+                     FStar_Extraction_ML_Syntax.expr =
+                       FStar_Extraction_ML_Syntax.MLE_Name mlp;
+                     FStar_Extraction_ML_Syntax.mlty = uu____6701;
+                     FStar_Extraction_ML_Syntax.loc = uu____6702;_},uu____6703);
+                FStar_Extraction_ML_Syntax.mlty = uu____6704;
+                FStar_Extraction_ML_Syntax.loc = uu____6705;_},mlargs),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_ctor uu____6707)) ->
+              let uu____6724 =
+                FStar_All.pipe_left
+                  (FStar_Extraction_ML_Syntax.with_ty
+                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
+                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
+                 in
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6724
           | (FStar_Extraction_ML_Syntax.MLE_Name
              mlp,FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor
              )) ->
-              let uu____6652 =
+              let uu____6730 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6652
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6730
           | (FStar_Extraction_ML_Syntax.MLE_Name
              mlp,FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6656)) ->
-              let uu____6665 =
+             (FStar_Syntax_Syntax.Record_ctor uu____6734)) ->
+              let uu____6743 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6665
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6743
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6669;
-                FStar_Extraction_ML_Syntax.loc = uu____6670;_},uu____6671),FStar_Pervasives_Native.Some
+                FStar_Extraction_ML_Syntax.mlty = uu____6747;
+                FStar_Extraction_ML_Syntax.loc = uu____6748;_},uu____6749),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Data_ctor )) ->
-              let uu____6678 =
+              let uu____6756 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6678
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6756
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6682;
-                FStar_Extraction_ML_Syntax.loc = uu____6683;_},uu____6684),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6685)) ->
-              let uu____6698 =
+                FStar_Extraction_ML_Syntax.mlty = uu____6760;
+                FStar_Extraction_ML_Syntax.loc = uu____6761;_},uu____6762),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_ctor uu____6763)) ->
+              let uu____6776 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6698
-          | uu____6701 -> mlAppExpr
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6776
+          | uu____6779 -> mlAppExpr
   
 let (maybe_promote_effect :
   FStar_Extraction_ML_Syntax.mlexpr ->
@@ -1936,7 +1983,7 @@ let (maybe_promote_effect :
            ,FStar_Extraction_ML_Syntax.MLTY_Erased ) ->
             (FStar_Extraction_ML_Syntax.ml_unit,
               FStar_Extraction_ML_Syntax.E_PURE)
-        | uu____6732 -> (ml_e, tag)
+        | uu____6810 -> (ml_e, tag)
   
 let (extract_lb_sig :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1948,26 +1995,26 @@ let (extract_lb_sig :
   =
   fun g  ->
     fun lbs  ->
-      let maybe_generalize uu____6793 =
-        match uu____6793 with
+      let maybe_generalize uu____6871 =
+        match uu____6871 with
         | { FStar_Syntax_Syntax.lbname = lbname_;
-            FStar_Syntax_Syntax.lbunivs = uu____6814;
+            FStar_Syntax_Syntax.lbunivs = uu____6892;
             FStar_Syntax_Syntax.lbtyp = lbtyp;
             FStar_Syntax_Syntax.lbeff = lbeff;
             FStar_Syntax_Syntax.lbdef = lbdef;
-            FStar_Syntax_Syntax.lbattrs = uu____6818;
-            FStar_Syntax_Syntax.lbpos = uu____6819;_} ->
+            FStar_Syntax_Syntax.lbattrs = uu____6896;
+            FStar_Syntax_Syntax.lbpos = uu____6897;_} ->
             let f_e = effect_as_etag g lbeff  in
             let lbtyp1 = FStar_Syntax_Subst.compress lbtyp  in
-            let no_gen uu____6900 =
+            let no_gen uu____6978 =
               let expected_t = term_as_mlty g lbtyp1  in
               (lbname_, f_e, (lbtyp1, ([], ([], expected_t))), false, lbdef)
                in
-            let uu____6977 =
+            let uu____7055 =
               FStar_TypeChecker_Util.must_erase_for_extraction
                 g.FStar_Extraction_ML_UEnv.env_tcenv lbtyp1
                in
-            if uu____6977
+            if uu____7055
             then
               (lbname_, f_e,
                 (lbtyp1, ([], ([], FStar_Extraction_ML_Syntax.MLTY_Erased))),
@@ -1975,71 +2022,71 @@ let (extract_lb_sig :
             else
               (match lbtyp1.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
-                   let uu____7063 = FStar_List.hd bs  in
-                   FStar_All.pipe_right uu____7063 (is_type_binder g) ->
-                   let uu____7085 = FStar_Syntax_Subst.open_comp bs c  in
-                   (match uu____7085 with
+                   let uu____7141 = FStar_List.hd bs  in
+                   FStar_All.pipe_right uu____7141 (is_type_binder g) ->
+                   let uu____7163 = FStar_Syntax_Subst.open_comp bs c  in
+                   (match uu____7163 with
                     | (bs1,c1) ->
-                        let uu____7111 =
-                          let uu____7124 =
+                        let uu____7189 =
+                          let uu____7202 =
                             FStar_Util.prefix_until
                               (fun x  ->
-                                 let uu____7170 = is_type_binder g x  in
-                                 Prims.op_Negation uu____7170) bs1
+                                 let uu____7248 = is_type_binder g x  in
+                                 Prims.op_Negation uu____7248) bs1
                              in
-                          match uu____7124 with
+                          match uu____7202 with
                           | FStar_Pervasives_Native.None  ->
                               (bs1, (FStar_Syntax_Util.comp_result c1))
                           | FStar_Pervasives_Native.Some (bs2,b,rest) ->
-                              let uu____7297 =
+                              let uu____7375 =
                                 FStar_Syntax_Util.arrow (b :: rest) c1  in
-                              (bs2, uu____7297)
+                              (bs2, uu____7375)
                            in
-                        (match uu____7111 with
+                        (match uu____7189 with
                          | (tbinders,tbody) ->
                              let n_tbinders = FStar_List.length tbinders  in
                              let lbdef1 =
-                               let uu____7359 = normalize_abs lbdef  in
-                               FStar_All.pipe_right uu____7359
+                               let uu____7437 = normalize_abs lbdef  in
+                               FStar_All.pipe_right uu____7437
                                  FStar_Syntax_Util.unmeta
                                 in
                              (match lbdef1.FStar_Syntax_Syntax.n with
                               | FStar_Syntax_Syntax.Tm_abs (bs2,body,copt) ->
-                                  let uu____7408 =
+                                  let uu____7486 =
                                     FStar_Syntax_Subst.open_term bs2 body  in
-                                  (match uu____7408 with
+                                  (match uu____7486 with
                                    | (bs3,body1) ->
                                        if
                                          n_tbinders <=
                                            (FStar_List.length bs3)
                                        then
-                                         let uu____7460 =
+                                         let uu____7538 =
                                            FStar_Util.first_N n_tbinders bs3
                                             in
-                                         (match uu____7460 with
+                                         (match uu____7538 with
                                           | (targs,rest_args) ->
                                               let expected_source_ty =
                                                 let s =
                                                   FStar_List.map2
-                                                    (fun uu____7563  ->
-                                                       fun uu____7564  ->
-                                                         match (uu____7563,
-                                                                 uu____7564)
+                                                    (fun uu____7641  ->
+                                                       fun uu____7642  ->
+                                                         match (uu____7641,
+                                                                 uu____7642)
                                                          with
-                                                         | ((x,uu____7590),
-                                                            (y,uu____7592))
+                                                         | ((x,uu____7668),
+                                                            (y,uu____7670))
                                                              ->
-                                                             let uu____7613 =
-                                                               let uu____7620
+                                                             let uu____7691 =
+                                                               let uu____7698
                                                                  =
                                                                  FStar_Syntax_Syntax.bv_to_name
                                                                    y
                                                                   in
                                                                (x,
-                                                                 uu____7620)
+                                                                 uu____7698)
                                                                 in
                                                              FStar_Syntax_Syntax.NT
-                                                               uu____7613)
+                                                               uu____7691)
                                                     tbinders targs
                                                    in
                                                 FStar_Syntax_Subst.subst s
@@ -2048,9 +2095,9 @@ let (extract_lb_sig :
                                               let env =
                                                 FStar_List.fold_left
                                                   (fun env  ->
-                                                     fun uu____7637  ->
-                                                       match uu____7637 with
-                                                       | (a,uu____7645) ->
+                                                     fun uu____7715  ->
+                                                       match uu____7715 with
+                                                       | (a,uu____7723) ->
                                                            FStar_Extraction_ML_UEnv.extend_ty
                                                              env a
                                                              FStar_Pervasives_Native.None)
@@ -2061,33 +2108,33 @@ let (extract_lb_sig :
                                                   expected_source_ty
                                                  in
                                               let polytype =
-                                                let uu____7656 =
+                                                let uu____7734 =
                                                   FStar_All.pipe_right targs
                                                     (FStar_List.map
-                                                       (fun uu____7675  ->
-                                                          match uu____7675
+                                                       (fun uu____7753  ->
+                                                          match uu____7753
                                                           with
-                                                          | (x,uu____7684) ->
+                                                          | (x,uu____7762) ->
                                                               FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
                                                                 x))
                                                    in
-                                                (uu____7656, expected_t)  in
+                                                (uu____7734, expected_t)  in
                                               let add_unit =
                                                 match rest_args with
                                                 | [] ->
-                                                    (let uu____7700 =
+                                                    (let uu____7778 =
                                                        is_fstar_value body1
                                                         in
                                                      Prims.op_Negation
-                                                       uu____7700)
+                                                       uu____7778)
                                                       ||
-                                                      (let uu____7703 =
+                                                      (let uu____7781 =
                                                          FStar_Syntax_Util.is_pure_comp
                                                            c1
                                                           in
                                                        Prims.op_Negation
-                                                         uu____7703)
-                                                | uu____7705 -> false  in
+                                                         uu____7781)
+                                                | uu____7783 -> false  in
                                               let rest_args1 =
                                                 if add_unit
                                                 then unit_binder :: rest_args
@@ -2107,13 +2154,13 @@ let (extract_lb_sig :
                                                 add_unit, body2))
                                        else
                                          failwith "Not enough type binders")
-                              | FStar_Syntax_Syntax.Tm_uinst uu____7767 ->
+                              | FStar_Syntax_Syntax.Tm_uinst uu____7845 ->
                                   let env =
                                     FStar_List.fold_left
                                       (fun env  ->
-                                         fun uu____7786  ->
-                                           match uu____7786 with
-                                           | (a,uu____7794) ->
+                                         fun uu____7864  ->
+                                           match uu____7864 with
+                                           | (a,uu____7872) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
                                                  env a
                                                  FStar_Pervasives_Native.None)
@@ -2121,28 +2168,28 @@ let (extract_lb_sig :
                                      in
                                   let expected_t = term_as_mlty env tbody  in
                                   let polytype =
-                                    let uu____7805 =
+                                    let uu____7883 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____7824  ->
-                                              match uu____7824 with
-                                              | (x,uu____7833) ->
+                                           (fun uu____7902  ->
+                                              match uu____7902 with
+                                              | (x,uu____7911) ->
                                                   FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
                                                     x))
                                        in
-                                    (uu____7805, expected_t)  in
+                                    (uu____7883, expected_t)  in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____7877  ->
-                                            match uu____7877 with
-                                            | (bv,uu____7885) ->
-                                                let uu____7890 =
+                                         (fun uu____7955  ->
+                                            match uu____7955 with
+                                            | (bv,uu____7963) ->
+                                                let uu____7968 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____7890
+                                                  uu____7968
                                                   FStar_Syntax_Syntax.as_arg))
                                      in
                                   let e =
@@ -2154,13 +2201,13 @@ let (extract_lb_sig :
                                      in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | FStar_Syntax_Syntax.Tm_fvar uu____7920 ->
+                              | FStar_Syntax_Syntax.Tm_fvar uu____7998 ->
                                   let env =
                                     FStar_List.fold_left
                                       (fun env  ->
-                                         fun uu____7933  ->
-                                           match uu____7933 with
-                                           | (a,uu____7941) ->
+                                         fun uu____8011  ->
+                                           match uu____8011 with
+                                           | (a,uu____8019) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
                                                  env a
                                                  FStar_Pervasives_Native.None)
@@ -2168,28 +2215,28 @@ let (extract_lb_sig :
                                      in
                                   let expected_t = term_as_mlty env tbody  in
                                   let polytype =
-                                    let uu____7952 =
+                                    let uu____8030 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____7971  ->
-                                              match uu____7971 with
-                                              | (x,uu____7980) ->
+                                           (fun uu____8049  ->
+                                              match uu____8049 with
+                                              | (x,uu____8058) ->
                                                   FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
                                                     x))
                                        in
-                                    (uu____7952, expected_t)  in
+                                    (uu____8030, expected_t)  in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____8024  ->
-                                            match uu____8024 with
-                                            | (bv,uu____8032) ->
-                                                let uu____8037 =
+                                         (fun uu____8102  ->
+                                            match uu____8102 with
+                                            | (bv,uu____8110) ->
+                                                let uu____8115 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____8037
+                                                  uu____8115
                                                   FStar_Syntax_Syntax.as_arg))
                                      in
                                   let e =
@@ -2201,13 +2248,13 @@ let (extract_lb_sig :
                                      in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | FStar_Syntax_Syntax.Tm_name uu____8067 ->
+                              | FStar_Syntax_Syntax.Tm_name uu____8145 ->
                                   let env =
                                     FStar_List.fold_left
                                       (fun env  ->
-                                         fun uu____8080  ->
-                                           match uu____8080 with
-                                           | (a,uu____8088) ->
+                                         fun uu____8158  ->
+                                           match uu____8158 with
+                                           | (a,uu____8166) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
                                                  env a
                                                  FStar_Pervasives_Native.None)
@@ -2215,28 +2262,28 @@ let (extract_lb_sig :
                                      in
                                   let expected_t = term_as_mlty env tbody  in
                                   let polytype =
-                                    let uu____8099 =
+                                    let uu____8177 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____8118  ->
-                                              match uu____8118 with
-                                              | (x,uu____8127) ->
+                                           (fun uu____8196  ->
+                                              match uu____8196 with
+                                              | (x,uu____8205) ->
                                                   FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
                                                     x))
                                        in
-                                    (uu____8099, expected_t)  in
+                                    (uu____8177, expected_t)  in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____8171  ->
-                                            match uu____8171 with
-                                            | (bv,uu____8179) ->
-                                                let uu____8184 =
+                                         (fun uu____8249  ->
+                                            match uu____8249 with
+                                            | (bv,uu____8257) ->
+                                                let uu____8262 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____8184
+                                                  uu____8262
                                                   FStar_Syntax_Syntax.as_arg))
                                      in
                                   let e =
@@ -2248,8 +2295,8 @@ let (extract_lb_sig :
                                      in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | uu____8214 -> err_value_restriction lbdef1)))
-               | uu____8234 -> no_gen ())
+                              | uu____8292 -> err_value_restriction lbdef1)))
+               | uu____8312 -> no_gen ())
          in
       FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
         (FStar_List.map maybe_generalize)
@@ -2270,19 +2317,19 @@ let (extract_lb_iface :
       let lbs1 = extract_lb_sig g lbs  in
       FStar_Util.fold_map
         (fun env  ->
-           fun uu____8385  ->
-             match uu____8385 with
+           fun uu____8463  ->
+             match uu____8463 with
              | (lbname,e_tag,(typ,(binders,mltyscheme)),add_unit,_body) ->
-                 let uu____8446 =
+                 let uu____8524 =
                    FStar_Extraction_ML_UEnv.extend_lb env lbname typ
                      mltyscheme add_unit is_rec
                     in
-                 (match uu____8446 with
-                  | (env1,uu____8463,exp_binding) ->
-                      let uu____8467 =
-                        let uu____8472 = FStar_Util.right lbname  in
-                        (uu____8472, exp_binding)  in
-                      (env1, uu____8467))) g lbs1
+                 (match uu____8524 with
+                  | (env1,uu____8541,exp_binding) ->
+                      let uu____8545 =
+                        let uu____8550 = FStar_Util.right lbname  in
+                        (uu____8550, exp_binding)  in
+                      (env1, uu____8545))) g lbs1
   
 let rec (check_term_as_mlexpr :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2297,55 +2344,55 @@ let rec (check_term_as_mlexpr :
       fun f  ->
         fun ty  ->
           FStar_Extraction_ML_UEnv.debug g
-            (fun uu____8538  ->
-               let uu____8539 = FStar_Syntax_Print.term_to_string e  in
-               let uu____8541 =
+            (fun uu____8616  ->
+               let uu____8617 = FStar_Syntax_Print.term_to_string e  in
+               let uu____8619 =
                  FStar_Extraction_ML_Code.string_of_mlty
                    g.FStar_Extraction_ML_UEnv.currentModule ty
                   in
-               FStar_Util.print2 "Checking %s at type %s\n" uu____8539
-                 uu____8541);
+               FStar_Util.print2 "Checking %s at type %s\n" uu____8617
+                 uu____8619);
           (match (f, ty) with
-           | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____8548) ->
+           | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____8626) ->
                (FStar_Extraction_ML_Syntax.ml_unit,
                  FStar_Extraction_ML_Syntax.MLTY_Erased)
            | (FStar_Extraction_ML_Syntax.E_PURE
               ,FStar_Extraction_ML_Syntax.MLTY_Erased ) ->
                (FStar_Extraction_ML_Syntax.ml_unit,
                  FStar_Extraction_ML_Syntax.MLTY_Erased)
-           | uu____8549 ->
-               let uu____8554 = term_as_mlexpr g e  in
-               (match uu____8554 with
+           | uu____8627 ->
+               let uu____8632 = term_as_mlexpr g e  in
+               (match uu____8632 with
                 | (ml_e,tag,t) ->
-                    let uu____8568 = maybe_promote_effect ml_e tag t  in
-                    (match uu____8568 with
+                    let uu____8646 = maybe_promote_effect ml_e tag t  in
+                    (match uu____8646 with
                      | (ml_e1,tag1) ->
-                         let uu____8579 =
+                         let uu____8657 =
                            FStar_Extraction_ML_Util.eff_leq tag1 f  in
-                         if uu____8579
+                         if uu____8657
                          then
-                           let uu____8586 =
+                           let uu____8664 =
                              maybe_coerce e.FStar_Syntax_Syntax.pos g ml_e1 t
                                ty
                               in
-                           (uu____8586, ty)
+                           (uu____8664, ty)
                          else
                            (match (tag1, f, ty) with
                             | (FStar_Extraction_ML_Syntax.E_GHOST
                                ,FStar_Extraction_ML_Syntax.E_PURE
                                ,FStar_Extraction_ML_Syntax.MLTY_Erased ) ->
-                                let uu____8593 =
+                                let uu____8671 =
                                   maybe_coerce e.FStar_Syntax_Syntax.pos g
                                     ml_e1 t ty
                                    in
-                                (uu____8593, ty)
-                            | uu____8594 ->
+                                (uu____8671, ty)
+                            | uu____8672 ->
                                 (err_unexpected_eff g e ty f tag1;
-                                 (let uu____8602 =
+                                 (let uu____8680 =
                                     maybe_coerce e.FStar_Syntax_Syntax.pos g
                                       ml_e1 t ty
                                      in
-                                  (uu____8602, ty)))))))
+                                  (uu____8680, ty)))))))
 
 and (term_as_mlexpr :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2355,11 +2402,11 @@ and (term_as_mlexpr :
   =
   fun g  ->
     fun e  ->
-      let uu____8605 = term_as_mlexpr' g e  in
-      match uu____8605 with
+      let uu____8683 = term_as_mlexpr' g e  in
+      match uu____8683 with
       | (e1,f,t) ->
-          let uu____8621 = maybe_promote_effect e1 f t  in
-          (match uu____8621 with | (e2,f1) -> (e2, f1, t))
+          let uu____8699 = maybe_promote_effect e1 f t  in
+          (match uu____8699 with | (e2,f1) -> (e2, f1, t))
 
 and (term_as_mlexpr' :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2371,53 +2418,53 @@ and (term_as_mlexpr' :
     fun top  ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____8646 =
-             let uu____8648 =
+           let uu____8724 =
+             let uu____8726 =
                FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos  in
-             let uu____8650 = FStar_Syntax_Print.tag_of_term top  in
-             let uu____8652 = FStar_Syntax_Print.term_to_string top  in
+             let uu____8728 = FStar_Syntax_Print.tag_of_term top  in
+             let uu____8730 = FStar_Syntax_Print.term_to_string top  in
              FStar_Util.format3 "%s: term_as_mlexpr' (%s) :  %s \n"
-               uu____8648 uu____8650 uu____8652
+               uu____8726 uu____8728 uu____8730
               in
-           FStar_Util.print_string uu____8646);
+           FStar_Util.print_string uu____8724);
       (let t = FStar_Syntax_Subst.compress top  in
        match t.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Tm_unknown  ->
-           let uu____8662 =
-             let uu____8664 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8664
+           let uu____8740 =
+             let uu____8742 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8742
               in
-           failwith uu____8662
-       | FStar_Syntax_Syntax.Tm_delayed uu____8673 ->
-           let uu____8696 =
-             let uu____8698 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8698
+           failwith uu____8740
+       | FStar_Syntax_Syntax.Tm_delayed uu____8751 ->
+           let uu____8774 =
+             let uu____8776 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8776
               in
-           failwith uu____8696
-       | FStar_Syntax_Syntax.Tm_uvar uu____8707 ->
-           let uu____8720 =
-             let uu____8722 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8722
+           failwith uu____8774
+       | FStar_Syntax_Syntax.Tm_uvar uu____8785 ->
+           let uu____8798 =
+             let uu____8800 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8800
               in
-           failwith uu____8720
-       | FStar_Syntax_Syntax.Tm_bvar uu____8731 ->
-           let uu____8732 =
-             let uu____8734 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8734
+           failwith uu____8798
+       | FStar_Syntax_Syntax.Tm_bvar uu____8809 ->
+           let uu____8810 =
+             let uu____8812 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8812
               in
-           failwith uu____8732
+           failwith uu____8810
        | FStar_Syntax_Syntax.Tm_lazy i ->
-           let uu____8744 = FStar_Syntax_Util.unfold_lazy i  in
-           term_as_mlexpr g uu____8744
-       | FStar_Syntax_Syntax.Tm_type uu____8745 ->
+           let uu____8822 = FStar_Syntax_Util.unfold_lazy i  in
+           term_as_mlexpr g uu____8822
+       | FStar_Syntax_Syntax.Tm_type uu____8823 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
-       | FStar_Syntax_Syntax.Tm_refine uu____8746 ->
+       | FStar_Syntax_Syntax.Tm_refine uu____8824 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
-       | FStar_Syntax_Syntax.Tm_arrow uu____8753 ->
+       | FStar_Syntax_Syntax.Tm_arrow uu____8831 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
@@ -2425,25 +2472,25 @@ and (term_as_mlexpr' :
            (qt,{
                  FStar_Syntax_Syntax.qkind =
                    FStar_Syntax_Syntax.Quote_dynamic ;
-                 FStar_Syntax_Syntax.antiquotes = uu____8769;_})
+                 FStar_Syntax_Syntax.antiquotes = uu____8847;_})
            ->
-           let uu____8782 =
-             let uu____8783 =
+           let uu____8860 =
+             let uu____8861 =
                FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.failwith_lid
                  FStar_Syntax_Syntax.delta_constant
                  FStar_Pervasives_Native.None
                 in
-             FStar_Extraction_ML_UEnv.lookup_fv g uu____8783  in
-           (match uu____8782 with
-            | { FStar_Extraction_ML_UEnv.exp_b_name = uu____8790;
+             FStar_Extraction_ML_UEnv.lookup_fv g uu____8861  in
+           (match uu____8860 with
+            | { FStar_Extraction_ML_UEnv.exp_b_name = uu____8868;
                 FStar_Extraction_ML_UEnv.exp_b_expr = fw;
-                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu____8792;
-                FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____8793;_} ->
-                let uu____8796 =
-                  let uu____8797 =
-                    let uu____8798 =
-                      let uu____8805 =
-                        let uu____8808 =
+                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu____8870;
+                FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____8871;_} ->
+                let uu____8874 =
+                  let uu____8875 =
+                    let uu____8876 =
+                      let uu____8883 =
+                        let uu____8886 =
                           FStar_All.pipe_left
                             (FStar_Extraction_ML_Syntax.with_ty
                                FStar_Extraction_ML_Syntax.ml_string_ty)
@@ -2451,130 +2498,130 @@ and (term_as_mlexpr' :
                                (FStar_Extraction_ML_Syntax.MLC_String
                                   "Cannot evaluate open quotation at runtime"))
                            in
-                        [uu____8808]  in
-                      (fw, uu____8805)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____8798  in
+                        [uu____8886]  in
+                      (fw, uu____8883)  in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____8876  in
                   FStar_All.pipe_left
                     (FStar_Extraction_ML_Syntax.with_ty
-                       FStar_Extraction_ML_Syntax.ml_int_ty) uu____8797
+                       FStar_Extraction_ML_Syntax.ml_int_ty) uu____8875
                    in
-                (uu____8796, FStar_Extraction_ML_Syntax.E_PURE,
+                (uu____8874, FStar_Extraction_ML_Syntax.E_PURE,
                   FStar_Extraction_ML_Syntax.ml_int_ty))
        | FStar_Syntax_Syntax.Tm_quoted
            (qt,{
                  FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_static ;
                  FStar_Syntax_Syntax.antiquotes = aqs;_})
            ->
-           let uu____8826 = FStar_Reflection_Basic.inspect_ln qt  in
-           (match uu____8826 with
+           let uu____8904 = FStar_Reflection_Basic.inspect_ln qt  in
+           (match uu____8904 with
             | FStar_Reflection_Data.Tv_Var bv ->
-                let uu____8834 = FStar_Syntax_Syntax.lookup_aq bv aqs  in
-                (match uu____8834 with
+                let uu____8912 = FStar_Syntax_Syntax.lookup_aq bv aqs  in
+                (match uu____8912 with
                  | FStar_Pervasives_Native.Some tm -> term_as_mlexpr g tm
                  | FStar_Pervasives_Native.None  ->
                      let tv =
-                       let uu____8845 =
-                         let uu____8852 =
+                       let uu____8923 =
+                         let uu____8930 =
                            FStar_Reflection_Embeddings.e_term_view_aq aqs  in
-                         FStar_Syntax_Embeddings.embed uu____8852
+                         FStar_Syntax_Embeddings.embed uu____8930
                            (FStar_Reflection_Data.Tv_Var bv)
                           in
-                       uu____8845 t.FStar_Syntax_Syntax.pos
+                       uu____8923 t.FStar_Syntax_Syntax.pos
                          FStar_Pervasives_Native.None
                          FStar_Syntax_Embeddings.id_norm_cb
                         in
                      let t1 =
-                       let uu____8860 =
-                         let uu____8871 = FStar_Syntax_Syntax.as_arg tv  in
-                         [uu____8871]  in
+                       let uu____8938 =
+                         let uu____8949 = FStar_Syntax_Syntax.as_arg tv  in
+                         [uu____8949]  in
                        FStar_Syntax_Util.mk_app
                          (FStar_Reflection_Data.refl_constant_term
                             FStar_Reflection_Data.fstar_refl_pack_ln)
-                         uu____8860
+                         uu____8938
                         in
                      term_as_mlexpr g t1)
             | tv ->
                 let tv1 =
-                  let uu____8898 =
-                    let uu____8905 =
+                  let uu____8976 =
+                    let uu____8983 =
                       FStar_Reflection_Embeddings.e_term_view_aq aqs  in
-                    FStar_Syntax_Embeddings.embed uu____8905 tv  in
-                  uu____8898 t.FStar_Syntax_Syntax.pos
+                    FStar_Syntax_Embeddings.embed uu____8983 tv  in
+                  uu____8976 t.FStar_Syntax_Syntax.pos
                     FStar_Pervasives_Native.None
                     FStar_Syntax_Embeddings.id_norm_cb
                    in
                 let t1 =
-                  let uu____8913 =
-                    let uu____8924 = FStar_Syntax_Syntax.as_arg tv1  in
-                    [uu____8924]  in
+                  let uu____8991 =
+                    let uu____9002 = FStar_Syntax_Syntax.as_arg tv1  in
+                    [uu____9002]  in
                   FStar_Syntax_Util.mk_app
                     (FStar_Reflection_Data.refl_constant_term
-                       FStar_Reflection_Data.fstar_refl_pack_ln) uu____8913
+                       FStar_Reflection_Data.fstar_refl_pack_ln) uu____8991
                    in
                 term_as_mlexpr g t1)
        | FStar_Syntax_Syntax.Tm_meta
-           (t1,FStar_Syntax_Syntax.Meta_monadic (m,uu____8951)) ->
+           (t1,FStar_Syntax_Syntax.Meta_monadic (m,uu____9029)) ->
            let t2 = FStar_Syntax_Subst.compress t1  in
            (match t2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) when
                 FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname ->
-                let uu____8984 =
-                  let uu____8991 =
+                let uu____9062 =
+                  let uu____9069 =
                     FStar_TypeChecker_Env.effect_decl_opt
                       g.FStar_Extraction_ML_UEnv.env_tcenv m
                      in
-                  FStar_Util.must uu____8991  in
-                (match uu____8984 with
+                  FStar_Util.must uu____9069  in
+                (match uu____9062 with
                  | (ed,qualifiers) ->
-                     let uu____9018 =
-                       let uu____9020 =
+                     let uu____9096 =
+                       let uu____9098 =
                          FStar_TypeChecker_Env.is_reifiable_effect
                            g.FStar_Extraction_ML_UEnv.env_tcenv
                            ed.FStar_Syntax_Syntax.mname
                           in
-                       Prims.op_Negation uu____9020  in
-                     if uu____9018
+                       Prims.op_Negation uu____9098  in
+                     if uu____9096
                      then term_as_mlexpr g t2
                      else
                        failwith
                          "This should not happen (should have been handled at Tm_abs level)")
-            | uu____9038 -> term_as_mlexpr g t2)
-       | FStar_Syntax_Syntax.Tm_meta (t1,uu____9040) -> term_as_mlexpr g t1
-       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____9046) -> term_as_mlexpr g t1
+            | uu____9116 -> term_as_mlexpr g t2)
+       | FStar_Syntax_Syntax.Tm_meta (t1,uu____9118) -> term_as_mlexpr g t1
+       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____9124) -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_constant c ->
-           let uu____9052 =
+           let uu____9130 =
              FStar_TypeChecker_TcTerm.type_of_tot_term
                g.FStar_Extraction_ML_UEnv.env_tcenv t
               in
-           (match uu____9052 with
-            | (uu____9065,ty,uu____9067) ->
+           (match uu____9130 with
+            | (uu____9143,ty,uu____9145) ->
                 let ml_ty = term_as_mlty g ty  in
-                let uu____9069 =
-                  let uu____9070 =
+                let uu____9147 =
+                  let uu____9148 =
                     FStar_Extraction_ML_Util.mlexpr_of_const
                       t.FStar_Syntax_Syntax.pos c
                      in
-                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____9070  in
-                (uu____9069, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
-       | FStar_Syntax_Syntax.Tm_name uu____9071 ->
-           let uu____9072 = is_type g t  in
-           if uu____9072
+                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____9148  in
+                (uu____9147, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
+       | FStar_Syntax_Syntax.Tm_name uu____9149 ->
+           let uu____9150 = is_type g t  in
+           if uu____9150
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____9083 = FStar_Extraction_ML_UEnv.lookup_term g t  in
-              match uu____9083 with
-              | (FStar_Util.Inl uu____9096,uu____9097) ->
+             (let uu____9161 = FStar_Extraction_ML_UEnv.lookup_term g t  in
+              match uu____9161 with
+              | (FStar_Util.Inl uu____9174,uu____9175) ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
               | (FStar_Util.Inr
-                 { FStar_Extraction_ML_UEnv.exp_b_name = uu____9102;
+                 { FStar_Extraction_ML_UEnv.exp_b_name = uu____9180;
                    FStar_Extraction_ML_UEnv.exp_b_expr = x;
                    FStar_Extraction_ML_UEnv.exp_b_tscheme = mltys;
-                   FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____9105;_},qual)
+                   FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____9183;_},qual)
                   ->
                   (match mltys with
                    | ([],t1) when t1 = FStar_Extraction_ML_Syntax.ml_unit_ty
@@ -2582,143 +2629,143 @@ and (term_as_mlexpr' :
                        (FStar_Extraction_ML_Syntax.ml_unit,
                          FStar_Extraction_ML_Syntax.E_PURE, t1)
                    | ([],t1) ->
-                       let uu____9123 =
+                       let uu____9201 =
                          maybe_eta_data_and_project_record g qual t1 x  in
-                       (uu____9123, FStar_Extraction_ML_Syntax.E_PURE, t1)
-                   | uu____9124 -> err_uninst g t mltys t))
+                       (uu____9201, FStar_Extraction_ML_Syntax.E_PURE, t1)
+                   | uu____9202 -> instantiate_maybe_partial x mltys []))
        | FStar_Syntax_Syntax.Tm_fvar fv ->
-           let uu____9132 = is_type g t  in
-           if uu____9132
+           let uu____9204 = is_type g t  in
+           if uu____9204
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____9143 = FStar_Extraction_ML_UEnv.try_lookup_fv g fv
+             (let uu____9215 = FStar_Extraction_ML_UEnv.try_lookup_fv g fv
                  in
-              match uu____9143 with
+              match uu____9215 with
               | FStar_Pervasives_Native.None  ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.MLTY_Erased)
               | FStar_Pervasives_Native.Some
-                  { FStar_Extraction_ML_UEnv.exp_b_name = uu____9152;
+                  { FStar_Extraction_ML_UEnv.exp_b_name = uu____9224;
                     FStar_Extraction_ML_UEnv.exp_b_expr = x;
                     FStar_Extraction_ML_UEnv.exp_b_tscheme = mltys;
-                    FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____9155;_}
+                    FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____9227;_}
                   ->
                   (FStar_Extraction_ML_UEnv.debug g
-                     (fun uu____9163  ->
-                        let uu____9164 = FStar_Syntax_Print.fv_to_string fv
+                     (fun uu____9235  ->
+                        let uu____9236 = FStar_Syntax_Print.fv_to_string fv
                            in
-                        let uu____9166 =
+                        let uu____9238 =
                           FStar_Extraction_ML_Code.string_of_mlexpr
                             g.FStar_Extraction_ML_UEnv.currentModule x
                            in
-                        let uu____9168 =
+                        let uu____9240 =
                           FStar_Extraction_ML_Code.string_of_mlty
                             g.FStar_Extraction_ML_UEnv.currentModule
                             (FStar_Pervasives_Native.snd mltys)
                            in
                         FStar_Util.print3 "looked up %s: got %s at %s \n"
-                          uu____9164 uu____9166 uu____9168);
+                          uu____9236 uu____9238 uu____9240);
                    (match mltys with
                     | ([],t1) when t1 = FStar_Extraction_ML_Syntax.ml_unit_ty
                         ->
                         (FStar_Extraction_ML_Syntax.ml_unit,
                           FStar_Extraction_ML_Syntax.E_PURE, t1)
                     | ([],t1) ->
-                        let uu____9181 =
+                        let uu____9253 =
                           maybe_eta_data_and_project_record g
                             fv.FStar_Syntax_Syntax.fv_qual t1 x
                            in
-                        (uu____9181, FStar_Extraction_ML_Syntax.E_PURE, t1)
-                    | uu____9182 -> err_uninst g t mltys t)))
+                        (uu____9253, FStar_Extraction_ML_Syntax.E_PURE, t1)
+                    | uu____9254 -> instantiate_maybe_partial x mltys [])))
        | FStar_Syntax_Syntax.Tm_abs (bs,body,rcopt) ->
-           let uu____9216 = FStar_Syntax_Subst.open_term bs body  in
-           (match uu____9216 with
+           let uu____9282 = FStar_Syntax_Subst.open_term bs body  in
+           (match uu____9282 with
             | (bs1,body1) ->
-                let uu____9229 = binders_as_ml_binders g bs1  in
-                (match uu____9229 with
+                let uu____9295 = binders_as_ml_binders g bs1  in
+                (match uu____9295 with
                  | (ml_bs,env) ->
                      let body2 =
                        match rcopt with
                        | FStar_Pervasives_Native.Some rc ->
-                           let uu____9265 =
+                           let uu____9331 =
                              FStar_TypeChecker_Env.is_reifiable_rc
                                env.FStar_Extraction_ML_UEnv.env_tcenv rc
                               in
-                           if uu____9265
+                           if uu____9331
                            then
                              FStar_TypeChecker_Util.reify_body
                                env.FStar_Extraction_ML_UEnv.env_tcenv body1
                            else body1
                        | FStar_Pervasives_Native.None  ->
                            (FStar_Extraction_ML_UEnv.debug g
-                              (fun uu____9273  ->
-                                 let uu____9274 =
+                              (fun uu____9339  ->
+                                 let uu____9340 =
                                    FStar_Syntax_Print.term_to_string body1
                                     in
                                  FStar_Util.print1
-                                   "No computation type for: %s\n" uu____9274);
+                                   "No computation type for: %s\n" uu____9340);
                             body1)
                         in
-                     let uu____9277 = term_as_mlexpr env body2  in
-                     (match uu____9277 with
+                     let uu____9343 = term_as_mlexpr env body2  in
+                     (match uu____9343 with
                       | (ml_body,f,t1) ->
-                          let uu____9293 =
+                          let uu____9359 =
                             FStar_List.fold_right
-                              (fun uu____9313  ->
-                                 fun uu____9314  ->
-                                   match (uu____9313, uu____9314) with
-                                   | ((uu____9337,targ),(f1,t2)) ->
+                              (fun uu____9379  ->
+                                 fun uu____9380  ->
+                                   match (uu____9379, uu____9380) with
+                                   | ((uu____9403,targ),(f1,t2)) ->
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          (FStar_Extraction_ML_Syntax.MLTY_Fun
                                             (targ, f1, t2)))) ml_bs (f, t1)
                              in
-                          (match uu____9293 with
+                          (match uu____9359 with
                            | (f1,tfun) ->
-                               let uu____9360 =
+                               let uu____9426 =
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty tfun)
                                    (FStar_Extraction_ML_Syntax.MLE_Fun
                                       (ml_bs, ml_body))
                                   in
-                               (uu____9360, f1, tfun)))))
+                               (uu____9426, f1, tfun)))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of );
-              FStar_Syntax_Syntax.pos = uu____9368;
-              FStar_Syntax_Syntax.vars = uu____9369;_},(a1,uu____9371)::[])
+              FStar_Syntax_Syntax.pos = uu____9434;
+              FStar_Syntax_Syntax.vars = uu____9435;_},(a1,uu____9437)::[])
            ->
            let ty =
-             let uu____9411 =
+             let uu____9477 =
                FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid  in
-             term_as_mlty g uu____9411  in
-           let uu____9412 =
-             let uu____9413 =
+             term_as_mlty g uu____9477  in
+           let uu____9478 =
+             let uu____9479 =
                FStar_Extraction_ML_Util.mlexpr_of_range
                  a1.FStar_Syntax_Syntax.pos
                 in
              FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty ty)
-               uu____9413
+               uu____9479
               in
-           (uu____9412, FStar_Extraction_ML_Syntax.E_PURE, ty)
+           (uu____9478, FStar_Extraction_ML_Syntax.E_PURE, ty)
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of );
-              FStar_Syntax_Syntax.pos = uu____9414;
-              FStar_Syntax_Syntax.vars = uu____9415;_},(t1,uu____9417)::
-            (r,uu____9419)::[])
+              FStar_Syntax_Syntax.pos = uu____9480;
+              FStar_Syntax_Syntax.vars = uu____9481;_},(t1,uu____9483)::
+            (r,uu____9485)::[])
            -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu____9474);
-              FStar_Syntax_Syntax.pos = uu____9475;
-              FStar_Syntax_Syntax.vars = uu____9476;_},uu____9477)
+                (FStar_Const.Const_reflect uu____9540);
+              FStar_Syntax_Syntax.pos = uu____9541;
+              FStar_Syntax_Syntax.vars = uu____9542;_},uu____9543)
            -> failwith "Unreachable? Tm_app Const_reflect"
        | FStar_Syntax_Syntax.Tm_app (head1,args) ->
            let is_total rc =
@@ -2727,18 +2774,18 @@ and (term_as_mlexpr' :
                ||
                (FStar_All.pipe_right rc.FStar_Syntax_Syntax.residual_flags
                   (FStar_List.existsb
-                     (fun uu___1_9546  ->
-                        match uu___1_9546 with
+                     (fun uu___1_9612  ->
+                        match uu___1_9612 with
                         | FStar_Syntax_Syntax.TOTAL  -> true
-                        | uu____9549 -> false)))
+                        | uu____9615 -> false)))
               in
-           let uu____9551 =
-             let uu____9556 =
-               let uu____9557 = FStar_Syntax_Subst.compress head1  in
-               uu____9557.FStar_Syntax_Syntax.n  in
-             ((head1.FStar_Syntax_Syntax.n), uu____9556)  in
-           (match uu____9551 with
-            | (FStar_Syntax_Syntax.Tm_uvar uu____9566,uu____9567) ->
+           let uu____9617 =
+             let uu____9622 =
+               let uu____9623 = FStar_Syntax_Subst.compress head1  in
+               uu____9623.FStar_Syntax_Syntax.n  in
+             ((head1.FStar_Syntax_Syntax.n), uu____9622)  in
+           (match uu____9617 with
+            | (FStar_Syntax_Syntax.Tm_uvar uu____9632,uu____9633) ->
                 let t1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Env.Beta;
@@ -2749,8 +2796,8 @@ and (term_as_mlexpr' :
                     g.FStar_Extraction_ML_UEnv.env_tcenv t
                    in
                 term_as_mlexpr g t1
-            | (uu____9581,FStar_Syntax_Syntax.Tm_abs
-               (bs,uu____9583,FStar_Pervasives_Native.Some rc)) when
+            | (uu____9647,FStar_Syntax_Syntax.Tm_abs
+               (bs,uu____9649,FStar_Pervasives_Native.Some rc)) when
                 is_total rc ->
                 let t1 =
                   FStar_TypeChecker_Normalize.normalize
@@ -2762,28 +2809,28 @@ and (term_as_mlexpr' :
                     g.FStar_Extraction_ML_UEnv.env_tcenv t
                    in
                 term_as_mlexpr g t1
-            | (uu____9608,FStar_Syntax_Syntax.Tm_constant
+            | (uu____9674,FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_reify )) ->
                 let e =
-                  let uu____9610 = FStar_List.hd args  in
+                  let uu____9676 = FStar_List.hd args  in
                   FStar_TypeChecker_Util.reify_body_with_arg
-                    g.FStar_Extraction_ML_UEnv.env_tcenv head1 uu____9610
+                    g.FStar_Extraction_ML_UEnv.env_tcenv head1 uu____9676
                    in
                 let tm =
-                  let uu____9622 =
-                    let uu____9627 = FStar_TypeChecker_Util.remove_reify e
+                  let uu____9688 =
+                    let uu____9693 = FStar_TypeChecker_Util.remove_reify e
                        in
-                    let uu____9628 = FStar_List.tl args  in
-                    FStar_Syntax_Syntax.mk_Tm_app uu____9627 uu____9628  in
-                  uu____9622 FStar_Pervasives_Native.None
+                    let uu____9694 = FStar_List.tl args  in
+                    FStar_Syntax_Syntax.mk_Tm_app uu____9693 uu____9694  in
+                  uu____9688 FStar_Pervasives_Native.None
                     t.FStar_Syntax_Syntax.pos
                    in
                 term_as_mlexpr g tm
-            | uu____9637 ->
-                let rec extract_app is_data uu____9690 uu____9691 restArgs =
-                  match (uu____9690, uu____9691) with
+            | uu____9703 ->
+                let rec extract_app is_data uu____9756 uu____9757 restArgs =
+                  match (uu____9756, uu____9757) with
                   | ((mlhead,mlargs_f),(f,t1)) ->
-                      let mk_head uu____9772 =
+                      let mk_head uu____9838 =
                         let mlargs =
                           FStar_All.pipe_right (FStar_List.rev mlargs_f)
                             (FStar_List.map FStar_Pervasives_Native.fst)
@@ -2794,82 +2841,82 @@ and (term_as_mlexpr' :
                              (mlhead, mlargs))
                          in
                       (FStar_Extraction_ML_UEnv.debug g
-                         (fun uu____9799  ->
-                            let uu____9800 =
-                              let uu____9802 = mk_head ()  in
+                         (fun uu____9865  ->
+                            let uu____9866 =
+                              let uu____9868 = mk_head ()  in
                               FStar_Extraction_ML_Code.string_of_mlexpr
                                 g.FStar_Extraction_ML_UEnv.currentModule
-                                uu____9802
+                                uu____9868
                                in
-                            let uu____9803 =
+                            let uu____9869 =
                               FStar_Extraction_ML_Code.string_of_mlty
                                 g.FStar_Extraction_ML_UEnv.currentModule t1
                                in
-                            let uu____9805 =
+                            let uu____9871 =
                               match restArgs with
                               | [] -> "none"
-                              | (hd1,uu____9816)::uu____9817 ->
+                              | (hd1,uu____9882)::uu____9883 ->
                                   FStar_Syntax_Print.term_to_string hd1
                                in
                             FStar_Util.print3
                               "extract_app ml_head=%s type of head = %s, next arg = %s\n"
-                              uu____9800 uu____9803 uu____9805);
+                              uu____9866 uu____9869 uu____9871);
                        (match (restArgs, t1) with
-                        | ([],uu____9851) ->
+                        | ([],uu____9917) ->
                             let app =
-                              let uu____9867 = mk_head ()  in
+                              let uu____9933 = mk_head ()  in
                               maybe_eta_data_and_project_record g is_data t1
-                                uu____9867
+                                uu____9933
                                in
                             (app, f, t1)
-                        | ((arg,uu____9869)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
+                        | ((arg,uu____9935)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                            (formal_t,f',t2)) when
                             (is_type g arg) &&
                               (type_leq g formal_t
                                  FStar_Extraction_ML_Syntax.ml_unit_ty)
                             ->
-                            let uu____9900 =
-                              let uu____9905 =
+                            let uu____9966 =
+                              let uu____9971 =
                                 FStar_Extraction_ML_Util.join
                                   arg.FStar_Syntax_Syntax.pos f f'
                                  in
-                              (uu____9905, t2)  in
+                              (uu____9971, t2)  in
                             extract_app is_data
                               (mlhead,
                                 ((FStar_Extraction_ML_Syntax.ml_unit,
                                    FStar_Extraction_ML_Syntax.E_PURE) ::
-                                mlargs_f)) uu____9900 rest
-                        | ((e0,uu____9917)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
+                                mlargs_f)) uu____9966 rest
+                        | ((e0,uu____9983)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                            (tExpected,f',t2)) ->
                             let r = e0.FStar_Syntax_Syntax.pos  in
                             let expected_effect =
-                              let uu____9950 =
+                              let uu____10016 =
                                 (FStar_Options.lax ()) &&
                                   (FStar_TypeChecker_Util.short_circuit_head
                                      head1)
                                  in
-                              if uu____9950
+                              if uu____10016
                               then FStar_Extraction_ML_Syntax.E_IMPURE
                               else FStar_Extraction_ML_Syntax.E_PURE  in
-                            let uu____9955 =
+                            let uu____10021 =
                               check_term_as_mlexpr g e0 expected_effect
                                 tExpected
                                in
-                            (match uu____9955 with
+                            (match uu____10021 with
                              | (e01,tInferred) ->
-                                 let uu____9968 =
-                                   let uu____9973 =
+                                 let uu____10034 =
+                                   let uu____10039 =
                                      FStar_Extraction_ML_Util.join_l r
                                        [f; f']
                                       in
-                                   (uu____9973, t2)  in
+                                   (uu____10039, t2)  in
                                  extract_app is_data
                                    (mlhead, ((e01, expected_effect) ::
-                                     mlargs_f)) uu____9968 rest)
-                        | uu____9984 ->
-                            let uu____9997 =
+                                     mlargs_f)) uu____10034 rest)
+                        | uu____10050 ->
+                            let uu____10063 =
                               FStar_Extraction_ML_Util.udelta_unfold g t1  in
-                            (match uu____9997 with
+                            (match uu____10063 with
                              | FStar_Pervasives_Native.Some t2 ->
                                  extract_app is_data (mlhead, mlargs_f)
                                    (f, t2) restArgs
@@ -2912,7 +2959,7 @@ and (term_as_mlexpr' :
                                          in
                                       extract_app is_data (mlhead1, [])
                                         (f, t2) restArgs
-                                  | uu____10069 ->
+                                  | uu____10135 ->
                                       let mlhead1 =
                                         let mlargs =
                                           FStar_All.pipe_right
@@ -2935,477 +2982,363 @@ and (term_as_mlexpr' :
                                       err_ill_typed_application g top mlhead1
                                         restArgs t1))))
                    in
-                let extract_app_maybe_projector is_data mlhead uu____10140
+                let extract_app_maybe_projector is_data mlhead uu____10206
                   args1 =
-                  match uu____10140 with
+                  match uu____10206 with
                   | (f,t1) ->
                       (match is_data with
                        | FStar_Pervasives_Native.Some
-                           (FStar_Syntax_Syntax.Record_projector uu____10170)
+                           (FStar_Syntax_Syntax.Record_projector uu____10236)
                            ->
                            let rec remove_implicits args2 f1 t2 =
                              match (args2, t2) with
                              | ((a0,FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____10254))::args3,FStar_Extraction_ML_Syntax.MLTY_Fun
-                                (uu____10256,f',t3)) ->
-                                 let uu____10294 =
+                                 (FStar_Syntax_Syntax.Implicit uu____10320))::args3,FStar_Extraction_ML_Syntax.MLTY_Fun
+                                (uu____10322,f',t3)) ->
+                                 let uu____10360 =
                                    FStar_Extraction_ML_Util.join
                                      a0.FStar_Syntax_Syntax.pos f1 f'
                                     in
-                                 remove_implicits args3 uu____10294 t3
-                             | uu____10295 -> (args2, f1, t2)  in
-                           let uu____10320 = remove_implicits args1 f t1  in
-                           (match uu____10320 with
+                                 remove_implicits args3 uu____10360 t3
+                             | uu____10361 -> (args2, f1, t2)  in
+                           let uu____10386 = remove_implicits args1 f t1  in
+                           (match uu____10386 with
                             | (args2,f1,t2) ->
                                 extract_app is_data (mlhead, []) (f1, t2)
                                   args2)
-                       | uu____10376 ->
+                       | uu____10442 ->
                            extract_app is_data (mlhead, []) (f, t1) args1)
                    in
-                let extract_app_with_instantiations uu____10400 =
+                let extract_app_with_instantiations uu____10466 =
                   let head2 = FStar_Syntax_Util.un_uinst head1  in
                   match head2.FStar_Syntax_Syntax.n with
-                  | FStar_Syntax_Syntax.Tm_name uu____10408 ->
-                      let uu____10409 =
-                        let uu____10430 =
+                  | FStar_Syntax_Syntax.Tm_name uu____10474 ->
+                      let uu____10475 =
+                        let uu____10496 =
                           FStar_Extraction_ML_UEnv.lookup_term g head2  in
-                        match uu____10430 with
+                        match uu____10496 with
                         | (FStar_Util.Inr exp_b,q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____10469  ->
-                                  let uu____10470 =
+                               (fun uu____10535  ->
+                                  let uu____10536 =
                                     FStar_Syntax_Print.term_to_string head2
                                      in
-                                  let uu____10472 =
+                                  let uu____10538 =
                                     FStar_Extraction_ML_Code.string_of_mlexpr
                                       g.FStar_Extraction_ML_UEnv.currentModule
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr
                                      in
-                                  let uu____10474 =
+                                  let uu____10540 =
                                     FStar_Extraction_ML_Code.string_of_mlty
                                       g.FStar_Extraction_ML_UEnv.currentModule
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)
                                      in
-                                  let uu____10476 =
+                                  let uu____10542 =
                                     FStar_Util.string_of_bool
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_inst_ok
                                      in
                                   FStar_Util.print4
                                     "@@@looked up %s: got %s at %s (inst_ok=%s)\n"
-                                    uu____10470 uu____10472 uu____10474
-                                    uu____10476);
+                                    uu____10536 uu____10538 uu____10540
+                                    uu____10542);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_inst_ok)),
                                q))
-                        | uu____10503 -> failwith "FIXME Ty"  in
-                      (match uu____10409 with
+                        | uu____10569 -> failwith "FIXME Ty"  in
+                      (match uu____10475 with
                        | ((head_ml,(vars,t1),inst_ok),qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a,uu____10579)::uu____10580 -> is_type g a
-                             | uu____10607 -> false  in
-                           let uu____10619 =
+                             | (a,uu____10645)::uu____10646 -> is_type g a
+                             | uu____10673 -> false  in
+                           let uu____10685 =
                              match vars with
-                             | uu____10648::uu____10649 when
+                             | uu____10714::uu____10715 when
                                  (Prims.op_Negation has_typ_apps) && inst_ok
                                  -> (head_ml, t1, args)
-                             | uu____10663 ->
+                             | uu____10729 ->
                                  let n1 = FStar_List.length vars  in
-                                 if n1 <= (FStar_List.length args)
-                                 then
-                                   let uu____10692 =
-                                     FStar_Util.first_N n1 args  in
-                                   (match uu____10692 with
-                                    | (prefix1,rest) ->
-                                        let prefixAsMLTypes =
-                                          FStar_List.map
-                                            (fun uu____10793  ->
-                                               match uu____10793 with
-                                               | (x,uu____10801) ->
-                                                   term_as_mlty g x) prefix1
-                                           in
-                                        let t2 =
-                                          instantiate (vars, t1)
-                                            prefixAsMLTypes
-                                           in
-                                        (FStar_Extraction_ML_UEnv.debug g
-                                           (fun uu____10813  ->
-                                              let uu____10814 =
-                                                FStar_Syntax_Print.term_to_string
-                                                  head2
-                                                 in
-                                              let uu____10816 =
-                                                FStar_Syntax_Print.args_to_string
-                                                  prefix1
-                                                 in
-                                              let uu____10818 =
-                                                let uu____10820 =
-                                                  FStar_List.map
-                                                    (FStar_Extraction_ML_Code.string_of_mlty
-                                                       g.FStar_Extraction_ML_UEnv.currentModule)
-                                                    prefixAsMLTypes
-                                                   in
-                                                FStar_All.pipe_right
-                                                  uu____10820
-                                                  (FStar_String.concat ", ")
-                                                 in
-                                              let uu____10830 =
-                                                FStar_Extraction_ML_Code.string_of_mlty
-                                                  g.FStar_Extraction_ML_UEnv.currentModule
-                                                  t2
-                                                 in
-                                              FStar_Util.print4
-                                                "@@@looked up %s, instantiated with [%s] translated to [%s], got %s\n"
-                                                uu____10814 uu____10816
-                                                uu____10818 uu____10830);
-                                         (let mk_tapp e ty_args =
-                                            match ty_args with
-                                            | [] -> e
-                                            | uu____10848 ->
-                                                let uu___1616_10851 = e  in
-                                                {
-                                                  FStar_Extraction_ML_Syntax.expr
-                                                    =
-                                                    (FStar_Extraction_ML_Syntax.MLE_TApp
-                                                       (e, ty_args));
-                                                  FStar_Extraction_ML_Syntax.mlty
-                                                    =
-                                                    (uu___1616_10851.FStar_Extraction_ML_Syntax.mlty);
-                                                  FStar_Extraction_ML_Syntax.loc
-                                                    =
-                                                    (uu___1616_10851.FStar_Extraction_ML_Syntax.loc)
-                                                }
+                                 let uu____10735 =
+                                   if (FStar_List.length args) <= n1
+                                   then
+                                     let uu____10773 =
+                                       FStar_List.map
+                                         (fun uu____10785  ->
+                                            match uu____10785 with
+                                            | (x,uu____10793) ->
+                                                term_as_mlty g x) args
+                                        in
+                                     (uu____10773, [])
+                                   else
+                                     (let uu____10816 =
+                                        FStar_Util.first_N n1 args  in
+                                      match uu____10816 with
+                                      | (prefix1,rest) ->
+                                          let uu____10905 =
+                                            FStar_List.map
+                                              (fun uu____10917  ->
+                                                 match uu____10917 with
+                                                 | (x,uu____10925) ->
+                                                     term_as_mlty g x)
+                                              prefix1
                                              in
-                                          let head3 =
-                                            match head_ml.FStar_Extraction_ML_Syntax.expr
-                                            with
-                                            | FStar_Extraction_ML_Syntax.MLE_Name
-                                                uu____10855 ->
-                                                let uu___1622_10856 =
-                                                  mk_tapp head_ml
-                                                    prefixAsMLTypes
-                                                   in
-                                                {
-                                                  FStar_Extraction_ML_Syntax.expr
-                                                    =
-                                                    (uu___1622_10856.FStar_Extraction_ML_Syntax.expr);
-                                                  FStar_Extraction_ML_Syntax.mlty
-                                                    = t2;
-                                                  FStar_Extraction_ML_Syntax.loc
-                                                    =
-                                                    (uu___1622_10856.FStar_Extraction_ML_Syntax.loc)
-                                                }
-                                            | FStar_Extraction_ML_Syntax.MLE_Var
-                                                uu____10857 ->
-                                                let uu___1622_10859 =
-                                                  mk_tapp head_ml
-                                                    prefixAsMLTypes
-                                                   in
-                                                {
-                                                  FStar_Extraction_ML_Syntax.expr
-                                                    =
-                                                    (uu___1622_10859.FStar_Extraction_ML_Syntax.expr);
-                                                  FStar_Extraction_ML_Syntax.mlty
-                                                    = t2;
-                                                  FStar_Extraction_ML_Syntax.loc
-                                                    =
-                                                    (uu___1622_10859.FStar_Extraction_ML_Syntax.loc)
-                                                }
-                                            | FStar_Extraction_ML_Syntax.MLE_App
-                                                (head3,{
-                                                         FStar_Extraction_ML_Syntax.expr
-                                                           =
-                                                           FStar_Extraction_ML_Syntax.MLE_Const
-                                                           (FStar_Extraction_ML_Syntax.MLC_Unit
-                                                           );
-                                                         FStar_Extraction_ML_Syntax.mlty
-                                                           = uu____10861;
-                                                         FStar_Extraction_ML_Syntax.loc
-                                                           = uu____10862;_}::[])
-                                                ->
-                                                FStar_All.pipe_right
-                                                  (FStar_Extraction_ML_Syntax.MLE_App
-                                                     ((let uu___1633_10868 =
-                                                         mk_tapp head3
-                                                           prefixAsMLTypes
-                                                          in
-                                                       {
-                                                         FStar_Extraction_ML_Syntax.expr
-                                                           =
-                                                           (uu___1633_10868.FStar_Extraction_ML_Syntax.expr);
-                                                         FStar_Extraction_ML_Syntax.mlty
-                                                           =
-                                                           (FStar_Extraction_ML_Syntax.MLTY_Fun
-                                                              (FStar_Extraction_ML_Syntax.ml_unit_ty,
-                                                                FStar_Extraction_ML_Syntax.E_PURE,
-                                                                t2));
-                                                         FStar_Extraction_ML_Syntax.loc
-                                                           =
-                                                           (uu___1633_10868.FStar_Extraction_ML_Syntax.loc)
-                                                       }),
-                                                       [FStar_Extraction_ML_Syntax.ml_unit]))
-                                                  (FStar_Extraction_ML_Syntax.with_ty
-                                                     t2)
-                                            | uu____10869 ->
-                                                failwith
-                                                  "Impossible: Unexpected head term"
-                                             in
-                                          (head3, t2, rest))))
-                                 else err_uninst g head2 (vars, t1) top
+                                          (uu____10905, rest))
+                                    in
+                                 (match uu____10735 with
+                                  | (provided_type_args,rest) ->
+                                      let uu____10976 =
+                                        match head_ml.FStar_Extraction_ML_Syntax.expr
+                                        with
+                                        | FStar_Extraction_ML_Syntax.MLE_Name
+                                            uu____10985 ->
+                                            let uu____10986 =
+                                              instantiate_maybe_partial
+                                                head_ml (vars, t1)
+                                                provided_type_args
+                                               in
+                                            (match uu____10986 with
+                                             | (head3,uu____10998,t2) ->
+                                                 (head3, t2))
+                                        | FStar_Extraction_ML_Syntax.MLE_Var
+                                            uu____11000 ->
+                                            let uu____11002 =
+                                              instantiate_maybe_partial
+                                                head_ml (vars, t1)
+                                                provided_type_args
+                                               in
+                                            (match uu____11002 with
+                                             | (head3,uu____11014,t2) ->
+                                                 (head3, t2))
+                                        | FStar_Extraction_ML_Syntax.MLE_App
+                                            (head3,{
+                                                     FStar_Extraction_ML_Syntax.expr
+                                                       =
+                                                       FStar_Extraction_ML_Syntax.MLE_Const
+                                                       (FStar_Extraction_ML_Syntax.MLC_Unit
+                                                       );
+                                                     FStar_Extraction_ML_Syntax.mlty
+                                                       = uu____11017;
+                                                     FStar_Extraction_ML_Syntax.loc
+                                                       = uu____11018;_}::[])
+                                            ->
+                                            let uu____11021 =
+                                              instantiate_maybe_partial head3
+                                                (vars, t1) provided_type_args
+                                               in
+                                            (match uu____11021 with
+                                             | (head4,uu____11033,t2) ->
+                                                 let uu____11035 =
+                                                   FStar_All.pipe_right
+                                                     (FStar_Extraction_ML_Syntax.MLE_App
+                                                        (head4,
+                                                          [FStar_Extraction_ML_Syntax.ml_unit]))
+                                                     (FStar_Extraction_ML_Syntax.with_ty
+                                                        t2)
+                                                    in
+                                                 (uu____11035, t2))
+                                        | uu____11038 ->
+                                            failwith
+                                              "Impossible: Unexpected head term"
+                                         in
+                                      (match uu____10976 with
+                                       | (head3,t2) -> (head3, t2, rest)))
                               in
-                           (match uu____10619 with
+                           (match uu____10685 with
                             | (head_ml1,head_t,args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____10935 =
+                                     let uu____11105 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1
                                         in
-                                     (uu____10935,
+                                     (uu____11105,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____10936 ->
+                                 | uu____11106 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | FStar_Syntax_Syntax.Tm_fvar uu____10945 ->
-                      let uu____10946 =
-                        let uu____10967 =
+                  | FStar_Syntax_Syntax.Tm_fvar uu____11115 ->
+                      let uu____11116 =
+                        let uu____11137 =
                           FStar_Extraction_ML_UEnv.lookup_term g head2  in
-                        match uu____10967 with
+                        match uu____11137 with
                         | (FStar_Util.Inr exp_b,q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____11006  ->
-                                  let uu____11007 =
+                               (fun uu____11176  ->
+                                  let uu____11177 =
                                     FStar_Syntax_Print.term_to_string head2
                                      in
-                                  let uu____11009 =
+                                  let uu____11179 =
                                     FStar_Extraction_ML_Code.string_of_mlexpr
                                       g.FStar_Extraction_ML_UEnv.currentModule
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr
                                      in
-                                  let uu____11011 =
+                                  let uu____11181 =
                                     FStar_Extraction_ML_Code.string_of_mlty
                                       g.FStar_Extraction_ML_UEnv.currentModule
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)
                                      in
-                                  let uu____11013 =
+                                  let uu____11183 =
                                     FStar_Util.string_of_bool
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_inst_ok
                                      in
                                   FStar_Util.print4
                                     "@@@looked up %s: got %s at %s (inst_ok=%s)\n"
-                                    uu____11007 uu____11009 uu____11011
-                                    uu____11013);
+                                    uu____11177 uu____11179 uu____11181
+                                    uu____11183);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_inst_ok)),
                                q))
-                        | uu____11040 -> failwith "FIXME Ty"  in
-                      (match uu____10946 with
+                        | uu____11210 -> failwith "FIXME Ty"  in
+                      (match uu____11116 with
                        | ((head_ml,(vars,t1),inst_ok),qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a,uu____11116)::uu____11117 -> is_type g a
-                             | uu____11144 -> false  in
-                           let uu____11156 =
+                             | (a,uu____11286)::uu____11287 -> is_type g a
+                             | uu____11314 -> false  in
+                           let uu____11326 =
                              match vars with
-                             | uu____11185::uu____11186 when
+                             | uu____11355::uu____11356 when
                                  (Prims.op_Negation has_typ_apps) && inst_ok
                                  -> (head_ml, t1, args)
-                             | uu____11200 ->
+                             | uu____11370 ->
                                  let n1 = FStar_List.length vars  in
-                                 if n1 <= (FStar_List.length args)
-                                 then
-                                   let uu____11229 =
-                                     FStar_Util.first_N n1 args  in
-                                   (match uu____11229 with
-                                    | (prefix1,rest) ->
-                                        let prefixAsMLTypes =
-                                          FStar_List.map
-                                            (fun uu____11330  ->
-                                               match uu____11330 with
-                                               | (x,uu____11338) ->
-                                                   term_as_mlty g x) prefix1
-                                           in
-                                        let t2 =
-                                          instantiate (vars, t1)
-                                            prefixAsMLTypes
-                                           in
-                                        (FStar_Extraction_ML_UEnv.debug g
-                                           (fun uu____11350  ->
-                                              let uu____11351 =
-                                                FStar_Syntax_Print.term_to_string
-                                                  head2
-                                                 in
-                                              let uu____11353 =
-                                                FStar_Syntax_Print.args_to_string
-                                                  prefix1
-                                                 in
-                                              let uu____11355 =
-                                                let uu____11357 =
-                                                  FStar_List.map
-                                                    (FStar_Extraction_ML_Code.string_of_mlty
-                                                       g.FStar_Extraction_ML_UEnv.currentModule)
-                                                    prefixAsMLTypes
-                                                   in
-                                                FStar_All.pipe_right
-                                                  uu____11357
-                                                  (FStar_String.concat ", ")
-                                                 in
-                                              let uu____11367 =
-                                                FStar_Extraction_ML_Code.string_of_mlty
-                                                  g.FStar_Extraction_ML_UEnv.currentModule
-                                                  t2
-                                                 in
-                                              FStar_Util.print4
-                                                "@@@looked up %s, instantiated with [%s] translated to [%s], got %s\n"
-                                                uu____11351 uu____11353
-                                                uu____11355 uu____11367);
-                                         (let mk_tapp e ty_args =
-                                            match ty_args with
-                                            | [] -> e
-                                            | uu____11385 ->
-                                                let uu___1616_11388 = e  in
-                                                {
-                                                  FStar_Extraction_ML_Syntax.expr
-                                                    =
-                                                    (FStar_Extraction_ML_Syntax.MLE_TApp
-                                                       (e, ty_args));
-                                                  FStar_Extraction_ML_Syntax.mlty
-                                                    =
-                                                    (uu___1616_11388.FStar_Extraction_ML_Syntax.mlty);
-                                                  FStar_Extraction_ML_Syntax.loc
-                                                    =
-                                                    (uu___1616_11388.FStar_Extraction_ML_Syntax.loc)
-                                                }
+                                 let uu____11376 =
+                                   if (FStar_List.length args) <= n1
+                                   then
+                                     let uu____11414 =
+                                       FStar_List.map
+                                         (fun uu____11426  ->
+                                            match uu____11426 with
+                                            | (x,uu____11434) ->
+                                                term_as_mlty g x) args
+                                        in
+                                     (uu____11414, [])
+                                   else
+                                     (let uu____11457 =
+                                        FStar_Util.first_N n1 args  in
+                                      match uu____11457 with
+                                      | (prefix1,rest) ->
+                                          let uu____11546 =
+                                            FStar_List.map
+                                              (fun uu____11558  ->
+                                                 match uu____11558 with
+                                                 | (x,uu____11566) ->
+                                                     term_as_mlty g x)
+                                              prefix1
                                              in
-                                          let head3 =
-                                            match head_ml.FStar_Extraction_ML_Syntax.expr
-                                            with
-                                            | FStar_Extraction_ML_Syntax.MLE_Name
-                                                uu____11392 ->
-                                                let uu___1622_11393 =
-                                                  mk_tapp head_ml
-                                                    prefixAsMLTypes
-                                                   in
-                                                {
-                                                  FStar_Extraction_ML_Syntax.expr
-                                                    =
-                                                    (uu___1622_11393.FStar_Extraction_ML_Syntax.expr);
-                                                  FStar_Extraction_ML_Syntax.mlty
-                                                    = t2;
-                                                  FStar_Extraction_ML_Syntax.loc
-                                                    =
-                                                    (uu___1622_11393.FStar_Extraction_ML_Syntax.loc)
-                                                }
-                                            | FStar_Extraction_ML_Syntax.MLE_Var
-                                                uu____11394 ->
-                                                let uu___1622_11396 =
-                                                  mk_tapp head_ml
-                                                    prefixAsMLTypes
-                                                   in
-                                                {
-                                                  FStar_Extraction_ML_Syntax.expr
-                                                    =
-                                                    (uu___1622_11396.FStar_Extraction_ML_Syntax.expr);
-                                                  FStar_Extraction_ML_Syntax.mlty
-                                                    = t2;
-                                                  FStar_Extraction_ML_Syntax.loc
-                                                    =
-                                                    (uu___1622_11396.FStar_Extraction_ML_Syntax.loc)
-                                                }
-                                            | FStar_Extraction_ML_Syntax.MLE_App
-                                                (head3,{
-                                                         FStar_Extraction_ML_Syntax.expr
-                                                           =
-                                                           FStar_Extraction_ML_Syntax.MLE_Const
-                                                           (FStar_Extraction_ML_Syntax.MLC_Unit
-                                                           );
-                                                         FStar_Extraction_ML_Syntax.mlty
-                                                           = uu____11398;
-                                                         FStar_Extraction_ML_Syntax.loc
-                                                           = uu____11399;_}::[])
-                                                ->
-                                                FStar_All.pipe_right
-                                                  (FStar_Extraction_ML_Syntax.MLE_App
-                                                     ((let uu___1633_11405 =
-                                                         mk_tapp head3
-                                                           prefixAsMLTypes
-                                                          in
-                                                       {
-                                                         FStar_Extraction_ML_Syntax.expr
-                                                           =
-                                                           (uu___1633_11405.FStar_Extraction_ML_Syntax.expr);
-                                                         FStar_Extraction_ML_Syntax.mlty
-                                                           =
-                                                           (FStar_Extraction_ML_Syntax.MLTY_Fun
-                                                              (FStar_Extraction_ML_Syntax.ml_unit_ty,
-                                                                FStar_Extraction_ML_Syntax.E_PURE,
-                                                                t2));
-                                                         FStar_Extraction_ML_Syntax.loc
-                                                           =
-                                                           (uu___1633_11405.FStar_Extraction_ML_Syntax.loc)
-                                                       }),
-                                                       [FStar_Extraction_ML_Syntax.ml_unit]))
-                                                  (FStar_Extraction_ML_Syntax.with_ty
-                                                     t2)
-                                            | uu____11406 ->
-                                                failwith
-                                                  "Impossible: Unexpected head term"
-                                             in
-                                          (head3, t2, rest))))
-                                 else err_uninst g head2 (vars, t1) top
+                                          (uu____11546, rest))
+                                    in
+                                 (match uu____11376 with
+                                  | (provided_type_args,rest) ->
+                                      let uu____11617 =
+                                        match head_ml.FStar_Extraction_ML_Syntax.expr
+                                        with
+                                        | FStar_Extraction_ML_Syntax.MLE_Name
+                                            uu____11626 ->
+                                            let uu____11627 =
+                                              instantiate_maybe_partial
+                                                head_ml (vars, t1)
+                                                provided_type_args
+                                               in
+                                            (match uu____11627 with
+                                             | (head3,uu____11639,t2) ->
+                                                 (head3, t2))
+                                        | FStar_Extraction_ML_Syntax.MLE_Var
+                                            uu____11641 ->
+                                            let uu____11643 =
+                                              instantiate_maybe_partial
+                                                head_ml (vars, t1)
+                                                provided_type_args
+                                               in
+                                            (match uu____11643 with
+                                             | (head3,uu____11655,t2) ->
+                                                 (head3, t2))
+                                        | FStar_Extraction_ML_Syntax.MLE_App
+                                            (head3,{
+                                                     FStar_Extraction_ML_Syntax.expr
+                                                       =
+                                                       FStar_Extraction_ML_Syntax.MLE_Const
+                                                       (FStar_Extraction_ML_Syntax.MLC_Unit
+                                                       );
+                                                     FStar_Extraction_ML_Syntax.mlty
+                                                       = uu____11658;
+                                                     FStar_Extraction_ML_Syntax.loc
+                                                       = uu____11659;_}::[])
+                                            ->
+                                            let uu____11662 =
+                                              instantiate_maybe_partial head3
+                                                (vars, t1) provided_type_args
+                                               in
+                                            (match uu____11662 with
+                                             | (head4,uu____11674,t2) ->
+                                                 let uu____11676 =
+                                                   FStar_All.pipe_right
+                                                     (FStar_Extraction_ML_Syntax.MLE_App
+                                                        (head4,
+                                                          [FStar_Extraction_ML_Syntax.ml_unit]))
+                                                     (FStar_Extraction_ML_Syntax.with_ty
+                                                        t2)
+                                                    in
+                                                 (uu____11676, t2))
+                                        | uu____11679 ->
+                                            failwith
+                                              "Impossible: Unexpected head term"
+                                         in
+                                      (match uu____11617 with
+                                       | (head3,t2) -> (head3, t2, rest)))
                               in
-                           (match uu____11156 with
+                           (match uu____11326 with
                             | (head_ml1,head_t,args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____11472 =
+                                     let uu____11746 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1
                                         in
-                                     (uu____11472,
+                                     (uu____11746,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____11473 ->
+                                 | uu____11747 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | uu____11482 ->
-                      let uu____11483 = term_as_mlexpr g head2  in
-                      (match uu____11483 with
+                  | uu____11756 ->
+                      let uu____11757 = term_as_mlexpr g head2  in
+                      (match uu____11757 with
                        | (head3,f,t1) ->
                            extract_app_maybe_projector
                              FStar_Pervasives_Native.None head3 (f, t1) args)
                    in
-                let uu____11499 = is_type g t  in
-                if uu____11499
+                let uu____11773 = is_type g t  in
+                if uu____11773
                 then
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
                 else
-                  (let uu____11510 =
-                     let uu____11511 = FStar_Syntax_Util.un_uinst head1  in
-                     uu____11511.FStar_Syntax_Syntax.n  in
-                   match uu____11510 with
+                  (let uu____11784 =
+                     let uu____11785 = FStar_Syntax_Util.un_uinst head1  in
+                     uu____11785.FStar_Syntax_Syntax.n  in
+                   match uu____11784 with
                    | FStar_Syntax_Syntax.Tm_fvar fv ->
-                       let uu____11521 =
+                       let uu____11795 =
                          FStar_Extraction_ML_UEnv.try_lookup_fv g fv  in
-                       (match uu____11521 with
+                       (match uu____11795 with
                         | FStar_Pervasives_Native.None  ->
                             (FStar_Extraction_ML_Syntax.ml_unit,
                               FStar_Extraction_ML_Syntax.E_PURE,
                               FStar_Extraction_ML_Syntax.MLTY_Erased)
-                        | uu____11530 -> extract_app_with_instantiations ())
-                   | uu____11533 -> extract_app_with_instantiations ()))
-       | FStar_Syntax_Syntax.Tm_ascribed (e0,(tc,uu____11536),f) ->
+                        | uu____11804 -> extract_app_with_instantiations ())
+                   | uu____11807 -> extract_app_with_instantiations ()))
+       | FStar_Syntax_Syntax.Tm_ascribed (e0,(tc,uu____11810),f) ->
            let t1 =
              match tc with
              | FStar_Util.Inl t1 -> term_as_mlty g t1
@@ -3417,39 +3350,39 @@ and (term_as_mlexpr' :
              | FStar_Pervasives_Native.None  ->
                  failwith "Ascription node with an empty effect label"
              | FStar_Pervasives_Native.Some l -> effect_as_etag g l  in
-           let uu____11604 = check_term_as_mlexpr g e0 f1 t1  in
-           (match uu____11604 with | (e,t2) -> (e, f1, t2))
+           let uu____11878 = check_term_as_mlexpr g e0 f1 t1  in
+           (match uu____11878 with | (e,t2) -> (e, f1, t2))
        | FStar_Syntax_Syntax.Tm_let ((is_rec,lbs),e') ->
            let top_level = FStar_Syntax_Syntax.is_top_level lbs  in
-           let uu____11639 =
+           let uu____11913 =
              if is_rec
              then FStar_Syntax_Subst.open_let_rec lbs e'
              else
-               (let uu____11655 = FStar_Syntax_Syntax.is_top_level lbs  in
-                if uu____11655
+               (let uu____11929 = FStar_Syntax_Syntax.is_top_level lbs  in
+                if uu____11929
                 then (lbs, e')
                 else
                   (let lb = FStar_List.hd lbs  in
                    let x =
-                     let uu____11670 =
+                     let uu____11944 =
                        FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                     FStar_Syntax_Syntax.freshen_bv uu____11670  in
+                     FStar_Syntax_Syntax.freshen_bv uu____11944  in
                    let lb1 =
-                     let uu___1684_11672 = lb  in
+                     let uu___1709_11946 = lb  in
                      {
                        FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                        FStar_Syntax_Syntax.lbunivs =
-                         (uu___1684_11672.FStar_Syntax_Syntax.lbunivs);
+                         (uu___1709_11946.FStar_Syntax_Syntax.lbunivs);
                        FStar_Syntax_Syntax.lbtyp =
-                         (uu___1684_11672.FStar_Syntax_Syntax.lbtyp);
+                         (uu___1709_11946.FStar_Syntax_Syntax.lbtyp);
                        FStar_Syntax_Syntax.lbeff =
-                         (uu___1684_11672.FStar_Syntax_Syntax.lbeff);
+                         (uu___1709_11946.FStar_Syntax_Syntax.lbeff);
                        FStar_Syntax_Syntax.lbdef =
-                         (uu___1684_11672.FStar_Syntax_Syntax.lbdef);
+                         (uu___1709_11946.FStar_Syntax_Syntax.lbdef);
                        FStar_Syntax_Syntax.lbattrs =
-                         (uu___1684_11672.FStar_Syntax_Syntax.lbattrs);
+                         (uu___1709_11946.FStar_Syntax_Syntax.lbattrs);
                        FStar_Syntax_Syntax.lbpos =
-                         (uu___1684_11672.FStar_Syntax_Syntax.lbpos)
+                         (uu___1709_11946.FStar_Syntax_Syntax.lbpos)
                      }  in
                    let e'1 =
                      FStar_Syntax_Subst.subst
@@ -3457,7 +3390,7 @@ and (term_as_mlexpr' :
                       in
                    ([lb1], e'1)))
               in
-           (match uu____11639 with
+           (match uu____11913 with
             | (lbs1,e'1) ->
                 let lbs2 =
                   if top_level
@@ -3466,7 +3399,7 @@ and (term_as_mlexpr' :
                       (FStar_List.map
                          (fun lb  ->
                             let tcenv =
-                              let uu____11706 =
+                              let uu____11980 =
                                 FStar_Ident.lid_of_path
                                   (FStar_List.append
                                      (FStar_Pervasives_Native.fst
@@ -3477,20 +3410,20 @@ and (term_as_mlexpr' :
                                  in
                               FStar_TypeChecker_Env.set_current_module
                                 g.FStar_Extraction_ML_UEnv.env_tcenv
-                                uu____11706
+                                uu____11980
                                in
                             let lbdef =
-                              let uu____11721 = FStar_Options.ml_ish ()  in
-                              if uu____11721
+                              let uu____11995 = FStar_Options.ml_ish ()  in
+                              if uu____11995
                               then lb.FStar_Syntax_Syntax.lbdef
                               else
-                                (let norm_call uu____11733 =
+                                (let norm_call uu____12007 =
                                    FStar_TypeChecker_Normalize.normalize
                                      (FStar_TypeChecker_Env.PureSubtermsWithinComputations
                                      :: extraction_norm_steps) tcenv
                                      lb.FStar_Syntax_Syntax.lbdef
                                     in
-                                 let uu____11734 =
+                                 let uu____12008 =
                                    (FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug tcenv)
                                       (FStar_Options.Other "Extraction"))
@@ -3499,78 +3432,78 @@ and (term_as_mlexpr' :
                                         (FStar_TypeChecker_Env.debug tcenv)
                                         (FStar_Options.Other "ExtractNorm"))
                                     in
-                                 if uu____11734
+                                 if uu____12008
                                  then
-                                   ((let uu____11744 =
+                                   ((let uu____12018 =
                                        FStar_Syntax_Print.lbname_to_string
                                          lb.FStar_Syntax_Syntax.lbname
                                         in
-                                     let uu____11746 =
+                                     let uu____12020 =
                                        FStar_Syntax_Print.term_to_string
                                          lb.FStar_Syntax_Syntax.lbdef
                                         in
                                      FStar_Util.print2
                                        "Starting to normalize top-level let %s)\n\tlbdef=%s"
-                                       uu____11744 uu____11746);
+                                       uu____12018 uu____12020);
                                     (let a =
-                                       let uu____11752 =
-                                         let uu____11754 =
+                                       let uu____12026 =
+                                         let uu____12028 =
                                            FStar_Syntax_Print.lbname_to_string
                                              lb.FStar_Syntax_Syntax.lbname
                                             in
                                          FStar_Util.format1
                                            "###(Time to normalize top-level let %s)"
-                                           uu____11754
+                                           uu____12028
                                           in
                                        FStar_Util.measure_execution_time
-                                         uu____11752 norm_call
+                                         uu____12026 norm_call
                                         in
-                                     (let uu____11760 =
+                                     (let uu____12034 =
                                         FStar_Syntax_Print.term_to_string a
                                          in
                                       FStar_Util.print1 "Normalized to %s\n"
-                                        uu____11760);
+                                        uu____12034);
                                      a))
                                  else norm_call ())
                                in
-                            let uu___1702_11765 = lb  in
+                            let uu___1727_12039 = lb  in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___1702_11765.FStar_Syntax_Syntax.lbname);
+                                (uu___1727_12039.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___1702_11765.FStar_Syntax_Syntax.lbunivs);
+                                (uu___1727_12039.FStar_Syntax_Syntax.lbunivs);
                               FStar_Syntax_Syntax.lbtyp =
-                                (uu___1702_11765.FStar_Syntax_Syntax.lbtyp);
+                                (uu___1727_12039.FStar_Syntax_Syntax.lbtyp);
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___1702_11765.FStar_Syntax_Syntax.lbeff);
+                                (uu___1727_12039.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef = lbdef;
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___1702_11765.FStar_Syntax_Syntax.lbattrs);
+                                (uu___1727_12039.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___1702_11765.FStar_Syntax_Syntax.lbpos)
+                                (uu___1727_12039.FStar_Syntax_Syntax.lbpos)
                             }))
                   else lbs1  in
-                let check_lb env uu____11818 =
-                  match uu____11818 with
+                let check_lb env uu____12092 =
+                  match uu____12092 with
                   | (nm,(_lbname,f,(_t,(targs,polytype)),add_unit,e)) ->
                       let env1 =
                         FStar_List.fold_left
                           (fun env1  ->
-                             fun uu____11974  ->
-                               match uu____11974 with
-                               | (a,uu____11982) ->
+                             fun uu____12248  ->
+                               match uu____12248 with
+                               | (a,uu____12256) ->
                                    FStar_Extraction_ML_UEnv.extend_ty env1 a
                                      FStar_Pervasives_Native.None) env targs
                          in
                       let expected_t = FStar_Pervasives_Native.snd polytype
                          in
-                      let uu____11988 =
+                      let uu____12262 =
                         check_term_as_mlexpr env1 e f expected_t  in
-                      (match uu____11988 with
+                      (match uu____12262 with
                        | (e1,ty) ->
-                           let uu____11999 =
+                           let uu____12273 =
                              maybe_promote_effect e1 f expected_t  in
-                           (match uu____11999 with
+                           (match uu____12273 with
                             | (e2,f1) ->
                                 let meta =
                                   match (f1, ty) with
@@ -3580,7 +3513,7 @@ and (term_as_mlexpr' :
                                   | (FStar_Extraction_ML_Syntax.E_GHOST
                                      ,FStar_Extraction_ML_Syntax.MLTY_Erased
                                      ) -> [FStar_Extraction_ML_Syntax.Erased]
-                                  | uu____12011 -> []  in
+                                  | uu____12285 -> []  in
                                 (f1,
                                   {
                                     FStar_Extraction_ML_Syntax.mllb_name = nm;
@@ -3596,26 +3529,26 @@ and (term_as_mlexpr' :
                                   })))
                    in
                 let lbs3 = extract_lb_sig g (is_rec, lbs2)  in
-                let uu____12042 =
+                let uu____12316 =
                   FStar_List.fold_right
                     (fun lb  ->
-                       fun uu____12139  ->
-                         match uu____12139 with
+                       fun uu____12413  ->
+                         match uu____12413 with
                          | (env,lbs4) ->
-                             let uu____12273 = lb  in
-                             (match uu____12273 with
-                              | (lbname,uu____12324,(t1,(uu____12326,polytype)),add_unit,uu____12329)
+                             let uu____12547 = lb  in
+                             (match uu____12547 with
+                              | (lbname,uu____12598,(t1,(uu____12600,polytype)),add_unit,uu____12603)
                                   ->
-                                  let uu____12344 =
+                                  let uu____12618 =
                                     FStar_Extraction_ML_UEnv.extend_lb env
                                       lbname t1 polytype add_unit true
                                      in
-                                  (match uu____12344 with
-                                   | (env1,nm,uu____12385) ->
+                                  (match uu____12618 with
+                                   | (env1,nm,uu____12659) ->
                                        (env1, ((nm, lb) :: lbs4))))) lbs3
                     (g, [])
                    in
-                (match uu____12042 with
+                (match uu____12316 with
                  | (env_body,lbs4) ->
                      let env_def = if is_rec then env_body else g  in
                      let lbs5 =
@@ -3623,46 +3556,46 @@ and (term_as_mlexpr' :
                          (FStar_List.map (check_lb env_def))
                         in
                      let e'_rng = e'1.FStar_Syntax_Syntax.pos  in
-                     let uu____12664 = term_as_mlexpr env_body e'1  in
-                     (match uu____12664 with
+                     let uu____12938 = term_as_mlexpr env_body e'1  in
+                     (match uu____12938 with
                       | (e'2,f',t') ->
                           let f =
-                            let uu____12681 =
-                              let uu____12684 =
+                            let uu____12955 =
+                              let uu____12958 =
                                 FStar_List.map FStar_Pervasives_Native.fst
                                   lbs5
                                  in
-                              f' :: uu____12684  in
+                              f' :: uu____12958  in
                             FStar_Extraction_ML_Util.join_l e'_rng
-                              uu____12681
+                              uu____12955
                              in
                           let is_rec1 =
                             if is_rec = true
                             then FStar_Extraction_ML_Syntax.Rec
                             else FStar_Extraction_ML_Syntax.NonRec  in
-                          let uu____12697 =
-                            let uu____12698 =
-                              let uu____12699 =
-                                let uu____12700 =
+                          let uu____12971 =
+                            let uu____12972 =
+                              let uu____12973 =
+                                let uu____12974 =
                                   FStar_List.map FStar_Pervasives_Native.snd
                                     lbs5
                                    in
-                                (is_rec1, uu____12700)  in
-                              mk_MLE_Let top_level uu____12699 e'2  in
-                            let uu____12709 =
+                                (is_rec1, uu____12974)  in
+                              mk_MLE_Let top_level uu____12973 e'2  in
+                            let uu____12983 =
                               FStar_Extraction_ML_Util.mlloc_of_range
                                 t.FStar_Syntax_Syntax.pos
                                in
                             FStar_Extraction_ML_Syntax.with_ty_loc t'
-                              uu____12698 uu____12709
+                              uu____12972 uu____12983
                              in
-                          (uu____12697, f, t'))))
+                          (uu____12971, f, t'))))
        | FStar_Syntax_Syntax.Tm_match (scrutinee,pats) ->
-           let uu____12748 = term_as_mlexpr g scrutinee  in
-           (match uu____12748 with
+           let uu____13022 = term_as_mlexpr g scrutinee  in
+           (match uu____13022 with
             | (e,f_e,t_e) ->
-                let uu____12764 = check_pats_for_ite pats  in
-                (match uu____12764 with
+                let uu____13038 = check_pats_for_ite pats  in
+                (match uu____13038 with
                  | (b,then_e,else_e) ->
                      let no_lift x t1 = x  in
                      if b
@@ -3670,81 +3603,81 @@ and (term_as_mlexpr' :
                        (match (then_e, else_e) with
                         | (FStar_Pervasives_Native.Some
                            then_e1,FStar_Pervasives_Native.Some else_e1) ->
-                            let uu____12829 = term_as_mlexpr g then_e1  in
-                            (match uu____12829 with
+                            let uu____13103 = term_as_mlexpr g then_e1  in
+                            (match uu____13103 with
                              | (then_mle,f_then,t_then) ->
-                                 let uu____12845 = term_as_mlexpr g else_e1
+                                 let uu____13119 = term_as_mlexpr g else_e1
                                     in
-                                 (match uu____12845 with
+                                 (match uu____13119 with
                                   | (else_mle,f_else,t_else) ->
-                                      let uu____12861 =
-                                        let uu____12872 =
+                                      let uu____13135 =
+                                        let uu____13146 =
                                           type_leq g t_then t_else  in
-                                        if uu____12872
+                                        if uu____13146
                                         then (t_else, no_lift)
                                         else
-                                          (let uu____12893 =
+                                          (let uu____13167 =
                                              type_leq g t_else t_then  in
-                                           if uu____12893
+                                           if uu____13167
                                            then (t_then, no_lift)
                                            else
                                              (FStar_Extraction_ML_Syntax.MLTY_Top,
                                                FStar_Extraction_ML_Syntax.apply_obj_repr))
                                          in
-                                      (match uu____12861 with
+                                      (match uu____13135 with
                                        | (t_branch,maybe_lift1) ->
-                                           let uu____12940 =
-                                             let uu____12941 =
-                                               let uu____12942 =
-                                                 let uu____12951 =
+                                           let uu____13214 =
+                                             let uu____13215 =
+                                               let uu____13216 =
+                                                 let uu____13225 =
                                                    maybe_lift1 then_mle
                                                      t_then
                                                     in
-                                                 let uu____12952 =
-                                                   let uu____12955 =
+                                                 let uu____13226 =
+                                                   let uu____13229 =
                                                      maybe_lift1 else_mle
                                                        t_else
                                                       in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____12955
+                                                     uu____13229
                                                     in
-                                                 (e, uu____12951,
-                                                   uu____12952)
+                                                 (e, uu____13225,
+                                                   uu____13226)
                                                   in
                                                FStar_Extraction_ML_Syntax.MLE_If
-                                                 uu____12942
+                                                 uu____13216
                                                 in
                                              FStar_All.pipe_left
                                                (FStar_Extraction_ML_Syntax.with_ty
-                                                  t_branch) uu____12941
+                                                  t_branch) uu____13215
                                               in
-                                           let uu____12958 =
+                                           let uu____13232 =
                                              FStar_Extraction_ML_Util.join
                                                then_e1.FStar_Syntax_Syntax.pos
                                                f_then f_else
                                               in
-                                           (uu____12940, uu____12958,
+                                           (uu____13214, uu____13232,
                                              t_branch))))
-                        | uu____12959 ->
+                        | uu____13233 ->
                             failwith
                               "ITE pats matched but then and else expressions not found?")
                      else
-                       (let uu____12977 =
+                       (let uu____13251 =
                           FStar_All.pipe_right pats
                             (FStar_Util.fold_map
                                (fun compat  ->
                                   fun br  ->
-                                    let uu____13076 =
+                                    let uu____13350 =
                                       FStar_Syntax_Subst.open_branch br  in
-                                    match uu____13076 with
+                                    match uu____13350 with
                                     | (pat,when_opt,branch1) ->
-                                        let uu____13121 =
+                                        let uu____13395 =
                                           extract_pat g pat t_e
                                             term_as_mlexpr
                                            in
-                                        (match uu____13121 with
+                                        (match uu____13395 with
                                          | (env,p,pat_t_compat) ->
-                                             let uu____13183 =
+                                             let uu____13457 =
                                                match when_opt with
                                                | FStar_Pervasives_Native.None
                                                     ->
@@ -3755,9 +3688,9 @@ and (term_as_mlexpr' :
                                                    let w_pos =
                                                      w.FStar_Syntax_Syntax.pos
                                                       in
-                                                   let uu____13206 =
+                                                   let uu____13480 =
                                                      term_as_mlexpr env w  in
-                                                   (match uu____13206 with
+                                                   (match uu____13480 with
                                                     | (w1,f_w,t_w) ->
                                                         let w2 =
                                                           maybe_coerce w_pos
@@ -3767,23 +3700,23 @@ and (term_as_mlexpr' :
                                                         ((FStar_Pervasives_Native.Some
                                                             w2), f_w))
                                                 in
-                                             (match uu____13183 with
+                                             (match uu____13457 with
                                               | (when_opt1,f_when) ->
-                                                  let uu____13256 =
+                                                  let uu____13530 =
                                                     term_as_mlexpr env
                                                       branch1
                                                      in
-                                                  (match uu____13256 with
+                                                  (match uu____13530 with
                                                    | (mlbranch,f_branch,t_branch)
                                                        ->
-                                                       let uu____13291 =
+                                                       let uu____13565 =
                                                          FStar_All.pipe_right
                                                            p
                                                            (FStar_List.map
                                                               (fun
-                                                                 uu____13368 
+                                                                 uu____13642 
                                                                  ->
-                                                                 match uu____13368
+                                                                 match uu____13642
                                                                  with
                                                                  | (p1,wopt)
                                                                     ->
@@ -3802,10 +3735,10 @@ and (term_as_mlexpr' :
                                                           in
                                                        ((compat &&
                                                            pat_t_compat),
-                                                         uu____13291)))))
+                                                         uu____13565)))))
                                true)
                            in
-                        match uu____12977 with
+                        match uu____13251 with
                         | (pat_t_compat,mlbranches) ->
                             let mlbranches1 = FStar_List.flatten mlbranches
                                in
@@ -3814,20 +3747,20 @@ and (term_as_mlexpr' :
                               then e
                               else
                                 (FStar_Extraction_ML_UEnv.debug g
-                                   (fun uu____13539  ->
-                                      let uu____13540 =
+                                   (fun uu____13813  ->
+                                      let uu____13814 =
                                         FStar_Extraction_ML_Code.string_of_mlexpr
                                           g.FStar_Extraction_ML_UEnv.currentModule
                                           e
                                          in
-                                      let uu____13542 =
+                                      let uu____13816 =
                                         FStar_Extraction_ML_Code.string_of_mlty
                                           g.FStar_Extraction_ML_UEnv.currentModule
                                           t_e
                                          in
                                       FStar_Util.print2
                                         "Coercing scrutinee %s from type %s because pattern type is incompatible\n"
-                                        uu____13540 uu____13542);
+                                        uu____13814 uu____13816);
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty t_e)
                                    (FStar_Extraction_ML_Syntax.MLE_Coerce
@@ -3836,32 +3769,32 @@ and (term_as_mlexpr' :
                                in
                             (match mlbranches1 with
                              | [] ->
-                                 let uu____13569 =
-                                   let uu____13570 =
+                                 let uu____13843 =
+                                   let uu____13844 =
                                      FStar_Syntax_Syntax.lid_as_fv
                                        FStar_Parser_Const.failwith_lid
                                        FStar_Syntax_Syntax.delta_constant
                                        FStar_Pervasives_Native.None
                                       in
                                    FStar_Extraction_ML_UEnv.lookup_fv g
-                                     uu____13570
+                                     uu____13844
                                     in
-                                 (match uu____13569 with
+                                 (match uu____13843 with
                                   | {
                                       FStar_Extraction_ML_UEnv.exp_b_name =
-                                        uu____13577;
+                                        uu____13851;
                                       FStar_Extraction_ML_UEnv.exp_b_expr =
                                         fw;
                                       FStar_Extraction_ML_UEnv.exp_b_tscheme
-                                        = uu____13579;
+                                        = uu____13853;
                                       FStar_Extraction_ML_UEnv.exp_b_inst_ok
-                                        = uu____13580;_}
+                                        = uu____13854;_}
                                       ->
-                                      let uu____13583 =
-                                        let uu____13584 =
-                                          let uu____13585 =
-                                            let uu____13592 =
-                                              let uu____13595 =
+                                      let uu____13857 =
+                                        let uu____13858 =
+                                          let uu____13859 =
+                                            let uu____13866 =
+                                              let uu____13869 =
                                                 FStar_All.pipe_left
                                                   (FStar_Extraction_ML_Syntax.with_ty
                                                      FStar_Extraction_ML_Syntax.ml_string_ty)
@@ -3869,29 +3802,29 @@ and (term_as_mlexpr' :
                                                      (FStar_Extraction_ML_Syntax.MLC_String
                                                         "unreachable"))
                                                  in
-                                              [uu____13595]  in
-                                            (fw, uu____13592)  in
+                                              [uu____13869]  in
+                                            (fw, uu____13866)  in
                                           FStar_Extraction_ML_Syntax.MLE_App
-                                            uu____13585
+                                            uu____13859
                                            in
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              FStar_Extraction_ML_Syntax.ml_int_ty)
-                                          uu____13584
+                                          uu____13858
                                          in
-                                      (uu____13583,
+                                      (uu____13857,
                                         FStar_Extraction_ML_Syntax.E_PURE,
                                         FStar_Extraction_ML_Syntax.ml_int_ty))
-                             | (uu____13599,uu____13600,(uu____13601,f_first,t_first))::rest
+                             | (uu____13873,uu____13874,(uu____13875,f_first,t_first))::rest
                                  ->
-                                 let uu____13661 =
+                                 let uu____13935 =
                                    FStar_List.fold_left
-                                     (fun uu____13703  ->
-                                        fun uu____13704  ->
-                                          match (uu____13703, uu____13704)
+                                     (fun uu____13977  ->
+                                        fun uu____13978  ->
+                                          match (uu____13977, uu____13978)
                                           with
-                                          | ((topt,f),(uu____13761,uu____13762,
-                                                       (uu____13763,f_branch,t_branch)))
+                                          | ((topt,f),(uu____14035,uu____14036,
+                                                       (uu____14037,f_branch,t_branch)))
                                               ->
                                               let f1 =
                                                 FStar_Extraction_ML_Util.join
@@ -3905,19 +3838,19 @@ and (term_as_mlexpr' :
                                                     FStar_Pervasives_Native.None
                                                 | FStar_Pervasives_Native.Some
                                                     t1 ->
-                                                    let uu____13819 =
+                                                    let uu____14093 =
                                                       type_leq g t1 t_branch
                                                        in
-                                                    if uu____13819
+                                                    if uu____14093
                                                     then
                                                       FStar_Pervasives_Native.Some
                                                         t_branch
                                                     else
-                                                      (let uu____13826 =
+                                                      (let uu____14100 =
                                                          type_leq g t_branch
                                                            t1
                                                           in
-                                                       if uu____13826
+                                                       if uu____14100
                                                        then
                                                          FStar_Pervasives_Native.Some
                                                            t1
@@ -3928,15 +3861,15 @@ and (term_as_mlexpr' :
                                      ((FStar_Pervasives_Native.Some t_first),
                                        f_first) rest
                                     in
-                                 (match uu____13661 with
+                                 (match uu____13935 with
                                   | (topt,f_match) ->
                                       let mlbranches2 =
                                         FStar_All.pipe_right mlbranches1
                                           (FStar_List.map
-                                             (fun uu____13924  ->
-                                                match uu____13924 with
-                                                | (p,(wopt,uu____13953),
-                                                   (b1,uu____13955,t1)) ->
+                                             (fun uu____14198  ->
+                                                match uu____14198 with
+                                                | (p,(wopt,uu____14227),
+                                                   (b1,uu____14229,t1)) ->
                                                     let b2 =
                                                       match topt with
                                                       | FStar_Pervasives_Native.None
@@ -3944,7 +3877,7 @@ and (term_as_mlexpr' :
                                                           FStar_Extraction_ML_Syntax.apply_obj_repr
                                                             b1 t1
                                                       | FStar_Pervasives_Native.Some
-                                                          uu____13974 -> b1
+                                                          uu____14248 -> b1
                                                        in
                                                     (p, wopt, b2)))
                                          in
@@ -3955,14 +3888,14 @@ and (term_as_mlexpr' :
                                         | FStar_Pervasives_Native.Some t1 ->
                                             t1
                                          in
-                                      let uu____13979 =
+                                      let uu____14253 =
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              t_match)
                                           (FStar_Extraction_ML_Syntax.MLE_Match
                                              (e1, mlbranches2))
                                          in
-                                      (uu____13979, f_match, t_match)))))))
+                                      (uu____14253, f_match, t_match)))))))
 
 let (ind_discriminator_body :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -3972,78 +3905,78 @@ let (ind_discriminator_body :
   fun env  ->
     fun discName  ->
       fun constrName  ->
-        let uu____14006 =
-          let uu____14011 =
+        let uu____14280 =
+          let uu____14285 =
             FStar_TypeChecker_Env.lookup_lid
               env.FStar_Extraction_ML_UEnv.env_tcenv discName
              in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____14011  in
-        match uu____14006 with
-        | (uu____14036,fstar_disc_type) ->
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____14285  in
+        match uu____14280 with
+        | (uu____14310,fstar_disc_type) ->
             let wildcards =
-              let uu____14046 =
-                let uu____14047 = FStar_Syntax_Subst.compress fstar_disc_type
+              let uu____14320 =
+                let uu____14321 = FStar_Syntax_Subst.compress fstar_disc_type
                    in
-                uu____14047.FStar_Syntax_Syntax.n  in
-              match uu____14046 with
-              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____14058) ->
-                  let uu____14079 =
+                uu____14321.FStar_Syntax_Syntax.n  in
+              match uu____14320 with
+              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____14332) ->
+                  let uu____14353 =
                     FStar_All.pipe_right binders
                       (FStar_List.filter
-                         (fun uu___2_14113  ->
-                            match uu___2_14113 with
-                            | (uu____14121,FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____14122)) ->
+                         (fun uu___2_14387  ->
+                            match uu___2_14387 with
+                            | (uu____14395,FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____14396)) ->
                                 true
-                            | uu____14127 -> false))
+                            | uu____14401 -> false))
                      in
-                  FStar_All.pipe_right uu____14079
+                  FStar_All.pipe_right uu____14353
                     (FStar_List.map
-                       (fun uu____14163  ->
-                          let uu____14170 = fresh "_"  in
-                          (uu____14170, FStar_Extraction_ML_Syntax.MLTY_Top)))
-              | uu____14174 -> failwith "Discriminator must be a function"
+                       (fun uu____14437  ->
+                          let uu____14444 = fresh "_"  in
+                          (uu____14444, FStar_Extraction_ML_Syntax.MLTY_Top)))
+              | uu____14448 -> failwith "Discriminator must be a function"
                in
             let mlid = fresh "_discr_"  in
             let targ = FStar_Extraction_ML_Syntax.MLTY_Top  in
             let disc_ty = FStar_Extraction_ML_Syntax.MLTY_Top  in
             let discrBody =
-              let uu____14189 =
-                let uu____14190 =
-                  let uu____14202 =
-                    let uu____14203 =
-                      let uu____14204 =
-                        let uu____14219 =
+              let uu____14463 =
+                let uu____14464 =
+                  let uu____14476 =
+                    let uu____14477 =
+                      let uu____14478 =
+                        let uu____14493 =
                           FStar_All.pipe_left
                             (FStar_Extraction_ML_Syntax.with_ty targ)
                             (FStar_Extraction_ML_Syntax.MLE_Name ([], mlid))
                            in
-                        let uu____14225 =
-                          let uu____14236 =
-                            let uu____14245 =
-                              let uu____14246 =
-                                let uu____14253 =
+                        let uu____14499 =
+                          let uu____14510 =
+                            let uu____14519 =
+                              let uu____14520 =
+                                let uu____14527 =
                                   FStar_Extraction_ML_Syntax.mlpath_of_lident
                                     constrName
                                    in
-                                (uu____14253,
+                                (uu____14527,
                                   [FStar_Extraction_ML_Syntax.MLP_Wild])
                                  in
-                              FStar_Extraction_ML_Syntax.MLP_CTor uu____14246
+                              FStar_Extraction_ML_Syntax.MLP_CTor uu____14520
                                in
-                            let uu____14256 =
+                            let uu____14530 =
                               FStar_All.pipe_left
                                 (FStar_Extraction_ML_Syntax.with_ty
                                    FStar_Extraction_ML_Syntax.ml_bool_ty)
                                 (FStar_Extraction_ML_Syntax.MLE_Const
                                    (FStar_Extraction_ML_Syntax.MLC_Bool true))
                                in
-                            (uu____14245, FStar_Pervasives_Native.None,
-                              uu____14256)
+                            (uu____14519, FStar_Pervasives_Native.None,
+                              uu____14530)
                              in
-                          let uu____14260 =
-                            let uu____14271 =
-                              let uu____14280 =
+                          let uu____14534 =
+                            let uu____14545 =
+                              let uu____14554 =
                                 FStar_All.pipe_left
                                   (FStar_Extraction_ML_Syntax.with_ty
                                      FStar_Extraction_ML_Syntax.ml_bool_ty)
@@ -4052,31 +3985,31 @@ let (ind_discriminator_body :
                                         false))
                                  in
                               (FStar_Extraction_ML_Syntax.MLP_Wild,
-                                FStar_Pervasives_Native.None, uu____14280)
+                                FStar_Pervasives_Native.None, uu____14554)
                                in
-                            [uu____14271]  in
-                          uu____14236 :: uu____14260  in
-                        (uu____14219, uu____14225)  in
-                      FStar_Extraction_ML_Syntax.MLE_Match uu____14204  in
+                            [uu____14545]  in
+                          uu____14510 :: uu____14534  in
+                        (uu____14493, uu____14499)  in
+                      FStar_Extraction_ML_Syntax.MLE_Match uu____14478  in
                     FStar_All.pipe_left
                       (FStar_Extraction_ML_Syntax.with_ty
-                         FStar_Extraction_ML_Syntax.ml_bool_ty) uu____14203
+                         FStar_Extraction_ML_Syntax.ml_bool_ty) uu____14477
                      in
-                  ((FStar_List.append wildcards [(mlid, targ)]), uu____14202)
+                  ((FStar_List.append wildcards [(mlid, targ)]), uu____14476)
                    in
-                FStar_Extraction_ML_Syntax.MLE_Fun uu____14190  in
+                FStar_Extraction_ML_Syntax.MLE_Fun uu____14464  in
               FStar_All.pipe_left
-                (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu____14189
+                (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu____14463
                in
-            let uu____14341 =
-              let uu____14342 =
-                let uu____14345 =
-                  let uu____14346 =
+            let uu____14615 =
+              let uu____14616 =
+                let uu____14619 =
+                  let uu____14620 =
                     FStar_Extraction_ML_UEnv.convIdent
                       discName.FStar_Ident.ident
                      in
                   {
-                    FStar_Extraction_ML_Syntax.mllb_name = uu____14346;
+                    FStar_Extraction_ML_Syntax.mllb_name = uu____14620;
                     FStar_Extraction_ML_Syntax.mllb_tysc =
                       FStar_Pervasives_Native.None;
                     FStar_Extraction_ML_Syntax.mllb_add_unit = false;
@@ -4084,7 +4017,7 @@ let (ind_discriminator_body :
                     FStar_Extraction_ML_Syntax.mllb_meta = [];
                     FStar_Extraction_ML_Syntax.print_typ = false
                   }  in
-                [uu____14345]  in
-              (FStar_Extraction_ML_Syntax.NonRec, uu____14342)  in
-            FStar_Extraction_ML_Syntax.MLM_Let uu____14341
+                [uu____14619]  in
+              (FStar_Extraction_ML_Syntax.NonRec, uu____14616)  in
+            FStar_Extraction_ML_Syntax.MLM_Let uu____14615
   

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -534,40 +534,43 @@ let (instantiate_maybe_partial :
             let n_args = FStar_List.length tyargs  in
             if n_args = n_vars
             then
-              let tapp =
-                let uu___363_2088 = e  in
-                {
-                  FStar_Extraction_ML_Syntax.expr =
-                    (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs));
-                  FStar_Extraction_ML_Syntax.mlty =
-                    (uu___363_2088.FStar_Extraction_ML_Syntax.mlty);
-                  FStar_Extraction_ML_Syntax.loc =
-                    (uu___363_2088.FStar_Extraction_ML_Syntax.loc)
-                }  in
-              let ts = instantiate_tyscheme (vars, t) tyargs  in
-              (tapp, FStar_Extraction_ML_Syntax.E_PURE, ts)
+              (if n_args = (Prims.parse_int "0")
+               then (e, FStar_Extraction_ML_Syntax.E_PURE, t)
+               else
+                 (let tapp =
+                    let uu___364_2099 = e  in
+                    {
+                      FStar_Extraction_ML_Syntax.expr =
+                        (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs));
+                      FStar_Extraction_ML_Syntax.mlty =
+                        (uu___364_2099.FStar_Extraction_ML_Syntax.mlty);
+                      FStar_Extraction_ML_Syntax.loc =
+                        (uu___364_2099.FStar_Extraction_ML_Syntax.loc)
+                    }  in
+                  let ts = instantiate_tyscheme (vars, t) tyargs  in
+                  (tapp, FStar_Extraction_ML_Syntax.E_PURE, ts)))
             else
               if n_args < n_vars
               then
                 (let extra_tyargs =
-                   let uu____2104 = FStar_Util.first_N n_args vars  in
-                   match uu____2104 with
-                   | (uu____2118,rest_vars) ->
+                   let uu____2115 = FStar_Util.first_N n_args vars  in
+                   match uu____2115 with
+                   | (uu____2129,rest_vars) ->
                        FStar_All.pipe_right rest_vars
                          (FStar_List.map
-                            (fun uu____2139  ->
+                            (fun uu____2150  ->
                                FStar_Extraction_ML_Syntax.MLTY_Erased))
                     in
                  let tyargs1 = FStar_List.append tyargs extra_tyargs  in
                  let tapp =
-                   let uu___374_2145 = e  in
+                   let uu___375_2156 = e  in
                    {
                      FStar_Extraction_ML_Syntax.expr =
                        (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs1));
                      FStar_Extraction_ML_Syntax.mlty =
-                       (uu___374_2145.FStar_Extraction_ML_Syntax.mlty);
+                       (uu___375_2156.FStar_Extraction_ML_Syntax.mlty);
                      FStar_Extraction_ML_Syntax.loc =
-                       (uu___374_2145.FStar_Extraction_ML_Syntax.loc)
+                       (uu___375_2156.FStar_Extraction_ML_Syntax.loc)
                    }  in
                  let ts = instantiate_tyscheme (vars, t) tyargs1  in
                  let t1 =
@@ -582,7 +585,7 @@ let (instantiate_maybe_partial :
                    let vs_ts =
                      FStar_List.map
                        (fun t2  ->
-                          let uu____2171 = fresh "t"  in (uu____2171, t2))
+                          let uu____2182 = fresh "t"  in (uu____2182, t2))
                        extra_tyargs
                       in
                    FStar_All.pipe_left
@@ -600,22 +603,22 @@ let (eta_expand :
   =
   fun t  ->
     fun e  ->
-      let uu____2202 = FStar_Extraction_ML_Util.doms_and_cod t  in
-      match uu____2202 with
+      let uu____2213 = FStar_Extraction_ML_Util.doms_and_cod t  in
+      match uu____2213 with
       | (ts,r) ->
           if ts = []
           then e
           else
-            (let vs = FStar_List.map (fun uu____2226  -> fresh "a") ts  in
+            (let vs = FStar_List.map (fun uu____2237  -> fresh "a") ts  in
              let vs_ts = FStar_List.zip vs ts  in
              let vs_es =
-               let uu____2240 = FStar_List.zip vs ts  in
+               let uu____2251 = FStar_List.zip vs ts  in
                FStar_List.map
-                 (fun uu____2257  ->
-                    match uu____2257 with
+                 (fun uu____2268  ->
+                    match uu____2268 with
                     | (v1,t1) ->
                         FStar_Extraction_ML_Syntax.with_ty t1
-                          (FStar_Extraction_ML_Syntax.MLE_Var v1)) uu____2240
+                          (FStar_Extraction_ML_Syntax.MLE_Var v1)) uu____2251
                 in
              let body =
                FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty r)
@@ -630,14 +633,14 @@ let (default_value_for_ty :
   =
   fun g  ->
     fun t  ->
-      let uu____2288 = FStar_Extraction_ML_Util.doms_and_cod t  in
-      match uu____2288 with
+      let uu____2299 = FStar_Extraction_ML_Util.doms_and_cod t  in
+      match uu____2299 with
       | (ts,r) ->
           let body r1 =
             let r2 =
-              let uu____2308 = FStar_Extraction_ML_Util.udelta_unfold g r1
+              let uu____2319 = FStar_Extraction_ML_Util.udelta_unfold g r1
                  in
-              match uu____2308 with
+              match uu____2319 with
               | FStar_Pervasives_Native.None  -> r1
               | FStar_Pervasives_Native.Some r2 -> r2  in
             match r2 with
@@ -647,7 +650,7 @@ let (default_value_for_ty :
                 FStar_Extraction_ML_Syntax.apply_obj_repr
                   FStar_Extraction_ML_Syntax.ml_unit
                   FStar_Extraction_ML_Syntax.MLTY_Erased
-            | uu____2312 ->
+            | uu____2323 ->
                 FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty r2)
                   (FStar_Extraction_ML_Syntax.MLE_Coerce
                      (FStar_Extraction_ML_Syntax.ml_unit,
@@ -656,14 +659,14 @@ let (default_value_for_ty :
           if ts = []
           then body r
           else
-            (let vs = FStar_List.map (fun uu____2324  -> fresh "a") ts  in
+            (let vs = FStar_List.map (fun uu____2335  -> fresh "a") ts  in
              let vs_ts = FStar_List.zip vs ts  in
-             let uu____2335 =
-               let uu____2336 =
-                 let uu____2348 = body r  in (vs_ts, uu____2348)  in
-               FStar_Extraction_ML_Syntax.MLE_Fun uu____2336  in
+             let uu____2346 =
+               let uu____2347 =
+                 let uu____2359 = body r  in (vs_ts, uu____2359)  in
+               FStar_Extraction_ML_Syntax.MLE_Fun uu____2347  in
              FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty t)
-               uu____2335)
+               uu____2346)
   
 let (maybe_eta_expand :
   FStar_Extraction_ML_Syntax.mlty ->
@@ -671,12 +674,12 @@ let (maybe_eta_expand :
   =
   fun expect  ->
     fun e  ->
-      let uu____2367 =
+      let uu____2378 =
         (FStar_Options.ml_no_eta_expand_coertions ()) ||
-          (let uu____2370 = FStar_Options.codegen ()  in
-           uu____2370 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin))
+          (let uu____2381 = FStar_Options.codegen ()  in
+           uu____2381 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin))
          in
-      if uu____2367 then e else eta_expand expect e
+      if uu____2378 then e else eta_expand expect e
   
 let (apply_coercion :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -693,54 +696,54 @@ let (apply_coercion :
             | FStar_Extraction_ML_Syntax.MLE_Fun (binders,body1) ->
                 FStar_Extraction_ML_Syntax.MLE_Fun
                   ((binder :: binders), body1)
-            | uu____2448 ->
+            | uu____2459 ->
                 FStar_Extraction_ML_Syntax.MLE_Fun ([binder], body)
              in
           let rec aux e1 ty1 expect1 =
-            let coerce_branch uu____2503 =
-              match uu____2503 with
+            let coerce_branch uu____2514 =
+              match uu____2514 with
               | (pat,w,b) ->
-                  let uu____2527 = aux b ty1 expect1  in (pat, w, uu____2527)
+                  let uu____2538 = aux b ty1 expect1  in (pat, w, uu____2538)
                in
             match ((e1.FStar_Extraction_ML_Syntax.expr), ty1, expect1) with
             | (FStar_Extraction_ML_Syntax.MLE_Fun
                (arg::rest,body),FStar_Extraction_ML_Syntax.MLTY_Fun
-               (t0,uu____2534,t1),FStar_Extraction_ML_Syntax.MLTY_Fun
-               (s0,uu____2537,s1)) ->
+               (t0,uu____2545,t1),FStar_Extraction_ML_Syntax.MLTY_Fun
+               (s0,uu____2548,s1)) ->
                 let body1 =
                   match rest with
                   | [] -> body
-                  | uu____2569 ->
+                  | uu____2580 ->
                       FStar_Extraction_ML_Syntax.with_ty t1
                         (FStar_Extraction_ML_Syntax.MLE_Fun (rest, body))
                    in
                 let body2 = aux body1 t1 s1  in
-                let uu____2585 = type_leq g s0 t0  in
-                if uu____2585
+                let uu____2596 = type_leq g s0 t0  in
+                if uu____2596
                 then
                   FStar_Extraction_ML_Syntax.with_ty expect1
                     (mk_fun arg body2)
                 else
                   (let lb =
-                     let uu____2591 =
-                       let uu____2592 =
-                         let uu____2593 =
-                           let uu____2600 =
+                     let uu____2602 =
+                       let uu____2603 =
+                         let uu____2604 =
+                           let uu____2611 =
                              FStar_All.pipe_left
                                (FStar_Extraction_ML_Syntax.with_ty s0)
                                (FStar_Extraction_ML_Syntax.MLE_Var
                                   (FStar_Pervasives_Native.fst arg))
                               in
-                           (uu____2600, s0, t0)  in
-                         FStar_Extraction_ML_Syntax.MLE_Coerce uu____2593  in
-                       FStar_Extraction_ML_Syntax.with_ty t0 uu____2592  in
+                           (uu____2611, s0, t0)  in
+                         FStar_Extraction_ML_Syntax.MLE_Coerce uu____2604  in
+                       FStar_Extraction_ML_Syntax.with_ty t0 uu____2603  in
                      {
                        FStar_Extraction_ML_Syntax.mllb_name =
                          (FStar_Pervasives_Native.fst arg);
                        FStar_Extraction_ML_Syntax.mllb_tysc =
                          (FStar_Pervasives_Native.Some ([], t0));
                        FStar_Extraction_ML_Syntax.mllb_add_unit = false;
-                       FStar_Extraction_ML_Syntax.mllb_def = uu____2591;
+                       FStar_Extraction_ML_Syntax.mllb_def = uu____2602;
                        FStar_Extraction_ML_Syntax.mllb_meta = [];
                        FStar_Extraction_ML_Syntax.print_typ = false
                      }  in
@@ -753,71 +756,71 @@ let (apply_coercion :
                    FStar_Extraction_ML_Syntax.with_ty expect1
                      (mk_fun ((FStar_Pervasives_Native.fst arg), s0) body3))
             | (FStar_Extraction_ML_Syntax.MLE_Let
-               (lbs,body),uu____2619,uu____2620) ->
-                let uu____2633 =
-                  let uu____2634 =
-                    let uu____2645 = aux body ty1 expect1  in
-                    (lbs, uu____2645)  in
-                  FStar_Extraction_ML_Syntax.MLE_Let uu____2634  in
+               (lbs,body),uu____2630,uu____2631) ->
+                let uu____2644 =
+                  let uu____2645 =
+                    let uu____2656 = aux body ty1 expect1  in
+                    (lbs, uu____2656)  in
+                  FStar_Extraction_ML_Syntax.MLE_Let uu____2645  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2633
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2644
             | (FStar_Extraction_ML_Syntax.MLE_Match
-               (s,branches),uu____2654,uu____2655) ->
-                let uu____2676 =
-                  let uu____2677 =
-                    let uu____2692 = FStar_List.map coerce_branch branches
+               (s,branches),uu____2665,uu____2666) ->
+                let uu____2687 =
+                  let uu____2688 =
+                    let uu____2703 = FStar_List.map coerce_branch branches
                        in
-                    (s, uu____2692)  in
-                  FStar_Extraction_ML_Syntax.MLE_Match uu____2677  in
+                    (s, uu____2703)  in
+                  FStar_Extraction_ML_Syntax.MLE_Match uu____2688  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2676
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2687
             | (FStar_Extraction_ML_Syntax.MLE_If
-               (s,b1,b2_opt),uu____2732,uu____2733) ->
-                let uu____2738 =
-                  let uu____2739 =
-                    let uu____2748 = aux b1 ty1 expect1  in
-                    let uu____2749 =
+               (s,b1,b2_opt),uu____2743,uu____2744) ->
+                let uu____2749 =
+                  let uu____2750 =
+                    let uu____2759 = aux b1 ty1 expect1  in
+                    let uu____2760 =
                       FStar_Util.map_opt b2_opt
                         (fun b2  -> aux b2 ty1 expect1)
                        in
-                    (s, uu____2748, uu____2749)  in
-                  FStar_Extraction_ML_Syntax.MLE_If uu____2739  in
+                    (s, uu____2759, uu____2760)  in
+                  FStar_Extraction_ML_Syntax.MLE_If uu____2750  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2738
-            | (FStar_Extraction_ML_Syntax.MLE_Seq es,uu____2757,uu____2758)
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2749
+            | (FStar_Extraction_ML_Syntax.MLE_Seq es,uu____2768,uu____2769)
                 ->
-                let uu____2761 = FStar_Util.prefix es  in
-                (match uu____2761 with
+                let uu____2772 = FStar_Util.prefix es  in
+                (match uu____2772 with
                  | (prefix1,last1) ->
-                     let uu____2774 =
-                       let uu____2775 =
-                         let uu____2778 =
-                           let uu____2781 = aux last1 ty1 expect1  in
-                           [uu____2781]  in
-                         FStar_List.append prefix1 uu____2778  in
-                       FStar_Extraction_ML_Syntax.MLE_Seq uu____2775  in
+                     let uu____2785 =
+                       let uu____2786 =
+                         let uu____2789 =
+                           let uu____2792 = aux last1 ty1 expect1  in
+                           [uu____2792]  in
+                         FStar_List.append prefix1 uu____2789  in
+                       FStar_Extraction_ML_Syntax.MLE_Seq uu____2786  in
                      FStar_All.pipe_left
                        (FStar_Extraction_ML_Syntax.with_ty expect1)
-                       uu____2774)
+                       uu____2785)
             | (FStar_Extraction_ML_Syntax.MLE_Try
-               (s,branches),uu____2784,uu____2785) ->
-                let uu____2806 =
-                  let uu____2807 =
-                    let uu____2822 = FStar_List.map coerce_branch branches
+               (s,branches),uu____2795,uu____2796) ->
+                let uu____2817 =
+                  let uu____2818 =
+                    let uu____2833 = FStar_List.map coerce_branch branches
                        in
-                    (s, uu____2822)  in
-                  FStar_Extraction_ML_Syntax.MLE_Try uu____2807  in
+                    (s, uu____2833)  in
+                  FStar_Extraction_ML_Syntax.MLE_Try uu____2818  in
                 FStar_All.pipe_left
-                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2806
-            | uu____2859 ->
+                  (FStar_Extraction_ML_Syntax.with_ty expect1) uu____2817
+            | uu____2870 ->
                 FStar_Extraction_ML_Syntax.with_ty expect1
                   (FStar_Extraction_ML_Syntax.MLE_Coerce (e1, ty1, expect1))
              in
           aux e ty expect
   
 let maybe_coerce :
-  'Auu____2879 .
-    'Auu____2879 ->
+  'Auu____2890 .
+    'Auu____2890 ->
       FStar_Extraction_ML_UEnv.uenv ->
         FStar_Extraction_ML_Syntax.mlexpr ->
           FStar_Extraction_ML_Syntax.mlty ->
@@ -830,62 +833,62 @@ let maybe_coerce :
         fun ty  ->
           fun expect  ->
             let ty1 = eraseTypeDeep g ty  in
-            let uu____2906 =
+            let uu____2917 =
               type_leq_c g (FStar_Pervasives_Native.Some e) ty1 expect  in
-            match uu____2906 with
+            match uu____2917 with
             | (true ,FStar_Pervasives_Native.Some e') -> e'
-            | uu____2919 ->
+            | uu____2930 ->
                 (match ty1 with
                  | FStar_Extraction_ML_Syntax.MLTY_Erased  ->
                      default_value_for_ty g expect
-                 | uu____2927 ->
-                     let uu____2928 =
-                       let uu____2930 =
+                 | uu____2938 ->
+                     let uu____2939 =
+                       let uu____2941 =
                          FStar_Extraction_ML_Util.erase_effect_annotations
                            ty1
                           in
-                       let uu____2931 =
+                       let uu____2942 =
                          FStar_Extraction_ML_Util.erase_effect_annotations
                            expect
                           in
-                       type_leq g uu____2930 uu____2931  in
-                     if uu____2928
+                       type_leq g uu____2941 uu____2942  in
+                     if uu____2939
                      then
                        (FStar_Extraction_ML_UEnv.debug g
-                          (fun uu____2937  ->
-                             let uu____2938 =
+                          (fun uu____2948  ->
+                             let uu____2949 =
                                FStar_Extraction_ML_Code.string_of_mlexpr
                                  g.FStar_Extraction_ML_UEnv.currentModule e
                                 in
-                             let uu____2940 =
+                             let uu____2951 =
                                FStar_Extraction_ML_Code.string_of_mlty
                                  g.FStar_Extraction_ML_UEnv.currentModule ty1
                                 in
                              FStar_Util.print2
                                "\n Effect mismatch on type of %s : %s\n"
-                               uu____2938 uu____2940);
+                               uu____2949 uu____2951);
                         e)
                      else
                        (FStar_Extraction_ML_UEnv.debug g
-                          (fun uu____2950  ->
-                             let uu____2951 =
+                          (fun uu____2961  ->
+                             let uu____2962 =
                                FStar_Extraction_ML_Code.string_of_mlexpr
                                  g.FStar_Extraction_ML_UEnv.currentModule e
                                 in
-                             let uu____2953 =
+                             let uu____2964 =
                                FStar_Extraction_ML_Code.string_of_mlty
                                  g.FStar_Extraction_ML_UEnv.currentModule ty1
                                 in
-                             let uu____2955 =
+                             let uu____2966 =
                                FStar_Extraction_ML_Code.string_of_mlty
                                  g.FStar_Extraction_ML_UEnv.currentModule
                                  expect
                                 in
                              FStar_Util.print3
                                "\n (*needed to coerce expression \n %s \n of type \n %s \n to type \n %s *) \n"
-                               uu____2951 uu____2953 uu____2955);
-                        (let uu____2958 = apply_coercion g e ty1 expect  in
-                         maybe_eta_expand expect uu____2958)))
+                               uu____2962 uu____2964 uu____2966);
+                        (let uu____2969 = apply_coercion g e ty1 expect  in
+                         maybe_eta_expand expect uu____2969)))
   
 let (bv_as_mlty :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -893,10 +896,10 @@ let (bv_as_mlty :
   =
   fun g  ->
     fun bv  ->
-      let uu____2970 = FStar_Extraction_ML_UEnv.lookup_bv g bv  in
-      match uu____2970 with
+      let uu____2981 = FStar_Extraction_ML_UEnv.lookup_bv g bv  in
+      match uu____2981 with
       | FStar_Util.Inl ty_b -> ty_b.FStar_Extraction_ML_UEnv.ty_b_ty
-      | uu____2972 -> FStar_Extraction_ML_Syntax.MLTY_Top
+      | uu____2983 -> FStar_Extraction_ML_Syntax.MLTY_Top
   
 let (extraction_norm_steps : FStar_TypeChecker_Env.step Prims.list) =
   [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -913,36 +916,36 @@ let (comp_no_args :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____2990 -> c
-    | FStar_Syntax_Syntax.GTotal uu____2999 -> c
+    | FStar_Syntax_Syntax.Total uu____3001 -> c
+    | FStar_Syntax_Syntax.GTotal uu____3010 -> c
     | FStar_Syntax_Syntax.Comp ct ->
         let effect_args =
           FStar_List.map
-            (fun uu____3035  ->
-               match uu____3035 with
-               | (uu____3050,aq) -> (FStar_Syntax_Syntax.t_unit, aq))
+            (fun uu____3046  ->
+               match uu____3046 with
+               | (uu____3061,aq) -> (FStar_Syntax_Syntax.t_unit, aq))
             ct.FStar_Syntax_Syntax.effect_args
            in
         let ct1 =
-          let uu___537_3063 = ct  in
+          let uu___538_3074 = ct  in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___537_3063.FStar_Syntax_Syntax.comp_univs);
+              (uu___538_3074.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___537_3063.FStar_Syntax_Syntax.effect_name);
+              (uu___538_3074.FStar_Syntax_Syntax.effect_name);
             FStar_Syntax_Syntax.result_typ =
-              (uu___537_3063.FStar_Syntax_Syntax.result_typ);
+              (uu___538_3074.FStar_Syntax_Syntax.result_typ);
             FStar_Syntax_Syntax.effect_args = effect_args;
             FStar_Syntax_Syntax.flags =
-              (uu___537_3063.FStar_Syntax_Syntax.flags)
+              (uu___538_3074.FStar_Syntax_Syntax.flags)
           }  in
         let c1 =
-          let uu___540_3067 = c  in
+          let uu___541_3078 = c  in
           {
             FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
-            FStar_Syntax_Syntax.pos = (uu___540_3067.FStar_Syntax_Syntax.pos);
+            FStar_Syntax_Syntax.pos = (uu___541_3078.FStar_Syntax_Syntax.pos);
             FStar_Syntax_Syntax.vars =
-              (uu___540_3067.FStar_Syntax_Syntax.vars)
+              (uu___541_3078.FStar_Syntax_Syntax.vars)
           }  in
         c1
   
@@ -952,29 +955,29 @@ let rec (translate_term_to_mlty :
   =
   fun g  ->
     fun t0  ->
-      let arg_as_mlty g1 uu____3116 =
-        match uu____3116 with
-        | (a,uu____3124) ->
-            let uu____3129 = is_type g1 a  in
-            if uu____3129
+      let arg_as_mlty g1 uu____3127 =
+        match uu____3127 with
+        | (a,uu____3135) ->
+            let uu____3140 = is_type g1 a  in
+            if uu____3140
             then translate_term_to_mlty g1 a
             else FStar_Extraction_ML_UEnv.erasedContent
          in
       let fv_app_as_mlty g1 fv args =
-        let uu____3150 =
-          let uu____3152 = FStar_Extraction_ML_UEnv.is_fv_type g1 fv  in
-          Prims.op_Negation uu____3152  in
-        if uu____3150
+        let uu____3161 =
+          let uu____3163 = FStar_Extraction_ML_UEnv.is_fv_type g1 fv  in
+          Prims.op_Negation uu____3163  in
+        if uu____3161
         then FStar_Extraction_ML_Syntax.MLTY_Top
         else
-          (let uu____3157 =
-             let uu____3172 =
+          (let uu____3168 =
+             let uu____3183 =
                FStar_TypeChecker_Env.lookup_lid
                  g1.FStar_Extraction_ML_UEnv.env_tcenv
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             match uu____3172 with
-             | ((uu____3195,fvty),uu____3197) ->
+             match uu____3183 with
+             | ((uu____3206,fvty),uu____3208) ->
                  let fvty1 =
                    FStar_TypeChecker_Normalize.normalize
                      [FStar_TypeChecker_Env.UnfoldUntil
@@ -983,28 +986,28 @@ let rec (translate_term_to_mlty :
                     in
                  FStar_Syntax_Util.arrow_formals fvty1
               in
-           match uu____3157 with
-           | (formals,uu____3204) ->
+           match uu____3168 with
+           | (formals,uu____3215) ->
                let mlargs = FStar_List.map (arg_as_mlty g1) args  in
                let mlargs1 =
                  let n_args = FStar_List.length args  in
                  if (FStar_List.length formals) > n_args
                  then
-                   let uu____3257 = FStar_Util.first_N n_args formals  in
-                   match uu____3257 with
-                   | (uu____3286,rest) ->
-                       let uu____3320 =
+                   let uu____3268 = FStar_Util.first_N n_args formals  in
+                   match uu____3268 with
+                   | (uu____3297,rest) ->
+                       let uu____3331 =
                          FStar_List.map
-                           (fun uu____3330  ->
+                           (fun uu____3341  ->
                               FStar_Extraction_ML_UEnv.erasedContent) rest
                           in
-                       FStar_List.append mlargs uu____3320
+                       FStar_List.append mlargs uu____3331
                  else mlargs  in
                let nm =
-                 let uu____3340 =
+                 let uu____3351 =
                    FStar_Extraction_ML_UEnv.maybe_mangle_type_projector g1 fv
                     in
-                 match uu____3340 with
+                 match uu____3351 with
                  | FStar_Pervasives_Native.Some p -> p
                  | FStar_Pervasives_Native.None  ->
                      FStar_Extraction_ML_Syntax.mlpath_of_lident
@@ -1015,54 +1018,54 @@ let rec (translate_term_to_mlty :
       let aux env t =
         let t1 = FStar_Syntax_Subst.compress t  in
         match t1.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_type uu____3358 ->
+        | FStar_Syntax_Syntax.Tm_type uu____3369 ->
             FStar_Extraction_ML_Syntax.MLTY_Erased
-        | FStar_Syntax_Syntax.Tm_bvar uu____3359 ->
-            let uu____3360 =
-              let uu____3362 = FStar_Syntax_Print.term_to_string t1  in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3362
+        | FStar_Syntax_Syntax.Tm_bvar uu____3370 ->
+            let uu____3371 =
+              let uu____3373 = FStar_Syntax_Print.term_to_string t1  in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3373
                in
-            failwith uu____3360
-        | FStar_Syntax_Syntax.Tm_delayed uu____3365 ->
-            let uu____3388 =
-              let uu____3390 = FStar_Syntax_Print.term_to_string t1  in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3390
+            failwith uu____3371
+        | FStar_Syntax_Syntax.Tm_delayed uu____3376 ->
+            let uu____3399 =
+              let uu____3401 = FStar_Syntax_Print.term_to_string t1  in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3401
                in
-            failwith uu____3388
+            failwith uu____3399
         | FStar_Syntax_Syntax.Tm_unknown  ->
-            let uu____3393 =
-              let uu____3395 = FStar_Syntax_Print.term_to_string t1  in
-              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3395
+            let uu____3404 =
+              let uu____3406 = FStar_Syntax_Print.term_to_string t1  in
+              FStar_Util.format1 "Impossible: Unexpected term %s" uu____3406
                in
-            failwith uu____3393
+            failwith uu____3404
         | FStar_Syntax_Syntax.Tm_lazy i ->
-            let uu____3399 = FStar_Syntax_Util.unfold_lazy i  in
-            translate_term_to_mlty env uu____3399
-        | FStar_Syntax_Syntax.Tm_constant uu____3400 ->
+            let uu____3410 = FStar_Syntax_Util.unfold_lazy i  in
+            translate_term_to_mlty env uu____3410
+        | FStar_Syntax_Syntax.Tm_constant uu____3411 ->
             FStar_Extraction_ML_UEnv.unknownType
-        | FStar_Syntax_Syntax.Tm_quoted uu____3401 ->
+        | FStar_Syntax_Syntax.Tm_quoted uu____3412 ->
             FStar_Extraction_ML_UEnv.unknownType
-        | FStar_Syntax_Syntax.Tm_uvar uu____3408 ->
+        | FStar_Syntax_Syntax.Tm_uvar uu____3419 ->
             FStar_Extraction_ML_UEnv.unknownType
-        | FStar_Syntax_Syntax.Tm_meta (t2,uu____3422) ->
+        | FStar_Syntax_Syntax.Tm_meta (t2,uu____3433) ->
             translate_term_to_mlty env t2
         | FStar_Syntax_Syntax.Tm_refine
-            ({ FStar_Syntax_Syntax.ppname = uu____3427;
-               FStar_Syntax_Syntax.index = uu____3428;
-               FStar_Syntax_Syntax.sort = t2;_},uu____3430)
+            ({ FStar_Syntax_Syntax.ppname = uu____3438;
+               FStar_Syntax_Syntax.index = uu____3439;
+               FStar_Syntax_Syntax.sort = t2;_},uu____3441)
             -> translate_term_to_mlty env t2
-        | FStar_Syntax_Syntax.Tm_uinst (t2,uu____3439) ->
+        | FStar_Syntax_Syntax.Tm_uinst (t2,uu____3450) ->
             translate_term_to_mlty env t2
-        | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____3445,uu____3446) ->
+        | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____3456,uu____3457) ->
             translate_term_to_mlty env t2
         | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
         | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv []
         | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-            let uu____3519 = FStar_Syntax_Subst.open_comp bs c  in
-            (match uu____3519 with
+            let uu____3530 = FStar_Syntax_Subst.open_comp bs c  in
+            (match uu____3530 with
              | (bs1,c1) ->
-                 let uu____3526 = binders_as_ml_binders env bs1  in
-                 (match uu____3526 with
+                 let uu____3537 = binders_as_ml_binders env bs1  in
+                 (match uu____3537 with
                   | (mlbs,env1) ->
                       let t_ret =
                         let eff =
@@ -1071,20 +1074,20 @@ let rec (translate_term_to_mlty :
                             (FStar_Syntax_Util.comp_effect_name c1)
                            in
                         let c2 = comp_no_args c1  in
-                        let uu____3559 =
-                          let uu____3566 =
+                        let uu____3570 =
+                          let uu____3577 =
                             FStar_TypeChecker_Env.effect_decl_opt
                               env1.FStar_Extraction_ML_UEnv.env_tcenv eff
                              in
-                          FStar_Util.must uu____3566  in
-                        match uu____3559 with
+                          FStar_Util.must uu____3577  in
+                        match uu____3570 with
                         | (ed,qualifiers) ->
-                            let uu____3587 =
+                            let uu____3598 =
                               FStar_TypeChecker_Env.is_reifiable_effect
                                 g.FStar_Extraction_ML_UEnv.env_tcenv
                                 ed.FStar_Syntax_Syntax.mname
                                in
-                            if uu____3587
+                            if uu____3598
                             then
                               let t2 =
                                 FStar_TypeChecker_Env.reify_comp
@@ -1092,33 +1095,33 @@ let rec (translate_term_to_mlty :
                                   FStar_Syntax_Syntax.U_unknown
                                  in
                               (FStar_Extraction_ML_UEnv.debug env1
-                                 (fun uu____3595  ->
-                                    let uu____3596 =
+                                 (fun uu____3606  ->
+                                    let uu____3607 =
                                       FStar_Syntax_Print.comp_to_string c2
                                        in
-                                    let uu____3598 =
+                                    let uu____3609 =
                                       FStar_Syntax_Print.term_to_string t2
                                        in
                                     FStar_Util.print2
                                       "Translating comp type %s as %s\n"
-                                      uu____3596 uu____3598);
+                                      uu____3607 uu____3609);
                                (let res = translate_term_to_mlty env1 t2  in
                                 FStar_Extraction_ML_UEnv.debug env1
-                                  (fun uu____3607  ->
-                                     let uu____3608 =
+                                  (fun uu____3618  ->
+                                     let uu____3619 =
                                        FStar_Syntax_Print.comp_to_string c2
                                         in
-                                     let uu____3610 =
+                                     let uu____3621 =
                                        FStar_Syntax_Print.term_to_string t2
                                         in
-                                     let uu____3612 =
+                                     let uu____3623 =
                                        FStar_Extraction_ML_Code.string_of_mlty
                                          env1.FStar_Extraction_ML_UEnv.currentModule
                                          res
                                         in
                                      FStar_Util.print3
                                        "Translated comp type %s as %s ... to %s\n"
-                                       uu____3608 uu____3610 uu____3612);
+                                       uu____3619 uu____3621 uu____3623);
                                 res))
                             else
                               translate_term_to_mlty env1
@@ -1128,66 +1131,66 @@ let rec (translate_term_to_mlty :
                         effect_as_etag env1
                           (FStar_Syntax_Util.comp_effect_name c1)
                          in
-                      let uu____3618 =
+                      let uu____3629 =
                         FStar_List.fold_right
-                          (fun uu____3638  ->
-                             fun uu____3639  ->
-                               match (uu____3638, uu____3639) with
-                               | ((uu____3662,t2),(tag,t')) ->
+                          (fun uu____3649  ->
+                             fun uu____3650  ->
+                               match (uu____3649, uu____3650) with
+                               | ((uu____3673,t2),(tag,t')) ->
                                    (FStar_Extraction_ML_Syntax.E_PURE,
                                      (FStar_Extraction_ML_Syntax.MLTY_Fun
                                         (t2, tag, t')))) mlbs (erase, t_ret)
                          in
-                      (match uu____3618 with | (uu____3677,t2) -> t2)))
+                      (match uu____3629 with | (uu____3688,t2) -> t2)))
         | FStar_Syntax_Syntax.Tm_app (head1,args) ->
             let res =
-              let uu____3706 =
-                let uu____3707 = FStar_Syntax_Util.un_uinst head1  in
-                uu____3707.FStar_Syntax_Syntax.n  in
-              match uu____3706 with
+              let uu____3717 =
+                let uu____3718 = FStar_Syntax_Util.un_uinst head1  in
+                uu____3718.FStar_Syntax_Syntax.n  in
+              match uu____3717 with
               | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
               | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv args
               | FStar_Syntax_Syntax.Tm_app (head2,args') ->
-                  let uu____3738 =
+                  let uu____3749 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_app
                          (head2, (FStar_List.append args' args)))
                       FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
                      in
-                  translate_term_to_mlty env uu____3738
-              | uu____3759 -> FStar_Extraction_ML_UEnv.unknownType  in
+                  translate_term_to_mlty env uu____3749
+              | uu____3770 -> FStar_Extraction_ML_UEnv.unknownType  in
             res
-        | FStar_Syntax_Syntax.Tm_abs (bs,ty,uu____3762) ->
-            let uu____3787 = FStar_Syntax_Subst.open_term bs ty  in
-            (match uu____3787 with
+        | FStar_Syntax_Syntax.Tm_abs (bs,ty,uu____3773) ->
+            let uu____3798 = FStar_Syntax_Subst.open_term bs ty  in
+            (match uu____3798 with
              | (bs1,ty1) ->
-                 let uu____3794 = binders_as_ml_binders env bs1  in
-                 (match uu____3794 with
+                 let uu____3805 = binders_as_ml_binders env bs1  in
+                 (match uu____3805 with
                   | (bts,env1) -> translate_term_to_mlty env1 ty1))
-        | FStar_Syntax_Syntax.Tm_let uu____3822 ->
+        | FStar_Syntax_Syntax.Tm_let uu____3833 ->
             FStar_Extraction_ML_UEnv.unknownType
-        | FStar_Syntax_Syntax.Tm_match uu____3836 ->
+        | FStar_Syntax_Syntax.Tm_match uu____3847 ->
             FStar_Extraction_ML_UEnv.unknownType
          in
       let rec is_top_ty t =
         match t with
         | FStar_Extraction_ML_Syntax.MLTY_Top  -> true
-        | FStar_Extraction_ML_Syntax.MLTY_Named uu____3868 ->
-            let uu____3875 = FStar_Extraction_ML_Util.udelta_unfold g t  in
-            (match uu____3875 with
+        | FStar_Extraction_ML_Syntax.MLTY_Named uu____3879 ->
+            let uu____3886 = FStar_Extraction_ML_Util.udelta_unfold g t  in
+            (match uu____3886 with
              | FStar_Pervasives_Native.None  -> false
              | FStar_Pervasives_Native.Some t1 -> is_top_ty t1)
-        | uu____3881 -> false  in
-      let uu____3883 =
+        | uu____3892 -> false  in
+      let uu____3894 =
         FStar_TypeChecker_Util.must_erase_for_extraction
           g.FStar_Extraction_ML_UEnv.env_tcenv t0
          in
-      if uu____3883
+      if uu____3894
       then FStar_Extraction_ML_Syntax.MLTY_Erased
       else
         (let mlt = aux g t0  in
-         let uu____3889 = is_top_ty mlt  in
-         if uu____3889 then FStar_Extraction_ML_Syntax.MLTY_Top else mlt)
+         let uu____3900 = is_top_ty mlt  in
+         if uu____3900 then FStar_Extraction_ML_Syntax.MLTY_Top else mlt)
 
 and (binders_as_ml_binders :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1197,15 +1200,15 @@ and (binders_as_ml_binders :
   =
   fun g  ->
     fun bs  ->
-      let uu____3907 =
+      let uu____3918 =
         FStar_All.pipe_right bs
           (FStar_List.fold_left
-             (fun uu____3963  ->
+             (fun uu____3974  ->
                 fun b  ->
-                  match uu____3963 with
+                  match uu____3974 with
                   | (ml_bs,env) ->
-                      let uu____4009 = is_type_binder g b  in
-                      if uu____4009
+                      let uu____4020 = is_type_binder g b  in
+                      if uu____4020
                       then
                         let b1 = FStar_Pervasives_Native.fst b  in
                         let env1 =
@@ -1214,9 +1217,9 @@ and (binders_as_ml_binders :
                                FStar_Extraction_ML_Syntax.MLTY_Top)
                            in
                         let ml_b =
-                          let uu____4035 =
+                          let uu____4046 =
                             FStar_Extraction_ML_UEnv.bv_as_ml_termvar b1  in
-                          (uu____4035, FStar_Extraction_ML_Syntax.ml_unit_ty)
+                          (uu____4046, FStar_Extraction_ML_Syntax.ml_unit_ty)
                            in
                         ((ml_b :: ml_bs), env1)
                       else
@@ -1225,19 +1228,19 @@ and (binders_as_ml_binders :
                            translate_term_to_mlty env
                              b1.FStar_Syntax_Syntax.sort
                             in
-                         let uu____4056 =
+                         let uu____4067 =
                            FStar_Extraction_ML_UEnv.extend_bv env b1 
                              ([], t) false false false
                             in
-                         match uu____4056 with
-                         | (env1,b2,uu____4081) ->
+                         match uu____4067 with
+                         | (env1,b2,uu____4092) ->
                              let ml_b =
-                               let uu____4090 =
+                               let uu____4101 =
                                  FStar_Extraction_ML_UEnv.removeTick b2  in
-                               (uu____4090, t)  in
+                               (uu____4101, t)  in
                              ((ml_b :: ml_bs), env1))) ([], g))
          in
-      match uu____3907 with | (ml_bs,env) -> ((FStar_List.rev ml_bs), env)
+      match uu____3918 with | (ml_bs,env) -> ((FStar_List.rev ml_bs), env)
 
 let (term_as_mlty :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1263,11 +1266,11 @@ let (mk_MLE_Seq :
       | (FStar_Extraction_ML_Syntax.MLE_Seq
          es1,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 es2)
-      | (FStar_Extraction_ML_Syntax.MLE_Seq es1,uu____4186) ->
+      | (FStar_Extraction_ML_Syntax.MLE_Seq es1,uu____4197) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (FStar_List.append es1 [e2])
-      | (uu____4189,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
+      | (uu____4200,FStar_Extraction_ML_Syntax.MLE_Seq es2) ->
           FStar_Extraction_ML_Syntax.MLE_Seq (e1 :: es2)
-      | uu____4193 -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
+      | uu____4204 -> FStar_Extraction_ML_Syntax.MLE_Seq [e1; e2]
   
 let (mk_MLE_Let :
   Prims.bool ->
@@ -1293,16 +1296,16 @@ let (mk_MLE_Let :
                     | FStar_Extraction_ML_Syntax.MLE_Var x when
                         x = lb.FStar_Extraction_ML_Syntax.mllb_name ->
                         (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
-                    | uu____4227 when
+                    | uu____4238 when
                         (lb.FStar_Extraction_ML_Syntax.mllb_def).FStar_Extraction_ML_Syntax.expr
                           =
                           FStar_Extraction_ML_Syntax.ml_unit.FStar_Extraction_ML_Syntax.expr
                         -> body.FStar_Extraction_ML_Syntax.expr
-                    | uu____4228 ->
+                    | uu____4239 ->
                         mk_MLE_Seq lb.FStar_Extraction_ML_Syntax.mllb_def
                           body)
-             | uu____4229 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
-        | uu____4238 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
+             | uu____4240 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body))
+        | uu____4249 -> FStar_Extraction_ML_Syntax.MLE_Let (lbs, body)
   
 let (resugar_pat :
   FStar_Syntax_Syntax.fv_qual FStar_Pervasives_Native.option ->
@@ -1313,11 +1316,11 @@ let (resugar_pat :
     fun p  ->
       match p with
       | FStar_Extraction_ML_Syntax.MLP_CTor (d,pats) ->
-          let uu____4266 = FStar_Extraction_ML_Util.is_xtuple d  in
-          (match uu____4266 with
+          let uu____4277 = FStar_Extraction_ML_Util.is_xtuple d  in
+          (match uu____4277 with
            | FStar_Pervasives_Native.Some n1 ->
                FStar_Extraction_ML_Syntax.MLP_Tuple pats
-           | uu____4273 ->
+           | uu____4284 ->
                (match q with
                 | FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.Record_ctor (ty,fns)) ->
@@ -1326,8 +1329,8 @@ let (resugar_pat :
                        in
                     let fs = record_fields fns pats  in
                     FStar_Extraction_ML_Syntax.MLP_Record (path, fs)
-                | uu____4306 -> p))
-      | uu____4309 -> p
+                | uu____4317 -> p))
+      | uu____4320 -> p
   
 let rec (extract_one_pat :
   Prims.bool ->
@@ -1358,81 +1361,81 @@ let rec (extract_one_pat :
                   (if Prims.op_Negation ok
                    then
                      FStar_Extraction_ML_UEnv.debug g
-                       (fun uu____4411  ->
-                          let uu____4412 =
+                       (fun uu____4422  ->
+                          let uu____4423 =
                             FStar_Extraction_ML_Code.string_of_mlty
                               g.FStar_Extraction_ML_UEnv.currentModule t'
                              in
-                          let uu____4414 =
+                          let uu____4425 =
                             FStar_Extraction_ML_Code.string_of_mlty
                               g.FStar_Extraction_ML_UEnv.currentModule t
                              in
                           FStar_Util.print2
                             "Expected pattern type %s; got pattern type %s\n"
-                            uu____4412 uu____4414)
+                            uu____4423 uu____4425)
                    else ();
                    ok)
                in
             match p.FStar_Syntax_Syntax.v with
             | FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_int
                 (c,swopt)) when
-                let uu____4450 = FStar_Options.codegen ()  in
-                uu____4450 <>
+                let uu____4461 = FStar_Options.codegen ()  in
+                uu____4461 <>
                   (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
                 ->
-                let uu____4455 =
+                let uu____4466 =
                   match swopt with
                   | FStar_Pervasives_Native.None  ->
-                      let uu____4468 =
-                        let uu____4469 =
-                          let uu____4470 =
+                      let uu____4479 =
+                        let uu____4480 =
+                          let uu____4481 =
                             FStar_Extraction_ML_Util.mlconst_of_const
                               p.FStar_Syntax_Syntax.p
                               (FStar_Const.Const_int
                                  (c, FStar_Pervasives_Native.None))
                              in
-                          FStar_Extraction_ML_Syntax.MLE_Const uu____4470  in
+                          FStar_Extraction_ML_Syntax.MLE_Const uu____4481  in
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.ml_int_ty) uu____4469
+                             FStar_Extraction_ML_Syntax.ml_int_ty) uu____4480
                          in
-                      (uu____4468, FStar_Extraction_ML_Syntax.ml_int_ty)
+                      (uu____4479, FStar_Extraction_ML_Syntax.ml_int_ty)
                   | FStar_Pervasives_Native.Some sw ->
                       let source_term =
                         FStar_ToSyntax_ToSyntax.desugar_machine_integer
                           (g.FStar_Extraction_ML_UEnv.env_tcenv).FStar_TypeChecker_Env.dsenv
                           c sw FStar_Range.dummyRange
                          in
-                      let uu____4492 = term_as_mlexpr g source_term  in
-                      (match uu____4492 with
-                       | (mlterm,uu____4504,mlty) -> (mlterm, mlty))
+                      let uu____4503 = term_as_mlexpr g source_term  in
+                      (match uu____4503 with
+                       | (mlterm,uu____4515,mlty) -> (mlterm, mlty))
                    in
-                (match uu____4455 with
+                (match uu____4466 with
                  | (mlc,ml_ty) ->
                      let x = FStar_Extraction_ML_Syntax.gensym ()  in
                      let when_clause =
-                       let uu____4526 =
-                         let uu____4527 =
-                           let uu____4534 =
-                             let uu____4537 =
+                       let uu____4537 =
+                         let uu____4538 =
+                           let uu____4545 =
+                             let uu____4548 =
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty ml_ty)
                                  (FStar_Extraction_ML_Syntax.MLE_Var x)
                                 in
-                             [uu____4537; mlc]  in
+                             [uu____4548; mlc]  in
                            (FStar_Extraction_ML_Util.prims_op_equality,
-                             uu____4534)
+                             uu____4545)
                             in
-                         FStar_Extraction_ML_Syntax.MLE_App uu____4527  in
+                         FStar_Extraction_ML_Syntax.MLE_App uu____4538  in
                        FStar_All.pipe_left
                          (FStar_Extraction_ML_Syntax.with_ty
-                            FStar_Extraction_ML_Syntax.ml_bool_ty) uu____4526
+                            FStar_Extraction_ML_Syntax.ml_bool_ty) uu____4537
                         in
-                     let uu____4540 = ok ml_ty  in
+                     let uu____4551 = ok ml_ty  in
                      (g,
                        (FStar_Pervasives_Native.Some
                           ((FStar_Extraction_ML_Syntax.MLP_Var x),
-                            [when_clause])), uu____4540))
+                            [when_clause])), uu____4551))
             | FStar_Syntax_Syntax.Pat_constant s ->
                 let t =
                   FStar_TypeChecker_TcTerm.tc_constant
@@ -1440,103 +1443,103 @@ let rec (extract_one_pat :
                     FStar_Range.dummyRange s
                    in
                 let mlty = term_as_mlty g t  in
-                let uu____4562 =
-                  let uu____4571 =
-                    let uu____4578 =
-                      let uu____4579 =
+                let uu____4573 =
+                  let uu____4582 =
+                    let uu____4589 =
+                      let uu____4590 =
                         FStar_Extraction_ML_Util.mlconst_of_const
                           p.FStar_Syntax_Syntax.p s
                          in
-                      FStar_Extraction_ML_Syntax.MLP_Const uu____4579  in
-                    (uu____4578, [])  in
-                  FStar_Pervasives_Native.Some uu____4571  in
-                let uu____4588 = ok mlty  in (g, uu____4562, uu____4588)
+                      FStar_Extraction_ML_Syntax.MLP_Const uu____4590  in
+                    (uu____4589, [])  in
+                  FStar_Pervasives_Native.Some uu____4582  in
+                let uu____4599 = ok mlty  in (g, uu____4573, uu____4599)
             | FStar_Syntax_Syntax.Pat_var x ->
                 let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort  in
-                let uu____4601 =
+                let uu____4612 =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false
                     false imp
                    in
-                (match uu____4601 with
-                 | (g1,x1,uu____4629) ->
-                     let uu____4632 = ok mlty  in
+                (match uu____4612 with
+                 | (g1,x1,uu____4640) ->
+                     let uu____4643 = ok mlty  in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
                         else
                           FStar_Pervasives_Native.Some
                             ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
-                       uu____4632))
+                       uu____4643))
             | FStar_Syntax_Syntax.Pat_wild x ->
                 let mlty = term_as_mlty g x.FStar_Syntax_Syntax.sort  in
-                let uu____4670 =
+                let uu____4681 =
                   FStar_Extraction_ML_UEnv.extend_bv g x ([], mlty) false
                     false imp
                    in
-                (match uu____4670 with
-                 | (g1,x1,uu____4698) ->
-                     let uu____4701 = ok mlty  in
+                (match uu____4681 with
+                 | (g1,x1,uu____4709) ->
+                     let uu____4712 = ok mlty  in
                      (g1,
                        (if imp
                         then FStar_Pervasives_Native.None
                         else
                           FStar_Pervasives_Native.Some
                             ((FStar_Extraction_ML_Syntax.MLP_Var x1), [])),
-                       uu____4701))
-            | FStar_Syntax_Syntax.Pat_dot_term uu____4737 ->
+                       uu____4712))
+            | FStar_Syntax_Syntax.Pat_dot_term uu____4748 ->
                 (g, FStar_Pervasives_Native.None, true)
             | FStar_Syntax_Syntax.Pat_cons (f,pats) ->
-                let uu____4780 =
-                  let uu____4789 = FStar_Extraction_ML_UEnv.lookup_fv g f  in
-                  match uu____4789 with
-                  | { FStar_Extraction_ML_UEnv.exp_b_name = uu____4798;
+                let uu____4791 =
+                  let uu____4800 = FStar_Extraction_ML_UEnv.lookup_fv g f  in
+                  match uu____4800 with
+                  | { FStar_Extraction_ML_UEnv.exp_b_name = uu____4809;
                       FStar_Extraction_ML_UEnv.exp_b_expr =
                         {
                           FStar_Extraction_ML_Syntax.expr =
                             FStar_Extraction_ML_Syntax.MLE_Name n1;
-                          FStar_Extraction_ML_Syntax.mlty = uu____4800;
-                          FStar_Extraction_ML_Syntax.loc = uu____4801;_};
+                          FStar_Extraction_ML_Syntax.mlty = uu____4811;
+                          FStar_Extraction_ML_Syntax.loc = uu____4812;_};
                       FStar_Extraction_ML_UEnv.exp_b_tscheme = ttys;
-                      FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____4803;_}
+                      FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____4814;_}
                       -> (n1, ttys)
-                  | uu____4810 -> failwith "Expected a constructor"  in
-                (match uu____4780 with
+                  | uu____4821 -> failwith "Expected a constructor"  in
+                (match uu____4791 with
                  | (d,tys) ->
                      let nTyVars =
                        FStar_List.length (FStar_Pervasives_Native.fst tys)
                         in
-                     let uu____4847 = FStar_Util.first_N nTyVars pats  in
-                     (match uu____4847 with
+                     let uu____4858 = FStar_Util.first_N nTyVars pats  in
+                     (match uu____4858 with
                       | (tysVarPats,restPats) ->
                           let f_ty_opt =
                             try
-                              (fun uu___835_4951  ->
+                              (fun uu___836_4962  ->
                                  match () with
                                  | () ->
                                      let mlty_args =
                                        FStar_All.pipe_right tysVarPats
                                          (FStar_List.map
-                                            (fun uu____4982  ->
-                                               match uu____4982 with
-                                               | (p1,uu____4989) ->
+                                            (fun uu____4993  ->
+                                               match uu____4993 with
+                                               | (p1,uu____5000) ->
                                                    (match p1.FStar_Syntax_Syntax.v
                                                     with
                                                     | FStar_Syntax_Syntax.Pat_dot_term
-                                                        (uu____4992,t) ->
+                                                        (uu____5003,t) ->
                                                         term_as_mlty g t
-                                                    | uu____4998 ->
+                                                    | uu____5009 ->
                                                         (FStar_Extraction_ML_UEnv.debug
                                                            g
-                                                           (fun uu____5002 
+                                                           (fun uu____5013 
                                                               ->
-                                                              let uu____5003
+                                                              let uu____5014
                                                                 =
                                                                 FStar_Syntax_Print.pat_to_string
                                                                   p1
                                                                  in
                                                               FStar_Util.print1
                                                                 "Pattern %s is not extractable"
-                                                                uu____5003);
+                                                                uu____5014);
                                                          FStar_Exn.raise
                                                            Un_extractable))))
                                         in
@@ -1544,39 +1547,39 @@ let rec (extract_one_pat :
                                        FStar_Extraction_ML_Util.subst tys
                                          mlty_args
                                         in
-                                     let uu____5007 =
+                                     let uu____5018 =
                                        FStar_Extraction_ML_Util.uncurry_mlty_fun
                                          f_ty
                                         in
-                                     FStar_Pervasives_Native.Some uu____5007)
+                                     FStar_Pervasives_Native.Some uu____5018)
                                 ()
                             with
                             | Un_extractable  -> FStar_Pervasives_Native.None
                              in
-                          let uu____5036 =
+                          let uu____5047 =
                             FStar_Util.fold_map
                               (fun g1  ->
-                                 fun uu____5073  ->
-                                   match uu____5073 with
+                                 fun uu____5084  ->
+                                   match uu____5084 with
                                    | (p1,imp1) ->
-                                       let uu____5095 =
+                                       let uu____5106 =
                                          extract_one_pat true g1 p1
                                            FStar_Pervasives_Native.None
                                            term_as_mlexpr
                                           in
-                                       (match uu____5095 with
-                                        | (g2,p2,uu____5126) -> (g2, p2))) g
+                                       (match uu____5106 with
+                                        | (g2,p2,uu____5137) -> (g2, p2))) g
                               tysVarPats
                              in
-                          (match uu____5036 with
+                          (match uu____5047 with
                            | (g1,tyMLPats) ->
-                               let uu____5190 =
+                               let uu____5201 =
                                  FStar_Util.fold_map
-                                   (fun uu____5255  ->
-                                      fun uu____5256  ->
-                                        match (uu____5255, uu____5256) with
+                                   (fun uu____5266  ->
+                                      fun uu____5267  ->
+                                        match (uu____5266, uu____5267) with
                                         | ((g2,f_ty_opt1),(p1,imp1)) ->
-                                            let uu____5354 =
+                                            let uu____5365 =
                                               match f_ty_opt1 with
                                               | FStar_Pervasives_Native.Some
                                                   (hd1::rest,res) ->
@@ -1584,64 +1587,64 @@ let rec (extract_one_pat :
                                                       (rest, res)),
                                                     (FStar_Pervasives_Native.Some
                                                        hd1))
-                                              | uu____5414 ->
+                                              | uu____5425 ->
                                                   (FStar_Pervasives_Native.None,
                                                     FStar_Pervasives_Native.None)
                                                in
-                                            (match uu____5354 with
+                                            (match uu____5365 with
                                              | (f_ty_opt2,expected_ty) ->
-                                                 let uu____5485 =
+                                                 let uu____5496 =
                                                    extract_one_pat false g2
                                                      p1 expected_ty
                                                      term_as_mlexpr
                                                     in
-                                                 (match uu____5485 with
-                                                  | (g3,p2,uu____5528) ->
+                                                 (match uu____5496 with
+                                                  | (g3,p2,uu____5539) ->
                                                       ((g3, f_ty_opt2), p2))))
                                    (g1, f_ty_opt) restPats
                                   in
-                               (match uu____5190 with
+                               (match uu____5201 with
                                 | ((g2,f_ty_opt1),restMLPats) ->
-                                    let uu____5649 =
-                                      let uu____5660 =
+                                    let uu____5660 =
+                                      let uu____5671 =
                                         FStar_All.pipe_right
                                           (FStar_List.append tyMLPats
                                              restMLPats)
                                           (FStar_List.collect
-                                             (fun uu___0_5711  ->
-                                                match uu___0_5711 with
+                                             (fun uu___0_5722  ->
+                                                match uu___0_5722 with
                                                 | FStar_Pervasives_Native.Some
                                                     x -> [x]
-                                                | uu____5753 -> []))
+                                                | uu____5764 -> []))
                                          in
-                                      FStar_All.pipe_right uu____5660
+                                      FStar_All.pipe_right uu____5671
                                         FStar_List.split
                                        in
-                                    (match uu____5649 with
+                                    (match uu____5660 with
                                      | (mlPats,when_clauses) ->
                                          let pat_ty_compat =
                                            match f_ty_opt1 with
                                            | FStar_Pervasives_Native.Some
                                                ([],t) -> ok t
-                                           | uu____5829 -> false  in
-                                         let uu____5839 =
-                                           let uu____5848 =
-                                             let uu____5855 =
+                                           | uu____5840 -> false  in
+                                         let uu____5850 =
+                                           let uu____5859 =
+                                             let uu____5866 =
                                                resugar_pat
                                                  f.FStar_Syntax_Syntax.fv_qual
                                                  (FStar_Extraction_ML_Syntax.MLP_CTor
                                                     (d, mlPats))
                                                 in
-                                             let uu____5858 =
+                                             let uu____5869 =
                                                FStar_All.pipe_right
                                                  when_clauses
                                                  FStar_List.flatten
                                                 in
-                                             (uu____5855, uu____5858)  in
+                                             (uu____5866, uu____5869)  in
                                            FStar_Pervasives_Native.Some
-                                             uu____5848
+                                             uu____5859
                                             in
-                                         (g2, uu____5839, pat_ty_compat))))))
+                                         (g2, uu____5850, pat_ty_compat))))))
   
 let (extract_pat :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1663,27 +1666,27 @@ let (extract_pat :
       fun expected_t  ->
         fun term_as_mlexpr  ->
           let extract_one_pat1 g1 p1 expected_t1 =
-            let uu____5990 =
+            let uu____6001 =
               extract_one_pat false g1 p1 expected_t1 term_as_mlexpr  in
-            match uu____5990 with
+            match uu____6001 with
             | (g2,FStar_Pervasives_Native.Some (x,v1),b) -> (g2, (x, v1), b)
-            | uu____6053 ->
+            | uu____6064 ->
                 failwith "Impossible: Unable to translate pattern"
              in
           let mk_when_clause whens =
             match whens with
             | [] -> FStar_Pervasives_Native.None
             | hd1::tl1 ->
-                let uu____6101 =
+                let uu____6112 =
                   FStar_List.fold_left FStar_Extraction_ML_Util.conjoin hd1
                     tl1
                    in
-                FStar_Pervasives_Native.Some uu____6101
+                FStar_Pervasives_Native.Some uu____6112
              in
-          let uu____6102 =
+          let uu____6113 =
             extract_one_pat1 g p (FStar_Pervasives_Native.Some expected_t)
              in
-          match uu____6102 with
+          match uu____6113 with
           | (g1,(p1,whens),b) ->
               let when_clause = mk_when_clause whens  in
               (g1, [(p1, when_clause)], b)
@@ -1701,40 +1704,40 @@ let (maybe_eta_data_and_project_record :
         fun mlAppExpr  ->
           let rec eta_args more_args t =
             match t with
-            | FStar_Extraction_ML_Syntax.MLTY_Fun (t0,uu____6262,t1) ->
+            | FStar_Extraction_ML_Syntax.MLTY_Fun (t0,uu____6273,t1) ->
                 let x = FStar_Extraction_ML_Syntax.gensym ()  in
-                let uu____6266 =
-                  let uu____6278 =
-                    let uu____6288 =
+                let uu____6277 =
+                  let uu____6289 =
+                    let uu____6299 =
                       FStar_All.pipe_left
                         (FStar_Extraction_ML_Syntax.with_ty t0)
                         (FStar_Extraction_ML_Syntax.MLE_Var x)
                        in
-                    ((x, t0), uu____6288)  in
-                  uu____6278 :: more_args  in
-                eta_args uu____6266 t1
-            | FStar_Extraction_ML_Syntax.MLTY_Named (uu____6304,uu____6305)
+                    ((x, t0), uu____6299)  in
+                  uu____6289 :: more_args  in
+                eta_args uu____6277 t1
+            | FStar_Extraction_ML_Syntax.MLTY_Named (uu____6315,uu____6316)
                 -> ((FStar_List.rev more_args), t)
-            | uu____6330 ->
-                let uu____6331 =
-                  let uu____6333 =
+            | uu____6341 ->
+                let uu____6342 =
+                  let uu____6344 =
                     FStar_Extraction_ML_Code.string_of_mlexpr
                       g.FStar_Extraction_ML_UEnv.currentModule mlAppExpr
                      in
-                  let uu____6335 =
+                  let uu____6346 =
                     FStar_Extraction_ML_Code.string_of_mlty
                       g.FStar_Extraction_ML_UEnv.currentModule t
                      in
                   FStar_Util.format2
                     "Impossible: Head type is not an arrow: (%s : %s)"
-                    uu____6333 uu____6335
+                    uu____6344 uu____6346
                    in
-                failwith uu____6331
+                failwith uu____6342
              in
           let as_record qual1 e =
             match ((e.FStar_Extraction_ML_Syntax.expr), qual1) with
             | (FStar_Extraction_ML_Syntax.MLE_CTor
-               (uu____6370,args),FStar_Pervasives_Native.Some
+               (uu____6381,args),FStar_Pervasives_Native.Some
                (FStar_Syntax_Syntax.Record_ctor (tyname,fields))) ->
                 let path =
                   FStar_List.map FStar_Ident.text_of_id tyname.FStar_Ident.ns
@@ -1744,25 +1747,25 @@ let (maybe_eta_data_and_project_record :
                   (FStar_Extraction_ML_Syntax.with_ty
                      e.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_Record (path, fields1))
-            | uu____6407 -> e  in
+            | uu____6418 -> e  in
           let resugar_and_maybe_eta qual1 e =
-            let uu____6429 = eta_args [] residualType  in
-            match uu____6429 with
+            let uu____6440 = eta_args [] residualType  in
+            match uu____6440 with
             | (eargs,tres) ->
                 (match eargs with
                  | [] ->
-                     let uu____6487 = as_record qual1 e  in
-                     FStar_Extraction_ML_Util.resugar_exp uu____6487
-                 | uu____6488 ->
-                     let uu____6500 = FStar_List.unzip eargs  in
-                     (match uu____6500 with
+                     let uu____6498 = as_record qual1 e  in
+                     FStar_Extraction_ML_Util.resugar_exp uu____6498
+                 | uu____6499 ->
+                     let uu____6511 = FStar_List.unzip eargs  in
+                     (match uu____6511 with
                       | (binders,eargs1) ->
                           (match e.FStar_Extraction_ML_Syntax.expr with
                            | FStar_Extraction_ML_Syntax.MLE_CTor (head1,args)
                                ->
                                let body =
-                                 let uu____6546 =
-                                   let uu____6547 =
+                                 let uu____6557 =
+                                   let uu____6558 =
                                      FStar_All.pipe_left
                                        (FStar_Extraction_ML_Syntax.with_ty
                                           tres)
@@ -1771,28 +1774,28 @@ let (maybe_eta_data_and_project_record :
                                             (FStar_List.append args eargs1)))
                                       in
                                    FStar_All.pipe_left (as_record qual1)
-                                     uu____6547
+                                     uu____6558
                                     in
                                  FStar_All.pipe_left
                                    FStar_Extraction_ML_Util.resugar_exp
-                                   uu____6546
+                                   uu____6557
                                   in
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     e.FStar_Extraction_ML_Syntax.mlty)
                                  (FStar_Extraction_ML_Syntax.MLE_Fun
                                     (binders, body))
-                           | uu____6557 ->
+                           | uu____6568 ->
                                failwith "Impossible: Not a constructor")))
              in
           match ((mlAppExpr.FStar_Extraction_ML_Syntax.expr), qual) with
-          | (uu____6561,FStar_Pervasives_Native.None ) -> mlAppExpr
+          | (uu____6572,FStar_Pervasives_Native.None ) -> mlAppExpr
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6565;
-                FStar_Extraction_ML_Syntax.loc = uu____6566;_},mle::args),FStar_Pervasives_Native.Some
+                FStar_Extraction_ML_Syntax.mlty = uu____6576;
+                FStar_Extraction_ML_Syntax.loc = uu____6577;_},mle::args),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
               let f1 =
                 FStar_Ident.lid_of_ids
@@ -1803,15 +1806,15 @@ let (maybe_eta_data_and_project_record :
               let e =
                 match args with
                 | [] -> proj
-                | uu____6589 ->
-                    let uu____6592 =
-                      let uu____6599 =
+                | uu____6600 ->
+                    let uu____6603 =
+                      let uu____6610 =
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
                              FStar_Extraction_ML_Syntax.MLTY_Top) proj
                          in
-                      (uu____6599, args)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____6592
+                      (uu____6610, args)  in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____6603
                  in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
@@ -1822,10 +1825,10 @@ let (maybe_eta_data_and_project_record :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6603;
-                     FStar_Extraction_ML_Syntax.loc = uu____6604;_},uu____6605);
-                FStar_Extraction_ML_Syntax.mlty = uu____6606;
-                FStar_Extraction_ML_Syntax.loc = uu____6607;_},mle::args),FStar_Pervasives_Native.Some
+                     FStar_Extraction_ML_Syntax.mlty = uu____6614;
+                     FStar_Extraction_ML_Syntax.loc = uu____6615;_},uu____6616);
+                FStar_Extraction_ML_Syntax.mlty = uu____6617;
+                FStar_Extraction_ML_Syntax.loc = uu____6618;_},mle::args),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Record_projector (constrname,f))) ->
               let f1 =
                 FStar_Ident.lid_of_ids
@@ -1836,15 +1839,15 @@ let (maybe_eta_data_and_project_record :
               let e =
                 match args with
                 | [] -> proj
-                | uu____6634 ->
-                    let uu____6637 =
-                      let uu____6644 =
+                | uu____6645 ->
+                    let uu____6648 =
+                      let uu____6655 =
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty
                              FStar_Extraction_ML_Syntax.MLTY_Top) proj
                          in
-                      (uu____6644, args)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____6637
+                      (uu____6655, args)  in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____6648
                  in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
@@ -1852,30 +1855,30 @@ let (maybe_eta_data_and_project_record :
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6648;
-                FStar_Extraction_ML_Syntax.loc = uu____6649;_},mlargs),FStar_Pervasives_Native.Some
+                FStar_Extraction_ML_Syntax.mlty = uu____6659;
+                FStar_Extraction_ML_Syntax.loc = uu____6660;_},mlargs),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Data_ctor )) ->
-              let uu____6657 =
+              let uu____6668 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6657
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6668
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6661;
-                FStar_Extraction_ML_Syntax.loc = uu____6662;_},mlargs),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6664)) ->
-              let uu____6677 =
+                FStar_Extraction_ML_Syntax.mlty = uu____6672;
+                FStar_Extraction_ML_Syntax.loc = uu____6673;_},mlargs),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_ctor uu____6675)) ->
+              let uu____6688 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6677
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6688
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -1883,18 +1886,18 @@ let (maybe_eta_data_and_project_record :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6681;
-                     FStar_Extraction_ML_Syntax.loc = uu____6682;_},uu____6683);
-                FStar_Extraction_ML_Syntax.mlty = uu____6684;
-                FStar_Extraction_ML_Syntax.loc = uu____6685;_},mlargs),FStar_Pervasives_Native.Some
+                     FStar_Extraction_ML_Syntax.mlty = uu____6692;
+                     FStar_Extraction_ML_Syntax.loc = uu____6693;_},uu____6694);
+                FStar_Extraction_ML_Syntax.mlty = uu____6695;
+                FStar_Extraction_ML_Syntax.loc = uu____6696;_},mlargs),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Data_ctor )) ->
-              let uu____6697 =
+              let uu____6708 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6697
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6708
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -1902,67 +1905,67 @@ let (maybe_eta_data_and_project_record :
                   ({
                      FStar_Extraction_ML_Syntax.expr =
                        FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                     FStar_Extraction_ML_Syntax.mlty = uu____6701;
-                     FStar_Extraction_ML_Syntax.loc = uu____6702;_},uu____6703);
-                FStar_Extraction_ML_Syntax.mlty = uu____6704;
-                FStar_Extraction_ML_Syntax.loc = uu____6705;_},mlargs),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6707)) ->
-              let uu____6724 =
+                     FStar_Extraction_ML_Syntax.mlty = uu____6712;
+                     FStar_Extraction_ML_Syntax.loc = uu____6713;_},uu____6714);
+                FStar_Extraction_ML_Syntax.mlty = uu____6715;
+                FStar_Extraction_ML_Syntax.loc = uu____6716;_},mlargs),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_ctor uu____6718)) ->
+              let uu____6735 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6724
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6735
           | (FStar_Extraction_ML_Syntax.MLE_Name
              mlp,FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor
              )) ->
-              let uu____6730 =
+              let uu____6741 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6730
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6741
           | (FStar_Extraction_ML_Syntax.MLE_Name
              mlp,FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6734)) ->
-              let uu____6743 =
+             (FStar_Syntax_Syntax.Record_ctor uu____6745)) ->
+              let uu____6754 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6743
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6754
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6747;
-                FStar_Extraction_ML_Syntax.loc = uu____6748;_},uu____6749),FStar_Pervasives_Native.Some
+                FStar_Extraction_ML_Syntax.mlty = uu____6758;
+                FStar_Extraction_ML_Syntax.loc = uu____6759;_},uu____6760),FStar_Pervasives_Native.Some
              (FStar_Syntax_Syntax.Data_ctor )) ->
-              let uu____6756 =
+              let uu____6767 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6756
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6767
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
                   FStar_Extraction_ML_Syntax.MLE_Name mlp;
-                FStar_Extraction_ML_Syntax.mlty = uu____6760;
-                FStar_Extraction_ML_Syntax.loc = uu____6761;_},uu____6762),FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Record_ctor uu____6763)) ->
-              let uu____6776 =
+                FStar_Extraction_ML_Syntax.mlty = uu____6771;
+                FStar_Extraction_ML_Syntax.loc = uu____6772;_},uu____6773),FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Record_ctor uu____6774)) ->
+              let uu____6787 =
                 FStar_All.pipe_left
                   (FStar_Extraction_ML_Syntax.with_ty
                      mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, []))
                  in
-              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6776
-          | uu____6779 -> mlAppExpr
+              FStar_All.pipe_left (resugar_and_maybe_eta qual) uu____6787
+          | uu____6790 -> mlAppExpr
   
 let (maybe_promote_effect :
   FStar_Extraction_ML_Syntax.mlexpr ->
@@ -1983,7 +1986,7 @@ let (maybe_promote_effect :
            ,FStar_Extraction_ML_Syntax.MLTY_Erased ) ->
             (FStar_Extraction_ML_Syntax.ml_unit,
               FStar_Extraction_ML_Syntax.E_PURE)
-        | uu____6810 -> (ml_e, tag)
+        | uu____6821 -> (ml_e, tag)
   
 let (extract_lb_sig :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1995,26 +1998,26 @@ let (extract_lb_sig :
   =
   fun g  ->
     fun lbs  ->
-      let maybe_generalize uu____6871 =
-        match uu____6871 with
+      let maybe_generalize uu____6882 =
+        match uu____6882 with
         | { FStar_Syntax_Syntax.lbname = lbname_;
-            FStar_Syntax_Syntax.lbunivs = uu____6892;
+            FStar_Syntax_Syntax.lbunivs = uu____6903;
             FStar_Syntax_Syntax.lbtyp = lbtyp;
             FStar_Syntax_Syntax.lbeff = lbeff;
             FStar_Syntax_Syntax.lbdef = lbdef;
-            FStar_Syntax_Syntax.lbattrs = uu____6896;
-            FStar_Syntax_Syntax.lbpos = uu____6897;_} ->
+            FStar_Syntax_Syntax.lbattrs = uu____6907;
+            FStar_Syntax_Syntax.lbpos = uu____6908;_} ->
             let f_e = effect_as_etag g lbeff  in
             let lbtyp1 = FStar_Syntax_Subst.compress lbtyp  in
-            let no_gen uu____6978 =
+            let no_gen uu____6989 =
               let expected_t = term_as_mlty g lbtyp1  in
               (lbname_, f_e, (lbtyp1, ([], ([], expected_t))), false, lbdef)
                in
-            let uu____7055 =
+            let uu____7066 =
               FStar_TypeChecker_Util.must_erase_for_extraction
                 g.FStar_Extraction_ML_UEnv.env_tcenv lbtyp1
                in
-            if uu____7055
+            if uu____7066
             then
               (lbname_, f_e,
                 (lbtyp1, ([], ([], FStar_Extraction_ML_Syntax.MLTY_Erased))),
@@ -2022,71 +2025,71 @@ let (extract_lb_sig :
             else
               (match lbtyp1.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
-                   let uu____7141 = FStar_List.hd bs  in
-                   FStar_All.pipe_right uu____7141 (is_type_binder g) ->
-                   let uu____7163 = FStar_Syntax_Subst.open_comp bs c  in
-                   (match uu____7163 with
+                   let uu____7152 = FStar_List.hd bs  in
+                   FStar_All.pipe_right uu____7152 (is_type_binder g) ->
+                   let uu____7174 = FStar_Syntax_Subst.open_comp bs c  in
+                   (match uu____7174 with
                     | (bs1,c1) ->
-                        let uu____7189 =
-                          let uu____7202 =
+                        let uu____7200 =
+                          let uu____7213 =
                             FStar_Util.prefix_until
                               (fun x  ->
-                                 let uu____7248 = is_type_binder g x  in
-                                 Prims.op_Negation uu____7248) bs1
+                                 let uu____7259 = is_type_binder g x  in
+                                 Prims.op_Negation uu____7259) bs1
                              in
-                          match uu____7202 with
+                          match uu____7213 with
                           | FStar_Pervasives_Native.None  ->
                               (bs1, (FStar_Syntax_Util.comp_result c1))
                           | FStar_Pervasives_Native.Some (bs2,b,rest) ->
-                              let uu____7375 =
+                              let uu____7386 =
                                 FStar_Syntax_Util.arrow (b :: rest) c1  in
-                              (bs2, uu____7375)
+                              (bs2, uu____7386)
                            in
-                        (match uu____7189 with
+                        (match uu____7200 with
                          | (tbinders,tbody) ->
                              let n_tbinders = FStar_List.length tbinders  in
                              let lbdef1 =
-                               let uu____7437 = normalize_abs lbdef  in
-                               FStar_All.pipe_right uu____7437
+                               let uu____7448 = normalize_abs lbdef  in
+                               FStar_All.pipe_right uu____7448
                                  FStar_Syntax_Util.unmeta
                                 in
                              (match lbdef1.FStar_Syntax_Syntax.n with
                               | FStar_Syntax_Syntax.Tm_abs (bs2,body,copt) ->
-                                  let uu____7486 =
+                                  let uu____7497 =
                                     FStar_Syntax_Subst.open_term bs2 body  in
-                                  (match uu____7486 with
+                                  (match uu____7497 with
                                    | (bs3,body1) ->
                                        if
                                          n_tbinders <=
                                            (FStar_List.length bs3)
                                        then
-                                         let uu____7538 =
+                                         let uu____7549 =
                                            FStar_Util.first_N n_tbinders bs3
                                             in
-                                         (match uu____7538 with
+                                         (match uu____7549 with
                                           | (targs,rest_args) ->
                                               let expected_source_ty =
                                                 let s =
                                                   FStar_List.map2
-                                                    (fun uu____7641  ->
-                                                       fun uu____7642  ->
-                                                         match (uu____7641,
-                                                                 uu____7642)
+                                                    (fun uu____7652  ->
+                                                       fun uu____7653  ->
+                                                         match (uu____7652,
+                                                                 uu____7653)
                                                          with
-                                                         | ((x,uu____7668),
-                                                            (y,uu____7670))
+                                                         | ((x,uu____7679),
+                                                            (y,uu____7681))
                                                              ->
-                                                             let uu____7691 =
-                                                               let uu____7698
+                                                             let uu____7702 =
+                                                               let uu____7709
                                                                  =
                                                                  FStar_Syntax_Syntax.bv_to_name
                                                                    y
                                                                   in
                                                                (x,
-                                                                 uu____7698)
+                                                                 uu____7709)
                                                                 in
                                                              FStar_Syntax_Syntax.NT
-                                                               uu____7691)
+                                                               uu____7702)
                                                     tbinders targs
                                                    in
                                                 FStar_Syntax_Subst.subst s
@@ -2095,9 +2098,9 @@ let (extract_lb_sig :
                                               let env =
                                                 FStar_List.fold_left
                                                   (fun env  ->
-                                                     fun uu____7715  ->
-                                                       match uu____7715 with
-                                                       | (a,uu____7723) ->
+                                                     fun uu____7726  ->
+                                                       match uu____7726 with
+                                                       | (a,uu____7734) ->
                                                            FStar_Extraction_ML_UEnv.extend_ty
                                                              env a
                                                              FStar_Pervasives_Native.None)
@@ -2108,33 +2111,33 @@ let (extract_lb_sig :
                                                   expected_source_ty
                                                  in
                                               let polytype =
-                                                let uu____7734 =
+                                                let uu____7745 =
                                                   FStar_All.pipe_right targs
                                                     (FStar_List.map
-                                                       (fun uu____7753  ->
-                                                          match uu____7753
+                                                       (fun uu____7764  ->
+                                                          match uu____7764
                                                           with
-                                                          | (x,uu____7762) ->
+                                                          | (x,uu____7773) ->
                                                               FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
                                                                 x))
                                                    in
-                                                (uu____7734, expected_t)  in
+                                                (uu____7745, expected_t)  in
                                               let add_unit =
                                                 match rest_args with
                                                 | [] ->
-                                                    (let uu____7778 =
+                                                    (let uu____7789 =
                                                        is_fstar_value body1
                                                         in
                                                      Prims.op_Negation
-                                                       uu____7778)
+                                                       uu____7789)
                                                       ||
-                                                      (let uu____7781 =
+                                                      (let uu____7792 =
                                                          FStar_Syntax_Util.is_pure_comp
                                                            c1
                                                           in
                                                        Prims.op_Negation
-                                                         uu____7781)
-                                                | uu____7783 -> false  in
+                                                         uu____7792)
+                                                | uu____7794 -> false  in
                                               let rest_args1 =
                                                 if add_unit
                                                 then unit_binder :: rest_args
@@ -2154,13 +2157,13 @@ let (extract_lb_sig :
                                                 add_unit, body2))
                                        else
                                          failwith "Not enough type binders")
-                              | FStar_Syntax_Syntax.Tm_uinst uu____7845 ->
+                              | FStar_Syntax_Syntax.Tm_uinst uu____7856 ->
                                   let env =
                                     FStar_List.fold_left
                                       (fun env  ->
-                                         fun uu____7864  ->
-                                           match uu____7864 with
-                                           | (a,uu____7872) ->
+                                         fun uu____7875  ->
+                                           match uu____7875 with
+                                           | (a,uu____7883) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
                                                  env a
                                                  FStar_Pervasives_Native.None)
@@ -2168,28 +2171,28 @@ let (extract_lb_sig :
                                      in
                                   let expected_t = term_as_mlty env tbody  in
                                   let polytype =
-                                    let uu____7883 =
+                                    let uu____7894 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____7902  ->
-                                              match uu____7902 with
-                                              | (x,uu____7911) ->
+                                           (fun uu____7913  ->
+                                              match uu____7913 with
+                                              | (x,uu____7922) ->
                                                   FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
                                                     x))
                                        in
-                                    (uu____7883, expected_t)  in
+                                    (uu____7894, expected_t)  in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____7955  ->
-                                            match uu____7955 with
-                                            | (bv,uu____7963) ->
-                                                let uu____7968 =
+                                         (fun uu____7966  ->
+                                            match uu____7966 with
+                                            | (bv,uu____7974) ->
+                                                let uu____7979 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____7968
+                                                  uu____7979
                                                   FStar_Syntax_Syntax.as_arg))
                                      in
                                   let e =
@@ -2201,13 +2204,13 @@ let (extract_lb_sig :
                                      in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | FStar_Syntax_Syntax.Tm_fvar uu____7998 ->
+                              | FStar_Syntax_Syntax.Tm_fvar uu____8009 ->
                                   let env =
                                     FStar_List.fold_left
                                       (fun env  ->
-                                         fun uu____8011  ->
-                                           match uu____8011 with
-                                           | (a,uu____8019) ->
+                                         fun uu____8022  ->
+                                           match uu____8022 with
+                                           | (a,uu____8030) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
                                                  env a
                                                  FStar_Pervasives_Native.None)
@@ -2215,28 +2218,28 @@ let (extract_lb_sig :
                                      in
                                   let expected_t = term_as_mlty env tbody  in
                                   let polytype =
-                                    let uu____8030 =
+                                    let uu____8041 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____8049  ->
-                                              match uu____8049 with
-                                              | (x,uu____8058) ->
+                                           (fun uu____8060  ->
+                                              match uu____8060 with
+                                              | (x,uu____8069) ->
                                                   FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
                                                     x))
                                        in
-                                    (uu____8030, expected_t)  in
+                                    (uu____8041, expected_t)  in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____8102  ->
-                                            match uu____8102 with
-                                            | (bv,uu____8110) ->
-                                                let uu____8115 =
+                                         (fun uu____8113  ->
+                                            match uu____8113 with
+                                            | (bv,uu____8121) ->
+                                                let uu____8126 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____8115
+                                                  uu____8126
                                                   FStar_Syntax_Syntax.as_arg))
                                      in
                                   let e =
@@ -2248,13 +2251,13 @@ let (extract_lb_sig :
                                      in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | FStar_Syntax_Syntax.Tm_name uu____8145 ->
+                              | FStar_Syntax_Syntax.Tm_name uu____8156 ->
                                   let env =
                                     FStar_List.fold_left
                                       (fun env  ->
-                                         fun uu____8158  ->
-                                           match uu____8158 with
-                                           | (a,uu____8166) ->
+                                         fun uu____8169  ->
+                                           match uu____8169 with
+                                           | (a,uu____8177) ->
                                                FStar_Extraction_ML_UEnv.extend_ty
                                                  env a
                                                  FStar_Pervasives_Native.None)
@@ -2262,28 +2265,28 @@ let (extract_lb_sig :
                                      in
                                   let expected_t = term_as_mlty env tbody  in
                                   let polytype =
-                                    let uu____8177 =
+                                    let uu____8188 =
                                       FStar_All.pipe_right tbinders
                                         (FStar_List.map
-                                           (fun uu____8196  ->
-                                              match uu____8196 with
-                                              | (x,uu____8205) ->
+                                           (fun uu____8207  ->
+                                              match uu____8207 with
+                                              | (x,uu____8216) ->
                                                   FStar_Extraction_ML_UEnv.bv_as_ml_tyvar
                                                     x))
                                        in
-                                    (uu____8177, expected_t)  in
+                                    (uu____8188, expected_t)  in
                                   let args =
                                     FStar_All.pipe_right tbinders
                                       (FStar_List.map
-                                         (fun uu____8249  ->
-                                            match uu____8249 with
-                                            | (bv,uu____8257) ->
-                                                let uu____8262 =
+                                         (fun uu____8260  ->
+                                            match uu____8260 with
+                                            | (bv,uu____8268) ->
+                                                let uu____8273 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     bv
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____8262
+                                                  uu____8273
                                                   FStar_Syntax_Syntax.as_arg))
                                      in
                                   let e =
@@ -2295,8 +2298,8 @@ let (extract_lb_sig :
                                      in
                                   (lbname_, f_e,
                                     (lbtyp1, (tbinders, polytype)), false, e)
-                              | uu____8292 -> err_value_restriction lbdef1)))
-               | uu____8312 -> no_gen ())
+                              | uu____8303 -> err_value_restriction lbdef1)))
+               | uu____8323 -> no_gen ())
          in
       FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
         (FStar_List.map maybe_generalize)
@@ -2317,19 +2320,19 @@ let (extract_lb_iface :
       let lbs1 = extract_lb_sig g lbs  in
       FStar_Util.fold_map
         (fun env  ->
-           fun uu____8463  ->
-             match uu____8463 with
+           fun uu____8474  ->
+             match uu____8474 with
              | (lbname,e_tag,(typ,(binders,mltyscheme)),add_unit,_body) ->
-                 let uu____8524 =
+                 let uu____8535 =
                    FStar_Extraction_ML_UEnv.extend_lb env lbname typ
                      mltyscheme add_unit is_rec
                     in
-                 (match uu____8524 with
-                  | (env1,uu____8541,exp_binding) ->
-                      let uu____8545 =
-                        let uu____8550 = FStar_Util.right lbname  in
-                        (uu____8550, exp_binding)  in
-                      (env1, uu____8545))) g lbs1
+                 (match uu____8535 with
+                  | (env1,uu____8552,exp_binding) ->
+                      let uu____8556 =
+                        let uu____8561 = FStar_Util.right lbname  in
+                        (uu____8561, exp_binding)  in
+                      (env1, uu____8556))) g lbs1
   
 let rec (check_term_as_mlexpr :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2344,55 +2347,55 @@ let rec (check_term_as_mlexpr :
       fun f  ->
         fun ty  ->
           FStar_Extraction_ML_UEnv.debug g
-            (fun uu____8616  ->
-               let uu____8617 = FStar_Syntax_Print.term_to_string e  in
-               let uu____8619 =
+            (fun uu____8627  ->
+               let uu____8628 = FStar_Syntax_Print.term_to_string e  in
+               let uu____8630 =
                  FStar_Extraction_ML_Code.string_of_mlty
                    g.FStar_Extraction_ML_UEnv.currentModule ty
                   in
-               FStar_Util.print2 "Checking %s at type %s\n" uu____8617
-                 uu____8619);
+               FStar_Util.print2 "Checking %s at type %s\n" uu____8628
+                 uu____8630);
           (match (f, ty) with
-           | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____8626) ->
+           | (FStar_Extraction_ML_Syntax.E_GHOST ,uu____8637) ->
                (FStar_Extraction_ML_Syntax.ml_unit,
                  FStar_Extraction_ML_Syntax.MLTY_Erased)
            | (FStar_Extraction_ML_Syntax.E_PURE
               ,FStar_Extraction_ML_Syntax.MLTY_Erased ) ->
                (FStar_Extraction_ML_Syntax.ml_unit,
                  FStar_Extraction_ML_Syntax.MLTY_Erased)
-           | uu____8627 ->
-               let uu____8632 = term_as_mlexpr g e  in
-               (match uu____8632 with
+           | uu____8638 ->
+               let uu____8643 = term_as_mlexpr g e  in
+               (match uu____8643 with
                 | (ml_e,tag,t) ->
-                    let uu____8646 = maybe_promote_effect ml_e tag t  in
-                    (match uu____8646 with
+                    let uu____8657 = maybe_promote_effect ml_e tag t  in
+                    (match uu____8657 with
                      | (ml_e1,tag1) ->
-                         let uu____8657 =
+                         let uu____8668 =
                            FStar_Extraction_ML_Util.eff_leq tag1 f  in
-                         if uu____8657
+                         if uu____8668
                          then
-                           let uu____8664 =
+                           let uu____8675 =
                              maybe_coerce e.FStar_Syntax_Syntax.pos g ml_e1 t
                                ty
                               in
-                           (uu____8664, ty)
+                           (uu____8675, ty)
                          else
                            (match (tag1, f, ty) with
                             | (FStar_Extraction_ML_Syntax.E_GHOST
                                ,FStar_Extraction_ML_Syntax.E_PURE
                                ,FStar_Extraction_ML_Syntax.MLTY_Erased ) ->
-                                let uu____8671 =
+                                let uu____8682 =
                                   maybe_coerce e.FStar_Syntax_Syntax.pos g
                                     ml_e1 t ty
                                    in
-                                (uu____8671, ty)
-                            | uu____8672 ->
+                                (uu____8682, ty)
+                            | uu____8683 ->
                                 (err_unexpected_eff g e ty f tag1;
-                                 (let uu____8680 =
+                                 (let uu____8691 =
                                     maybe_coerce e.FStar_Syntax_Syntax.pos g
                                       ml_e1 t ty
                                      in
-                                  (uu____8680, ty)))))))
+                                  (uu____8691, ty)))))))
 
 and (term_as_mlexpr :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2402,11 +2405,11 @@ and (term_as_mlexpr :
   =
   fun g  ->
     fun e  ->
-      let uu____8683 = term_as_mlexpr' g e  in
-      match uu____8683 with
+      let uu____8694 = term_as_mlexpr' g e  in
+      match uu____8694 with
       | (e1,f,t) ->
-          let uu____8699 = maybe_promote_effect e1 f t  in
-          (match uu____8699 with | (e2,f1) -> (e2, f1, t))
+          let uu____8710 = maybe_promote_effect e1 f t  in
+          (match uu____8710 with | (e2,f1) -> (e2, f1, t))
 
 and (term_as_mlexpr' :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -2418,53 +2421,53 @@ and (term_as_mlexpr' :
     fun top  ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____8724 =
-             let uu____8726 =
+           let uu____8735 =
+             let uu____8737 =
                FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos  in
-             let uu____8728 = FStar_Syntax_Print.tag_of_term top  in
-             let uu____8730 = FStar_Syntax_Print.term_to_string top  in
+             let uu____8739 = FStar_Syntax_Print.tag_of_term top  in
+             let uu____8741 = FStar_Syntax_Print.term_to_string top  in
              FStar_Util.format3 "%s: term_as_mlexpr' (%s) :  %s \n"
-               uu____8726 uu____8728 uu____8730
+               uu____8737 uu____8739 uu____8741
               in
-           FStar_Util.print_string uu____8724);
+           FStar_Util.print_string uu____8735);
       (let t = FStar_Syntax_Subst.compress top  in
        match t.FStar_Syntax_Syntax.n with
        | FStar_Syntax_Syntax.Tm_unknown  ->
-           let uu____8740 =
-             let uu____8742 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8742
+           let uu____8751 =
+             let uu____8753 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8753
               in
-           failwith uu____8740
-       | FStar_Syntax_Syntax.Tm_delayed uu____8751 ->
-           let uu____8774 =
-             let uu____8776 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8776
+           failwith uu____8751
+       | FStar_Syntax_Syntax.Tm_delayed uu____8762 ->
+           let uu____8785 =
+             let uu____8787 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8787
               in
-           failwith uu____8774
-       | FStar_Syntax_Syntax.Tm_uvar uu____8785 ->
-           let uu____8798 =
-             let uu____8800 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8800
+           failwith uu____8785
+       | FStar_Syntax_Syntax.Tm_uvar uu____8796 ->
+           let uu____8809 =
+             let uu____8811 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8811
               in
-           failwith uu____8798
-       | FStar_Syntax_Syntax.Tm_bvar uu____8809 ->
-           let uu____8810 =
-             let uu____8812 = FStar_Syntax_Print.tag_of_term t  in
-             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8812
+           failwith uu____8809
+       | FStar_Syntax_Syntax.Tm_bvar uu____8820 ->
+           let uu____8821 =
+             let uu____8823 = FStar_Syntax_Print.tag_of_term t  in
+             FStar_Util.format1 "Impossible: Unexpected term: %s" uu____8823
               in
-           failwith uu____8810
+           failwith uu____8821
        | FStar_Syntax_Syntax.Tm_lazy i ->
-           let uu____8822 = FStar_Syntax_Util.unfold_lazy i  in
-           term_as_mlexpr g uu____8822
-       | FStar_Syntax_Syntax.Tm_type uu____8823 ->
+           let uu____8833 = FStar_Syntax_Util.unfold_lazy i  in
+           term_as_mlexpr g uu____8833
+       | FStar_Syntax_Syntax.Tm_type uu____8834 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
-       | FStar_Syntax_Syntax.Tm_refine uu____8824 ->
+       | FStar_Syntax_Syntax.Tm_refine uu____8835 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
-       | FStar_Syntax_Syntax.Tm_arrow uu____8831 ->
+       | FStar_Syntax_Syntax.Tm_arrow uu____8842 ->
            (FStar_Extraction_ML_Syntax.ml_unit,
              FStar_Extraction_ML_Syntax.E_PURE,
              FStar_Extraction_ML_Syntax.ml_unit_ty)
@@ -2472,25 +2475,25 @@ and (term_as_mlexpr' :
            (qt,{
                  FStar_Syntax_Syntax.qkind =
                    FStar_Syntax_Syntax.Quote_dynamic ;
-                 FStar_Syntax_Syntax.antiquotes = uu____8847;_})
+                 FStar_Syntax_Syntax.antiquotes = uu____8858;_})
            ->
-           let uu____8860 =
-             let uu____8861 =
+           let uu____8871 =
+             let uu____8872 =
                FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.failwith_lid
                  FStar_Syntax_Syntax.delta_constant
                  FStar_Pervasives_Native.None
                 in
-             FStar_Extraction_ML_UEnv.lookup_fv g uu____8861  in
-           (match uu____8860 with
-            | { FStar_Extraction_ML_UEnv.exp_b_name = uu____8868;
+             FStar_Extraction_ML_UEnv.lookup_fv g uu____8872  in
+           (match uu____8871 with
+            | { FStar_Extraction_ML_UEnv.exp_b_name = uu____8879;
                 FStar_Extraction_ML_UEnv.exp_b_expr = fw;
-                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu____8870;
-                FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____8871;_} ->
-                let uu____8874 =
-                  let uu____8875 =
-                    let uu____8876 =
-                      let uu____8883 =
-                        let uu____8886 =
+                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu____8881;
+                FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____8882;_} ->
+                let uu____8885 =
+                  let uu____8886 =
+                    let uu____8887 =
+                      let uu____8894 =
+                        let uu____8897 =
                           FStar_All.pipe_left
                             (FStar_Extraction_ML_Syntax.with_ty
                                FStar_Extraction_ML_Syntax.ml_string_ty)
@@ -2498,130 +2501,130 @@ and (term_as_mlexpr' :
                                (FStar_Extraction_ML_Syntax.MLC_String
                                   "Cannot evaluate open quotation at runtime"))
                            in
-                        [uu____8886]  in
-                      (fw, uu____8883)  in
-                    FStar_Extraction_ML_Syntax.MLE_App uu____8876  in
+                        [uu____8897]  in
+                      (fw, uu____8894)  in
+                    FStar_Extraction_ML_Syntax.MLE_App uu____8887  in
                   FStar_All.pipe_left
                     (FStar_Extraction_ML_Syntax.with_ty
-                       FStar_Extraction_ML_Syntax.ml_int_ty) uu____8875
+                       FStar_Extraction_ML_Syntax.ml_int_ty) uu____8886
                    in
-                (uu____8874, FStar_Extraction_ML_Syntax.E_PURE,
+                (uu____8885, FStar_Extraction_ML_Syntax.E_PURE,
                   FStar_Extraction_ML_Syntax.ml_int_ty))
        | FStar_Syntax_Syntax.Tm_quoted
            (qt,{
                  FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_static ;
                  FStar_Syntax_Syntax.antiquotes = aqs;_})
            ->
-           let uu____8904 = FStar_Reflection_Basic.inspect_ln qt  in
-           (match uu____8904 with
+           let uu____8915 = FStar_Reflection_Basic.inspect_ln qt  in
+           (match uu____8915 with
             | FStar_Reflection_Data.Tv_Var bv ->
-                let uu____8912 = FStar_Syntax_Syntax.lookup_aq bv aqs  in
-                (match uu____8912 with
+                let uu____8923 = FStar_Syntax_Syntax.lookup_aq bv aqs  in
+                (match uu____8923 with
                  | FStar_Pervasives_Native.Some tm -> term_as_mlexpr g tm
                  | FStar_Pervasives_Native.None  ->
                      let tv =
-                       let uu____8923 =
-                         let uu____8930 =
+                       let uu____8934 =
+                         let uu____8941 =
                            FStar_Reflection_Embeddings.e_term_view_aq aqs  in
-                         FStar_Syntax_Embeddings.embed uu____8930
+                         FStar_Syntax_Embeddings.embed uu____8941
                            (FStar_Reflection_Data.Tv_Var bv)
                           in
-                       uu____8923 t.FStar_Syntax_Syntax.pos
+                       uu____8934 t.FStar_Syntax_Syntax.pos
                          FStar_Pervasives_Native.None
                          FStar_Syntax_Embeddings.id_norm_cb
                         in
                      let t1 =
-                       let uu____8938 =
-                         let uu____8949 = FStar_Syntax_Syntax.as_arg tv  in
-                         [uu____8949]  in
+                       let uu____8949 =
+                         let uu____8960 = FStar_Syntax_Syntax.as_arg tv  in
+                         [uu____8960]  in
                        FStar_Syntax_Util.mk_app
                          (FStar_Reflection_Data.refl_constant_term
                             FStar_Reflection_Data.fstar_refl_pack_ln)
-                         uu____8938
+                         uu____8949
                         in
                      term_as_mlexpr g t1)
             | tv ->
                 let tv1 =
-                  let uu____8976 =
-                    let uu____8983 =
+                  let uu____8987 =
+                    let uu____8994 =
                       FStar_Reflection_Embeddings.e_term_view_aq aqs  in
-                    FStar_Syntax_Embeddings.embed uu____8983 tv  in
-                  uu____8976 t.FStar_Syntax_Syntax.pos
+                    FStar_Syntax_Embeddings.embed uu____8994 tv  in
+                  uu____8987 t.FStar_Syntax_Syntax.pos
                     FStar_Pervasives_Native.None
                     FStar_Syntax_Embeddings.id_norm_cb
                    in
                 let t1 =
-                  let uu____8991 =
-                    let uu____9002 = FStar_Syntax_Syntax.as_arg tv1  in
-                    [uu____9002]  in
+                  let uu____9002 =
+                    let uu____9013 = FStar_Syntax_Syntax.as_arg tv1  in
+                    [uu____9013]  in
                   FStar_Syntax_Util.mk_app
                     (FStar_Reflection_Data.refl_constant_term
-                       FStar_Reflection_Data.fstar_refl_pack_ln) uu____8991
+                       FStar_Reflection_Data.fstar_refl_pack_ln) uu____9002
                    in
                 term_as_mlexpr g t1)
        | FStar_Syntax_Syntax.Tm_meta
-           (t1,FStar_Syntax_Syntax.Meta_monadic (m,uu____9029)) ->
+           (t1,FStar_Syntax_Syntax.Meta_monadic (m,uu____9040)) ->
            let t2 = FStar_Syntax_Subst.compress t1  in
            (match t2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) when
                 FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname ->
-                let uu____9062 =
-                  let uu____9069 =
+                let uu____9073 =
+                  let uu____9080 =
                     FStar_TypeChecker_Env.effect_decl_opt
                       g.FStar_Extraction_ML_UEnv.env_tcenv m
                      in
-                  FStar_Util.must uu____9069  in
-                (match uu____9062 with
+                  FStar_Util.must uu____9080  in
+                (match uu____9073 with
                  | (ed,qualifiers) ->
-                     let uu____9096 =
-                       let uu____9098 =
+                     let uu____9107 =
+                       let uu____9109 =
                          FStar_TypeChecker_Env.is_reifiable_effect
                            g.FStar_Extraction_ML_UEnv.env_tcenv
                            ed.FStar_Syntax_Syntax.mname
                           in
-                       Prims.op_Negation uu____9098  in
-                     if uu____9096
+                       Prims.op_Negation uu____9109  in
+                     if uu____9107
                      then term_as_mlexpr g t2
                      else
                        failwith
                          "This should not happen (should have been handled at Tm_abs level)")
-            | uu____9116 -> term_as_mlexpr g t2)
-       | FStar_Syntax_Syntax.Tm_meta (t1,uu____9118) -> term_as_mlexpr g t1
-       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____9124) -> term_as_mlexpr g t1
+            | uu____9127 -> term_as_mlexpr g t2)
+       | FStar_Syntax_Syntax.Tm_meta (t1,uu____9129) -> term_as_mlexpr g t1
+       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____9135) -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_constant c ->
-           let uu____9130 =
+           let uu____9141 =
              FStar_TypeChecker_TcTerm.type_of_tot_term
                g.FStar_Extraction_ML_UEnv.env_tcenv t
               in
-           (match uu____9130 with
-            | (uu____9143,ty,uu____9145) ->
+           (match uu____9141 with
+            | (uu____9154,ty,uu____9156) ->
                 let ml_ty = term_as_mlty g ty  in
-                let uu____9147 =
-                  let uu____9148 =
+                let uu____9158 =
+                  let uu____9159 =
                     FStar_Extraction_ML_Util.mlexpr_of_const
                       t.FStar_Syntax_Syntax.pos c
                      in
-                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____9148  in
-                (uu____9147, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
-       | FStar_Syntax_Syntax.Tm_name uu____9149 ->
-           let uu____9150 = is_type g t  in
-           if uu____9150
+                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu____9159  in
+                (uu____9158, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
+       | FStar_Syntax_Syntax.Tm_name uu____9160 ->
+           let uu____9161 = is_type g t  in
+           if uu____9161
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____9161 = FStar_Extraction_ML_UEnv.lookup_term g t  in
-              match uu____9161 with
-              | (FStar_Util.Inl uu____9174,uu____9175) ->
+             (let uu____9172 = FStar_Extraction_ML_UEnv.lookup_term g t  in
+              match uu____9172 with
+              | (FStar_Util.Inl uu____9185,uu____9186) ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
               | (FStar_Util.Inr
-                 { FStar_Extraction_ML_UEnv.exp_b_name = uu____9180;
+                 { FStar_Extraction_ML_UEnv.exp_b_name = uu____9191;
                    FStar_Extraction_ML_UEnv.exp_b_expr = x;
                    FStar_Extraction_ML_UEnv.exp_b_tscheme = mltys;
-                   FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____9183;_},qual)
+                   FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____9194;_},qual)
                   ->
                   (match mltys with
                    | ([],t1) when t1 = FStar_Extraction_ML_Syntax.ml_unit_ty
@@ -2629,143 +2632,143 @@ and (term_as_mlexpr' :
                        (FStar_Extraction_ML_Syntax.ml_unit,
                          FStar_Extraction_ML_Syntax.E_PURE, t1)
                    | ([],t1) ->
-                       let uu____9201 =
+                       let uu____9212 =
                          maybe_eta_data_and_project_record g qual t1 x  in
-                       (uu____9201, FStar_Extraction_ML_Syntax.E_PURE, t1)
-                   | uu____9202 -> instantiate_maybe_partial x mltys []))
+                       (uu____9212, FStar_Extraction_ML_Syntax.E_PURE, t1)
+                   | uu____9213 -> instantiate_maybe_partial x mltys []))
        | FStar_Syntax_Syntax.Tm_fvar fv ->
-           let uu____9204 = is_type g t  in
-           if uu____9204
+           let uu____9215 = is_type g t  in
+           if uu____9215
            then
              (FStar_Extraction_ML_Syntax.ml_unit,
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu____9215 = FStar_Extraction_ML_UEnv.try_lookup_fv g fv
+             (let uu____9226 = FStar_Extraction_ML_UEnv.try_lookup_fv g fv
                  in
-              match uu____9215 with
+              match uu____9226 with
               | FStar_Pervasives_Native.None  ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.MLTY_Erased)
               | FStar_Pervasives_Native.Some
-                  { FStar_Extraction_ML_UEnv.exp_b_name = uu____9224;
+                  { FStar_Extraction_ML_UEnv.exp_b_name = uu____9235;
                     FStar_Extraction_ML_UEnv.exp_b_expr = x;
                     FStar_Extraction_ML_UEnv.exp_b_tscheme = mltys;
-                    FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____9227;_}
+                    FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____9238;_}
                   ->
                   (FStar_Extraction_ML_UEnv.debug g
-                     (fun uu____9235  ->
-                        let uu____9236 = FStar_Syntax_Print.fv_to_string fv
+                     (fun uu____9246  ->
+                        let uu____9247 = FStar_Syntax_Print.fv_to_string fv
                            in
-                        let uu____9238 =
+                        let uu____9249 =
                           FStar_Extraction_ML_Code.string_of_mlexpr
                             g.FStar_Extraction_ML_UEnv.currentModule x
                            in
-                        let uu____9240 =
+                        let uu____9251 =
                           FStar_Extraction_ML_Code.string_of_mlty
                             g.FStar_Extraction_ML_UEnv.currentModule
                             (FStar_Pervasives_Native.snd mltys)
                            in
                         FStar_Util.print3 "looked up %s: got %s at %s \n"
-                          uu____9236 uu____9238 uu____9240);
+                          uu____9247 uu____9249 uu____9251);
                    (match mltys with
                     | ([],t1) when t1 = FStar_Extraction_ML_Syntax.ml_unit_ty
                         ->
                         (FStar_Extraction_ML_Syntax.ml_unit,
                           FStar_Extraction_ML_Syntax.E_PURE, t1)
                     | ([],t1) ->
-                        let uu____9253 =
+                        let uu____9264 =
                           maybe_eta_data_and_project_record g
                             fv.FStar_Syntax_Syntax.fv_qual t1 x
                            in
-                        (uu____9253, FStar_Extraction_ML_Syntax.E_PURE, t1)
-                    | uu____9254 -> instantiate_maybe_partial x mltys [])))
+                        (uu____9264, FStar_Extraction_ML_Syntax.E_PURE, t1)
+                    | uu____9265 -> instantiate_maybe_partial x mltys [])))
        | FStar_Syntax_Syntax.Tm_abs (bs,body,rcopt) ->
-           let uu____9282 = FStar_Syntax_Subst.open_term bs body  in
-           (match uu____9282 with
+           let uu____9293 = FStar_Syntax_Subst.open_term bs body  in
+           (match uu____9293 with
             | (bs1,body1) ->
-                let uu____9295 = binders_as_ml_binders g bs1  in
-                (match uu____9295 with
+                let uu____9306 = binders_as_ml_binders g bs1  in
+                (match uu____9306 with
                  | (ml_bs,env) ->
                      let body2 =
                        match rcopt with
                        | FStar_Pervasives_Native.Some rc ->
-                           let uu____9331 =
+                           let uu____9342 =
                              FStar_TypeChecker_Env.is_reifiable_rc
                                env.FStar_Extraction_ML_UEnv.env_tcenv rc
                               in
-                           if uu____9331
+                           if uu____9342
                            then
                              FStar_TypeChecker_Util.reify_body
                                env.FStar_Extraction_ML_UEnv.env_tcenv body1
                            else body1
                        | FStar_Pervasives_Native.None  ->
                            (FStar_Extraction_ML_UEnv.debug g
-                              (fun uu____9339  ->
-                                 let uu____9340 =
+                              (fun uu____9350  ->
+                                 let uu____9351 =
                                    FStar_Syntax_Print.term_to_string body1
                                     in
                                  FStar_Util.print1
-                                   "No computation type for: %s\n" uu____9340);
+                                   "No computation type for: %s\n" uu____9351);
                             body1)
                         in
-                     let uu____9343 = term_as_mlexpr env body2  in
-                     (match uu____9343 with
+                     let uu____9354 = term_as_mlexpr env body2  in
+                     (match uu____9354 with
                       | (ml_body,f,t1) ->
-                          let uu____9359 =
+                          let uu____9370 =
                             FStar_List.fold_right
-                              (fun uu____9379  ->
-                                 fun uu____9380  ->
-                                   match (uu____9379, uu____9380) with
-                                   | ((uu____9403,targ),(f1,t2)) ->
+                              (fun uu____9390  ->
+                                 fun uu____9391  ->
+                                   match (uu____9390, uu____9391) with
+                                   | ((uu____9414,targ),(f1,t2)) ->
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          (FStar_Extraction_ML_Syntax.MLTY_Fun
                                             (targ, f1, t2)))) ml_bs (f, t1)
                              in
-                          (match uu____9359 with
+                          (match uu____9370 with
                            | (f1,tfun) ->
-                               let uu____9426 =
+                               let uu____9437 =
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty tfun)
                                    (FStar_Extraction_ML_Syntax.MLE_Fun
                                       (ml_bs, ml_body))
                                   in
-                               (uu____9426, f1, tfun)))))
+                               (uu____9437, f1, tfun)))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of );
-              FStar_Syntax_Syntax.pos = uu____9434;
-              FStar_Syntax_Syntax.vars = uu____9435;_},(a1,uu____9437)::[])
+              FStar_Syntax_Syntax.pos = uu____9445;
+              FStar_Syntax_Syntax.vars = uu____9446;_},(a1,uu____9448)::[])
            ->
            let ty =
-             let uu____9477 =
+             let uu____9488 =
                FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid  in
-             term_as_mlty g uu____9477  in
-           let uu____9478 =
-             let uu____9479 =
+             term_as_mlty g uu____9488  in
+           let uu____9489 =
+             let uu____9490 =
                FStar_Extraction_ML_Util.mlexpr_of_range
                  a1.FStar_Syntax_Syntax.pos
                 in
              FStar_All.pipe_left (FStar_Extraction_ML_Syntax.with_ty ty)
-               uu____9479
+               uu____9490
               in
-           (uu____9478, FStar_Extraction_ML_Syntax.E_PURE, ty)
+           (uu____9489, FStar_Extraction_ML_Syntax.E_PURE, ty)
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of );
-              FStar_Syntax_Syntax.pos = uu____9480;
-              FStar_Syntax_Syntax.vars = uu____9481;_},(t1,uu____9483)::
-            (r,uu____9485)::[])
+              FStar_Syntax_Syntax.pos = uu____9491;
+              FStar_Syntax_Syntax.vars = uu____9492;_},(t1,uu____9494)::
+            (r,uu____9496)::[])
            -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu____9540);
-              FStar_Syntax_Syntax.pos = uu____9541;
-              FStar_Syntax_Syntax.vars = uu____9542;_},uu____9543)
+                (FStar_Const.Const_reflect uu____9551);
+              FStar_Syntax_Syntax.pos = uu____9552;
+              FStar_Syntax_Syntax.vars = uu____9553;_},uu____9554)
            -> failwith "Unreachable? Tm_app Const_reflect"
        | FStar_Syntax_Syntax.Tm_app (head1,args) ->
            let is_total rc =
@@ -2774,18 +2777,18 @@ and (term_as_mlexpr' :
                ||
                (FStar_All.pipe_right rc.FStar_Syntax_Syntax.residual_flags
                   (FStar_List.existsb
-                     (fun uu___1_9612  ->
-                        match uu___1_9612 with
+                     (fun uu___1_9623  ->
+                        match uu___1_9623 with
                         | FStar_Syntax_Syntax.TOTAL  -> true
-                        | uu____9615 -> false)))
+                        | uu____9626 -> false)))
               in
-           let uu____9617 =
-             let uu____9622 =
-               let uu____9623 = FStar_Syntax_Subst.compress head1  in
-               uu____9623.FStar_Syntax_Syntax.n  in
-             ((head1.FStar_Syntax_Syntax.n), uu____9622)  in
-           (match uu____9617 with
-            | (FStar_Syntax_Syntax.Tm_uvar uu____9632,uu____9633) ->
+           let uu____9628 =
+             let uu____9633 =
+               let uu____9634 = FStar_Syntax_Subst.compress head1  in
+               uu____9634.FStar_Syntax_Syntax.n  in
+             ((head1.FStar_Syntax_Syntax.n), uu____9633)  in
+           (match uu____9628 with
+            | (FStar_Syntax_Syntax.Tm_uvar uu____9643,uu____9644) ->
                 let t1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Env.Beta;
@@ -2796,8 +2799,8 @@ and (term_as_mlexpr' :
                     g.FStar_Extraction_ML_UEnv.env_tcenv t
                    in
                 term_as_mlexpr g t1
-            | (uu____9647,FStar_Syntax_Syntax.Tm_abs
-               (bs,uu____9649,FStar_Pervasives_Native.Some rc)) when
+            | (uu____9658,FStar_Syntax_Syntax.Tm_abs
+               (bs,uu____9660,FStar_Pervasives_Native.Some rc)) when
                 is_total rc ->
                 let t1 =
                   FStar_TypeChecker_Normalize.normalize
@@ -2809,28 +2812,28 @@ and (term_as_mlexpr' :
                     g.FStar_Extraction_ML_UEnv.env_tcenv t
                    in
                 term_as_mlexpr g t1
-            | (uu____9674,FStar_Syntax_Syntax.Tm_constant
+            | (uu____9685,FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_reify )) ->
                 let e =
-                  let uu____9676 = FStar_List.hd args  in
+                  let uu____9687 = FStar_List.hd args  in
                   FStar_TypeChecker_Util.reify_body_with_arg
-                    g.FStar_Extraction_ML_UEnv.env_tcenv head1 uu____9676
+                    g.FStar_Extraction_ML_UEnv.env_tcenv head1 uu____9687
                    in
                 let tm =
-                  let uu____9688 =
-                    let uu____9693 = FStar_TypeChecker_Util.remove_reify e
+                  let uu____9699 =
+                    let uu____9704 = FStar_TypeChecker_Util.remove_reify e
                        in
-                    let uu____9694 = FStar_List.tl args  in
-                    FStar_Syntax_Syntax.mk_Tm_app uu____9693 uu____9694  in
-                  uu____9688 FStar_Pervasives_Native.None
+                    let uu____9705 = FStar_List.tl args  in
+                    FStar_Syntax_Syntax.mk_Tm_app uu____9704 uu____9705  in
+                  uu____9699 FStar_Pervasives_Native.None
                     t.FStar_Syntax_Syntax.pos
                    in
                 term_as_mlexpr g tm
-            | uu____9703 ->
-                let rec extract_app is_data uu____9756 uu____9757 restArgs =
-                  match (uu____9756, uu____9757) with
+            | uu____9714 ->
+                let rec extract_app is_data uu____9767 uu____9768 restArgs =
+                  match (uu____9767, uu____9768) with
                   | ((mlhead,mlargs_f),(f,t1)) ->
-                      let mk_head uu____9838 =
+                      let mk_head uu____9849 =
                         let mlargs =
                           FStar_All.pipe_right (FStar_List.rev mlargs_f)
                             (FStar_List.map FStar_Pervasives_Native.fst)
@@ -2841,82 +2844,82 @@ and (term_as_mlexpr' :
                              (mlhead, mlargs))
                          in
                       (FStar_Extraction_ML_UEnv.debug g
-                         (fun uu____9865  ->
-                            let uu____9866 =
-                              let uu____9868 = mk_head ()  in
+                         (fun uu____9876  ->
+                            let uu____9877 =
+                              let uu____9879 = mk_head ()  in
                               FStar_Extraction_ML_Code.string_of_mlexpr
                                 g.FStar_Extraction_ML_UEnv.currentModule
-                                uu____9868
+                                uu____9879
                                in
-                            let uu____9869 =
+                            let uu____9880 =
                               FStar_Extraction_ML_Code.string_of_mlty
                                 g.FStar_Extraction_ML_UEnv.currentModule t1
                                in
-                            let uu____9871 =
+                            let uu____9882 =
                               match restArgs with
                               | [] -> "none"
-                              | (hd1,uu____9882)::uu____9883 ->
+                              | (hd1,uu____9893)::uu____9894 ->
                                   FStar_Syntax_Print.term_to_string hd1
                                in
                             FStar_Util.print3
                               "extract_app ml_head=%s type of head = %s, next arg = %s\n"
-                              uu____9866 uu____9869 uu____9871);
+                              uu____9877 uu____9880 uu____9882);
                        (match (restArgs, t1) with
-                        | ([],uu____9917) ->
+                        | ([],uu____9928) ->
                             let app =
-                              let uu____9933 = mk_head ()  in
+                              let uu____9944 = mk_head ()  in
                               maybe_eta_data_and_project_record g is_data t1
-                                uu____9933
+                                uu____9944
                                in
                             (app, f, t1)
-                        | ((arg,uu____9935)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
+                        | ((arg,uu____9946)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                            (formal_t,f',t2)) when
                             (is_type g arg) &&
                               (type_leq g formal_t
                                  FStar_Extraction_ML_Syntax.ml_unit_ty)
                             ->
-                            let uu____9966 =
-                              let uu____9971 =
+                            let uu____9977 =
+                              let uu____9982 =
                                 FStar_Extraction_ML_Util.join
                                   arg.FStar_Syntax_Syntax.pos f f'
                                  in
-                              (uu____9971, t2)  in
+                              (uu____9982, t2)  in
                             extract_app is_data
                               (mlhead,
                                 ((FStar_Extraction_ML_Syntax.ml_unit,
                                    FStar_Extraction_ML_Syntax.E_PURE) ::
-                                mlargs_f)) uu____9966 rest
-                        | ((e0,uu____9983)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
+                                mlargs_f)) uu____9977 rest
+                        | ((e0,uu____9994)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                            (tExpected,f',t2)) ->
                             let r = e0.FStar_Syntax_Syntax.pos  in
                             let expected_effect =
-                              let uu____10016 =
+                              let uu____10027 =
                                 (FStar_Options.lax ()) &&
                                   (FStar_TypeChecker_Util.short_circuit_head
                                      head1)
                                  in
-                              if uu____10016
+                              if uu____10027
                               then FStar_Extraction_ML_Syntax.E_IMPURE
                               else FStar_Extraction_ML_Syntax.E_PURE  in
-                            let uu____10021 =
+                            let uu____10032 =
                               check_term_as_mlexpr g e0 expected_effect
                                 tExpected
                                in
-                            (match uu____10021 with
+                            (match uu____10032 with
                              | (e01,tInferred) ->
-                                 let uu____10034 =
-                                   let uu____10039 =
+                                 let uu____10045 =
+                                   let uu____10050 =
                                      FStar_Extraction_ML_Util.join_l r
                                        [f; f']
                                       in
-                                   (uu____10039, t2)  in
+                                   (uu____10050, t2)  in
                                  extract_app is_data
                                    (mlhead, ((e01, expected_effect) ::
-                                     mlargs_f)) uu____10034 rest)
-                        | uu____10050 ->
-                            let uu____10063 =
+                                     mlargs_f)) uu____10045 rest)
+                        | uu____10061 ->
+                            let uu____10074 =
                               FStar_Extraction_ML_Util.udelta_unfold g t1  in
-                            (match uu____10063 with
+                            (match uu____10074 with
                              | FStar_Pervasives_Native.Some t2 ->
                                  extract_app is_data (mlhead, mlargs_f)
                                    (f, t2) restArgs
@@ -2959,7 +2962,7 @@ and (term_as_mlexpr' :
                                          in
                                       extract_app is_data (mlhead1, [])
                                         (f, t2) restArgs
-                                  | uu____10135 ->
+                                  | uu____10146 ->
                                       let mlhead1 =
                                         let mlargs =
                                           FStar_All.pipe_right
@@ -2982,134 +2985,134 @@ and (term_as_mlexpr' :
                                       err_ill_typed_application g top mlhead1
                                         restArgs t1))))
                    in
-                let extract_app_maybe_projector is_data mlhead uu____10206
+                let extract_app_maybe_projector is_data mlhead uu____10217
                   args1 =
-                  match uu____10206 with
+                  match uu____10217 with
                   | (f,t1) ->
                       (match is_data with
                        | FStar_Pervasives_Native.Some
-                           (FStar_Syntax_Syntax.Record_projector uu____10236)
+                           (FStar_Syntax_Syntax.Record_projector uu____10247)
                            ->
                            let rec remove_implicits args2 f1 t2 =
                              match (args2, t2) with
                              | ((a0,FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____10320))::args3,FStar_Extraction_ML_Syntax.MLTY_Fun
-                                (uu____10322,f',t3)) ->
-                                 let uu____10360 =
+                                 (FStar_Syntax_Syntax.Implicit uu____10331))::args3,FStar_Extraction_ML_Syntax.MLTY_Fun
+                                (uu____10333,f',t3)) ->
+                                 let uu____10371 =
                                    FStar_Extraction_ML_Util.join
                                      a0.FStar_Syntax_Syntax.pos f1 f'
                                     in
-                                 remove_implicits args3 uu____10360 t3
-                             | uu____10361 -> (args2, f1, t2)  in
-                           let uu____10386 = remove_implicits args1 f t1  in
-                           (match uu____10386 with
+                                 remove_implicits args3 uu____10371 t3
+                             | uu____10372 -> (args2, f1, t2)  in
+                           let uu____10397 = remove_implicits args1 f t1  in
+                           (match uu____10397 with
                             | (args2,f1,t2) ->
                                 extract_app is_data (mlhead, []) (f1, t2)
                                   args2)
-                       | uu____10442 ->
+                       | uu____10453 ->
                            extract_app is_data (mlhead, []) (f, t1) args1)
                    in
-                let extract_app_with_instantiations uu____10466 =
+                let extract_app_with_instantiations uu____10477 =
                   let head2 = FStar_Syntax_Util.un_uinst head1  in
                   match head2.FStar_Syntax_Syntax.n with
-                  | FStar_Syntax_Syntax.Tm_name uu____10474 ->
-                      let uu____10475 =
-                        let uu____10496 =
+                  | FStar_Syntax_Syntax.Tm_name uu____10485 ->
+                      let uu____10486 =
+                        let uu____10507 =
                           FStar_Extraction_ML_UEnv.lookup_term g head2  in
-                        match uu____10496 with
+                        match uu____10507 with
                         | (FStar_Util.Inr exp_b,q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____10535  ->
-                                  let uu____10536 =
+                               (fun uu____10546  ->
+                                  let uu____10547 =
                                     FStar_Syntax_Print.term_to_string head2
                                      in
-                                  let uu____10538 =
+                                  let uu____10549 =
                                     FStar_Extraction_ML_Code.string_of_mlexpr
                                       g.FStar_Extraction_ML_UEnv.currentModule
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr
                                      in
-                                  let uu____10540 =
+                                  let uu____10551 =
                                     FStar_Extraction_ML_Code.string_of_mlty
                                       g.FStar_Extraction_ML_UEnv.currentModule
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)
                                      in
-                                  let uu____10542 =
+                                  let uu____10553 =
                                     FStar_Util.string_of_bool
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_inst_ok
                                      in
                                   FStar_Util.print4
                                     "@@@looked up %s: got %s at %s (inst_ok=%s)\n"
-                                    uu____10536 uu____10538 uu____10540
-                                    uu____10542);
+                                    uu____10547 uu____10549 uu____10551
+                                    uu____10553);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_inst_ok)),
                                q))
-                        | uu____10569 -> failwith "FIXME Ty"  in
-                      (match uu____10475 with
+                        | uu____10580 -> failwith "FIXME Ty"  in
+                      (match uu____10486 with
                        | ((head_ml,(vars,t1),inst_ok),qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a,uu____10645)::uu____10646 -> is_type g a
-                             | uu____10673 -> false  in
-                           let uu____10685 =
+                             | (a,uu____10656)::uu____10657 -> is_type g a
+                             | uu____10684 -> false  in
+                           let uu____10696 =
                              match vars with
-                             | uu____10714::uu____10715 when
+                             | uu____10725::uu____10726 when
                                  (Prims.op_Negation has_typ_apps) && inst_ok
                                  -> (head_ml, t1, args)
-                             | uu____10729 ->
+                             | uu____10740 ->
                                  let n1 = FStar_List.length vars  in
-                                 let uu____10735 =
+                                 let uu____10746 =
                                    if (FStar_List.length args) <= n1
                                    then
-                                     let uu____10773 =
+                                     let uu____10784 =
                                        FStar_List.map
-                                         (fun uu____10785  ->
-                                            match uu____10785 with
-                                            | (x,uu____10793) ->
+                                         (fun uu____10796  ->
+                                            match uu____10796 with
+                                            | (x,uu____10804) ->
                                                 term_as_mlty g x) args
                                         in
-                                     (uu____10773, [])
+                                     (uu____10784, [])
                                    else
-                                     (let uu____10816 =
+                                     (let uu____10827 =
                                         FStar_Util.first_N n1 args  in
-                                      match uu____10816 with
+                                      match uu____10827 with
                                       | (prefix1,rest) ->
-                                          let uu____10905 =
+                                          let uu____10916 =
                                             FStar_List.map
-                                              (fun uu____10917  ->
-                                                 match uu____10917 with
-                                                 | (x,uu____10925) ->
+                                              (fun uu____10928  ->
+                                                 match uu____10928 with
+                                                 | (x,uu____10936) ->
                                                      term_as_mlty g x)
                                               prefix1
                                              in
-                                          (uu____10905, rest))
+                                          (uu____10916, rest))
                                     in
-                                 (match uu____10735 with
+                                 (match uu____10746 with
                                   | (provided_type_args,rest) ->
-                                      let uu____10976 =
+                                      let uu____10987 =
                                         match head_ml.FStar_Extraction_ML_Syntax.expr
                                         with
                                         | FStar_Extraction_ML_Syntax.MLE_Name
-                                            uu____10985 ->
-                                            let uu____10986 =
+                                            uu____10996 ->
+                                            let uu____10997 =
                                               instantiate_maybe_partial
                                                 head_ml (vars, t1)
                                                 provided_type_args
                                                in
-                                            (match uu____10986 with
-                                             | (head3,uu____10998,t2) ->
+                                            (match uu____10997 with
+                                             | (head3,uu____11009,t2) ->
                                                  (head3, t2))
                                         | FStar_Extraction_ML_Syntax.MLE_Var
-                                            uu____11000 ->
-                                            let uu____11002 =
+                                            uu____11011 ->
+                                            let uu____11013 =
                                               instantiate_maybe_partial
                                                 head_ml (vars, t1)
                                                 provided_type_args
                                                in
-                                            (match uu____11002 with
-                                             | (head3,uu____11014,t2) ->
+                                            (match uu____11013 with
+                                             | (head3,uu____11025,t2) ->
                                                  (head3, t2))
                                         | FStar_Extraction_ML_Syntax.MLE_App
                                             (head3,{
@@ -3119,17 +3122,17 @@ and (term_as_mlexpr' :
                                                        (FStar_Extraction_ML_Syntax.MLC_Unit
                                                        );
                                                      FStar_Extraction_ML_Syntax.mlty
-                                                       = uu____11017;
+                                                       = uu____11028;
                                                      FStar_Extraction_ML_Syntax.loc
-                                                       = uu____11018;_}::[])
+                                                       = uu____11029;_}::[])
                                             ->
-                                            let uu____11021 =
+                                            let uu____11032 =
                                               instantiate_maybe_partial head3
                                                 (vars, t1) provided_type_args
                                                in
-                                            (match uu____11021 with
-                                             | (head4,uu____11033,t2) ->
-                                                 let uu____11035 =
+                                            (match uu____11032 with
+                                             | (head4,uu____11044,t2) ->
+                                                 let uu____11046 =
                                                    FStar_All.pipe_right
                                                      (FStar_Extraction_ML_Syntax.MLE_App
                                                         (head4,
@@ -3137,128 +3140,128 @@ and (term_as_mlexpr' :
                                                      (FStar_Extraction_ML_Syntax.with_ty
                                                         t2)
                                                     in
-                                                 (uu____11035, t2))
-                                        | uu____11038 ->
+                                                 (uu____11046, t2))
+                                        | uu____11049 ->
                                             failwith
                                               "Impossible: Unexpected head term"
                                          in
-                                      (match uu____10976 with
+                                      (match uu____10987 with
                                        | (head3,t2) -> (head3, t2, rest)))
                               in
-                           (match uu____10685 with
+                           (match uu____10696 with
                             | (head_ml1,head_t,args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____11105 =
+                                     let uu____11116 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1
                                         in
-                                     (uu____11105,
+                                     (uu____11116,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____11106 ->
+                                 | uu____11117 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | FStar_Syntax_Syntax.Tm_fvar uu____11115 ->
-                      let uu____11116 =
-                        let uu____11137 =
+                  | FStar_Syntax_Syntax.Tm_fvar uu____11126 ->
+                      let uu____11127 =
+                        let uu____11148 =
                           FStar_Extraction_ML_UEnv.lookup_term g head2  in
-                        match uu____11137 with
+                        match uu____11148 with
                         | (FStar_Util.Inr exp_b,q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____11176  ->
-                                  let uu____11177 =
+                               (fun uu____11187  ->
+                                  let uu____11188 =
                                     FStar_Syntax_Print.term_to_string head2
                                      in
-                                  let uu____11179 =
+                                  let uu____11190 =
                                     FStar_Extraction_ML_Code.string_of_mlexpr
                                       g.FStar_Extraction_ML_UEnv.currentModule
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr
                                      in
-                                  let uu____11181 =
+                                  let uu____11192 =
                                     FStar_Extraction_ML_Code.string_of_mlty
                                       g.FStar_Extraction_ML_UEnv.currentModule
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)
                                      in
-                                  let uu____11183 =
+                                  let uu____11194 =
                                     FStar_Util.string_of_bool
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_inst_ok
                                      in
                                   FStar_Util.print4
                                     "@@@looked up %s: got %s at %s (inst_ok=%s)\n"
-                                    uu____11177 uu____11179 uu____11181
-                                    uu____11183);
+                                    uu____11188 uu____11190 uu____11192
+                                    uu____11194);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_inst_ok)),
                                q))
-                        | uu____11210 -> failwith "FIXME Ty"  in
-                      (match uu____11116 with
+                        | uu____11221 -> failwith "FIXME Ty"  in
+                      (match uu____11127 with
                        | ((head_ml,(vars,t1),inst_ok),qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a,uu____11286)::uu____11287 -> is_type g a
-                             | uu____11314 -> false  in
-                           let uu____11326 =
+                             | (a,uu____11297)::uu____11298 -> is_type g a
+                             | uu____11325 -> false  in
+                           let uu____11337 =
                              match vars with
-                             | uu____11355::uu____11356 when
+                             | uu____11366::uu____11367 when
                                  (Prims.op_Negation has_typ_apps) && inst_ok
                                  -> (head_ml, t1, args)
-                             | uu____11370 ->
+                             | uu____11381 ->
                                  let n1 = FStar_List.length vars  in
-                                 let uu____11376 =
+                                 let uu____11387 =
                                    if (FStar_List.length args) <= n1
                                    then
-                                     let uu____11414 =
+                                     let uu____11425 =
                                        FStar_List.map
-                                         (fun uu____11426  ->
-                                            match uu____11426 with
-                                            | (x,uu____11434) ->
+                                         (fun uu____11437  ->
+                                            match uu____11437 with
+                                            | (x,uu____11445) ->
                                                 term_as_mlty g x) args
                                         in
-                                     (uu____11414, [])
+                                     (uu____11425, [])
                                    else
-                                     (let uu____11457 =
+                                     (let uu____11468 =
                                         FStar_Util.first_N n1 args  in
-                                      match uu____11457 with
+                                      match uu____11468 with
                                       | (prefix1,rest) ->
-                                          let uu____11546 =
+                                          let uu____11557 =
                                             FStar_List.map
-                                              (fun uu____11558  ->
-                                                 match uu____11558 with
-                                                 | (x,uu____11566) ->
+                                              (fun uu____11569  ->
+                                                 match uu____11569 with
+                                                 | (x,uu____11577) ->
                                                      term_as_mlty g x)
                                               prefix1
                                              in
-                                          (uu____11546, rest))
+                                          (uu____11557, rest))
                                     in
-                                 (match uu____11376 with
+                                 (match uu____11387 with
                                   | (provided_type_args,rest) ->
-                                      let uu____11617 =
+                                      let uu____11628 =
                                         match head_ml.FStar_Extraction_ML_Syntax.expr
                                         with
                                         | FStar_Extraction_ML_Syntax.MLE_Name
-                                            uu____11626 ->
-                                            let uu____11627 =
+                                            uu____11637 ->
+                                            let uu____11638 =
                                               instantiate_maybe_partial
                                                 head_ml (vars, t1)
                                                 provided_type_args
                                                in
-                                            (match uu____11627 with
-                                             | (head3,uu____11639,t2) ->
+                                            (match uu____11638 with
+                                             | (head3,uu____11650,t2) ->
                                                  (head3, t2))
                                         | FStar_Extraction_ML_Syntax.MLE_Var
-                                            uu____11641 ->
-                                            let uu____11643 =
+                                            uu____11652 ->
+                                            let uu____11654 =
                                               instantiate_maybe_partial
                                                 head_ml (vars, t1)
                                                 provided_type_args
                                                in
-                                            (match uu____11643 with
-                                             | (head3,uu____11655,t2) ->
+                                            (match uu____11654 with
+                                             | (head3,uu____11666,t2) ->
                                                  (head3, t2))
                                         | FStar_Extraction_ML_Syntax.MLE_App
                                             (head3,{
@@ -3268,17 +3271,17 @@ and (term_as_mlexpr' :
                                                        (FStar_Extraction_ML_Syntax.MLC_Unit
                                                        );
                                                      FStar_Extraction_ML_Syntax.mlty
-                                                       = uu____11658;
+                                                       = uu____11669;
                                                      FStar_Extraction_ML_Syntax.loc
-                                                       = uu____11659;_}::[])
+                                                       = uu____11670;_}::[])
                                             ->
-                                            let uu____11662 =
+                                            let uu____11673 =
                                               instantiate_maybe_partial head3
                                                 (vars, t1) provided_type_args
                                                in
-                                            (match uu____11662 with
-                                             | (head4,uu____11674,t2) ->
-                                                 let uu____11676 =
+                                            (match uu____11673 with
+                                             | (head4,uu____11685,t2) ->
+                                                 let uu____11687 =
                                                    FStar_All.pipe_right
                                                      (FStar_Extraction_ML_Syntax.MLE_App
                                                         (head4,
@@ -3286,59 +3289,59 @@ and (term_as_mlexpr' :
                                                      (FStar_Extraction_ML_Syntax.with_ty
                                                         t2)
                                                     in
-                                                 (uu____11676, t2))
-                                        | uu____11679 ->
+                                                 (uu____11687, t2))
+                                        | uu____11690 ->
                                             failwith
                                               "Impossible: Unexpected head term"
                                          in
-                                      (match uu____11617 with
+                                      (match uu____11628 with
                                        | (head3,t2) -> (head3, t2, rest)))
                               in
-                           (match uu____11326 with
+                           (match uu____11337 with
                             | (head_ml1,head_t,args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____11746 =
+                                     let uu____11757 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1
                                         in
-                                     (uu____11746,
+                                     (uu____11757,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____11747 ->
+                                 | uu____11758 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | uu____11756 ->
-                      let uu____11757 = term_as_mlexpr g head2  in
-                      (match uu____11757 with
+                  | uu____11767 ->
+                      let uu____11768 = term_as_mlexpr g head2  in
+                      (match uu____11768 with
                        | (head3,f,t1) ->
                            extract_app_maybe_projector
                              FStar_Pervasives_Native.None head3 (f, t1) args)
                    in
-                let uu____11773 = is_type g t  in
-                if uu____11773
+                let uu____11784 = is_type g t  in
+                if uu____11784
                 then
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
                 else
-                  (let uu____11784 =
-                     let uu____11785 = FStar_Syntax_Util.un_uinst head1  in
-                     uu____11785.FStar_Syntax_Syntax.n  in
-                   match uu____11784 with
+                  (let uu____11795 =
+                     let uu____11796 = FStar_Syntax_Util.un_uinst head1  in
+                     uu____11796.FStar_Syntax_Syntax.n  in
+                   match uu____11795 with
                    | FStar_Syntax_Syntax.Tm_fvar fv ->
-                       let uu____11795 =
+                       let uu____11806 =
                          FStar_Extraction_ML_UEnv.try_lookup_fv g fv  in
-                       (match uu____11795 with
+                       (match uu____11806 with
                         | FStar_Pervasives_Native.None  ->
                             (FStar_Extraction_ML_Syntax.ml_unit,
                               FStar_Extraction_ML_Syntax.E_PURE,
                               FStar_Extraction_ML_Syntax.MLTY_Erased)
-                        | uu____11804 -> extract_app_with_instantiations ())
-                   | uu____11807 -> extract_app_with_instantiations ()))
-       | FStar_Syntax_Syntax.Tm_ascribed (e0,(tc,uu____11810),f) ->
+                        | uu____11815 -> extract_app_with_instantiations ())
+                   | uu____11818 -> extract_app_with_instantiations ()))
+       | FStar_Syntax_Syntax.Tm_ascribed (e0,(tc,uu____11821),f) ->
            let t1 =
              match tc with
              | FStar_Util.Inl t1 -> term_as_mlty g t1
@@ -3350,39 +3353,39 @@ and (term_as_mlexpr' :
              | FStar_Pervasives_Native.None  ->
                  failwith "Ascription node with an empty effect label"
              | FStar_Pervasives_Native.Some l -> effect_as_etag g l  in
-           let uu____11878 = check_term_as_mlexpr g e0 f1 t1  in
-           (match uu____11878 with | (e,t2) -> (e, f1, t2))
+           let uu____11889 = check_term_as_mlexpr g e0 f1 t1  in
+           (match uu____11889 with | (e,t2) -> (e, f1, t2))
        | FStar_Syntax_Syntax.Tm_let ((is_rec,lbs),e') ->
            let top_level = FStar_Syntax_Syntax.is_top_level lbs  in
-           let uu____11913 =
+           let uu____11924 =
              if is_rec
              then FStar_Syntax_Subst.open_let_rec lbs e'
              else
-               (let uu____11929 = FStar_Syntax_Syntax.is_top_level lbs  in
-                if uu____11929
+               (let uu____11940 = FStar_Syntax_Syntax.is_top_level lbs  in
+                if uu____11940
                 then (lbs, e')
                 else
                   (let lb = FStar_List.hd lbs  in
                    let x =
-                     let uu____11944 =
+                     let uu____11955 =
                        FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                     FStar_Syntax_Syntax.freshen_bv uu____11944  in
+                     FStar_Syntax_Syntax.freshen_bv uu____11955  in
                    let lb1 =
-                     let uu___1709_11946 = lb  in
+                     let uu___1710_11957 = lb  in
                      {
                        FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                        FStar_Syntax_Syntax.lbunivs =
-                         (uu___1709_11946.FStar_Syntax_Syntax.lbunivs);
+                         (uu___1710_11957.FStar_Syntax_Syntax.lbunivs);
                        FStar_Syntax_Syntax.lbtyp =
-                         (uu___1709_11946.FStar_Syntax_Syntax.lbtyp);
+                         (uu___1710_11957.FStar_Syntax_Syntax.lbtyp);
                        FStar_Syntax_Syntax.lbeff =
-                         (uu___1709_11946.FStar_Syntax_Syntax.lbeff);
+                         (uu___1710_11957.FStar_Syntax_Syntax.lbeff);
                        FStar_Syntax_Syntax.lbdef =
-                         (uu___1709_11946.FStar_Syntax_Syntax.lbdef);
+                         (uu___1710_11957.FStar_Syntax_Syntax.lbdef);
                        FStar_Syntax_Syntax.lbattrs =
-                         (uu___1709_11946.FStar_Syntax_Syntax.lbattrs);
+                         (uu___1710_11957.FStar_Syntax_Syntax.lbattrs);
                        FStar_Syntax_Syntax.lbpos =
-                         (uu___1709_11946.FStar_Syntax_Syntax.lbpos)
+                         (uu___1710_11957.FStar_Syntax_Syntax.lbpos)
                      }  in
                    let e'1 =
                      FStar_Syntax_Subst.subst
@@ -3390,7 +3393,7 @@ and (term_as_mlexpr' :
                       in
                    ([lb1], e'1)))
               in
-           (match uu____11913 with
+           (match uu____11924 with
             | (lbs1,e'1) ->
                 let lbs2 =
                   if top_level
@@ -3399,7 +3402,7 @@ and (term_as_mlexpr' :
                       (FStar_List.map
                          (fun lb  ->
                             let tcenv =
-                              let uu____11980 =
+                              let uu____11991 =
                                 FStar_Ident.lid_of_path
                                   (FStar_List.append
                                      (FStar_Pervasives_Native.fst
@@ -3410,20 +3413,20 @@ and (term_as_mlexpr' :
                                  in
                               FStar_TypeChecker_Env.set_current_module
                                 g.FStar_Extraction_ML_UEnv.env_tcenv
-                                uu____11980
+                                uu____11991
                                in
                             let lbdef =
-                              let uu____11995 = FStar_Options.ml_ish ()  in
-                              if uu____11995
+                              let uu____12006 = FStar_Options.ml_ish ()  in
+                              if uu____12006
                               then lb.FStar_Syntax_Syntax.lbdef
                               else
-                                (let norm_call uu____12007 =
+                                (let norm_call uu____12018 =
                                    FStar_TypeChecker_Normalize.normalize
                                      (FStar_TypeChecker_Env.PureSubtermsWithinComputations
                                      :: extraction_norm_steps) tcenv
                                      lb.FStar_Syntax_Syntax.lbdef
                                     in
-                                 let uu____12008 =
+                                 let uu____12019 =
                                    (FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug tcenv)
                                       (FStar_Options.Other "Extraction"))
@@ -3432,78 +3435,78 @@ and (term_as_mlexpr' :
                                         (FStar_TypeChecker_Env.debug tcenv)
                                         (FStar_Options.Other "ExtractNorm"))
                                     in
-                                 if uu____12008
+                                 if uu____12019
                                  then
-                                   ((let uu____12018 =
+                                   ((let uu____12029 =
                                        FStar_Syntax_Print.lbname_to_string
                                          lb.FStar_Syntax_Syntax.lbname
                                         in
-                                     let uu____12020 =
+                                     let uu____12031 =
                                        FStar_Syntax_Print.term_to_string
                                          lb.FStar_Syntax_Syntax.lbdef
                                         in
                                      FStar_Util.print2
                                        "Starting to normalize top-level let %s)\n\tlbdef=%s"
-                                       uu____12018 uu____12020);
+                                       uu____12029 uu____12031);
                                     (let a =
-                                       let uu____12026 =
-                                         let uu____12028 =
+                                       let uu____12037 =
+                                         let uu____12039 =
                                            FStar_Syntax_Print.lbname_to_string
                                              lb.FStar_Syntax_Syntax.lbname
                                             in
                                          FStar_Util.format1
                                            "###(Time to normalize top-level let %s)"
-                                           uu____12028
+                                           uu____12039
                                           in
                                        FStar_Util.measure_execution_time
-                                         uu____12026 norm_call
+                                         uu____12037 norm_call
                                         in
-                                     (let uu____12034 =
+                                     (let uu____12045 =
                                         FStar_Syntax_Print.term_to_string a
                                          in
                                       FStar_Util.print1 "Normalized to %s\n"
-                                        uu____12034);
+                                        uu____12045);
                                      a))
                                  else norm_call ())
                                in
-                            let uu___1727_12039 = lb  in
+                            let uu___1728_12050 = lb  in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___1727_12039.FStar_Syntax_Syntax.lbname);
+                                (uu___1728_12050.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___1727_12039.FStar_Syntax_Syntax.lbunivs);
+                                (uu___1728_12050.FStar_Syntax_Syntax.lbunivs);
                               FStar_Syntax_Syntax.lbtyp =
-                                (uu___1727_12039.FStar_Syntax_Syntax.lbtyp);
+                                (uu___1728_12050.FStar_Syntax_Syntax.lbtyp);
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___1727_12039.FStar_Syntax_Syntax.lbeff);
+                                (uu___1728_12050.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef = lbdef;
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___1727_12039.FStar_Syntax_Syntax.lbattrs);
+                                (uu___1728_12050.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___1727_12039.FStar_Syntax_Syntax.lbpos)
+                                (uu___1728_12050.FStar_Syntax_Syntax.lbpos)
                             }))
                   else lbs1  in
-                let check_lb env uu____12092 =
-                  match uu____12092 with
+                let check_lb env uu____12103 =
+                  match uu____12103 with
                   | (nm,(_lbname,f,(_t,(targs,polytype)),add_unit,e)) ->
                       let env1 =
                         FStar_List.fold_left
                           (fun env1  ->
-                             fun uu____12248  ->
-                               match uu____12248 with
-                               | (a,uu____12256) ->
+                             fun uu____12259  ->
+                               match uu____12259 with
+                               | (a,uu____12267) ->
                                    FStar_Extraction_ML_UEnv.extend_ty env1 a
                                      FStar_Pervasives_Native.None) env targs
                          in
                       let expected_t = FStar_Pervasives_Native.snd polytype
                          in
-                      let uu____12262 =
+                      let uu____12273 =
                         check_term_as_mlexpr env1 e f expected_t  in
-                      (match uu____12262 with
+                      (match uu____12273 with
                        | (e1,ty) ->
-                           let uu____12273 =
+                           let uu____12284 =
                              maybe_promote_effect e1 f expected_t  in
-                           (match uu____12273 with
+                           (match uu____12284 with
                             | (e2,f1) ->
                                 let meta =
                                   match (f1, ty) with
@@ -3513,7 +3516,7 @@ and (term_as_mlexpr' :
                                   | (FStar_Extraction_ML_Syntax.E_GHOST
                                      ,FStar_Extraction_ML_Syntax.MLTY_Erased
                                      ) -> [FStar_Extraction_ML_Syntax.Erased]
-                                  | uu____12285 -> []  in
+                                  | uu____12296 -> []  in
                                 (f1,
                                   {
                                     FStar_Extraction_ML_Syntax.mllb_name = nm;
@@ -3529,26 +3532,26 @@ and (term_as_mlexpr' :
                                   })))
                    in
                 let lbs3 = extract_lb_sig g (is_rec, lbs2)  in
-                let uu____12316 =
+                let uu____12327 =
                   FStar_List.fold_right
                     (fun lb  ->
-                       fun uu____12413  ->
-                         match uu____12413 with
+                       fun uu____12424  ->
+                         match uu____12424 with
                          | (env,lbs4) ->
-                             let uu____12547 = lb  in
-                             (match uu____12547 with
-                              | (lbname,uu____12598,(t1,(uu____12600,polytype)),add_unit,uu____12603)
+                             let uu____12558 = lb  in
+                             (match uu____12558 with
+                              | (lbname,uu____12609,(t1,(uu____12611,polytype)),add_unit,uu____12614)
                                   ->
-                                  let uu____12618 =
+                                  let uu____12629 =
                                     FStar_Extraction_ML_UEnv.extend_lb env
                                       lbname t1 polytype add_unit true
                                      in
-                                  (match uu____12618 with
-                                   | (env1,nm,uu____12659) ->
+                                  (match uu____12629 with
+                                   | (env1,nm,uu____12670) ->
                                        (env1, ((nm, lb) :: lbs4))))) lbs3
                     (g, [])
                    in
-                (match uu____12316 with
+                (match uu____12327 with
                  | (env_body,lbs4) ->
                      let env_def = if is_rec then env_body else g  in
                      let lbs5 =
@@ -3556,46 +3559,46 @@ and (term_as_mlexpr' :
                          (FStar_List.map (check_lb env_def))
                         in
                      let e'_rng = e'1.FStar_Syntax_Syntax.pos  in
-                     let uu____12938 = term_as_mlexpr env_body e'1  in
-                     (match uu____12938 with
+                     let uu____12949 = term_as_mlexpr env_body e'1  in
+                     (match uu____12949 with
                       | (e'2,f',t') ->
                           let f =
-                            let uu____12955 =
-                              let uu____12958 =
+                            let uu____12966 =
+                              let uu____12969 =
                                 FStar_List.map FStar_Pervasives_Native.fst
                                   lbs5
                                  in
-                              f' :: uu____12958  in
+                              f' :: uu____12969  in
                             FStar_Extraction_ML_Util.join_l e'_rng
-                              uu____12955
+                              uu____12966
                              in
                           let is_rec1 =
                             if is_rec = true
                             then FStar_Extraction_ML_Syntax.Rec
                             else FStar_Extraction_ML_Syntax.NonRec  in
-                          let uu____12971 =
-                            let uu____12972 =
-                              let uu____12973 =
-                                let uu____12974 =
+                          let uu____12982 =
+                            let uu____12983 =
+                              let uu____12984 =
+                                let uu____12985 =
                                   FStar_List.map FStar_Pervasives_Native.snd
                                     lbs5
                                    in
-                                (is_rec1, uu____12974)  in
-                              mk_MLE_Let top_level uu____12973 e'2  in
-                            let uu____12983 =
+                                (is_rec1, uu____12985)  in
+                              mk_MLE_Let top_level uu____12984 e'2  in
+                            let uu____12994 =
                               FStar_Extraction_ML_Util.mlloc_of_range
                                 t.FStar_Syntax_Syntax.pos
                                in
                             FStar_Extraction_ML_Syntax.with_ty_loc t'
-                              uu____12972 uu____12983
+                              uu____12983 uu____12994
                              in
-                          (uu____12971, f, t'))))
+                          (uu____12982, f, t'))))
        | FStar_Syntax_Syntax.Tm_match (scrutinee,pats) ->
-           let uu____13022 = term_as_mlexpr g scrutinee  in
-           (match uu____13022 with
+           let uu____13033 = term_as_mlexpr g scrutinee  in
+           (match uu____13033 with
             | (e,f_e,t_e) ->
-                let uu____13038 = check_pats_for_ite pats  in
-                (match uu____13038 with
+                let uu____13049 = check_pats_for_ite pats  in
+                (match uu____13049 with
                  | (b,then_e,else_e) ->
                      let no_lift x t1 = x  in
                      if b
@@ -3603,81 +3606,81 @@ and (term_as_mlexpr' :
                        (match (then_e, else_e) with
                         | (FStar_Pervasives_Native.Some
                            then_e1,FStar_Pervasives_Native.Some else_e1) ->
-                            let uu____13103 = term_as_mlexpr g then_e1  in
-                            (match uu____13103 with
+                            let uu____13114 = term_as_mlexpr g then_e1  in
+                            (match uu____13114 with
                              | (then_mle,f_then,t_then) ->
-                                 let uu____13119 = term_as_mlexpr g else_e1
+                                 let uu____13130 = term_as_mlexpr g else_e1
                                     in
-                                 (match uu____13119 with
+                                 (match uu____13130 with
                                   | (else_mle,f_else,t_else) ->
-                                      let uu____13135 =
-                                        let uu____13146 =
+                                      let uu____13146 =
+                                        let uu____13157 =
                                           type_leq g t_then t_else  in
-                                        if uu____13146
+                                        if uu____13157
                                         then (t_else, no_lift)
                                         else
-                                          (let uu____13167 =
+                                          (let uu____13178 =
                                              type_leq g t_else t_then  in
-                                           if uu____13167
+                                           if uu____13178
                                            then (t_then, no_lift)
                                            else
                                              (FStar_Extraction_ML_Syntax.MLTY_Top,
                                                FStar_Extraction_ML_Syntax.apply_obj_repr))
                                          in
-                                      (match uu____13135 with
+                                      (match uu____13146 with
                                        | (t_branch,maybe_lift1) ->
-                                           let uu____13214 =
-                                             let uu____13215 =
-                                               let uu____13216 =
-                                                 let uu____13225 =
+                                           let uu____13225 =
+                                             let uu____13226 =
+                                               let uu____13227 =
+                                                 let uu____13236 =
                                                    maybe_lift1 then_mle
                                                      t_then
                                                     in
-                                                 let uu____13226 =
-                                                   let uu____13229 =
+                                                 let uu____13237 =
+                                                   let uu____13240 =
                                                      maybe_lift1 else_mle
                                                        t_else
                                                       in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____13229
+                                                     uu____13240
                                                     in
-                                                 (e, uu____13225,
-                                                   uu____13226)
+                                                 (e, uu____13236,
+                                                   uu____13237)
                                                   in
                                                FStar_Extraction_ML_Syntax.MLE_If
-                                                 uu____13216
+                                                 uu____13227
                                                 in
                                              FStar_All.pipe_left
                                                (FStar_Extraction_ML_Syntax.with_ty
-                                                  t_branch) uu____13215
+                                                  t_branch) uu____13226
                                               in
-                                           let uu____13232 =
+                                           let uu____13243 =
                                              FStar_Extraction_ML_Util.join
                                                then_e1.FStar_Syntax_Syntax.pos
                                                f_then f_else
                                               in
-                                           (uu____13214, uu____13232,
+                                           (uu____13225, uu____13243,
                                              t_branch))))
-                        | uu____13233 ->
+                        | uu____13244 ->
                             failwith
                               "ITE pats matched but then and else expressions not found?")
                      else
-                       (let uu____13251 =
+                       (let uu____13262 =
                           FStar_All.pipe_right pats
                             (FStar_Util.fold_map
                                (fun compat  ->
                                   fun br  ->
-                                    let uu____13350 =
+                                    let uu____13361 =
                                       FStar_Syntax_Subst.open_branch br  in
-                                    match uu____13350 with
+                                    match uu____13361 with
                                     | (pat,when_opt,branch1) ->
-                                        let uu____13395 =
+                                        let uu____13406 =
                                           extract_pat g pat t_e
                                             term_as_mlexpr
                                            in
-                                        (match uu____13395 with
+                                        (match uu____13406 with
                                          | (env,p,pat_t_compat) ->
-                                             let uu____13457 =
+                                             let uu____13468 =
                                                match when_opt with
                                                | FStar_Pervasives_Native.None
                                                     ->
@@ -3688,9 +3691,9 @@ and (term_as_mlexpr' :
                                                    let w_pos =
                                                      w.FStar_Syntax_Syntax.pos
                                                       in
-                                                   let uu____13480 =
+                                                   let uu____13491 =
                                                      term_as_mlexpr env w  in
-                                                   (match uu____13480 with
+                                                   (match uu____13491 with
                                                     | (w1,f_w,t_w) ->
                                                         let w2 =
                                                           maybe_coerce w_pos
@@ -3700,23 +3703,23 @@ and (term_as_mlexpr' :
                                                         ((FStar_Pervasives_Native.Some
                                                             w2), f_w))
                                                 in
-                                             (match uu____13457 with
+                                             (match uu____13468 with
                                               | (when_opt1,f_when) ->
-                                                  let uu____13530 =
+                                                  let uu____13541 =
                                                     term_as_mlexpr env
                                                       branch1
                                                      in
-                                                  (match uu____13530 with
+                                                  (match uu____13541 with
                                                    | (mlbranch,f_branch,t_branch)
                                                        ->
-                                                       let uu____13565 =
+                                                       let uu____13576 =
                                                          FStar_All.pipe_right
                                                            p
                                                            (FStar_List.map
                                                               (fun
-                                                                 uu____13642 
+                                                                 uu____13653 
                                                                  ->
-                                                                 match uu____13642
+                                                                 match uu____13653
                                                                  with
                                                                  | (p1,wopt)
                                                                     ->
@@ -3735,10 +3738,10 @@ and (term_as_mlexpr' :
                                                           in
                                                        ((compat &&
                                                            pat_t_compat),
-                                                         uu____13565)))))
+                                                         uu____13576)))))
                                true)
                            in
-                        match uu____13251 with
+                        match uu____13262 with
                         | (pat_t_compat,mlbranches) ->
                             let mlbranches1 = FStar_List.flatten mlbranches
                                in
@@ -3747,20 +3750,20 @@ and (term_as_mlexpr' :
                               then e
                               else
                                 (FStar_Extraction_ML_UEnv.debug g
-                                   (fun uu____13813  ->
-                                      let uu____13814 =
+                                   (fun uu____13824  ->
+                                      let uu____13825 =
                                         FStar_Extraction_ML_Code.string_of_mlexpr
                                           g.FStar_Extraction_ML_UEnv.currentModule
                                           e
                                          in
-                                      let uu____13816 =
+                                      let uu____13827 =
                                         FStar_Extraction_ML_Code.string_of_mlty
                                           g.FStar_Extraction_ML_UEnv.currentModule
                                           t_e
                                          in
                                       FStar_Util.print2
                                         "Coercing scrutinee %s from type %s because pattern type is incompatible\n"
-                                        uu____13814 uu____13816);
+                                        uu____13825 uu____13827);
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty t_e)
                                    (FStar_Extraction_ML_Syntax.MLE_Coerce
@@ -3769,32 +3772,32 @@ and (term_as_mlexpr' :
                                in
                             (match mlbranches1 with
                              | [] ->
-                                 let uu____13843 =
-                                   let uu____13844 =
+                                 let uu____13854 =
+                                   let uu____13855 =
                                      FStar_Syntax_Syntax.lid_as_fv
                                        FStar_Parser_Const.failwith_lid
                                        FStar_Syntax_Syntax.delta_constant
                                        FStar_Pervasives_Native.None
                                       in
                                    FStar_Extraction_ML_UEnv.lookup_fv g
-                                     uu____13844
+                                     uu____13855
                                     in
-                                 (match uu____13843 with
+                                 (match uu____13854 with
                                   | {
                                       FStar_Extraction_ML_UEnv.exp_b_name =
-                                        uu____13851;
+                                        uu____13862;
                                       FStar_Extraction_ML_UEnv.exp_b_expr =
                                         fw;
                                       FStar_Extraction_ML_UEnv.exp_b_tscheme
-                                        = uu____13853;
+                                        = uu____13864;
                                       FStar_Extraction_ML_UEnv.exp_b_inst_ok
-                                        = uu____13854;_}
+                                        = uu____13865;_}
                                       ->
-                                      let uu____13857 =
-                                        let uu____13858 =
-                                          let uu____13859 =
-                                            let uu____13866 =
-                                              let uu____13869 =
+                                      let uu____13868 =
+                                        let uu____13869 =
+                                          let uu____13870 =
+                                            let uu____13877 =
+                                              let uu____13880 =
                                                 FStar_All.pipe_left
                                                   (FStar_Extraction_ML_Syntax.with_ty
                                                      FStar_Extraction_ML_Syntax.ml_string_ty)
@@ -3802,29 +3805,29 @@ and (term_as_mlexpr' :
                                                      (FStar_Extraction_ML_Syntax.MLC_String
                                                         "unreachable"))
                                                  in
-                                              [uu____13869]  in
-                                            (fw, uu____13866)  in
+                                              [uu____13880]  in
+                                            (fw, uu____13877)  in
                                           FStar_Extraction_ML_Syntax.MLE_App
-                                            uu____13859
+                                            uu____13870
                                            in
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              FStar_Extraction_ML_Syntax.ml_int_ty)
-                                          uu____13858
+                                          uu____13869
                                          in
-                                      (uu____13857,
+                                      (uu____13868,
                                         FStar_Extraction_ML_Syntax.E_PURE,
                                         FStar_Extraction_ML_Syntax.ml_int_ty))
-                             | (uu____13873,uu____13874,(uu____13875,f_first,t_first))::rest
+                             | (uu____13884,uu____13885,(uu____13886,f_first,t_first))::rest
                                  ->
-                                 let uu____13935 =
+                                 let uu____13946 =
                                    FStar_List.fold_left
-                                     (fun uu____13977  ->
-                                        fun uu____13978  ->
-                                          match (uu____13977, uu____13978)
+                                     (fun uu____13988  ->
+                                        fun uu____13989  ->
+                                          match (uu____13988, uu____13989)
                                           with
-                                          | ((topt,f),(uu____14035,uu____14036,
-                                                       (uu____14037,f_branch,t_branch)))
+                                          | ((topt,f),(uu____14046,uu____14047,
+                                                       (uu____14048,f_branch,t_branch)))
                                               ->
                                               let f1 =
                                                 FStar_Extraction_ML_Util.join
@@ -3838,19 +3841,19 @@ and (term_as_mlexpr' :
                                                     FStar_Pervasives_Native.None
                                                 | FStar_Pervasives_Native.Some
                                                     t1 ->
-                                                    let uu____14093 =
+                                                    let uu____14104 =
                                                       type_leq g t1 t_branch
                                                        in
-                                                    if uu____14093
+                                                    if uu____14104
                                                     then
                                                       FStar_Pervasives_Native.Some
                                                         t_branch
                                                     else
-                                                      (let uu____14100 =
+                                                      (let uu____14111 =
                                                          type_leq g t_branch
                                                            t1
                                                           in
-                                                       if uu____14100
+                                                       if uu____14111
                                                        then
                                                          FStar_Pervasives_Native.Some
                                                            t1
@@ -3861,15 +3864,15 @@ and (term_as_mlexpr' :
                                      ((FStar_Pervasives_Native.Some t_first),
                                        f_first) rest
                                     in
-                                 (match uu____13935 with
+                                 (match uu____13946 with
                                   | (topt,f_match) ->
                                       let mlbranches2 =
                                         FStar_All.pipe_right mlbranches1
                                           (FStar_List.map
-                                             (fun uu____14198  ->
-                                                match uu____14198 with
-                                                | (p,(wopt,uu____14227),
-                                                   (b1,uu____14229,t1)) ->
+                                             (fun uu____14209  ->
+                                                match uu____14209 with
+                                                | (p,(wopt,uu____14238),
+                                                   (b1,uu____14240,t1)) ->
                                                     let b2 =
                                                       match topt with
                                                       | FStar_Pervasives_Native.None
@@ -3877,7 +3880,7 @@ and (term_as_mlexpr' :
                                                           FStar_Extraction_ML_Syntax.apply_obj_repr
                                                             b1 t1
                                                       | FStar_Pervasives_Native.Some
-                                                          uu____14248 -> b1
+                                                          uu____14259 -> b1
                                                        in
                                                     (p, wopt, b2)))
                                          in
@@ -3888,14 +3891,14 @@ and (term_as_mlexpr' :
                                         | FStar_Pervasives_Native.Some t1 ->
                                             t1
                                          in
-                                      let uu____14253 =
+                                      let uu____14264 =
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              t_match)
                                           (FStar_Extraction_ML_Syntax.MLE_Match
                                              (e1, mlbranches2))
                                          in
-                                      (uu____14253, f_match, t_match)))))))
+                                      (uu____14264, f_match, t_match)))))))
 
 let (ind_discriminator_body :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -3905,78 +3908,78 @@ let (ind_discriminator_body :
   fun env  ->
     fun discName  ->
       fun constrName  ->
-        let uu____14280 =
-          let uu____14285 =
+        let uu____14291 =
+          let uu____14296 =
             FStar_TypeChecker_Env.lookup_lid
               env.FStar_Extraction_ML_UEnv.env_tcenv discName
              in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____14285  in
-        match uu____14280 with
-        | (uu____14310,fstar_disc_type) ->
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____14296  in
+        match uu____14291 with
+        | (uu____14321,fstar_disc_type) ->
             let wildcards =
-              let uu____14320 =
-                let uu____14321 = FStar_Syntax_Subst.compress fstar_disc_type
+              let uu____14331 =
+                let uu____14332 = FStar_Syntax_Subst.compress fstar_disc_type
                    in
-                uu____14321.FStar_Syntax_Syntax.n  in
-              match uu____14320 with
-              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____14332) ->
-                  let uu____14353 =
+                uu____14332.FStar_Syntax_Syntax.n  in
+              match uu____14331 with
+              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____14343) ->
+                  let uu____14364 =
                     FStar_All.pipe_right binders
                       (FStar_List.filter
-                         (fun uu___2_14387  ->
-                            match uu___2_14387 with
-                            | (uu____14395,FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____14396)) ->
+                         (fun uu___2_14398  ->
+                            match uu___2_14398 with
+                            | (uu____14406,FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____14407)) ->
                                 true
-                            | uu____14401 -> false))
+                            | uu____14412 -> false))
                      in
-                  FStar_All.pipe_right uu____14353
+                  FStar_All.pipe_right uu____14364
                     (FStar_List.map
-                       (fun uu____14437  ->
-                          let uu____14444 = fresh "_"  in
-                          (uu____14444, FStar_Extraction_ML_Syntax.MLTY_Top)))
-              | uu____14448 -> failwith "Discriminator must be a function"
+                       (fun uu____14448  ->
+                          let uu____14455 = fresh "_"  in
+                          (uu____14455, FStar_Extraction_ML_Syntax.MLTY_Top)))
+              | uu____14459 -> failwith "Discriminator must be a function"
                in
             let mlid = fresh "_discr_"  in
             let targ = FStar_Extraction_ML_Syntax.MLTY_Top  in
             let disc_ty = FStar_Extraction_ML_Syntax.MLTY_Top  in
             let discrBody =
-              let uu____14463 =
-                let uu____14464 =
-                  let uu____14476 =
-                    let uu____14477 =
-                      let uu____14478 =
-                        let uu____14493 =
+              let uu____14474 =
+                let uu____14475 =
+                  let uu____14487 =
+                    let uu____14488 =
+                      let uu____14489 =
+                        let uu____14504 =
                           FStar_All.pipe_left
                             (FStar_Extraction_ML_Syntax.with_ty targ)
                             (FStar_Extraction_ML_Syntax.MLE_Name ([], mlid))
                            in
-                        let uu____14499 =
-                          let uu____14510 =
-                            let uu____14519 =
-                              let uu____14520 =
-                                let uu____14527 =
+                        let uu____14510 =
+                          let uu____14521 =
+                            let uu____14530 =
+                              let uu____14531 =
+                                let uu____14538 =
                                   FStar_Extraction_ML_Syntax.mlpath_of_lident
                                     constrName
                                    in
-                                (uu____14527,
+                                (uu____14538,
                                   [FStar_Extraction_ML_Syntax.MLP_Wild])
                                  in
-                              FStar_Extraction_ML_Syntax.MLP_CTor uu____14520
+                              FStar_Extraction_ML_Syntax.MLP_CTor uu____14531
                                in
-                            let uu____14530 =
+                            let uu____14541 =
                               FStar_All.pipe_left
                                 (FStar_Extraction_ML_Syntax.with_ty
                                    FStar_Extraction_ML_Syntax.ml_bool_ty)
                                 (FStar_Extraction_ML_Syntax.MLE_Const
                                    (FStar_Extraction_ML_Syntax.MLC_Bool true))
                                in
-                            (uu____14519, FStar_Pervasives_Native.None,
-                              uu____14530)
+                            (uu____14530, FStar_Pervasives_Native.None,
+                              uu____14541)
                              in
-                          let uu____14534 =
-                            let uu____14545 =
-                              let uu____14554 =
+                          let uu____14545 =
+                            let uu____14556 =
+                              let uu____14565 =
                                 FStar_All.pipe_left
                                   (FStar_Extraction_ML_Syntax.with_ty
                                      FStar_Extraction_ML_Syntax.ml_bool_ty)
@@ -3985,31 +3988,31 @@ let (ind_discriminator_body :
                                         false))
                                  in
                               (FStar_Extraction_ML_Syntax.MLP_Wild,
-                                FStar_Pervasives_Native.None, uu____14554)
+                                FStar_Pervasives_Native.None, uu____14565)
                                in
-                            [uu____14545]  in
-                          uu____14510 :: uu____14534  in
-                        (uu____14493, uu____14499)  in
-                      FStar_Extraction_ML_Syntax.MLE_Match uu____14478  in
+                            [uu____14556]  in
+                          uu____14521 :: uu____14545  in
+                        (uu____14504, uu____14510)  in
+                      FStar_Extraction_ML_Syntax.MLE_Match uu____14489  in
                     FStar_All.pipe_left
                       (FStar_Extraction_ML_Syntax.with_ty
-                         FStar_Extraction_ML_Syntax.ml_bool_ty) uu____14477
+                         FStar_Extraction_ML_Syntax.ml_bool_ty) uu____14488
                      in
-                  ((FStar_List.append wildcards [(mlid, targ)]), uu____14476)
+                  ((FStar_List.append wildcards [(mlid, targ)]), uu____14487)
                    in
-                FStar_Extraction_ML_Syntax.MLE_Fun uu____14464  in
+                FStar_Extraction_ML_Syntax.MLE_Fun uu____14475  in
               FStar_All.pipe_left
-                (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu____14463
+                (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu____14474
                in
-            let uu____14615 =
-              let uu____14616 =
-                let uu____14619 =
-                  let uu____14620 =
+            let uu____14626 =
+              let uu____14627 =
+                let uu____14630 =
+                  let uu____14631 =
                     FStar_Extraction_ML_UEnv.convIdent
                       discName.FStar_Ident.ident
                      in
                   {
-                    FStar_Extraction_ML_Syntax.mllb_name = uu____14620;
+                    FStar_Extraction_ML_Syntax.mllb_name = uu____14631;
                     FStar_Extraction_ML_Syntax.mllb_tysc =
                       FStar_Pervasives_Native.None;
                     FStar_Extraction_ML_Syntax.mllb_add_unit = false;
@@ -4017,7 +4020,7 @@ let (ind_discriminator_body :
                     FStar_Extraction_ML_Syntax.mllb_meta = [];
                     FStar_Extraction_ML_Syntax.print_typ = false
                   }  in
-                [uu____14619]  in
-              (FStar_Extraction_ML_Syntax.NonRec, uu____14616)  in
-            FStar_Extraction_ML_Syntax.MLM_Let uu____14615
+                [uu____14630]  in
+              (FStar_Extraction_ML_Syntax.NonRec, uu____14627)  in
+            FStar_Extraction_ML_Syntax.MLM_Let uu____14626
   

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -537,17 +537,16 @@ let (instantiate_maybe_partial :
               (if n_args = (Prims.parse_int "0")
                then (e, FStar_Extraction_ML_Syntax.E_PURE, t)
                else
-                 (let tapp =
-                    let uu___364_2099 = e  in
+                 (let ts = instantiate_tyscheme (vars, t) tyargs  in
+                  let tapp =
+                    let uu___365_2100 = e  in
                     {
                       FStar_Extraction_ML_Syntax.expr =
                         (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs));
-                      FStar_Extraction_ML_Syntax.mlty =
-                        (uu___364_2099.FStar_Extraction_ML_Syntax.mlty);
+                      FStar_Extraction_ML_Syntax.mlty = ts;
                       FStar_Extraction_ML_Syntax.loc =
-                        (uu___364_2099.FStar_Extraction_ML_Syntax.loc)
+                        (uu___365_2100.FStar_Extraction_ML_Syntax.loc)
                     }  in
-                  let ts = instantiate_tyscheme (vars, t) tyargs  in
                   (tapp, FStar_Extraction_ML_Syntax.E_PURE, ts)))
             else
               if n_args < n_vars
@@ -562,17 +561,16 @@ let (instantiate_maybe_partial :
                                FStar_Extraction_ML_Syntax.MLTY_Erased))
                     in
                  let tyargs1 = FStar_List.append tyargs extra_tyargs  in
+                 let ts = instantiate_tyscheme (vars, t) tyargs1  in
                  let tapp =
-                   let uu___375_2156 = e  in
+                   let uu___376_2157 = e  in
                    {
                      FStar_Extraction_ML_Syntax.expr =
                        (FStar_Extraction_ML_Syntax.MLE_TApp (e, tyargs1));
-                     FStar_Extraction_ML_Syntax.mlty =
-                       (uu___375_2156.FStar_Extraction_ML_Syntax.mlty);
+                     FStar_Extraction_ML_Syntax.mlty = ts;
                      FStar_Extraction_ML_Syntax.loc =
-                       (uu___375_2156.FStar_Extraction_ML_Syntax.loc)
+                       (uu___376_2157.FStar_Extraction_ML_Syntax.loc)
                    }  in
-                 let ts = instantiate_tyscheme (vars, t) tyargs1  in
                  let t1 =
                    FStar_List.fold_left
                      (fun out  ->


### PR DESCRIPTION
Bug report #1694 notices that F* does not properly extract partial type applications. 

The issue stems from confusion between optimizations that aim to translate type polymorphic F* definitions to polymorphic ML definitions, and restrictions in ML that force some polymorphic F* code to be extracted to monomorphic ML code with Obj.t types.

The fix is to coerce first-class polymorphic F* values into ML values into functions that take additional unit arguments, one for each of their type arguments.