### PR TITLE
Fix Docu: use 64-bit version of OCaml compiler

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -197,7 +197,7 @@ The steps require a working OCaml setup. OCaml version 4.04.X, 4.05.X, 4.06.X, o
    So switch to a supported OCaml version by running the following commands:
   ```sh
   $ opam switch list-available
-  $ opam switch create ocaml-variants.4.07.1+mingw32c
+  $ opam switch create ocaml-variants.4.07.1+mingw64c
   ```
 
 3. Afterwards you can install the `depext` and `depext-cygwinports` packages,


### PR DESCRIPTION
From what I gather, the 32-bit version of the OCaml compiler current won't compile F*, so in this manual, it really must be the 64-bit version. I'm working through the steps in the instructions right now, and it doesn't work with the 32-bit version.