### PR TITLE
Addition of example that uses the benchmarking hooks

### DIFF
--- a/examples/benchmarking/README.md
+++ b/examples/benchmarking/README.md
@@ -1,0 +1,38 @@
+Benchmarking FStar
+==================
+
+There are hooks within the FStar makefiles to make it easy to run a benchmarks of examples/micro-benchmarks, ulib and OCaml extraction of the FStar compiler itself.
+
+To get started, you can run the micro-benchmarks using GNU time to measure execution with:
+```
+ $ make -C examples/micro-benchmarks BENCHMARK_CMD=time
+```
+This will output .bench files for each of the benchmarks.
+
+
+Example of full benchmarks
+--------------------------
+
+The `make_bench_results.sh` script is an example which:
+ - places all the results into the directory `./bench_results/YYYY_HHMMSS`
+ - cleans the fstar tree to start from a known state
+ - builds the fstar compiler
+ - builds a fresh ulib
+ - uses taskset to optionally pin the process to a CPU (if TASKSET_CPU is set)
+ - executes the benchmarks for micro-benchmarks, ulib and OCaml extraction
+ - collates the JSON results into a CSV file and also timing summaries in the results directory
+
+To run this script you may need to install:
+ - orun which to collect OCaml profiling information including GC stats and is part of the sandmark OCaml benchmarking suite (https://github.com/ocaml-bench/sandmark). To install a local pinned copy of orun do the following:
+```
+ $ git clone https://github.com/ocaml-bench/sandmark.git sandmark
+ $ cd sandmark/orun
+ $ opam install .
+```
+ - jq which collates JSON into CSV (https://stedolan.github.io/jq/)
+
+To run the script execute (from the fstar root directory)
+```
+ $ examples/benchmarking/make_bench_results.sh
+```
+

--- a/examples/benchmarking/README.md
+++ b/examples/benchmarking/README.md
@@ -18,7 +18,6 @@ The `make_bench_results.sh` script is an example which:
  - cleans the fstar tree to start from a known state
  - builds the fstar compiler
  - builds a fresh ulib
- - uses taskset to optionally pin the process to a CPU (if TASKSET_CPU is set)
  - executes the benchmarks for micro-benchmarks, ulib and OCaml extraction
  - collates the JSON results into a CSV file and also timing summaries in the results directory
 
@@ -34,5 +33,10 @@ To run this script you may need to install:
 To run the script execute (from the fstar root directory)
 ```
  $ examples/benchmarking/make_bench_results.sh
+```
+
+The script has options to set wrappers for tasksetting and/or setting FStar OTHERFLAGS, for example:
+```
+ $ BENCH_WRAP='taskset --cpu-list 3' BENCH_OTHERFLAGS='--admit_smt_queries true' examples/benchmarking/make_bench_results.sh
 ```
 

--- a/examples/benchmarking/make_bench_results.sh
+++ b/examples/benchmarking/make_bench_results.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# example script to run benchmarks and collate them
+
+set -x
+
+# BENCH_OTHERFLAGS are passed to the benchmark commands when they execute,
+#  we default to '--admit_smt_queries true' to exclude Z3 execution time from the benchmarks
+BENCH_OTHERFLAGS=${BENCH_OTHERFLAGS-"--admit_smt_queries true"}
+
+# BENCH_WRAP can be used to set up CPU affinity with taskset, for example:
+#   BENCH_WRAP='taskset --cpu-list 4'
+BENCH_WRAP=${BENCH_WRAP-}
+
+# BENCH_OUTDIR is the location of the output directory
+BENCH_OUTDIR=${BENCH_OUTDIR-"./bench_results/"`date +'%Y%m%d_%H%M%S'`}
+
+write_simple_summary() {
+	IN=${1}
+	OUT=${1}.summary
+	echo ${IN} > ${OUT}
+    cat ${IN}.csv | awk -F',' 'BEGIN {total=0; user=0; sys=0} NR>0 {total+=$2; user+=$3; sys+=$4} END {printf "n\ttotal\tuser\tsystem\t\n%d\t%.4g\t%.4g\t%.4g\n", NR-1,total, user, sys}' >> ${OUT}
+}
+
+write_csv() {
+	IN=${1}
+	OUT=${1}.csv
+
+	FIELDS=('name', 'time_secs', 'user_time_secs', 'sys_time_secs', 'maxrss_kB', 'gc.allocated_words', 'gc.minor_words', 'gc.promoted_words', 'gc.major_words', 'gc.minor_collections', 'gc.major_collections', 'gc.heap_words', 'gc.heap_chunks', 'gc.top_heap_words', 'gc.compactions')
+	HEADER=$(printf "%s" ${FIELDS[@]})
+	JQ_ARGS=$(printf ".%s" ${FIELDS[@]})
+
+	echo $HEADER > ${OUT}
+	cat ${IN}.bench | jq -s -r ".[] | [$JQ_ARGS] | @csv" >> ${OUT}
+}
+
+write_csv_and_summary() {
+	if hash jq 2>/dev/null; then
+		write_csv $1
+		write_simple_summary $1
+	else
+		echo "Unable to find jq to create csv and summary (https://stedolan.github.io/jq/)"
+	fi
+}
+
+mkdir -p ${BENCH_OUTDIR}
+
+# setup clean fstar to clean state
+make clean
+make -C src clean_boot
+make -C src clean
+git checkout -- src/ocaml-output
+rm src/.cache.boot/*.checked.lax
+
+# log the git state of the tree
+git log -n 1 2>&1 | tee -a ${BENCH_OUTDIR}/git_info.log
+git status -v -v 2>&1 | tee -a ${BENCH_OUTDIR}/git_info.log
+
+# build fstar compiler bootstrap
+T0=`date +'%Y%m%d_%H%M%S'`
+echo "Starting fstar compiler bootstrap ${T0}"
+make -C src ocaml-fstar-ocaml 2>&1 | tee ${BENCH_OUTDIR}/build_fstar.log
+T1=`date +'%Y%m%d_%H%M%S'`
+echo "Finished fstar compiler boostrap ${T1} (started at ${T0})"
+
+# verify ulib and install
+T0=`date +'%Y%m%d_%H%M%S'`
+echo "Starting fstarlib build ${T0}"
+make -C src fstarlib 2>&1 | tee ${BENCH_OUTDIR}/build_fstarlib.log
+T1=`date +'%Y%m%d_%H%M%S'`
+echo "Finished fstar compiler boostrap ${T1} (started at ${T0})"
+
+ls -ltr ulib >> ${BENCH_OUTDIR}/build_fstarlib.log
+
+# benchmark examples/micro-benchmarks
+BENCH_DIR=examples/micro-benchmarks; NME=micro-benchmarks
+rm -f ${BENCH_DIR}/*.bench
+${BENCH_WRAP} make -C ${BENCH_DIR} BENCHMARK_FSTAR=true BENCHMARK_CMD=orun OTHERFLAGS="${BENCH_OTHERFLAGS}" 2>&1 | tee ${BENCH_OUTDIR}/${NME}.log
+cat ${BENCH_DIR}/*.bench > ${BENCH_OUTDIR}/${NME}.bench
+write_csv_and_summary ${BENCH_OUTDIR}/${NME}
+
+# benchmark ulib
+BENCH_DIR=ulib; NME=ulib
+rm -f ${BENCH_DIR}/*.bench
+${BENCH_WRAP} make -C ${BENCH_DIR} benchmark BENCHMARK_FSTAR=true BENCHMARK_CMD=orun OTHERFLAGS="${BENCH_OTHERFLAGS}" 2>&1 | tee ${BENCH_OUTDIR}/${NME}.log
+cat ${BENCH_DIR}/*.bench > ${BENCH_OUTDIR}/${NME}.bench
+write_csv_and_summary ${BENCH_OUTDIR}/${NME}
+
+# ocaml_extract: make -C src ocaml
+make -C src clean_boot
+#make -C src clean # will do a clean-ocaml as well
+NME=ocaml_extract
+rm -f src/ocaml-output/*.bench
+${BENCH_WRAP} make -C src ocaml BENCHMARK_FSTAR=true BENCHMARK_CMD=orun OTHERFLAGS="${BENCH_OTHERFLAGS}" 2>&1 | tee ${BENCH_OUTDIR}/${NME}.log
+cat src/ocaml-output/*.bench > ${BENCH_OUTDIR}/${NME}.bench
+write_csv_and_summary ${BENCH_OUTDIR}/${NME}
+


### PR DESCRIPTION

This PR adds the script I have been using to make use of the benchmarking hooks (added in #1795) to generate benchmarking numbers for examples/micro-benchmarks, ulib and ocaml_extract.

It should allow others to generate the same collated benchmarking numbers I have been putting into optimization PR requests. 