### PR TITLE
Fix extraction of recursively defined types

### DIFF
--- a/examples/bug-reports/Bug1714.fst
+++ b/examples/bug-reports/Bug1714.fst
@@ -1,0 +1,36 @@
+module Bug1714
+
+let arrow (a b:Type) = a -> b
+unfold let coerce (#b #a:Type) (x:a{a == b}) : b = x
+
+type p = | Print : string -> p
+
+let rec t (b:bool) : Type0 =
+  match b with
+  | false -> p
+  | true -> arrow int p
+
+let run (b:bool) (f:t b) : p =
+  match b with
+  | false -> f
+  | true ->
+      let f = coerce #(arrow int (t false)) f in
+      f 3
+
+let rec t' (b:bool) : Type0 =
+  match b with
+  | false -> unit
+  | true -> string
+
+let run' (b:bool) (f: arrow (t' b) string) : string =
+  match b with
+  | false -> f ()
+  | true -> f "ok"
+
+let s:string =
+  let f : t true = fun src -> Print "mov" in
+  let ip = run true f in
+  match ip with Print x -> "hello " ^ x
+
+let s':string =
+  run' true (fun x -> "goodbye " ^ x)

--- a/src/basic/FStar.Errors.fs
+++ b/src/basic/FStar.Errors.fs
@@ -332,7 +332,7 @@ type raw_error =
   | Warning_EffectfulArgumentToErasedFunction
   | Fatal_EmptySurfaceLet
   | Warning_UnexpectedCheckedFile
-
+  | Fatal_ExtractionUnsupported
 
 type flag = error_flag
 
@@ -662,6 +662,7 @@ let default_flags =
   (Warning_EffectfulArgumentToErasedFunction         , CWarning);
   (Fatal_EmptySurfaceLet                             , CFatal);
   (Warning_UnexpectedCheckedFile                     , CWarning); //321
+  (Fatal_ExtractionUnsupported                       , CFatal);
   (* Protip: if we keep the semicolon at the end, we modify exactly one
    * line for each error we add. This means we get a cleaner git history/blame *)
   ]

--- a/src/extraction/FStar.Extraction.ML.Syntax.fs
+++ b/src/extraction/FStar.Extraction.ML.Syntax.fs
@@ -86,11 +86,6 @@ let rec gensyms x = match x with
   | 0 -> []
   | n -> gensym ()::gensyms (n-1)
 
-(* -------------------------------------------------------------------- *)
-let mlpath_of_lident (x : lident) : mlpath =
-    if Ident.lid_equals x FStar.Parser.Const.failwith_lid
-    then ([], x.ident.idText)
-    else (List.map (fun x -> x.idText) x.ns, x.ident.idText)
 
 (* -------------------------------------------------------------------- *)
 type mlidents  = list<mlident>
@@ -292,6 +287,12 @@ let bv_as_mlident (x:bv): mlident =
   || is_null_bv x || is_reserved x.ppname.idText
   then avoid_keyword <| x.ppname.idText ^ "_" ^ (string_of_int x.index)
   else avoid_keyword <| x.ppname.idText
+
+(* -------------------------------------------------------------------- *)
+let mlpath_of_lident (x : lident) : mlpath =
+    if Ident.lid_equals x FStar.Parser.Const.failwith_lid
+    then ([], x.ident.idText)
+    else (List.map (fun x -> x.idText) x.ns, avoid_keyword x.ident.idText)
 
 let push_unit (ts : mltyscheme) : mltyscheme =
     let vs, ty = ts in

--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -322,6 +322,7 @@ type raw_error =
   | Warning_EffectfulArgumentToErasedFunction 
   | Fatal_EmptySurfaceLet 
   | Warning_UnexpectedCheckedFile 
+  | Fatal_ExtractionUnsupported 
 let (uu___is_Error_DependencyAnalysisFailed : raw_error -> Prims.bool) =
   fun projectee  ->
     match projectee with
@@ -2228,6 +2229,12 @@ let (uu___is_Warning_UnexpectedCheckedFile : raw_error -> Prims.bool) =
     | Warning_UnexpectedCheckedFile  -> true
     | uu____3550 -> false
   
