### PR TITLE
Fix issue 1793 with bad z3 restart params

### DIFF
--- a/src/smtencoding/FStar.SMTEncoding.Z3.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Z3.fs
@@ -243,12 +243,12 @@ let bg_z3_proc =
     let z3proc () =
       if !the_z3proc = None then make_new_z3_proc (z3_cmd_and_args ());
       must (!the_z3proc) in
-    let next_params = z3_cmd_and_args () in
     let ask input =
         incr the_z3proc_ask_count;
         let kill_handler () = "\nkilled\n" in
         BU.ask_process (z3proc ()) input kill_handler in
     let refresh () =
+        let next_params = z3_cmd_and_args () in
         let old_params = must (!the_z3proc_params) in
         if (Options.log_queries()) || (!the_z3proc_ask_count > 0) || (not (old_params = next_params)) then begin
           if (Options.query_stats()) && (not (!the_z3proc = None)) then
@@ -259,6 +259,7 @@ let bg_z3_proc =
         query_logging.close_log() in
     let restart () =
         query_logging.close_log();
+        let next_params = z3_cmd_and_args () in
         make_new_z3_proc next_params in
     let x : list<unit> = [] in
     BU.mk_ref ({ask = BU.with_monitor x ask;


### PR DESCRIPTION
This fixes the z3 restart optimisation where the params were not always being picked up. 