### PR TITLE
[Makefile.boot] Make the rule on .depend less fragile

### DIFF
--- a/src/Makefile.boot
+++ b/src/Makefile.boot
@@ -81,20 +81,14 @@ ocaml-output/%.ml:
 # file as the roots, mentioning the the modules that are to be
 # extracted. This emits dependences for each of the ML files we want
 # to produce.
-#
-# We do an indirection via ._depend so we don't write an empty file if
-# the dependency analysis failed.
 
 .depend:
-	$(FSTAR_C) --dep full                 \
+	$(FSTAR_C) --dep full             \
 		   fstar/FStar.Main.fs	      \
 		   boot/FStar.Tests.Test.fst  \
-		   $(EXTRACT)		      > ._depend
-	mv ._depend .depend
+		   $(EXTRACT) > $@
 	mkdir -p $(CACHE_DIR)
 
-depend: .depend
-
-include .depend
+-include .depend
 
 all-ml: $(ALL_ML_FILES)


### PR DESCRIPTION
Redirecting output to ._depend, and then copying it over to .depend
serves no purpose, and the `include` directive often fails anyway.
Improve the situation by using `-include` and a single redirect with
error.

Signed-off-by: Ramkumar Ramachandra <artagnon@gmail.com>