### PR TITLE
[FStar.Options] Drop --eager_inference (fixes #444)

### DIFF
--- a/.completion/fish/fstar.exe.fish
+++ b/.completion/fish/fstar.exe.fish
@@ -12,7 +12,6 @@ complete -c fstar.exe -l detail_errors --description "Emit a detailed error repo
 complete -c fstar.exe -l detail_hint_replay --description "Emit a detailed report for proof whose unsat core fails to replay;"
 complete -c fstar.exe -l doc --description "Extract Markdown documentation files for the input modules, as well as an index. Output is written to --odir directory."
 complete -c fstar.exe -l dump_module --description "[module name]"
-complete -c fstar.exe -l eager_inference --description "Solve all type-inference constraints eagerly; more efficient but at the cost of generality"
 complete -c fstar.exe -l extract_module -r --description "Only extract the specified modules (instead of the possibly-partial dependency graph)"
 complete -c fstar.exe -l extract_namespace -r --description "Only extract modules in the specified namespace"
 complete -c fstar.exe -l fstar_home -r --description "Set the FSTAR_HOME variable to [dir]"

--- a/examples/vale/X64.Poly1305.Math_i.fst
+++ b/examples/vale/X64.Poly1305.Math_i.fst
@@ -35,7 +35,7 @@ lemma_BitwiseMul64()
 
 // private unfold let op_Star = op_Multiply
 
-#reset-options "--z3cliopt smt.QI.EAGER_THRESHOLD=100 --z3cliopt smt.CASE_SPLIT=3 --z3cliopt smt.arith.nl=false --max_fuel 0 --max_ifuel 0 --smtencoding.elim_box true --eager_inference --smtencoding.nl_arith_repr wrapped --smtencoding.l_arith_repr native"
+#reset-options "--z3cliopt smt.QI.EAGER_THRESHOLD=100 --z3cliopt smt.CASE_SPLIT=3 --z3cliopt smt.arith.nl=false --max_fuel 0 --max_ifuel 0 --smtencoding.elim_box true --smtencoding.nl_arith_repr wrapped --smtencoding.l_arith_repr native"
 
 (*
 let heapletTo128_preserved (m:mem) (m':mem) (i:int) (len:nat) =

--- a/src/Makefile.boot
+++ b/src/Makefile.boot
@@ -1,8 +1,5 @@
 include Makefile.config
 
-# FSTAR_C: This is the way in which we invoke F* for boostrapping
-#   -- we use automatic dependence analysis based on files in ulib, src/{basic, ...} and boot
-#   -- eager_inference, MLish, lax: all tune type-inference for use with unverified ML programs
 INCLUDE_PATHS = \
 	../ulib \
 	boot \
@@ -24,6 +21,10 @@ INCLUDE_PATHS = \
 CACHE_DIR?=./.cache.boot
 
 FSTAR_BOOT ?= $(FSTAR)
+
+# FSTAR_C: This is the way in which we invoke F* for boostrapping
+#   -- we use automatic dependence analysis based on files in ulib, src/{basic, ...} and boot
+#   -- MLish and lax tune type-inference for use with unverified ML programs
 FSTAR_C=$(FSTAR_BOOT) $(OTHERFLAGS) --cache_checked_modules		\
 	--use_extracted_interfaces false                                \
 	--lax --MLish --no_location_info				\

--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -46,16 +46,6 @@ type option_val =
   | List of list<option_val>
   | Unset
 
-//These wrappers provide each constructor with the ML effect
-//They are needed to make type-inference work well with the
-//--eager_inference flag that is used during bootstrapping,
-//which explicitly disables some subtyping/sub-effecting
-let mk_bool   : bool -> option_val = Bool
-let mk_string : string -> option_val = String
-let mk_path   : string -> option_val = Path
-let mk_int    : int -> option_val = Int
-let mk_list   : list<option_val> -> option_val = List
-
 type options =
   | Set
   | Reset
@@ -190,7 +180,6 @@ let defaults =
       ("detail_hint_replay"           , Bool false);
       ("doc"                          , Bool false);
       ("dump_module"                  , List []);
-      ("eager_inference"              , Bool false);
       ("eager_subtyping"              , Bool false);
       ("expose_interfaces"            , Bool false);
       ("extract"                      , Unset);
@@ -485,14 +474,14 @@ let mk_spec o : opt =
 
 let accumulated_option name value =
     let prev_values = Util.dflt [] (lookup_opt name (as_option as_list')) in
-    mk_list (value :: prev_values)
+    List (value :: prev_values)
 
 let reverse_accumulated_option name value =
     let prev_values = Util.dflt [] (lookup_opt name (as_option as_list')) in
-    mk_list (prev_values @ [value])
+    List (prev_values @ [value])
 
 let accumulate_string name post_processor value =
-    set_option name (accumulated_option name (mk_string (post_processor value)))
+    set_option name (accumulated_option name (String (post_processor value)))
 
 let add_extract_module s =
     accumulate_string "extract_module" String.lowercase s
@@ -541,16 +530,16 @@ let rec parse_opt_val (opt_name: string) (typ: opt_type) (str_val: string) : opt
     match typ with
     | Const c -> c
     | IntStr _ -> (match safe_int_of_string str_val with
-                  | Some v -> mk_int v
+                  | Some v -> Int v
                   | None -> raise (InvalidArgument opt_name))
-    | BoolStr -> mk_bool (if str_val = "true" then true
+    | BoolStr -> Bool (if str_val = "true" then true
                          else if str_val = "false" then false
                          else raise (InvalidArgument opt_name))
-    | PathStr _ -> mk_path str_val
-    | SimpleStr _ -> mk_string str_val
-    | EnumStr strs -> if List.mem str_val strs then mk_string str_val
+    | PathStr _ -> Path str_val
+    | SimpleStr _ -> String str_val
+    | EnumStr strs -> if List.mem str_val strs then String str_val
                      else raise (InvalidArgument opt_name)
-    | OpenEnumStr _ -> mk_string str_val
+    | OpenEnumStr _ -> String str_val
     | PostProcessed (pp, elem_spec) -> pp (parse_opt_val opt_name elem_spec str_val)
     | Accumulated elem_spec -> let v = parse_opt_val opt_name elem_spec str_val in
                               accumulated_option opt_name v
@@ -590,7 +579,7 @@ let pp_validate_dir p =
   p
 
 let pp_lowercase s =
-  mk_string (String.lowercase (as_string s))
+  String (String.lowercase (as_string s))
 
 let abort_counter : ref<int> =
     mk_ref 0
@@ -620,7 +609,7 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
       ( noshort,
         "cache_checked_modules",
-        Const (mk_bool true),
+        Const (Bool true),
         "Write a '.checked' file for each module after verification and read from it if present, instead of re-verifying");
 
       ( noshort,
@@ -630,12 +619,12 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
       ( noshort,
         "cache_off",
-        Const (mk_bool true),
+        Const (Bool true),
         "Do not read or write any .checked files");
 
       ( noshort,
         "cmi",
-        Const (mk_bool true),
+        Const (Bool true),
         "Inline across module interfaces during extraction (aka. cross-module inlining)");
 
       ( noshort,
@@ -677,19 +666,19 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "detail_errors",
-        Const (mk_bool true),
+        Const (Bool true),
          "Emit a detailed error report by asking the SMT solver many queries; will take longer;
          implies n_cores=1");
 
        ( noshort,
         "detail_hint_replay",
-        Const (mk_bool true),
+        Const (Bool true),
          "Emit a detailed report for proof whose unsat core fails to replay;
          implies n_cores=1");
 
        ( noshort,
         "doc",
-        Const (mk_bool true),
+        Const (Bool true),
          "Extract Markdown documentation files for the input modules, as well as an index. Output is written to --odir directory.");
 
        ( noshort,
@@ -697,14 +686,9 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
         Accumulated (SimpleStr "module_name"),
         "");
 
-       ( noshort,
-        "eager_inference",
-        Const (mk_bool true),
-        "Deprecated: Solve all type-inference constraints eagerly; more efficient but at the cost of generality");
-
        (noshort,
         "eager_subtyping",
-        Const (mk_bool true),
+        Const (Bool true),
         "Try to solve subtyping constraints at each binder (loses precision but may be slightly more efficient)");
 
        ( noshort,
@@ -732,12 +716,12 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "expose_interfaces",
-        Const (mk_bool true),
+        Const (Bool true),
         "Explicitly break the abstraction imposed by the interface of any implementation file that appears on the command line (use with care!)");
 
        ( noshort,
         "hide_uvar_nums",
-        Const (mk_bool true),
+        Const (Bool true),
         "Don't print unification variable numbers");
 
        ( noshort,
@@ -747,17 +731,17 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "hint_info",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print information regarding hints (deprecated; use --query_stats instead)");
 
        ( noshort,
         "in",
-        Const (mk_bool true),
+        Const (Bool true),
         "Legacy interactive mode; reads input from stdin");
 
        ( noshort,
         "ide",
-        Const (mk_bool true),
+        Const (Bool true),
         "JSON-based interactive mode for IDEs");
 
        ( noshort,
@@ -767,17 +751,17 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "print",
-        Const (mk_bool true),
+        Const (Bool true),
         "Parses and prettyprints the files included on the command line");
 
        ( noshort,
         "print_in_place",
-        Const (mk_bool true),
+        Const (Bool true),
         "Parses and prettyprints in place the files included on the command line");
 
        ( noshort,
         "profile",
-        Const (mk_bool true),
+        Const (Bool true),
         "Prints timing information for various operations in the compiler");
 
        ( noshort,
@@ -797,7 +781,7 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "lax",
-        Const (mk_bool true),
+        Const (Bool true),
         "Run the lax-type checker only (admit all verification conditions)");
 
       ( noshort,
@@ -807,12 +791,12 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "log_types",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print types computed for data/val/let-bindings");
 
        ( noshort,
         "log_queries",
-        Const (mk_bool true),
+        Const (Bool true),
         "Log the Z3 queries in several queries-*.smt2 files, as we go");
 
        ( noshort,
@@ -832,7 +816,7 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "MLish",
-        Const (mk_bool true),
+        Const (Bool true),
         "Trigger various specializations for compiling the F* compiler itself (not meant for user code)");
 
        ( noshort,
@@ -842,7 +826,7 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "no_default_includes",
-        Const (mk_bool true),
+        Const (Bool true),
         "Ignore the default module search paths");
 
        ( noshort,
@@ -852,17 +836,17 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "no_location_info",
-        Const (mk_bool true),
+        Const (Bool true),
         "Suppress location information in the generated OCaml output (only relevant with --codegen OCaml)");
 
        ( noshort,
         "no_smt",
-        Const (mk_bool true),
+        Const (Bool true),
         "Do not send any queries to the SMT solver, and fail on them instead");
 
        ( noshort,
         "normalize_pure_terms_for_extraction",
-        Const (mk_bool true),
+        Const (Bool true),
         "Extract top-level pure terms after normalizing them. This can lead to very large code, but can result in more partial evaluation and compile-time specialization.");
 
        ( noshort,
@@ -877,47 +861,47 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "print_bound_var_types",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print the types of bound variables");
 
        ( noshort,
         "print_effect_args",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print inferred predicate transformers for all computation types");
 
        ( noshort,
         "print_full_names",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print full names of variables");
 
        ( noshort,
         "print_implicits",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print implicit arguments");
 
        ( noshort,
         "print_universes",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print universes");
 
        ( noshort,
         "print_z3_statistics",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print Z3 statistics for each SMT query (details such as relevant modules, facts, etc. for each proof)");
 
        ( noshort,
         "prn",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print full names (deprecated; use --print_full_names instead)");
 
        ( noshort,
         "query_stats",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print SMT query statistics");
 
        ( noshort,
         "record_hints",
-        Const (mk_bool true),
+        Const (Bool true),
         "Record a database of hints for efficient proof replay");
 
        ( noshort,
@@ -927,7 +911,7 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "silent",
-        Const (mk_bool true),
+        Const (Bool true),
         "Disable all non-critical output");
 
        ( noshort,
@@ -969,22 +953,22 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "tactic_raw_binders",
-        Const (mk_bool true),
+        Const (Bool true),
         "Do not use the lexical scope of tactics to improve binder names");
 
        ( noshort,
         "tactics_failhard",
-        Const (mk_bool true),
+        Const (Bool true),
         "Do not recover from metaprogramming errors, and abort if one occurs");
 
        ( noshort,
         "tactics_info",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print some rough information on tactics, such as the time they take to run");
 
        ( noshort,
         "tactic_trace",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print a depth-indexed trace of tactic execution (Warning: very verbose)");
 
        ( noshort,
@@ -994,7 +978,7 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "__tactics_nbe",
-        Const (mk_bool true),
+        Const (Bool true),
         "Use NBE to evaluate metaprograms (experimental)");
 
        ( noshort,
@@ -1004,43 +988,43 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "timing",
-        Const (mk_bool true),
+        Const (Bool true),
         "Print the time it takes to verify each top-level definition");
 
        ( noshort,
         "trace_error",
-        Const (mk_bool true),
+        Const (Bool true),
         "Don't print an error message; show an exception trace instead");
 
       ( noshort,
         "ugly",
-        Const (mk_bool true),
+        Const (Bool true),
         "Emit output formatted for debugging");
 
        ( noshort,
         "unthrottle_inductives",
-        Const (mk_bool true),
+        Const (Bool true),
         "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)");
 
        ( noshort,
         "unsafe_tactic_exec",
-        Const (mk_bool true),
+        Const (Bool true),
         "Allow tactics to run external processes. WARNING: checking an untrusted F* file while \
          using this option can have disastrous effects.");
 
        ( noshort,
         "use_eq_at_higher_order",
-        Const (mk_bool true),
+        Const (Bool true),
         "Use equality constraints when comparing higher-order types (Temporary)");
 
        ( noshort,
         "use_hints",
-        Const (mk_bool true),
+        Const (Bool true),
         "Use a previously recorded hints database for proof replay");
 
        ( noshort,
         "use_hint_hashes",
-        Const (mk_bool true),
+        Const (Bool true),
         "Admit queries if their hash matches the hash recorded in the hints database");
 
        ( noshort,
@@ -1050,12 +1034,12 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "no_plugins",
-        Const (mk_bool true),
+        Const (Bool true),
         "Do not run plugins natively and interpret them as usual instead");
 
        ( noshort,
         "no_tactics",
-        Const (mk_bool true),
+        Const (Bool true),
         "Do not run the tactic engine before discharging a VC");
 
        ( noshort,
@@ -1090,18 +1074,18 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "__temp_fast_implicits",
-        Const (mk_bool true),
+        Const (Bool true),
         "Don't use this option yet");
 
        ( 'v',
          "version",
          WithSideEffect ((fun _ -> display_version(); exit 0),
-                         (Const (mk_bool true))),
+                         (Const (Bool true))),
          "Display version number");
 
        ( noshort,
          "warn_default_effects",
-         Const (mk_bool true),
+         Const (Bool true),
          "Warn when (a -> b) is desugared to (a -> Tot b)");
 
        ( noshort,
@@ -1111,7 +1095,7 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "z3refresh",
-        Const (mk_bool true),
+        Const (Bool true),
         "Restart Z3 after each query; useful for ensuring proof robustness");
 
        ( noshort,
@@ -1136,12 +1120,12 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
 
        ( noshort,
         "__no_positivity",
-        Const (mk_bool true),
+        Const (Bool true),
         "Don't check positivity of inductive types");
 
        ( noshort,
         "__ml_no_eta_expand_coertions",
-        Const (mk_bool true),
+        Const (Bool true),
         "Do not eta-expand coertions in generated OCaml");
 
         ( noshort,
@@ -1167,18 +1151,18 @@ let rec specs_with_types () : list<(char * string * opt_type * string)> =
         ( noshort,
           "__debug_embedding",
            WithSideEffect ((fun _ -> debug_embedding := true),
-                           (Const (mk_bool true))),
+                           (Const (Bool true))),
           "Debug messages for embeddings/unembeddings of natively compiled terms");
 
        ( noshort,
         "eager_embedding",
          WithSideEffect ((fun _ -> eager_embedding := true),
-                          (Const (mk_bool true))),
+                          (Const (Bool true))),
         "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking");
 
        ('h',
         "help", WithSideEffect ((fun _ -> display_usage_aux (specs ()); exit 0),
-                                (Const (mk_bool true))),
+                                (Const (Bool true))),
         "Display this information")]
 
 and specs () : list<FStar.Getopt.opt> = // FIXME: Why does the interactive mode log the type of opt_specs_with_types as a triple??
@@ -1197,7 +1181,6 @@ let settable = function
     | "defensive"
     | "detail_errors"
     | "detail_hint_replay"
-    | "eager_inference"
     | "eager_subtyping"
     | "hide_uvar_nums"
     | "hint_info"
@@ -1298,7 +1281,7 @@ let restore_cmd_line_options should_clear =
     let old_verify_module = get_verify_module() in
     if should_clear then clear() else init();
     let r = Getopt.parse_cmdline (specs()) (fun x -> ()) in
-    set_option' ("verify_module", List (List.map mk_string old_verify_module));
+    set_option' ("verify_module", List (List.map String old_verify_module));
     r
 
 let module_name_of_file_name f =


### PR DESCRIPTION
To quote Nikhil in Dec 2015 (in #444),

  It will be yet another configuration of the type-checker to test. I
  don't think our regression suite uses it at all. So, I worry that
  counting on it going forward will lead to unpredictability.

  If you really want to keep it, I don't mind. Let's document it as
  "experimental" or "brittle" or something like that.

Signed-off-by: Ramkumar Ramachandra <artagnon@gmail.com>