### PR TITLE
OCaml hashtable replace optim

### DIFF
--- a/src/basic/ml/FStar_Util.ml
+++ b/src/basic/ml/FStar_Util.ml
@@ -356,8 +356,7 @@ module StringMap = BatMap.Make(StringOps)
 type 'value smap = 'value StringHashtbl.t
 let smap_create (i:Z.t) : 'value smap = StringHashtbl.create (Z.to_int i)
 let smap_clear (s:('value smap)) = StringHashtbl.clear s
-let smap_add (m:'value smap) k (v:'value) =
-    StringHashtbl.remove m k; StringHashtbl.add m k v
+let smap_add (m:'value smap) k (v:'value) = StringHashtbl.replace m k v
 let smap_of_list (l: (string * 'value) list) =
   let s = StringHashtbl.create (BatList.length l) in
   FStar_List.iter (fun (x,y) -> smap_add s x y) l;
@@ -395,7 +394,7 @@ module ZMap = BatMap.Make(Z)
 type 'value imap = 'value ZHashtbl.t
 let imap_create (i:Z.t) : 'value imap = ZHashtbl.create (Z.to_int i)
 let imap_clear (s:('value imap)) = ZHashtbl.clear s
-let imap_add (m:'value imap) k (v:'value) = ZHashtbl.add m k v
+let imap_add (m:'value imap) k (v:'value) = ZHashtbl.replace m k v
 let imap_of_list (l: (Z.t * 'value) list) =
   let s = ZHashtbl.create (BatList.length l) in
   FStar_List.iter (fun (x,y) -> imap_add s x y) l;


### PR DESCRIPTION

This PR uses replace rather than separate remove/add for smap_add; it also makes imap_add consistent (rather than shadowing old element with add). The replace is the same as remove/add but can be more efficient (docs here http://ocaml-batteries-team.github.io/batteries-included/hdoc2/BatHashtbl.html). 

Benchmarking (--admit_smt_queries true, Linux) for this change gives:
```
                  Old                               New
                  n       total   user    system    n       total   user    system
micro-benchmarks  61      60.91   56.84   3.626     61      58.96   54.65   3.867
ocaml_extract     38      121.6   117.3   4.276     38      120.7   116     4.649
ulib              208     403.9   382.5   19.88     208     401.1   379.4   20.11
```

Only a small improvement in aggregate and on individual benchmarks I didn't see any regressions. However on some test cases the improvement is more meaningful, for example `micro-benchmarks/ChrisCheck` we get ~5% (29.8s old vs 28.3s new).