+let (uu___is_Fatal_ExtractionUnsupported : raw_error -> Prims.bool) =
+  fun projectee  ->
+    match projectee with
+    | Fatal_ExtractionUnsupported  -> true
+    | uu____3561 -> false
+  
 type flag = FStar_Options.error_flag
 let (default_flags : (raw_error * FStar_Options.error_flag) Prims.list) =
   [(Error_DependencyAnalysisFailed, FStar_Options.CAlwaysError);
@@ -2552,39 +2559,40 @@ let (default_flags : (raw_error * FStar_Options.error_flag) Prims.list) =
   (Error_MustEraseMissing, FStar_Options.CWarning);
   (Warning_EffectfulArgumentToErasedFunction, FStar_Options.CWarning);
   (Fatal_EmptySurfaceLet, FStar_Options.CFatal);
-  (Warning_UnexpectedCheckedFile, FStar_Options.CWarning)] 
+  (Warning_UnexpectedCheckedFile, FStar_Options.CWarning);
+  (Fatal_ExtractionUnsupported, FStar_Options.CFatal)] 
 exception Err of (raw_error * Prims.string) 
 let (uu___is_Err : Prims.exn -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Err uu____4868 -> true | uu____4875 -> false
+    match projectee with | Err uu____4883 -> true | uu____4890 -> false
   
 let (__proj__Err__item__uu___ : Prims.exn -> (raw_error * Prims.string)) =
-  fun projectee  -> match projectee with | Err uu____4893 -> uu____4893 
+  fun projectee  -> match projectee with | Err uu____4908 -> uu____4908 
 exception Error of (raw_error * Prims.string * FStar_Range.range) 
 let (uu___is_Error : Prims.exn -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Error uu____4918 -> true | uu____4927 -> false
+    match projectee with | Error uu____4933 -> true | uu____4942 -> false
   
 let (__proj__Error__item__uu___ :
   Prims.exn -> (raw_error * Prims.string * FStar_Range.range)) =
-  fun projectee  -> match projectee with | Error uu____4949 -> uu____4949 
+  fun projectee  -> match projectee with | Error uu____4964 -> uu____4964 
 exception Warning of (raw_error * Prims.string * FStar_Range.range) 
 let (uu___is_Warning : Prims.exn -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Warning uu____4976 -> true | uu____4985 -> false
+    match projectee with | Warning uu____4991 -> true | uu____5000 -> false
   
 let (__proj__Warning__item__uu___ :
   Prims.exn -> (raw_error * Prims.string * FStar_Range.range)) =
-  fun projectee  -> match projectee with | Warning uu____5007 -> uu____5007 
+  fun projectee  -> match projectee with | Warning uu____5022 -> uu____5022 
 exception Stop 
 let (uu___is_Stop : Prims.exn -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Stop  -> true | uu____5024 -> false
+    match projectee with | Stop  -> true | uu____5039 -> false
   
 exception Empty_frag 
 let (uu___is_Empty_frag : Prims.exn -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Empty_frag  -> true | uu____5035 -> false
+    match projectee with | Empty_frag  -> true | uu____5050 -> false
   
 type issue_level =
   | ENotImplemented 
@@ -2593,19 +2601,19 @@ type issue_level =
   | EError 
 let (uu___is_ENotImplemented : issue_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | ENotImplemented  -> true | uu____5046 -> false
+    match projectee with | ENotImplemented  -> true | uu____5061 -> false
   
 let (uu___is_EInfo : issue_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | EInfo  -> true | uu____5057 -> false
+    match projectee with | EInfo  -> true | uu____5072 -> false
   
 let (uu___is_EWarning : issue_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | EWarning  -> true | uu____5068 -> false
+    match projectee with | EWarning  -> true | uu____5083 -> false
   
 let (uu___is_EError : issue_level -> Prims.bool) =
   fun projectee  ->
-    match projectee with | EError  -> true | uu____5079 -> false
+    match projectee with | EError  -> true | uu____5094 -> false
   
 type issue =
   {
@@ -2678,36 +2686,36 @@ let (format_issue : issue -> Prims.string) =
       | EWarning  -> "Warning"
       | EError  -> "Error"
       | ENotImplemented  -> "Feature not yet implemented: "  in
-    let uu____5374 =
+    let uu____5389 =
       match issue.issue_range with
       | FStar_Pervasives_Native.None  -> ("", "")
       | FStar_Pervasives_Native.Some r when r = FStar_Range.dummyRange ->
           ("", "")
       | FStar_Pervasives_Native.Some r ->
-          let uu____5397 =
-            let uu____5399 = FStar_Range.string_of_use_range r  in
-            FStar_Util.format1 "%s: " uu____5399  in
-          let uu____5402 =
-            let uu____5404 =
-              let uu____5406 = FStar_Range.use_range r  in
-              let uu____5407 = FStar_Range.def_range r  in
-              uu____5406 = uu____5407  in
-            if uu____5404
+          let uu____5412 =
+            let uu____5414 = FStar_Range.string_of_use_range r  in
+            FStar_Util.format1 "%s: " uu____5414  in
+          let uu____5417 =
+            let uu____5419 =
+              let uu____5421 = FStar_Range.use_range r  in
+              let uu____5422 = FStar_Range.def_range r  in
+              uu____5421 = uu____5422  in
+            if uu____5419
             then ""
             else
-              (let uu____5413 = FStar_Range.string_of_range r  in
-               FStar_Util.format1 " (see also %s)" uu____5413)
+              (let uu____5428 = FStar_Range.string_of_range r  in
+               FStar_Util.format1 " (see also %s)" uu____5428)
              in
-          (uu____5397, uu____5402)
+          (uu____5412, uu____5417)
        in
-    match uu____5374 with
+    match uu____5389 with
     | (range_str,see_also_str) ->
         let issue_number =
           match issue.issue_number with
           | FStar_Pervasives_Native.None  -> ""
           | FStar_Pervasives_Native.Some n1 ->
-              let uu____5433 = FStar_Util.string_of_int n1  in
-              FStar_Util.format1 " %s" uu____5433
+              let uu____5448 = FStar_Util.string_of_int n1  in
+              FStar_Util.format1 " %s" uu____5448
            in
         FStar_Util.format5 "%s(%s%s) %s%s\n" range_str level_header
           issue_number issue.issue_message see_also_str
@@ -2720,7 +2728,7 @@ let (print_issue : issue -> unit) =
       | EWarning  -> FStar_Util.print_warning
       | EError  -> FStar_Util.print_error
       | ENotImplemented  -> FStar_Util.print_error  in
-    let uu____5453 = format_issue issue  in printer uu____5453
+    let uu____5468 = format_issue issue  in printer uu____5468
   
 let (compare_issues : issue -> issue -> Prims.int) =
   fun i1  ->
@@ -2729,8 +2737,8 @@ let (compare_issues : issue -> issue -> Prims.int) =
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.None ) ->
           (Prims.parse_int "0")
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some
-         uu____5477) -> ~- (Prims.parse_int "1")
-      | (FStar_Pervasives_Native.Some uu____5483,FStar_Pervasives_Native.None
+         uu____5492) -> ~- (Prims.parse_int "1")
+      | (FStar_Pervasives_Native.Some uu____5498,FStar_Pervasives_Native.None
          ) -> (Prims.parse_int "1")
       | (FStar_Pervasives_Native.Some r1,FStar_Pervasives_Native.Some r2) ->
           FStar_Range.compare_use_range r1 r2
@@ -2741,19 +2749,19 @@ let (mk_default_handler : Prims.bool -> error_handler) =
     let add_one e =
       match e.issue_level with
       | EError  ->
-          let uu____5516 =
-            let uu____5519 = FStar_ST.op_Bang errs  in e :: uu____5519  in
-          FStar_ST.op_Colon_Equals errs uu____5516
-      | uu____5568 -> print_issue e  in
-    let count_errors uu____5574 =
-      let uu____5575 = FStar_ST.op_Bang errs  in FStar_List.length uu____5575
+          let uu____5531 =
+            let uu____5534 = FStar_ST.op_Bang errs  in e :: uu____5534  in
+          FStar_ST.op_Colon_Equals errs uu____5531
+      | uu____5583 -> print_issue e  in
+    let count_errors uu____5589 =
+      let uu____5590 = FStar_ST.op_Bang errs  in FStar_List.length uu____5590
        in
-    let report uu____5608 =
+    let report uu____5623 =
       let sorted1 =
-        let uu____5612 = FStar_ST.op_Bang errs  in
-        FStar_List.sortWith compare_issues uu____5612  in
+        let uu____5627 = FStar_ST.op_Bang errs  in
+        FStar_List.sortWith compare_issues uu____5627  in
       if print7 then FStar_List.iter print_issue sorted1 else (); sorted1  in
-    let clear1 uu____5647 = FStar_ST.op_Colon_Equals errs []  in
+    let clear1 uu____5662 = FStar_ST.op_Colon_Equals errs []  in
     {
       eh_add_one = add_one;
       eh_count_errors = count_errors;
@@ -2781,11 +2789,11 @@ let (mk_issue :
           }
   
 let (get_err_count : unit -> Prims.int) =
-  fun uu____5715  ->
-    let uu____5716 =
-      let uu____5722 = FStar_ST.op_Bang current_handler  in
-      uu____5722.eh_count_errors  in
-    uu____5716 ()
+  fun uu____5730  ->
+    let uu____5731 =
+      let uu____5737 = FStar_ST.op_Bang current_handler  in
+      uu____5737.eh_count_errors  in
+    uu____5731 ()
   
 let (wrapped_eh_add_one : error_handler -> issue -> unit) =
   fun h  ->
@@ -2793,45 +2801,45 @@ let (wrapped_eh_add_one : error_handler -> issue -> unit) =
       h.eh_add_one issue;
       if issue.issue_level <> EInfo
       then
-        ((let uu____5756 =
-            let uu____5758 = FStar_ST.op_Bang FStar_Options.abort_counter  in
-            uu____5758 - (Prims.parse_int "1")  in
-          FStar_ST.op_Colon_Equals FStar_Options.abort_counter uu____5756);
-         (let uu____5803 =
-            let uu____5805 = FStar_ST.op_Bang FStar_Options.abort_counter  in
-            uu____5805 = (Prims.parse_int "0")  in
-          if uu____5803 then failwith "Aborting due to --abort_on" else ()))
+        ((let uu____5771 =
+            let uu____5773 = FStar_ST.op_Bang FStar_Options.abort_counter  in
+            uu____5773 - (Prims.parse_int "1")  in
+          FStar_ST.op_Colon_Equals FStar_Options.abort_counter uu____5771);
+         (let uu____5818 =
+            let uu____5820 = FStar_ST.op_Bang FStar_Options.abort_counter  in
+            uu____5820 = (Prims.parse_int "0")  in
+          if uu____5818 then failwith "Aborting due to --abort_on" else ()))
       else ()
   
 let (add_one : issue -> unit) =
   fun issue  ->
     FStar_Util.atomically
-      (fun uu____5844  ->
-         let uu____5845 = FStar_ST.op_Bang current_handler  in
-         wrapped_eh_add_one uu____5845 issue)
+      (fun uu____5859  ->
+         let uu____5860 = FStar_ST.op_Bang current_handler  in
+         wrapped_eh_add_one uu____5860 issue)
   
 let (add_many : issue Prims.list -> unit) =
   fun issues  ->
     FStar_Util.atomically
-      (fun uu____5877  ->
-         let uu____5878 =
-           let uu____5883 = FStar_ST.op_Bang current_handler  in
-           wrapped_eh_add_one uu____5883  in
-         FStar_List.iter uu____5878 issues)
+      (fun uu____5892  ->
+         let uu____5893 =
+           let uu____5898 = FStar_ST.op_Bang current_handler  in
+           wrapped_eh_add_one uu____5898  in
+         FStar_List.iter uu____5893 issues)
   
 let (report_all : unit -> issue Prims.list) =
-  fun uu____5910  ->
-    let uu____5911 =
-      let uu____5918 = FStar_ST.op_Bang current_handler  in
-      uu____5918.eh_report  in
-    uu____5911 ()
+  fun uu____5925  ->
+    let uu____5926 =
+      let uu____5933 = FStar_ST.op_Bang current_handler  in
+      uu____5933.eh_report  in
+    uu____5926 ()
   
 let (clear : unit -> unit) =
-  fun uu____5943  ->
-    let uu____5944 =
-      let uu____5949 = FStar_ST.op_Bang current_handler  in
-      uu____5949.eh_clear  in
-    uu____5944 ()
+  fun uu____5958  ->
+    let uu____5959 =
+      let uu____5964 = FStar_ST.op_Bang current_handler  in
+      uu____5964.eh_clear  in
+    uu____5959 ()
   
 let (set_handler : error_handler -> unit) =
   fun handler  ->
@@ -2867,29 +2875,29 @@ let (message_prefix : error_message_prefix) =
   let pfx = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
   let set_prefix s =
     FStar_ST.op_Colon_Equals pfx (FStar_Pervasives_Native.Some s)  in
-  let clear_prefix uu____6172 =
+  let clear_prefix uu____6187 =
     FStar_ST.op_Colon_Equals pfx FStar_Pervasives_Native.None  in
   let append_prefix s =
-    let uu____6208 = FStar_ST.op_Bang pfx  in
-    match uu____6208 with
+    let uu____6223 = FStar_ST.op_Bang pfx  in
+    match uu____6223 with
     | FStar_Pervasives_Native.None  -> s
     | FStar_Pervasives_Native.Some p ->
-        let uu____6242 = FStar_String.op_Hat ": " s  in
-        FStar_String.op_Hat p uu____6242
+        let uu____6257 = FStar_String.op_Hat ": " s  in
+        FStar_String.op_Hat p uu____6257
      in
   { set_prefix; append_prefix; clear_prefix } 
 let findIndex :
-  'Auu____6254 'Auu____6255 .
-    ('Auu____6254 * 'Auu____6255) Prims.list -> 'Auu____6254 -> Prims.int
+  'Auu____6269 'Auu____6270 .
+    ('Auu____6269 * 'Auu____6270) Prims.list -> 'Auu____6269 -> Prims.int
   =
   fun l  ->
     fun v1  ->
       FStar_All.pipe_right l
         (FStar_List.index
-           (fun uu___0_6293  ->
-              match uu___0_6293 with
-              | (e,uu____6300) when e = v1 -> true
-              | uu____6302 -> false))
+           (fun uu___0_6308  ->
+              match uu___0_6308 with
+              | (e,uu____6315) when e = v1 -> true
+              | uu____6317 -> false))
   
 let (errno_of_error : raw_error -> Prims.int) =
   fun e  -> findIndex default_flags e 
@@ -2898,8 +2906,8 @@ let (init_warn_error_flags : FStar_Options.error_flag Prims.list) =
 let (diag : FStar_Range.range -> Prims.string -> unit) =
   fun r  ->
     fun msg  ->
-      let uu____6335 = FStar_Options.debug_any ()  in
-      if uu____6335
+      let uu____6350 = FStar_Options.debug_any ()  in
+      if uu____6350
       then
         add_one
           (mk_issue EInfo (FStar_Pervasives_Native.Some r) msg
@@ -2913,22 +2921,22 @@ let (lookup :
   =
   fun flags  ->
     fun errno  ->
-      let uu____6360 =
+      let uu____6375 =
         (errno = defensive_errno) && (FStar_Options.defensive_fail ())  in
-      if uu____6360
+      if uu____6375
       then FStar_Options.CAlwaysError
       else FStar_List.nth flags errno
   
 let (log_issue : FStar_Range.range -> (raw_error * Prims.string) -> unit) =
   fun r  ->
-    fun uu____6381  ->
-      match uu____6381 with
+    fun uu____6396  ->
+      match uu____6396 with
       | (e,msg) ->
           let errno = errno_of_error e  in
-          let uu____6393 =
-            let uu____6394 = FStar_Options.error_flags ()  in
-            lookup uu____6394 errno  in
-          (match uu____6393 with
+          let uu____6408 =
+            let uu____6409 = FStar_Options.error_flags ()  in
+            lookup uu____6409 errno  in
+          (match uu____6408 with
            | FStar_Options.CAlwaysError  ->
                add_one
                  (mk_issue EError (FStar_Pervasives_Native.Some r) msg
@@ -2947,97 +2955,97 @@ let (log_issue : FStar_Range.range -> (raw_error * Prims.string) -> unit) =
                  mk_issue EError (FStar_Pervasives_Native.Some r) msg
                    (FStar_Pervasives_Native.Some errno)
                   in
-               let uu____6402 = FStar_Options.ide ()  in
-               if uu____6402
+               let uu____6417 = FStar_Options.ide ()  in
+               if uu____6417
                then add_one i
                else
-                 (let uu____6407 =
-                    let uu____6409 = format_issue i  in
+                 (let uu____6422 =
+                    let uu____6424 = format_issue i  in
                     FStar_String.op_Hat
                       "don't use log_issue to report fatal error, should use raise_error: "
-                      uu____6409
+                      uu____6424
                      in
-                  failwith uu____6407))
+                  failwith uu____6422))
   
 let (add_errors :
   (raw_error * Prims.string * FStar_Range.range) Prims.list -> unit) =
   fun errs  ->
     FStar_Util.atomically
-      (fun uu____6437  ->
+      (fun uu____6452  ->
          FStar_List.iter
-           (fun uu____6450  ->
-              match uu____6450 with
+           (fun uu____6465  ->
+              match uu____6465 with
               | (e,msg,r) ->
-                  let uu____6463 =
-                    let uu____6469 = message_prefix.append_prefix msg  in
-                    (e, uu____6469)  in
-                  log_issue r uu____6463) errs)
+                  let uu____6478 =
+                    let uu____6484 = message_prefix.append_prefix msg  in
+                    (e, uu____6484)  in
+                  log_issue r uu____6478) errs)
   
 let (issue_of_exn : Prims.exn -> issue FStar_Pervasives_Native.option) =
-  fun uu___1_6479  ->
-    match uu___1_6479 with
+  fun uu___1_6494  ->
+    match uu___1_6494 with
     | Error (e,msg,r) ->
         let errno = errno_of_error e  in
-        let uu____6489 =
-          let uu____6490 = message_prefix.append_prefix msg  in
-          mk_issue EError (FStar_Pervasives_Native.Some r) uu____6490
+        let uu____6504 =
+          let uu____6505 = message_prefix.append_prefix msg  in
+          mk_issue EError (FStar_Pervasives_Native.Some r) uu____6505
             (FStar_Pervasives_Native.Some errno)
            in
-        FStar_Pervasives_Native.Some uu____6489
+        FStar_Pervasives_Native.Some uu____6504
     | FStar_Util.NYI msg ->
-        let uu____6495 =
-          let uu____6496 = message_prefix.append_prefix msg  in
-          mk_issue ENotImplemented FStar_Pervasives_Native.None uu____6496
+        let uu____6510 =
+          let uu____6511 = message_prefix.append_prefix msg  in
+          mk_issue ENotImplemented FStar_Pervasives_Native.None uu____6511
             FStar_Pervasives_Native.None
            in
-        FStar_Pervasives_Native.Some uu____6495
+        FStar_Pervasives_Native.Some uu____6510
     | Err (e,msg) ->
         let errno = errno_of_error e  in
-        let uu____6505 =
-          let uu____6506 = message_prefix.append_prefix msg  in
-          mk_issue EError FStar_Pervasives_Native.None uu____6506
+        let uu____6520 =
+          let uu____6521 = message_prefix.append_prefix msg  in
+          mk_issue EError FStar_Pervasives_Native.None uu____6521
             (FStar_Pervasives_Native.Some errno)
            in
-        FStar_Pervasives_Native.Some uu____6505
-    | uu____6509 -> FStar_Pervasives_Native.None
+        FStar_Pervasives_Native.Some uu____6520
+    | uu____6524 -> FStar_Pervasives_Native.None
   
 let (err_exn : Prims.exn -> unit) =
   fun exn  ->
     if exn = Stop
     then ()
     else
-      (let uu____6519 = issue_of_exn exn  in
-       match uu____6519 with
+      (let uu____6534 = issue_of_exn exn  in
+       match uu____6534 with
        | FStar_Pervasives_Native.Some issue -> add_one issue
        | FStar_Pervasives_Native.None  -> FStar_Exn.raise exn)
   
 let (handleable : Prims.exn -> Prims.bool) =
-  fun uu___2_6529  ->
-    match uu___2_6529 with
-    | Error uu____6531 -> true
-    | FStar_Util.NYI uu____6540 -> true
+  fun uu___2_6544  ->
+    match uu___2_6544 with
+    | Error uu____6546 -> true
+    | FStar_Util.NYI uu____6555 -> true
     | Stop  -> true
-    | Err uu____6544 -> true
-    | uu____6551 -> false
+    | Err uu____6559 -> true
+    | uu____6566 -> false
   
 let (stop_if_err : unit -> unit) =
-  fun uu____6558  ->
-    let uu____6559 =
-      let uu____6561 = get_err_count ()  in
-      uu____6561 > (Prims.parse_int "0")  in
-    if uu____6559 then FStar_Exn.raise Stop else ()
+  fun uu____6573  ->
+    let uu____6574 =
+      let uu____6576 = get_err_count ()  in
+      uu____6576 > (Prims.parse_int "0")  in
+    if uu____6574 then FStar_Exn.raise Stop else ()
   
 let raise_error :
-  'Auu____6574 .
-    (raw_error * Prims.string) -> FStar_Range.range -> 'Auu____6574
+  'Auu____6589 .
+    (raw_error * Prims.string) -> FStar_Range.range -> 'Auu____6589
   =
-  fun uu____6588  ->
+  fun uu____6603  ->
     fun r  ->
-      match uu____6588 with | (e,msg) -> FStar_Exn.raise (Error (e, msg, r))
+      match uu____6603 with | (e,msg) -> FStar_Exn.raise (Error (e, msg, r))
   
-let raise_err : 'Auu____6605 . (raw_error * Prims.string) -> 'Auu____6605 =
-  fun uu____6615  ->
-    match uu____6615 with | (e,msg) -> FStar_Exn.raise (Err (e, msg))
+let raise_err : 'Auu____6620 . (raw_error * Prims.string) -> 'Auu____6620 =
+  fun uu____6630  ->
+    match uu____6630 with | (e,msg) -> FStar_Exn.raise (Err (e, msg))
   
 let (update_flags :
   (FStar_Options.error_flag * Prims.string) Prims.list ->
@@ -3045,9 +3053,9 @@ let (update_flags :
   =
   fun l  ->
     let flags = init_warn_error_flags  in
-    let compare1 uu____6683 uu____6684 =
-      match (uu____6683, uu____6684) with
-      | ((uu____6726,(a,uu____6728)),(uu____6729,(b,uu____6731))) ->
+    let compare1 uu____6698 uu____6699 =
+      match (uu____6698, uu____6699) with
+      | ((uu____6741,(a,uu____6743)),(uu____6744,(b,uu____6746))) ->
           if a > b
           then (Prims.parse_int "1")
           else
@@ -3066,11 +3074,11 @@ let (update_flags :
       | (FStar_Options.CSilent ,FStar_Options.CAlwaysError ) ->
           raise_err
             (Fatal_InvalidWarnErrorSetting, "cannot silence an error")
-      | (uu____6800,FStar_Options.CFatal ) ->
+      | (uu____6815,FStar_Options.CFatal ) ->
           raise_err
             (Fatal_InvalidWarnErrorSetting,
               "cannot reset the error level of a fatal error")
-      | uu____6803 -> f  in
+      | uu____6818 -> f  in
     let rec set_flag i l1 =
       let d = FStar_List.nth flags i  in
       match l1 with
@@ -3084,45 +3092,45 @@ let (update_flags :
       match l1 with
       | [] -> f
       | hd1::tl1 ->
-          let uu____6961 =
-            let uu____6964 =
-              let uu____6967 = set_flag i sorted1  in [uu____6967]  in
-            FStar_List.append f uu____6964  in
-          aux uu____6961 (i + (Prims.parse_int "1")) tl1 sorted1
+          let uu____6976 =
+            let uu____6979 =
+              let uu____6982 = set_flag i sorted1  in [uu____6982]  in
+            FStar_List.append f uu____6979  in
+          aux uu____6976 (i + (Prims.parse_int "1")) tl1 sorted1
        in
     let rec compute_range result l1 =
       match l1 with
       | [] -> result
       | (f,s)::tl1 ->
           let r = FStar_Util.split s ".."  in
-          let uu____7069 =
+          let uu____7084 =
             match r with
             | r1::r2::[] ->
-                let uu____7089 = FStar_Util.int_of_string r1  in
-                let uu____7091 = FStar_Util.int_of_string r2  in
-                (uu____7089, uu____7091)
-            | uu____7095 ->
-                let uu____7099 =
-                  let uu____7105 =
+                let uu____7104 = FStar_Util.int_of_string r1  in
+                let uu____7106 = FStar_Util.int_of_string r2  in
+                (uu____7104, uu____7106)
+            | uu____7110 ->
+                let uu____7114 =
+                  let uu____7120 =
                     FStar_Util.format1 "Malformed warn-error range %s" s  in
-                  (Fatal_InvalidWarnErrorSetting, uu____7105)  in
-                raise_err uu____7099
+                  (Fatal_InvalidWarnErrorSetting, uu____7120)  in
+                raise_err uu____7114
              in
-          (match uu____7069 with
+          (match uu____7084 with
            | (l2,h) ->
                (if
                   (l2 < (Prims.parse_int "0")) ||
                     (h >= (FStar_List.length default_flags))
                 then
-                  (let uu____7140 =
-                     let uu____7146 =
-                       let uu____7148 = FStar_Util.string_of_int l2  in
-                       let uu____7150 = FStar_Util.string_of_int h  in
+                  (let uu____7155 =
+                     let uu____7161 =
+                       let uu____7163 = FStar_Util.string_of_int l2  in
+                       let uu____7165 = FStar_Util.string_of_int h  in
                        FStar_Util.format2 "No error for warn_error %s..%s"
-                         uu____7148 uu____7150
+                         uu____7163 uu____7165
                         in
-                     (Fatal_InvalidWarnErrorSetting, uu____7146)  in
-                   raise_err uu____7140)
+                     (Fatal_InvalidWarnErrorSetting, uu____7161)  in
+                   raise_err uu____7155)
                 else ();
                 compute_range (FStar_List.append result [(f, (l2, h))]) tl1))
        in
@@ -3139,12 +3147,12 @@ let catch_errors :
     FStar_ST.op_Colon_Equals current_handler newh;
     (let r =
        try
-         (fun uu___279_7314  ->
+         (fun uu___279_7329  ->
             match () with
             | () -> let r = f ()  in FStar_Pervasives_Native.Some r) ()
        with
-       | uu___278_7320 ->
-           (err_exn uu___278_7320; FStar_Pervasives_Native.None)
+       | uu___278_7335 ->
+           (err_exn uu___278_7335; FStar_Pervasives_Native.None)
         in
      let errs = newh.eh_report ()  in
      FStar_ST.op_Colon_Equals current_handler old; (errs, r))

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -641,155 +641,204 @@ let (extract_typ_abbrev :
     FStar_Syntax_Syntax.qualifier Prims.list ->
       FStar_Syntax_Syntax.term Prims.list ->
         FStar_Syntax_Syntax.letbinding ->
-          FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option ->
-            (env_t * iface * FStar_Extraction_ML_Syntax.mlmodule1 Prims.list))
+          (env_t * iface * FStar_Extraction_ML_Syntax.mlmodule1 Prims.list))
   =
   fun env  ->
     fun quals  ->
       fun attrs  ->
         fun lb  ->
-          fun body_mlty_opt  ->
+          let uu____1639 =
             let uu____1648 =
-              let uu____1657 =
-                FStar_TypeChecker_Env.open_universes_in
-                  env.FStar_Extraction_ML_UEnv.env_tcenv
-                  lb.FStar_Syntax_Syntax.lbunivs
-                  [lb.FStar_Syntax_Syntax.lbdef;
-                  lb.FStar_Syntax_Syntax.lbtyp]
-                 in
-              match uu____1657 with
-              | (tcenv,uu____1675,def_typ) ->
-                  let uu____1681 = as_pair def_typ  in (tcenv, uu____1681)
+              FStar_TypeChecker_Env.open_universes_in
+                env.FStar_Extraction_ML_UEnv.env_tcenv
+                lb.FStar_Syntax_Syntax.lbunivs
+                [lb.FStar_Syntax_Syntax.lbdef; lb.FStar_Syntax_Syntax.lbtyp]
                in
             match uu____1648 with
-            | (tcenv,(lbdef,lbtyp)) ->
-                let lbtyp1 =
-                  FStar_TypeChecker_Normalize.normalize
-                    [FStar_TypeChecker_Env.Beta;
-                    FStar_TypeChecker_Env.UnfoldUntil
-                      FStar_Syntax_Syntax.delta_constant] tcenv lbtyp
+            | (tcenv,uu____1666,def_typ) ->
+                let uu____1672 = as_pair def_typ  in (tcenv, uu____1672)
+             in
+          match uu____1639 with
+          | (tcenv,(lbdef,lbtyp)) ->
+              let lbtyp1 =
+                FStar_TypeChecker_Normalize.normalize
+                  [FStar_TypeChecker_Env.Beta;
+                  FStar_TypeChecker_Env.UnfoldUntil
+                    FStar_Syntax_Syntax.delta_constant] tcenv lbtyp
+                 in
+              let lbdef1 =
+                FStar_TypeChecker_Normalize.eta_expand_with_type tcenv lbdef
+                  lbtyp1
+                 in
+              let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
+              let lid =
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
+              let def =
+                let uu____1703 =
+                  let uu____1704 = FStar_Syntax_Subst.compress lbdef1  in
+                  FStar_All.pipe_right uu____1704 FStar_Syntax_Util.unmeta
                    in
-                let lbdef1 =
-                  FStar_TypeChecker_Normalize.eta_expand_with_type tcenv
-                    lbdef lbtyp1
-                   in
-                let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                let lid =
-                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-                let def =
-                  let uu____1712 =
-                    let uu____1713 = FStar_Syntax_Subst.compress lbdef1  in
-                    FStar_All.pipe_right uu____1713 FStar_Syntax_Util.unmeta
-                     in
-                  FStar_All.pipe_right uu____1712 FStar_Syntax_Util.un_uinst
-                   in
-                let def1 =
-                  match def.FStar_Syntax_Syntax.n with
-                  | FStar_Syntax_Syntax.Tm_abs uu____1721 ->
-                      FStar_Extraction_ML_Term.normalize_abs def
-                  | uu____1740 -> def  in
-                let uu____1741 =
-                  match def1.FStar_Syntax_Syntax.n with
-                  | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____1752) ->
-                      FStar_Syntax_Subst.open_term bs body
-                  | uu____1777 -> ([], def1)  in
-                (match uu____1741 with
-                 | (bs,body) ->
-                     let assumed =
-                       FStar_Util.for_some
-                         (fun uu___3_1797  ->
-                            match uu___3_1797 with
-                            | FStar_Syntax_Syntax.Assumption  -> true
-                            | uu____1800 -> false) quals
+                FStar_All.pipe_right uu____1703 FStar_Syntax_Util.un_uinst
+                 in
+              let def1 =
+                match def.FStar_Syntax_Syntax.n with
+                | FStar_Syntax_Syntax.Tm_abs uu____1712 ->
+                    FStar_Extraction_ML_Term.normalize_abs def
+                | uu____1731 -> def  in
+              let uu____1732 =
+                match def1.FStar_Syntax_Syntax.n with
+                | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____1743) ->
+                    FStar_Syntax_Subst.open_term bs body
+                | uu____1768 -> ([], def1)  in
+              (match uu____1732 with
+               | (bs,body) ->
+                   let assumed =
+                     FStar_Util.for_some
+                       (fun uu___3_1788  ->
+                          match uu___3_1788 with
+                          | FStar_Syntax_Syntax.Assumption  -> true
+                          | uu____1791 -> false) quals
+                      in
+                   let uu____1793 = binders_as_mlty_binders env bs  in
+                   (match uu____1793 with
+                    | (env1,ml_bs) ->
+                        let body1 =
+                          let uu____1820 =
+                            FStar_Extraction_ML_Term.term_as_mlty env1 body
+                             in
+                          FStar_All.pipe_right uu____1820
+                            (FStar_Extraction_ML_Util.eraseTypeDeep
+                               (FStar_Extraction_ML_Util.udelta_unfold env1))
+                           in
+                        let mangled_projector =
+                          let uu____1825 =
+                            FStar_All.pipe_right quals
+                              (FStar_Util.for_some
+                                 (fun uu___4_1832  ->
+                                    match uu___4_1832 with
+                                    | FStar_Syntax_Syntax.Projector
+                                        uu____1834 -> true
+                                    | uu____1840 -> false))
+                             in
+                          if uu____1825
+                          then
+                            let mname = mangle_projector_lid lid  in
+                            FStar_Pervasives_Native.Some
+                              ((mname.FStar_Ident.ident).FStar_Ident.idText)
+                          else FStar_Pervasives_Native.None  in
+                        let metadata =
+                          let uu____1854 = extract_metadata attrs  in
+                          let uu____1857 =
+                            FStar_List.choose flag_of_qual quals  in
+                          FStar_List.append uu____1854 uu____1857  in
+                        let td =
+                          let uu____1880 = lident_as_mlsymbol lid  in
+                          (assumed, uu____1880, mangled_projector, ml_bs,
+                            metadata,
+                            (FStar_Pervasives_Native.Some
+                               (FStar_Extraction_ML_Syntax.MLTD_Abbrev body1)))
+                           in
+                        let def2 =
+                          let uu____1892 =
+                            let uu____1893 =
+                              let uu____1894 = FStar_Ident.range_of_lid lid
+                                 in
+                              FStar_Extraction_ML_Util.mlloc_of_range
+                                uu____1894
+                               in
+                            FStar_Extraction_ML_Syntax.MLM_Loc uu____1893  in
+                          [uu____1892;
+                          FStar_Extraction_ML_Syntax.MLM_Ty [td]]  in
+                        let uu____1895 =
+                          let uu____1900 =
+                            FStar_All.pipe_right quals
+                              (FStar_Util.for_some
+                                 (fun uu___5_1906  ->
+                                    match uu___5_1906 with
+                                    | FStar_Syntax_Syntax.Assumption  -> true
+                                    | FStar_Syntax_Syntax.New  -> true
+                                    | uu____1910 -> false))
+                             in
+                          if uu____1900
+                          then
+                            let uu____1917 =
+                              FStar_Extraction_ML_UEnv.extend_type_name env
+                                fv
+                               in
+                            (uu____1917, (iface_of_type_names [fv]))
+                          else
+                            (let uu____1920 =
+                               FStar_Extraction_ML_UEnv.extend_tydef env fv
+                                 td
+                                in
+                             match uu____1920 with
+                             | (env2,tydef) ->
+                                 let uu____1931 = iface_of_tydefs [tydef]  in
+                                 (env2, uu____1931))
+                           in
+                        (match uu____1895 with
+                         | (env2,iface1) -> (env2, iface1, def2))))
+  
+let (extract_let_rec_type :
+  FStar_Extraction_ML_UEnv.uenv ->
+    FStar_Syntax_Syntax.qualifier Prims.list ->
+      FStar_Syntax_Syntax.term Prims.list ->
+        FStar_Syntax_Syntax.letbinding ->
+          (env_t * iface * FStar_Extraction_ML_Syntax.mlmodule1 Prims.list))
+  =
+  fun env  ->
+    fun quals  ->
+      fun attrs  ->
+        fun lb  ->
+          let lbtyp =
+            FStar_TypeChecker_Normalize.normalize
+              [FStar_TypeChecker_Env.Beta;
+              FStar_TypeChecker_Env.AllowUnboundUniverses;
+              FStar_TypeChecker_Env.EraseUniverses;
+              FStar_TypeChecker_Env.UnfoldUntil
+                FStar_Syntax_Syntax.delta_constant]
+              env.FStar_Extraction_ML_UEnv.env_tcenv
+              lb.FStar_Syntax_Syntax.lbtyp
+             in
+          let uu____1990 = FStar_Syntax_Util.arrow_formals lbtyp  in
+          match uu____1990 with
+          | (bs,uu____2014) ->
+              let uu____2035 = binders_as_mlty_binders env bs  in
+              (match uu____2035 with
+               | (env1,ml_bs) ->
+                   let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname
+                      in
+                   let lid =
+                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                      in
+                   let body = FStar_Extraction_ML_Syntax.MLTY_Top  in
+                   let metadata =
+                     let uu____2067 = extract_metadata attrs  in
+                     let uu____2070 = FStar_List.choose flag_of_qual quals
                         in
-                     let uu____1802 = binders_as_mlty_binders env bs  in
-                     (match uu____1802 with
-                      | (env1,ml_bs) ->
-                          let body1 =
-                            match body_mlty_opt with
-                            | FStar_Pervasives_Native.Some t -> t
-                            | uu____1830 ->
-                                let uu____1833 =
-                                  FStar_Extraction_ML_Term.term_as_mlty env1
-                                    body
-                                   in
-                                FStar_All.pipe_right uu____1833
-                                  (FStar_Extraction_ML_Util.eraseTypeDeep
-                                     (FStar_Extraction_ML_Util.udelta_unfold
-                                        env1))
-                             in
-                          let mangled_projector =
-                            let uu____1838 =
-                              FStar_All.pipe_right quals
-                                (FStar_Util.for_some
-                                   (fun uu___4_1845  ->
-                                      match uu___4_1845 with
-                                      | FStar_Syntax_Syntax.Projector
-                                          uu____1847 -> true
-                                      | uu____1853 -> false))
-                               in
-                            if uu____1838
-                            then
-                              let mname = mangle_projector_lid lid  in
-                              FStar_Pervasives_Native.Some
-                                ((mname.FStar_Ident.ident).FStar_Ident.idText)
-                            else FStar_Pervasives_Native.None  in
-                          let metadata =
-                            let uu____1867 = extract_metadata attrs  in
-                            let uu____1870 =
-                              FStar_List.choose flag_of_qual quals  in
-                            FStar_List.append uu____1867 uu____1870  in
-                          let td =
-                            let uu____1893 = lident_as_mlsymbol lid  in
-                            (assumed, uu____1893, mangled_projector, ml_bs,
-                              metadata,
-                              (FStar_Pervasives_Native.Some
-                                 (FStar_Extraction_ML_Syntax.MLTD_Abbrev
-                                    body1)))
-                             in
-                          let def2 =
-                            let uu____1905 =
-                              let uu____1906 =
-                                let uu____1907 = FStar_Ident.range_of_lid lid
-                                   in
-                                FStar_Extraction_ML_Util.mlloc_of_range
-                                  uu____1907
-                                 in
-                              FStar_Extraction_ML_Syntax.MLM_Loc uu____1906
-                               in
-                            [uu____1905;
-                            FStar_Extraction_ML_Syntax.MLM_Ty [td]]  in
-                          let uu____1908 =
-                            let uu____1913 =
-                              FStar_All.pipe_right quals
-                                (FStar_Util.for_some
-                                   (fun uu___5_1919  ->
-                                      match uu___5_1919 with
-                                      | FStar_Syntax_Syntax.Assumption  ->
-                                          true
-                                      | FStar_Syntax_Syntax.New  -> true
-                                      | uu____1923 -> false))
-                               in
-                            if uu____1913
-                            then
-                              let uu____1930 =
-                                FStar_Extraction_ML_UEnv.extend_type_name env
-                                  fv
-                                 in
-                              (uu____1930, (iface_of_type_names [fv]))
-                            else
-                              (let uu____1933 =
-                                 FStar_Extraction_ML_UEnv.extend_tydef env fv
-                                   td
-                                  in
-                               match uu____1933 with
-                               | (env2,tydef) ->
-                                   let uu____1944 = iface_of_tydefs [tydef]
-                                      in
-                                   (env2, uu____1944))
-                             in
-                          (match uu____1908 with
-                           | (env2,iface1) -> (env2, iface1, def2))))
+                     FStar_List.append uu____2067 uu____2070  in
+                   let assumed = false  in
+                   let td =
+                     let uu____2096 = lident_as_mlsymbol lid  in
+                     (assumed, uu____2096, FStar_Pervasives_Native.None,
+                       ml_bs, metadata,
+                       (FStar_Pervasives_Native.Some
+                          (FStar_Extraction_ML_Syntax.MLTD_Abbrev body)))
+                      in
+                   let def =
+                     let uu____2109 =
+                       let uu____2110 =
+                         let uu____2111 = FStar_Ident.range_of_lid lid  in
+                         FStar_Extraction_ML_Util.mlloc_of_range uu____2111
+                          in
+                       FStar_Extraction_ML_Syntax.MLM_Loc uu____2110  in
+                     [uu____2109; FStar_Extraction_ML_Syntax.MLM_Ty [td]]  in
+                   let uu____2112 =
+                     FStar_Extraction_ML_UEnv.extend_tydef env fv td  in
+                   (match uu____2112 with
+                    | (env2,tydef) ->
+                        let iface1 = iface_of_tydefs [tydef]  in
+                        (env2, iface1, def)))
   
 let (extract_bundle_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -799,25 +848,25 @@ let (extract_bundle_iface :
     fun se  ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____2020 =
+          let uu____2193 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp  in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____2020
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____2193
            in
         let tys = (ml_tyvars, mlt)  in
         let fvv = FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp  in
-        let uu____2027 =
+        let uu____2200 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false  in
-        match uu____2027 with | (env2,uu____2046,b) -> (env2, (fvv, b))  in
+        match uu____2200 with | (env2,uu____2219,b) -> (env2, (fvv, b))  in
       let extract_one_family env1 ind =
-        let uu____2085 = binders_as_mlty_binders env1 ind.iparams  in
-        match uu____2085 with
+        let uu____2258 = binders_as_mlty_binders env1 ind.iparams  in
+        match uu____2258 with
         | (env_iparams,vars) ->
-            let uu____2113 =
+            let uu____2286 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1)
                in
-            (match uu____2113 with | (env2,ctors) -> (env2, ctors))
+            (match uu____2286 with | (env2,ctors) -> (env2, ctors))
          in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
@@ -825,37 +874,37 @@ let (extract_bundle_iface :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l,uu____2177,t,uu____2179,uu____2180,uu____2181);
-            FStar_Syntax_Syntax.sigrng = uu____2182;
-            FStar_Syntax_Syntax.sigquals = uu____2183;
-            FStar_Syntax_Syntax.sigmeta = uu____2184;
-            FStar_Syntax_Syntax.sigattrs = uu____2185;_}::[],uu____2186),(FStar_Syntax_Syntax.ExceptionConstructor
+              (l,uu____2350,t,uu____2352,uu____2353,uu____2354);
+            FStar_Syntax_Syntax.sigrng = uu____2355;
+            FStar_Syntax_Syntax.sigquals = uu____2356;
+            FStar_Syntax_Syntax.sigmeta = uu____2357;
+            FStar_Syntax_Syntax.sigattrs = uu____2358;_}::[],uu____2359),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____2205 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____2378 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____2205 with
+          (match uu____2378 with
            | (env1,ctor) -> (env1, (iface_of_bindings [ctor])))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____2238),quals) ->
-          let uu____2252 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____2411),quals) ->
+          let uu____2425 =
             bundle_as_inductive_families env ses quals
               se.FStar_Syntax_Syntax.sigattrs
              in
-          (match uu____2252 with
+          (match uu____2425 with
            | (env1,ifams) ->
-               let uu____2269 =
+               let uu____2442 =
                  FStar_Util.fold_map extract_one_family env1 ifams  in
-               (match uu____2269 with
+               (match uu____2442 with
                 | (env2,td) ->
-                    let uu____2310 =
-                      let uu____2311 =
-                        let uu____2312 =
+                    let uu____2483 =
+                      let uu____2484 =
+                        let uu____2485 =
                           FStar_List.map (fun x  -> x.ifv) ifams  in
-                        iface_of_type_names uu____2312  in
-                      iface_union uu____2311
+                        iface_of_type_names uu____2485  in
+                      iface_union uu____2484
                         (iface_of_bindings (FStar_List.flatten td))
                        in
-                    (env2, uu____2310)))
-      | uu____2321 -> failwith "Unexpected signature element"
+                    (env2, uu____2483)))
+      | uu____2494 -> failwith "Unexpected signature element"
   
 let (extract_type_declaration :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -873,29 +922,29 @@ let (extract_type_declaration :
         fun attrs  ->
           fun univs1  ->
             fun t  ->
-              let uu____2396 =
-                let uu____2398 =
+              let uu____2569 =
+                let uu____2571 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
-                       (fun uu___6_2404  ->
-                          match uu___6_2404 with
+                       (fun uu___6_2577  ->
+                          match uu___6_2577 with
                           | FStar_Syntax_Syntax.Assumption  -> true
-                          | uu____2407 -> false))
+                          | uu____2580 -> false))
                    in
-                Prims.op_Negation uu____2398  in
-              if uu____2396
+                Prims.op_Negation uu____2571  in
+              if uu____2569
               then (g, empty_iface, [])
               else
-                (let uu____2422 = FStar_Syntax_Util.arrow_formals t  in
-                 match uu____2422 with
-                 | (bs,uu____2446) ->
+                (let uu____2595 = FStar_Syntax_Util.arrow_formals t  in
+                 match uu____2595 with
+                 | (bs,uu____2619) ->
                      let fv =
                        FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None
                         in
                      let lb =
-                       let uu____2469 =
+                       let uu____2642 =
                          FStar_Syntax_Util.abs bs FStar_Syntax_Syntax.t_unit
                            FStar_Pervasives_Native.None
                           in
@@ -905,13 +954,12 @@ let (extract_type_declaration :
                          FStar_Syntax_Syntax.lbtyp = t;
                          FStar_Syntax_Syntax.lbeff =
                            FStar_Parser_Const.effect_Tot_lid;
-                         FStar_Syntax_Syntax.lbdef = uu____2469;
+                         FStar_Syntax_Syntax.lbdef = uu____2642;
                          FStar_Syntax_Syntax.lbattrs = attrs;
                          FStar_Syntax_Syntax.lbpos =
                            (t.FStar_Syntax_Syntax.pos)
                        }  in
-                     extract_typ_abbrev g quals attrs lb
-                       FStar_Pervasives_Native.None)
+                     extract_typ_abbrev g quals attrs lb)
   
 let (extract_reifiable_effect :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -926,18 +974,18 @@ let (extract_reifiable_effect :
           FStar_Syntax_Syntax.lid_as_fv lid
             FStar_Syntax_Syntax.delta_equational FStar_Pervasives_Native.None
            in
-        let uu____2532 =
+        let uu____2705 =
           FStar_Extraction_ML_UEnv.extend_fv' g1 fv ml_name tysc false false
            in
-        match uu____2532 with
+        match uu____2705 with
         | (g2,mangled_name,exp_binding) ->
-            ((let uu____2554 =
+            ((let uu____2727 =
                 FStar_All.pipe_left
                   (FStar_TypeChecker_Env.debug
                      g2.FStar_Extraction_ML_UEnv.env_tcenv)
                   (FStar_Options.Other "ExtractionReify")
                  in
-              if uu____2554
+              if uu____2727
               then FStar_Util.print1 "Mangled name: %s\n" mangled_name
               else ());
              (let lb =
@@ -955,80 +1003,80 @@ let (extract_reifiable_effect :
                    (FStar_Extraction_ML_Syntax.NonRec, [lb])))))
          in
       let rec extract_fv tm =
-        (let uu____2590 =
+        (let uu____2763 =
            FStar_All.pipe_left
              (FStar_TypeChecker_Env.debug
                 g.FStar_Extraction_ML_UEnv.env_tcenv)
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2590
+         if uu____2763
          then
-           let uu____2595 = FStar_Syntax_Print.term_to_string tm  in
-           FStar_Util.print1 "extract_fv term: %s\n" uu____2595
+           let uu____2768 = FStar_Syntax_Print.term_to_string tm  in
+           FStar_Util.print1 "extract_fv term: %s\n" uu____2768
          else ());
-        (let uu____2600 =
-           let uu____2601 = FStar_Syntax_Subst.compress tm  in
-           uu____2601.FStar_Syntax_Syntax.n  in
-         match uu____2600 with
-         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2609) -> extract_fv tm1
+        (let uu____2773 =
+           let uu____2774 = FStar_Syntax_Subst.compress tm  in
+           uu____2774.FStar_Syntax_Syntax.n  in
+         match uu____2773 with
+         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2782) -> extract_fv tm1
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              let mlp =
                FStar_Extraction_ML_Syntax.mlpath_of_lident
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             let uu____2616 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
-             (match uu____2616 with
-              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2621;
-                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2622;
+             let uu____2789 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
+             (match uu____2789 with
+              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2794;
+                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2795;
                   FStar_Extraction_ML_UEnv.exp_b_tscheme = tysc;
-                  FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____2624;_} ->
-                  let uu____2627 =
+                  FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____2797;_} ->
+                  let uu____2800 =
                     FStar_All.pipe_left
                       (FStar_Extraction_ML_Syntax.with_ty
                          FStar_Extraction_ML_Syntax.MLTY_Top)
                       (FStar_Extraction_ML_Syntax.MLE_Name mlp)
                      in
-                  (uu____2627, tysc))
-         | uu____2628 ->
-             let uu____2629 =
-               let uu____2631 =
+                  (uu____2800, tysc))
+         | uu____2801 ->
+             let uu____2802 =
+               let uu____2804 =
                  FStar_Range.string_of_range tm.FStar_Syntax_Syntax.pos  in
-               let uu____2633 = FStar_Syntax_Print.term_to_string tm  in
-               FStar_Util.format2 "(%s) Not an fv: %s" uu____2631 uu____2633
+               let uu____2806 = FStar_Syntax_Print.term_to_string tm  in
+               FStar_Util.format2 "(%s) Not an fv: %s" uu____2804 uu____2806
                 in
-             failwith uu____2629)
+             failwith uu____2802)
          in
       let extract_action g1 a =
-        (let uu____2661 =
+        (let uu____2834 =
            FStar_All.pipe_left
              (FStar_TypeChecker_Env.debug
                 g1.FStar_Extraction_ML_UEnv.env_tcenv)
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2661
+         if uu____2834
          then
-           let uu____2666 =
+           let uu____2839 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_typ
               in
-           let uu____2668 =
+           let uu____2841 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_defn
               in
-           FStar_Util.print2 "Action type %s and term %s\n" uu____2666
-             uu____2668
+           FStar_Util.print2 "Action type %s and term %s\n" uu____2839
+             uu____2841
          else ());
-        (let uu____2673 = FStar_Extraction_ML_UEnv.action_name ed a  in
-         match uu____2673 with
+        (let uu____2846 = FStar_Extraction_ML_UEnv.action_name ed a  in
+         match uu____2846 with
          | (a_nm,a_lid) ->
              let lbname =
-               let uu____2693 =
+               let uu____2866 =
                  FStar_Syntax_Syntax.new_bv
                    (FStar_Pervasives_Native.Some
                       ((a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos))
                    FStar_Syntax_Syntax.tun
                   in
-               FStar_Util.Inl uu____2693  in
+               FStar_Util.Inl uu____2866  in
              let lb =
                FStar_Syntax_Syntax.mk_lb
                  (lbname, (a.FStar_Syntax_Syntax.action_univs),
@@ -1045,28 +1093,28 @@ let (extract_reifiable_effect :
                  FStar_Pervasives_Native.None
                  (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                 in
-             let uu____2723 =
+             let uu____2896 =
                FStar_Extraction_ML_Term.term_as_mlexpr g1 action_lb  in
-             (match uu____2723 with
-              | (a_let,uu____2739,ty) ->
-                  ((let uu____2742 =
+             (match uu____2896 with
+              | (a_let,uu____2912,ty) ->
+                  ((let uu____2915 =
                       FStar_All.pipe_left
                         (FStar_TypeChecker_Env.debug
                            g1.FStar_Extraction_ML_UEnv.env_tcenv)
                         (FStar_Options.Other "ExtractionReify")
                        in
-                    if uu____2742
+                    if uu____2915
                     then
-                      let uu____2747 =
+                      let uu____2920 =
                         FStar_Extraction_ML_Code.string_of_mlexpr a_nm a_let
                          in
                       FStar_Util.print1 "Extracted action term: %s\n"
-                        uu____2747
+                        uu____2920
                     else ());
-                   (let uu____2752 =
+                   (let uu____2925 =
                       match a_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((uu____2775,mllb::[]),uu____2777) ->
+                          ((uu____2948,mllb::[]),uu____2950) ->
                           (match mllb.FStar_Extraction_ML_Syntax.mllb_tysc
                            with
                            | FStar_Pervasives_Native.Some tysc ->
@@ -1074,80 +1122,80 @@ let (extract_reifiable_effect :
                                  tysc)
                            | FStar_Pervasives_Native.None  ->
                                failwith "No type scheme")
-                      | uu____2817 -> failwith "Impossible"  in
-                    match uu____2752 with
+                      | uu____2990 -> failwith "Impossible"  in
+                    match uu____2925 with
                     | (exp,tysc) ->
-                        ((let uu____2855 =
+                        ((let uu____3028 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug
                                  g1.FStar_Extraction_ML_UEnv.env_tcenv)
                               (FStar_Options.Other "ExtractionReify")
                              in
-                          if uu____2855
+                          if uu____3028
                           then
-                            ((let uu____2861 =
+                            ((let uu____3034 =
                                 FStar_Extraction_ML_Code.string_of_mlty a_nm
                                   (FStar_Pervasives_Native.snd tysc)
                                  in
                               FStar_Util.print1 "Extracted action type: %s\n"
-                                uu____2861);
+                                uu____3034);
                              FStar_List.iter
                                (fun x  ->
                                   FStar_Util.print1 "and binders: %s\n" x)
                                (FStar_Pervasives_Native.fst tysc))
                           else ());
-                         (let uu____2877 = extend_env g1 a_lid a_nm exp tysc
+                         (let uu____3050 = extend_env g1 a_lid a_nm exp tysc
                              in
-                          match uu____2877 with
+                          match uu____3050 with
                           | (env,iface1,impl) -> (env, (iface1, impl))))))))
          in
-      let uu____2899 =
-        let uu____2906 =
+      let uu____3072 =
+        let uu____3079 =
           extract_fv
             (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.return_repr)
            in
-        match uu____2906 with
+        match uu____3079 with
         | (return_tm,ty_sc) ->
-            let uu____2923 =
+            let uu____3096 =
               FStar_Extraction_ML_UEnv.monad_op_name ed "return"  in
-            (match uu____2923 with
+            (match uu____3096 with
              | (return_nm,return_lid) ->
                  extend_env g return_lid return_nm return_tm ty_sc)
          in
-      match uu____2899 with
+      match uu____3072 with
       | (g1,return_iface,return_decl) ->
-          let uu____2948 =
-            let uu____2955 =
+          let uu____3121 =
+            let uu____3128 =
               extract_fv
                 (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.bind_repr)
                in
-            match uu____2955 with
+            match uu____3128 with
             | (bind_tm,ty_sc) ->
-                let uu____2972 =
+                let uu____3145 =
                   FStar_Extraction_ML_UEnv.monad_op_name ed "bind"  in
-                (match uu____2972 with
+                (match uu____3145 with
                  | (bind_nm,bind_lid) ->
                      extend_env g1 bind_lid bind_nm bind_tm ty_sc)
              in
-          (match uu____2948 with
+          (match uu____3121 with
            | (g2,bind_iface,bind_decl) ->
-               let uu____2997 =
+               let uu____3170 =
                  FStar_Util.fold_map extract_action g2
                    ed.FStar_Syntax_Syntax.actions
                   in
-               (match uu____2997 with
+               (match uu____3170 with
                 | (g3,actions) ->
-                    let uu____3034 = FStar_List.unzip actions  in
-                    (match uu____3034 with
+                    let uu____3207 = FStar_List.unzip actions  in
+                    (match uu____3207 with
                      | (actions_iface,actions1) ->
-                         let uu____3061 =
+                         let uu____3234 =
                            iface_union_l (return_iface :: bind_iface ::
                              actions_iface)
                             in
-                         (g3, uu____3061, (return_decl :: bind_decl ::
+                         (g3, uu____3234, (return_decl :: bind_decl ::
                            actions1)))))
   
-let (extract_let_rec_type :
+let (extract_let_rec_types :
   FStar_Syntax_Syntax.sigelt ->
     FStar_Extraction_ML_UEnv.uenv ->
       FStar_Syntax_Syntax.letbinding Prims.list ->
@@ -1157,57 +1205,55 @@ let (extract_let_rec_type :
   fun se  ->
     fun env  ->
       fun lbs  ->
-        let uu____3092 =
+        let uu____3265 =
           FStar_Util.for_some
             (fun lb  ->
-               let uu____3097 =
+               let uu____3270 =
                  FStar_Extraction_ML_Term.is_arity env
                    lb.FStar_Syntax_Syntax.lbtyp
                   in
-               Prims.op_Negation uu____3097) lbs
+               Prims.op_Negation uu____3270) lbs
            in
-        if uu____3092
+        if uu____3265
         then
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExtractionUnsupported,
               "Mutually recursively defined typed and terms cannot yet be extracted")
             se.FStar_Syntax_Syntax.sigrng
         else
-          (let uu____3120 =
+          (let uu____3293 =
              FStar_List.fold_left
-               (fun uu____3155  ->
+               (fun uu____3328  ->
                   fun lb  ->
-                    match uu____3155 with
+                    match uu____3328 with
                     | (env1,iface_opt,impls) ->
-                        let uu____3196 =
-                          extract_typ_abbrev env1
+                        let uu____3369 =
+                          extract_let_rec_type env1
                             se.FStar_Syntax_Syntax.sigquals
                             se.FStar_Syntax_Syntax.sigattrs lb
-                            (FStar_Pervasives_Native.Some
-                               FStar_Extraction_ML_Syntax.MLTY_Top)
                            in
-                        (match uu____3196 with
+                        (match uu____3369 with
                          | (env2,iface1,impl) ->
                              let iface_opt1 =
                                match iface_opt with
                                | FStar_Pervasives_Native.None  ->
                                    FStar_Pervasives_Native.Some iface1
                                | FStar_Pervasives_Native.Some iface' ->
-                                   let uu____3230 = iface_union iface' iface1
+                                   let uu____3403 = iface_union iface' iface1
                                       in
-                                   FStar_Pervasives_Native.Some uu____3230
+                                   FStar_Pervasives_Native.Some uu____3403
                                 in
                              (env2, iface_opt1, (impl :: impls))))
                (env, FStar_Pervasives_Native.None, []) lbs
               in
-           match uu____3120 with
+           match uu____3293 with
            | (env1,iface_opt,impls) ->
-               let uu____3270 = FStar_Option.get iface_opt  in
-               let uu____3271 =
+               let uu____3443 = FStar_Option.get iface_opt  in
+               let uu____3444 =
                  FStar_All.pipe_right (FStar_List.rev impls)
                    FStar_List.flatten
                   in
-               (env1, uu____3270, uu____3271))
+               (env1, uu____3443, uu____3444))
   
 let (extract_sigelt_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1216,84 +1262,84 @@ let (extract_sigelt_iface :
   fun g  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle uu____3303 ->
+      | FStar_Syntax_Syntax.Sig_bundle uu____3476 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3312 ->
+      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3485 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_datacon uu____3329 ->
+      | FStar_Syntax_Syntax.Sig_datacon uu____3502 ->
           extract_bundle_iface g se
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs1,t) when
           FStar_Extraction_ML_Term.is_arity g t ->
-          let uu____3348 =
+          let uu____3521 =
             extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs univs1 t
              in
-          (match uu____3348 with | (env,iface1,uu____3363) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3369) when
+          (match uu____3521 with | (env,iface1,uu____3536) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3542) when
           FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp ->
-          let uu____3378 =
+          let uu____3551 =
             extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
-              se.FStar_Syntax_Syntax.sigattrs lb FStar_Pervasives_Native.None
+              se.FStar_Syntax_Syntax.sigattrs lb
              in
-          (match uu____3378 with | (env,iface1,uu____3393) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____3399) when
+          (match uu____3551 with | (env,iface1,uu____3566) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____3572) when
           FStar_Util.for_some
             (fun lb  ->
                FStar_Extraction_ML_Term.is_arity g
                  lb.FStar_Syntax_Syntax.lbtyp) lbs
           ->
-          let uu____3412 = extract_let_rec_type se g lbs  in
-          (match uu____3412 with | (env,iface1,uu____3427) -> (env, iface1))
+          let uu____3585 = extract_let_rec_types se g lbs  in
+          (match uu____3585 with | (env,iface1,uu____3600) -> (env, iface1))
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,_univs,t) ->
           let quals = se.FStar_Syntax_Syntax.sigquals  in
-          let uu____3438 =
+          let uu____3611 =
             (FStar_All.pipe_right quals
                (FStar_List.contains FStar_Syntax_Syntax.Assumption))
               &&
-              (let uu____3444 =
+              (let uu____3617 =
                  FStar_TypeChecker_Util.must_erase_for_extraction
                    g.FStar_Extraction_ML_UEnv.env_tcenv t
                   in
-               Prims.op_Negation uu____3444)
+               Prims.op_Negation uu____3617)
              in
-          if uu____3438
+          if uu____3611
           then
-            let uu____3451 =
-              let uu____3462 =
-                let uu____3463 =
-                  let uu____3466 = always_fail lid t  in [uu____3466]  in
-                (false, uu____3463)  in
-              FStar_Extraction_ML_Term.extract_lb_iface g uu____3462  in
-            (match uu____3451 with
+            let uu____3624 =
+              let uu____3635 =
+                let uu____3636 =
+                  let uu____3639 = always_fail lid t  in [uu____3639]  in
+                (false, uu____3636)  in
+              FStar_Extraction_ML_Term.extract_lb_iface g uu____3635  in
+            (match uu____3624 with
              | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
           else (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3492) ->
-          let uu____3497 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
+      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3665) ->
+          let uu____3670 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
              in
-          (match uu____3497 with
+          (match uu____3670 with
            | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
-      | FStar_Syntax_Syntax.Sig_main uu____3526 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____3527 ->
+      | FStar_Syntax_Syntax.Sig_main uu____3699 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____3700 ->
           (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_assume uu____3528 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_sub_effect uu____3535 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3536 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_assume uu____3701 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_sub_effect uu____3708 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3709 -> (g, empty_iface)
       | FStar_Syntax_Syntax.Sig_pragma p ->
           (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
            (g, empty_iface))
-      | FStar_Syntax_Syntax.Sig_splice uu____3551 ->
+      | FStar_Syntax_Syntax.Sig_splice uu____3724 ->
           failwith "impossible: trying to extract splice"
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____3564 =
+          let uu____3737 =
             (FStar_TypeChecker_Env.is_reifiable_effect
                g.FStar_Extraction_ML_UEnv.env_tcenv
                ed.FStar_Syntax_Syntax.mname)
               && (FStar_List.isEmpty ed.FStar_Syntax_Syntax.binders)
              in
-          if uu____3564
+          if uu____3737
           then
-            let uu____3577 = extract_reifiable_effect g ed  in
-            (match uu____3577 with | (env,iface1,uu____3592) -> (env, iface1))
+            let uu____3750 = extract_reifiable_effect g ed  in
+            (match uu____3750 with | (env,iface1,uu____3765) -> (env, iface1))
           else (g, empty_iface)
   
 let (extract_iface' :
@@ -1302,34 +1348,34 @@ let (extract_iface' :
   =
   fun g  ->
     fun modul  ->
-      let uu____3614 = FStar_Options.interactive ()  in
-      if uu____3614
+      let uu____3787 = FStar_Options.interactive ()  in
+      if uu____3787
       then (g, empty_iface)
       else
-        (let uu____3623 = FStar_Options.restore_cmd_line_options true  in
+        (let uu____3796 = FStar_Options.restore_cmd_line_options true  in
          let decls = modul.FStar_Syntax_Syntax.declarations  in
          let iface1 =
-           let uu___591_3627 = empty_iface  in
+           let uu___609_3800 = empty_iface  in
            {
              iface_module_name = (g.FStar_Extraction_ML_UEnv.currentModule);
-             iface_bindings = (uu___591_3627.iface_bindings);
-             iface_tydefs = (uu___591_3627.iface_tydefs);
-             iface_type_names = (uu___591_3627.iface_type_names)
+             iface_bindings = (uu___609_3800.iface_bindings);
+             iface_tydefs = (uu___609_3800.iface_tydefs);
+             iface_type_names = (uu___609_3800.iface_type_names)
            }  in
          let res =
            FStar_List.fold_left
-             (fun uu____3645  ->
+             (fun uu____3818  ->
                 fun se  ->
-                  match uu____3645 with
+                  match uu____3818 with
                   | (g1,iface2) ->
-                      let uu____3657 = extract_sigelt_iface g1 se  in
-                      (match uu____3657 with
+                      let uu____3830 = extract_sigelt_iface g1 se  in
+                      (match uu____3830 with
                        | (g2,iface') ->
-                           let uu____3668 = iface_union iface2 iface'  in
-                           (g2, uu____3668))) (g, iface1) decls
+                           let uu____3841 = iface_union iface2 iface'  in
+                           (g2, uu____3841))) (g, iface1) decls
             in
-         (let uu____3670 = FStar_Options.restore_cmd_line_options true  in
-          FStar_All.pipe_left (fun a1  -> ()) uu____3670);
+         (let uu____3843 = FStar_Options.restore_cmd_line_options true  in
+          FStar_All.pipe_left (fun a1  -> ()) uu____3843);
          res)
   
 let (extract_iface :
@@ -1338,33 +1384,33 @@ let (extract_iface :
   =
   fun g  ->
     fun modul  ->
-      let uu____3687 = FStar_Options.debug_any ()  in
-      if uu____3687
+      let uu____3860 = FStar_Options.debug_any ()  in
+      if uu____3860
       then
-        let uu____3694 =
+        let uu____3867 =
           FStar_Util.format1 "Extracted interface of %s"
             (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
            in
-        FStar_Util.measure_execution_time uu____3694
-          (fun uu____3702  -> extract_iface' g modul)
+        FStar_Util.measure_execution_time uu____3867
+          (fun uu____3875  -> extract_iface' g modul)
       else extract_iface' g modul
   
 let (extend_with_iface :
   FStar_Extraction_ML_UEnv.uenv -> iface -> FStar_Extraction_ML_UEnv.uenv) =
   fun g  ->
     fun iface1  ->
-      let uu___609_3716 = g  in
-      let uu____3717 =
-        let uu____3720 =
-          FStar_List.map (fun _3727  -> FStar_Extraction_ML_UEnv.Fv _3727)
+      let uu___627_3889 = g  in
+      let uu____3890 =
+        let uu____3893 =
+          FStar_List.map (fun _3900  -> FStar_Extraction_ML_UEnv.Fv _3900)
             iface1.iface_bindings
            in
-        FStar_List.append uu____3720 g.FStar_Extraction_ML_UEnv.env_bindings
+        FStar_List.append uu____3893 g.FStar_Extraction_ML_UEnv.env_bindings
          in
       {
         FStar_Extraction_ML_UEnv.env_tcenv =
-          (uu___609_3716.FStar_Extraction_ML_UEnv.env_tcenv);
-        FStar_Extraction_ML_UEnv.env_bindings = uu____3717;
+          (uu___627_3889.FStar_Extraction_ML_UEnv.env_tcenv);
+        FStar_Extraction_ML_UEnv.env_bindings = uu____3890;
         FStar_Extraction_ML_UEnv.tydefs =
           (FStar_List.append iface1.iface_tydefs
              g.FStar_Extraction_ML_UEnv.tydefs);
@@ -1372,7 +1418,7 @@ let (extend_with_iface :
           (FStar_List.append iface1.iface_type_names
              g.FStar_Extraction_ML_UEnv.type_names);
         FStar_Extraction_ML_UEnv.currentModule =
-          (uu___609_3716.FStar_Extraction_ML_UEnv.currentModule)
+          (uu___627_3889.FStar_Extraction_ML_UEnv.currentModule)
       }
   
 let (extract_bundle :
@@ -1384,10 +1430,10 @@ let (extract_bundle :
     fun se  ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____3805 =
+          let uu____3978 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp  in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____3805
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____3978
            in
         let steps =
           [FStar_TypeChecker_Env.Inlining;
@@ -1396,104 +1442,104 @@ let (extract_bundle :
           FStar_TypeChecker_Env.EraseUniverses;
           FStar_TypeChecker_Env.AllowUnboundUniverses]  in
         let names1 =
-          let uu____3813 =
-            let uu____3814 =
-              let uu____3817 =
+          let uu____3986 =
+            let uu____3987 =
+              let uu____3990 =
                 FStar_TypeChecker_Normalize.normalize steps
                   env_iparams.FStar_Extraction_ML_UEnv.env_tcenv ctor.dtyp
                  in
-              FStar_Syntax_Subst.compress uu____3817  in
-            uu____3814.FStar_Syntax_Syntax.n  in
-          match uu____3813 with
-          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____3822) ->
+              FStar_Syntax_Subst.compress uu____3990  in
+            uu____3987.FStar_Syntax_Syntax.n  in
+          match uu____3986 with
+          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____3995) ->
               FStar_List.map
-                (fun uu____3855  ->
-                   match uu____3855 with
+                (fun uu____4028  ->
+                   match uu____4028 with
                    | ({ FStar_Syntax_Syntax.ppname = ppname;
-                        FStar_Syntax_Syntax.index = uu____3864;
-                        FStar_Syntax_Syntax.sort = uu____3865;_},uu____3866)
+                        FStar_Syntax_Syntax.index = uu____4037;
+                        FStar_Syntax_Syntax.sort = uu____4038;_},uu____4039)
                        -> ppname.FStar_Ident.idText) bs
-          | uu____3874 -> []  in
+          | uu____4047 -> []  in
         let tys = (ml_tyvars, mlt)  in
         let fvv = FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp  in
-        let uu____3882 =
+        let uu____4055 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false  in
-        match uu____3882 with
-        | (env2,uu____3909,uu____3910) ->
-            let uu____3913 =
-              let uu____3926 = lident_as_mlsymbol ctor.dname  in
-              let uu____3928 =
-                let uu____3936 = FStar_Extraction_ML_Util.argTypes mlt  in
-                FStar_List.zip names1 uu____3936  in
-              (uu____3926, uu____3928)  in
-            (env2, uu____3913)
+        match uu____4055 with
+        | (env2,uu____4082,uu____4083) ->
+            let uu____4086 =
+              let uu____4099 = lident_as_mlsymbol ctor.dname  in
+              let uu____4101 =
+                let uu____4109 = FStar_Extraction_ML_Util.argTypes mlt  in
+                FStar_List.zip names1 uu____4109  in
+              (uu____4099, uu____4101)  in
+            (env2, uu____4086)
          in
       let extract_one_family env1 ind =
-        let uu____3997 = binders_as_mlty_binders env1 ind.iparams  in
-        match uu____3997 with
+        let uu____4170 = binders_as_mlty_binders env1 ind.iparams  in
+        match uu____4170 with
         | (env_iparams,vars) ->
-            let uu____4041 =
+            let uu____4214 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1)
                in
-            (match uu____4041 with
+            (match uu____4214 with
              | (env2,ctors) ->
-                 let uu____4148 = FStar_Syntax_Util.arrow_formals ind.ityp
+                 let uu____4321 = FStar_Syntax_Util.arrow_formals ind.ityp
                     in
-                 (match uu____4148 with
-                  | (indices,uu____4190) ->
+                 (match uu____4321 with
+                  | (indices,uu____4363) ->
                       let ml_params =
-                        let uu____4215 =
+                        let uu____4388 =
                           FStar_All.pipe_right indices
                             (FStar_List.mapi
                                (fun i  ->
-                                  fun uu____4241  ->
-                                    let uu____4249 =
+                                  fun uu____4414  ->
+                                    let uu____4422 =
                                       FStar_Util.string_of_int i  in
-                                    Prims.op_Hat "'dummyV" uu____4249))
+                                    Prims.op_Hat "'dummyV" uu____4422))
                            in
-                        FStar_List.append vars uu____4215  in
+                        FStar_List.append vars uu____4388  in
                       let tbody =
-                        let uu____4254 =
+                        let uu____4427 =
                           FStar_Util.find_opt
-                            (fun uu___7_4259  ->
-                               match uu___7_4259 with
-                               | FStar_Syntax_Syntax.RecordType uu____4261 ->
+                            (fun uu___7_4432  ->
+                               match uu___7_4432 with
+                               | FStar_Syntax_Syntax.RecordType uu____4434 ->
                                    true
-                               | uu____4271 -> false) ind.iquals
+                               | uu____4444 -> false) ind.iquals
                            in
-                        match uu____4254 with
+                        match uu____4427 with
                         | FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.RecordType (ns,ids)) ->
-                            let uu____4283 = FStar_List.hd ctors  in
-                            (match uu____4283 with
-                             | (uu____4308,c_ty) ->
+                            let uu____4456 = FStar_List.hd ctors  in
+                            (match uu____4456 with
+                             | (uu____4481,c_ty) ->
                                  let fields =
                                    FStar_List.map2
                                      (fun id1  ->
-                                        fun uu____4352  ->
-                                          match uu____4352 with
-                                          | (uu____4363,ty) ->
+                                        fun uu____4525  ->
+                                          match uu____4525 with
+                                          | (uu____4536,ty) ->
                                               let lid =
                                                 FStar_Ident.lid_of_ids
                                                   (FStar_List.append ns [id1])
                                                  in
-                                              let uu____4368 =
+                                              let uu____4541 =
                                                 lident_as_mlsymbol lid  in
-                                              (uu____4368, ty)) ids c_ty
+                                              (uu____4541, ty)) ids c_ty
                                     in
                                  FStar_Extraction_ML_Syntax.MLTD_Record
                                    fields)
-                        | uu____4371 ->
+                        | uu____4544 ->
                             FStar_Extraction_ML_Syntax.MLTD_DType ctors
                          in
-                      let uu____4374 =
-                        let uu____4397 = lident_as_mlsymbol ind.iname  in
-                        (false, uu____4397, FStar_Pervasives_Native.None,
+                      let uu____4547 =
+                        let uu____4570 = lident_as_mlsymbol ind.iname  in
+                        (false, uu____4570, FStar_Pervasives_Native.None,
                           ml_params, (ind.imetadata),
                           (FStar_Pervasives_Native.Some tbody))
                          in
-                      (env2, uu____4374)))
+                      (env2, uu____4547)))
          in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
@@ -1501,28 +1547,28 @@ let (extract_bundle :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l,uu____4442,t,uu____4444,uu____4445,uu____4446);
-            FStar_Syntax_Syntax.sigrng = uu____4447;
-            FStar_Syntax_Syntax.sigquals = uu____4448;
-            FStar_Syntax_Syntax.sigmeta = uu____4449;
-            FStar_Syntax_Syntax.sigattrs = uu____4450;_}::[],uu____4451),(FStar_Syntax_Syntax.ExceptionConstructor
+              (l,uu____4615,t,uu____4617,uu____4618,uu____4619);
+            FStar_Syntax_Syntax.sigrng = uu____4620;
+            FStar_Syntax_Syntax.sigquals = uu____4621;
+            FStar_Syntax_Syntax.sigmeta = uu____4622;
+            FStar_Syntax_Syntax.sigattrs = uu____4623;_}::[],uu____4624),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____4470 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____4643 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____4470 with
+          (match uu____4643 with
            | (env1,ctor) -> (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____4523),quals) ->
-          let uu____4537 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____4696),quals) ->
+          let uu____4710 =
             bundle_as_inductive_families env ses quals
               se.FStar_Syntax_Syntax.sigattrs
              in
-          (match uu____4537 with
+          (match uu____4710 with
            | (env1,ifams) ->
-               let uu____4556 =
+               let uu____4729 =
                  FStar_Util.fold_map extract_one_family env1 ifams  in
-               (match uu____4556 with
+               (match uu____4729 with
                 | (env2,td) -> (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
-      | uu____4665 -> failwith "Unexpected signature element"
+      | uu____4838 -> failwith "Unexpected signature element"
   
 let (maybe_register_plugin :
   env_t ->
@@ -1538,43 +1584,43 @@ let (maybe_register_plugin :
       let plugin_with_arity attrs =
         FStar_Util.find_map attrs
           (fun t  ->
-             let uu____4723 = FStar_Syntax_Util.head_and_args t  in
-             match uu____4723 with
+             let uu____4896 = FStar_Syntax_Util.head_and_args t  in
+             match uu____4896 with
              | (head1,args) ->
-                 let uu____4771 =
-                   let uu____4773 =
+                 let uu____4944 =
+                   let uu____4946 =
                      FStar_Syntax_Util.is_fvar FStar_Parser_Const.plugin_attr
                        head1
                       in
-                   Prims.op_Negation uu____4773  in
-                 if uu____4771
+                   Prims.op_Negation uu____4946  in
+                 if uu____4944
                  then FStar_Pervasives_Native.None
                  else
                    (match args with
                     | ({
                          FStar_Syntax_Syntax.n =
                            FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_int (s,uu____4792));
-                         FStar_Syntax_Syntax.pos = uu____4793;
-                         FStar_Syntax_Syntax.vars = uu____4794;_},uu____4795)::[]
+                           (FStar_Const.Const_int (s,uu____4965));
+                         FStar_Syntax_Syntax.pos = uu____4966;
+                         FStar_Syntax_Syntax.vars = uu____4967;_},uu____4968)::[]
                         ->
-                        let uu____4834 =
-                          let uu____4838 = FStar_Util.int_of_string s  in
-                          FStar_Pervasives_Native.Some uu____4838  in
-                        FStar_Pervasives_Native.Some uu____4834
-                    | uu____4844 ->
+                        let uu____5007 =
+                          let uu____5011 = FStar_Util.int_of_string s  in
+                          FStar_Pervasives_Native.Some uu____5011  in
+                        FStar_Pervasives_Native.Some uu____5007
+                    | uu____5017 ->
                         FStar_Pervasives_Native.Some
                           FStar_Pervasives_Native.None))
          in
-      let uu____4859 =
-        let uu____4861 = FStar_Options.codegen ()  in
-        uu____4861 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
-      if uu____4859
+      let uu____5032 =
+        let uu____5034 = FStar_Options.codegen ()  in
+        uu____5034 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
+      if uu____5032
       then []
       else
-        (let uu____4871 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
+        (let uu____5044 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
             in
-         match uu____4871 with
+         match uu____5044 with
          | FStar_Pervasives_Native.None  -> []
          | FStar_Pervasives_Native.Some arity_opt ->
              (match se.FStar_Syntax_Syntax.sigel with
@@ -1587,20 +1633,20 @@ let (maybe_register_plugin :
                        in
                     let fv_t = lb.FStar_Syntax_Syntax.lbtyp  in
                     let ml_name_str =
-                      let uu____4913 =
-                        let uu____4914 = FStar_Ident.string_of_lid fv_lid1
+                      let uu____5086 =
+                        let uu____5087 = FStar_Ident.string_of_lid fv_lid1
                            in
-                        FStar_Extraction_ML_Syntax.MLC_String uu____4914  in
-                      FStar_Extraction_ML_Syntax.MLE_Const uu____4913  in
-                    let uu____4916 =
+                        FStar_Extraction_ML_Syntax.MLC_String uu____5087  in
+                      FStar_Extraction_ML_Syntax.MLE_Const uu____5086  in
+                    let uu____5089 =
                       FStar_Extraction_ML_Util.interpret_plugin_as_term_fun
                         g.FStar_Extraction_ML_UEnv.env_tcenv fv fv_t
                         arity_opt ml_name_str
                        in
-                    match uu____4916 with
+                    match uu____5089 with
                     | FStar_Pervasives_Native.Some
                         (interp,nbe_interp,arity,plugin1) ->
-                        let uu____4949 =
+                        let uu____5122 =
                           if plugin1
                           then
                             ("FStar_Tactics_Native.register_plugin",
@@ -1609,36 +1655,36 @@ let (maybe_register_plugin :
                             ("FStar_Tactics_Native.register_tactic",
                               [interp])
                            in
-                        (match uu____4949 with
+                        (match uu____5122 with
                          | (register,args) ->
                              let h =
-                               let uu____4986 =
-                                 let uu____4987 =
-                                   let uu____4988 =
+                               let uu____5159 =
+                                 let uu____5160 =
+                                   let uu____5161 =
                                      FStar_Ident.lid_of_str register  in
                                    FStar_Extraction_ML_Syntax.mlpath_of_lident
-                                     uu____4988
+                                     uu____5161
                                     in
                                  FStar_Extraction_ML_Syntax.MLE_Name
-                                   uu____4987
+                                   uu____5160
                                   in
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     FStar_Extraction_ML_Syntax.MLTY_Top)
-                                 uu____4986
+                                 uu____5159
                                 in
                              let arity1 =
-                               let uu____4990 =
-                                 let uu____4991 =
-                                   let uu____5003 =
+                               let uu____5163 =
+                                 let uu____5164 =
+                                   let uu____5176 =
                                      FStar_Util.string_of_int arity  in
-                                   (uu____5003, FStar_Pervasives_Native.None)
+                                   (uu____5176, FStar_Pervasives_Native.None)
                                     in
                                  FStar_Extraction_ML_Syntax.MLC_Int
-                                   uu____4991
+                                   uu____5164
                                   in
                                FStar_Extraction_ML_Syntax.MLE_Const
-                                 uu____4990
+                                 uu____5163
                                 in
                              let app =
                                FStar_All.pipe_left
@@ -1653,7 +1699,7 @@ let (maybe_register_plugin :
                     | FStar_Pervasives_Native.None  -> []  in
                   FStar_List.collect mk_registration
                     (FStar_Pervasives_Native.snd lbs)
-              | uu____5032 -> []))
+              | uu____5205 -> []))
   
 let rec (extract_sig :
   env_t ->
@@ -1664,60 +1710,59 @@ let rec (extract_sig :
     fun se  ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____5060 = FStar_Syntax_Print.sigelt_to_string se  in
-           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5060);
+           let uu____5233 = FStar_Syntax_Print.sigelt_to_string se  in
+           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5233);
       (match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_bundle uu____5069 -> extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5078 ->
+       | FStar_Syntax_Syntax.Sig_bundle uu____5242 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5251 ->
            extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_datacon uu____5095 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_datacon uu____5268 -> extract_bundle g se
        | FStar_Syntax_Syntax.Sig_new_effect ed when
            FStar_TypeChecker_Env.is_reifiable_effect
              g.FStar_Extraction_ML_UEnv.env_tcenv
              ed.FStar_Syntax_Syntax.mname
            ->
-           let uu____5112 = extract_reifiable_effect g ed  in
-           (match uu____5112 with | (env,_iface,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_splice uu____5136 ->
+           let uu____5285 = extract_reifiable_effect g ed  in
+           (match uu____5285 with | (env,_iface,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_splice uu____5309 ->
            failwith "impossible: trying to extract splice"
-       | FStar_Syntax_Syntax.Sig_new_effect uu____5150 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_new_effect uu____5323 -> (g, [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs1,t) when
            FStar_Extraction_ML_Term.is_arity g t ->
-           let uu____5156 =
+           let uu____5329 =
              extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs univs1 t
               in
-           (match uu____5156 with | (env,uu____5172,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5181) when
+           (match uu____5329 with | (env,uu____5345,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5354) when
            FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
            ->
-           let uu____5190 =
+           let uu____5363 =
              extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs lb
-               FStar_Pervasives_Native.None
               in
-           (match uu____5190 with | (env,uu____5206,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5215) when
+           (match uu____5363 with | (env,uu____5379,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5388) when
            FStar_Util.for_some
              (fun lb  ->
                 FStar_Extraction_ML_Term.is_arity g
                   lb.FStar_Syntax_Syntax.lbtyp) lbs
            ->
-           let uu____5228 = extract_let_rec_type se g lbs  in
-           (match uu____5228 with | (env,uu____5244,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let (lbs,uu____5253) ->
+           let uu____5401 = extract_let_rec_types se g lbs  in
+           (match uu____5401 with | (env,uu____5417,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let (lbs,uu____5426) ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs  in
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____5264 =
-             let uu____5273 =
+           let uu____5437 =
+             let uu____5446 =
                FStar_Syntax_Util.extract_attr'
                  FStar_Parser_Const.postprocess_extr_with attrs
                 in
-             match uu____5273 with
+             match uu____5446 with
              | FStar_Pervasives_Native.None  ->
                  (attrs, FStar_Pervasives_Native.None)
              | FStar_Pervasives_Native.Some
-                 (ats,(tau,FStar_Pervasives_Native.None )::uu____5302) ->
+                 (ats,(tau,FStar_Pervasives_Native.None )::uu____5475) ->
                  (ats, (FStar_Pervasives_Native.Some tau))
              | FStar_Pervasives_Native.Some (ats,args) ->
                  (FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
@@ -1725,7 +1770,7 @@ let rec (extract_sig :
                       "Ill-formed application of `postprocess_for_extraction_with`");
                   (attrs, FStar_Pervasives_Native.None))
               in
-           (match uu____5264 with
+           (match uu____5437 with
             | (attrs1,post_tau) ->
                 let postprocess_lb tau lb =
                   let lbdef =
@@ -1734,24 +1779,24 @@ let rec (extract_sig :
                       lb.FStar_Syntax_Syntax.lbtyp
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  let uu___839_5388 = lb  in
+                  let uu___857_5561 = lb  in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___839_5388.FStar_Syntax_Syntax.lbname);
+                      (uu___857_5561.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___839_5388.FStar_Syntax_Syntax.lbunivs);
+                      (uu___857_5561.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp =
-                      (uu___839_5388.FStar_Syntax_Syntax.lbtyp);
+                      (uu___857_5561.FStar_Syntax_Syntax.lbtyp);
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___839_5388.FStar_Syntax_Syntax.lbeff);
+                      (uu___857_5561.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = lbdef;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___839_5388.FStar_Syntax_Syntax.lbattrs);
+                      (uu___857_5561.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___839_5388.FStar_Syntax_Syntax.lbpos)
+                      (uu___857_5561.FStar_Syntax_Syntax.lbpos)
                   }  in
                 let lbs1 =
-                  let uu____5397 =
+                  let uu____5570 =
                     match post_tau with
                     | FStar_Pervasives_Native.Some tau ->
                         FStar_List.map (postprocess_lb tau)
@@ -1759,176 +1804,176 @@ let rec (extract_sig :
                     | FStar_Pervasives_Native.None  ->
                         FStar_Pervasives_Native.snd lbs
                      in
-                  ((FStar_Pervasives_Native.fst lbs), uu____5397)  in
-                let uu____5415 =
-                  let uu____5422 =
+                  ((FStar_Pervasives_Native.fst lbs), uu____5570)  in
+                let uu____5588 =
+                  let uu____5595 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_let
                          (lbs1, FStar_Syntax_Util.exp_false_bool))
                       FStar_Pervasives_Native.None
                       se.FStar_Syntax_Syntax.sigrng
                      in
-                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5422  in
-                (match uu____5415 with
-                 | (ml_let,uu____5439,uu____5440) ->
+                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5595  in
+                (match uu____5588 with
+                 | (ml_let,uu____5612,uu____5613) ->
                      (match ml_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((flavor,bindings),uu____5449) ->
+                          ((flavor,bindings),uu____5622) ->
                           let flags = FStar_List.choose flag_of_qual quals
                              in
                           let flags' = extract_metadata attrs1  in
-                          let uu____5466 =
+                          let uu____5639 =
                             FStar_List.fold_left2
-                              (fun uu____5492  ->
+                              (fun uu____5665  ->
                                  fun ml_lb  ->
-                                   fun uu____5494  ->
-                                     match (uu____5492, uu____5494) with
+                                   fun uu____5667  ->
+                                     match (uu____5665, uu____5667) with
                                      | ((env,ml_lbs),{
                                                        FStar_Syntax_Syntax.lbname
                                                          = lbname;
                                                        FStar_Syntax_Syntax.lbunivs
-                                                         = uu____5516;
+                                                         = uu____5689;
                                                        FStar_Syntax_Syntax.lbtyp
                                                          = t;
                                                        FStar_Syntax_Syntax.lbeff
-                                                         = uu____5518;
+                                                         = uu____5691;
                                                        FStar_Syntax_Syntax.lbdef
-                                                         = uu____5519;
+                                                         = uu____5692;
                                                        FStar_Syntax_Syntax.lbattrs
-                                                         = uu____5520;
+                                                         = uu____5693;
                                                        FStar_Syntax_Syntax.lbpos
-                                                         = uu____5521;_})
+                                                         = uu____5694;_})
                                          ->
-                                         let uu____5546 =
+                                         let uu____5719 =
                                            FStar_All.pipe_right
                                              ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
                                              (FStar_List.contains
                                                 FStar_Extraction_ML_Syntax.Erased)
                                             in
-                                         if uu____5546
+                                         if uu____5719
                                          then (env, ml_lbs)
                                          else
                                            (let lb_lid =
-                                              let uu____5563 =
-                                                let uu____5566 =
+                                              let uu____5736 =
+                                                let uu____5739 =
                                                   FStar_Util.right lbname  in
-                                                uu____5566.FStar_Syntax_Syntax.fv_name
+                                                uu____5739.FStar_Syntax_Syntax.fv_name
                                                  in
-                                              uu____5563.FStar_Syntax_Syntax.v
+                                              uu____5736.FStar_Syntax_Syntax.v
                                                in
                                             let flags'' =
-                                              let uu____5570 =
-                                                let uu____5571 =
+                                              let uu____5743 =
+                                                let uu____5744 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____5571.FStar_Syntax_Syntax.n
+                                                uu____5744.FStar_Syntax_Syntax.n
                                                  in
-                                              match uu____5570 with
+                                              match uu____5743 with
                                               | FStar_Syntax_Syntax.Tm_arrow
-                                                  (uu____5576,{
+                                                  (uu____5749,{
                                                                 FStar_Syntax_Syntax.n
                                                                   =
                                                                   FStar_Syntax_Syntax.Comp
                                                                   {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____5577;
+                                                                    uu____5750;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     = e;
                                                                     FStar_Syntax_Syntax.result_typ
                                                                     =
-                                                                    uu____5579;
+                                                                    uu____5752;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____5580;
+                                                                    uu____5753;
                                                                     FStar_Syntax_Syntax.flags
                                                                     =
-                                                                    uu____5581;_};
+                                                                    uu____5754;_};
                                                                 FStar_Syntax_Syntax.pos
                                                                   =
-                                                                  uu____5582;
+                                                                  uu____5755;
                                                                 FStar_Syntax_Syntax.vars
                                                                   =
-                                                                  uu____5583;_})
+                                                                  uu____5756;_})
                                                   when
-                                                  let uu____5618 =
+                                                  let uu____5791 =
                                                     FStar_Ident.string_of_lid
                                                       e
                                                      in
-                                                  uu____5618 =
+                                                  uu____5791 =
                                                     "FStar.HyperStack.ST.StackInline"
                                                   ->
                                                   [FStar_Extraction_ML_Syntax.StackInline]
-                                              | uu____5622 -> []  in
+                                              | uu____5795 -> []  in
                                             let meta =
                                               FStar_List.append flags
                                                 (FStar_List.append flags'
                                                    flags'')
                                                in
                                             let ml_lb1 =
-                                              let uu___887_5627 = ml_lb  in
+                                              let uu___905_5800 = ml_lb  in
                                               {
                                                 FStar_Extraction_ML_Syntax.mllb_name
                                                   =
-                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.mllb_name);
+                                                  (uu___905_5800.FStar_Extraction_ML_Syntax.mllb_name);
                                                 FStar_Extraction_ML_Syntax.mllb_tysc
                                                   =
-                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                  (uu___905_5800.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
                                                   =
-                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                  (uu___905_5800.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                 FStar_Extraction_ML_Syntax.mllb_def
                                                   =
-                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.mllb_def);
+                                                  (uu___905_5800.FStar_Extraction_ML_Syntax.mllb_def);
                                                 FStar_Extraction_ML_Syntax.mllb_meta
                                                   = meta;
                                                 FStar_Extraction_ML_Syntax.print_typ
                                                   =
-                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.print_typ)
+                                                  (uu___905_5800.FStar_Extraction_ML_Syntax.print_typ)
                                               }  in
-                                            let uu____5628 =
-                                              let uu____5633 =
+                                            let uu____5801 =
+                                              let uu____5806 =
                                                 FStar_All.pipe_right quals
                                                   (FStar_Util.for_some
-                                                     (fun uu___8_5640  ->
-                                                        match uu___8_5640
+                                                     (fun uu___8_5813  ->
+                                                        match uu___8_5813
                                                         with
                                                         | FStar_Syntax_Syntax.Projector
-                                                            uu____5642 ->
+                                                            uu____5815 ->
                                                             true
-                                                        | uu____5648 -> false))
+                                                        | uu____5821 -> false))
                                                  in
-                                              if uu____5633
+                                              if uu____5806
                                               then
                                                 let mname =
-                                                  let uu____5664 =
+                                                  let uu____5837 =
                                                     mangle_projector_lid
                                                       lb_lid
                                                      in
                                                   FStar_All.pipe_right
-                                                    uu____5664
+                                                    uu____5837
                                                     FStar_Extraction_ML_Syntax.mlpath_of_lident
                                                    in
-                                                let uu____5673 =
-                                                  let uu____5681 =
+                                                let uu____5846 =
+                                                  let uu____5854 =
                                                     FStar_Util.right lbname
                                                      in
-                                                  let uu____5682 =
+                                                  let uu____5855 =
                                                     FStar_Util.must
                                                       ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                      in
                                                   FStar_Extraction_ML_UEnv.extend_fv'
-                                                    env uu____5681 mname
-                                                    uu____5682
+                                                    env uu____5854 mname
+                                                    uu____5855
                                                     ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                     false
                                                    in
-                                                match uu____5673 with
-                                                | (env1,uu____5689,uu____5690)
+                                                match uu____5846 with
+                                                | (env1,uu____5862,uu____5863)
                                                     ->
                                                     (env1,
-                                                      (let uu___900_5694 =
+                                                      (let uu___918_5867 =
                                                          ml_lb1  in
                                                        {
                                                          FStar_Extraction_ML_Syntax.mllb_name
@@ -1937,169 +1982,169 @@ let rec (extract_sig :
                                                               mname);
                                                          FStar_Extraction_ML_Syntax.mllb_tysc
                                                            =
-                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                           (uu___918_5867.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                          FStar_Extraction_ML_Syntax.mllb_add_unit
                                                            =
-                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                           (uu___918_5867.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                          FStar_Extraction_ML_Syntax.mllb_def
                                                            =
-                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.mllb_def);
+                                                           (uu___918_5867.FStar_Extraction_ML_Syntax.mllb_def);
                                                          FStar_Extraction_ML_Syntax.mllb_meta
                                                            =
-                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.mllb_meta);
+                                                           (uu___918_5867.FStar_Extraction_ML_Syntax.mllb_meta);
                                                          FStar_Extraction_ML_Syntax.print_typ
                                                            =
-                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.print_typ)
+                                                           (uu___918_5867.FStar_Extraction_ML_Syntax.print_typ)
                                                        }))
                                               else
-                                                (let uu____5701 =
-                                                   let uu____5709 =
+                                                (let uu____5874 =
+                                                   let uu____5882 =
                                                      FStar_Util.must
                                                        ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                       in
                                                    FStar_Extraction_ML_UEnv.extend_lb
-                                                     env lbname t uu____5709
+                                                     env lbname t uu____5882
                                                      ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                      false
                                                     in
-                                                 match uu____5701 with
-                                                 | (env1,uu____5716,uu____5717)
+                                                 match uu____5874 with
+                                                 | (env1,uu____5889,uu____5890)
                                                      -> (env1, ml_lb1))
                                                in
-                                            match uu____5628 with
+                                            match uu____5801 with
                                             | (g1,ml_lb2) ->
                                                 (g1, (ml_lb2 :: ml_lbs))))
                               (g, []) bindings
                               (FStar_Pervasives_Native.snd lbs1)
                              in
-                          (match uu____5466 with
+                          (match uu____5639 with
                            | (g1,ml_lbs') ->
-                               let uu____5747 =
-                                 let uu____5750 =
-                                   let uu____5753 =
-                                     let uu____5754 =
+                               let uu____5920 =
+                                 let uu____5923 =
+                                   let uu____5926 =
+                                     let uu____5927 =
                                        FStar_Extraction_ML_Util.mlloc_of_range
                                          se.FStar_Syntax_Syntax.sigrng
                                         in
                                      FStar_Extraction_ML_Syntax.MLM_Loc
-                                       uu____5754
+                                       uu____5927
                                       in
-                                   [uu____5753;
+                                   [uu____5926;
                                    FStar_Extraction_ML_Syntax.MLM_Let
                                      (flavor, (FStar_List.rev ml_lbs'))]
                                     in
-                                 let uu____5757 = maybe_register_plugin g1 se
+                                 let uu____5930 = maybe_register_plugin g1 se
                                     in
-                                 FStar_List.append uu____5750 uu____5757  in
-                               (g1, uu____5747))
-                      | uu____5762 ->
-                          let uu____5763 =
-                            let uu____5765 =
+                                 FStar_List.append uu____5923 uu____5930  in
+                               (g1, uu____5920))
+                      | uu____5935 ->
+                          let uu____5936 =
+                            let uu____5938 =
                               FStar_Extraction_ML_Code.string_of_mlexpr
                                 g.FStar_Extraction_ML_UEnv.currentModule
                                 ml_let
                                in
                             FStar_Util.format1
                               "Impossible: Translated a let to a non-let: %s"
-                              uu____5765
+                              uu____5938
                              in
-                          failwith uu____5763)))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5775,t) ->
+                          failwith uu____5936)))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5948,t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____5780 =
+           let uu____5953 =
              (FStar_All.pipe_right quals
                 (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                &&
-               (let uu____5786 =
+               (let uu____5959 =
                   FStar_TypeChecker_Util.must_erase_for_extraction
                     g.FStar_Extraction_ML_UEnv.env_tcenv t
                    in
-                Prims.op_Negation uu____5786)
+                Prims.op_Negation uu____5959)
               in
-           if uu____5780
+           if uu____5953
            then
              let always_fail1 =
-               let uu___920_5796 = se  in
-               let uu____5797 =
-                 let uu____5798 =
-                   let uu____5805 =
-                     let uu____5806 =
-                       let uu____5809 = always_fail lid t  in [uu____5809]
+               let uu___938_5969 = se  in
+               let uu____5970 =
+                 let uu____5971 =
+                   let uu____5978 =
+                     let uu____5979 =
+                       let uu____5982 = always_fail lid t  in [uu____5982]
                         in
-                     (false, uu____5806)  in
-                   (uu____5805, [])  in
-                 FStar_Syntax_Syntax.Sig_let uu____5798  in
+                     (false, uu____5979)  in
+                   (uu____5978, [])  in
+                 FStar_Syntax_Syntax.Sig_let uu____5971  in
                {
-                 FStar_Syntax_Syntax.sigel = uu____5797;
+                 FStar_Syntax_Syntax.sigel = uu____5970;
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___920_5796.FStar_Syntax_Syntax.sigrng);
+                   (uu___938_5969.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___920_5796.FStar_Syntax_Syntax.sigquals);
+                   (uu___938_5969.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___920_5796.FStar_Syntax_Syntax.sigmeta);
+                   (uu___938_5969.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___920_5796.FStar_Syntax_Syntax.sigattrs)
+                   (uu___938_5969.FStar_Syntax_Syntax.sigattrs)
                }  in
-             let uu____5816 = extract_sig g always_fail1  in
-             (match uu____5816 with
+             let uu____5989 = extract_sig g always_fail1  in
+             (match uu____5989 with
               | (g1,mlm) ->
-                  let uu____5835 =
+                  let uu____6008 =
                     FStar_Util.find_map quals
-                      (fun uu___9_5840  ->
-                         match uu___9_5840 with
+                      (fun uu___9_6013  ->
+                         match uu___9_6013 with
                          | FStar_Syntax_Syntax.Discriminator l ->
                              FStar_Pervasives_Native.Some l
-                         | uu____5844 -> FStar_Pervasives_Native.None)
+                         | uu____6017 -> FStar_Pervasives_Native.None)
                      in
-                  (match uu____5835 with
+                  (match uu____6008 with
                    | FStar_Pervasives_Native.Some l ->
-                       let uu____5852 =
-                         let uu____5855 =
-                           let uu____5856 =
+                       let uu____6025 =
+                         let uu____6028 =
+                           let uu____6029 =
                              FStar_Extraction_ML_Util.mlloc_of_range
                                se.FStar_Syntax_Syntax.sigrng
                               in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____5856  in
-                         let uu____5857 =
-                           let uu____5860 =
+                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6029  in
+                         let uu____6030 =
+                           let uu____6033 =
                              FStar_Extraction_ML_Term.ind_discriminator_body
                                g1 lid l
                               in
-                           [uu____5860]  in
-                         uu____5855 :: uu____5857  in
-                       (g1, uu____5852)
-                   | uu____5863 ->
-                       let uu____5866 =
+                           [uu____6033]  in
+                         uu____6028 :: uu____6030  in
+                       (g1, uu____6025)
+                   | uu____6036 ->
+                       let uu____6039 =
                          FStar_Util.find_map quals
-                           (fun uu___10_5872  ->
-                              match uu___10_5872 with
-                              | FStar_Syntax_Syntax.Projector (l,uu____5876)
+                           (fun uu___10_6045  ->
+                              match uu___10_6045 with
+                              | FStar_Syntax_Syntax.Projector (l,uu____6049)
                                   -> FStar_Pervasives_Native.Some l
-                              | uu____5877 -> FStar_Pervasives_Native.None)
+                              | uu____6050 -> FStar_Pervasives_Native.None)
                           in
-                       (match uu____5866 with
-                        | FStar_Pervasives_Native.Some uu____5884 -> (g1, [])
-                        | uu____5887 -> (g1, mlm))))
+                       (match uu____6039 with
+                        | FStar_Pervasives_Native.Some uu____6057 -> (g1, [])
+                        | uu____6060 -> (g1, mlm))))
            else (g, [])
        | FStar_Syntax_Syntax.Sig_main e ->
-           let uu____5897 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
-           (match uu____5897 with
-            | (ml_main,uu____5911,uu____5912) ->
-                let uu____5913 =
-                  let uu____5916 =
-                    let uu____5917 =
+           let uu____6070 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
+           (match uu____6070 with
+            | (ml_main,uu____6084,uu____6085) ->
+                let uu____6086 =
+                  let uu____6089 =
+                    let uu____6090 =
                       FStar_Extraction_ML_Util.mlloc_of_range
                         se.FStar_Syntax_Syntax.sigrng
                        in
-                    FStar_Extraction_ML_Syntax.MLM_Loc uu____5917  in
-                  [uu____5916; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
+                    FStar_Extraction_ML_Syntax.MLM_Loc uu____6090  in
+                  [uu____6089; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
                    in
-                (g, uu____5913))
-       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____5920 ->
+                (g, uu____6086))
+       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____6093 ->
            failwith "impossible -- removed by tc.fs"
-       | FStar_Syntax_Syntax.Sig_assume uu____5928 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____5937 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____5940 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_assume uu____6101 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_sub_effect uu____6110 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6113 -> (g, [])
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
             (g, [])))
@@ -2112,72 +2157,72 @@ let (extract' :
   =
   fun g  ->
     fun m  ->
-      let uu____5982 = FStar_Options.restore_cmd_line_options true  in
+      let uu____6155 = FStar_Options.restore_cmd_line_options true  in
       let name =
         FStar_Extraction_ML_Syntax.mlpath_of_lident
           m.FStar_Syntax_Syntax.name
          in
       let g1 =
-        let uu___963_5986 = g  in
-        let uu____5987 =
+        let uu___981_6159 = g  in
+        let uu____6160 =
           FStar_TypeChecker_Env.set_current_module
             g.FStar_Extraction_ML_UEnv.env_tcenv m.FStar_Syntax_Syntax.name
            in
         {
-          FStar_Extraction_ML_UEnv.env_tcenv = uu____5987;
+          FStar_Extraction_ML_UEnv.env_tcenv = uu____6160;
           FStar_Extraction_ML_UEnv.env_bindings =
-            (uu___963_5986.FStar_Extraction_ML_UEnv.env_bindings);
+            (uu___981_6159.FStar_Extraction_ML_UEnv.env_bindings);
           FStar_Extraction_ML_UEnv.tydefs =
-            (uu___963_5986.FStar_Extraction_ML_UEnv.tydefs);
+            (uu___981_6159.FStar_Extraction_ML_UEnv.tydefs);
           FStar_Extraction_ML_UEnv.type_names =
-            (uu___963_5986.FStar_Extraction_ML_UEnv.type_names);
+            (uu___981_6159.FStar_Extraction_ML_UEnv.type_names);
           FStar_Extraction_ML_UEnv.currentModule = name
         }  in
-      let uu____5988 =
+      let uu____6161 =
         FStar_Util.fold_map
           (fun g2  ->
              fun se  ->
-               let uu____6007 =
+               let uu____6180 =
                  FStar_Options.debug_module
                    (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                   in
-               if uu____6007
+               if uu____6180
                then
                  let nm =
-                   let uu____6018 =
+                   let uu____6191 =
                      FStar_All.pipe_right
                        (FStar_Syntax_Util.lids_of_sigelt se)
                        (FStar_List.map FStar_Ident.string_of_lid)
                       in
-                   FStar_All.pipe_right uu____6018 (FStar_String.concat ", ")
+                   FStar_All.pipe_right uu____6191 (FStar_String.concat ", ")
                     in
                  (FStar_Util.print1 "+++About to extract {%s}\n" nm;
-                  (let uu____6035 = FStar_Util.format1 "---Extracted {%s}" nm
+                  (let uu____6208 = FStar_Util.format1 "---Extracted {%s}" nm
                       in
-                   FStar_Util.measure_execution_time uu____6035
-                     (fun uu____6045  -> extract_sig g2 se)))
+                   FStar_Util.measure_execution_time uu____6208
+                     (fun uu____6218  -> extract_sig g2 se)))
                else extract_sig g2 se) g1 m.FStar_Syntax_Syntax.declarations
          in
-      match uu____5988 with
+      match uu____6161 with
       | (g2,sigs) ->
           let mlm = FStar_List.flatten sigs  in
           let is_kremlin =
-            let uu____6067 = FStar_Options.codegen ()  in
-            uu____6067 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
+            let uu____6240 = FStar_Options.codegen ()  in
+            uu____6240 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
              in
           if
             ((m.FStar_Syntax_Syntax.name).FStar_Ident.str <> "Prims") &&
               (is_kremlin ||
                  (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
           then
-            ((let uu____6082 =
-                let uu____6084 = FStar_Options.silent ()  in
-                Prims.op_Negation uu____6084  in
-              if uu____6082
+            ((let uu____6255 =
+                let uu____6257 = FStar_Options.silent ()  in
+                Prims.op_Negation uu____6257  in
+              if uu____6255
               then
-                let uu____6087 =
+                let uu____6260 =
                   FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-                FStar_Util.print1 "Extracted module %s\n" uu____6087
+                FStar_Util.print1 "Extracted module %s\n" uu____6260
               else ());
              (g2,
                (FStar_Pervasives_Native.Some
@@ -2194,42 +2239,42 @@ let (extract :
   =
   fun g  ->
     fun m  ->
-      (let uu____6162 = FStar_Options.restore_cmd_line_options true  in
-       FStar_All.pipe_left (fun a2  -> ()) uu____6162);
-      (let uu____6165 =
-         let uu____6167 =
+      (let uu____6335 = FStar_Options.restore_cmd_line_options true  in
+       FStar_All.pipe_left (fun a2  -> ()) uu____6335);
+      (let uu____6338 =
+         let uu____6340 =
            FStar_Options.should_extract
              (m.FStar_Syntax_Syntax.name).FStar_Ident.str
             in
-         Prims.op_Negation uu____6167  in
-       if uu____6165
+         Prims.op_Negation uu____6340  in
+       if uu____6338
        then
-         let uu____6170 =
-           let uu____6172 =
+         let uu____6343 =
+           let uu____6345 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
            FStar_Util.format1
              "Extract called on a module %s that should not be extracted"
-             uu____6172
+             uu____6345
             in
-         failwith uu____6170
+         failwith uu____6343
        else ());
-      (let uu____6177 = FStar_Options.interactive ()  in
-       if uu____6177
+      (let uu____6350 = FStar_Options.interactive ()  in
+       if uu____6350
        then (g, FStar_Pervasives_Native.None)
        else
          (let res =
-            let uu____6197 = FStar_Options.debug_any ()  in
-            if uu____6197
+            let uu____6370 = FStar_Options.debug_any ()  in
+            if uu____6370
             then
               let msg =
-                let uu____6208 =
+                let uu____6381 =
                   FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name
                    in
-                FStar_Util.format1 "Extracting module %s\n" uu____6208  in
+                FStar_Util.format1 "Extracting module %s\n" uu____6381  in
               FStar_Util.measure_execution_time msg
-                (fun uu____6218  -> extract' g m)
+                (fun uu____6391  -> extract' g m)
             else extract' g m  in
-          (let uu____6222 = FStar_Options.restore_cmd_line_options true  in
-           FStar_All.pipe_left (fun a3  -> ()) uu____6222);
+          (let uu____6395 = FStar_Options.restore_cmd_line_options true  in
+           FStar_All.pipe_left (fun a3  -> ()) uu____6395);
           res))
   

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -641,143 +641,155 @@ let (extract_typ_abbrev :
     FStar_Syntax_Syntax.qualifier Prims.list ->
       FStar_Syntax_Syntax.term Prims.list ->
         FStar_Syntax_Syntax.letbinding ->
-          (env_t * iface * FStar_Extraction_ML_Syntax.mlmodule1 Prims.list))
+          FStar_Extraction_ML_Syntax.mlty FStar_Pervasives_Native.option ->
+            (env_t * iface * FStar_Extraction_ML_Syntax.mlmodule1 Prims.list))
   =
   fun env  ->
     fun quals  ->
       fun attrs  ->
         fun lb  ->
-          let uu____1639 =
+          fun body_mlty_opt  ->
             let uu____1648 =
-              FStar_TypeChecker_Env.open_universes_in
-                env.FStar_Extraction_ML_UEnv.env_tcenv
-                lb.FStar_Syntax_Syntax.lbunivs
-                [lb.FStar_Syntax_Syntax.lbdef; lb.FStar_Syntax_Syntax.lbtyp]
+              let uu____1657 =
+                FStar_TypeChecker_Env.open_universes_in
+                  env.FStar_Extraction_ML_UEnv.env_tcenv
+                  lb.FStar_Syntax_Syntax.lbunivs
+                  [lb.FStar_Syntax_Syntax.lbdef;
+                  lb.FStar_Syntax_Syntax.lbtyp]
+                 in
+              match uu____1657 with
+              | (tcenv,uu____1675,def_typ) ->
+                  let uu____1681 = as_pair def_typ  in (tcenv, uu____1681)
                in
             match uu____1648 with
-            | (tcenv,uu____1666,def_typ) ->
-                let uu____1672 = as_pair def_typ  in (tcenv, uu____1672)
-             in
-          match uu____1639 with
-          | (tcenv,(lbdef,lbtyp)) ->
-              let lbtyp1 =
-                FStar_TypeChecker_Normalize.normalize
-                  [FStar_TypeChecker_Env.Beta;
-                  FStar_TypeChecker_Env.UnfoldUntil
-                    FStar_Syntax_Syntax.delta_constant] tcenv lbtyp
-                 in
-              let lbdef1 =
-                FStar_TypeChecker_Normalize.eta_expand_with_type tcenv lbdef
-                  lbtyp1
-                 in
-              let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-              let lid =
-                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-              let def =
-                let uu____1703 =
-                  let uu____1704 = FStar_Syntax_Subst.compress lbdef1  in
-                  FStar_All.pipe_right uu____1704 FStar_Syntax_Util.unmeta
+            | (tcenv,(lbdef,lbtyp)) ->
+                let lbtyp1 =
+                  FStar_TypeChecker_Normalize.normalize
+                    [FStar_TypeChecker_Env.Beta;
+                    FStar_TypeChecker_Env.UnfoldUntil
+                      FStar_Syntax_Syntax.delta_constant] tcenv lbtyp
                    in
-                FStar_All.pipe_right uu____1703 FStar_Syntax_Util.un_uinst
-                 in
-              let def1 =
-                match def.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_abs uu____1712 ->
-                    FStar_Extraction_ML_Term.normalize_abs def
-                | uu____1731 -> def  in
-              let uu____1732 =
-                match def1.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____1743) ->
-                    FStar_Syntax_Subst.open_term bs body
-                | uu____1768 -> ([], def1)  in
-              (match uu____1732 with
-               | (bs,body) ->
-                   let assumed =
-                     FStar_Util.for_some
-                       (fun uu___3_1788  ->
-                          match uu___3_1788 with
-                          | FStar_Syntax_Syntax.Assumption  -> true
-                          | uu____1791 -> false) quals
-                      in
-                   let uu____1793 = binders_as_mlty_binders env bs  in
-                   (match uu____1793 with
-                    | (env1,ml_bs) ->
-                        let body1 =
-                          let uu____1820 =
-                            FStar_Extraction_ML_Term.term_as_mlty env1 body
+                let lbdef1 =
+                  FStar_TypeChecker_Normalize.eta_expand_with_type tcenv
+                    lbdef lbtyp1
+                   in
+                let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
+                let lid =
+                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
+                let def =
+                  let uu____1712 =
+                    let uu____1713 = FStar_Syntax_Subst.compress lbdef1  in
+                    FStar_All.pipe_right uu____1713 FStar_Syntax_Util.unmeta
+                     in
+                  FStar_All.pipe_right uu____1712 FStar_Syntax_Util.un_uinst
+                   in
+                let def1 =
+                  match def.FStar_Syntax_Syntax.n with
+                  | FStar_Syntax_Syntax.Tm_abs uu____1721 ->
+                      FStar_Extraction_ML_Term.normalize_abs def
+                  | uu____1740 -> def  in
+                let uu____1741 =
+                  match def1.FStar_Syntax_Syntax.n with
+                  | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____1752) ->
+                      FStar_Syntax_Subst.open_term bs body
+                  | uu____1777 -> ([], def1)  in
+                (match uu____1741 with
+                 | (bs,body) ->
+                     let assumed =
+                       FStar_Util.for_some
+                         (fun uu___3_1797  ->
+                            match uu___3_1797 with
+                            | FStar_Syntax_Syntax.Assumption  -> true
+                            | uu____1800 -> false) quals
+                        in
+                     let uu____1802 = binders_as_mlty_binders env bs  in
+                     (match uu____1802 with
+                      | (env1,ml_bs) ->
+                          let body1 =
+                            match body_mlty_opt with
+                            | FStar_Pervasives_Native.Some t -> t
+                            | uu____1830 ->
+                                let uu____1833 =
+                                  FStar_Extraction_ML_Term.term_as_mlty env1
+                                    body
+                                   in
+                                FStar_All.pipe_right uu____1833
+                                  (FStar_Extraction_ML_Util.eraseTypeDeep
+                                     (FStar_Extraction_ML_Util.udelta_unfold
+                                        env1))
                              in
-                          FStar_All.pipe_right uu____1820
-                            (FStar_Extraction_ML_Util.eraseTypeDeep
-                               (FStar_Extraction_ML_Util.udelta_unfold env1))
-                           in
-                        let mangled_projector =
-                          let uu____1825 =
-                            FStar_All.pipe_right quals
-                              (FStar_Util.for_some
-                                 (fun uu___4_1832  ->
-                                    match uu___4_1832 with
-                                    | FStar_Syntax_Syntax.Projector
-                                        uu____1834 -> true
-                                    | uu____1840 -> false))
+                          let mangled_projector =
+                            let uu____1838 =
+                              FStar_All.pipe_right quals
+                                (FStar_Util.for_some
+                                   (fun uu___4_1845  ->
+                                      match uu___4_1845 with
+                                      | FStar_Syntax_Syntax.Projector
+                                          uu____1847 -> true
+                                      | uu____1853 -> false))
+                               in
+                            if uu____1838
+                            then
+                              let mname = mangle_projector_lid lid  in
+                              FStar_Pervasives_Native.Some
+                                ((mname.FStar_Ident.ident).FStar_Ident.idText)
+                            else FStar_Pervasives_Native.None  in
+                          let metadata =
+                            let uu____1867 = extract_metadata attrs  in
+                            let uu____1870 =
+                              FStar_List.choose flag_of_qual quals  in
+                            FStar_List.append uu____1867 uu____1870  in
+                          let td =
+                            let uu____1893 = lident_as_mlsymbol lid  in
+                            (assumed, uu____1893, mangled_projector, ml_bs,
+                              metadata,
+                              (FStar_Pervasives_Native.Some
+                                 (FStar_Extraction_ML_Syntax.MLTD_Abbrev
+                                    body1)))
                              in
-                          if uu____1825
-                          then
-                            let mname = mangle_projector_lid lid  in
-                            FStar_Pervasives_Native.Some
-                              ((mname.FStar_Ident.ident).FStar_Ident.idText)
-                          else FStar_Pervasives_Native.None  in
-                        let metadata =
-                          let uu____1854 = extract_metadata attrs  in
-                          let uu____1857 =
-                            FStar_List.choose flag_of_qual quals  in
-                          FStar_List.append uu____1854 uu____1857  in
-                        let td =
-                          let uu____1880 = lident_as_mlsymbol lid  in
-                          (assumed, uu____1880, mangled_projector, ml_bs,
-                            metadata,
-                            (FStar_Pervasives_Native.Some
-                               (FStar_Extraction_ML_Syntax.MLTD_Abbrev body1)))
-                           in
-                        let def2 =
-                          let uu____1892 =
-                            let uu____1893 =
-                              let uu____1894 = FStar_Ident.range_of_lid lid
+                          let def2 =
+                            let uu____1905 =
+                              let uu____1906 =
+                                let uu____1907 = FStar_Ident.range_of_lid lid
+                                   in
+                                FStar_Extraction_ML_Util.mlloc_of_range
+                                  uu____1907
                                  in
-                              FStar_Extraction_ML_Util.mlloc_of_range
-                                uu____1894
+                              FStar_Extraction_ML_Syntax.MLM_Loc uu____1906
                                in
-                            FStar_Extraction_ML_Syntax.MLM_Loc uu____1893  in
-                          [uu____1892;
-                          FStar_Extraction_ML_Syntax.MLM_Ty [td]]  in
-                        let uu____1895 =
-                          let uu____1900 =
-                            FStar_All.pipe_right quals
-                              (FStar_Util.for_some
-                                 (fun uu___5_1906  ->
-                                    match uu___5_1906 with
-                                    | FStar_Syntax_Syntax.Assumption  -> true
-                                    | FStar_Syntax_Syntax.New  -> true
-                                    | uu____1910 -> false))
+                            [uu____1905;
+                            FStar_Extraction_ML_Syntax.MLM_Ty [td]]  in
+                          let uu____1908 =
+                            let uu____1913 =
+                              FStar_All.pipe_right quals
+                                (FStar_Util.for_some
+                                   (fun uu___5_1919  ->
+                                      match uu___5_1919 with
+                                      | FStar_Syntax_Syntax.Assumption  ->
+                                          true
+                                      | FStar_Syntax_Syntax.New  -> true
+                                      | uu____1923 -> false))
+                               in
+                            if uu____1913
+                            then
+                              let uu____1930 =
+                                FStar_Extraction_ML_UEnv.extend_type_name env
+                                  fv
+                                 in
+                              (uu____1930, (iface_of_type_names [fv]))
+                            else
+                              (let uu____1933 =
+                                 FStar_Extraction_ML_UEnv.extend_tydef env fv
+                                   td
+                                  in
+                               match uu____1933 with
+                               | (env2,tydef) ->
+                                   let uu____1944 = iface_of_tydefs [tydef]
+                                      in
+                                   (env2, uu____1944))
                              in
-                          if uu____1900
-                          then
-                            let uu____1917 =
-                              FStar_Extraction_ML_UEnv.extend_type_name env
-                                fv
-                               in
-                            (uu____1917, (iface_of_type_names [fv]))
-                          else
-                            (let uu____1920 =
-                               FStar_Extraction_ML_UEnv.extend_tydef env fv
-                                 td
-                                in
-                             match uu____1920 with
-                             | (env2,tydef) ->
-                                 let uu____1931 = iface_of_tydefs [tydef]  in
-                                 (env2, uu____1931))
-                           in
-                        (match uu____1895 with
-                         | (env2,iface1) -> (env2, iface1, def2))))
+                          (match uu____1908 with
+                           | (env2,iface1) -> (env2, iface1, def2))))
   
 let (extract_bundle_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -787,25 +799,25 @@ let (extract_bundle_iface :
     fun se  ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____2007 =
+          let uu____2020 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp  in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____2007
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____2020
            in
         let tys = (ml_tyvars, mlt)  in
         let fvv = FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp  in
-        let uu____2014 =
+        let uu____2027 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false  in
-        match uu____2014 with | (env2,uu____2033,b) -> (env2, (fvv, b))  in
+        match uu____2027 with | (env2,uu____2046,b) -> (env2, (fvv, b))  in
       let extract_one_family env1 ind =
-        let uu____2072 = binders_as_mlty_binders env1 ind.iparams  in
-        match uu____2072 with
+        let uu____2085 = binders_as_mlty_binders env1 ind.iparams  in
+        match uu____2085 with
         | (env_iparams,vars) ->
-            let uu____2100 =
+            let uu____2113 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1)
                in
-            (match uu____2100 with | (env2,ctors) -> (env2, ctors))
+            (match uu____2113 with | (env2,ctors) -> (env2, ctors))
          in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
@@ -813,37 +825,37 @@ let (extract_bundle_iface :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l,uu____2164,t,uu____2166,uu____2167,uu____2168);
-            FStar_Syntax_Syntax.sigrng = uu____2169;
-            FStar_Syntax_Syntax.sigquals = uu____2170;
-            FStar_Syntax_Syntax.sigmeta = uu____2171;
-            FStar_Syntax_Syntax.sigattrs = uu____2172;_}::[],uu____2173),(FStar_Syntax_Syntax.ExceptionConstructor
+              (l,uu____2177,t,uu____2179,uu____2180,uu____2181);
+            FStar_Syntax_Syntax.sigrng = uu____2182;
+            FStar_Syntax_Syntax.sigquals = uu____2183;
+            FStar_Syntax_Syntax.sigmeta = uu____2184;
+            FStar_Syntax_Syntax.sigattrs = uu____2185;_}::[],uu____2186),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____2192 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____2205 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____2192 with
+          (match uu____2205 with
            | (env1,ctor) -> (env1, (iface_of_bindings [ctor])))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____2225),quals) ->
-          let uu____2239 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____2238),quals) ->
+          let uu____2252 =
             bundle_as_inductive_families env ses quals
               se.FStar_Syntax_Syntax.sigattrs
              in
-          (match uu____2239 with
+          (match uu____2252 with
            | (env1,ifams) ->
-               let uu____2256 =
+               let uu____2269 =
                  FStar_Util.fold_map extract_one_family env1 ifams  in
-               (match uu____2256 with
+               (match uu____2269 with
                 | (env2,td) ->
-                    let uu____2297 =
-                      let uu____2298 =
-                        let uu____2299 =
+                    let uu____2310 =
+                      let uu____2311 =
+                        let uu____2312 =
                           FStar_List.map (fun x  -> x.ifv) ifams  in
-                        iface_of_type_names uu____2299  in
-                      iface_union uu____2298
+                        iface_of_type_names uu____2312  in
+                      iface_union uu____2311
                         (iface_of_bindings (FStar_List.flatten td))
                        in
-                    (env2, uu____2297)))
-      | uu____2308 -> failwith "Unexpected signature element"
+                    (env2, uu____2310)))
+      | uu____2321 -> failwith "Unexpected signature element"
   
 let (extract_type_declaration :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -861,29 +873,29 @@ let (extract_type_declaration :
         fun attrs  ->
           fun univs1  ->
             fun t  ->
-              let uu____2383 =
-                let uu____2385 =
+              let uu____2396 =
+                let uu____2398 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
-                       (fun uu___6_2391  ->
-                          match uu___6_2391 with
+                       (fun uu___6_2404  ->
+                          match uu___6_2404 with
                           | FStar_Syntax_Syntax.Assumption  -> true
-                          | uu____2394 -> false))
+                          | uu____2407 -> false))
                    in
-                Prims.op_Negation uu____2385  in
-              if uu____2383
+                Prims.op_Negation uu____2398  in
+              if uu____2396
               then (g, empty_iface, [])
               else
-                (let uu____2409 = FStar_Syntax_Util.arrow_formals t  in
-                 match uu____2409 with
-                 | (bs,uu____2433) ->
+                (let uu____2422 = FStar_Syntax_Util.arrow_formals t  in
+                 match uu____2422 with
+                 | (bs,uu____2446) ->
                      let fv =
                        FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None
                         in
                      let lb =
-                       let uu____2456 =
+                       let uu____2469 =
                          FStar_Syntax_Util.abs bs FStar_Syntax_Syntax.t_unit
                            FStar_Pervasives_Native.None
                           in
@@ -893,12 +905,13 @@ let (extract_type_declaration :
                          FStar_Syntax_Syntax.lbtyp = t;
                          FStar_Syntax_Syntax.lbeff =
                            FStar_Parser_Const.effect_Tot_lid;
-                         FStar_Syntax_Syntax.lbdef = uu____2456;
+                         FStar_Syntax_Syntax.lbdef = uu____2469;
                          FStar_Syntax_Syntax.lbattrs = attrs;
                          FStar_Syntax_Syntax.lbpos =
                            (t.FStar_Syntax_Syntax.pos)
                        }  in
-                     extract_typ_abbrev g quals attrs lb)
+                     extract_typ_abbrev g quals attrs lb
+                       FStar_Pervasives_Native.None)
   
 let (extract_reifiable_effect :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -913,18 +926,18 @@ let (extract_reifiable_effect :
           FStar_Syntax_Syntax.lid_as_fv lid
             FStar_Syntax_Syntax.delta_equational FStar_Pervasives_Native.None
            in
-        let uu____2519 =
+        let uu____2532 =
           FStar_Extraction_ML_UEnv.extend_fv' g1 fv ml_name tysc false false
            in
-        match uu____2519 with
+        match uu____2532 with
         | (g2,mangled_name,exp_binding) ->
-            ((let uu____2541 =
+            ((let uu____2554 =
                 FStar_All.pipe_left
                   (FStar_TypeChecker_Env.debug
                      g2.FStar_Extraction_ML_UEnv.env_tcenv)
                   (FStar_Options.Other "ExtractionReify")
                  in
-              if uu____2541
+              if uu____2554
               then FStar_Util.print1 "Mangled name: %s\n" mangled_name
               else ());
              (let lb =
@@ -942,80 +955,80 @@ let (extract_reifiable_effect :
                    (FStar_Extraction_ML_Syntax.NonRec, [lb])))))
          in
       let rec extract_fv tm =
-        (let uu____2577 =
+        (let uu____2590 =
            FStar_All.pipe_left
              (FStar_TypeChecker_Env.debug
                 g.FStar_Extraction_ML_UEnv.env_tcenv)
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2577
+         if uu____2590
          then
-           let uu____2582 = FStar_Syntax_Print.term_to_string tm  in
-           FStar_Util.print1 "extract_fv term: %s\n" uu____2582
+           let uu____2595 = FStar_Syntax_Print.term_to_string tm  in
+           FStar_Util.print1 "extract_fv term: %s\n" uu____2595
          else ());
-        (let uu____2587 =
-           let uu____2588 = FStar_Syntax_Subst.compress tm  in
-           uu____2588.FStar_Syntax_Syntax.n  in
-         match uu____2587 with
-         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2596) -> extract_fv tm1
+        (let uu____2600 =
+           let uu____2601 = FStar_Syntax_Subst.compress tm  in
+           uu____2601.FStar_Syntax_Syntax.n  in
+         match uu____2600 with
+         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2609) -> extract_fv tm1
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              let mlp =
                FStar_Extraction_ML_Syntax.mlpath_of_lident
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             let uu____2603 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
-             (match uu____2603 with
-              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2608;
-                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2609;
+             let uu____2616 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
+             (match uu____2616 with
+              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2621;
+                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2622;
                   FStar_Extraction_ML_UEnv.exp_b_tscheme = tysc;
-                  FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____2611;_} ->
-                  let uu____2614 =
+                  FStar_Extraction_ML_UEnv.exp_b_inst_ok = uu____2624;_} ->
+                  let uu____2627 =
                     FStar_All.pipe_left
                       (FStar_Extraction_ML_Syntax.with_ty
                          FStar_Extraction_ML_Syntax.MLTY_Top)
                       (FStar_Extraction_ML_Syntax.MLE_Name mlp)
                      in
-                  (uu____2614, tysc))
-         | uu____2615 ->
-             let uu____2616 =
-               let uu____2618 =
+                  (uu____2627, tysc))
+         | uu____2628 ->
+             let uu____2629 =
+               let uu____2631 =
                  FStar_Range.string_of_range tm.FStar_Syntax_Syntax.pos  in
-               let uu____2620 = FStar_Syntax_Print.term_to_string tm  in
-               FStar_Util.format2 "(%s) Not an fv: %s" uu____2618 uu____2620
+               let uu____2633 = FStar_Syntax_Print.term_to_string tm  in
+               FStar_Util.format2 "(%s) Not an fv: %s" uu____2631 uu____2633
                 in
-             failwith uu____2616)
+             failwith uu____2629)
          in
       let extract_action g1 a =
-        (let uu____2648 =
+        (let uu____2661 =
            FStar_All.pipe_left
              (FStar_TypeChecker_Env.debug
                 g1.FStar_Extraction_ML_UEnv.env_tcenv)
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2648
+         if uu____2661
          then
-           let uu____2653 =
+           let uu____2666 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_typ
               in
-           let uu____2655 =
+           let uu____2668 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_defn
               in
-           FStar_Util.print2 "Action type %s and term %s\n" uu____2653
-             uu____2655
+           FStar_Util.print2 "Action type %s and term %s\n" uu____2666
+             uu____2668
          else ());
-        (let uu____2660 = FStar_Extraction_ML_UEnv.action_name ed a  in
-         match uu____2660 with
+        (let uu____2673 = FStar_Extraction_ML_UEnv.action_name ed a  in
+         match uu____2673 with
          | (a_nm,a_lid) ->
              let lbname =
-               let uu____2680 =
+               let uu____2693 =
                  FStar_Syntax_Syntax.new_bv
                    (FStar_Pervasives_Native.Some
                       ((a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos))
                    FStar_Syntax_Syntax.tun
                   in
-               FStar_Util.Inl uu____2680  in
+               FStar_Util.Inl uu____2693  in
              let lb =
                FStar_Syntax_Syntax.mk_lb
                  (lbname, (a.FStar_Syntax_Syntax.action_univs),
@@ -1032,28 +1045,28 @@ let (extract_reifiable_effect :
                  FStar_Pervasives_Native.None
                  (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                 in
-             let uu____2710 =
+             let uu____2723 =
                FStar_Extraction_ML_Term.term_as_mlexpr g1 action_lb  in
-             (match uu____2710 with
-              | (a_let,uu____2726,ty) ->
-                  ((let uu____2729 =
+             (match uu____2723 with
+              | (a_let,uu____2739,ty) ->
+                  ((let uu____2742 =
                       FStar_All.pipe_left
                         (FStar_TypeChecker_Env.debug
                            g1.FStar_Extraction_ML_UEnv.env_tcenv)
                         (FStar_Options.Other "ExtractionReify")
                        in
-                    if uu____2729
+                    if uu____2742
                     then
-                      let uu____2734 =
+                      let uu____2747 =
                         FStar_Extraction_ML_Code.string_of_mlexpr a_nm a_let
                          in
                       FStar_Util.print1 "Extracted action term: %s\n"
-                        uu____2734
+                        uu____2747
                     else ());
-                   (let uu____2739 =
+                   (let uu____2752 =
                       match a_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((uu____2762,mllb::[]),uu____2764) ->
+                          ((uu____2775,mllb::[]),uu____2777) ->
                           (match mllb.FStar_Extraction_ML_Syntax.mllb_tysc
                            with
                            | FStar_Pervasives_Native.Some tysc ->
@@ -1061,78 +1074,140 @@ let (extract_reifiable_effect :
                                  tysc)
                            | FStar_Pervasives_Native.None  ->
                                failwith "No type scheme")
-                      | uu____2804 -> failwith "Impossible"  in
-                    match uu____2739 with
+                      | uu____2817 -> failwith "Impossible"  in
+                    match uu____2752 with
                     | (exp,tysc) ->
-                        ((let uu____2842 =
+                        ((let uu____2855 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug
                                  g1.FStar_Extraction_ML_UEnv.env_tcenv)
                               (FStar_Options.Other "ExtractionReify")
                              in
-                          if uu____2842
+                          if uu____2855
                           then
-                            ((let uu____2848 =
+                            ((let uu____2861 =
                                 FStar_Extraction_ML_Code.string_of_mlty a_nm
                                   (FStar_Pervasives_Native.snd tysc)
                                  in
                               FStar_Util.print1 "Extracted action type: %s\n"
-                                uu____2848);
+                                uu____2861);
                              FStar_List.iter
                                (fun x  ->
                                   FStar_Util.print1 "and binders: %s\n" x)
                                (FStar_Pervasives_Native.fst tysc))
                           else ());
-                         (let uu____2864 = extend_env g1 a_lid a_nm exp tysc
+                         (let uu____2877 = extend_env g1 a_lid a_nm exp tysc
                              in
-                          match uu____2864 with
+                          match uu____2877 with
                           | (env,iface1,impl) -> (env, (iface1, impl))))))))
          in
-      let uu____2886 =
-        let uu____2893 =
+      let uu____2899 =
+        let uu____2906 =
           extract_fv
             (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.return_repr)
            in
-        match uu____2893 with
+        match uu____2906 with
         | (return_tm,ty_sc) ->
-            let uu____2910 =
+            let uu____2923 =
               FStar_Extraction_ML_UEnv.monad_op_name ed "return"  in
-            (match uu____2910 with
+            (match uu____2923 with
              | (return_nm,return_lid) ->
                  extend_env g return_lid return_nm return_tm ty_sc)
          in
-      match uu____2886 with
+      match uu____2899 with
       | (g1,return_iface,return_decl) ->
-          let uu____2935 =
-            let uu____2942 =
+          let uu____2948 =
+            let uu____2955 =
               extract_fv
                 (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.bind_repr)
                in
-            match uu____2942 with
+            match uu____2955 with
             | (bind_tm,ty_sc) ->
-                let uu____2959 =
+                let uu____2972 =
                   FStar_Extraction_ML_UEnv.monad_op_name ed "bind"  in
-                (match uu____2959 with
+                (match uu____2972 with
                  | (bind_nm,bind_lid) ->
                      extend_env g1 bind_lid bind_nm bind_tm ty_sc)
              in
-          (match uu____2935 with
+          (match uu____2948 with
            | (g2,bind_iface,bind_decl) ->
-               let uu____2984 =
+               let uu____2997 =
                  FStar_Util.fold_map extract_action g2
                    ed.FStar_Syntax_Syntax.actions
                   in
-               (match uu____2984 with
+               (match uu____2997 with
                 | (g3,actions) ->
-                    let uu____3021 = FStar_List.unzip actions  in
-                    (match uu____3021 with
+                    let uu____3034 = FStar_List.unzip actions  in
+                    (match uu____3034 with
                      | (actions_iface,actions1) ->
-                         let uu____3048 =
+                         let uu____3061 =
                            iface_union_l (return_iface :: bind_iface ::
                              actions_iface)
                             in
-                         (g3, uu____3048, (return_decl :: bind_decl ::
+                         (g3, uu____3061, (return_decl :: bind_decl ::
                            actions1)))))
+  
+let (extract_let_rec_type :
+  FStar_Syntax_Syntax.sigelt ->
+    FStar_Extraction_ML_UEnv.uenv ->
+      FStar_Syntax_Syntax.letbinding Prims.list ->
+        (FStar_Extraction_ML_UEnv.uenv * iface *
+          FStar_Extraction_ML_Syntax.mlmodule1 Prims.list))
+  =
+  fun se  ->
+    fun env  ->
+      fun lbs  ->
+        let uu____3092 =
+          FStar_Util.for_some
+            (fun lb  ->
+               let uu____3097 =
+                 FStar_Extraction_ML_Term.is_arity env
+                   lb.FStar_Syntax_Syntax.lbtyp
+                  in
+               Prims.op_Negation uu____3097) lbs
+           in
+        if uu____3092
+        then
+          FStar_Errors.raise_error
+            (FStar_Errors.Fatal_ExtractionUnsupported,
+              "Mutually recursively defined typed and terms cannot yet be extracted")
+            se.FStar_Syntax_Syntax.sigrng
+        else
+          (let uu____3120 =
+             FStar_List.fold_left
+               (fun uu____3155  ->
+                  fun lb  ->
+                    match uu____3155 with
+                    | (env1,iface_opt,impls) ->
+                        let uu____3196 =
+                          extract_typ_abbrev env1
+                            se.FStar_Syntax_Syntax.sigquals
+                            se.FStar_Syntax_Syntax.sigattrs lb
+                            (FStar_Pervasives_Native.Some
+                               FStar_Extraction_ML_Syntax.MLTY_Top)
+                           in
+                        (match uu____3196 with
+                         | (env2,iface1,impl) ->
+                             let iface_opt1 =
+                               match iface_opt with
+                               | FStar_Pervasives_Native.None  ->
+                                   FStar_Pervasives_Native.Some iface1
+                               | FStar_Pervasives_Native.Some iface' ->
+                                   let uu____3230 = iface_union iface' iface1
+                                      in
+                                   FStar_Pervasives_Native.Some uu____3230
+                                in
+                             (env2, iface_opt1, (impl :: impls))))
+               (env, FStar_Pervasives_Native.None, []) lbs
+              in
+           match uu____3120 with
+           | (env1,iface_opt,impls) ->
+               let uu____3270 = FStar_Option.get iface_opt  in
+               let uu____3271 =
+                 FStar_All.pipe_right (FStar_List.rev impls)
+                   FStar_List.flatten
+                  in
+               (env1, uu____3270, uu____3271))
   
 let (extract_sigelt_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1141,76 +1216,84 @@ let (extract_sigelt_iface :
   fun g  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle uu____3070 ->
+      | FStar_Syntax_Syntax.Sig_bundle uu____3303 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3079 ->
+      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3312 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_datacon uu____3096 ->
+      | FStar_Syntax_Syntax.Sig_datacon uu____3329 ->
           extract_bundle_iface g se
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs1,t) when
           FStar_Extraction_ML_Term.is_arity g t ->
-          let uu____3115 =
+          let uu____3348 =
             extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs univs1 t
              in
-          (match uu____3115 with | (env,iface1,uu____3130) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3136) when
+          (match uu____3348 with | (env,iface1,uu____3363) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3369) when
           FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp ->
-          let uu____3145 =
+          let uu____3378 =
             extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
-              se.FStar_Syntax_Syntax.sigattrs lb
+              se.FStar_Syntax_Syntax.sigattrs lb FStar_Pervasives_Native.None
              in
-          (match uu____3145 with | (env,iface1,uu____3160) -> (env, iface1))
+          (match uu____3378 with | (env,iface1,uu____3393) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____3399) when
+          FStar_Util.for_some
+            (fun lb  ->
+               FStar_Extraction_ML_Term.is_arity g
+                 lb.FStar_Syntax_Syntax.lbtyp) lbs
+          ->
+          let uu____3412 = extract_let_rec_type se g lbs  in
+          (match uu____3412 with | (env,iface1,uu____3427) -> (env, iface1))
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,_univs,t) ->
           let quals = se.FStar_Syntax_Syntax.sigquals  in
-          let uu____3171 =
+          let uu____3438 =
             (FStar_All.pipe_right quals
                (FStar_List.contains FStar_Syntax_Syntax.Assumption))
               &&
-              (let uu____3177 =
+              (let uu____3444 =
                  FStar_TypeChecker_Util.must_erase_for_extraction
                    g.FStar_Extraction_ML_UEnv.env_tcenv t
                   in
-               Prims.op_Negation uu____3177)
+               Prims.op_Negation uu____3444)
              in
-          if uu____3171
+          if uu____3438
           then
-            let uu____3184 =
-              let uu____3195 =
-                let uu____3196 =
-                  let uu____3199 = always_fail lid t  in [uu____3199]  in
-                (false, uu____3196)  in
-              FStar_Extraction_ML_Term.extract_lb_iface g uu____3195  in
-            (match uu____3184 with
+            let uu____3451 =
+              let uu____3462 =
+                let uu____3463 =
+                  let uu____3466 = always_fail lid t  in [uu____3466]  in
+                (false, uu____3463)  in
+              FStar_Extraction_ML_Term.extract_lb_iface g uu____3462  in
+            (match uu____3451 with
              | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
           else (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3225) ->
-          let uu____3230 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
+      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3492) ->
+          let uu____3497 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
              in
-          (match uu____3230 with
+          (match uu____3497 with
            | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
-      | FStar_Syntax_Syntax.Sig_main uu____3259 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____3260 ->
+      | FStar_Syntax_Syntax.Sig_main uu____3526 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____3527 ->
           (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_assume uu____3261 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_sub_effect uu____3268 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3269 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_assume uu____3528 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_sub_effect uu____3535 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3536 -> (g, empty_iface)
       | FStar_Syntax_Syntax.Sig_pragma p ->
           (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
            (g, empty_iface))
-      | FStar_Syntax_Syntax.Sig_splice uu____3284 ->
+      | FStar_Syntax_Syntax.Sig_splice uu____3551 ->
           failwith "impossible: trying to extract splice"
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____3297 =
+          let uu____3564 =
             (FStar_TypeChecker_Env.is_reifiable_effect
                g.FStar_Extraction_ML_UEnv.env_tcenv
                ed.FStar_Syntax_Syntax.mname)
               && (FStar_List.isEmpty ed.FStar_Syntax_Syntax.binders)
              in
-          if uu____3297
+          if uu____3564
           then
-            let uu____3310 = extract_reifiable_effect g ed  in
-            (match uu____3310 with | (env,iface1,uu____3325) -> (env, iface1))
+            let uu____3577 = extract_reifiable_effect g ed  in
+            (match uu____3577 with | (env,iface1,uu____3592) -> (env, iface1))
           else (g, empty_iface)
   
 let (extract_iface' :
@@ -1219,34 +1302,34 @@ let (extract_iface' :
   =
   fun g  ->
     fun modul  ->
-      let uu____3347 = FStar_Options.interactive ()  in
-      if uu____3347
+      let uu____3614 = FStar_Options.interactive ()  in
+      if uu____3614
       then (g, empty_iface)
       else
-        (let uu____3356 = FStar_Options.restore_cmd_line_options true  in
+        (let uu____3623 = FStar_Options.restore_cmd_line_options true  in
          let decls = modul.FStar_Syntax_Syntax.declarations  in
          let iface1 =
-           let uu___554_3360 = empty_iface  in
+           let uu___591_3627 = empty_iface  in
            {
              iface_module_name = (g.FStar_Extraction_ML_UEnv.currentModule);
-             iface_bindings = (uu___554_3360.iface_bindings);
-             iface_tydefs = (uu___554_3360.iface_tydefs);
-             iface_type_names = (uu___554_3360.iface_type_names)
+             iface_bindings = (uu___591_3627.iface_bindings);
+             iface_tydefs = (uu___591_3627.iface_tydefs);
+             iface_type_names = (uu___591_3627.iface_type_names)
            }  in
          let res =
            FStar_List.fold_left
-             (fun uu____3378  ->
+             (fun uu____3645  ->
                 fun se  ->
-                  match uu____3378 with
+                  match uu____3645 with
                   | (g1,iface2) ->
-                      let uu____3390 = extract_sigelt_iface g1 se  in
-                      (match uu____3390 with
+                      let uu____3657 = extract_sigelt_iface g1 se  in
+                      (match uu____3657 with
                        | (g2,iface') ->
-                           let uu____3401 = iface_union iface2 iface'  in
-                           (g2, uu____3401))) (g, iface1) decls
+                           let uu____3668 = iface_union iface2 iface'  in
+                           (g2, uu____3668))) (g, iface1) decls
             in
-         (let uu____3403 = FStar_Options.restore_cmd_line_options true  in
-          FStar_All.pipe_left (fun a1  -> ()) uu____3403);
+         (let uu____3670 = FStar_Options.restore_cmd_line_options true  in
+          FStar_All.pipe_left (fun a1  -> ()) uu____3670);
          res)
   
 let (extract_iface :
@@ -1255,33 +1338,33 @@ let (extract_iface :
   =
   fun g  ->
     fun modul  ->
-      let uu____3420 = FStar_Options.debug_any ()  in
-      if uu____3420
+      let uu____3687 = FStar_Options.debug_any ()  in
+      if uu____3687
       then
-        let uu____3427 =
+        let uu____3694 =
           FStar_Util.format1 "Extracted interface of %s"
             (modul.FStar_Syntax_Syntax.name).FStar_Ident.str
            in
-        FStar_Util.measure_execution_time uu____3427
-          (fun uu____3435  -> extract_iface' g modul)
+        FStar_Util.measure_execution_time uu____3694
+          (fun uu____3702  -> extract_iface' g modul)
       else extract_iface' g modul
   
 let (extend_with_iface :
   FStar_Extraction_ML_UEnv.uenv -> iface -> FStar_Extraction_ML_UEnv.uenv) =
   fun g  ->
     fun iface1  ->
-      let uu___572_3449 = g  in
-      let uu____3450 =
-        let uu____3453 =
-          FStar_List.map (fun _3460  -> FStar_Extraction_ML_UEnv.Fv _3460)
+      let uu___609_3716 = g  in
+      let uu____3717 =
+        let uu____3720 =
+          FStar_List.map (fun _3727  -> FStar_Extraction_ML_UEnv.Fv _3727)
             iface1.iface_bindings
            in
-        FStar_List.append uu____3453 g.FStar_Extraction_ML_UEnv.env_bindings
+        FStar_List.append uu____3720 g.FStar_Extraction_ML_UEnv.env_bindings
          in
       {
         FStar_Extraction_ML_UEnv.env_tcenv =
-          (uu___572_3449.FStar_Extraction_ML_UEnv.env_tcenv);
-        FStar_Extraction_ML_UEnv.env_bindings = uu____3450;
+          (uu___609_3716.FStar_Extraction_ML_UEnv.env_tcenv);
+        FStar_Extraction_ML_UEnv.env_bindings = uu____3717;
         FStar_Extraction_ML_UEnv.tydefs =
           (FStar_List.append iface1.iface_tydefs
              g.FStar_Extraction_ML_UEnv.tydefs);
@@ -1289,7 +1372,7 @@ let (extend_with_iface :
           (FStar_List.append iface1.iface_type_names
              g.FStar_Extraction_ML_UEnv.type_names);
         FStar_Extraction_ML_UEnv.currentModule =
-          (uu___572_3449.FStar_Extraction_ML_UEnv.currentModule)
+          (uu___609_3716.FStar_Extraction_ML_UEnv.currentModule)
       }
   
 let (extract_bundle :
@@ -1301,10 +1384,10 @@ let (extract_bundle :
     fun se  ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____3538 =
+          let uu____3805 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp  in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____3538
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____3805
            in
         let steps =
           [FStar_TypeChecker_Env.Inlining;
@@ -1313,104 +1396,104 @@ let (extract_bundle :
           FStar_TypeChecker_Env.EraseUniverses;
           FStar_TypeChecker_Env.AllowUnboundUniverses]  in
         let names1 =
-          let uu____3546 =
-            let uu____3547 =
-              let uu____3550 =
+          let uu____3813 =
+            let uu____3814 =
+              let uu____3817 =
                 FStar_TypeChecker_Normalize.normalize steps
                   env_iparams.FStar_Extraction_ML_UEnv.env_tcenv ctor.dtyp
                  in
-              FStar_Syntax_Subst.compress uu____3550  in
-            uu____3547.FStar_Syntax_Syntax.n  in
-          match uu____3546 with
-          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____3555) ->
+              FStar_Syntax_Subst.compress uu____3817  in
+            uu____3814.FStar_Syntax_Syntax.n  in
+          match uu____3813 with
+          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____3822) ->
               FStar_List.map
-                (fun uu____3588  ->
-                   match uu____3588 with
+                (fun uu____3855  ->
+                   match uu____3855 with
                    | ({ FStar_Syntax_Syntax.ppname = ppname;
-                        FStar_Syntax_Syntax.index = uu____3597;
-                        FStar_Syntax_Syntax.sort = uu____3598;_},uu____3599)
+                        FStar_Syntax_Syntax.index = uu____3864;
+                        FStar_Syntax_Syntax.sort = uu____3865;_},uu____3866)
                        -> ppname.FStar_Ident.idText) bs
-          | uu____3607 -> []  in
+          | uu____3874 -> []  in
         let tys = (ml_tyvars, mlt)  in
         let fvv = FStar_Extraction_ML_UEnv.mkFvvar ctor.dname ctor.dtyp  in
-        let uu____3615 =
+        let uu____3882 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false false  in
-        match uu____3615 with
-        | (env2,uu____3642,uu____3643) ->
-            let uu____3646 =
-              let uu____3659 = lident_as_mlsymbol ctor.dname  in
-              let uu____3661 =
-                let uu____3669 = FStar_Extraction_ML_Util.argTypes mlt  in
-                FStar_List.zip names1 uu____3669  in
-              (uu____3659, uu____3661)  in
-            (env2, uu____3646)
+        match uu____3882 with
+        | (env2,uu____3909,uu____3910) ->
+            let uu____3913 =
+              let uu____3926 = lident_as_mlsymbol ctor.dname  in
+              let uu____3928 =
+                let uu____3936 = FStar_Extraction_ML_Util.argTypes mlt  in
+                FStar_List.zip names1 uu____3936  in
+              (uu____3926, uu____3928)  in
+            (env2, uu____3913)
          in
       let extract_one_family env1 ind =
-        let uu____3730 = binders_as_mlty_binders env1 ind.iparams  in
-        match uu____3730 with
+        let uu____3997 = binders_as_mlty_binders env1 ind.iparams  in
+        match uu____3997 with
         | (env_iparams,vars) ->
-            let uu____3774 =
+            let uu____4041 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1)
                in
-            (match uu____3774 with
+            (match uu____4041 with
              | (env2,ctors) ->
-                 let uu____3881 = FStar_Syntax_Util.arrow_formals ind.ityp
+                 let uu____4148 = FStar_Syntax_Util.arrow_formals ind.ityp
                     in
-                 (match uu____3881 with
-                  | (indices,uu____3923) ->
+                 (match uu____4148 with
+                  | (indices,uu____4190) ->
                       let ml_params =
-                        let uu____3948 =
+                        let uu____4215 =
                           FStar_All.pipe_right indices
                             (FStar_List.mapi
                                (fun i  ->
-                                  fun uu____3974  ->
-                                    let uu____3982 =
+                                  fun uu____4241  ->
+                                    let uu____4249 =
                                       FStar_Util.string_of_int i  in
-                                    Prims.op_Hat "'dummyV" uu____3982))
+                                    Prims.op_Hat "'dummyV" uu____4249))
                            in
-                        FStar_List.append vars uu____3948  in
+                        FStar_List.append vars uu____4215  in
                       let tbody =
-                        let uu____3987 =
+                        let uu____4254 =
                           FStar_Util.find_opt
-                            (fun uu___7_3992  ->
-                               match uu___7_3992 with
-                               | FStar_Syntax_Syntax.RecordType uu____3994 ->
+                            (fun uu___7_4259  ->
+                               match uu___7_4259 with
+                               | FStar_Syntax_Syntax.RecordType uu____4261 ->
                                    true
-                               | uu____4004 -> false) ind.iquals
+                               | uu____4271 -> false) ind.iquals
                            in
-                        match uu____3987 with
+                        match uu____4254 with
                         | FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.RecordType (ns,ids)) ->
-                            let uu____4016 = FStar_List.hd ctors  in
-                            (match uu____4016 with
-                             | (uu____4041,c_ty) ->
+                            let uu____4283 = FStar_List.hd ctors  in
+                            (match uu____4283 with
+                             | (uu____4308,c_ty) ->
                                  let fields =
                                    FStar_List.map2
                                      (fun id1  ->
-                                        fun uu____4085  ->
-                                          match uu____4085 with
-                                          | (uu____4096,ty) ->
+                                        fun uu____4352  ->
+                                          match uu____4352 with
+                                          | (uu____4363,ty) ->
                                               let lid =
                                                 FStar_Ident.lid_of_ids
                                                   (FStar_List.append ns [id1])
                                                  in
-                                              let uu____4101 =
+                                              let uu____4368 =
                                                 lident_as_mlsymbol lid  in
-                                              (uu____4101, ty)) ids c_ty
+                                              (uu____4368, ty)) ids c_ty
                                     in
                                  FStar_Extraction_ML_Syntax.MLTD_Record
                                    fields)
-                        | uu____4104 ->
+                        | uu____4371 ->
                             FStar_Extraction_ML_Syntax.MLTD_DType ctors
                          in
-                      let uu____4107 =
-                        let uu____4130 = lident_as_mlsymbol ind.iname  in
-                        (false, uu____4130, FStar_Pervasives_Native.None,
+                      let uu____4374 =
+                        let uu____4397 = lident_as_mlsymbol ind.iname  in
+                        (false, uu____4397, FStar_Pervasives_Native.None,
                           ml_params, (ind.imetadata),
                           (FStar_Pervasives_Native.Some tbody))
                          in
-                      (env2, uu____4107)))
+                      (env2, uu____4374)))
          in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
@@ -1418,28 +1501,28 @@ let (extract_bundle :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l,uu____4175,t,uu____4177,uu____4178,uu____4179);
-            FStar_Syntax_Syntax.sigrng = uu____4180;
-            FStar_Syntax_Syntax.sigquals = uu____4181;
-            FStar_Syntax_Syntax.sigmeta = uu____4182;
-            FStar_Syntax_Syntax.sigattrs = uu____4183;_}::[],uu____4184),(FStar_Syntax_Syntax.ExceptionConstructor
+              (l,uu____4442,t,uu____4444,uu____4445,uu____4446);
+            FStar_Syntax_Syntax.sigrng = uu____4447;
+            FStar_Syntax_Syntax.sigquals = uu____4448;
+            FStar_Syntax_Syntax.sigmeta = uu____4449;
+            FStar_Syntax_Syntax.sigattrs = uu____4450;_}::[],uu____4451),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____4203 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____4470 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____4203 with
+          (match uu____4470 with
            | (env1,ctor) -> (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____4256),quals) ->
-          let uu____4270 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____4523),quals) ->
+          let uu____4537 =
             bundle_as_inductive_families env ses quals
               se.FStar_Syntax_Syntax.sigattrs
              in
-          (match uu____4270 with
+          (match uu____4537 with
            | (env1,ifams) ->
-               let uu____4289 =
+               let uu____4556 =
                  FStar_Util.fold_map extract_one_family env1 ifams  in
-               (match uu____4289 with
+               (match uu____4556 with
                 | (env2,td) -> (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
-      | uu____4398 -> failwith "Unexpected signature element"
+      | uu____4665 -> failwith "Unexpected signature element"
   
 let (maybe_register_plugin :
   env_t ->
@@ -1455,43 +1538,43 @@ let (maybe_register_plugin :
       let plugin_with_arity attrs =
         FStar_Util.find_map attrs
           (fun t  ->
-             let uu____4456 = FStar_Syntax_Util.head_and_args t  in
-             match uu____4456 with
+             let uu____4723 = FStar_Syntax_Util.head_and_args t  in
+             match uu____4723 with
              | (head1,args) ->
-                 let uu____4504 =
-                   let uu____4506 =
+                 let uu____4771 =
+                   let uu____4773 =
                      FStar_Syntax_Util.is_fvar FStar_Parser_Const.plugin_attr
                        head1
                       in
-                   Prims.op_Negation uu____4506  in
-                 if uu____4504
+                   Prims.op_Negation uu____4773  in
+                 if uu____4771
                  then FStar_Pervasives_Native.None
                  else
                    (match args with
                     | ({
                          FStar_Syntax_Syntax.n =
                            FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_int (s,uu____4525));
-                         FStar_Syntax_Syntax.pos = uu____4526;
-                         FStar_Syntax_Syntax.vars = uu____4527;_},uu____4528)::[]
+                           (FStar_Const.Const_int (s,uu____4792));
+                         FStar_Syntax_Syntax.pos = uu____4793;
+                         FStar_Syntax_Syntax.vars = uu____4794;_},uu____4795)::[]
                         ->
-                        let uu____4567 =
-                          let uu____4571 = FStar_Util.int_of_string s  in
-                          FStar_Pervasives_Native.Some uu____4571  in
-                        FStar_Pervasives_Native.Some uu____4567
-                    | uu____4577 ->
+                        let uu____4834 =
+                          let uu____4838 = FStar_Util.int_of_string s  in
+                          FStar_Pervasives_Native.Some uu____4838  in
+                        FStar_Pervasives_Native.Some uu____4834
+                    | uu____4844 ->
                         FStar_Pervasives_Native.Some
                           FStar_Pervasives_Native.None))
          in
-      let uu____4592 =
-        let uu____4594 = FStar_Options.codegen ()  in
-        uu____4594 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
-      if uu____4592
+      let uu____4859 =
+        let uu____4861 = FStar_Options.codegen ()  in
+        uu____4861 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
+      if uu____4859
       then []
       else
-        (let uu____4604 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
+        (let uu____4871 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
             in
-         match uu____4604 with
+         match uu____4871 with
          | FStar_Pervasives_Native.None  -> []
          | FStar_Pervasives_Native.Some arity_opt ->
              (match se.FStar_Syntax_Syntax.sigel with
@@ -1504,20 +1587,20 @@ let (maybe_register_plugin :
                        in
                     let fv_t = lb.FStar_Syntax_Syntax.lbtyp  in
                     let ml_name_str =
-                      let uu____4646 =
-                        let uu____4647 = FStar_Ident.string_of_lid fv_lid1
+                      let uu____4913 =
+                        let uu____4914 = FStar_Ident.string_of_lid fv_lid1
                            in
-                        FStar_Extraction_ML_Syntax.MLC_String uu____4647  in
-                      FStar_Extraction_ML_Syntax.MLE_Const uu____4646  in
-                    let uu____4649 =
+                        FStar_Extraction_ML_Syntax.MLC_String uu____4914  in
+                      FStar_Extraction_ML_Syntax.MLE_Const uu____4913  in
+                    let uu____4916 =
                       FStar_Extraction_ML_Util.interpret_plugin_as_term_fun
                         g.FStar_Extraction_ML_UEnv.env_tcenv fv fv_t
                         arity_opt ml_name_str
                        in
-                    match uu____4649 with
+                    match uu____4916 with
                     | FStar_Pervasives_Native.Some
                         (interp,nbe_interp,arity,plugin1) ->
-                        let uu____4682 =
+                        let uu____4949 =
                           if plugin1
                           then
                             ("FStar_Tactics_Native.register_plugin",
@@ -1526,36 +1609,36 @@ let (maybe_register_plugin :
                             ("FStar_Tactics_Native.register_tactic",
                               [interp])
                            in
-                        (match uu____4682 with
+                        (match uu____4949 with
                          | (register,args) ->
                              let h =
-                               let uu____4719 =
-                                 let uu____4720 =
-                                   let uu____4721 =
+                               let uu____4986 =
+                                 let uu____4987 =
+                                   let uu____4988 =
                                      FStar_Ident.lid_of_str register  in
                                    FStar_Extraction_ML_Syntax.mlpath_of_lident
-                                     uu____4721
+                                     uu____4988
                                     in
                                  FStar_Extraction_ML_Syntax.MLE_Name
-                                   uu____4720
+                                   uu____4987
                                   in
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
                                     FStar_Extraction_ML_Syntax.MLTY_Top)
-                                 uu____4719
+                                 uu____4986
                                 in
                              let arity1 =
-                               let uu____4723 =
-                                 let uu____4724 =
-                                   let uu____4736 =
+                               let uu____4990 =
+                                 let uu____4991 =
+                                   let uu____5003 =
                                      FStar_Util.string_of_int arity  in
-                                   (uu____4736, FStar_Pervasives_Native.None)
+                                   (uu____5003, FStar_Pervasives_Native.None)
                                     in
                                  FStar_Extraction_ML_Syntax.MLC_Int
-                                   uu____4724
+                                   uu____4991
                                   in
                                FStar_Extraction_ML_Syntax.MLE_Const
-                                 uu____4723
+                                 uu____4990
                                 in
                              let app =
                                FStar_All.pipe_left
@@ -1570,7 +1653,7 @@ let (maybe_register_plugin :
                     | FStar_Pervasives_Native.None  -> []  in
                   FStar_List.collect mk_registration
                     (FStar_Pervasives_Native.snd lbs)
-              | uu____4765 -> []))
+              | uu____5032 -> []))
   
 let rec (extract_sig :
   env_t ->
@@ -1581,51 +1664,60 @@ let rec (extract_sig :
     fun se  ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____4793 = FStar_Syntax_Print.sigelt_to_string se  in
-           FStar_Util.print1 ">>>> extract_sig %s \n" uu____4793);
+           let uu____5060 = FStar_Syntax_Print.sigelt_to_string se  in
+           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5060);
       (match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_bundle uu____4802 -> extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_inductive_typ uu____4811 ->
+       | FStar_Syntax_Syntax.Sig_bundle uu____5069 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5078 ->
            extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_datacon uu____4828 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_datacon uu____5095 -> extract_bundle g se
        | FStar_Syntax_Syntax.Sig_new_effect ed when
            FStar_TypeChecker_Env.is_reifiable_effect
              g.FStar_Extraction_ML_UEnv.env_tcenv
              ed.FStar_Syntax_Syntax.mname
            ->
-           let uu____4845 = extract_reifiable_effect g ed  in
-           (match uu____4845 with | (env,_iface,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_splice uu____4869 ->
+           let uu____5112 = extract_reifiable_effect g ed  in
+           (match uu____5112 with | (env,_iface,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_splice uu____5136 ->
            failwith "impossible: trying to extract splice"
-       | FStar_Syntax_Syntax.Sig_new_effect uu____4883 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_new_effect uu____5150 -> (g, [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs1,t) when
            FStar_Extraction_ML_Term.is_arity g t ->
-           let uu____4889 =
+           let uu____5156 =
              extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs univs1 t
               in
-           (match uu____4889 with | (env,uu____4905,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____4914) when
+           (match uu____5156 with | (env,uu____5172,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5181) when
            FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
            ->
-           let uu____4923 =
+           let uu____5190 =
              extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs lb
+               FStar_Pervasives_Native.None
               in
-           (match uu____4923 with | (env,uu____4939,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let (lbs,uu____4948) ->
+           (match uu____5190 with | (env,uu____5206,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5215) when
+           FStar_Util.for_some
+             (fun lb  ->
+                FStar_Extraction_ML_Term.is_arity g
+                  lb.FStar_Syntax_Syntax.lbtyp) lbs
+           ->
+           let uu____5228 = extract_let_rec_type se g lbs  in
+           (match uu____5228 with | (env,uu____5244,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let (lbs,uu____5253) ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs  in
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____4959 =
-             let uu____4968 =
+           let uu____5264 =
+             let uu____5273 =
                FStar_Syntax_Util.extract_attr'
                  FStar_Parser_Const.postprocess_extr_with attrs
                 in
-             match uu____4968 with
+             match uu____5273 with
              | FStar_Pervasives_Native.None  ->
                  (attrs, FStar_Pervasives_Native.None)
              | FStar_Pervasives_Native.Some
-                 (ats,(tau,FStar_Pervasives_Native.None )::uu____4997) ->
+                 (ats,(tau,FStar_Pervasives_Native.None )::uu____5302) ->
                  (ats, (FStar_Pervasives_Native.Some tau))
              | FStar_Pervasives_Native.Some (ats,args) ->
                  (FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
@@ -1633,7 +1725,7 @@ let rec (extract_sig :
                       "Ill-formed application of `postprocess_for_extraction_with`");
                   (attrs, FStar_Pervasives_Native.None))
               in
-           (match uu____4959 with
+           (match uu____5264 with
             | (attrs1,post_tau) ->
                 let postprocess_lb tau lb =
                   let lbdef =
@@ -1642,24 +1734,24 @@ let rec (extract_sig :
                       lb.FStar_Syntax_Syntax.lbtyp
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  let uu___791_5083 = lb  in
+                  let uu___839_5388 = lb  in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___791_5083.FStar_Syntax_Syntax.lbname);
+                      (uu___839_5388.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___791_5083.FStar_Syntax_Syntax.lbunivs);
+                      (uu___839_5388.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp =
-                      (uu___791_5083.FStar_Syntax_Syntax.lbtyp);
+                      (uu___839_5388.FStar_Syntax_Syntax.lbtyp);
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___791_5083.FStar_Syntax_Syntax.lbeff);
+                      (uu___839_5388.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = lbdef;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___791_5083.FStar_Syntax_Syntax.lbattrs);
+                      (uu___839_5388.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___791_5083.FStar_Syntax_Syntax.lbpos)
+                      (uu___839_5388.FStar_Syntax_Syntax.lbpos)
                   }  in
                 let lbs1 =
-                  let uu____5092 =
+                  let uu____5397 =
                     match post_tau with
                     | FStar_Pervasives_Native.Some tau ->
                         FStar_List.map (postprocess_lb tau)
@@ -1667,176 +1759,176 @@ let rec (extract_sig :
                     | FStar_Pervasives_Native.None  ->
                         FStar_Pervasives_Native.snd lbs
                      in
-                  ((FStar_Pervasives_Native.fst lbs), uu____5092)  in
-                let uu____5110 =
-                  let uu____5117 =
+                  ((FStar_Pervasives_Native.fst lbs), uu____5397)  in
+                let uu____5415 =
+                  let uu____5422 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_let
                          (lbs1, FStar_Syntax_Util.exp_false_bool))
                       FStar_Pervasives_Native.None
                       se.FStar_Syntax_Syntax.sigrng
                      in
-                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5117  in
-                (match uu____5110 with
-                 | (ml_let,uu____5134,uu____5135) ->
+                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5422  in
+                (match uu____5415 with
+                 | (ml_let,uu____5439,uu____5440) ->
                      (match ml_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((flavor,bindings),uu____5144) ->
+                          ((flavor,bindings),uu____5449) ->
                           let flags = FStar_List.choose flag_of_qual quals
                              in
                           let flags' = extract_metadata attrs1  in
-                          let uu____5161 =
+                          let uu____5466 =
                             FStar_List.fold_left2
-                              (fun uu____5187  ->
+                              (fun uu____5492  ->
                                  fun ml_lb  ->
-                                   fun uu____5189  ->
-                                     match (uu____5187, uu____5189) with
+                                   fun uu____5494  ->
+                                     match (uu____5492, uu____5494) with
                                      | ((env,ml_lbs),{
                                                        FStar_Syntax_Syntax.lbname
                                                          = lbname;
                                                        FStar_Syntax_Syntax.lbunivs
-                                                         = uu____5211;
+                                                         = uu____5516;
                                                        FStar_Syntax_Syntax.lbtyp
                                                          = t;
                                                        FStar_Syntax_Syntax.lbeff
-                                                         = uu____5213;
+                                                         = uu____5518;
                                                        FStar_Syntax_Syntax.lbdef
-                                                         = uu____5214;
+                                                         = uu____5519;
                                                        FStar_Syntax_Syntax.lbattrs
-                                                         = uu____5215;
+                                                         = uu____5520;
                                                        FStar_Syntax_Syntax.lbpos
-                                                         = uu____5216;_})
+                                                         = uu____5521;_})
                                          ->
-                                         let uu____5241 =
+                                         let uu____5546 =
                                            FStar_All.pipe_right
                                              ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
                                              (FStar_List.contains
                                                 FStar_Extraction_ML_Syntax.Erased)
                                             in
-                                         if uu____5241
+                                         if uu____5546
                                          then (env, ml_lbs)
                                          else
                                            (let lb_lid =
-                                              let uu____5258 =
-                                                let uu____5261 =
+                                              let uu____5563 =
+                                                let uu____5566 =
                                                   FStar_Util.right lbname  in
-                                                uu____5261.FStar_Syntax_Syntax.fv_name
+                                                uu____5566.FStar_Syntax_Syntax.fv_name
                                                  in
-                                              uu____5258.FStar_Syntax_Syntax.v
+                                              uu____5563.FStar_Syntax_Syntax.v
                                                in
                                             let flags'' =
-                                              let uu____5265 =
-                                                let uu____5266 =
+                                              let uu____5570 =
+                                                let uu____5571 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____5266.FStar_Syntax_Syntax.n
+                                                uu____5571.FStar_Syntax_Syntax.n
                                                  in
-                                              match uu____5265 with
+                                              match uu____5570 with
                                               | FStar_Syntax_Syntax.Tm_arrow
-                                                  (uu____5271,{
+                                                  (uu____5576,{
                                                                 FStar_Syntax_Syntax.n
                                                                   =
                                                                   FStar_Syntax_Syntax.Comp
                                                                   {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____5272;
+                                                                    uu____5577;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     = e;
                                                                     FStar_Syntax_Syntax.result_typ
                                                                     =
-                                                                    uu____5274;
+                                                                    uu____5579;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____5275;
+                                                                    uu____5580;
                                                                     FStar_Syntax_Syntax.flags
                                                                     =
-                                                                    uu____5276;_};
+                                                                    uu____5581;_};
                                                                 FStar_Syntax_Syntax.pos
                                                                   =
-                                                                  uu____5277;
+                                                                  uu____5582;
                                                                 FStar_Syntax_Syntax.vars
                                                                   =
-                                                                  uu____5278;_})
+                                                                  uu____5583;_})
                                                   when
-                                                  let uu____5313 =
+                                                  let uu____5618 =
                                                     FStar_Ident.string_of_lid
                                                       e
                                                      in
-                                                  uu____5313 =
+                                                  uu____5618 =
                                                     "FStar.HyperStack.ST.StackInline"
                                                   ->
                                                   [FStar_Extraction_ML_Syntax.StackInline]
-                                              | uu____5317 -> []  in
+                                              | uu____5622 -> []  in
                                             let meta =
                                               FStar_List.append flags
                                                 (FStar_List.append flags'
                                                    flags'')
                                                in
                                             let ml_lb1 =
-                                              let uu___839_5322 = ml_lb  in
+                                              let uu___887_5627 = ml_lb  in
                                               {
                                                 FStar_Extraction_ML_Syntax.mllb_name
                                                   =
-                                                  (uu___839_5322.FStar_Extraction_ML_Syntax.mllb_name);
+                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.mllb_name);
                                                 FStar_Extraction_ML_Syntax.mllb_tysc
                                                   =
-                                                  (uu___839_5322.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
                                                   =
-                                                  (uu___839_5322.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                 FStar_Extraction_ML_Syntax.mllb_def
                                                   =
-                                                  (uu___839_5322.FStar_Extraction_ML_Syntax.mllb_def);
+                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.mllb_def);
                                                 FStar_Extraction_ML_Syntax.mllb_meta
                                                   = meta;
                                                 FStar_Extraction_ML_Syntax.print_typ
                                                   =
-                                                  (uu___839_5322.FStar_Extraction_ML_Syntax.print_typ)
+                                                  (uu___887_5627.FStar_Extraction_ML_Syntax.print_typ)
                                               }  in
-                                            let uu____5323 =
-                                              let uu____5328 =
+                                            let uu____5628 =
+                                              let uu____5633 =
                                                 FStar_All.pipe_right quals
                                                   (FStar_Util.for_some
-                                                     (fun uu___8_5335  ->
-                                                        match uu___8_5335
+                                                     (fun uu___8_5640  ->
+                                                        match uu___8_5640
                                                         with
                                                         | FStar_Syntax_Syntax.Projector
-                                                            uu____5337 ->
+                                                            uu____5642 ->
                                                             true
-                                                        | uu____5343 -> false))
+                                                        | uu____5648 -> false))
                                                  in
-                                              if uu____5328
+                                              if uu____5633
                                               then
                                                 let mname =
-                                                  let uu____5359 =
+                                                  let uu____5664 =
                                                     mangle_projector_lid
                                                       lb_lid
                                                      in
                                                   FStar_All.pipe_right
-                                                    uu____5359
+                                                    uu____5664
                                                     FStar_Extraction_ML_Syntax.mlpath_of_lident
                                                    in
-                                                let uu____5368 =
-                                                  let uu____5376 =
+                                                let uu____5673 =
+                                                  let uu____5681 =
                                                     FStar_Util.right lbname
                                                      in
-                                                  let uu____5377 =
+                                                  let uu____5682 =
                                                     FStar_Util.must
                                                       ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                      in
                                                   FStar_Extraction_ML_UEnv.extend_fv'
-                                                    env uu____5376 mname
-                                                    uu____5377
+                                                    env uu____5681 mname
+                                                    uu____5682
                                                     ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                     false
                                                    in
-                                                match uu____5368 with
-                                                | (env1,uu____5384,uu____5385)
+                                                match uu____5673 with
+                                                | (env1,uu____5689,uu____5690)
                                                     ->
                                                     (env1,
-                                                      (let uu___852_5389 =
+                                                      (let uu___900_5694 =
                                                          ml_lb1  in
                                                        {
                                                          FStar_Extraction_ML_Syntax.mllb_name
@@ -1845,169 +1937,169 @@ let rec (extract_sig :
                                                               mname);
                                                          FStar_Extraction_ML_Syntax.mllb_tysc
                                                            =
-                                                           (uu___852_5389.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                          FStar_Extraction_ML_Syntax.mllb_add_unit
                                                            =
-                                                           (uu___852_5389.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                          FStar_Extraction_ML_Syntax.mllb_def
                                                            =
-                                                           (uu___852_5389.FStar_Extraction_ML_Syntax.mllb_def);
+                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.mllb_def);
                                                          FStar_Extraction_ML_Syntax.mllb_meta
                                                            =
-                                                           (uu___852_5389.FStar_Extraction_ML_Syntax.mllb_meta);
+                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.mllb_meta);
                                                          FStar_Extraction_ML_Syntax.print_typ
                                                            =
-                                                           (uu___852_5389.FStar_Extraction_ML_Syntax.print_typ)
+                                                           (uu___900_5694.FStar_Extraction_ML_Syntax.print_typ)
                                                        }))
                                               else
-                                                (let uu____5396 =
-                                                   let uu____5404 =
+                                                (let uu____5701 =
+                                                   let uu____5709 =
                                                      FStar_Util.must
                                                        ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                       in
                                                    FStar_Extraction_ML_UEnv.extend_lb
-                                                     env lbname t uu____5404
+                                                     env lbname t uu____5709
                                                      ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                      false
                                                     in
-                                                 match uu____5396 with
-                                                 | (env1,uu____5411,uu____5412)
+                                                 match uu____5701 with
+                                                 | (env1,uu____5716,uu____5717)
                                                      -> (env1, ml_lb1))
                                                in
-                                            match uu____5323 with
+                                            match uu____5628 with
                                             | (g1,ml_lb2) ->
                                                 (g1, (ml_lb2 :: ml_lbs))))
                               (g, []) bindings
                               (FStar_Pervasives_Native.snd lbs1)
                              in
-                          (match uu____5161 with
+                          (match uu____5466 with
                            | (g1,ml_lbs') ->
-                               let uu____5442 =
-                                 let uu____5445 =
-                                   let uu____5448 =
-                                     let uu____5449 =
+                               let uu____5747 =
+                                 let uu____5750 =
+                                   let uu____5753 =
+                                     let uu____5754 =
                                        FStar_Extraction_ML_Util.mlloc_of_range
                                          se.FStar_Syntax_Syntax.sigrng
                                         in
                                      FStar_Extraction_ML_Syntax.MLM_Loc
-                                       uu____5449
+                                       uu____5754
                                       in
-                                   [uu____5448;
+                                   [uu____5753;
                                    FStar_Extraction_ML_Syntax.MLM_Let
                                      (flavor, (FStar_List.rev ml_lbs'))]
                                     in
-                                 let uu____5452 = maybe_register_plugin g1 se
+                                 let uu____5757 = maybe_register_plugin g1 se
                                     in
-                                 FStar_List.append uu____5445 uu____5452  in
-                               (g1, uu____5442))
-                      | uu____5457 ->
-                          let uu____5458 =
-                            let uu____5460 =
+                                 FStar_List.append uu____5750 uu____5757  in
+                               (g1, uu____5747))
+                      | uu____5762 ->
+                          let uu____5763 =
+                            let uu____5765 =
                               FStar_Extraction_ML_Code.string_of_mlexpr
                                 g.FStar_Extraction_ML_UEnv.currentModule
                                 ml_let
                                in
                             FStar_Util.format1
                               "Impossible: Translated a let to a non-let: %s"
-                              uu____5460
+                              uu____5765
                              in
-                          failwith uu____5458)))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5470,t) ->
+                          failwith uu____5763)))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5775,t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____5475 =
+           let uu____5780 =
              (FStar_All.pipe_right quals
                 (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                &&
-               (let uu____5481 =
+               (let uu____5786 =
                   FStar_TypeChecker_Util.must_erase_for_extraction
                     g.FStar_Extraction_ML_UEnv.env_tcenv t
                    in
-                Prims.op_Negation uu____5481)
+                Prims.op_Negation uu____5786)
               in
-           if uu____5475
+           if uu____5780
            then
              let always_fail1 =
-               let uu___872_5491 = se  in
-               let uu____5492 =
-                 let uu____5493 =
-                   let uu____5500 =
-                     let uu____5501 =
-                       let uu____5504 = always_fail lid t  in [uu____5504]
+               let uu___920_5796 = se  in
+               let uu____5797 =
+                 let uu____5798 =
+                   let uu____5805 =
+                     let uu____5806 =
+                       let uu____5809 = always_fail lid t  in [uu____5809]
                         in
-                     (false, uu____5501)  in
-                   (uu____5500, [])  in
-                 FStar_Syntax_Syntax.Sig_let uu____5493  in
+                     (false, uu____5806)  in
+                   (uu____5805, [])  in
+                 FStar_Syntax_Syntax.Sig_let uu____5798  in
                {
-                 FStar_Syntax_Syntax.sigel = uu____5492;
+                 FStar_Syntax_Syntax.sigel = uu____5797;
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___872_5491.FStar_Syntax_Syntax.sigrng);
+                   (uu___920_5796.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___872_5491.FStar_Syntax_Syntax.sigquals);
+                   (uu___920_5796.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___872_5491.FStar_Syntax_Syntax.sigmeta);
+                   (uu___920_5796.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___872_5491.FStar_Syntax_Syntax.sigattrs)
+                   (uu___920_5796.FStar_Syntax_Syntax.sigattrs)
                }  in
-             let uu____5511 = extract_sig g always_fail1  in
-             (match uu____5511 with
+             let uu____5816 = extract_sig g always_fail1  in
+             (match uu____5816 with
               | (g1,mlm) ->
-                  let uu____5530 =
+                  let uu____5835 =
                     FStar_Util.find_map quals
-                      (fun uu___9_5535  ->
-                         match uu___9_5535 with
+                      (fun uu___9_5840  ->
+                         match uu___9_5840 with
                          | FStar_Syntax_Syntax.Discriminator l ->
                              FStar_Pervasives_Native.Some l
-                         | uu____5539 -> FStar_Pervasives_Native.None)
+                         | uu____5844 -> FStar_Pervasives_Native.None)
                      in
-                  (match uu____5530 with
+                  (match uu____5835 with
                    | FStar_Pervasives_Native.Some l ->
-                       let uu____5547 =
-                         let uu____5550 =
-                           let uu____5551 =
+                       let uu____5852 =
+                         let uu____5855 =
+                           let uu____5856 =
                              FStar_Extraction_ML_Util.mlloc_of_range
                                se.FStar_Syntax_Syntax.sigrng
                               in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____5551  in
-                         let uu____5552 =
-                           let uu____5555 =
+                           FStar_Extraction_ML_Syntax.MLM_Loc uu____5856  in
+                         let uu____5857 =
+                           let uu____5860 =
                              FStar_Extraction_ML_Term.ind_discriminator_body
                                g1 lid l
                               in
-                           [uu____5555]  in
-                         uu____5550 :: uu____5552  in
-                       (g1, uu____5547)
-                   | uu____5558 ->
-                       let uu____5561 =
+                           [uu____5860]  in
+                         uu____5855 :: uu____5857  in
+                       (g1, uu____5852)
+                   | uu____5863 ->
+                       let uu____5866 =
                          FStar_Util.find_map quals
-                           (fun uu___10_5567  ->
-                              match uu___10_5567 with
-                              | FStar_Syntax_Syntax.Projector (l,uu____5571)
+                           (fun uu___10_5872  ->
+                              match uu___10_5872 with
+                              | FStar_Syntax_Syntax.Projector (l,uu____5876)
                                   -> FStar_Pervasives_Native.Some l
-                              | uu____5572 -> FStar_Pervasives_Native.None)
+                              | uu____5877 -> FStar_Pervasives_Native.None)
                           in
-                       (match uu____5561 with
-                        | FStar_Pervasives_Native.Some uu____5579 -> (g1, [])
-                        | uu____5582 -> (g1, mlm))))
+                       (match uu____5866 with
+                        | FStar_Pervasives_Native.Some uu____5884 -> (g1, [])
+                        | uu____5887 -> (g1, mlm))))
            else (g, [])
        | FStar_Syntax_Syntax.Sig_main e ->
-           let uu____5592 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
-           (match uu____5592 with
-            | (ml_main,uu____5606,uu____5607) ->
-                let uu____5608 =
-                  let uu____5611 =
-                    let uu____5612 =
+           let uu____5897 = FStar_Extraction_ML_Term.term_as_mlexpr g e  in
+           (match uu____5897 with
+            | (ml_main,uu____5911,uu____5912) ->
+                let uu____5913 =
+                  let uu____5916 =
+                    let uu____5917 =
                       FStar_Extraction_ML_Util.mlloc_of_range
                         se.FStar_Syntax_Syntax.sigrng
                        in
-                    FStar_Extraction_ML_Syntax.MLM_Loc uu____5612  in
-                  [uu____5611; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
+                    FStar_Extraction_ML_Syntax.MLM_Loc uu____5917  in
+                  [uu____5916; FStar_Extraction_ML_Syntax.MLM_Top ml_main]
                    in
-                (g, uu____5608))
-       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____5615 ->
+                (g, uu____5913))
+       | FStar_Syntax_Syntax.Sig_new_effect_for_free uu____5920 ->
            failwith "impossible -- removed by tc.fs"
-       | FStar_Syntax_Syntax.Sig_assume uu____5623 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____5632 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____5635 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_assume uu____5928 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_sub_effect uu____5937 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____5940 -> (g, [])
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
             (g, [])))
@@ -2020,72 +2112,72 @@ let (extract' :
   =
   fun g  ->
     fun m  ->
-      let uu____5677 = FStar_Options.restore_cmd_line_options true  in
+      let uu____5982 = FStar_Options.restore_cmd_line_options true  in
       let name =
         FStar_Extraction_ML_Syntax.mlpath_of_lident
           m.FStar_Syntax_Syntax.name
          in
       let g1 =
-        let uu___915_5681 = g  in
-        let uu____5682 =
+        let uu___963_5986 = g  in
+        let uu____5987 =
           FStar_TypeChecker_Env.set_current_module
             g.FStar_Extraction_ML_UEnv.env_tcenv m.FStar_Syntax_Syntax.name
            in
         {
-          FStar_Extraction_ML_UEnv.env_tcenv = uu____5682;
+          FStar_Extraction_ML_UEnv.env_tcenv = uu____5987;
           FStar_Extraction_ML_UEnv.env_bindings =
-            (uu___915_5681.FStar_Extraction_ML_UEnv.env_bindings);
+            (uu___963_5986.FStar_Extraction_ML_UEnv.env_bindings);
           FStar_Extraction_ML_UEnv.tydefs =
-            (uu___915_5681.FStar_Extraction_ML_UEnv.tydefs);
+            (uu___963_5986.FStar_Extraction_ML_UEnv.tydefs);
           FStar_Extraction_ML_UEnv.type_names =
-            (uu___915_5681.FStar_Extraction_ML_UEnv.type_names);
+            (uu___963_5986.FStar_Extraction_ML_UEnv.type_names);
           FStar_Extraction_ML_UEnv.currentModule = name
         }  in
-      let uu____5683 =
+      let uu____5988 =
         FStar_Util.fold_map
           (fun g2  ->
              fun se  ->
-               let uu____5702 =
+               let uu____6007 =
                  FStar_Options.debug_module
                    (m.FStar_Syntax_Syntax.name).FStar_Ident.str
                   in
-               if uu____5702
+               if uu____6007
                then
                  let nm =
-                   let uu____5713 =
+                   let uu____6018 =
                      FStar_All.pipe_right
                        (FStar_Syntax_Util.lids_of_sigelt se)
                        (FStar_List.map FStar_Ident.string_of_lid)
                       in
-                   FStar_All.pipe_right uu____5713 (FStar_String.concat ", ")
+                   FStar_All.pipe_right uu____6018 (FStar_String.concat ", ")
                     in
                  (FStar_Util.print1 "+++About to extract {%s}\n" nm;
-                  (let uu____5730 = FStar_Util.format1 "---Extracted {%s}" nm
+                  (let uu____6035 = FStar_Util.format1 "---Extracted {%s}" nm
                       in
-                   FStar_Util.measure_execution_time uu____5730
-                     (fun uu____5740  -> extract_sig g2 se)))
+                   FStar_Util.measure_execution_time uu____6035
+                     (fun uu____6045  -> extract_sig g2 se)))
                else extract_sig g2 se) g1 m.FStar_Syntax_Syntax.declarations
          in
-      match uu____5683 with
+      match uu____5988 with
       | (g2,sigs) ->
           let mlm = FStar_List.flatten sigs  in
           let is_kremlin =
-            let uu____5762 = FStar_Options.codegen ()  in
-            uu____5762 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
+            let uu____6067 = FStar_Options.codegen ()  in
+            uu____6067 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
              in
           if
             ((m.FStar_Syntax_Syntax.name).FStar_Ident.str <> "Prims") &&
               (is_kremlin ||
                  (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
           then
-            ((let uu____5777 =
-                let uu____5779 = FStar_Options.silent ()  in
-                Prims.op_Negation uu____5779  in
-              if uu____5777
+            ((let uu____6082 =
+                let uu____6084 = FStar_Options.silent ()  in
+                Prims.op_Negation uu____6084  in
+              if uu____6082
               then
-                let uu____5782 =
+                let uu____6087 =
                   FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-                FStar_Util.print1 "Extracted module %s\n" uu____5782
+                FStar_Util.print1 "Extracted module %s\n" uu____6087
               else ());
              (g2,
                (FStar_Pervasives_Native.Some
@@ -2102,42 +2194,42 @@ let (extract :
   =
   fun g  ->
     fun m  ->
-      (let uu____5857 = FStar_Options.restore_cmd_line_options true  in
-       FStar_All.pipe_left (fun a2  -> ()) uu____5857);
-      (let uu____5860 =
-         let uu____5862 =
+      (let uu____6162 = FStar_Options.restore_cmd_line_options true  in
+       FStar_All.pipe_left (fun a2  -> ()) uu____6162);
+      (let uu____6165 =
+         let uu____6167 =
            FStar_Options.should_extract
              (m.FStar_Syntax_Syntax.name).FStar_Ident.str
             in
-         Prims.op_Negation uu____5862  in
-       if uu____5860
+         Prims.op_Negation uu____6167  in
+       if uu____6165
        then
-         let uu____5865 =
-           let uu____5867 =
+         let uu____6170 =
+           let uu____6172 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
            FStar_Util.format1
              "Extract called on a module %s that should not be extracted"
-             uu____5867
+             uu____6172
             in
-         failwith uu____5865
+         failwith uu____6170
        else ());
-      (let uu____5872 = FStar_Options.interactive ()  in
-       if uu____5872
+      (let uu____6177 = FStar_Options.interactive ()  in
+       if uu____6177
        then (g, FStar_Pervasives_Native.None)
        else
          (let res =
-            let uu____5892 = FStar_Options.debug_any ()  in
-            if uu____5892
+            let uu____6197 = FStar_Options.debug_any ()  in
+            if uu____6197
             then
               let msg =
-                let uu____5903 =
+                let uu____6208 =
                   FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name
                    in
-                FStar_Util.format1 "Extracting module %s\n" uu____5903  in
+                FStar_Util.format1 "Extracting module %s\n" uu____6208  in
               FStar_Util.measure_execution_time msg
-                (fun uu____5913  -> extract' g m)
+                (fun uu____6218  -> extract' g m)
             else extract' g m  in
-          (let uu____5917 = FStar_Options.restore_cmd_line_options true  in
-           FStar_All.pipe_left (fun a3  -> ()) uu____5917);
+          (let uu____6222 = FStar_Options.restore_cmd_line_options true  in
+           FStar_All.pipe_left (fun a3  -> ()) uu____6222);
           res))
   

--- a/src/ocaml-output/FStar_Extraction_ML_Syntax.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Syntax.ml
@@ -192,18 +192,6 @@ let rec (gensyms : Prims.int -> Prims.string Prims.list) =
         let uu____444 = gensyms (n1 - (Prims.parse_int "1"))  in uu____442 ::
           uu____444
   
-let (mlpath_of_lident : FStar_Ident.lident -> mlpath) =
-  fun x  ->
-    let uu____456 = FStar_Ident.lid_equals x FStar_Parser_Const.failwith_lid
-       in
-    if uu____456
-    then ([], ((x.FStar_Ident.ident).FStar_Ident.idText))
-    else
-      (let uu____466 =
-         FStar_List.map (fun x1  -> x1.FStar_Ident.idText) x.FStar_Ident.ns
-          in
-       (uu____466, ((x.FStar_Ident.ident).FStar_Ident.idText)))
-  
 type mlidents = mlident Prims.list
 type mlsymbols = mlsymbol Prims.list
 type e_tag =
@@ -212,15 +200,15 @@ type e_tag =
   | E_IMPURE 
 let (uu___is_E_PURE : e_tag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | E_PURE  -> true | uu____492 -> false
+    match projectee with | E_PURE  -> true | uu____465 -> false
   
 let (uu___is_E_GHOST : e_tag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | E_GHOST  -> true | uu____503 -> false
+    match projectee with | E_GHOST  -> true | uu____476 -> false
   
 let (uu___is_E_IMPURE : e_tag -> Prims.bool) =
   fun projectee  ->
-    match projectee with | E_IMPURE  -> true | uu____514 -> false
+    match projectee with | E_IMPURE  -> true | uu____487 -> false
   
 type mlloc = (Prims.int * Prims.string)
 let (dummy_loc : mlloc) = ((Prims.parse_int "0"), "") 
@@ -233,35 +221,35 @@ type mlty =
   | MLTY_Erased 
 let (uu___is_MLTY_Var : mlty -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLTY_Var _0 -> true | uu____573 -> false
+    match projectee with | MLTY_Var _0 -> true | uu____546 -> false
   
 let (__proj__MLTY_Var__item___0 : mlty -> mlident) =
   fun projectee  -> match projectee with | MLTY_Var _0 -> _0 
 let (uu___is_MLTY_Fun : mlty -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLTY_Fun _0 -> true | uu____601 -> false
+    match projectee with | MLTY_Fun _0 -> true | uu____574 -> false
   
 let (__proj__MLTY_Fun__item___0 : mlty -> (mlty * e_tag * mlty)) =
   fun projectee  -> match projectee with | MLTY_Fun _0 -> _0 
 let (uu___is_MLTY_Named : mlty -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLTY_Named _0 -> true | uu____644 -> false
+    match projectee with | MLTY_Named _0 -> true | uu____617 -> false
   
 let (__proj__MLTY_Named__item___0 : mlty -> (mlty Prims.list * mlpath)) =
   fun projectee  -> match projectee with | MLTY_Named _0 -> _0 
 let (uu___is_MLTY_Tuple : mlty -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLTY_Tuple _0 -> true | uu____683 -> false
+    match projectee with | MLTY_Tuple _0 -> true | uu____656 -> false
   
 let (__proj__MLTY_Tuple__item___0 : mlty -> mlty Prims.list) =
   fun projectee  -> match projectee with | MLTY_Tuple _0 -> _0 
 let (uu___is_MLTY_Top : mlty -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLTY_Top  -> true | uu____707 -> false
+    match projectee with | MLTY_Top  -> true | uu____680 -> false
   
 let (uu___is_MLTY_Erased : mlty -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLTY_Erased  -> true | uu____718 -> false
+    match projectee with | MLTY_Erased  -> true | uu____691 -> false
   
 type mltyscheme = (mlidents * mlty)
 type mlconstant =
@@ -275,17 +263,17 @@ type mlconstant =
   | MLC_Bytes of FStar_BaseTypes.byte Prims.array 
 let (uu___is_MLC_Unit : mlconstant -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLC_Unit  -> true | uu____779 -> false
+    match projectee with | MLC_Unit  -> true | uu____752 -> false
   
 let (uu___is_MLC_Bool : mlconstant -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLC_Bool _0 -> true | uu____792 -> false
+    match projectee with | MLC_Bool _0 -> true | uu____765 -> false
   
 let (__proj__MLC_Bool__item___0 : mlconstant -> Prims.bool) =
   fun projectee  -> match projectee with | MLC_Bool _0 -> _0 
 let (uu___is_MLC_Int : mlconstant -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLC_Int _0 -> true | uu____825 -> false
+    match projectee with | MLC_Int _0 -> true | uu____798 -> false
   
 let (__proj__MLC_Int__item___0 :
   mlconstant ->
@@ -294,25 +282,25 @@ let (__proj__MLC_Int__item___0 :
   = fun projectee  -> match projectee with | MLC_Int _0 -> _0 
 let (uu___is_MLC_Float : mlconstant -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLC_Float _0 -> true | uu____877 -> false
+    match projectee with | MLC_Float _0 -> true | uu____850 -> false
   
 let (__proj__MLC_Float__item___0 : mlconstant -> FStar_BaseTypes.float) =
   fun projectee  -> match projectee with | MLC_Float _0 -> _0 
 let (uu___is_MLC_Char : mlconstant -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLC_Char _0 -> true | uu____897 -> false
+    match projectee with | MLC_Char _0 -> true | uu____870 -> false
   
 let (__proj__MLC_Char__item___0 : mlconstant -> FStar_BaseTypes.char) =
   fun projectee  -> match projectee with | MLC_Char _0 -> _0 
 let (uu___is_MLC_String : mlconstant -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLC_String _0 -> true | uu____920 -> false
+    match projectee with | MLC_String _0 -> true | uu____893 -> false
   
 let (__proj__MLC_String__item___0 : mlconstant -> Prims.string) =
   fun projectee  -> match projectee with | MLC_String _0 -> _0 
 let (uu___is_MLC_Bytes : mlconstant -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLC_Bytes _0 -> true | uu____944 -> false
+    match projectee with | MLC_Bytes _0 -> true | uu____917 -> false
   
 let (__proj__MLC_Bytes__item___0 :
   mlconstant -> FStar_BaseTypes.byte Prims.array) =
@@ -327,43 +315,43 @@ type mlpattern =
   | MLP_Tuple of mlpattern Prims.list 
 let (uu___is_MLP_Wild : mlpattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLP_Wild  -> true | uu____1023 -> false
+    match projectee with | MLP_Wild  -> true | uu____996 -> false
   
 let (uu___is_MLP_Const : mlpattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLP_Const _0 -> true | uu____1035 -> false
+    match projectee with | MLP_Const _0 -> true | uu____1008 -> false
   
 let (__proj__MLP_Const__item___0 : mlpattern -> mlconstant) =
   fun projectee  -> match projectee with | MLP_Const _0 -> _0 
 let (uu___is_MLP_Var : mlpattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLP_Var _0 -> true | uu____1055 -> false
+    match projectee with | MLP_Var _0 -> true | uu____1028 -> false
   
 let (__proj__MLP_Var__item___0 : mlpattern -> mlident) =
   fun projectee  -> match projectee with | MLP_Var _0 -> _0 
 let (uu___is_MLP_CTor : mlpattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLP_CTor _0 -> true | uu____1083 -> false
+    match projectee with | MLP_CTor _0 -> true | uu____1056 -> false
   
 let (__proj__MLP_CTor__item___0 :
   mlpattern -> (mlpath * mlpattern Prims.list)) =
   fun projectee  -> match projectee with | MLP_CTor _0 -> _0 
 let (uu___is_MLP_Branch : mlpattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLP_Branch _0 -> true | uu____1122 -> false
+    match projectee with | MLP_Branch _0 -> true | uu____1095 -> false
   
 let (__proj__MLP_Branch__item___0 : mlpattern -> mlpattern Prims.list) =
   fun projectee  -> match projectee with | MLP_Branch _0 -> _0 
 let (uu___is_MLP_Record : mlpattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLP_Record _0 -> true | uu____1161 -> false
+    match projectee with | MLP_Record _0 -> true | uu____1134 -> false
   
 let (__proj__MLP_Record__item___0 :
   mlpattern -> (mlsymbol Prims.list * (mlsymbol * mlpattern) Prims.list)) =
   fun projectee  -> match projectee with | MLP_Record _0 -> _0 
 let (uu___is_MLP_Tuple : mlpattern -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLP_Tuple _0 -> true | uu____1224 -> false
+    match projectee with | MLP_Tuple _0 -> true | uu____1197 -> false
   
 let (__proj__MLP_Tuple__item___0 : mlpattern -> mlpattern Prims.list) =
   fun projectee  -> match projectee with | MLP_Tuple _0 -> _0 
@@ -389,103 +377,103 @@ type meta =
   | CIfDef 
 let (uu___is_Mutable : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Mutable  -> true | uu____1284 -> false
+    match projectee with | Mutable  -> true | uu____1257 -> false
   
 let (uu___is_Assumed : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Assumed  -> true | uu____1295 -> false
+    match projectee with | Assumed  -> true | uu____1268 -> false
   
 let (uu___is_Private : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Private  -> true | uu____1306 -> false
+    match projectee with | Private  -> true | uu____1279 -> false
   
 let (uu___is_NoExtract : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NoExtract  -> true | uu____1317 -> false
+    match projectee with | NoExtract  -> true | uu____1290 -> false
   
 let (uu___is_CInline : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CInline  -> true | uu____1328 -> false
+    match projectee with | CInline  -> true | uu____1301 -> false
   
 let (uu___is_Substitute : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Substitute  -> true | uu____1339 -> false
+    match projectee with | Substitute  -> true | uu____1312 -> false
   
 let (uu___is_GCType : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | GCType  -> true | uu____1350 -> false
+    match projectee with | GCType  -> true | uu____1323 -> false
   
 let (uu___is_PpxDerivingShow : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PpxDerivingShow  -> true | uu____1361 -> false
+    match projectee with | PpxDerivingShow  -> true | uu____1334 -> false
   
 let (uu___is_PpxDerivingShowConstant : meta -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | PpxDerivingShowConstant _0 -> true
-    | uu____1374 -> false
+    | uu____1347 -> false
   
 let (__proj__PpxDerivingShowConstant__item___0 : meta -> Prims.string) =
   fun projectee  -> match projectee with | PpxDerivingShowConstant _0 -> _0 
 let (uu___is_PpxDerivingYoJson : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | PpxDerivingYoJson  -> true | uu____1395 -> false
+    match projectee with | PpxDerivingYoJson  -> true | uu____1368 -> false
   
 let (uu___is_Comment : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Comment _0 -> true | uu____1408 -> false
+    match projectee with | Comment _0 -> true | uu____1381 -> false
   
 let (__proj__Comment__item___0 : meta -> Prims.string) =
   fun projectee  -> match projectee with | Comment _0 -> _0 
 let (uu___is_StackInline : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | StackInline  -> true | uu____1429 -> false
+    match projectee with | StackInline  -> true | uu____1402 -> false
   
 let (uu___is_CPrologue : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CPrologue _0 -> true | uu____1442 -> false
+    match projectee with | CPrologue _0 -> true | uu____1415 -> false
   
 let (__proj__CPrologue__item___0 : meta -> Prims.string) =
   fun projectee  -> match projectee with | CPrologue _0 -> _0 
 let (uu___is_CEpilogue : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CEpilogue _0 -> true | uu____1465 -> false
+    match projectee with | CEpilogue _0 -> true | uu____1438 -> false
   
 let (__proj__CEpilogue__item___0 : meta -> Prims.string) =
   fun projectee  -> match projectee with | CEpilogue _0 -> _0 
 let (uu___is_CConst : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CConst _0 -> true | uu____1488 -> false
+    match projectee with | CConst _0 -> true | uu____1461 -> false
   
 let (__proj__CConst__item___0 : meta -> Prims.string) =
   fun projectee  -> match projectee with | CConst _0 -> _0 
 let (uu___is_CCConv : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CCConv _0 -> true | uu____1511 -> false
+    match projectee with | CCConv _0 -> true | uu____1484 -> false
   
 let (__proj__CCConv__item___0 : meta -> Prims.string) =
   fun projectee  -> match projectee with | CCConv _0 -> _0 
 let (uu___is_Erased : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Erased  -> true | uu____1532 -> false
+    match projectee with | Erased  -> true | uu____1505 -> false
   
 let (uu___is_CAbstract : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CAbstract  -> true | uu____1543 -> false
+    match projectee with | CAbstract  -> true | uu____1516 -> false
   
 let (uu___is_CIfDef : meta -> Prims.bool) =
   fun projectee  ->
-    match projectee with | CIfDef  -> true | uu____1554 -> false
+    match projectee with | CIfDef  -> true | uu____1527 -> false
   
 type metadata = meta Prims.list
 type mlletflavor =
   | Rec 
   | NonRec 
 let (uu___is_Rec : mlletflavor -> Prims.bool) =
-  fun projectee  -> match projectee with | Rec  -> true | uu____1567 -> false 
+  fun projectee  -> match projectee with | Rec  -> true | uu____1540 -> false 
 let (uu___is_NonRec : mlletflavor -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NonRec  -> true | uu____1578 -> false
+    match projectee with | NonRec  -> true | uu____1551 -> false
   
 type mlexpr' =
   | MLE_Const of mlconstant 
@@ -521,51 +509,51 @@ and mllb =
   print_typ: Prims.bool }
 let (uu___is_MLE_Const : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Const _0 -> true | uu____1835 -> false
+    match projectee with | MLE_Const _0 -> true | uu____1808 -> false
   
 let (__proj__MLE_Const__item___0 : mlexpr' -> mlconstant) =
   fun projectee  -> match projectee with | MLE_Const _0 -> _0 
 let (uu___is_MLE_Var : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Var _0 -> true | uu____1855 -> false
+    match projectee with | MLE_Var _0 -> true | uu____1828 -> false
   
 let (__proj__MLE_Var__item___0 : mlexpr' -> mlident) =
   fun projectee  -> match projectee with | MLE_Var _0 -> _0 
 let (uu___is_MLE_Name : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Name _0 -> true | uu____1877 -> false
+    match projectee with | MLE_Name _0 -> true | uu____1850 -> false
   
 let (__proj__MLE_Name__item___0 : mlexpr' -> mlpath) =
   fun projectee  -> match projectee with | MLE_Name _0 -> _0 
 let (uu___is_MLE_Let : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Let _0 -> true | uu____1906 -> false
+    match projectee with | MLE_Let _0 -> true | uu____1879 -> false
   
 let (__proj__MLE_Let__item___0 :
   mlexpr' -> ((mlletflavor * mllb Prims.list) * mlexpr)) =
   fun projectee  -> match projectee with | MLE_Let _0 -> _0 
 let (uu___is_MLE_App : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_App _0 -> true | uu____1961 -> false
+    match projectee with | MLE_App _0 -> true | uu____1934 -> false
   
 let (__proj__MLE_App__item___0 : mlexpr' -> (mlexpr * mlexpr Prims.list)) =
   fun projectee  -> match projectee with | MLE_App _0 -> _0 
 let (uu___is_MLE_TApp : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_TApp _0 -> true | uu____2004 -> false
+    match projectee with | MLE_TApp _0 -> true | uu____1977 -> false
   
 let (__proj__MLE_TApp__item___0 : mlexpr' -> (mlexpr * mlty Prims.list)) =
   fun projectee  -> match projectee with | MLE_TApp _0 -> _0 
 let (uu___is_MLE_Fun : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Fun _0 -> true | uu____2052 -> false
+    match projectee with | MLE_Fun _0 -> true | uu____2025 -> false
   
 let (__proj__MLE_Fun__item___0 :
   mlexpr' -> ((mlident * mlty) Prims.list * mlexpr)) =
   fun projectee  -> match projectee with | MLE_Fun _0 -> _0 
 let (uu___is_MLE_Match : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Match _0 -> true | uu____2118 -> false
+    match projectee with | MLE_Match _0 -> true | uu____2091 -> false
   
 let (__proj__MLE_Match__item___0 :
   mlexpr' ->
@@ -574,57 +562,57 @@ let (__proj__MLE_Match__item___0 :
   = fun projectee  -> match projectee with | MLE_Match _0 -> _0 
 let (uu___is_MLE_Coerce : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Coerce _0 -> true | uu____2185 -> false
+    match projectee with | MLE_Coerce _0 -> true | uu____2158 -> false
   
 let (__proj__MLE_Coerce__item___0 : mlexpr' -> (mlexpr * mlty * mlty)) =
   fun projectee  -> match projectee with | MLE_Coerce _0 -> _0 
 let (uu___is_MLE_CTor : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_CTor _0 -> true | uu____2228 -> false
+    match projectee with | MLE_CTor _0 -> true | uu____2201 -> false
   
 let (__proj__MLE_CTor__item___0 : mlexpr' -> (mlpath * mlexpr Prims.list)) =
   fun projectee  -> match projectee with | MLE_CTor _0 -> _0 
 let (uu___is_MLE_Seq : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Seq _0 -> true | uu____2267 -> false
+    match projectee with | MLE_Seq _0 -> true | uu____2240 -> false
   
 let (__proj__MLE_Seq__item___0 : mlexpr' -> mlexpr Prims.list) =
   fun projectee  -> match projectee with | MLE_Seq _0 -> _0 
 let (uu___is_MLE_Tuple : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Tuple _0 -> true | uu____2294 -> false
+    match projectee with | MLE_Tuple _0 -> true | uu____2267 -> false
   
 let (__proj__MLE_Tuple__item___0 : mlexpr' -> mlexpr Prims.list) =
   fun projectee  -> match projectee with | MLE_Tuple _0 -> _0 
 let (uu___is_MLE_Record : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Record _0 -> true | uu____2333 -> false
+    match projectee with | MLE_Record _0 -> true | uu____2306 -> false
   
 let (__proj__MLE_Record__item___0 :
   mlexpr' -> (mlsymbol Prims.list * (mlsymbol * mlexpr) Prims.list)) =
   fun projectee  -> match projectee with | MLE_Record _0 -> _0 
 let (uu___is_MLE_Proj : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Proj _0 -> true | uu____2398 -> false
+    match projectee with | MLE_Proj _0 -> true | uu____2371 -> false
   
 let (__proj__MLE_Proj__item___0 : mlexpr' -> (mlexpr * mlpath)) =
   fun projectee  -> match projectee with | MLE_Proj _0 -> _0 
 let (uu___is_MLE_If : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_If _0 -> true | uu____2437 -> false
+    match projectee with | MLE_If _0 -> true | uu____2410 -> false
   
 let (__proj__MLE_If__item___0 :
   mlexpr' -> (mlexpr * mlexpr * mlexpr FStar_Pervasives_Native.option)) =
   fun projectee  -> match projectee with | MLE_If _0 -> _0 
 let (uu___is_MLE_Raise : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Raise _0 -> true | uu____2486 -> false
+    match projectee with | MLE_Raise _0 -> true | uu____2459 -> false
   
 let (__proj__MLE_Raise__item___0 : mlexpr' -> (mlpath * mlexpr Prims.list)) =
   fun projectee  -> match projectee with | MLE_Raise _0 -> _0 
 let (uu___is_MLE_Try : mlexpr' -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLE_Try _0 -> true | uu____2537 -> false
+    match projectee with | MLE_Try _0 -> true | uu____2510 -> false
   
 let (__proj__MLE_Try__item___0 :
   mlexpr' ->
@@ -682,20 +670,20 @@ type mltybody =
   | MLTD_DType of (mlsymbol * (mlsymbol * mlty) Prims.list) Prims.list 
 let (uu___is_MLTD_Abbrev : mltybody -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLTD_Abbrev _0 -> true | uu____2787 -> false
+    match projectee with | MLTD_Abbrev _0 -> true | uu____2760 -> false
   
 let (__proj__MLTD_Abbrev__item___0 : mltybody -> mlty) =
   fun projectee  -> match projectee with | MLTD_Abbrev _0 -> _0 
 let (uu___is_MLTD_Record : mltybody -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLTD_Record _0 -> true | uu____2813 -> false
+    match projectee with | MLTD_Record _0 -> true | uu____2786 -> false
   
 let (__proj__MLTD_Record__item___0 :
   mltybody -> (mlsymbol * mlty) Prims.list) =
   fun projectee  -> match projectee with | MLTD_Record _0 -> _0 
 let (uu___is_MLTD_DType : mltybody -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLTD_DType _0 -> true | uu____2867 -> false
+    match projectee with | MLTD_DType _0 -> true | uu____2840 -> false
   
 let (__proj__MLTD_DType__item___0 :
   mltybody -> (mlsymbol * (mlsymbol * mlty) Prims.list) Prims.list) =
@@ -712,32 +700,32 @@ type mlmodule1 =
   | MLM_Loc of mlloc 
 let (uu___is_MLM_Ty : mlmodule1 -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLM_Ty _0 -> true | uu____2986 -> false
+    match projectee with | MLM_Ty _0 -> true | uu____2959 -> false
   
 let (__proj__MLM_Ty__item___0 : mlmodule1 -> mltydecl) =
   fun projectee  -> match projectee with | MLM_Ty _0 -> _0 
 let (uu___is_MLM_Let : mlmodule1 -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLM_Let _0 -> true | uu____3005 -> false
+    match projectee with | MLM_Let _0 -> true | uu____2978 -> false
   
 let (__proj__MLM_Let__item___0 : mlmodule1 -> mlletbinding) =
   fun projectee  -> match projectee with | MLM_Let _0 -> _0 
 let (uu___is_MLM_Exn : mlmodule1 -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLM_Exn _0 -> true | uu____3036 -> false
+    match projectee with | MLM_Exn _0 -> true | uu____3009 -> false
   
 let (__proj__MLM_Exn__item___0 :
   mlmodule1 -> (mlsymbol * (mlsymbol * mlty) Prims.list)) =
   fun projectee  -> match projectee with | MLM_Exn _0 -> _0 
 let (uu___is_MLM_Top : mlmodule1 -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLM_Top _0 -> true | uu____3091 -> false
+    match projectee with | MLM_Top _0 -> true | uu____3064 -> false
   
 let (__proj__MLM_Top__item___0 : mlmodule1 -> mlexpr) =
   fun projectee  -> match projectee with | MLM_Top _0 -> _0 
 let (uu___is_MLM_Loc : mlmodule1 -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLM_Loc _0 -> true | uu____3110 -> false
+    match projectee with | MLM_Loc _0 -> true | uu____3083 -> false
   
 let (__proj__MLM_Loc__item___0 : mlmodule1 -> mlloc) =
   fun projectee  -> match projectee with | MLM_Loc _0 -> _0 
@@ -749,25 +737,25 @@ type mlsig1 =
   | MLS_Exn of (mlsymbol * mlty Prims.list) 
 let (uu___is_MLS_Mod : mlsig1 -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLS_Mod _0 -> true | uu____3177 -> false
+    match projectee with | MLS_Mod _0 -> true | uu____3150 -> false
   
 let (__proj__MLS_Mod__item___0 : mlsig1 -> (mlsymbol * mlsig1 Prims.list)) =
   fun projectee  -> match projectee with | MLS_Mod _0 -> _0 
 let (uu___is_MLS_Ty : mlsig1 -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLS_Ty _0 -> true | uu____3217 -> false
+    match projectee with | MLS_Ty _0 -> true | uu____3190 -> false
   
 let (__proj__MLS_Ty__item___0 : mlsig1 -> mltydecl) =
   fun projectee  -> match projectee with | MLS_Ty _0 -> _0 
 let (uu___is_MLS_Val : mlsig1 -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLS_Val _0 -> true | uu____3241 -> false
+    match projectee with | MLS_Val _0 -> true | uu____3214 -> false
   
 let (__proj__MLS_Val__item___0 : mlsig1 -> (mlsymbol * mltyscheme)) =
   fun projectee  -> match projectee with | MLS_Val _0 -> _0 
 let (uu___is_MLS_Exn : mlsig1 -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MLS_Exn _0 -> true | uu____3282 -> false
+    match projectee with | MLS_Exn _0 -> true | uu____3255 -> false
   
 let (__proj__MLS_Exn__item___0 : mlsig1 -> (mlsymbol * mlty Prims.list)) =
   fun projectee  -> match projectee with | MLS_Exn _0 -> _0 
@@ -796,11 +784,11 @@ let (apply_obj_repr : mlexpr -> mlty -> mlexpr) =
   fun x  ->
     fun t  ->
       let obj_ns =
-        let uu____3482 =
-          let uu____3484 = FStar_Options.codegen ()  in
-          uu____3484 = (FStar_Pervasives_Native.Some FStar_Options.FSharp)
+        let uu____3455 =
+          let uu____3457 = FStar_Options.codegen ()  in
+          uu____3457 = (FStar_Pervasives_Native.Some FStar_Options.FSharp)
            in
-        if uu____3482 then "FSharp.Compatibility.OCaml.Obj" else "Obj"  in
+        if uu____3455 then "FSharp.Compatibility.OCaml.Obj" else "Obj"  in
       let obj_repr =
         with_ty (MLTY_Fun (t, E_PURE, MLTY_Top))
           (MLE_Name ([obj_ns], "repr"))
@@ -809,48 +797,62 @@ let (apply_obj_repr : mlexpr -> mlty -> mlexpr) =
   
 let (avoid_keyword : Prims.string -> Prims.string) =
   fun s  ->
-    let uu____3514 = is_reserved s  in
-    if uu____3514 then Prims.op_Hat s "_" else s
+    let uu____3487 = is_reserved s  in
+    if uu____3487 then Prims.op_Hat s "_" else s
   
 let (bv_as_mlident : FStar_Syntax_Syntax.bv -> mlident) =
   fun x  ->
-    let uu____3529 =
+    let uu____3502 =
       ((FStar_Util.starts_with
           (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
           FStar_Ident.reserved_prefix)
          || (FStar_Syntax_Syntax.is_null_bv x))
         || (is_reserved (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText)
        in
-    if uu____3529
+    if uu____3502
     then
-      let uu____3533 =
-        let uu____3535 =
-          let uu____3537 =
+      let uu____3506 =
+        let uu____3508 =
+          let uu____3510 =
             FStar_Util.string_of_int x.FStar_Syntax_Syntax.index  in
-          Prims.op_Hat "_" uu____3537  in
+          Prims.op_Hat "_" uu____3510  in
         Prims.op_Hat (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
-          uu____3535
+          uu____3508
          in
-      FStar_All.pipe_left avoid_keyword uu____3533
+      FStar_All.pipe_left avoid_keyword uu____3506
     else
       FStar_All.pipe_left avoid_keyword
         (x.FStar_Syntax_Syntax.ppname).FStar_Ident.idText
   
+let (mlpath_of_lident : FStar_Ident.lident -> mlpath) =
+  fun x  ->
+    let uu____3525 = FStar_Ident.lid_equals x FStar_Parser_Const.failwith_lid
+       in
+    if uu____3525
+    then ([], ((x.FStar_Ident.ident).FStar_Ident.idText))
+    else
+      (let uu____3535 =
+         FStar_List.map (fun x1  -> x1.FStar_Ident.idText) x.FStar_Ident.ns
+          in
+       let uu____3542 =
+         avoid_keyword (x.FStar_Ident.ident).FStar_Ident.idText  in
+       (uu____3535, uu____3542))
+  
 let (push_unit : mltyscheme -> mltyscheme) =
   fun ts  ->
-    let uu____3552 = ts  in
-    match uu____3552 with
+    let uu____3554 = ts  in
+    match uu____3554 with
     | (vs,ty) -> (vs, (MLTY_Fun (ml_unit_ty, E_PURE, ty)))
   
 let (pop_unit : mltyscheme -> mltyscheme) =
   fun ts  ->
-    let uu____3561 = ts  in
-    match uu____3561 with
+    let uu____3563 = ts  in
+    match uu____3563 with
     | (vs,ty) ->
         (match ty with
          | MLTY_Fun (l,E_PURE ,t) ->
              if l = ml_unit_ty
              then (vs, t)
              else failwith "unexpected: pop_unit: domain was not unit"
-         | uu____3570 -> failwith "unexpected: pop_unit: not a function type")
+         | uu____3572 -> failwith "unexpected: pop_unit: not a function type")
   


### PR DESCRIPTION
Types defined by `let rec` were incorrectly being erased to `unit`, see issue #1714.

They are now correctly extracted to Obj.t

This has an F* and Everest green