### PR TITLE
[INSTALL, Makefile] Use BSD/GNU compatible options

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,9 +35,6 @@ required dependencies (except for Z3) using the following commands:
         $ opam pin add fstar --dev-repo
         $ opam install fstar
 
-### Platform specific early troubleshooting ###
-- for mac users, make sure that `ginstall`, `gsed` and `gfind` are on your system (present in macports in `coreutils` and `findutils`)
-
 ## Binary releases ##
 
 Every now and then we release [F\* binaries on GitHub] (for Windows, Mac, and Linux)
@@ -227,7 +224,7 @@ The steps require a working OCaml setup. OCaml version 4.04.X, 4.05.X, 4.06.X, o
   ```sh
   $ opam install ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir ulex ppx_deriving ppx_deriving_yojson process pprint ulex
   ```
-  
+
   **Note:** this list of packages is longer than the list in the
   [Testing a binary package](#testing-a-binary-package) section above,
   because the additional packages here are necessary to compile F\*.

--- a/bin/fstar-any.sh
+++ b/bin/fstar-any.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-if which greadlink >/dev/null 2>&1; then
-  READLINK=greadlink
-else
-  READLINK=readlink
-fi
-FSTAR=$(dirname $($READLINK -f $0))/fstar.exe
+FSTAR=$(cd "$(dirname "$0")" && pwd -P)/fstar.exe
 if [ ! -f "$FSTAR" ]; then
   echo "fstar.exe not found"
   exit 1

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -9,3 +9,4 @@ u_ocaml-output
 [Oo]bj/
 
 Makefile.local
+*.bak

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,42 +56,41 @@ ALL_BOOT=$(addprefix boot/FStar., Util.fsti List.fsti			\
 
 boot/%.fsti: basic/boot/%.fsi | boot_dir
 	cp $^ $@
-	$(SED) -i 's/<.* when .* : equality>//g' $@
-	$(SED) -i '/\/\/ *JUST *FSHARP */d' $@
+	$(SED) -i.bak 's/<.* when .* : equality>//g' $@
+	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
 	touch -r $^ $@
 
 boot/%.fsti: prettyprint/boot/%.fsi | boot_dir
 	cp $^ $@
-	$(SED) -i '/\/\/ *JUST *FSHARP */d' $@
+	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
 	touch -r $^ $@
 
 #fix up a use of polymorphic recursion in F#, which has a different syntax than F*
 boot/FStar.Tactics.Interpreter.fst: tactics/boot/FStar.Tactics.Interpreter.fs | boot_dir
 	cp $^ $@
-	$(SED) -i '/\/\/ *JUST *FSHARP */d' $@
-	$(SED) -i 's,^ *// *IN *F\* *:,,g' $@
+	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
+	$(SED) -i.bak 's,^ *// *IN *F\* *:,,g' $@
 	touch -r $^ $@
 
 #fix up by adding an annotation to suppress universe polymorphism in a mutually recursive type
 boot/FStar.TypeChecker.NBETerm.fst: typechecker/boot/FStar.TypeChecker.NBETerm.fs | boot_dir
 	cp $^ $@
-	$(SED) -i '/\/\/ *JUST *FSHARP */d' $@
-	$(SED) -i 's,^ *// *IN *F\* *:,,g' $@
+	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
+	$(SED) -i.bak 's,^ *// *IN *F\* *:,,g' $@
 
 boot/FStar.TypeChecker.NBETerm.fsti: typechecker/boot/FStar.TypeChecker.NBETerm.fsi | boot_dir
 	cp $^ $@
-	$(SED) -i '/\/\/ *JUST *FSHARP */d' $@
-	$(SED) -i 's,^ *// *IN *F\* *:,,g' $@
+	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
+	$(SED) -i.bak 's,^ *// *IN *F\* *:,,g' $@
 
 boot/FStar.Tests.Test.fst: tests/boot/FStar.Tests.Test.fs | boot_dir
 	cp $^ $@
-	$(SED) -i '/\/\/ *JUST *FSHARP */d' $@
+	$(SED) -i.bak '/\/\/ *JUST *FSHARP */d' $@
 	touch -r $^ $@
 
 boot/FStar.Parser.Parse.fsti: parser/parse.fsi | boot_dir
 	echo "#light \"off\"" > $@
-	$(HEAD) -n -12 $^ >> $@
-	$(SED) -i 's/module FStar.Parser.Parse/module FStar.Parser.Parse\nopen FStar.All\nopen FStar.BaseTypes\ntype bytes = array<byte>\nopen FStar.Syntax.Syntax/' $@
+	$(HEAD) -n12 $^ >> $@
 	touch -r parser/parse.mly $@
 
 boot/%.fst: basic/boot/%.fs | boot_dir

--- a/src/Makefile.config
+++ b/src/Makefile.config
@@ -28,15 +28,9 @@ CONFIGURATION?=Release
 MSBUILD := $(MSBUILD) /verbosity:minimal /p:Configuration=$(CONFIGURATION)
 DOS2UNIX=$(shell which dos2unix >/dev/null 2>&1 && echo dos2unix || echo true)
 
-ifeq ($(UNAME),Darwin)
-  HEAD=ghead
-  SED=gsed
-  FIND=gfind
-else
-  HEAD=head
-  SED=sed
-  FIND=find
-endif
+# Use options compatible between BSD and GNU versions, on macOS and Linux
+HEAD=head
+SED=sed
+FIND=find
 
 # --------------------------------------------------------------------
-

--- a/ulib/gen_mllib.sh
+++ b/ulib/gen_mllib.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-FIND=$(which gfind > /dev/null 2>&1 && echo gfind || echo find)
-SED=$(which gsed > /dev/null 2>&1 && echo gsed || echo sed)
-
-$FIND "$@" -maxdepth 1 -name "*.ml" -print \
+find "$@" -maxdepth 1 -name "*.ml" -print \
     | xargs -n 1 basename \
-    | $SED -e 's/\.ml//g' | sort | uniq
+    | sed -e 's/\.ml//g' | sort | uniq


### PR DESCRIPTION
Avoid unnecessary dependency on coreutils and gnu-sed on macOS. The hunk
in src/Makefile.config is non-trivial, as there is no known method to
replace a single line by multiple lines in sed, in a compatible way; but
it was found that this replacement is completely unnecessary, as
evidenced by the built fstar being able to check the entire ulib.

See also #1729 for discussion about this -- this PR is simply that PR turned
into an F\* branch.

Signed-off-by: Ramkumar Ramachandra <artagnon@gmail.com>