### PR TITLE
Work around strange flakyness in FStar.Math.Lemmas

### DIFF
--- a/ulib/FStar.Math.Lemmas.fst
+++ b/ulib/FStar.Math.Lemmas.fst
@@ -432,8 +432,12 @@ let rec lemma_mod_mul_distr_l (a:int) (b:int) (n:pos) =
     mod_add_both (a * b + a) ((a % n) * b + a) (-a) n
   )
 
+#push-options "--z3rlimit 10"
+
 val lemma_mod_mul_distr_r (a:int) (b:int) (n:pos) : Lemma ((a * b) % n = (a * (b % n)) % n)
 let lemma_mod_mul_distr_r (a:int) (b:int) (n:pos) = lemma_mod_mul_distr_l b a n
+
+#pop-options
 
 val lemma_mod_injective: p:pos -> a:nat -> b:nat -> Lemma
   (requires (a < p /\ b < p /\ a % p = b % p))


### PR DESCRIPTION
No clue what's causing this, but this fails only in the binary package, even if the `--debug_level Low` and `--debug_level SMTQuery` log is exactly the same until the failed SMT query.
```
FStar.Math.Lemmas.fst(436,52-436,79): (Error 16) Unknown assertion failed (SMT solver says: unknown because canceled (fuel=8; ifuel=2; ); SMT solver says: unknown because canceled (fuel=4; ifuel=2; ); SMT solver says: unknown because canceled (fuel=2; ifuel=2; ); SMT solver says: unknown because canceled (fuel=2; ifuel=1; ); SMT solver says: unknown because canceled (fuel=2; ifuel=2; with hint))
```