### PR TITLE
Optimization of TypeChecker config function

### DIFF
--- a/src/typechecker/FStar.TypeChecker.Cfg.fs
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fs
@@ -196,6 +196,18 @@ type debug_switches = {
     print_normalized : bool;
 }
 
+let no_debug_switches = {
+    gen              = false;
+    top              = false;
+    cfg              = false;
+    primop           = false;
+    unfolding        = false;
+    b380             = false;
+    wpe              = false;
+    norm_delayed     = false;
+    print_normalized = false;
+}
+
 type primitive_step = {
      name:Ident.lid;
      arity:int;
@@ -949,24 +961,26 @@ let config' psteps s e =
     let d = match d with
         | [] -> [Env.NoDelta]
         | _ -> d in
+    let steps = to_fsteps s |> add_nbe in
     {tcenv = e;
-     debug = { gen = Env.debug e (Options.Other "Norm")
+     debug = if Options.debug_any () then
+            { gen = Env.debug e (Options.Other "Norm")
              ; top = Env.debug e (Options.Other "NormTop")
              ; cfg = Env.debug e (Options.Other "NormCfg")
              ; primop = Env.debug e (Options.Other "Primops")
              ; unfolding = Env.debug e (Options.Other "Unfolding")
              ; b380 = Env.debug e (Options.Other "380")
-             ; wpe  = Env.debug e (Options.Other "WPE")
+             ; wpe = Env.debug e (Options.Other "WPE")
              ; norm_delayed = Env.debug e (Options.Other "NormDelayed")
-             ; print_normalized = Env.debug e (Options.Other "print_normalized_terms") };
-     steps = to_fsteps s |> add_nbe ;
+             ; print_normalized = Env.debug e (Options.Other "print_normalized_terms")}
+            else no_debug_switches
+      ;
+     steps = steps;
      delta_level = d;
      primitive_steps = add_steps built_in_primitive_steps (retrieve_plugins () @ psteps);
      strong = false;
      memoize_lazy = true;
-     normalize_pure_lets =
-       (Options.normalize_pure_terms_for_extraction()
-        || not (s |> BU.for_some (eq_step PureSubtermsWithinComputations)));
+     normalize_pure_lets = (not steps.pure_subterms_within_computations) || Options.normalize_pure_terms_for_extraction();
      reifying = false}
 
 let config s e = config' [] s e


### PR DESCRIPTION
The function `config'` in `TypeChecker.Cfg` can be called frequently in the Normalizer.

This PR optimizes the `config'` in the following ways:
 - when debug switches are off which cuts lookups into the Options table.
 - avoid searching the list `s` for `PureSubtermsWithinComputations ` because this information is already `steps` following `to_fsteps`.

I see the following results from benchmarking the change (`--smt_admit_queries true`) on Linux:
```
                  Old                               New
                  n       total   user    system    n       total   user    system
micro-benchmarks  61      60.09   55.73   3.918     61      57.03   52.85   3.731
ocaml_extract     38      120.6   116.4   4.146     38      117.4   113.1   4.306
ulib              208     399.8   378.6   19.6      208     380.6   359.3   19.68

```
 